### PR TITLE
Don't apply frame delay project setting to the editor

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -328,7 +328,8 @@
 			Changes to this setting will only be applied upon restarting the application.
 		</member>
 		<member name="application/run/frame_delay_msec" type="int" setter="" getter="" default="0">
-			Forces a delay between frames in the main loop (in milliseconds). This may be useful if you plan to disable vertical synchronization.
+			Forces a [i]constant[/i] delay between frames in the main loop (in milliseconds). In most situations, [member application/run/max_fps] should be preferred as an FPS limiter as it's more precise.
+			This setting can be overridden using the [code]--frame-delay &lt;ms;&gt;[/code] command line argument.
 		</member>
 		<member name="application/run/low_processor_mode" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables low-processor usage mode. This setting only works on desktop platforms. The screen is not redrawn if nothing changes visually. This is meant for writing applications and editors, but is pretty useless (and can hurt performance) in most games.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2128,6 +2128,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (frame_delay == 0) {
 		frame_delay = GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/frame_delay_msec", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), 0);
+		if (Engine::get_singleton()->is_editor_hint()) {
+			frame_delay = 0;
+		}
 	}
 
 	if (audio_output_latency >= 1) {


### PR DESCRIPTION
This appears to already be the case for the Max FPS project setting.

I've tested manual override in a running project via project setting or CLI argument and it still works as expected. `--frame-delay` also still works on the editor itself, if you really want to use it.

- This closes https://github.com/godotengine/godot/issues/82922.
