### PR TITLE
Make gizmo plugin handle `SpriteBase3D` instead of `Sprite3D`

### DIFF
--- a/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  sprite_3d_gizmo_plugin.h                                              */
+/*  sprite_base_3d_gizmo_plugin.cpp                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,22 +28,37 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef SPRITE_3D_GIZMO_PLUGIN_H
-#define SPRITE_3D_GIZMO_PLUGIN_H
+#include "sprite_base_3d_gizmo_plugin.h"
 
-#include "editor/plugins/node_3d_editor_gizmos.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
+#include "scene/3d/sprite_3d.h"
 
-class Sprite3DGizmoPlugin : public EditorNode3DGizmoPlugin {
-	GDCLASS(Sprite3DGizmoPlugin, EditorNode3DGizmoPlugin);
+SpriteBase3DGizmoPlugin::SpriteBase3DGizmoPlugin() {
+}
 
-public:
-	bool has_gizmo(Node3D *p_spatial) override;
-	String get_gizmo_name() const override;
-	int get_priority() const override;
-	bool can_be_hidden() const override;
-	void redraw(EditorNode3DGizmo *p_gizmo) override;
+bool SpriteBase3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
+	return Object::cast_to<SpriteBase3D>(p_spatial) != nullptr;
+}
 
-	Sprite3DGizmoPlugin();
-};
+String SpriteBase3DGizmoPlugin::get_gizmo_name() const {
+	return "SpriteBase3D";
+}
 
-#endif // SPRITE_3D_GIZMO_PLUGIN_H
+int SpriteBase3DGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+bool SpriteBase3DGizmoPlugin::can_be_hidden() const {
+	return false;
+}
+
+void SpriteBase3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
+	SpriteBase3D *sprite_base = Object::cast_to<SpriteBase3D>(p_gizmo->get_node_3d());
+
+	p_gizmo->clear();
+
+	Ref<TriangleMesh> tm = sprite_base->generate_triangle_mesh();
+	if (tm.is_valid()) {
+		p_gizmo->add_collision_triangles(tm);
+	}
+}

--- a/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.h
+++ b/editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  sprite_3d_gizmo_plugin.cpp                                            */
+/*  sprite_base_3d_gizmo_plugin.h                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,37 +28,22 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "sprite_3d_gizmo_plugin.h"
+#ifndef SPRITE_BASE_3D_GIZMO_PLUGIN_H
+#define SPRITE_BASE_3D_GIZMO_PLUGIN_H
 
-#include "editor/plugins/node_3d_editor_plugin.h"
-#include "scene/3d/sprite_3d.h"
+#include "editor/plugins/node_3d_editor_gizmos.h"
 
-Sprite3DGizmoPlugin::Sprite3DGizmoPlugin() {
-}
+class SpriteBase3DGizmoPlugin : public EditorNode3DGizmoPlugin {
+	GDCLASS(SpriteBase3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
-bool Sprite3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<Sprite3D>(p_spatial) != nullptr;
-}
+public:
+	bool has_gizmo(Node3D *p_spatial) override;
+	String get_gizmo_name() const override;
+	int get_priority() const override;
+	bool can_be_hidden() const override;
+	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-String Sprite3DGizmoPlugin::get_gizmo_name() const {
-	return "Sprite3D";
-}
+	SpriteBase3DGizmoPlugin();
+};
 
-int Sprite3DGizmoPlugin::get_priority() const {
-	return -1;
-}
-
-bool Sprite3DGizmoPlugin::can_be_hidden() const {
-	return false;
-}
-
-void Sprite3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Sprite3D *sprite = Object::cast_to<Sprite3D>(p_gizmo->get_node_3d());
-
-	p_gizmo->clear();
-
-	Ref<TriangleMesh> tm = sprite->generate_triangle_mesh();
-	if (tm.is_valid()) {
-		p_gizmo->add_collision_triangles(tm);
-	}
-}
+#endif // SPRITE_BASE_3D_GIZMO_PLUGIN_H

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -71,7 +71,7 @@
 #include "editor/plugins/gizmos/shape_cast_3d_gizmo_plugin.h"
 #include "editor/plugins/gizmos/soft_body_3d_gizmo_plugin.h"
 #include "editor/plugins/gizmos/spring_arm_3d_gizmo_plugin.h"
-#include "editor/plugins/gizmos/sprite_3d_gizmo_plugin.h"
+#include "editor/plugins/gizmos/sprite_base_3d_gizmo_plugin.h"
 #include "editor/plugins/gizmos/vehicle_body_3d_gizmo_plugin.h"
 #include "editor/plugins/gizmos/visible_on_screen_notifier_3d_gizmo_plugin.h"
 #include "editor/plugins/gizmos/voxel_gi_gizmo_plugin.h"
@@ -7071,7 +7071,7 @@ void Node3DEditor::_init_grid() {
 	if (primary_grid_steps != 10) { // Log10 of 10 is 1.
 		// Change of base rule, divide by ln(10).
 		real_t div = Math::log((real_t)primary_grid_steps) / (real_t)2.302585092994045901094;
-		// Trucation (towards zero) is intentional.
+		// Truncation (towards zero) is intentional.
 		division_level_max = (int)(division_level_max / div);
 		division_level_min = (int)(division_level_min / div);
 	}
@@ -7972,7 +7972,7 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<MeshInstance3DGizmoPlugin>(memnew(MeshInstance3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<OccluderInstance3DGizmoPlugin>(memnew(OccluderInstance3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<SoftBody3DGizmoPlugin>(memnew(SoftBody3DGizmoPlugin)));
-	add_gizmo_plugin(Ref<Sprite3DGizmoPlugin>(memnew(Sprite3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<SpriteBase3DGizmoPlugin>(memnew(SpriteBase3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Label3DGizmoPlugin>(memnew(Label3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Marker3DGizmoPlugin>(memnew(Marker3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<RayCast3DGizmoPlugin>(memnew(RayCast3DGizmoPlugin)));

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -398,12 +398,10 @@ Ref<TriangleMesh> SpriteBase3D::generate_triangle_mesh() const {
 	real_t px_size = get_pixel_size();
 
 	Vector2 vertices[4] = {
-
 		(final_rect.position + Vector2(0, final_rect.size.y)) * px_size,
 		(final_rect.position + final_rect.size) * px_size,
 		(final_rect.position + Vector2(final_rect.size.x, 0)) * px_size,
 		final_rect.position * px_size,
-
 	};
 
 	int x_axis = ((axis + 1) % 3);
@@ -1191,7 +1189,7 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 	Size2 s = t->get_size();
 
 	Point2 ofs = get_offset();
-	if (centered) {
+	if (is_centered()) {
 		ofs -= s / 2;
 	}
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -236,8 +236,6 @@ class AnimatedSprite3D : public SpriteBase3D {
 	float speed_scale = 1.0;
 	float custom_speed_scale = 1.0;
 
-	bool centered = false;
-
 	real_t frame_speed_scale = 1.0;
 	real_t frame_progress = 0.0;
 


### PR DESCRIPTION
Fixes #82873. There was no gizmo plugin handling `AnimatedSprite3D`... :upside_down_face:

Replaces `Sprite3DGizmoPlugin` with `SpriteBase3DGizmoPlugin` (rename + changed handled type from `Sprite3D` to `SpriteBase3D`).

Removes redundant `AnimatedSprite3D::centered` member which was always `false`. It was used only in `AnimatedSprite3D::get_item_rect()` where it was incorrectly checked instead of `SpriteBase3D::centered` (which is `private` and hence needs to be checked with `SpriteBase3D::is_centered()`). This buggy check wasn't affecting anything before this PR as `AnimatedSprite3D::get_item_rect()` is called only within `SpriteBase3D::generate_triangle_mesh()` which was never called for an `AnimatedSprite3D` as there was no gizmo plugin handling it. With a gizmo plugin handling `AnimatedSprite3D` added it was making it selectable by the non-centered area regardless of the `centered` property value.