### PR TITLE
GDScript LSP resolve item

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -656,6 +656,10 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const lsp::Position &p_c
 						first_part = line.substr(0, c);
 						first_part += p_symbol;
 						break;
+					} else if (left_cursor_text == ".") {
+						first_part = line.substr(0, c);
+						first_part += "." + p_symbol;
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
The tooltip documentation for autocomplete was not loaded for GDScript (in VSCode) directly after the ".".

I've added a check to resolve the item documentation autocomplete if the character  left from the cursor is "." as else if condition to the normal `begins_with` check.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
