### PR TITLE
Rename ImportSettings dialogs to have "Dialog" in the name

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7330,13 +7330,13 @@ EditorNode::EditorNode() {
 	project_settings_editor = memnew(ProjectSettingsEditor(&editor_data));
 	gui_base->add_child(project_settings_editor);
 
-	scene_import_settings = memnew(SceneImportSettings);
+	scene_import_settings = memnew(SceneImportSettingsDialog);
 	gui_base->add_child(scene_import_settings);
 
-	audio_stream_import_settings = memnew(AudioStreamImportSettings);
+	audio_stream_import_settings = memnew(AudioStreamImportSettingsDialog);
 	gui_base->add_child(audio_stream_import_settings);
 
-	fontdata_import_settings = memnew(DynamicFontImportSettings);
+	fontdata_import_settings = memnew(DynamicFontImportSettingsDialog);
 	gui_base->add_child(fontdata_import_settings);
 
 	export_template_manager = memnew(ExportTemplateManager);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -68,12 +68,12 @@ class VBoxContainer;
 class VSplitContainer;
 class Window;
 
-class AudioStreamImportSettings;
+class AudioStreamImportSettingsDialog;
 class AudioStreamPreviewGenerator;
 class BackgroundProgress;
 class DependencyEditor;
 class DependencyErrorDialog;
-class DynamicFontImportSettings;
+class DynamicFontImportSettingsDialog;
 class EditorAbout;
 class EditorBuildProfileManager;
 class EditorCommandPalette;
@@ -111,7 +111,7 @@ class ProgressDialog;
 class ProjectExportDialog;
 class ProjectSettingsEditor;
 class RunSettingsDialog;
-class SceneImportSettings;
+class SceneImportSettingsDialog;
 class ScriptCreateDialog;
 class SurfaceUpgradeTool;
 class SurfaceUpgradeDialog;
@@ -483,9 +483,9 @@ private:
 	String open_navigate;
 	String saving_scene;
 
-	DynamicFontImportSettings *fontdata_import_settings = nullptr;
-	SceneImportSettings *scene_import_settings = nullptr;
-	AudioStreamImportSettings *audio_stream_import_settings = nullptr;
+	DynamicFontImportSettingsDialog *fontdata_import_settings = nullptr;
+	SceneImportSettingsDialog *scene_import_settings = nullptr;
+	AudioStreamImportSettingsDialog *audio_stream_import_settings = nullptr;
 
 	String import_reload_fn;
 

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -35,13 +35,13 @@
 #include "editor/editor_string_names.h"
 #include "scene/gui/check_box.h"
 
-AudioStreamImportSettings *AudioStreamImportSettings::singleton = nullptr;
+AudioStreamImportSettingsDialog *AudioStreamImportSettingsDialog::singleton = nullptr;
 
-void AudioStreamImportSettings::_notification(int p_what) {
+void AudioStreamImportSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AudioStreamImportSettings::_preview_changed));
-			connect("confirmed", callable_mp(this, &AudioStreamImportSettings::_reimport));
+			AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AudioStreamImportSettingsDialog::_preview_changed));
+			connect("confirmed", callable_mp(this, &AudioStreamImportSettingsDialog::_reimport));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -82,7 +82,7 @@ void AudioStreamImportSettings::_notification(int p_what) {
 	}
 }
 
-void AudioStreamImportSettings::_draw_preview() {
+void AudioStreamImportSettingsDialog::_draw_preview() {
 	Rect2 rect = _preview->get_rect();
 	Size2 rect_size = rect.size;
 	int width = rect_size.width;
@@ -173,13 +173,13 @@ void AudioStreamImportSettings::_draw_preview() {
 	}
 }
 
-void AudioStreamImportSettings::_preview_changed(ObjectID p_which) {
+void AudioStreamImportSettingsDialog::_preview_changed(ObjectID p_which) {
 	if (stream.is_valid() && stream->get_instance_id() == p_which) {
 		_preview->queue_redraw();
 	}
 }
 
-void AudioStreamImportSettings::_preview_zoom_in() {
+void AudioStreamImportSettingsDialog::_preview_zoom_in() {
 	if (!stream.is_valid()) {
 		return;
 	}
@@ -191,7 +191,7 @@ void AudioStreamImportSettings::_preview_zoom_in() {
 	_indicator->queue_redraw();
 }
 
-void AudioStreamImportSettings::_preview_zoom_out() {
+void AudioStreamImportSettingsDialog::_preview_zoom_out() {
 	if (!stream.is_valid()) {
 		return;
 	}
@@ -203,7 +203,7 @@ void AudioStreamImportSettings::_preview_zoom_out() {
 	_indicator->queue_redraw();
 }
 
-void AudioStreamImportSettings::_preview_zoom_reset() {
+void AudioStreamImportSettingsDialog::_preview_zoom_reset() {
 	if (!stream.is_valid()) {
 		return;
 	}
@@ -214,12 +214,12 @@ void AudioStreamImportSettings::_preview_zoom_reset() {
 	_indicator->queue_redraw();
 }
 
-void AudioStreamImportSettings::_preview_zoom_offset_changed(double) {
+void AudioStreamImportSettingsDialog::_preview_zoom_offset_changed(double) {
 	_preview->queue_redraw();
 	_indicator->queue_redraw();
 }
 
-void AudioStreamImportSettings::_audio_changed() {
+void AudioStreamImportSettingsDialog::_audio_changed() {
 	if (!is_visible()) {
 		return;
 	}
@@ -228,7 +228,7 @@ void AudioStreamImportSettings::_audio_changed() {
 	color_rect->queue_redraw();
 }
 
-void AudioStreamImportSettings::_play() {
+void AudioStreamImportSettingsDialog::_play() {
 	if (_player->is_playing()) {
 		// '_pausing' variable indicates that we want to pause the audio player, not stop it. See '_on_finished()'.
 		_pausing = true;
@@ -242,7 +242,7 @@ void AudioStreamImportSettings::_play() {
 	}
 }
 
-void AudioStreamImportSettings::_stop() {
+void AudioStreamImportSettingsDialog::_stop() {
 	_player->stop();
 	_play_button->set_icon(get_editor_theme_icon(SNAME("MainPlay")));
 	_current = 0;
@@ -250,7 +250,7 @@ void AudioStreamImportSettings::_stop() {
 	set_process(false);
 }
 
-void AudioStreamImportSettings::_on_finished() {
+void AudioStreamImportSettingsDialog::_on_finished() {
 	_play_button->set_icon(get_editor_theme_icon(SNAME("MainPlay")));
 	if (!_pausing) {
 		_current = 0;
@@ -261,7 +261,7 @@ void AudioStreamImportSettings::_on_finished() {
 	set_process(false);
 }
 
-void AudioStreamImportSettings::_draw_indicator() {
+void AudioStreamImportSettingsDialog::_draw_indicator() {
 	if (!stream.is_valid()) {
 		return;
 	}
@@ -314,12 +314,12 @@ void AudioStreamImportSettings::_draw_indicator() {
 	_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
 }
 
-void AudioStreamImportSettings::_on_indicator_mouse_exited() {
+void AudioStreamImportSettingsDialog::_on_indicator_mouse_exited() {
 	_hovering_beat = -1;
 	_indicator->queue_redraw();
 }
 
-void AudioStreamImportSettings::_on_input_indicator(Ref<InputEvent> p_event) {
+void AudioStreamImportSettingsDialog::_on_input_indicator(Ref<InputEvent> p_event) {
 	const Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (stream->get_bpm() > 0) {
@@ -369,7 +369,7 @@ void AudioStreamImportSettings::_on_input_indicator(Ref<InputEvent> p_event) {
 	}
 }
 
-int AudioStreamImportSettings::_get_beat_at_pos(real_t p_x) {
+int AudioStreamImportSettingsDialog::_get_beat_at_pos(real_t p_x) {
 	float ofs_sec = zoom_bar->get_value() + p_x * zoom_bar->get_page() / _preview->get_size().width;
 	ofs_sec = CLAMP(ofs_sec, 0, stream->get_length());
 	float beat_size = 60 / float(stream->get_bpm());
@@ -381,7 +381,7 @@ int AudioStreamImportSettings::_get_beat_at_pos(real_t p_x) {
 	return beat;
 }
 
-void AudioStreamImportSettings::_set_beat_len_to(real_t p_x) {
+void AudioStreamImportSettingsDialog::_set_beat_len_to(real_t p_x) {
 	int beat = _get_beat_at_pos(p_x);
 	if (beat < 1) {
 		beat = 1; // Because 0 is disable.
@@ -393,16 +393,16 @@ void AudioStreamImportSettings::_set_beat_len_to(real_t p_x) {
 	_settings_changed();
 }
 
-void AudioStreamImportSettings::_seek_to(real_t p_x) {
+void AudioStreamImportSettingsDialog::_seek_to(real_t p_x) {
 	_current = zoom_bar->get_value() + p_x / _preview->get_rect().size.x * zoom_bar->get_page();
 	_current = CLAMP(_current, 0, stream->get_length());
 	_player->seek(_current);
 	_indicator->queue_redraw();
 }
 
-void AudioStreamImportSettings::edit(const String &p_path, const String &p_importer, const Ref<AudioStream> &p_stream) {
+void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p_importer, const Ref<AudioStream> &p_stream) {
 	if (!stream.is_null()) {
-		stream->disconnect_changed(callable_mp(this, &AudioStreamImportSettings::_audio_changed));
+		stream->disconnect_changed(callable_mp(this, &AudioStreamImportSettingsDialog::_audio_changed));
 	}
 
 	importer = p_importer;
@@ -415,7 +415,7 @@ void AudioStreamImportSettings::edit(const String &p_path, const String &p_impor
 	_duration_label->set_text(text);
 
 	if (!stream.is_null()) {
-		stream->connect_changed(callable_mp(this, &AudioStreamImportSettings::_audio_changed));
+		stream->connect_changed(callable_mp(this, &AudioStreamImportSettingsDialog::_audio_changed));
 		_preview->queue_redraw();
 		_indicator->queue_redraw();
 		color_rect->queue_redraw();
@@ -464,7 +464,7 @@ void AudioStreamImportSettings::edit(const String &p_path, const String &p_impor
 	}
 }
 
-void AudioStreamImportSettings::_settings_changed() {
+void AudioStreamImportSettingsDialog::_settings_changed() {
 	if (updating_settings) {
 		return;
 	}
@@ -515,7 +515,7 @@ void AudioStreamImportSettings::_settings_changed() {
 	color_rect->queue_redraw();
 }
 
-void AudioStreamImportSettings::_reimport() {
+void AudioStreamImportSettingsDialog::_reimport() {
 	params["loop"] = loop->is_pressed();
 	params["loop_offset"] = loop_offset->get_value();
 	params["bpm"] = bpm_enabled->is_pressed() ? double(bpm_edit->get_value()) : double(0);
@@ -525,7 +525,7 @@ void AudioStreamImportSettings::_reimport() {
 	EditorFileSystem::get_singleton()->reimport_file_with_custom_parameters(path, importer, params);
 }
 
-AudioStreamImportSettings::AudioStreamImportSettings() {
+AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	get_ok_button()->set_text(TTR("Reimport"));
 	get_cancel_button()->set_text(TTR("Close"));
 
@@ -537,7 +537,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	loop = memnew(CheckBox);
 	loop->set_text(TTR("Enable"));
 	loop->set_tooltip_text(TTR("Enable looping."));
-	loop->connect("toggled", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	loop->connect("toggled", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	loop_hb->add_child(loop);
 	loop_hb->add_spacer();
 	loop_hb->add_child(memnew(Label(TTR("Offset:"))));
@@ -546,7 +546,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	loop_offset->set_step(0.001);
 	loop_offset->set_suffix("sec");
 	loop_offset->set_tooltip_text(TTR("Loop offset (from beginning). Note that if BPM is set, this setting will be ignored."));
-	loop_offset->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	loop_offset->connect("value_changed", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	loop_hb->add_child(loop_offset);
 	main_vbox->add_margin_child(TTR("Loop:"), loop_hb);
 
@@ -554,23 +554,23 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	interactive_hb->add_theme_constant_override("separation", 4 * EDSCALE);
 	bpm_enabled = memnew(CheckBox);
 	bpm_enabled->set_text((TTR("BPM:")));
-	bpm_enabled->connect("toggled", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	bpm_enabled->connect("toggled", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	interactive_hb->add_child(bpm_enabled);
 	bpm_edit = memnew(SpinBox);
 	bpm_edit->set_max(400);
 	bpm_edit->set_step(0.01);
 	bpm_edit->set_tooltip_text(TTR("Configure the Beats Per Measure (tempo) used for the interactive streams.\nThis is required in order to configure beat information."));
-	bpm_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	bpm_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	interactive_hb->add_child(bpm_edit);
 	interactive_hb->add_spacer();
 	beats_enabled = memnew(CheckBox);
 	beats_enabled->set_text(TTR("Beat Count:"));
-	beats_enabled->connect("toggled", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	beats_enabled->connect("toggled", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	interactive_hb->add_child(beats_enabled);
 	beats_edit = memnew(SpinBox);
 	beats_edit->set_tooltip_text(TTR("Configure the amount of Beats used for music-aware looping. If zero, it will be autodetected from the length.\nIt is recommended to set this value (either manually or by clicking on a beat number in the preview) to ensure looping works properly."));
 	beats_edit->set_max(99999);
-	beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	interactive_hb->add_child(beats_edit);
 	bar_beats_label = memnew(Label(TTR("Bar Beats:")));
 	interactive_hb->add_child(bar_beats_label);
@@ -578,7 +578,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	bar_beats_edit->set_tooltip_text(TTR("Configure the Beats Per Bar. This used for music-aware transitions between AudioStreams."));
 	bar_beats_edit->set_min(2);
 	bar_beats_edit->set_max(32);
-	bar_beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	bar_beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	interactive_hb->add_child(bar_beats_edit);
 	interactive_hb->add_spacer();
 	main_vbox->add_margin_child(TTR("Music Playback:"), interactive_hb);
@@ -590,7 +590,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	color_rect->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	_player = memnew(AudioStreamPlayer);
-	_player->connect("finished", callable_mp(this, &AudioStreamImportSettings::_on_finished));
+	_player->connect("finished", callable_mp(this, &AudioStreamImportSettingsDialog::_on_finished));
 	color_rect->add_child(_player);
 
 	VBoxContainer *vbox = memnew(VBoxContainer);
@@ -600,7 +600,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 
 	_preview = memnew(ColorRect);
 	_preview->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	_preview->connect("draw", callable_mp(this, &AudioStreamImportSettings::_draw_preview));
+	_preview->connect("draw", callable_mp(this, &AudioStreamImportSettingsDialog::_draw_preview));
 	_preview->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbox->add_child(_preview);
 
@@ -618,17 +618,17 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	zoom_hbox->add_child(zoom_out);
 	zoom_hbox->add_child(zoom_reset);
 	zoom_hbox->add_child(zoom_in);
-	zoom_in->connect("pressed", callable_mp(this, &AudioStreamImportSettings::_preview_zoom_in));
-	zoom_reset->connect("pressed", callable_mp(this, &AudioStreamImportSettings::_preview_zoom_reset));
-	zoom_out->connect("pressed", callable_mp(this, &AudioStreamImportSettings::_preview_zoom_out));
-	zoom_bar->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_preview_zoom_offset_changed));
+	zoom_in->connect("pressed", callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_in));
+	zoom_reset->connect("pressed", callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_reset));
+	zoom_out->connect("pressed", callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_out));
+	zoom_bar->connect("value_changed", callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_offset_changed));
 	vbox->add_child(zoom_hbox);
 
 	_indicator = memnew(Control);
 	_indicator->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
-	_indicator->connect("draw", callable_mp(this, &AudioStreamImportSettings::_draw_indicator));
-	_indicator->connect("gui_input", callable_mp(this, &AudioStreamImportSettings::_on_input_indicator));
-	_indicator->connect("mouse_exited", callable_mp(this, &AudioStreamImportSettings::_on_indicator_mouse_exited));
+	_indicator->connect("draw", callable_mp(this, &AudioStreamImportSettingsDialog::_draw_indicator));
+	_indicator->connect("gui_input", callable_mp(this, &AudioStreamImportSettingsDialog::_on_input_indicator));
+	_indicator->connect("mouse_exited", callable_mp(this, &AudioStreamImportSettingsDialog::_on_indicator_mouse_exited));
 	_preview->add_child(_indicator);
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
@@ -639,13 +639,13 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	_play_button->set_flat(true);
 	hbox->add_child(_play_button);
 	_play_button->set_focus_mode(Control::FOCUS_NONE);
-	_play_button->connect("pressed", callable_mp(this, &AudioStreamImportSettings::_play));
+	_play_button->connect("pressed", callable_mp(this, &AudioStreamImportSettingsDialog::_play));
 
 	_stop_button = memnew(Button);
 	_stop_button->set_flat(true);
 	hbox->add_child(_stop_button);
 	_stop_button->set_focus_mode(Control::FOCUS_NONE);
-	_stop_button->connect("pressed", callable_mp(this, &AudioStreamImportSettings::_stop));
+	_stop_button->connect("pressed", callable_mp(this, &AudioStreamImportSettingsDialog::_stop));
 
 	_current_label = memnew(Label);
 	_current_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);

--- a/editor/import/audio_stream_import_settings.h
+++ b/editor/import/audio_stream_import_settings.h
@@ -40,8 +40,8 @@
 
 class CheckBox;
 
-class AudioStreamImportSettings : public ConfirmationDialog {
-	GDCLASS(AudioStreamImportSettings, ConfirmationDialog);
+class AudioStreamImportSettingsDialog : public ConfirmationDialog {
+	GDCLASS(AudioStreamImportSettingsDialog, ConfirmationDialog);
 
 	CheckBox *bpm_enabled = nullptr;
 	SpinBox *bpm_edit = nullptr;
@@ -81,7 +81,7 @@ class AudioStreamImportSettings : public ConfirmationDialog {
 
 	void _audio_changed();
 
-	static AudioStreamImportSettings *singleton;
+	static AudioStreamImportSettingsDialog *singleton;
 
 	void _settings_changed();
 
@@ -109,9 +109,9 @@ protected:
 public:
 	void edit(const String &p_path, const String &p_importer, const Ref<AudioStream> &p_stream);
 
-	static AudioStreamImportSettings *get_singleton() { return singleton; }
+	static AudioStreamImportSettingsDialog *get_singleton() { return singleton; }
 
-	AudioStreamImportSettings();
+	AudioStreamImportSettingsDialog();
 };
 
 #endif // AUDIO_STREAM_IMPORT_SETTINGS_H

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -427,7 +427,7 @@ static UniRange unicode_ranges[] = {
 	{ 0x10FFFF, 0x10FFFF, String() }
 };
 
-void DynamicFontImportSettings::_add_glyph_range_item(int32_t p_start, int32_t p_end, const String &p_name) {
+void DynamicFontImportSettingsDialog::_add_glyph_range_item(int32_t p_start, int32_t p_end, const String &p_name) {
 	const int page_size = 512;
 	int pages = (p_end - p_start) / page_size;
 	int remain = (p_end - p_start) % page_size;
@@ -456,7 +456,7 @@ void DynamicFontImportSettings::_add_glyph_range_item(int32_t p_start, int32_t p
 /* Page 1 callbacks: Rendering Options                                   */
 /*************************************************************************/
 
-void DynamicFontImportSettings::_main_prop_changed(const String &p_edited_property) {
+void DynamicFontImportSettingsDialog::_main_prop_changed(const String &p_edited_property) {
 	// Update font preview.
 
 	if (font_preview.is_valid()) {
@@ -494,7 +494,7 @@ void DynamicFontImportSettings::_main_prop_changed(const String &p_edited_proper
 /* Page 2 callbacks: Configurations                                      */
 /*************************************************************************/
 
-void DynamicFontImportSettings::_variation_add() {
+void DynamicFontImportSettingsDialog::_variation_add() {
 	TreeItem *vars_item = vars_list->create_item(vars_list_root);
 	ERR_FAIL_NULL(vars_item);
 
@@ -522,7 +522,7 @@ void DynamicFontImportSettings::_variation_add() {
 	_variations_validate();
 }
 
-void DynamicFontImportSettings::_variation_selected() {
+void DynamicFontImportSettingsDialog::_variation_selected() {
 	TreeItem *vars_item = vars_list->get_selected();
 	if (vars_item) {
 		Ref<DynamicFontImportSettingsData> import_variation_data = vars_item->get_metadata(0);
@@ -543,7 +543,7 @@ void DynamicFontImportSettings::_variation_selected() {
 	}
 }
 
-void DynamicFontImportSettings::_variation_remove(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+void DynamicFontImportSettingsDialog::_variation_remove(Object *p_item, int p_column, int p_id, MouseButton p_button) {
 	if (p_button != MouseButton::LEFT) {
 		return;
 	}
@@ -574,11 +574,11 @@ void DynamicFontImportSettings::_variation_remove(Object *p_item, int p_column, 
 	}
 }
 
-void DynamicFontImportSettings::_variation_changed(const String &p_edited_property) {
+void DynamicFontImportSettingsDialog::_variation_changed(const String &p_edited_property) {
 	_variations_validate();
 }
 
-void DynamicFontImportSettings::_variations_validate() {
+void DynamicFontImportSettingsDialog::_variations_validate() {
 	String warn;
 	if (!vars_list_root->get_first_child()) {
 		warn = TTR("Warning: There are no configurations specified, no glyphs will be pre-rendered.");
@@ -621,7 +621,7 @@ void DynamicFontImportSettings::_variations_validate() {
 /* Page 2.1 callbacks: Text to select glyphs                             */
 /*************************************************************************/
 
-void DynamicFontImportSettings::_change_text_opts() {
+void DynamicFontImportSettingsDialog::_change_text_opts() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -644,7 +644,7 @@ void DynamicFontImportSettings::_change_text_opts() {
 	text_edit->add_theme_font_override("font", font_main_text);
 }
 
-void DynamicFontImportSettings::_glyph_update_lbl() {
+void DynamicFontImportSettingsDialog::_glyph_update_lbl() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -665,7 +665,7 @@ void DynamicFontImportSettings::_glyph_update_lbl() {
 	label_glyphs->set_text(vformat(TTR("Preloaded glyphs: %d"), unlinked_glyphs + import_variation_data->selected_chars.size()));
 }
 
-void DynamicFontImportSettings::_glyph_clear() {
+void DynamicFontImportSettingsDialog::_glyph_clear() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -681,7 +681,7 @@ void DynamicFontImportSettings::_glyph_clear() {
 	_range_selected();
 }
 
-void DynamicFontImportSettings::_glyph_text_selected() {
+void DynamicFontImportSettingsDialog::_glyph_text_selected() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -713,7 +713,7 @@ void DynamicFontImportSettings::_glyph_text_selected() {
 /* Page 2.2 callbacks: Character map                                     */
 /*************************************************************************/
 
-void DynamicFontImportSettings::_glyph_selected() {
+void DynamicFontImportSettingsDialog::_glyph_selected() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -768,14 +768,14 @@ void DynamicFontImportSettings::_glyph_selected() {
 	}
 }
 
-void DynamicFontImportSettings::_range_edited() {
+void DynamicFontImportSettingsDialog::_range_edited() {
 	TreeItem *item = glyph_tree->get_selected();
 	ERR_FAIL_NULL(item);
 	Vector2i range = item->get_metadata(0);
 	_range_update(range.x, range.y);
 }
 
-void DynamicFontImportSettings::_range_selected() {
+void DynamicFontImportSettingsDialog::_range_selected() {
 	TreeItem *item = glyph_tree->get_selected();
 	if (item) {
 		Vector2i range = item->get_metadata(0);
@@ -783,7 +783,7 @@ void DynamicFontImportSettings::_range_selected() {
 	}
 }
 
-void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
+void DynamicFontImportSettingsDialog::_edit_range(int32_t p_start, int32_t p_end) {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -845,7 +845,7 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 	_glyph_update_lbl();
 }
 
-bool DynamicFontImportSettings::_char_update(int32_t p_char) {
+bool DynamicFontImportSettingsDialog::_char_update(int32_t p_char) {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -868,7 +868,7 @@ bool DynamicFontImportSettings::_char_update(int32_t p_char) {
 	}
 }
 
-void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
+void DynamicFontImportSettingsDialog::_range_update(int32_t p_start, int32_t p_end) {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -912,17 +912,17 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 /* Common                                                                */
 /*************************************************************************/
 
-DynamicFontImportSettings *DynamicFontImportSettings::singleton = nullptr;
+DynamicFontImportSettingsDialog *DynamicFontImportSettingsDialog::singleton = nullptr;
 
-String DynamicFontImportSettings::_pad_zeros(const String &p_hex) const {
+String DynamicFontImportSettingsDialog::_pad_zeros(const String &p_hex) const {
 	int len = CLAMP(5 - p_hex.length(), 0, 5);
 	return String("0").repeat(len) + p_hex;
 }
 
-void DynamicFontImportSettings::_notification(int p_what) {
+void DynamicFontImportSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			connect("confirmed", callable_mp(this, &DynamicFontImportSettings::_re_import));
+			connect("confirmed", callable_mp(this, &DynamicFontImportSettingsDialog::_re_import));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -932,7 +932,7 @@ void DynamicFontImportSettings::_notification(int p_what) {
 	}
 }
 
-void DynamicFontImportSettings::_re_import() {
+void DynamicFontImportSettingsDialog::_re_import() {
 	HashMap<StringName, Variant> main_settings;
 
 	main_settings["face_index"] = import_settings_data->get("face_index");
@@ -999,13 +999,13 @@ void DynamicFontImportSettings::_re_import() {
 	EditorFileSystem::get_singleton()->reimport_file_with_custom_parameters(base_path, "font_data_dynamic", main_settings);
 }
 
-void DynamicFontImportSettings::_locale_edited() {
+void DynamicFontImportSettingsDialog::_locale_edited() {
 	TreeItem *item = locale_tree->get_selected();
 	ERR_FAIL_NULL(item);
 	item->set_checked(0, !item->is_checked(0));
 }
 
-void DynamicFontImportSettings::_process_locales() {
+void DynamicFontImportSettingsDialog::_process_locales() {
 	Ref<DynamicFontImportSettingsData> import_variation_data;
 
 	TreeItem *vars_item = vars_list->get_selected();
@@ -1049,7 +1049,7 @@ void DynamicFontImportSettings::_process_locales() {
 	_range_selected();
 }
 
-void DynamicFontImportSettings::open_settings(const String &p_path) {
+void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	// Load base font data.
 	Vector<uint8_t> font_data = FileAccess::get_file_as_bytes(p_path);
 
@@ -1234,11 +1234,11 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 	set_title(vformat(TTR("Advanced Import Settings for '%s'"), base_path.get_file()));
 }
 
-DynamicFontImportSettings *DynamicFontImportSettings::get_singleton() {
+DynamicFontImportSettingsDialog *DynamicFontImportSettingsDialog::get_singleton() {
 	return singleton;
 }
 
-DynamicFontImportSettings::DynamicFontImportSettings() {
+DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	singleton = this;
 
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::NIL, "Rendering", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
@@ -1334,7 +1334,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_general->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_general->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
 	page1_hb->add_child(inspector_general);
-	inspector_general->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_main_prop_changed));
+	inspector_general->connect("property_edited", callable_mp(this, &DynamicFontImportSettingsDialog::_main_prop_changed));
 
 	// Page 2 layout: Configurations
 	VBoxContainer *page2_vb = memnew(VBoxContainer);
@@ -1367,7 +1367,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_var = memnew(Button);
 	add_var->set_tooltip_text(TTR("Add configuration"));
 	page2_hb_vars->add_child(add_var);
-	add_var->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_variation_add));
+	add_var->connect("pressed", callable_mp(this, &DynamicFontImportSettingsDialog::_variation_add));
 
 	vars_list = memnew(Tree);
 	vars_list->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
@@ -1379,13 +1379,13 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	vars_list->set_column_custom_minimum_width(1, 50 * EDSCALE);
 	vars_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	page2_side_vb->add_child(vars_list);
-	vars_list->connect("item_selected", callable_mp(this, &DynamicFontImportSettings::_variation_selected));
-	vars_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettings::_variation_remove));
+	vars_list->connect("item_selected", callable_mp(this, &DynamicFontImportSettingsDialog::_variation_selected));
+	vars_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettingsDialog::_variation_remove));
 
 	inspector_vars = memnew(EditorInspector);
 	inspector_vars->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	page2_side_vb->add_child(inspector_vars);
-	inspector_vars->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_variation_changed));
+	inspector_vars->connect("property_edited", callable_mp(this, &DynamicFontImportSettingsDialog::_variation_changed));
 
 	VBoxContainer *preload_pages_vb = memnew(VBoxContainer);
 	page2_hb->add_child(preload_pages_vb);
@@ -1408,7 +1408,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	Button *btn_clear = memnew(Button);
 	btn_clear->set_text(TTR("Clear Glyph List"));
 	gl_hb->add_child(btn_clear);
-	btn_clear->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_glyph_clear));
+	btn_clear->connect("pressed", callable_mp(this, &DynamicFontImportSettingsDialog::_glyph_clear));
 
 	VBoxContainer *page2_0_vb = memnew(VBoxContainer);
 	page2_0_vb->set_name(TTR("Glyphs from the Translations"));
@@ -1427,7 +1427,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	locale_tree->set_column_custom_minimum_width(0, 120 * EDSCALE);
 	locale_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	page2_0_vb->add_child(locale_tree);
-	locale_tree->connect("item_activated", callable_mp(this, &DynamicFontImportSettings::_locale_edited));
+	locale_tree->connect("item_activated", callable_mp(this, &DynamicFontImportSettingsDialog::_locale_edited));
 
 	locale_root = locale_tree->create_item();
 
@@ -1438,7 +1438,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	btn_fill_locales = memnew(Button);
 	btn_fill_locales->set_text(TTR("Shape all Strings in the Translations and Add Glyphs"));
 	locale_hb->add_child(btn_fill_locales);
-	btn_fill_locales->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_process_locales));
+	btn_fill_locales->connect("pressed", callable_mp(this, &DynamicFontImportSettingsDialog::_process_locales));
 
 	// Page 2.1 layout: Text to select glyphs
 	VBoxContainer *page2_1_vb = memnew(VBoxContainer);
@@ -1461,7 +1461,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_text->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
 	page2_1_hb->add_child(inspector_text);
-	inspector_text->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_change_text_opts));
+	inspector_text->connect("property_edited", callable_mp(this, &DynamicFontImportSettingsDialog::_change_text_opts));
 
 	text_edit = memnew(TextEdit);
 	text_edit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1475,7 +1475,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	btn_fill = memnew(Button);
 	btn_fill->set_text(TTR("Shape Text and Add Glyphs"));
 	text_hb->add_child(btn_fill);
-	btn_fill->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_glyph_text_selected));
+	btn_fill->connect("pressed", callable_mp(this, &DynamicFontImportSettingsDialog::_glyph_text_selected));
 
 	// Page 2.2 layout: Character map
 	VBoxContainer *page2_2_vb = memnew(VBoxContainer);
@@ -1510,7 +1510,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	glyph_table->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	glyphs_split->add_child(glyph_table);
-	glyph_table->connect("item_activated", callable_mp(this, &DynamicFontImportSettings::_glyph_selected));
+	glyph_table->connect("item_activated", callable_mp(this, &DynamicFontImportSettingsDialog::_glyph_selected));
 
 	glyph_tree = memnew(Tree);
 	glyph_tree->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
@@ -1525,8 +1525,8 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 		_add_glyph_range_item(unicode_ranges[i].start, unicode_ranges[i].end, unicode_ranges[i].name);
 	}
 	glyphs_split->add_child(glyph_tree);
-	glyph_tree->connect("item_activated", callable_mp(this, &DynamicFontImportSettings::_range_edited));
-	glyph_tree->connect("item_selected", callable_mp(this, &DynamicFontImportSettings::_range_selected));
+	glyph_tree->connect("item_activated", callable_mp(this, &DynamicFontImportSettingsDialog::_range_edited));
+	glyph_tree->connect("item_selected", callable_mp(this, &DynamicFontImportSettingsDialog::_range_selected));
 
 	// Common
 

--- a/editor/import/dynamic_font_import_settings.h
+++ b/editor/import/dynamic_font_import_settings.h
@@ -45,16 +45,16 @@
 #include "scene/resources/font.h"
 #include "servers/text_server.h"
 
-class DynamicFontImportSettings;
+class DynamicFontImportSettingsDialog;
 
 class DynamicFontImportSettingsData : public RefCounted {
 	GDCLASS(DynamicFontImportSettingsData, RefCounted)
-	friend class DynamicFontImportSettings;
+	friend class DynamicFontImportSettingsDialog;
 
 	HashMap<StringName, Variant> settings;
 	HashMap<StringName, Variant> defaults;
 	List<ResourceImporter::ImportOption> options;
-	DynamicFontImportSettings *owner = nullptr;
+	DynamicFontImportSettingsDialog *owner = nullptr;
 
 	HashSet<char32_t> selected_chars;
 	HashSet<int32_t> selected_glyphs;
@@ -73,8 +73,8 @@ class EditorFileDialog;
 class EditorInspector;
 class EditorLocaleDialog;
 
-class DynamicFontImportSettings : public ConfirmationDialog {
-	GDCLASS(DynamicFontImportSettings, ConfirmationDialog)
+class DynamicFontImportSettingsDialog : public ConfirmationDialog {
+	GDCLASS(DynamicFontImportSettingsDialog, ConfirmationDialog)
 	friend class DynamicFontImportSettingsData;
 
 	enum ItemButton {
@@ -82,7 +82,7 @@ class DynamicFontImportSettings : public ConfirmationDialog {
 		BUTTON_REMOVE_VAR,
 	};
 
-	static DynamicFontImportSettings *singleton;
+	static DynamicFontImportSettingsDialog *singleton;
 
 	String base_path;
 
@@ -172,9 +172,9 @@ protected:
 
 public:
 	void open_settings(const String &p_path);
-	static DynamicFontImportSettings *get_singleton();
+	static DynamicFontImportSettingsDialog *get_singleton();
 
-	DynamicFontImportSettings();
+	DynamicFontImportSettingsDialog();
 };
 
 #endif // DYNAMIC_FONT_IMPORT_SETTINGS_H

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -137,7 +137,7 @@ bool ResourceImporterDynamicFont::has_advanced_options() const {
 	return true;
 }
 void ResourceImporterDynamicFont::show_advanced_options(const String &p_path) {
-	DynamicFontImportSettings::get_singleton()->open_settings(p_path);
+	DynamicFontImportSettingsDialog::get_singleton()->open_settings(p_path);
 }
 
 Error ResourceImporterDynamicFont::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2670,7 +2670,7 @@ bool ResourceImporterScene::has_advanced_options() const {
 	return true;
 }
 void ResourceImporterScene::show_advanced_options(const String &p_path) {
-	SceneImportSettings::get_singleton()->open_settings(p_path, animation_importer);
+	SceneImportSettingsDialog::get_singleton()->open_settings(p_path, animation_importer);
 }
 
 ResourceImporterScene::ResourceImporterScene(bool p_animation_import, bool p_singleton) {

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -45,7 +45,7 @@
 
 class SceneImportSettingsData : public Object {
 	GDCLASS(SceneImportSettingsData, Object)
-	friend class SceneImportSettings;
+	friend class SceneImportSettingsDialog;
 	HashMap<StringName, Variant> *settings = nullptr;
 	HashMap<StringName, Variant> current;
 	HashMap<StringName, Variant> defaults;
@@ -67,27 +67,27 @@ class SceneImportSettingsData : public Object {
 
 			// SceneImportSettings must decide if a new collider should be generated or not.
 			if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE) {
-				SceneImportSettings::get_singleton()->request_generate_collider();
+				SceneImportSettingsDialog::get_singleton()->request_generate_collider();
 			}
 
-			if (SceneImportSettings::get_singleton()->is_editing_animation()) {
+			if (SceneImportSettingsDialog::get_singleton()->is_editing_animation()) {
 				if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
 					if (ResourceImporterScene::get_animation_singleton()->get_option_visibility(path, p_name, current)) {
-						SceneImportSettings::get_singleton()->update_view();
+						SceneImportSettingsDialog::get_singleton()->update_view();
 					}
 				} else {
 					if (ResourceImporterScene::get_animation_singleton()->get_internal_option_update_view_required(category, p_name, current)) {
-						SceneImportSettings::get_singleton()->update_view();
+						SceneImportSettingsDialog::get_singleton()->update_view();
 					}
 				}
 			} else {
 				if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
 					if (ResourceImporterScene::get_scene_singleton()->get_option_visibility(path, p_name, current)) {
-						SceneImportSettings::get_singleton()->update_view();
+						SceneImportSettingsDialog::get_singleton()->update_view();
 					}
 				} else {
 					if (ResourceImporterScene::get_scene_singleton()->get_internal_option_update_view_required(category, p_name, current)) {
-						SceneImportSettings::get_singleton()->update_view();
+						SceneImportSettingsDialog::get_singleton()->update_view();
 					}
 				}
 			}
@@ -114,7 +114,7 @@ class SceneImportSettingsData : public Object {
 			return;
 		}
 		for (const ResourceImporter::ImportOption &E : options) {
-			if (SceneImportSettings::get_singleton()->is_editing_animation()) {
+			if (SceneImportSettingsDialog::get_singleton()->is_editing_animation()) {
 				if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
 					if (ResourceImporterScene::get_animation_singleton()->get_option_visibility(path, E.option.name, current)) {
 						p_list->push_back(E.option);
@@ -139,7 +139,7 @@ class SceneImportSettingsData : public Object {
 	}
 };
 
-void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_material, TreeItem *p_parent) {
+void SceneImportSettingsDialog::_fill_material(Tree *p_tree, const Ref<Material> &p_material, TreeItem *p_parent) {
 	String import_id;
 	bool has_import_id = false;
 
@@ -199,7 +199,7 @@ void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_ma
 	}
 }
 
-void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, TreeItem *p_parent) {
+void SceneImportSettingsDialog::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, TreeItem *p_parent) {
 	String import_id;
 
 	bool has_import_id = false;
@@ -263,7 +263,7 @@ void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, Tree
 	}
 }
 
-void SceneImportSettings::_fill_animation(Tree *p_tree, const Ref<Animation> &p_anim, const String &p_name, TreeItem *p_parent) {
+void SceneImportSettingsDialog::_fill_animation(Tree *p_tree, const Ref<Animation> &p_anim, const String &p_name, TreeItem *p_parent) {
 	if (!animation_map.has(p_name)) {
 		AnimationData ad;
 		ad.animation = p_anim;
@@ -289,7 +289,7 @@ void SceneImportSettings::_fill_animation(Tree *p_tree, const Ref<Animation> &p_
 	animation_data.scene_node = item;
 }
 
-void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
+void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 	String import_id;
 
 	if (p_node->has_meta("import_id")) {
@@ -353,7 +353,7 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 				category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE;
 
 				animation_player = Object::cast_to<AnimationPlayer>(p_node);
-				animation_player->connect(SNAME("animation_finished"), callable_mp(this, &SceneImportSettings::_animation_finished));
+				animation_player->connect(SNAME("animation_finished"), callable_mp(this, &SceneImportSettingsDialog::_animation_finished));
 			} else if (Object::cast_to<Skeleton3D>(p_node)) {
 				category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_SKELETON_3D_NODE;
 				skeletons.push_back(Object::cast_to<Skeleton3D>(p_node));
@@ -413,7 +413,7 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 	}
 }
 
-void SceneImportSettings::_update_scene() {
+void SceneImportSettingsDialog::_update_scene() {
 	scene_tree->clear();
 	material_tree->clear();
 	mesh_tree->clear();
@@ -425,7 +425,7 @@ void SceneImportSettings::_update_scene() {
 	_fill_scene(scene, nullptr);
 }
 
-void SceneImportSettings::_update_view_gizmos() {
+void SceneImportSettingsDialog::_update_view_gizmos() {
 	if (!is_visible()) {
 		return;
 	}
@@ -516,7 +516,7 @@ void SceneImportSettings::_update_view_gizmos() {
 	generate_collider = false;
 }
 
-void SceneImportSettings::_update_camera() {
+void SceneImportSettingsDialog::_update_camera() {
 	AABB camera_aabb;
 
 	float rot_x = cam_rot_x;
@@ -557,7 +557,7 @@ void SceneImportSettings::_update_camera() {
 	camera->set_transform(xf);
 }
 
-void SceneImportSettings::_load_default_subresource_settings(HashMap<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category) {
+void SceneImportSettingsDialog::_load_default_subresource_settings(HashMap<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category) {
 	if (base_subresource_settings.has(p_type)) {
 		Dictionary d = base_subresource_settings[p_type];
 		if (d.has(p_import_id)) {
@@ -578,15 +578,15 @@ void SceneImportSettings::_load_default_subresource_settings(HashMap<StringName,
 	}
 }
 
-void SceneImportSettings::request_generate_collider() {
+void SceneImportSettingsDialog::request_generate_collider() {
 	generate_collider = true;
 }
 
-void SceneImportSettings::update_view() {
+void SceneImportSettingsDialog::update_view() {
 	update_view_timer->start();
 }
 
-void SceneImportSettings::open_settings(const String &p_path, bool p_for_animation) {
+void SceneImportSettingsDialog::open_settings(const String &p_path, bool p_for_animation) {
 	if (scene) {
 		memdelete(scene);
 		scene = nullptr;
@@ -678,20 +678,20 @@ void SceneImportSettings::open_settings(const String &p_path, bool p_for_animati
 	}
 }
 
-SceneImportSettings *SceneImportSettings::singleton = nullptr;
+SceneImportSettingsDialog *SceneImportSettingsDialog::singleton = nullptr;
 
-SceneImportSettings *SceneImportSettings::get_singleton() {
+SceneImportSettingsDialog *SceneImportSettingsDialog::get_singleton() {
 	return singleton;
 }
 
-Node *SceneImportSettings::get_selected_node() {
+Node *SceneImportSettingsDialog::get_selected_node() {
 	if (selected_id == "") {
 		return nullptr;
 	}
 	return node_map[selected_id].node;
 }
 
-void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
+void SceneImportSettingsDialog::_select(Tree *p_from, String p_type, String p_id) {
 	selecting = true;
 	scene_import_settings_data->hide_options = false;
 
@@ -859,7 +859,7 @@ void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 	scene_import_settings_data->notify_property_list_changed();
 }
 
-void SceneImportSettings::_inspector_property_edited(const String &p_name) {
+void SceneImportSettingsDialog::_inspector_property_edited(const String &p_name) {
 	if (p_name == "settings/loop_mode") {
 		if (!animation_map.has(selected_id)) {
 			return;
@@ -873,13 +873,13 @@ void SceneImportSettings::_inspector_property_edited(const String &p_name) {
 	}
 }
 
-void SceneImportSettings::_reset_bone_transforms() {
+void SceneImportSettingsDialog::_reset_bone_transforms() {
 	for (Skeleton3D *skeleton : skeletons) {
 		skeleton->reset_bone_poses();
 	}
 }
 
-void SceneImportSettings::_play_animation() {
+void SceneImportSettingsDialog::_play_animation() {
 	if (animation_player == nullptr) {
 		return;
 	}
@@ -897,7 +897,7 @@ void SceneImportSettings::_play_animation() {
 	}
 }
 
-void SceneImportSettings::_stop_current_animation() {
+void SceneImportSettingsDialog::_stop_current_animation() {
 	animation_pingpong = false;
 	animation_player->stop();
 	animation_play_button->set_icon(get_editor_theme_icon(SNAME("MainPlay")));
@@ -905,7 +905,7 @@ void SceneImportSettings::_stop_current_animation() {
 	set_process(false);
 }
 
-void SceneImportSettings::_reset_animation(const String &p_animation_name) {
+void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name) {
 	if (p_animation_name.is_empty()) {
 		animation_preview->hide();
 
@@ -943,7 +943,7 @@ void SceneImportSettings::_reset_animation(const String &p_animation_name) {
 	}
 }
 
-void SceneImportSettings::_animation_slider_value_changed(double p_value) {
+void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) {
 	if (animation_player == nullptr || !animation_map.has(selected_id) || animation_map[selected_id].animation.is_null()) {
 		return;
 	}
@@ -955,7 +955,7 @@ void SceneImportSettings::_animation_slider_value_changed(double p_value) {
 	animation_player->seek(p_value * animation_map[selected_id].animation->get_length(), true);
 }
 
-void SceneImportSettings::_animation_finished(const StringName &p_name) {
+void SceneImportSettingsDialog::_animation_finished(const StringName &p_name) {
 	Animation::LoopMode loop_mode = animation_loop_mode;
 
 	switch (loop_mode) {
@@ -980,7 +980,7 @@ void SceneImportSettings::_animation_finished(const StringName &p_name) {
 	}
 }
 
-void SceneImportSettings::_material_tree_selected() {
+void SceneImportSettingsDialog::_material_tree_selected() {
 	if (selecting) {
 		return;
 	}
@@ -991,7 +991,7 @@ void SceneImportSettings::_material_tree_selected() {
 	_select(material_tree, type, import_id);
 }
 
-void SceneImportSettings::_mesh_tree_selected() {
+void SceneImportSettingsDialog::_mesh_tree_selected() {
 	if (selecting) {
 		return;
 	}
@@ -1003,7 +1003,7 @@ void SceneImportSettings::_mesh_tree_selected() {
 	_select(mesh_tree, type, import_id);
 }
 
-void SceneImportSettings::_scene_tree_selected() {
+void SceneImportSettingsDialog::_scene_tree_selected() {
 	if (selecting) {
 		return;
 	}
@@ -1014,16 +1014,16 @@ void SceneImportSettings::_scene_tree_selected() {
 	_select(scene_tree, type, import_id);
 }
 
-void SceneImportSettings::_cleanup() {
+void SceneImportSettingsDialog::_cleanup() {
 	skeletons.clear();
 	if (animation_player != nullptr) {
-		animation_player->disconnect(SNAME("animation_finished"), callable_mp(this, &SceneImportSettings::_animation_finished));
+		animation_player->disconnect(SNAME("animation_finished"), callable_mp(this, &SceneImportSettingsDialog::_animation_finished));
 		animation_player = nullptr;
 	}
 	set_process(false);
 }
 
-void SceneImportSettings::_viewport_input(const Ref<InputEvent> &p_input) {
+void SceneImportSettingsDialog::_viewport_input(const Ref<InputEvent> &p_input) {
 	float *rot_x = &cam_rot_x;
 	float *rot_y = &cam_rot_y;
 	float *zoom = &cam_zoom;
@@ -1066,7 +1066,7 @@ void SceneImportSettings::_viewport_input(const Ref<InputEvent> &p_input) {
 	}
 }
 
-void SceneImportSettings::_re_import() {
+void SceneImportSettingsDialog::_re_import() {
 	HashMap<StringName, Variant> main_settings;
 
 	main_settings = scene_import_settings_data->current;
@@ -1137,10 +1137,10 @@ void SceneImportSettings::_re_import() {
 	EditorFileSystem::get_singleton()->reimport_file_with_custom_parameters(base_path, editing_animation ? "animation_library" : "scene", main_settings);
 }
 
-void SceneImportSettings::_notification(int p_what) {
+void SceneImportSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			connect("confirmed", callable_mp(this, &SceneImportSettings::_re_import));
+			connect("confirmed", callable_mp(this, &SceneImportSettingsDialog::_re_import));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1172,7 +1172,7 @@ void SceneImportSettings::_notification(int p_what) {
 	}
 }
 
-void SceneImportSettings::_menu_callback(int p_id) {
+void SceneImportSettingsDialog::_menu_callback(int p_id) {
 	switch (p_id) {
 		case ACTION_EXTRACT_MATERIALS: {
 			save_path->set_title(TTR("Select folder to extract material resources"));
@@ -1193,7 +1193,7 @@ void SceneImportSettings::_menu_callback(int p_id) {
 	save_path->popup_centered_ratio();
 }
 
-void SceneImportSettings::_save_path_changed(const String &p_path) {
+void SceneImportSettingsDialog::_save_path_changed(const String &p_path) {
 	save_path_item->set_text(1, p_path);
 
 	if (FileAccess::exists(p_path)) {
@@ -1207,7 +1207,7 @@ void SceneImportSettings::_save_path_changed(const String &p_path) {
 	}
 }
 
-void SceneImportSettings::_browse_save_callback(Object *p_item, int p_column, int p_id, MouseButton p_button) {
+void SceneImportSettingsDialog::_browse_save_callback(Object *p_item, int p_column, int p_id, MouseButton p_button) {
 	if (p_button != MouseButton::LEFT) {
 		return;
 	}
@@ -1222,7 +1222,7 @@ void SceneImportSettings::_browse_save_callback(Object *p_item, int p_column, in
 	item_save_path->popup_centered_ratio();
 }
 
-void SceneImportSettings::_save_dir_callback(const String &p_path) {
+void SceneImportSettingsDialog::_save_dir_callback(const String &p_path) {
 	external_path_tree->clear();
 	TreeItem *root = external_path_tree->create_item();
 	save_path_items.clear();
@@ -1386,7 +1386,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 	external_paths->popup_centered_ratio();
 }
 
-void SceneImportSettings::_save_dir_confirm() {
+void SceneImportSettingsDialog::_save_dir_confirm() {
 	for (int i = 0; i < save_path_items.size(); i++) {
 		TreeItem *item = save_path_items[i];
 		if (!item->is_checked(0)) {
@@ -1441,7 +1441,7 @@ void SceneImportSettings::_save_dir_confirm() {
 	}
 }
 
-SceneImportSettings::SceneImportSettings() {
+SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	singleton = this;
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
@@ -1461,7 +1461,7 @@ SceneImportSettings::SceneImportSettings() {
 	action_menu->get_popup()->add_item(TTR("Set Animation Save Paths"), ACTION_CHOOSE_ANIMATION_SAVE_PATHS);
 	action_menu->get_popup()->add_item(TTR("Set Mesh Save Paths"), ACTION_CHOOSE_MESH_SAVE_PATHS);
 
-	action_menu->get_popup()->connect("id_pressed", callable_mp(this, &SceneImportSettings::_menu_callback));
+	action_menu->get_popup()->connect("id_pressed", callable_mp(this, &SceneImportSettingsDialog::_menu_callback));
 
 	tree_split = memnew(HSplitContainer);
 	main_vb->add_child(tree_split);
@@ -1479,18 +1479,18 @@ SceneImportSettings::SceneImportSettings() {
 	scene_tree = memnew(Tree);
 	scene_tree->set_name(TTR("Scene"));
 	data_mode->add_child(scene_tree);
-	scene_tree->connect("cell_selected", callable_mp(this, &SceneImportSettings::_scene_tree_selected));
+	scene_tree->connect("cell_selected", callable_mp(this, &SceneImportSettingsDialog::_scene_tree_selected));
 
 	mesh_tree = memnew(Tree);
 	mesh_tree->set_name(TTR("Meshes"));
 	data_mode->add_child(mesh_tree);
 	mesh_tree->set_hide_root(true);
-	mesh_tree->connect("cell_selected", callable_mp(this, &SceneImportSettings::_mesh_tree_selected));
+	mesh_tree->connect("cell_selected", callable_mp(this, &SceneImportSettingsDialog::_mesh_tree_selected));
 
 	material_tree = memnew(Tree);
 	material_tree->set_name(TTR("Materials"));
 	data_mode->add_child(material_tree);
-	material_tree->connect("cell_selected", callable_mp(this, &SceneImportSettings::_material_tree_selected));
+	material_tree->connect("cell_selected", callable_mp(this, &SceneImportSettingsDialog::_material_tree_selected));
 
 	material_tree->set_hide_root(true);
 
@@ -1504,7 +1504,7 @@ SceneImportSettings::SceneImportSettings() {
 	vp_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vp_container->set_custom_minimum_size(Size2(10, 10));
 	vp_container->set_stretch(true);
-	vp_container->connect("gui_input", callable_mp(this, &SceneImportSettings::_viewport_input));
+	vp_container->connect("gui_input", callable_mp(this, &SceneImportSettingsDialog::_viewport_input));
 	vp_vb->add_child(vp_container);
 
 	base_viewport = memnew(SubViewport);
@@ -1523,13 +1523,13 @@ SceneImportSettings::SceneImportSettings() {
 	animation_play_button->set_flat(true);
 	animation_play_button->set_focus_mode(Control::FOCUS_NONE);
 	animation_play_button->set_shortcut(ED_SHORTCUT("scene_import_settings/play_selected_animation", TTR("Selected Animation Play/Pause"), Key::SPACE));
-	animation_play_button->connect(SNAME("pressed"), callable_mp(this, &SceneImportSettings::_play_animation));
+	animation_play_button->connect(SNAME("pressed"), callable_mp(this, &SceneImportSettingsDialog::_play_animation));
 
 	animation_stop_button = memnew(Button);
 	animation_hbox->add_child(animation_stop_button);
 	animation_stop_button->set_flat(true);
 	animation_stop_button->set_focus_mode(Control::FOCUS_NONE);
-	animation_stop_button->connect(SNAME("pressed"), callable_mp(this, &SceneImportSettings::_stop_current_animation));
+	animation_stop_button->connect(SNAME("pressed"), callable_mp(this, &SceneImportSettingsDialog::_stop_current_animation));
 
 	animation_slider = memnew(HSlider);
 	animation_hbox->add_child(animation_slider);
@@ -1539,7 +1539,7 @@ SceneImportSettings::SceneImportSettings() {
 	animation_slider->set_step(1.0 / 100.0);
 	animation_slider->set_value_no_signal(0.0);
 	animation_slider->set_focus_mode(Control::FOCUS_NONE);
-	animation_slider->connect(SNAME("value_changed"), callable_mp(this, &SceneImportSettings::_animation_slider_value_changed));
+	animation_slider->connect(SNAME("value_changed"), callable_mp(this, &SceneImportSettingsDialog::_animation_slider_value_changed));
 
 	base_viewport->set_use_own_world_3d(true);
 
@@ -1609,7 +1609,7 @@ SceneImportSettings::SceneImportSettings() {
 
 	inspector = memnew(EditorInspector);
 	inspector->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
-	inspector->connect(SNAME("property_edited"), callable_mp(this, &SceneImportSettings::_inspector_property_edited));
+	inspector->connect(SNAME("property_edited"), callable_mp(this, &SceneImportSettingsDialog::_inspector_property_edited));
 
 	property_split->add_child(inspector);
 
@@ -1622,8 +1622,8 @@ SceneImportSettings::SceneImportSettings() {
 	add_child(external_paths);
 	external_path_tree = memnew(Tree);
 	external_paths->add_child(external_path_tree);
-	external_path_tree->connect("button_clicked", callable_mp(this, &SceneImportSettings::_browse_save_callback));
-	external_paths->connect("confirmed", callable_mp(this, &SceneImportSettings::_save_dir_confirm));
+	external_path_tree->connect("button_clicked", callable_mp(this, &SceneImportSettingsDialog::_browse_save_callback));
+	external_paths->connect("confirmed", callable_mp(this, &SceneImportSettingsDialog::_save_dir_confirm));
 	external_path_tree->set_columns(3);
 	external_path_tree->set_column_titles_visible(true);
 	external_path_tree->set_column_expand(0, true);
@@ -1653,16 +1653,16 @@ SceneImportSettings::SceneImportSettings() {
 	item_save_path->add_filter("*.tres", TTR("Text Resource"));
 	item_save_path->add_filter("*.res", TTR("Binary Resource"));
 	add_child(item_save_path);
-	item_save_path->connect("file_selected", callable_mp(this, &SceneImportSettings::_save_path_changed));
+	item_save_path->connect("file_selected", callable_mp(this, &SceneImportSettingsDialog::_save_path_changed));
 
-	save_path->connect("dir_selected", callable_mp(this, &SceneImportSettings::_save_dir_callback));
+	save_path->connect("dir_selected", callable_mp(this, &SceneImportSettingsDialog::_save_dir_callback));
 
 	update_view_timer = memnew(Timer);
 	update_view_timer->set_wait_time(0.2);
-	update_view_timer->connect("timeout", callable_mp(this, &SceneImportSettings::_update_view_gizmos));
+	update_view_timer->connect("timeout", callable_mp(this, &SceneImportSettingsDialog::_update_view_gizmos));
 	add_child(update_view_timer);
 }
 
-SceneImportSettings::~SceneImportSettings() {
+SceneImportSettingsDialog::~SceneImportSettingsDialog() {
 	memdelete(scene_import_settings_data);
 }

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -52,10 +52,10 @@ class EditorFileDialog;
 class EditorInspector;
 class SceneImportSettingsData;
 
-class SceneImportSettings : public ConfirmationDialog {
-	GDCLASS(SceneImportSettings, ConfirmationDialog)
+class SceneImportSettingsDialog : public ConfirmationDialog {
+	GDCLASS(SceneImportSettingsDialog, ConfirmationDialog)
 
-	static SceneImportSettings *singleton;
+	static SceneImportSettingsDialog *singleton;
 
 	enum Actions {
 		ACTION_EXTRACT_MATERIALS,
@@ -223,10 +223,10 @@ public:
 	void request_generate_collider();
 	void update_view();
 	void open_settings(const String &p_path, bool p_for_animation = false);
-	static SceneImportSettings *get_singleton();
+	static SceneImportSettingsDialog *get_singleton();
 	Node *get_selected_node();
-	SceneImportSettings();
-	~SceneImportSettings();
+	SceneImportSettingsDialog();
+	~SceneImportSettingsDialog();
 };
 
 #endif // SCENE_IMPORT_SETTINGS_H

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -1347,7 +1347,7 @@ void BoneMapEditor::create_editors() {
 void BoneMapEditor::fetch_objects() {
 	skeleton = nullptr;
 	// Hackey... but it may be the easiest way to get a selected object from "ImporterScene".
-	SceneImportSettings *si = SceneImportSettings::get_singleton();
+	SceneImportSettingsDialog *si = SceneImportSettingsDialog::get_singleton();
 	if (!si) {
 		return;
 	}

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -89,7 +89,7 @@ bool ResourceImporterMP3::has_advanced_options() const {
 void ResourceImporterMP3::show_advanced_options(const String &p_path) {
 	Ref<AudioStreamMP3> mp3_stream = import_mp3(p_path);
 	if (mp3_stream.is_valid()) {
-		AudioStreamImportSettings::get_singleton()->edit(p_path, "mp3", mp3_stream);
+		AudioStreamImportSettingsDialog::get_singleton()->edit(p_path, "mp3", mp3_stream);
 	}
 }
 #endif

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -90,7 +90,7 @@ bool ResourceImporterOggVorbis::has_advanced_options() const {
 void ResourceImporterOggVorbis::show_advanced_options(const String &p_path) {
 	Ref<AudioStreamOggVorbis> ogg_stream = load_from_file(p_path);
 	if (ogg_stream.is_valid()) {
-		AudioStreamImportSettings::get_singleton()->edit(p_path, "oggvorbisstr", ogg_stream);
+		AudioStreamImportSettingsDialog::get_singleton()->edit(p_path, "oggvorbisstr", ogg_stream);
 	}
 }
 #endif


### PR DESCRIPTION
(Note: This will conflict with #82988. We can merge in either order, I will rebase the other PR).

Tonight I looked into how ResourceImporterScene and SceneImportSettings interact with each other, and I saw that SceneImportSettings contained settings, so I was confused as to why it was a singleton instead of a self-contained class that holds settings. I did not realize it was a dialog for about half an hour. If we have dialog in the name, it becomes clear that it's a dialog, and it makes sense why it's a singleton (we only need one instance of the dialog).

This PR renames SceneImportSettings to SceneImportSettingsDialog. It also renames DynamicFontImportSettings to DynamicFontImportSettingsDialog and AudioStreamImportSettings to AudioStreamImportSettingsDialog.

These are just internal names, they are not exposed to scripting.