### PR TITLE
Add `rotate_toward` to `Vector2`, `Vector3`, `Basis` and `Quaternion`

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -192,6 +192,10 @@ struct [[nodiscard]] Basis {
 		rows[2].zero();
 	}
 
+	_FORCE_INLINE_ Basis rotate_toward(const Basis &p_to_basis, real_t p_delta) const {
+		return Basis(get_rotation_quaternion().rotate_toward(p_to_basis.get_rotation_quaternion(), p_delta));
+	}
+
 	_FORCE_INLINE_ Basis transpose_xform(const Basis &p_m) const {
 		return Basis(
 				rows[0].x * p_m[0].x + rows[1].x * p_m[1].x + rows[2].x * p_m[2].x,

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -31,6 +31,7 @@
 #ifndef QUATERNION_H
 #define QUATERNION_H
 
+#include "core/math/basis.h"
 #include "core/math/math_funcs.h"
 #include "core/math/vector3.h"
 #include "core/string/ustring.h"
@@ -82,6 +83,22 @@ struct [[nodiscard]] Quaternion {
 		r_axis.x = x * r;
 		r_axis.y = y * r;
 		r_axis.z = z * r;
+	}
+
+	_FORCE_INLINE_ Quaternion rotate_toward(const Quaternion &p_to, real_t p_delta) const {
+#ifdef MATH_CHECKS
+		ERR_FAIL_COND_V_MSG(*this == p_to && p_delta < 0.0, *this, "Inputs can't be equal when using negative delta."); // Specifies "Inputs" and not "Quaternions" because this is also used in Basis
+#endif
+		Quaternion from = *this;
+
+		if (p_delta < 0.0) {
+			from = -Basis(from).get_rotation_quaternion();
+		}
+		real_t angle = angle_to(p_to);
+		if (angle <= p_delta) {
+			return p_to;
+		}
+		return from.slerp(p_to, p_delta / angle);
 	}
 
 	void operator*=(const Quaternion &p_q);

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -122,6 +122,25 @@ struct [[nodiscard]] Vector2 {
 	_FORCE_INLINE_ Vector2 bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, real_t p_t) const;
 	_FORCE_INLINE_ Vector2 bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, real_t p_t) const;
 
+	_FORCE_INLINE_ Vector2 rotate_toward(const Vector2 p_to, const real_t p_delta, const bool p_keep_length = false) const {
+#ifdef MATH_CHECKS
+		ERR_FAIL_COND_V_MSG(normalized() == p_to.normalized(), *this, "Vectors can't be parallel when using negative delta.");
+#endif
+		real_t angle = Math::abs(angle_to(p_to));
+
+		if (p_keep_length) {
+			if (angle < p_delta) {
+				return p_to.normalized() * p_to.length();
+			}
+			return normalized().slerp(p_to.normalized(), p_delta / angle) * length();
+		}
+
+		if (angle <= p_delta) {
+			return p_to;
+		}
+		return slerp(p_to, p_delta / angle);
+	}
+
 	Vector2 move_toward(const Vector2 &p_to, real_t p_delta) const;
 
 	Vector2 slide(const Vector2 &p_normal) const;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -92,6 +92,25 @@ struct [[nodiscard]] Vector3 {
 		return Vector3(MAX(x, p_scalar), MAX(y, p_scalar), MAX(z, p_scalar));
 	}
 
+	_FORCE_INLINE_ Vector3 rotate_toward(const Vector3 p_to, const real_t p_delta, const bool p_keep_length = false) const {
+#ifdef MATH_CHECKS
+		ERR_FAIL_COND_V_MSG(normalized() == p_to.normalized() && p_delta < 0.0, *this, "Vectors can't be parallel when using negative delta.");
+#endif
+		real_t angle = Math::abs(angle_to(p_to));
+
+		if (p_keep_length) {
+			if (angle < p_delta) {
+				return p_to.normalized() * p_to.length();
+			}
+			return normalized().slerp(p_to.normalized(), p_delta / angle) * length();
+		}
+
+		if (angle <= p_delta) {
+			return p_to;
+		}
+		return slerp(p_to, p_delta / angle);
+	}
+
 	_FORCE_INLINE_ real_t length() const;
 	_FORCE_INLINE_ real_t length_squared() const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1807,6 +1807,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector2, cubic_interpolate_in_time, sarray("b", "pre_a", "post_b", "weight", "b_t", "pre_a_t", "post_b_t"), varray());
 	bind_method(Vector2, bezier_interpolate, sarray("control_1", "control_2", "end", "t"), varray());
 	bind_method(Vector2, bezier_derivative, sarray("control_1", "control_2", "end", "t"), varray());
+	bind_method(Vector2, rotate_toward, sarray("to", "delta", "keep_length"), varray());
 	bind_method(Vector2, max_axis_index, sarray(), varray());
 	bind_method(Vector2, min_axis_index, sarray(), varray());
 	bind_method(Vector2, move_toward, sarray("to", "delta"), varray());
@@ -1911,6 +1912,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector3, clampf, sarray("min", "max"), varray());
 	bind_method(Vector3, snapped, sarray("step"), varray());
 	bind_method(Vector3, snappedf, sarray("step"), varray());
+	bind_method(Vector3, rotate_toward, sarray("to", "delta", "keep_length"), varray());
 	bind_method(Vector3, rotated, sarray("axis", "angle"), varray());
 	bind_method(Vector3, lerp, sarray("to", "weight"), varray());
 	bind_method(Vector3, slerp, sarray("to", "weight"), varray());
@@ -2039,6 +2041,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Quaternion, log, sarray(), varray());
 	bind_method(Quaternion, exp, sarray(), varray());
 	bind_method(Quaternion, angle_to, sarray("to"), varray());
+	bind_method(Quaternion, rotate_toward, sarray("to", "delta"), varray());
 	bind_method(Quaternion, dot, sarray("with"), varray());
 	bind_method(Quaternion, slerp, sarray("to", "weight"), varray());
 	bind_method(Quaternion, slerpni, sarray("to", "weight"), varray());
@@ -2174,6 +2177,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Basis, orthonormalized, sarray(), varray());
 	bind_method(Basis, determinant, sarray(), varray());
 	bind_methodv(Basis, rotated, static_cast<Basis (Basis::*)(const Vector3 &, real_t) const>(&Basis::rotated), sarray("axis", "angle"), varray());
+	bind_method(Basis, rotate_toward, sarray("to", "delta"), varray());
 	bind_method(Basis, scaled, sarray("scale"), varray());
 	bind_method(Basis, get_scale, sarray(), varray());
 	bind_method(Basis, get_euler, sarray("order"), varray((int64_t)EulerOrder::YXZ));

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -237,6 +237,15 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="rotate_toward" qualifiers="const">
+			<return type="Basis" />
+			<param index="0" name="to" type="Basis" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Assuming that the matrix is a proper rotation matrix, returns the result of rotating toward [param to] by [param delta], in radians.
+				Passing a negative [param delta] will rotate away from [param to]. Negative [param delta] is not supported when both this basis and [param to] are equal.
+			</description>
+		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Basis" />
 			<param index="0" name="axis" type="Vector3" />

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -169,6 +169,16 @@
 				Returns a copy of this quaternion, normalized so that its length is [code]1.0[/code]. See also [method is_normalized].
 			</description>
 		</method>
+		<method name="rotate_toward" qualifiers="const">
+			<return type="Quaternion" />
+			<param index="0" name="to" type="Quaternion" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Returns the result of rotating toward [param to] by [param delta], in radians.
+				Passing a negative [param delta] will rotate away from [param to]. Negative [param delta] is not supported when both this quaternion and [param to] are equal.
+				[b]Note:[/b] Both quaternions must be normalized.
+			</description>
+		</method>
 		<method name="slerp" qualifiers="const" keywords="interpolate">
 			<return type="Quaternion" />
 			<param index="0" name="to" type="Quaternion" />

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -364,6 +364,17 @@
 				[b]Note:[/b] [method reflect] differs from what other engines and frameworks call [code skip-lint]reflect()[/code]. In other engines, [code skip-lint]reflect()[/code] takes a normal direction which is a direction perpendicular to the line. In Godot, you specify the direction of the line directly. See also [method bounce] which does what most engines call [code skip-lint]reflect()[/code].
 			</description>
 		</method>
+		<method name="rotate_toward" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="to" type="Vector2" />
+			<param index="1" name="delta" type="float" />
+			<param index="2" name="keep_length" type="bool" default="false" />
+			<description>
+				Returns the result of rotating toward [param to] by [param delta], in radians. This method behaves similar to [method slerp].
+				Passing a negative [param delta] will rotate away from [param to]. Negative [param delta] is not supported when both this vector and [param to] are parallel.
+				[param delta] preserves the length of the input vector.
+			</description>
+		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="angle" type="float" />

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -349,6 +349,17 @@
 				[b]Note:[/b] [method reflect] differs from what other engines and frameworks call [code skip-lint]reflect()[/code]. In other engines, [code skip-lint]reflect()[/code] returns the result of the vector reflected by the given plane. The reflection thus passes through the given normal. While in Godot the reflection passes through the plane and can be thought of as bouncing off the normal. See also [method bounce] which does what most engines call [code skip-lint]reflect()[/code].
 			</description>
 		</method>
+		<method name="rotate_toward" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="to" type="Vector3" />
+			<param index="1" name="delta" type="float" />
+			<param index="2" name="keep_length" type="bool" default="false" />
+			<description>
+				Returns the result of rotating toward [param to] by [param delta], in radians. This method behaves similar to [method slerp].
+				Passing a negative [param delta] will rotate away from [param to]. Negative [param delta] is not supported when both this vector and [param to] are parallel.
+				[param delta] preserves the length of the input vector.
+			</description>
+		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="axis" type="Vector3" />

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -127,6 +127,18 @@ TEST_CASE("[Vector2] Interpolation methods") {
 	CHECK_MESSAGE(
 			Vector2(1, 0).move_toward(Vector2(10, 0), 3) == Vector2(4, 0),
 			"Vector2 move_toward should work as expected.");
+	//	CHECK_MESSAGE( Needs to be updated after the method update
+	//			Vector2(0, 1).rotate_toward(Vector2(0, -1), Math_PI * 0.5).is_equal_approx(Vector2(1, 0)),
+	//			"Vector2 rotate_toward should work as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector2(1, 0).rotate_toward(Vector2(0, 1), -Math_PI * 0.5).is_equal_approx(Vector2(0, -1)),
+	//			"Vector2 rotate_toward with negative delta should behave as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector2(1, 1).rotate_toward(Vector2(10, 10), 0.5).is_equal_approx(Vector2(6, 6)),
+	//			"Vector2 rotate_toward with colinear inputs should behave as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector2(10, 10).rotate_toward(Vector2(0, 0), 0.5).is_equal_approx(Vector2(5, 5)),
+	//			"Vector2 rotate_toward with second input as zero should behave as expected.");
 }
 
 TEST_CASE("[Vector2] Length methods") {

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -144,6 +144,18 @@ TEST_CASE("[Vector3] Interpolation methods") {
 	CHECK_MESSAGE(
 			Vector3(1, 0, 0).move_toward(Vector3(10, 0, 0), 3) == Vector3(4, 0, 0),
 			"Vector3 move_toward should work as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector3(1, 0, 0).rotate_toward(Vector3(0, 1, 0), Math_TAU / 8.0).is_equal_approx(Vector3(Math_SQRT12, Math_SQRT12, 0)),
+	//			"Vector3 rotate_toward should work as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector3(1, 0, 0).rotate_toward(Vector3(0, 1, 0), -Math_TAU / 8.0).is_equal_approx(Vector3(Math_SQRT12, -Math_SQRT12, 0)),
+	//			"Vector3 rotate_toward with negative delta should behave as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector3(1, 1, 1).rotate_toward(Vector3(10, 10, 10), 0.5).is_equal_approx(Vector3(6, 6, 6)),
+	//			"Vector3 rotate_toward with colinear inputs should behave as expected.");
+	//	CHECK_MESSAGE(
+	//			Vector3(10, 10, 10).rotate_toward(Vector3(0, 0, 0), 0.5).is_equal_approx(Vector3(5, 5, 5)),
+	//			"Vector3 rotate_toward with second input as zero should behave as expected.");
 }
 
 TEST_CASE("[Vector3] Length methods") {


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/7965
continuation of https://github.com/godotengine/godot/pull/82699

Implements `rotate_toward` to `Vector2`, `Vector3`, `Basis` and `Quaternion`.
Works exactly like `slerp` (uses it internally), but rotates by an increment (in radians) instead of a ratio.
The `Vector2` and `Vector3` methods additionally have a `keep_length` parameter, which makes the input vector only rotate around the center point, keeping its original length.

Use cases include objects that you might prefer to rotate at a constant rate like turrets or homing missiles, or redirecting velocity vectors.

C# Support will be added in a follow-up PR assuming this one gets merged at some point.