### PR TITLE
Fix rename warning dialog

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1734,7 +1734,8 @@ void FileSystemDock::_rename_operation_confirm() {
 
 	if (tree->has_focus()) {
 		new_name = s->get_text(col_index).strip_edges();
-	} else if (files->has_focus()) {
+	} else {
+		// Rename happened from FileSystemList.
 		new_name = files->get_edit_text().strip_edges();
 	}
 	String old_name = to_rename.is_file ? to_rename.path.get_file() : to_rename.path.left(-1).get_file();
@@ -1757,10 +1758,11 @@ void FileSystemDock::_rename_operation_confirm() {
 	}
 
 	// Restore original name.
-	if (rename_error && tree->has_focus()) {
-		s->set_text(col_index, old_name);
-		return;
-	} else if (rename_error && files->has_focus()) {
+	if (rename_error) {
+		if (tree->has_focus()) {
+			s->set_text(col_index, old_name);
+		}
+		// No adjustmens necessary, when renaming from FileSystemList.
 		return;
 	}
 


### PR DESCRIPTION
When renaming files from `FileSystemList`, the focus changes to the `LineEdit`. Don't check if the `FileSystemList` has focus, since it doesn't have focus.
This ensures to return always from the function when a rename error happens. Currently there is an execution path, that allows staying in the function, which results in the situation, that the warning-message-popup is opened a second time, that causes the error message in the console.

resolve part of #82543