### PR TITLE
Add `sdf_collision` property description to LightOccluder2D

### DIFF
--- a/doc/classes/LightOccluder2D.xml
+++ b/doc/classes/LightOccluder2D.xml
@@ -17,6 +17,7 @@
 			The LightOccluder2D's occluder light mask. The LightOccluder2D will cast shadows only from Light2D(s) that have the same light mask(s).
 		</member>
 		<member name="sdf_collision" type="bool" setter="set_as_sdf_collision" getter="is_set_as_sdf_collision" default="true">
+			If enabled, the occluder will be part of a real-time generated signed distance field that can be used in custom shaders.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds description to the [LightOccluder2D](https://docs.godotengine.org/en/latest/classes/class_lightoccluder2d.html#property-descriptions)'s `sdf_collision` property from [godotengine/godot-docs@`4431a72`](https://github.com/godotengine/godot-docs/commit/4431a725fef3782792e4b6a44cf48b2f0382fa02#diff-32feb9d1bb698ebaa33c6aa221accae6b64ecb83115568f0833df22a60bd4a79R188-R189)