### PR TITLE
Allow `@export`ed Arrays to set property hints for their elements

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1737,7 +1737,7 @@ def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_
 # Formatting helpers.
 
 
-RESERVED_FORMATTING_TAGS = ["i", "b", "u", "code", "kbd", "center", "url", "br"]
+RESERVED_FORMATTING_TAGS = ["i", "b", "u", "lb", "rb", "code", "kbd", "center", "url", "br"]
 RESERVED_LAYOUT_TAGS = ["codeblocks"]
 RESERVED_CODEBLOCK_TAGS = ["codeblock", "gdscript", "csharp"]
 RESERVED_CROSSLINK_TAGS = [
@@ -2310,6 +2310,12 @@ def format_text_block(
                     tag_depth += 1
                     escape_pre = True
                 tag_text = ""
+
+            elif tag_state.name == "lb":
+                tag_text = "\\["
+
+            elif tag_state.name == "rb":
+                tag_text = "\\]"
 
             elif tag_state.name == "kbd":
                 tag_text = "`"

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3869,27 +3869,27 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::PACKED_BYTE_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_BYTE_ARRAY);
+			editor->setup(Variant::PACKED_BYTE_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_INT32_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_INT32_ARRAY);
+			editor->setup(Variant::PACKED_INT32_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_INT64_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_INT64_ARRAY);
+			editor->setup(Variant::PACKED_INT64_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_FLOAT32_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_FLOAT32_ARRAY);
+			editor->setup(Variant::PACKED_FLOAT32_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_FLOAT64_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_FLOAT64_ARRAY);
+			editor->setup(Variant::PACKED_FLOAT64_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_STRING_ARRAY: {
@@ -3899,17 +3899,17 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::PACKED_VECTOR2_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_VECTOR2_ARRAY);
+			editor->setup(Variant::PACKED_VECTOR2_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_VECTOR3_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_VECTOR3_ARRAY);
+			editor->setup(Variant::PACKED_VECTOR3_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_COLOR_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_COLOR_ARRAY);
+			editor->setup(Variant::PACKED_COLOR_ARRAY, p_hint_text);
 			return editor;
 		} break;
 		default: {

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -333,20 +333,22 @@
 		<annotation name="@export_color_no_alpha">
 			<return type="void" />
 			<description>
-				Export a [Color] property without allowing its transparency ([member Color.a]) to be edited.
+				Export a [Color], [Array][lb][Color][rb], or [PackedColorArray] property without allowing its transparency ([member Color.a]) to be edited.
 				See also [constant PROPERTY_HINT_COLOR_NO_ALPHA].
 				[codeblock]
 				@export_color_no_alpha var dye_color: Color
+				@export_color_no_alpha var dye_colors: Array[Color]
 				[/codeblock]
 			</description>
 		</annotation>
 		<annotation name="@export_dir">
 			<return type="void" />
 			<description>
-				Export a [String] property as a path to a directory. The path will be limited to the project folder and its subfolders. See [annotation @export_global_dir] to allow picking from the entire filesystem.
+				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as a path to a directory. The path will be limited to the project folder and its subfolders. See [annotation @export_global_dir] to allow picking from the entire filesystem.
 				See also [constant PROPERTY_HINT_DIR].
 				[codeblock]
 				@export_dir var sprite_folder_path: String
+				@export_dir var sprite_folder_paths: Array[String]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -354,12 +356,15 @@
 			<return type="void" />
 			<param index="0" name="names" type="String" />
 			<description>
-				Export an [int] or [String] property as an enumerated list of options. If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
+				Export an [int], [String], [Array][lb][int][rb], [Array][lb][String][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], or [PackedStringArray] property as an enumerated list of options (or an array of options). If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
 				See also [constant PROPERTY_HINT_ENUM].
 				[codeblock]
 				@export_enum("Warrior", "Magician", "Thief") var character_class: int
 				@export_enum("Slow:30", "Average:60", "Very Fast:200") var character_speed: int
 				@export_enum("Rebecca", "Mary", "Leah") var character_name: String
+
+				@export_enum("Sword", "Spear", "Mace") var character_items: Array[int]
+				@export_enum("double_jump", "climb", "dash") var character_skills: Array[String]
 				[/codeblock]
 				If you want to set an initial value, you must specify it explicitly:
 				[codeblock]
@@ -369,6 +374,9 @@
 				[codeblock]
 				enum CharacterName {REBECCA, MARY, LEAH}
 				@export var character_name: CharacterName
+
+				enum CharacterItem {SWORD, SPEAR, MACE}
+				@export var character_items: Array[CharacterItem]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -382,6 +390,7 @@
 				@export_exp_easing var transition_speed
 				@export_exp_easing("attenuation") var fading_attenuation
 				@export_exp_easing("positive_only") var effect_power
+				@export_exp_easing var speeds: Array[float]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -389,12 +398,13 @@
 			<return type="void" />
 			<param index="0" name="filter" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [String] property as a path to a file. The path will be limited to the project folder and its subfolders. See [annotation @export_global_file] to allow picking from the entire filesystem.
+				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as a path to a file. The path will be limited to the project folder and its subfolders. See [annotation @export_global_file] to allow picking from the entire filesystem.
 				If [param filter] is provided, only matching files will be available for picking.
 				See also [constant PROPERTY_HINT_FILE].
 				[codeblock]
 				@export_file var sound_effect_path: String
 				@export_file("*.txt") var notes_path: String
+				@export_file var level_paths: Array[String]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -421,6 +431,10 @@
 				[codeblock]
 				@export_flags("A:16", "B", "C") var x
 				[/codeblock]
+				You can also use the annotation on [Array][lb][int][rb], [PackedByteArray], [PackedInt32Array], and [PackedInt64Array]
+				[codeblock]
+				@export_flags("Fire", "Water", "Earth", "Wind") var phase_elements: Array[int]
+				[/codeblock]
 			</description>
 		</annotation>
 		<annotation name="@export_flags_2d_navigation">
@@ -430,6 +444,7 @@
 				See also [constant PROPERTY_HINT_LAYERS_2D_NAVIGATION].
 				[codeblock]
 				@export_flags_2d_navigation var navigation_layers: int
+				@export_flags_2d_navigation var navigation_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -440,6 +455,7 @@
 				See also [constant PROPERTY_HINT_LAYERS_2D_PHYSICS].
 				[codeblock]
 				@export_flags_2d_physics var physics_layers: int
+				@export_flags_2d_physics var physics_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -450,6 +466,7 @@
 				See also [constant PROPERTY_HINT_LAYERS_2D_RENDER].
 				[codeblock]
 				@export_flags_2d_render var render_layers: int
+				@export_flags_2d_render var render_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -460,6 +477,7 @@
 				See also [constant PROPERTY_HINT_LAYERS_3D_NAVIGATION].
 				[codeblock]
 				@export_flags_3d_navigation var navigation_layers: int
+				@export_flags_3d_navigation var navigation_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -470,6 +488,7 @@
 				See also [constant PROPERTY_HINT_LAYERS_3D_PHYSICS].
 				[codeblock]
 				@export_flags_3d_physics var physics_layers: int
+				@export_flags_3d_physics var physics_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -480,6 +499,7 @@
 				See also [constant PROPERTY_HINT_LAYERS_3D_RENDER].
 				[codeblock]
 				@export_flags_3d_render var render_layers: int
+				@export_flags_3d_render var render_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -490,16 +510,18 @@
 				See also [constant PROPERTY_HINT_LAYERS_AVOIDANCE].
 				[codeblock]
 				@export_flags_avoidance var avoidance_layers: int
+				@export_flags_avoidance var avoidance_layers_array: Array[int]
 				[/codeblock]
 			</description>
 		</annotation>
 		<annotation name="@export_global_dir">
 			<return type="void" />
 			<description>
-				Export a [String] property as an absolute path to a directory. The path can be picked from the entire filesystem. See [annotation @export_dir] to limit it to the project folder and its subfolders.
+				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as an absolute path to a directory. The path can be picked from the entire filesystem. See [annotation @export_dir] to limit it to the project folder and its subfolders.
 				See also [constant PROPERTY_HINT_GLOBAL_DIR].
 				[codeblock]
 				@export_global_dir var sprite_folder_path: String
+				@export_global_dir var sprite_folder_paths: Array[String]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -507,12 +529,13 @@
 			<return type="void" />
 			<param index="0" name="filter" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [String] property as an absolute path to a file. The path can be picked from the entire filesystem. See [annotation @export_file] to limit it to the project folder and its subfolders.
+				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as an absolute path to a file. The path can be picked from the entire filesystem. See [annotation @export_file] to limit it to the project folder and its subfolders.
 				If [param filter] is provided, only matching files will be available for picking.
 				See also [constant PROPERTY_HINT_GLOBAL_FILE].
 				[codeblock]
 				@export_global_file var sound_effect_path: String
 				@export_global_file("*.txt") var notes_path: String
+				@export_global_file var multiple_paths: Array[String]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -542,10 +565,11 @@
 		<annotation name="@export_multiline">
 			<return type="void" />
 			<description>
-				Export a [String] property with a large [TextEdit] widget instead of a [LineEdit]. This adds support for multiline content and makes it easier to edit large amount of text stored in the property.
+				Export a [String], [Array][lb][String][rb], [PackedStringArray], [Dictionary] or [Array][lb][Dictionary][rb] property with a large [TextEdit] widget instead of a [LineEdit]. This adds support for multiline content and makes it easier to edit large amount of text stored in the property.
 				See also [constant PROPERTY_HINT_MULTILINE_TEXT].
 				[codeblock]
 				@export_multiline var character_biography
+				@export_multiline var npc_dialogs: Array[String]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -553,10 +577,11 @@
 			<return type="void" />
 			<param index="0" name="type" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [NodePath] property with a filter for allowed node types.
+				Export a [NodePath] or [Array][lb][NodePath][rb] property with a filter for allowed node types.
 				See also [constant PROPERTY_HINT_NODE_PATH_VALID_TYPES].
 				[codeblock]
 				@export_node_path("Button", "TouchScreenButton") var some_button
+				@export_node_path("Button", "TouchScreenButton") var many_buttons: Array[NodePath]
 				[/codeblock]
 				[b]Note:[/b] The type must be a native class or a globally registered script (using the [code]class_name[/code] keyword) that inherits [Node].
 			</description>
@@ -565,10 +590,11 @@
 			<return type="void" />
 			<param index="0" name="placeholder" type="String" />
 			<description>
-				Export a [String] property with a placeholder text displayed in the editor widget when no value is present.
+				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property with a placeholder text displayed in the editor widget when no value is present.
 				See also [constant PROPERTY_HINT_PLACEHOLDER_TEXT].
 				[codeblock]
 				@export_placeholder("Name in lowercase") var character_id: String
+				@export_placeholder("Name in lowercase") var friend_ids: Array[String]
 				[/codeblock]
 			</description>
 		</annotation>
@@ -579,7 +605,7 @@
 			<param index="2" name="step" type="float" default="1.0" />
 			<param index="3" name="extra_hints" type="String" default="&quot;&quot;" />
 			<description>
-				Export an [int] or [float] property as a range value. The range must be defined by [param min] and [param max], as well as an optional [param step] and a variety of extra hints. The [param step] defaults to [code]1[/code] for integer properties. For floating-point numbers this value depends on your [member EditorSettings.interface/inspector/default_float_step] setting.
+				Export an [int], [float], [Array][lb][int][rb], [Array][lb][float][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], or [PackedFloat64Array] property as a range value. The range must be defined by [param min] and [param max], as well as an optional [param step] and a variety of extra hints. The [param step] defaults to [code]1[/code] for integer properties. For floating-point numbers this value depends on your [member EditorSettings.interface/inspector/default_float_step] setting.
 				If hints [code]"or_greater"[/code] and [code]"or_less"[/code] are provided, the editor widget will not cap the value at range boundaries. The [code]"exp"[/code] hint will make the edited values on range to change exponentially. The [code]"hide_slider"[/code] hint will hide the slider element of the editor widget.
 				Hints also allow to indicate the units for the edited value. Using [code]"radians_as_degrees"[/code] you can specify that the actual value is in radians, but should be displayed in degrees in the Inspector dock (the range values are also in degrees). [code]"degrees"[/code] allows to add a degree sign as a unit suffix (the value is unchanged). Finally, a custom suffix can be provided using [code]"suffix:unit"[/code], where "unit" can be any string.
 				See also [constant PROPERTY_HINT_RANGE].
@@ -587,6 +613,7 @@
 				@export_range(0, 20) var number
 				@export_range(-10, 20) var number
 				@export_range(-10, 20, 0.2) var number: float
+				@export_range(0, 20) var numbers: Array[float]
 
 				@export_range(0, 100, 1, "or_greater") var power_percent
 				@export_range(0, 100, 1, "or_greater", "or_less") var health_delta

--- a/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_array_type.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_array_type.gd
@@ -1,0 +1,4 @@
+@export_enum("A", "B", "C") var x: Array[Color]
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_array_type.out
+++ b/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_array_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+"@export_enum" annotation requires a variable of type "int", "Array[int]", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "String", "Array[String]", or "PackedStringArray", but type "Array[Color]" was given instead.

--- a/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_type.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_type.gd
@@ -1,0 +1,4 @@
+@export_enum("A", "B", "C") var x: Color
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_type.out
+++ b/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+"@export_enum" annotation requires a variable of type "int", "Array[int]", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "String", "Array[String]", or "PackedStringArray", but type "Color" was given instead.

--- a/modules/gdscript/tests/scripts/parser/features/export_arrays.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_arrays.gd
@@ -1,0 +1,86 @@
+const Utils = preload("../../utils.notest.gd")
+
+@export_dir var test_dir: Array[String]
+@export_dir var test_dir_packed: PackedStringArray
+@export_file var test_file: Array[String]
+@export_file var test_file_packed: PackedStringArray
+@export_global_dir var test_global_dir: Array[String]
+@export_global_dir var test_global_dir_packed: PackedStringArray
+@export_global_file var test_global_file: Array[String]
+@export_global_file var test_global_file_packed: PackedStringArray
+@export_flags("A", "B", "C") var test_bit_flag: Array[int]
+@export_flags("A", "B", "C") var test_bit_flag_packed_byte: PackedByteArray
+@export_flags("A", "B", "C") var test_bit_flag_packed32: PackedInt32Array
+@export_flags("A", "B", "C") var test_bit_flag_packed64: PackedInt64Array
+@export_flags_2d_navigation var test_bit_flag_2d_nav: Array[int]
+@export_flags_2d_navigation var test_bit_flag_2d_nav_packed_byte: PackedByteArray
+@export_flags_2d_navigation var test_bit_flag_2d_nav_packed32: PackedInt32Array
+@export_flags_2d_navigation var test_bit_flag_2d_nav_packed64: PackedInt64Array
+@export_flags_2d_physics var test_bit_flag_2d_phys: Array[int]
+@export_flags_2d_physics var test_bit_flag_2d_phys_packed_byte: PackedByteArray
+@export_flags_2d_physics var test_bit_flag_2d_phys_packed32: PackedInt32Array
+@export_flags_2d_physics var test_bit_flag_2d_phys_packed64: PackedInt64Array
+@export_flags_2d_render var test_bit_flag_2d_render: Array[int]
+@export_flags_2d_render var test_bit_flag_2d_render_packed_byte: PackedByteArray
+@export_flags_2d_render var test_bit_flag_2d_render_packed32: PackedInt32Array
+@export_flags_2d_render var test_bit_flag_2d_render_packed64: PackedInt64Array
+@export_flags_3d_navigation var test_bit_flag_3d_nav: Array[int]
+@export_flags_3d_navigation var test_bit_flag_3d_nav_packed_byte: PackedByteArray
+@export_flags_3d_navigation var test_bit_flag_3d_nav_packed32: PackedInt32Array
+@export_flags_3d_navigation var test_bit_flag_3d_nav_packed64: PackedInt64Array
+@export_flags_3d_physics var test_bit_flag_3d_phys: Array[int]
+@export_flags_3d_physics var test_bit_flag_3d_phys_packed_byte: PackedByteArray
+@export_flags_3d_physics var test_bit_flag_3d_phys_packed32: PackedInt32Array
+@export_flags_3d_physics var test_bit_flag_3d_phys_packed64: PackedInt64Array
+@export_flags_3d_render var test_bit_flag_3d_render: Array[int]
+@export_flags_3d_render var test_bit_flag_3d_render_packed_byte: PackedByteArray
+@export_flags_3d_render var test_bit_flag_3d_render_packed32: PackedInt32Array
+@export_flags_3d_render var test_bit_flag_3d_render_packed64: PackedInt64Array
+@export_multiline var test_multiline: Array[String]
+@export_multiline var test_multiline_packed: PackedStringArray
+@export_placeholder("Placeholder") var test_placeholder: Array[String]
+@export_placeholder("Placeholder") var test_placeholder_packed: PackedStringArray
+@export_range(1, 10) var test_range_int: Array[int]
+@export_range(1, 10) var test_range_int_packed_byte: PackedByteArray
+@export_range(1, 10) var test_range_int_packed32: PackedInt32Array
+@export_range(1, 10) var test_range_int_packed64: PackedInt64Array
+@export_range(1, 10, 0.01) var test_range_int_float_step: Array[int]
+@export_range(1.0, 10.0) var test_range_float: Array[float]
+@export_range(1.0, 10.0) var test_range_float_packed32: PackedFloat32Array
+@export_range(1.0, 10.0) var test_range_float_packed64: PackedFloat64Array
+@export_exp_easing var test_exp_easing: Array[float]
+@export_exp_easing var test_exp_easing_packed32: PackedFloat32Array
+@export_exp_easing var test_exp_easing_packed64: PackedFloat64Array
+@export_node_path var test_node_path: Array[NodePath]
+@export_color_no_alpha var test_color: Array[Color]
+@export_color_no_alpha var test_color_packed: PackedColorArray
+
+var temp_packed_byte_array: PackedByteArray
+var temp_packed_int32_array: PackedInt32Array
+var temp_packed_int64_array: PackedInt64Array
+var temp_packed_float32_array: PackedFloat32Array
+var temp_packed_float64_array: PackedFloat64Array
+var temp_packed_color_array: PackedColorArray
+var temp_packed_vector2_array: PackedVector2Array
+var temp_packed_vector3_array: PackedVector3Array
+
+@export var test_weak_packed_byte_array = temp_packed_byte_array
+@export var test_weak_packed_int32_array = temp_packed_int32_array
+@export var test_weak_packed_int64_array = temp_packed_int64_array
+@export var test_weak_packed_float32_array = temp_packed_float32_array
+@export var test_weak_packed_float64_array = temp_packed_float64_array
+@export var test_weak_packed_color_array = temp_packed_color_array
+@export var test_weak_packed_vector2_array = temp_packed_vector2_array
+@export var test_weak_packed_vector3_array = temp_packed_vector3_array
+
+@export_range(1, 10) var test_range_weak_packed_byte_array = temp_packed_byte_array
+@export_range(1, 10) var test_range_weak_packed_int32_array = temp_packed_int32_array
+@export_range(1, 10) var test_range_weak_packed_int64_array = temp_packed_int64_array
+@export_range(1, 10) var test_range_weak_packed_float32_array = temp_packed_float32_array
+@export_range(1, 10) var test_range_weak_packed_float64_array = temp_packed_float64_array
+@export_color_no_alpha var test_noalpha_weak_packed_color_array = temp_packed_color_array
+
+func test():
+	for property in get_property_list():
+		if str(property.name).begins_with("test_"):
+			Utils.print_property_extended_info(property)

--- a/modules/gdscript/tests/scripts/parser/features/export_arrays.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_arrays.out
@@ -1,0 +1,137 @@
+GDTEST_OK
+var test_dir: Array
+  hint=TYPE_STRING hint_string="String/DIR:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_dir_packed: PackedStringArray
+  hint=TYPE_STRING hint_string="String/DIR:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_file: Array
+  hint=TYPE_STRING hint_string="String/FILE:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_file_packed: PackedStringArray
+  hint=TYPE_STRING hint_string="String/FILE:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_global_dir: Array
+  hint=TYPE_STRING hint_string="String/GLOBAL_DIR:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_global_dir_packed: PackedStringArray
+  hint=TYPE_STRING hint_string="String/GLOBAL_DIR:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_global_file: Array
+  hint=TYPE_STRING hint_string="String/GLOBAL_FILE:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_global_file_packed: PackedStringArray
+  hint=TYPE_STRING hint_string="String/GLOBAL_FILE:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag: Array
+  hint=TYPE_STRING hint_string="int/FLAGS:A,B,C" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/FLAGS:A,B,C" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/FLAGS:A,B,C" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/FLAGS:A,B,C" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_nav: Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_nav_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_nav_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_nav_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_phys: Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_phys_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_phys_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_phys_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_render: Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_render_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_render_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_2d_render_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/LAYERS_2D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_nav: Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_nav_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_nav_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_nav_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_NAVIGATION:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_phys: Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_phys_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_phys_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_phys_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_PHYSICS:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_render: Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_render_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_render_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_bit_flag_3d_render_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/LAYERS_3D_RENDER:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_multiline: Array
+  hint=TYPE_STRING hint_string="String/MULTILINE_TEXT:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_multiline_packed: PackedStringArray
+  hint=TYPE_STRING hint_string="String/MULTILINE_TEXT:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_placeholder: Array
+  hint=TYPE_STRING hint_string="String/PLACEHOLDER_TEXT:Placeholder" usage=DEFAULT|SCRIPT_VARIABLE
+var test_placeholder_packed: PackedStringArray
+  hint=TYPE_STRING hint_string="String/PLACEHOLDER_TEXT:Placeholder" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_int: Array
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_int_packed_byte: PackedByteArray
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_int_packed32: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_int_packed64: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_int_float_step: Array
+  hint=TYPE_STRING hint_string="int/RANGE:1,10,0.01" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_float: Array
+  hint=TYPE_STRING hint_string="float/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_float_packed32: PackedFloat32Array
+  hint=TYPE_STRING hint_string="float/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_float_packed64: PackedFloat64Array
+  hint=TYPE_STRING hint_string="float/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_exp_easing: Array
+  hint=TYPE_STRING hint_string="float/EXP_EASING:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_exp_easing_packed32: PackedFloat32Array
+  hint=TYPE_STRING hint_string="float/EXP_EASING:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_exp_easing_packed64: PackedFloat64Array
+  hint=TYPE_STRING hint_string="float/EXP_EASING:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_node_path: Array
+  hint=TYPE_STRING hint_string="NodePath/NODE_PATH_VALID_TYPES:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_color: Array
+  hint=TYPE_STRING hint_string="Color/COLOR_NO_ALPHA:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_color_packed: PackedColorArray
+  hint=TYPE_STRING hint_string="Color/COLOR_NO_ALPHA:" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_byte_array: PackedByteArray
+  hint=TYPE_STRING hint_string="int:int" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_int32_array: PackedInt32Array
+  hint=TYPE_STRING hint_string="int:int" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_int64_array: PackedInt64Array
+  hint=TYPE_STRING hint_string="int:int" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_float32_array: PackedFloat32Array
+  hint=TYPE_STRING hint_string="float:float" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_float64_array: PackedFloat64Array
+  hint=TYPE_STRING hint_string="float:float" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_color_array: PackedColorArray
+  hint=TYPE_STRING hint_string="Color:Color" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_vector2_array: PackedVector2Array
+  hint=TYPE_STRING hint_string="Vector2:Vector2" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_vector3_array: PackedVector3Array
+  hint=TYPE_STRING hint_string="Vector3:Vector3" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_weak_packed_byte_array: PackedByteArray
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_weak_packed_int32_array: PackedInt32Array
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_weak_packed_int64_array: PackedInt64Array
+  hint=TYPE_STRING hint_string="int/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_weak_packed_float32_array: PackedFloat32Array
+  hint=TYPE_STRING hint_string="float/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_range_weak_packed_float64_array: PackedFloat64Array
+  hint=TYPE_STRING hint_string="float/RANGE:1,10" usage=DEFAULT|SCRIPT_VARIABLE
+var test_noalpha_weak_packed_color_array: PackedColorArray
+  hint=TYPE_STRING hint_string="Color/COLOR_NO_ALPHA:" usage=DEFAULT|SCRIPT_VARIABLE

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.gd
@@ -1,14 +1,35 @@
 const Utils = preload("../../utils.notest.gd")
 
 @export_enum("Red", "Green", "Blue") var test_untyped
+@export_enum("Red:10", "Green:20", "Blue:30") var test_with_values
 
+var temp_array_int: Array[int]
+var temp_array_string: Array[String]
+var temp_packed_byte_array: PackedByteArray
+var temp_packed_int32_array: PackedInt32Array
+var temp_packed_int64_array: PackedInt64Array
+var temp_packed_string_array: PackedStringArray
+
+@export_enum("Red", "Green", "Blue") var test_weak_variant
 @export_enum("Red", "Green", "Blue") var test_weak_int = 0
 @export_enum("Red", "Green", "Blue") var test_weak_string = ""
+@export_enum("Red", "Green", "Blue") var test_weak_array_int = temp_array_int
+@export_enum("Red", "Green", "Blue") var test_weak_array_string = temp_array_string
+@export_enum("Red", "Green", "Blue") var test_weak_packed_byte_array = temp_packed_byte_array
+@export_enum("Red", "Green", "Blue") var test_weak_packed_int32_array = temp_packed_int32_array
+@export_enum("Red", "Green", "Blue") var test_weak_packed_int64_array = temp_packed_int64_array
+@export_enum("Red", "Green", "Blue") var test_weak_packed_string_array = temp_packed_string_array
 
+@export_enum("Red", "Green", "Blue") var test_hard_variant: Variant
 @export_enum("Red", "Green", "Blue") var test_hard_int: int
 @export_enum("Red", "Green", "Blue") var test_hard_string: String
+@export_enum("Red", "Green", "Blue") var test_hard_array_int: Array[int]
+@export_enum("Red", "Green", "Blue") var test_hard_array_string: Array[String]
 
-@export_enum("Red:10", "Green:20", "Blue:30") var test_with_values
+@export_enum("Red", "Green", "Blue") var test_variant_array_int: Variant = temp_array_int
+@export_enum("Red", "Green", "Blue") var test_variant_packed_int32_array: Variant = temp_packed_int32_array
+@export_enum("Red", "Green", "Blue") var test_variant_array_string: Variant = temp_array_string
+@export_enum("Red", "Green", "Blue") var test_variant_packed_string_array: Variant = temp_packed_string_array
 
 func test():
 	for property in get_property_list():

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.out
@@ -1,13 +1,41 @@
 GDTEST_OK
 var test_untyped: int = null
   hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_with_values: int = null
+  hint=ENUM hint_string="Red:10,Green:20,Blue:30" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_variant: int = null
+  hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
 var test_weak_int: int = 0
   hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
 var test_weak_string: String = ""
+  hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_array_int: Array = Array[int]([])
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_array_string: Array = Array[String]([])
+  hint=TYPE_STRING hint_string="String/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_byte_array: PackedByteArray = PackedByteArray()
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_int32_array: PackedInt32Array = PackedInt32Array()
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_int64_array: PackedInt64Array = PackedInt64Array()
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_weak_packed_string_array: PackedStringArray = PackedStringArray()
+  hint=TYPE_STRING hint_string="String/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_hard_variant: int = null
   hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
 var test_hard_int: int = 0
   hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
 var test_hard_string: String = ""
   hint=ENUM hint_string="Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
-var test_with_values: int = null
-  hint=ENUM hint_string="Red:10,Green:20,Blue:30" usage=DEFAULT|SCRIPT_VARIABLE
+var test_hard_array_int: Array = Array[int]([])
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_hard_array_string: Array = Array[String]([])
+  hint=TYPE_STRING hint_string="String/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_variant_array_int: Array = Array[int]([])
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_variant_packed_int32_array: PackedInt32Array = PackedInt32Array()
+  hint=TYPE_STRING hint_string="int/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_variant_array_string: Array = Array[String]([])
+  hint=TYPE_STRING hint_string="String/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE
+var test_variant_packed_string_array: PackedStringArray = PackedStringArray()
+  hint=TYPE_STRING hint_string="String/ENUM:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.out
@@ -24,4 +24,4 @@ var test_node_path: NodePath = NodePath("hello")
 var test_node: Node = null
   hint=NODE_TYPE hint_string="Node" usage=DEFAULT|SCRIPT_VARIABLE
 var test_node_array: Array = Array[Node]([])
-  hint=TYPE_STRING hint_string="24/34:Node" usage=DEFAULT|SCRIPT_VARIABLE
+  hint=TYPE_STRING hint_string="Object/NODE_TYPE:Node" usage=DEFAULT|SCRIPT_VARIABLE

--- a/modules/gdscript/tests/scripts/utils.notest.gd
+++ b/modules/gdscript/tests/scripts/utils.notest.gd
@@ -39,11 +39,46 @@ static func get_property_signature(property: Dictionary, base: Object = null, is
 	return result
 
 
+static func get_human_readable_hint_string(property: Dictionary) -> String:
+	if property.type >= TYPE_ARRAY and property.hint == PROPERTY_HINT_TYPE_STRING:
+		var type_hint_prefixes: String = ""
+		var hint_string: String = property.hint_string
+
+		while true:
+			if not hint_string.contains(":"):
+				push_error("Invalid PROPERTY_HINT_TYPE_STRING format.")
+			var elem_type_hint: String = hint_string.get_slice(":", 0)
+			hint_string = hint_string.substr(elem_type_hint.length() + 1)
+
+			var elem_type: int
+			var elem_hint: int
+
+			if elem_type_hint.is_valid_int():
+				elem_type = elem_type_hint.to_int()
+				type_hint_prefixes += type_string(elem_type) + ":"
+			else:
+				if elem_type_hint.count("/") != 1:
+					push_error("Invalid PROPERTY_HINT_TYPE_STRING format.")
+				elem_type = elem_type_hint.get_slice("/", 0).to_int()
+				elem_hint = elem_type_hint.get_slice("/", 1).to_int()
+				type_hint_prefixes += "%s/%s:" % [
+				type_string(elem_type),
+				get_property_hint_name(elem_hint).trim_prefix("PROPERTY_HINT_"),
+				]
+
+			if elem_type < TYPE_ARRAY:
+				break
+
+		return type_hint_prefixes + hint_string
+
+	return property.hint_string
+
+
 static func print_property_extended_info(property: Dictionary, base: Object = null, is_static: bool = false) -> void:
 	print(get_property_signature(property, base, is_static))
 	print('  hint=%s hint_string="%s" usage=%s' % [
 		get_property_hint_name(property.hint).trim_prefix("PROPERTY_HINT_"),
-		str(property.hint_string).c_escape(),
+		get_human_readable_hint_string(property),
 		get_property_usage_string(property.usage).replace("PROPERTY_USAGE_", ""),
 	])
 


### PR DESCRIPTION
* Closes godotengine/godot-proposals#8005.
* Closes #60516.
* Closes #65925
* Supersedes #72951

I just modified the parser to handle Arrays and their Packed versions for exported properties.

~~I didn't implement @export_enum, as it's already being handled in this PR: https://github.com/godotengine/godot/pull/72951~~
Also implemented @export_enum, and made the implementations for @export_multiline and @export generic, so they don't have to care about Arrays.

_Bugsquad edit:_ Linked issues.