### PR TITLE
C#: Upgrade the platform-specific TargetFramework version automatically

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -422,6 +422,8 @@ namespace GodotTools
 
                 ProjectUtils.EnsureGodotSdkIsUpToDate(msbuildProject);
 
+                ProjectUtils.EnsureTargetFrameworkIsSet(msbuildProject);
+
                 if (msbuildProject.HasUnsavedChanges)
                 {
                     // Save a copy of the project before replacing it


### PR DESCRIPTION
Our minumum TargetFramework is net6.0, but for Android is net7.0, and for iOS is net8.0. By default, existing projects will be broken for these platforms, and the csproj files need to be manually changed by users in order to make things work. 

When we generate a new csproj, we inject additional TargetFramework properties with a condition matching each platform, so we don't break our current requirements, and things still work for users trying these platforms out. We can do the same for existing projects, by injecting or updating these additional properties, if needed.

This PR finds all TargetFramework properties and, per platform, checks whether any of them is applicable to the platform. If no TargetFramework properties are usable, it adds a property with a platform check condition and the required version. 

If the default TargetFramework is already set to a high enough value, no properties are injected.

If existing properties that match our platform condition (ones we've injected before) have an unusable version, they get updated.

Users can skip the automatic project update by setting a `GodotSkipProjectUpdate` property to true/1.

See https://github.com/godotengine/godot/pull/82762/files#r1345098244 and https://github.com/godotengine/godot/pull/82729#discussion_r1346074023 for more context