### PR TITLE
Defend against invalid GL_MAX_UNIFORM_BLOCK_SIZE.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5151,9 +5151,11 @@ void RasterizerSceneGLES3::initialize() {
 
 	{
 		//spot and omni ubos
-
-		int max_ubo_size;
+		int max_ubo_size = 0;
 		glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &max_ubo_size);
+		// 16384 is the minimum value for this in the spec, and some bad drivers return a negative number when running through ANGLE.
+		max_ubo_size = MAX(16384, max_ubo_size);
+
 		const int ubo_light_size = 160;
 		state.ubo_light_size = ubo_light_size;
 		state.max_ubo_lights = MIN(render_list.max_lights, max_ubo_size / ubo_light_size);


### PR DESCRIPTION
I have a Radeon RX580, and I run Linux Mint latest stable, with up to date drivers.

I receive this error when running Godot 3.x games in chrome:
![image](https://github.com/godotengine/godot/assets/78934401/a3129ee7-b1da-4a9a-892e-2c863accf143)

I think it might be causing a crash in the 3d renderer, but we are only using the 2d renderer.

My GPU driver, in chrome and firefox, returns an invalid value for GL_MAX_UNIFORM_BLOCK_SIZE.

https://webglreport.com/?v=2
![image](https://github.com/godotengine/godot/assets/78934401/218bf830-202b-4d92-8660-9b38ccb4d0bf)

It actually returns this binary number: 10000000000000000000000000000000, which is a negative int, and webglreport is rendering it as a 64 bit int.

Anyways, this commit uses the minimum value of 16384 as specified in the opengl spec to gaurd against this invalid value from the driver.

https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGet.xhtml