### PR TITLE
Drag property with CTRL/SHIFT generates code to get/set the property

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_properties.h"
+#include "editor/editor_properties_array_dict.h"
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -1085,11 +1086,47 @@ Variant EditorProperty::get_drag_data(const Point2 &p_point) {
 		return Variant();
 	}
 
+	Variant container = Variant(object);
+	EditorPropertyArrayObject *array_object = Object::cast_to<EditorPropertyArrayObject>(object);
+	if (array_object) {
+		container = array_object->get_array();
+	}
+	EditorPropertyDictionaryObject *dict_object = Object::cast_to<EditorPropertyDictionaryObject>(object);
+	if (dict_object) {
+		container = dict_object->get_dict();
+	}
+
 	Dictionary dp;
 	dp["type"] = "obj_property";
-	dp["object"] = object;
-	dp["property"] = property;
+	dp["object"] = container;
+	dp["property"] = property_path.is_empty() ? String(property) : property_path;
 	dp["value"] = object->get(property);
+
+	PackedStringArray access_path = PackedStringArray();
+	Object *root_object = object;
+
+	Node *parent = get_parent();
+	EditorProperty *parent_property = nullptr;
+	while (parent && !parent_property) {
+		parent_property = Object::cast_to<EditorProperty>(parent);
+		parent = parent->get_parent();
+	}
+
+	while (parent_property) {
+		root_object = parent_property->get_edited_object();
+		access_path.append(parent_property->get_edited_property());
+
+		parent_property = nullptr;
+		while (parent && !parent_property) {
+			parent_property = Object::cast_to<EditorProperty>(parent);
+			parent = parent->get_parent();
+		}
+	}
+
+	access_path.reverse();
+
+	dp["access_path"] = access_path;
+	dp["root_object"] = root_object;
 
 	Label *drag_label = memnew(Label);
 	drag_label->set_text(property);


### PR DESCRIPTION
This pull request implements and closes: https://github.com/godotengine/godot-proposals/issues/8017

Supercedes https://github.com/godotengine/godot/pull/82946

This pull request will allow Godot to:
- Generate code to get value of a property dragged from the inspector while holding CTRL.
- Generate code to set/assign a value of a property dragged from the inspector while holding SHIFT. The value being set will be the default value of the type of property, ~~and it will be automatically selected in the code editor~~.
- Generating code to access arrays and dictionaries is supported. ~~But generating code for keys containing objects is not supported (this is a toast error)~~. Similarly dropping the labels for a new item is not supported (this is a toast error).
- Generating code to access metadata is supported.
- Fixes dropping metadata generating text prefixed with "metadata/". Now the name of the metadata is dropped.
- Fixes dropping dictionary keys or array indexes prefixes with "indices/" and "keys/". ~~The key or index is dropped if possible, otherwise it is a toast error.~~
- Bonus: dragging a property from project settings will drop the full property path (the code to get it or set it will not be generated).

Little demo of what it does:

https://github.com/user-attachments/assets/468c367e-66d7-472a-9857-021ecfebf61a

