### PR TITLE
C#: Report diagnostic for Node exports in a type that doesn't derive from Node

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -220,6 +220,31 @@ namespace Godot.SourceGenerators
                 location?.SourceTree?.FilePath));
         }
 
+        public static void ReportOnlyNodesShouldExportNodes(
+            GeneratorExecutionContext context,
+            ISymbol exportedMemberSymbol
+        )
+        {
+            var locations = exportedMemberSymbol.Locations;
+            var location = locations.FirstOrDefault(l => l.SourceTree != null) ?? locations.FirstOrDefault();
+            bool isField = exportedMemberSymbol is IFieldSymbol;
+
+            string message = $"Types not derived from Node should not export Node {(isField ? "fields" : "properties")}";
+
+            string description = $"{message}. Node export is only supported in Node-derived classes.";
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(id: "GD0107",
+                    title: message,
+                    messageFormat: message,
+                    category: "Usage",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description),
+                location,
+                location?.SourceTree?.FilePath));
+        }
+
         public static void ReportSignalDelegateMissingSuffix(
             GeneratorExecutionContext context,
             INamedTypeSymbol delegateSymbol)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -32,7 +32,7 @@ namespace Godot.SourceGenerators
             disabledGenerators != null &&
             disabledGenerators.Split(';').Contains(generatorName));
 
-        public static bool InheritsFrom(this INamedTypeSymbol? symbol, string assemblyName, string typeFullName)
+        public static bool InheritsFrom(this ITypeSymbol? symbol, string assemblyName, string typeFullName)
         {
             while (symbol != null)
             {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -166,6 +166,15 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
+                if (marshalType == MarshalType.GodotObjectOrDerived)
+                {
+                    if (!symbol.InheritsFrom("GodotSharp", "Godot.Node") &&
+                        propertyType.InheritsFrom("GodotSharp", "Godot.Node"))
+                    {
+                        Common.ReportOnlyNodesShouldExportNodes(context, property);
+                    }
+                }
+
                 var propertyDeclarationSyntax = property.DeclaringSyntaxReferences
                     .Select(r => r.GetSyntax() as PropertyDeclarationSyntax).FirstOrDefault();
 
@@ -259,6 +268,15 @@ namespace Godot.SourceGenerators
                 {
                     Common.ReportExportedMemberTypeNotSupported(context, field);
                     continue;
+                }
+
+                if (marshalType == MarshalType.GodotObjectOrDerived)
+                {
+                    if (!symbol.InheritsFrom("GodotSharp", "Godot.Node") &&
+                        fieldType.InheritsFrom("GodotSharp", "Godot.Node"))
+                    {
+                        Common.ReportOnlyNodesShouldExportNodes(context, field);
+                    }
                 }
 
                 EqualsValueClauseSyntax? initializer = field.DeclaringSyntaxReferences


### PR DESCRIPTION
- C# version of https://github.com/godotengine/godot/pull/82843
- Adds new diagnostic GD0107 that is reported for `[Export]` members of type `Node` (or derived) when the containing type is not a `Node` (or derived).