### PR TITLE
Orthonormalize PhysicalBone3D transforms when resetting them

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2239,11 +2239,14 @@ void PhysicalBone3D::reset_physics_simulation_state() {
 
 void PhysicalBone3D::reset_to_rest_position() {
 	if (parent_skeleton) {
-		if (-1 == bone_id) {
-			set_global_transform(parent_skeleton->get_global_transform() * body_offset);
+		Transform3D new_transform = parent_skeleton->get_global_transform();
+		if (bone_id == -1) {
+			new_transform *= body_offset;
 		} else {
-			set_global_transform(parent_skeleton->get_global_transform() * parent_skeleton->get_bone_global_pose(bone_id) * body_offset);
+			new_transform *= parent_skeleton->get_bone_global_pose(bone_id) * body_offset;
 		}
+		new_transform.orthonormalize();
+		set_global_transform(new_transform);
 	}
 }
 


### PR DESCRIPTION
Fixes #77575. I have added the "needs testing" label and put this on the 4.3 milestone because this needs testing, it could subtly break things, and I'm not an expert in this part of the code. But still... I'm fairly confident this is good.

The change on the line with `get_bone_global_pose` changes the multiplication order, so it may give slightly different results due to floating-point error, but I think it's better the way it is in this PR. It makes sense to do the skeleton's calculations locally first, and only afterwards convert to global, so that skeletons far from the origin are more precise.