### PR TITLE
[3.x] Make gizmo plugin handle `SpriteBase3D` instead of `Sprite3D`

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -6775,7 +6775,7 @@ void SpatialEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<ListenerSpatialGizmoPlugin>(memnew(ListenerSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<MeshInstanceSpatialGizmoPlugin>(memnew(MeshInstanceSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<SoftBodySpatialGizmoPlugin>(memnew(SoftBodySpatialGizmoPlugin)));
-	add_gizmo_plugin(Ref<Sprite3DSpatialGizmoPlugin>(memnew(Sprite3DSpatialGizmoPlugin)));
+	add_gizmo_plugin(Ref<SpriteBase3DSpatialGizmoPlugin>(memnew(SpriteBase3DSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<Label3DSpatialGizmoPlugin>(memnew(Label3DSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<SkeletonSpatialGizmoPlugin>(memnew(SkeletonSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<Position3DSpatialGizmoPlugin>(memnew(Position3DSpatialGizmoPlugin)));

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1534,31 +1534,31 @@ void MeshInstanceSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 }
 
 /////
-Sprite3DSpatialGizmoPlugin::Sprite3DSpatialGizmoPlugin() {
+SpriteBase3DSpatialGizmoPlugin::SpriteBase3DSpatialGizmoPlugin() {
 }
 
-bool Sprite3DSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
-	return Object::cast_to<Sprite3D>(p_spatial) != nullptr;
+bool SpriteBase3DSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
+	return Object::cast_to<SpriteBase3D>(p_spatial) != nullptr;
 }
 
-String Sprite3DSpatialGizmoPlugin::get_name() const {
-	return "Sprite3D";
+String SpriteBase3DSpatialGizmoPlugin::get_name() const {
+	return "SpriteBase3D";
 }
 
-int Sprite3DSpatialGizmoPlugin::get_priority() const {
+int SpriteBase3DSpatialGizmoPlugin::get_priority() const {
 	return -1;
 }
 
-bool Sprite3DSpatialGizmoPlugin::can_be_hidden() const {
+bool SpriteBase3DSpatialGizmoPlugin::can_be_hidden() const {
 	return false;
 }
 
-void Sprite3DSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
-	Sprite3D *sprite = Object::cast_to<Sprite3D>(p_gizmo->get_spatial_node());
+void SpriteBase3DSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
+	SpriteBase3D *sprite_base = Object::cast_to<SpriteBase3D>(p_gizmo->get_spatial_node());
 
 	p_gizmo->clear();
 
-	Ref<TriangleMesh> tm = sprite->generate_triangle_mesh();
+	Ref<TriangleMesh> tm = sprite_base->generate_triangle_mesh();
 	if (tm.is_valid()) {
 		p_gizmo->add_collision_triangles(tm);
 	}

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -113,8 +113,8 @@ public:
 	MeshInstanceSpatialGizmoPlugin();
 };
 
-class Sprite3DSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {
-	GDCLASS(Sprite3DSpatialGizmoPlugin, EditorSpatialGizmoPlugin);
+class SpriteBase3DSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {
+	GDCLASS(SpriteBase3DSpatialGizmoPlugin, EditorSpatialGizmoPlugin);
 
 public:
 	bool has_gizmo(Spatial *p_spatial);
@@ -123,7 +123,7 @@ public:
 	bool can_be_hidden() const;
 	void redraw(EditorSpatialGizmo *p_gizmo);
 
-	Sprite3DSpatialGizmoPlugin();
+	SpriteBase3DSpatialGizmoPlugin();
 };
 
 class Label3DSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1013,7 +1013,7 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 	Size2 s = t->get_size();
 
 	Point2 ofs = get_offset();
-	if (centered) {
+	if (is_centered()) {
 		ofs -= s / 2;
 	}
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -206,8 +206,6 @@ class AnimatedSprite3D : public SpriteBase3D {
 	StringName animation;
 	int frame;
 
-	bool centered;
-
 	float timeout;
 
 	bool hflip;


### PR DESCRIPTION
3.x version of #82901.