### PR TITLE
Tweak metadata property tooltip to avoid being misleading

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2875,7 +2875,11 @@ void EditorHelpTooltip::parse_tooltip(const String &p_text) {
 
 		if (type == "property") {
 			description = get_property_description(class_name, property_name);
-			formatted_text = TTR("Property:");
+			if (property_name.begins_with("metadata/")) {
+				formatted_text = TTR("Metadata:");
+			} else {
+				formatted_text = TTR("Property:");
+			}
 		} else if (type == "method") {
 			description = get_method_description(class_name, property_name);
 			formatted_text = TTR("Method:");
@@ -2890,7 +2894,8 @@ void EditorHelpTooltip::parse_tooltip(const String &p_text) {
 		}
 	}
 
-	formatted_text += " [u][b]" + title + "[/b][/u]" + property_args + "\n";
+	// Metadata special handling replaces "Property:" with "Metadata": above.
+	formatted_text += " [u][b]" + title.trim_prefix("metadata/") + "[/b][/u]" + property_args + "\n";
 	formatted_text += description.is_empty() ? "[i]" + TTR("No description available.") + "[/i]" : description;
 	set_text(formatted_text);
 }


### PR DESCRIPTION
- See https://github.com/godotengine/godot/issues/82938.

We could perhaps display usage instructions (also for theme items) at the bottom of the tooltip, but this may be a bit annoying over time.

For instance:

> Use `get_meta("name")`/`set_meta("name", ...)` to get/set this metadata.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/51aa3960-06ae-4cff-be15-e340bc80eb66)
