### PR TITLE
Help compilers optimize `Object::cast_to()`

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -798,12 +798,12 @@ public:
 
 	template <class T>
 	static T *cast_to(Object *p_object) {
-		return dynamic_cast<T *>(p_object);
+		return p_object ? dynamic_cast<T *>(p_object) : nullptr;
 	}
 
 	template <class T>
 	static const T *cast_to(const Object *p_object) {
-		return dynamic_cast<const T *>(p_object);
+		return p_object ? dynamic_cast<const T *>(p_object) : nullptr;
 	}
 
 	enum {


### PR DESCRIPTION
This PR adds an explicit null-check to `Object::cast_to()`. At `-O2` both GCC and Clang seem to do the check themselves to avoid the call to the implementation of `dynamic_cast` when there's no object. However, MSVC (`/O2`) doesn't add a check and will do the call regardless.

All the three compilers can fuse the check here with any explicit check done at the call site. That said, if the contract of `cast_to()` is that it can take null just fine and any optimization is up to it (it's inlined anyway), the callers shouldn't be trying to outsmart it (or the compiler).

One could argue that in cases where there's an object for sure, the check is superfluous. However, in compilers that don't add it before the call to `dynamic_cast`, it will have to happen within anyway.

I've figured this out by using this little sample (with recent versions of the three compilers, targeting both x64 and ARM64):
https://godbolt.org/z/oPfdz8hTM