### PR TITLE
Add unit tests for C# source generators

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Godot.SourceGenerators.Tests;
+
+public static class CSharpSourceGeneratorVerifier<TSourceGenerator>
+where TSourceGenerator : ISourceGenerator, new()
+{
+    public class Test : CSharpSourceGeneratorTest<TSourceGenerator, XUnitVerifier>
+    {
+        public Test()
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+
+            SolutionTransforms.Add((Solution solution, ProjectId projectId) =>
+            {
+                Project project = solution.GetProject(projectId)!
+                    .AddMetadataReference(Constants.GodotSharpAssembly.CreateMetadataReference());
+
+                return project.Solution;
+            });
+        }
+    }
+
+    public static Task Verify(string source, params string[] generatedSources)
+    {
+        return Verify(new string[] { source }, generatedSources);
+    }
+
+    public static Task VerifyNoCompilerDiagnostics(string source, params string[] generatedSources)
+    {
+        return VerifyNoCompilerDiagnostics(new string[] { source }, generatedSources);
+    }
+
+    public static Task Verify(ICollection<string> sources, params string[] generatedSources)
+    {
+        return MakeVerifier(sources, generatedSources).RunAsync();
+    }
+
+    public static Task VerifyNoCompilerDiagnostics(ICollection<string> sources, params string[] generatedSources)
+    {
+        var verifier = MakeVerifier(sources, generatedSources);
+        verifier.CompilerDiagnostics = CompilerDiagnostics.None;
+        return verifier.RunAsync();
+    }
+
+    public static Test MakeVerifier(ICollection<string> sources, ICollection<string> generatedSources)
+    {
+        var verifier = new Test();
+
+        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"""
+        is_global = true
+        build_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}
+        """));
+
+        verifier.TestState.Sources.AddRange(sources.Select(source =>
+        {
+            return (source, SourceText.From(File.ReadAllText(Path.Combine(Constants.SourceFolderPath, source))));
+        }));
+
+        verifier.TestState.GeneratedSources.AddRange(generatedSources.Select(generatedSource =>
+        {
+            return (FullGeneratedSourceName(generatedSource), SourceText.From(File.ReadAllText(Path.Combine(Constants.GeneratedSourceFolderPath, generatedSource)), Encoding.UTF8));
+        }));
+
+        return verifier;
+    }
+
+    private static string FullGeneratedSourceName(string name)
+    {
+        var generatorType = typeof(TSourceGenerator);
+        return Path.Combine(generatorType.Namespace!, generatorType.FullName!, name);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Constants.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Constants.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using System.Reflection;
+
+namespace Godot.SourceGenerators.Tests;
+
+public static class Constants
+{
+    public static Assembly GodotSharpAssembly => typeof(GodotObject).Assembly;
+
+    public static string ExecutingAssemblyPath { get; }
+    public static string SourceFolderPath { get; }
+    public static string GeneratedSourceFolderPath { get; }
+
+    static Constants()
+    {
+        ExecutingAssemblyPath = Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location!)!);
+
+        var testDataPath = Path.Combine(ExecutingAssemblyPath, "TestData");
+
+        SourceFolderPath = Path.Combine(testDataPath, "Sources");
+        GeneratedSourceFolderPath = Path.Combine(testDataPath, "GeneratedSources");
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Extensions.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Extensions.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace Godot.SourceGenerators.Tests;
+
+public static class Extensions
+{
+    public static MetadataReference CreateMetadataReference(this Assembly assembly)
+    {
+        return MetadataReference.CreateFromFile(assembly.Location);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <LangVersion>11</LangVersion>
+
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefaultItemExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);TestData\**</DefaultItemExcludesInProjectFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\glue\GodotSharp\GodotSharp\GodotSharp.csproj" />
+    <ProjectReference Include="..\Godot.SourceGenerators\Godot.SourceGenerators.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="TestData\**\*.cs" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptMethodsGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptMethodsGeneratorTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptMethodsGeneratorTests
+{
+    [Fact]
+    public async void Methods()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
+            "Methods.cs",
+            "Methods_ScriptMethods.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void ScriptBoilerplate()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
+            "ScriptBoilerplate.cs",
+            "ScriptBoilerplate_ScriptMethods.generated.cs", "OuterClass.NestedClass_ScriptMethods.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPathAttributeGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPathAttributeGeneratorTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptPathAttributeGeneratorTests
+{
+    private static (string, SourceText) MakeAssemblyScriptTypesGeneratedSource(ICollection<string> types)
+    {
+        return (
+            Path.Combine("Godot.SourceGenerators", "Godot.SourceGenerators.ScriptPathAttributeGenerator", "AssemblyScriptTypes.generated.cs"),
+            SourceText.From($$"""
+            [assembly:Godot.AssemblyHasScriptsAttribute(new System.Type[] {{{string.Join(", ", types.Select(type => $"typeof({type})"))}}})]
+
+            """, Encoding.UTF8)
+        );
+    }
+
+    [Fact]
+    public async void ScriptBoilerplate()
+    {
+        var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
+            new string[] { "ScriptBoilerplate.cs" },
+            new string[] { "ScriptBoilerplate_ScriptPath.generated.cs" }
+        );
+        verifier.TestState.GeneratedSources.Add(MakeAssemblyScriptTypesGeneratedSource(new string[] { "global::ScriptBoilerplate" }));
+        await verifier.RunAsync();
+    }
+
+    [Fact]
+    public async void FooBar()
+    {
+        var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
+            new string[] { "Foo.cs", "Bar.cs" },
+            new string[] { "Foo_ScriptPath.generated.cs", "Bar_ScriptPath.generated.cs" }
+        );
+        verifier.TestState.GeneratedSources.Add(MakeAssemblyScriptTypesGeneratedSource(new string[] { "global::Foo", "global::Bar" }));
+        await verifier.RunAsync();
+    }
+
+    [Fact]
+    public async void Generic()
+    {
+        var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
+            new string[] { "Generic.cs" },
+            new string[] { "Generic_ScriptPath.generated.cs" }
+        );
+        verifier.TestState.GeneratedSources.Add(MakeAssemblyScriptTypesGeneratedSource(new string[] { "global::Generic" }));
+        await verifier.RunAsync();
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertiesGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertiesGeneratorTests.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptPropertiesGeneratorTests
+{
+    [Fact]
+    public async void ExportedFields()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            new string[] { "ExportedFields.cs", "MoreExportedFields.cs" },
+            new string[] { "ExportedFields_ScriptProperties.generated.cs" }
+        );
+    }
+
+    [Fact]
+    public async void ExportedProperties()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            "ExportedProperties.cs",
+            "ExportedProperties_ScriptProperties.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void OneWayPropertiesAllReadOnly()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            "AllReadOnly.cs",
+            "AllReadOnly_ScriptProperties.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void OneWayPropertiesAllWriteOnly()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            "AllWriteOnly.cs",
+            "AllWriteOnly_ScriptProperties.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void OneWayPropertiesMixedReadonlyWriteOnly()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            "MixedReadOnlyWriteOnly.cs",
+            "MixedReadOnlyWriteOnly_ScriptProperties.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void ScriptBoilerplate()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            "ScriptBoilerplate.cs",
+            "ScriptBoilerplate_ScriptProperties.generated.cs", "OuterClass.NestedClass_ScriptProperties.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertyDefValGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertyDefValGeneratorTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptPropertyDefValGeneratorTests
+{
+    [Fact]
+    public async void ExportedFields()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
+            new string[] { "ExportedFields.cs", "MoreExportedFields.cs" },
+            new string[] { "ExportedFields_ScriptPropertyDefVal.generated.cs" }
+        );
+    }
+
+    [Fact]
+    public async void ExportedProperties()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
+            "ExportedProperties.cs",
+            "ExportedProperties_ScriptPropertyDefVal.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSerializationGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSerializationGeneratorTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptSerializationGeneratorTests
+{
+    [Fact]
+    public async void ScriptBoilerplate()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptSerializationGenerator>.VerifyNoCompilerDiagnostics(
+            "ScriptBoilerplate.cs",
+            "ScriptBoilerplate_ScriptSerialization.generated.cs", "OuterClass.NestedClass_ScriptSerialization.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSignalsGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSignalsGeneratorTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptSignalsGeneratorTests
+{
+    [Fact]
+    public async void EventSignals()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptSignalsGenerator>.Verify(
+            "EventSignals.cs",
+            "EventSignals_ScriptSignals.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/.editorconfig
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+exclude = true
+generated_code = true

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllReadOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllReadOnly_ScriptProperties.generated.cs
@@ -1,0 +1,66 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class AllReadOnly
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.GodotObject.PropertyName {
+        /// <summary>
+        /// Cached name for the 'readonly_auto_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName readonly_auto_property = "readonly_auto_property";
+        /// <summary>
+        /// Cached name for the 'readonly_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName readonly_property = "readonly_property";
+        /// <summary>
+        /// Cached name for the 'initonly_auto_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName initonly_auto_property = "initonly_auto_property";
+        /// <summary>
+        /// Cached name for the 'readonly_field' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName readonly_field = "readonly_field";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.readonly_auto_property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.readonly_auto_property);
+            return true;
+        }
+        else if (name == PropertyName.readonly_property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.readonly_property);
+            return true;
+        }
+        else if (name == PropertyName.initonly_auto_property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.initonly_auto_property);
+            return true;
+        }
+        else if (name == PropertyName.readonly_field) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.readonly_field);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.readonly_field, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.readonly_auto_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.readonly_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.initonly_auto_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllWriteOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllWriteOnly_ScriptProperties.generated.cs
@@ -1,0 +1,58 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class AllWriteOnly
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.GodotObject.PropertyName {
+        /// <summary>
+        /// Cached name for the 'writeonly_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName writeonly_property = "writeonly_property";
+        /// <summary>
+        /// Cached name for the 'writeonly_backing_field' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName writeonly_backing_field = "writeonly_backing_field";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.writeonly_property) {
+            this.writeonly_property = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        else if (name == PropertyName.writeonly_backing_field) {
+            this.writeonly_backing_field = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.writeonly_backing_field) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.writeonly_backing_field);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.writeonly_backing_field, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.writeonly_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Bar_ScriptPath.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Bar_ScriptPath.generated.cs
@@ -1,0 +1,5 @@
+using Godot;
+[ScriptPathAttribute("res://Bar.cs")]
+partial class Bar
+{
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
@@ -1,0 +1,54 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class EventSignals
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the signals contained in this class, for fast lookup.
+    /// </summary>
+    public new class SignalName : global::Godot.GodotObject.SignalName {
+        /// <summary>
+        /// Cached name for the 'MySignal' signal.
+        /// </summary>
+        public new static readonly global::Godot.StringName MySignal = "MySignal";
+    }
+    /// <summary>
+    /// Get the signal information for all the signals declared in this class.
+    /// This method is used by Godot to register the available signals in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GetGodotSignalList()
+    {
+        var signals = new global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>(1);
+        signals.Add(new(name: SignalName.MySignal, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)4, name: "str", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), new(type: (global::Godot.Variant.Type)2, name: "num", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        return signals;
+    }
+#pragma warning restore CS0109
+    private global::EventSignals.MySignalEventHandler backing_MySignal;
+    /// <inheritdoc cref="global::EventSignals.MySignalEventHandler"/>
+    public event global::EventSignals.MySignalEventHandler MySignal {
+        add => backing_MySignal += value;
+        remove => backing_MySignal -= value;
+}
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override void RaiseGodotClassSignalCallbacks(in godot_string_name signal, NativeVariantPtrArgs args)
+    {
+        if (signal == SignalName.MySignal && args.Count == 2) {
+            backing_MySignal?.Invoke(global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
+            return;
+        }
+        base.RaiseGodotClassSignalCallbacks(signal, args);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool HasGodotClassSignal(in godot_string_name signal)
+    {
+        if (signal == SignalName.MySignal) {
+           return true;
+        }
+        return base.HasGodotClassSignal(signal);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
@@ -1,0 +1,816 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ExportedFields
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.GodotObject.PropertyName {
+        /// <summary>
+        /// Cached name for the 'field_Boolean' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Boolean = "field_Boolean";
+        /// <summary>
+        /// Cached name for the 'field_Char' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Char = "field_Char";
+        /// <summary>
+        /// Cached name for the 'field_SByte' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_SByte = "field_SByte";
+        /// <summary>
+        /// Cached name for the 'field_Int16' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Int16 = "field_Int16";
+        /// <summary>
+        /// Cached name for the 'field_Int32' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Int32 = "field_Int32";
+        /// <summary>
+        /// Cached name for the 'field_Int64' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Int64 = "field_Int64";
+        /// <summary>
+        /// Cached name for the 'field_Byte' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Byte = "field_Byte";
+        /// <summary>
+        /// Cached name for the 'field_UInt16' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_UInt16 = "field_UInt16";
+        /// <summary>
+        /// Cached name for the 'field_UInt32' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_UInt32 = "field_UInt32";
+        /// <summary>
+        /// Cached name for the 'field_UInt64' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_UInt64 = "field_UInt64";
+        /// <summary>
+        /// Cached name for the 'field_Single' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Single = "field_Single";
+        /// <summary>
+        /// Cached name for the 'field_Double' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Double = "field_Double";
+        /// <summary>
+        /// Cached name for the 'field_String' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_String = "field_String";
+        /// <summary>
+        /// Cached name for the 'field_Vector2' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector2 = "field_Vector2";
+        /// <summary>
+        /// Cached name for the 'field_Vector2I' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector2I = "field_Vector2I";
+        /// <summary>
+        /// Cached name for the 'field_Rect2' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Rect2 = "field_Rect2";
+        /// <summary>
+        /// Cached name for the 'field_Rect2I' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Rect2I = "field_Rect2I";
+        /// <summary>
+        /// Cached name for the 'field_Transform2D' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Transform2D = "field_Transform2D";
+        /// <summary>
+        /// Cached name for the 'field_Vector3' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector3 = "field_Vector3";
+        /// <summary>
+        /// Cached name for the 'field_Vector3I' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector3I = "field_Vector3I";
+        /// <summary>
+        /// Cached name for the 'field_Basis' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Basis = "field_Basis";
+        /// <summary>
+        /// Cached name for the 'field_Quaternion' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Quaternion = "field_Quaternion";
+        /// <summary>
+        /// Cached name for the 'field_Transform3D' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Transform3D = "field_Transform3D";
+        /// <summary>
+        /// Cached name for the 'field_Vector4' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector4 = "field_Vector4";
+        /// <summary>
+        /// Cached name for the 'field_Vector4I' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector4I = "field_Vector4I";
+        /// <summary>
+        /// Cached name for the 'field_Projection' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Projection = "field_Projection";
+        /// <summary>
+        /// Cached name for the 'field_Aabb' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Aabb = "field_Aabb";
+        /// <summary>
+        /// Cached name for the 'field_Color' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Color = "field_Color";
+        /// <summary>
+        /// Cached name for the 'field_Plane' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Plane = "field_Plane";
+        /// <summary>
+        /// Cached name for the 'field_Callable' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Callable = "field_Callable";
+        /// <summary>
+        /// Cached name for the 'field_Signal' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Signal = "field_Signal";
+        /// <summary>
+        /// Cached name for the 'field_Enum' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Enum = "field_Enum";
+        /// <summary>
+        /// Cached name for the 'field_FlagsEnum' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_FlagsEnum = "field_FlagsEnum";
+        /// <summary>
+        /// Cached name for the 'field_ByteArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_ByteArray = "field_ByteArray";
+        /// <summary>
+        /// Cached name for the 'field_Int32Array' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Int32Array = "field_Int32Array";
+        /// <summary>
+        /// Cached name for the 'field_Int64Array' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Int64Array = "field_Int64Array";
+        /// <summary>
+        /// Cached name for the 'field_SingleArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_SingleArray = "field_SingleArray";
+        /// <summary>
+        /// Cached name for the 'field_DoubleArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_DoubleArray = "field_DoubleArray";
+        /// <summary>
+        /// Cached name for the 'field_StringArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_StringArray = "field_StringArray";
+        /// <summary>
+        /// Cached name for the 'field_StringArrayEnum' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_StringArrayEnum = "field_StringArrayEnum";
+        /// <summary>
+        /// Cached name for the 'field_Vector2Array' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector2Array = "field_Vector2Array";
+        /// <summary>
+        /// Cached name for the 'field_Vector3Array' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Vector3Array = "field_Vector3Array";
+        /// <summary>
+        /// Cached name for the 'field_ColorArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_ColorArray = "field_ColorArray";
+        /// <summary>
+        /// Cached name for the 'field_GodotObjectOrDerivedArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotObjectOrDerivedArray = "field_GodotObjectOrDerivedArray";
+        /// <summary>
+        /// Cached name for the 'field_StringNameArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_StringNameArray = "field_StringNameArray";
+        /// <summary>
+        /// Cached name for the 'field_NodePathArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_NodePathArray = "field_NodePathArray";
+        /// <summary>
+        /// Cached name for the 'field_RidArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_RidArray = "field_RidArray";
+        /// <summary>
+        /// Cached name for the 'field_empty_Int32Array' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_empty_Int32Array = "field_empty_Int32Array";
+        /// <summary>
+        /// Cached name for the 'field_array_from_list' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_array_from_list = "field_array_from_list";
+        /// <summary>
+        /// Cached name for the 'field_Variant' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Variant = "field_Variant";
+        /// <summary>
+        /// Cached name for the 'field_GodotObjectOrDerived' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotObjectOrDerived = "field_GodotObjectOrDerived";
+        /// <summary>
+        /// Cached name for the 'field_GodotResourceTexture' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotResourceTexture = "field_GodotResourceTexture";
+        /// <summary>
+        /// Cached name for the 'field_StringName' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_StringName = "field_StringName";
+        /// <summary>
+        /// Cached name for the 'field_NodePath' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_NodePath = "field_NodePath";
+        /// <summary>
+        /// Cached name for the 'field_Rid' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_Rid = "field_Rid";
+        /// <summary>
+        /// Cached name for the 'field_GodotDictionary' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotDictionary = "field_GodotDictionary";
+        /// <summary>
+        /// Cached name for the 'field_GodotArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotArray = "field_GodotArray";
+        /// <summary>
+        /// Cached name for the 'field_GodotGenericDictionary' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotGenericDictionary = "field_GodotGenericDictionary";
+        /// <summary>
+        /// Cached name for the 'field_GodotGenericArray' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_GodotGenericArray = "field_GodotGenericArray";
+        /// <summary>
+        /// Cached name for the 'field_empty_Int64Array' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_empty_Int64Array = "field_empty_Int64Array";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.field_Boolean) {
+            this.field_Boolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Char) {
+            this.field_Char = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_SByte) {
+            this.field_SByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Int16) {
+            this.field_Int16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Int32) {
+            this.field_Int32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Int64) {
+            this.field_Int64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Byte) {
+            this.field_Byte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_UInt16) {
+            this.field_UInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_UInt32) {
+            this.field_UInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_UInt64) {
+            this.field_UInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Single) {
+            this.field_Single = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Double) {
+            this.field_Double = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_String) {
+            this.field_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector2) {
+            this.field_Vector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector2I) {
+            this.field_Vector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Rect2) {
+            this.field_Rect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Rect2I) {
+            this.field_Rect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Transform2D) {
+            this.field_Transform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector3) {
+            this.field_Vector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector3I) {
+            this.field_Vector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Basis) {
+            this.field_Basis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Quaternion) {
+            this.field_Quaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Transform3D) {
+            this.field_Transform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector4) {
+            this.field_Vector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector4I) {
+            this.field_Vector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Projection) {
+            this.field_Projection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Aabb) {
+            this.field_Aabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Color) {
+            this.field_Color = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Plane) {
+            this.field_Plane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Callable) {
+            this.field_Callable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Signal) {
+            this.field_Signal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Enum) {
+            this.field_Enum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyEnum>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_FlagsEnum) {
+            this.field_FlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyFlagsEnum>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_ByteArray) {
+            this.field_ByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Int32Array) {
+            this.field_Int32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Int64Array) {
+            this.field_Int64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_SingleArray) {
+            this.field_SingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_DoubleArray) {
+            this.field_DoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_StringArray) {
+            this.field_StringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_StringArrayEnum) {
+            this.field_StringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector2Array) {
+            this.field_Vector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector3Array) {
+            this.field_Vector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_ColorArray) {
+            this.field_ColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotObjectOrDerivedArray) {
+            this.field_GodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_StringNameArray) {
+            this.field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_NodePathArray) {
+            this.field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_RidArray) {
+            this.field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_empty_Int32Array) {
+            this.field_empty_Int32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_array_from_list) {
+            this.field_array_from_list = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Variant) {
+            this.field_Variant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotObjectOrDerived) {
+            this.field_GodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotResourceTexture) {
+            this.field_GodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_StringName) {
+            this.field_StringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_NodePath) {
+            this.field_NodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_Rid) {
+            this.field_Rid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotDictionary) {
+            this.field_GodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotArray) {
+            this.field_GodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotGenericDictionary) {
+            this.field_GodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotGenericArray) {
+            this.field_GodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_empty_Int64Array) {
+            this.field_empty_Int64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.field_Boolean) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.field_Boolean);
+            return true;
+        }
+        else if (name == PropertyName.field_Char) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.field_Char);
+            return true;
+        }
+        else if (name == PropertyName.field_SByte) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.field_SByte);
+            return true;
+        }
+        else if (name == PropertyName.field_Int16) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.field_Int16);
+            return true;
+        }
+        else if (name == PropertyName.field_Int32) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.field_Int32);
+            return true;
+        }
+        else if (name == PropertyName.field_Int64) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.field_Int64);
+            return true;
+        }
+        else if (name == PropertyName.field_Byte) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.field_Byte);
+            return true;
+        }
+        else if (name == PropertyName.field_UInt16) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.field_UInt16);
+            return true;
+        }
+        else if (name == PropertyName.field_UInt32) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.field_UInt32);
+            return true;
+        }
+        else if (name == PropertyName.field_UInt64) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.field_UInt64);
+            return true;
+        }
+        else if (name == PropertyName.field_Single) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.field_Single);
+            return true;
+        }
+        else if (name == PropertyName.field_Double) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.field_Double);
+            return true;
+        }
+        else if (name == PropertyName.field_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.field_String);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector2) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.field_Vector2);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector2I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.field_Vector2I);
+            return true;
+        }
+        else if (name == PropertyName.field_Rect2) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.field_Rect2);
+            return true;
+        }
+        else if (name == PropertyName.field_Rect2I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.field_Rect2I);
+            return true;
+        }
+        else if (name == PropertyName.field_Transform2D) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.field_Transform2D);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector3) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.field_Vector3);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector3I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.field_Vector3I);
+            return true;
+        }
+        else if (name == PropertyName.field_Basis) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.field_Basis);
+            return true;
+        }
+        else if (name == PropertyName.field_Quaternion) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.field_Quaternion);
+            return true;
+        }
+        else if (name == PropertyName.field_Transform3D) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.field_Transform3D);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector4) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.field_Vector4);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector4I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.field_Vector4I);
+            return true;
+        }
+        else if (name == PropertyName.field_Projection) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.field_Projection);
+            return true;
+        }
+        else if (name == PropertyName.field_Aabb) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.field_Aabb);
+            return true;
+        }
+        else if (name == PropertyName.field_Color) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.field_Color);
+            return true;
+        }
+        else if (name == PropertyName.field_Plane) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.field_Plane);
+            return true;
+        }
+        else if (name == PropertyName.field_Callable) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.field_Callable);
+            return true;
+        }
+        else if (name == PropertyName.field_Signal) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.field_Signal);
+            return true;
+        }
+        else if (name == PropertyName.field_Enum) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyEnum>(this.field_Enum);
+            return true;
+        }
+        else if (name == PropertyName.field_FlagsEnum) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyFlagsEnum>(this.field_FlagsEnum);
+            return true;
+        }
+        else if (name == PropertyName.field_ByteArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.field_ByteArray);
+            return true;
+        }
+        else if (name == PropertyName.field_Int32Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.field_Int32Array);
+            return true;
+        }
+        else if (name == PropertyName.field_Int64Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.field_Int64Array);
+            return true;
+        }
+        else if (name == PropertyName.field_SingleArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.field_SingleArray);
+            return true;
+        }
+        else if (name == PropertyName.field_DoubleArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.field_DoubleArray);
+            return true;
+        }
+        else if (name == PropertyName.field_StringArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.field_StringArray);
+            return true;
+        }
+        else if (name == PropertyName.field_StringArrayEnum) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.field_StringArrayEnum);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector2Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.field_Vector2Array);
+            return true;
+        }
+        else if (name == PropertyName.field_Vector3Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.field_Vector3Array);
+            return true;
+        }
+        else if (name == PropertyName.field_ColorArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.field_ColorArray);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotObjectOrDerivedArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.field_GodotObjectOrDerivedArray);
+            return true;
+        }
+        else if (name == PropertyName.field_StringNameArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.field_StringNameArray);
+            return true;
+        }
+        else if (name == PropertyName.field_NodePathArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.field_NodePathArray);
+            return true;
+        }
+        else if (name == PropertyName.field_RidArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.field_RidArray);
+            return true;
+        }
+        else if (name == PropertyName.field_empty_Int32Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.field_empty_Int32Array);
+            return true;
+        }
+        else if (name == PropertyName.field_array_from_list) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.field_array_from_list);
+            return true;
+        }
+        else if (name == PropertyName.field_Variant) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.field_Variant);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotObjectOrDerived) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.field_GodotObjectOrDerived);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotResourceTexture) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.field_GodotResourceTexture);
+            return true;
+        }
+        else if (name == PropertyName.field_StringName) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.field_StringName);
+            return true;
+        }
+        else if (name == PropertyName.field_NodePath) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.field_NodePath);
+            return true;
+        }
+        else if (name == PropertyName.field_Rid) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.field_Rid);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotDictionary) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.field_GodotDictionary);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.field_GodotArray);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotGenericDictionary) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.field_GodotGenericDictionary);
+            return true;
+        }
+        else if (name == PropertyName.field_GodotGenericArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.field_GodotGenericArray);
+            return true;
+        }
+        else if (name == PropertyName.field_empty_Int64Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.field_empty_Int64Array);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.field_Boolean, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_Char, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_SByte, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_Int16, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_Int32, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_Int64, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_Byte, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_UInt16, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_UInt32, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_UInt64, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.field_Single, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.field_Double, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.field_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)5, name: PropertyName.field_Vector2, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)6, name: PropertyName.field_Vector2I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)7, name: PropertyName.field_Rect2, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)8, name: PropertyName.field_Rect2I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)11, name: PropertyName.field_Transform2D, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)9, name: PropertyName.field_Vector3, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)10, name: PropertyName.field_Vector3I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)17, name: PropertyName.field_Basis, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)15, name: PropertyName.field_Quaternion, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)18, name: PropertyName.field_Transform3D, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)12, name: PropertyName.field_Vector4, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)13, name: PropertyName.field_Vector4I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)19, name: PropertyName.field_Projection, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)16, name: PropertyName.field_Aabb, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)20, name: PropertyName.field_Color, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)14, name: PropertyName.field_Plane, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)25, name: PropertyName.field_Callable, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)26, name: PropertyName.field_Signal, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_Enum, hint: (global::Godot.PropertyHint)2, hintString: "A,B,C", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.field_FlagsEnum, hint: (global::Godot.PropertyHint)6, hintString: "A:0,B:1,C:2", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)29, name: PropertyName.field_ByteArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)30, name: PropertyName.field_Int32Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)31, name: PropertyName.field_Int64Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)32, name: PropertyName.field_SingleArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)33, name: PropertyName.field_DoubleArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)34, name: PropertyName.field_StringArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)34, name: PropertyName.field_StringArrayEnum, hint: (global::Godot.PropertyHint)23, hintString: "4/2:A,B,C", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)35, name: PropertyName.field_Vector2Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)36, name: PropertyName.field_Vector3Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)37, name: PropertyName.field_ColorArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_GodotObjectOrDerivedArray, hint: (global::Godot.PropertyHint)23, hintString: "24/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_StringNameArray, hint: (global::Godot.PropertyHint)23, hintString: "21/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_NodePathArray, hint: (global::Godot.PropertyHint)23, hintString: "22/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_RidArray, hint: (global::Godot.PropertyHint)23, hintString: "23/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)30, name: PropertyName.field_empty_Int32Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)30, name: PropertyName.field_array_from_list, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)0, name: PropertyName.field_Variant, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)135174, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.field_GodotObjectOrDerived, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.field_GodotResourceTexture, hint: (global::Godot.PropertyHint)17, hintString: "Texture", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)21, name: PropertyName.field_StringName, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)22, name: PropertyName.field_NodePath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)23, name: PropertyName.field_Rid, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)27, name: PropertyName.field_GodotDictionary, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_GodotArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)27, name: PropertyName.field_GodotGenericDictionary, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_GodotGenericArray, hint: (global::Godot.PropertyHint)23, hintString: "2/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)31, name: PropertyName.field_empty_Int64Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
@@ -1,0 +1,139 @@
+partial class ExportedFields
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+#if TOOLS
+    /// <summary>
+    /// Get the default values for all properties declared in this class.
+    /// This method is used by Godot to determine the value that will be
+    /// used by the inspector when resetting properties.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
+    {
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(60);
+        bool __field_Boolean_default_value = true;
+        values.Add(PropertyName.field_Boolean, global::Godot.Variant.From<bool>(__field_Boolean_default_value));
+        char __field_Char_default_value = 'f';
+        values.Add(PropertyName.field_Char, global::Godot.Variant.From<char>(__field_Char_default_value));
+        sbyte __field_SByte_default_value = 10;
+        values.Add(PropertyName.field_SByte, global::Godot.Variant.From<sbyte>(__field_SByte_default_value));
+        short __field_Int16_default_value = 10;
+        values.Add(PropertyName.field_Int16, global::Godot.Variant.From<short>(__field_Int16_default_value));
+        int __field_Int32_default_value = 10;
+        values.Add(PropertyName.field_Int32, global::Godot.Variant.From<int>(__field_Int32_default_value));
+        long __field_Int64_default_value = 10;
+        values.Add(PropertyName.field_Int64, global::Godot.Variant.From<long>(__field_Int64_default_value));
+        byte __field_Byte_default_value = 10;
+        values.Add(PropertyName.field_Byte, global::Godot.Variant.From<byte>(__field_Byte_default_value));
+        ushort __field_UInt16_default_value = 10;
+        values.Add(PropertyName.field_UInt16, global::Godot.Variant.From<ushort>(__field_UInt16_default_value));
+        uint __field_UInt32_default_value = 10;
+        values.Add(PropertyName.field_UInt32, global::Godot.Variant.From<uint>(__field_UInt32_default_value));
+        ulong __field_UInt64_default_value = 10;
+        values.Add(PropertyName.field_UInt64, global::Godot.Variant.From<ulong>(__field_UInt64_default_value));
+        float __field_Single_default_value = 10;
+        values.Add(PropertyName.field_Single, global::Godot.Variant.From<float>(__field_Single_default_value));
+        double __field_Double_default_value = 10;
+        values.Add(PropertyName.field_Double, global::Godot.Variant.From<double>(__field_Double_default_value));
+        string __field_String_default_value = "foo";
+        values.Add(PropertyName.field_String, global::Godot.Variant.From<string>(__field_String_default_value));
+        global::Godot.Vector2 __field_Vector2_default_value = new(10f, 10f);
+        values.Add(PropertyName.field_Vector2, global::Godot.Variant.From<global::Godot.Vector2>(__field_Vector2_default_value));
+        global::Godot.Vector2I __field_Vector2I_default_value = global::Godot.Vector2I.Up;
+        values.Add(PropertyName.field_Vector2I, global::Godot.Variant.From<global::Godot.Vector2I>(__field_Vector2I_default_value));
+        global::Godot.Rect2 __field_Rect2_default_value = new(new global::Godot.Vector2(10f, 10f), new global::Godot.Vector2(10f, 10f));
+        values.Add(PropertyName.field_Rect2, global::Godot.Variant.From<global::Godot.Rect2>(__field_Rect2_default_value));
+        global::Godot.Rect2I __field_Rect2I_default_value = new(new global::Godot.Vector2I(10, 10), new global::Godot.Vector2I(10, 10));
+        values.Add(PropertyName.field_Rect2I, global::Godot.Variant.From<global::Godot.Rect2I>(__field_Rect2I_default_value));
+        global::Godot.Transform2D __field_Transform2D_default_value = global::Godot.Transform2D.Identity;
+        values.Add(PropertyName.field_Transform2D, global::Godot.Variant.From<global::Godot.Transform2D>(__field_Transform2D_default_value));
+        global::Godot.Vector3 __field_Vector3_default_value = new(10f, 10f, 10f);
+        values.Add(PropertyName.field_Vector3, global::Godot.Variant.From<global::Godot.Vector3>(__field_Vector3_default_value));
+        global::Godot.Vector3I __field_Vector3I_default_value = global::Godot.Vector3I.Back;
+        values.Add(PropertyName.field_Vector3I, global::Godot.Variant.From<global::Godot.Vector3I>(__field_Vector3I_default_value));
+        global::Godot.Basis __field_Basis_default_value = new global::Godot.Basis(global::Godot.Quaternion.Identity);
+        values.Add(PropertyName.field_Basis, global::Godot.Variant.From<global::Godot.Basis>(__field_Basis_default_value));
+        global::Godot.Quaternion __field_Quaternion_default_value = new global::Godot.Quaternion(global::Godot.Basis.Identity);
+        values.Add(PropertyName.field_Quaternion, global::Godot.Variant.From<global::Godot.Quaternion>(__field_Quaternion_default_value));
+        global::Godot.Transform3D __field_Transform3D_default_value = global::Godot.Transform3D.Identity;
+        values.Add(PropertyName.field_Transform3D, global::Godot.Variant.From<global::Godot.Transform3D>(__field_Transform3D_default_value));
+        global::Godot.Vector4 __field_Vector4_default_value = new(10f, 10f, 10f, 10f);
+        values.Add(PropertyName.field_Vector4, global::Godot.Variant.From<global::Godot.Vector4>(__field_Vector4_default_value));
+        global::Godot.Vector4I __field_Vector4I_default_value = global::Godot.Vector4I.One;
+        values.Add(PropertyName.field_Vector4I, global::Godot.Variant.From<global::Godot.Vector4I>(__field_Vector4I_default_value));
+        global::Godot.Projection __field_Projection_default_value = global::Godot.Projection.Identity;
+        values.Add(PropertyName.field_Projection, global::Godot.Variant.From<global::Godot.Projection>(__field_Projection_default_value));
+        global::Godot.Aabb __field_Aabb_default_value = new global::Godot.Aabb(10f, 10f, 10f, new global::Godot.Vector3(1f, 1f, 1f));
+        values.Add(PropertyName.field_Aabb, global::Godot.Variant.From<global::Godot.Aabb>(__field_Aabb_default_value));
+        global::Godot.Color __field_Color_default_value = global::Godot.Colors.Aquamarine;
+        values.Add(PropertyName.field_Color, global::Godot.Variant.From<global::Godot.Color>(__field_Color_default_value));
+        global::Godot.Plane __field_Plane_default_value = global::Godot.Plane.PlaneXZ;
+        values.Add(PropertyName.field_Plane, global::Godot.Variant.From<global::Godot.Plane>(__field_Plane_default_value));
+        global::Godot.Callable __field_Callable_default_value = new global::Godot.Callable(global::Godot.Engine.GetMainLoop(), "_process");
+        values.Add(PropertyName.field_Callable, global::Godot.Variant.From<global::Godot.Callable>(__field_Callable_default_value));
+        global::Godot.Signal __field_Signal_default_value = new global::Godot.Signal(global::Godot.Engine.GetMainLoop(), "property_list_changed");
+        values.Add(PropertyName.field_Signal, global::Godot.Variant.From<global::Godot.Signal>(__field_Signal_default_value));
+        global::ExportedFields.MyEnum __field_Enum_default_value = global::ExportedFields.MyEnum.C;
+        values.Add(PropertyName.field_Enum, global::Godot.Variant.From<global::ExportedFields.MyEnum>(__field_Enum_default_value));
+        global::ExportedFields.MyFlagsEnum __field_FlagsEnum_default_value = global::ExportedFields.MyFlagsEnum.C;
+        values.Add(PropertyName.field_FlagsEnum, global::Godot.Variant.From<global::ExportedFields.MyFlagsEnum>(__field_FlagsEnum_default_value));
+        byte[] __field_ByteArray_default_value = { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.field_ByteArray, global::Godot.Variant.From<byte[]>(__field_ByteArray_default_value));
+        int[] __field_Int32Array_default_value = { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.field_Int32Array, global::Godot.Variant.From<int[]>(__field_Int32Array_default_value));
+        long[] __field_Int64Array_default_value = { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.field_Int64Array, global::Godot.Variant.From<long[]>(__field_Int64Array_default_value));
+        float[] __field_SingleArray_default_value = { 0f, 1f, 2f, 3f, 4f, 5f, 6f  };
+        values.Add(PropertyName.field_SingleArray, global::Godot.Variant.From<float[]>(__field_SingleArray_default_value));
+        double[] __field_DoubleArray_default_value = { 0d, 1d, 2d, 3d, 4d, 5d, 6d  };
+        values.Add(PropertyName.field_DoubleArray, global::Godot.Variant.From<double[]>(__field_DoubleArray_default_value));
+        string[] __field_StringArray_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.field_StringArray, global::Godot.Variant.From<string[]>(__field_StringArray_default_value));
+        string[] __field_StringArrayEnum_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.field_StringArrayEnum, global::Godot.Variant.From<string[]>(__field_StringArrayEnum_default_value));
+        global::Godot.Vector2[] __field_Vector2Array_default_value = { global::Godot.Vector2.Up, global::Godot.Vector2.Down, global::Godot.Vector2.Left, global::Godot.Vector2.Right   };
+        values.Add(PropertyName.field_Vector2Array, global::Godot.Variant.From<global::Godot.Vector2[]>(__field_Vector2Array_default_value));
+        global::Godot.Vector3[] __field_Vector3Array_default_value = { global::Godot.Vector3.Up, global::Godot.Vector3.Down, global::Godot.Vector3.Left, global::Godot.Vector3.Right   };
+        values.Add(PropertyName.field_Vector3Array, global::Godot.Variant.From<global::Godot.Vector3[]>(__field_Vector3Array_default_value));
+        global::Godot.Color[] __field_ColorArray_default_value = { global::Godot.Colors.Aqua, global::Godot.Colors.Aquamarine, global::Godot.Colors.Azure, global::Godot.Colors.Beige   };
+        values.Add(PropertyName.field_ColorArray, global::Godot.Variant.From<global::Godot.Color[]>(__field_ColorArray_default_value));
+        global::Godot.GodotObject[] __field_GodotObjectOrDerivedArray_default_value = { null  };
+        values.Add(PropertyName.field_GodotObjectOrDerivedArray, global::Godot.Variant.CreateFrom(__field_GodotObjectOrDerivedArray_default_value));
+        global::Godot.StringName[] __field_StringNameArray_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.field_StringNameArray, global::Godot.Variant.From<global::Godot.StringName[]>(__field_StringNameArray_default_value));
+        global::Godot.NodePath[] __field_NodePathArray_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.field_NodePathArray, global::Godot.Variant.From<global::Godot.NodePath[]>(__field_NodePathArray_default_value));
+        global::Godot.Rid[] __field_RidArray_default_value = { default, default, default  };
+        values.Add(PropertyName.field_RidArray, global::Godot.Variant.From<global::Godot.Rid[]>(__field_RidArray_default_value));
+        int[] __field_empty_Int32Array_default_value = global::System.Array.Empty<int>();
+        values.Add(PropertyName.field_empty_Int32Array, global::Godot.Variant.From<int[]>(__field_empty_Int32Array_default_value));
+        int[] __field_array_from_list_default_value = new global::System.Collections.Generic.List<int>(global::System.Array.Empty<int>()).ToArray();
+        values.Add(PropertyName.field_array_from_list, global::Godot.Variant.From<int[]>(__field_array_from_list_default_value));
+        global::Godot.Variant __field_Variant_default_value = "foo";
+        values.Add(PropertyName.field_Variant, global::Godot.Variant.From<global::Godot.Variant>(__field_Variant_default_value));
+        global::Godot.GodotObject __field_GodotObjectOrDerived_default_value = default;
+        values.Add(PropertyName.field_GodotObjectOrDerived, global::Godot.Variant.From<global::Godot.GodotObject>(__field_GodotObjectOrDerived_default_value));
+        global::Godot.Texture __field_GodotResourceTexture_default_value = default;
+        values.Add(PropertyName.field_GodotResourceTexture, global::Godot.Variant.From<global::Godot.Texture>(__field_GodotResourceTexture_default_value));
+        global::Godot.StringName __field_StringName_default_value = new global::Godot.StringName("foo");
+        values.Add(PropertyName.field_StringName, global::Godot.Variant.From<global::Godot.StringName>(__field_StringName_default_value));
+        global::Godot.NodePath __field_NodePath_default_value = new global::Godot.NodePath("foo");
+        values.Add(PropertyName.field_NodePath, global::Godot.Variant.From<global::Godot.NodePath>(__field_NodePath_default_value));
+        global::Godot.Rid __field_Rid_default_value = default;
+        values.Add(PropertyName.field_Rid, global::Godot.Variant.From<global::Godot.Rid>(__field_Rid_default_value));
+        global::Godot.Collections.Dictionary __field_GodotDictionary_default_value = new()  { { "foo", 10  }, { global::Godot.Vector2.Up, global::Godot.Colors.Chocolate   }  };
+        values.Add(PropertyName.field_GodotDictionary, global::Godot.Variant.From<global::Godot.Collections.Dictionary>(__field_GodotDictionary_default_value));
+        global::Godot.Collections.Array __field_GodotArray_default_value = new()  { "foo", 10, global::Godot.Vector2.Up, global::Godot.Colors.Chocolate   };
+        values.Add(PropertyName.field_GodotArray, global::Godot.Variant.From<global::Godot.Collections.Array>(__field_GodotArray_default_value));
+        global::Godot.Collections.Dictionary<string, bool> __field_GodotGenericDictionary_default_value = new()  { { "foo", true  }, { "bar", false  }  };
+        values.Add(PropertyName.field_GodotGenericDictionary, global::Godot.Variant.CreateFrom(__field_GodotGenericDictionary_default_value));
+        global::Godot.Collections.Array<int> __field_GodotGenericArray_default_value = new()  { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.field_GodotGenericArray, global::Godot.Variant.CreateFrom(__field_GodotGenericArray_default_value));
+        long[] __field_empty_Int64Array_default_value = global::System.Array.Empty<long>();
+        values.Add(PropertyName.field_empty_Int64Array, global::Godot.Variant.From<long[]>(__field_empty_Int64Array_default_value));
+        return values;
+    }
+#endif // TOOLS
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -1,0 +1,933 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ExportedProperties
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.GodotObject.PropertyName {
+        /// <summary>
+        /// Cached name for the 'NotGenerate_Complex_Lamda_Property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName NotGenerate_Complex_Lamda_Property = "NotGenerate_Complex_Lamda_Property";
+        /// <summary>
+        /// Cached name for the 'NotGenerate_Lamda_NoField_Property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName NotGenerate_Lamda_NoField_Property = "NotGenerate_Lamda_NoField_Property";
+        /// <summary>
+        /// Cached name for the 'NotGenerate_Complex_Return_Property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName NotGenerate_Complex_Return_Property = "NotGenerate_Complex_Return_Property";
+        /// <summary>
+        /// Cached name for the 'NotGenerate_Returns_Property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName NotGenerate_Returns_Property = "NotGenerate_Returns_Property";
+        /// <summary>
+        /// Cached name for the 'FullProperty_String' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName FullProperty_String = "FullProperty_String";
+        /// <summary>
+        /// Cached name for the 'FullProperty_String_Complex' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName FullProperty_String_Complex = "FullProperty_String_Complex";
+        /// <summary>
+        /// Cached name for the 'LamdaProperty_String' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName LamdaProperty_String = "LamdaProperty_String";
+        /// <summary>
+        /// Cached name for the 'property_Boolean' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Boolean = "property_Boolean";
+        /// <summary>
+        /// Cached name for the 'property_Char' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Char = "property_Char";
+        /// <summary>
+        /// Cached name for the 'property_SByte' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_SByte = "property_SByte";
+        /// <summary>
+        /// Cached name for the 'property_Int16' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Int16 = "property_Int16";
+        /// <summary>
+        /// Cached name for the 'property_Int32' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Int32 = "property_Int32";
+        /// <summary>
+        /// Cached name for the 'property_Int64' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Int64 = "property_Int64";
+        /// <summary>
+        /// Cached name for the 'property_Byte' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Byte = "property_Byte";
+        /// <summary>
+        /// Cached name for the 'property_UInt16' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_UInt16 = "property_UInt16";
+        /// <summary>
+        /// Cached name for the 'property_UInt32' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_UInt32 = "property_UInt32";
+        /// <summary>
+        /// Cached name for the 'property_UInt64' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_UInt64 = "property_UInt64";
+        /// <summary>
+        /// Cached name for the 'property_Single' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Single = "property_Single";
+        /// <summary>
+        /// Cached name for the 'property_Double' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Double = "property_Double";
+        /// <summary>
+        /// Cached name for the 'property_String' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_String = "property_String";
+        /// <summary>
+        /// Cached name for the 'property_Vector2' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector2 = "property_Vector2";
+        /// <summary>
+        /// Cached name for the 'property_Vector2I' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector2I = "property_Vector2I";
+        /// <summary>
+        /// Cached name for the 'property_Rect2' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Rect2 = "property_Rect2";
+        /// <summary>
+        /// Cached name for the 'property_Rect2I' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Rect2I = "property_Rect2I";
+        /// <summary>
+        /// Cached name for the 'property_Transform2D' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Transform2D = "property_Transform2D";
+        /// <summary>
+        /// Cached name for the 'property_Vector3' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector3 = "property_Vector3";
+        /// <summary>
+        /// Cached name for the 'property_Vector3I' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector3I = "property_Vector3I";
+        /// <summary>
+        /// Cached name for the 'property_Basis' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Basis = "property_Basis";
+        /// <summary>
+        /// Cached name for the 'property_Quaternion' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Quaternion = "property_Quaternion";
+        /// <summary>
+        /// Cached name for the 'property_Transform3D' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Transform3D = "property_Transform3D";
+        /// <summary>
+        /// Cached name for the 'property_Vector4' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector4 = "property_Vector4";
+        /// <summary>
+        /// Cached name for the 'property_Vector4I' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector4I = "property_Vector4I";
+        /// <summary>
+        /// Cached name for the 'property_Projection' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Projection = "property_Projection";
+        /// <summary>
+        /// Cached name for the 'property_Aabb' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Aabb = "property_Aabb";
+        /// <summary>
+        /// Cached name for the 'property_Color' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Color = "property_Color";
+        /// <summary>
+        /// Cached name for the 'property_Plane' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Plane = "property_Plane";
+        /// <summary>
+        /// Cached name for the 'property_Callable' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Callable = "property_Callable";
+        /// <summary>
+        /// Cached name for the 'property_Signal' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Signal = "property_Signal";
+        /// <summary>
+        /// Cached name for the 'property_Enum' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Enum = "property_Enum";
+        /// <summary>
+        /// Cached name for the 'property_FlagsEnum' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_FlagsEnum = "property_FlagsEnum";
+        /// <summary>
+        /// Cached name for the 'property_ByteArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_ByteArray = "property_ByteArray";
+        /// <summary>
+        /// Cached name for the 'property_Int32Array' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Int32Array = "property_Int32Array";
+        /// <summary>
+        /// Cached name for the 'property_Int64Array' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Int64Array = "property_Int64Array";
+        /// <summary>
+        /// Cached name for the 'property_SingleArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_SingleArray = "property_SingleArray";
+        /// <summary>
+        /// Cached name for the 'property_DoubleArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_DoubleArray = "property_DoubleArray";
+        /// <summary>
+        /// Cached name for the 'property_StringArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_StringArray = "property_StringArray";
+        /// <summary>
+        /// Cached name for the 'property_StringArrayEnum' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_StringArrayEnum = "property_StringArrayEnum";
+        /// <summary>
+        /// Cached name for the 'property_Vector2Array' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector2Array = "property_Vector2Array";
+        /// <summary>
+        /// Cached name for the 'property_Vector3Array' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Vector3Array = "property_Vector3Array";
+        /// <summary>
+        /// Cached name for the 'property_ColorArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_ColorArray = "property_ColorArray";
+        /// <summary>
+        /// Cached name for the 'property_GodotObjectOrDerivedArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotObjectOrDerivedArray = "property_GodotObjectOrDerivedArray";
+        /// <summary>
+        /// Cached name for the 'field_StringNameArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_StringNameArray = "field_StringNameArray";
+        /// <summary>
+        /// Cached name for the 'field_NodePathArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_NodePathArray = "field_NodePathArray";
+        /// <summary>
+        /// Cached name for the 'field_RidArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName field_RidArray = "field_RidArray";
+        /// <summary>
+        /// Cached name for the 'property_Variant' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Variant = "property_Variant";
+        /// <summary>
+        /// Cached name for the 'property_GodotObjectOrDerived' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotObjectOrDerived = "property_GodotObjectOrDerived";
+        /// <summary>
+        /// Cached name for the 'property_GodotResourceTexture' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotResourceTexture = "property_GodotResourceTexture";
+        /// <summary>
+        /// Cached name for the 'property_StringName' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_StringName = "property_StringName";
+        /// <summary>
+        /// Cached name for the 'property_NodePath' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_NodePath = "property_NodePath";
+        /// <summary>
+        /// Cached name for the 'property_Rid' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_Rid = "property_Rid";
+        /// <summary>
+        /// Cached name for the 'property_GodotDictionary' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotDictionary = "property_GodotDictionary";
+        /// <summary>
+        /// Cached name for the 'property_GodotArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotArray = "property_GodotArray";
+        /// <summary>
+        /// Cached name for the 'property_GodotGenericDictionary' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotGenericDictionary = "property_GodotGenericDictionary";
+        /// <summary>
+        /// Cached name for the 'property_GodotGenericArray' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName property_GodotGenericArray = "property_GodotGenericArray";
+        /// <summary>
+        /// Cached name for the '_notGenerate_Property_String' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _notGenerate_Property_String = "_notGenerate_Property_String";
+        /// <summary>
+        /// Cached name for the '_notGenerate_Property_Int' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _notGenerate_Property_Int = "_notGenerate_Property_Int";
+        /// <summary>
+        /// Cached name for the '_fullProperty_String' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _fullProperty_String = "_fullProperty_String";
+        /// <summary>
+        /// Cached name for the '_fullProperty_String_Complex' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _fullProperty_String_Complex = "_fullProperty_String_Complex";
+        /// <summary>
+        /// Cached name for the '_lamdaProperty_String' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _lamdaProperty_String = "_lamdaProperty_String";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.NotGenerate_Complex_Lamda_Property) {
+            this.NotGenerate_Complex_Lamda_Property = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.NotGenerate_Lamda_NoField_Property) {
+            this.NotGenerate_Lamda_NoField_Property = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.NotGenerate_Complex_Return_Property) {
+            this.NotGenerate_Complex_Return_Property = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.NotGenerate_Returns_Property) {
+            this.NotGenerate_Returns_Property = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.FullProperty_String) {
+            this.FullProperty_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.FullProperty_String_Complex) {
+            this.FullProperty_String_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.LamdaProperty_String) {
+            this.LamdaProperty_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Boolean) {
+            this.property_Boolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Char) {
+            this.property_Char = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_SByte) {
+            this.property_SByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Int16) {
+            this.property_Int16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Int32) {
+            this.property_Int32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Int64) {
+            this.property_Int64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Byte) {
+            this.property_Byte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_UInt16) {
+            this.property_UInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_UInt32) {
+            this.property_UInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_UInt64) {
+            this.property_UInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Single) {
+            this.property_Single = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Double) {
+            this.property_Double = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_String) {
+            this.property_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector2) {
+            this.property_Vector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector2I) {
+            this.property_Vector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Rect2) {
+            this.property_Rect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Rect2I) {
+            this.property_Rect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Transform2D) {
+            this.property_Transform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector3) {
+            this.property_Vector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector3I) {
+            this.property_Vector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Basis) {
+            this.property_Basis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Quaternion) {
+            this.property_Quaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Transform3D) {
+            this.property_Transform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector4) {
+            this.property_Vector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector4I) {
+            this.property_Vector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Projection) {
+            this.property_Projection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Aabb) {
+            this.property_Aabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Color) {
+            this.property_Color = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Plane) {
+            this.property_Plane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Callable) {
+            this.property_Callable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Signal) {
+            this.property_Signal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Enum) {
+            this.property_Enum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyEnum>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_FlagsEnum) {
+            this.property_FlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyFlagsEnum>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_ByteArray) {
+            this.property_ByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Int32Array) {
+            this.property_Int32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Int64Array) {
+            this.property_Int64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_SingleArray) {
+            this.property_SingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_DoubleArray) {
+            this.property_DoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_StringArray) {
+            this.property_StringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_StringArrayEnum) {
+            this.property_StringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector2Array) {
+            this.property_Vector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector3Array) {
+            this.property_Vector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_ColorArray) {
+            this.property_ColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotObjectOrDerivedArray) {
+            this.property_GodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_StringNameArray) {
+            this.field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_NodePathArray) {
+            this.field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.field_RidArray) {
+            this.field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Variant) {
+            this.property_Variant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotObjectOrDerived) {
+            this.property_GodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotResourceTexture) {
+            this.property_GodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_StringName) {
+            this.property_StringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_NodePath) {
+            this.property_NodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_Rid) {
+            this.property_Rid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotDictionary) {
+            this.property_GodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotArray) {
+            this.property_GodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotGenericDictionary) {
+            this.property_GodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotGenericArray) {
+            this.property_GodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
+            return true;
+        }
+        else if (name == PropertyName._notGenerate_Property_String) {
+            this._notGenerate_Property_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName._notGenerate_Property_Int) {
+            this._notGenerate_Property_Int = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            return true;
+        }
+        else if (name == PropertyName._fullProperty_String) {
+            this._fullProperty_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName._fullProperty_String_Complex) {
+            this._fullProperty_String_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        else if (name == PropertyName._lamdaProperty_String) {
+            this._lamdaProperty_String = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.NotGenerate_Complex_Lamda_Property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerate_Complex_Lamda_Property);
+            return true;
+        }
+        else if (name == PropertyName.NotGenerate_Lamda_NoField_Property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerate_Lamda_NoField_Property);
+            return true;
+        }
+        else if (name == PropertyName.NotGenerate_Complex_Return_Property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerate_Complex_Return_Property);
+            return true;
+        }
+        else if (name == PropertyName.NotGenerate_Returns_Property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.NotGenerate_Returns_Property);
+            return true;
+        }
+        else if (name == PropertyName.FullProperty_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.FullProperty_String);
+            return true;
+        }
+        else if (name == PropertyName.FullProperty_String_Complex) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.FullProperty_String_Complex);
+            return true;
+        }
+        else if (name == PropertyName.LamdaProperty_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.LamdaProperty_String);
+            return true;
+        }
+        else if (name == PropertyName.property_Boolean) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.property_Boolean);
+            return true;
+        }
+        else if (name == PropertyName.property_Char) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.property_Char);
+            return true;
+        }
+        else if (name == PropertyName.property_SByte) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.property_SByte);
+            return true;
+        }
+        else if (name == PropertyName.property_Int16) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.property_Int16);
+            return true;
+        }
+        else if (name == PropertyName.property_Int32) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.property_Int32);
+            return true;
+        }
+        else if (name == PropertyName.property_Int64) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.property_Int64);
+            return true;
+        }
+        else if (name == PropertyName.property_Byte) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.property_Byte);
+            return true;
+        }
+        else if (name == PropertyName.property_UInt16) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.property_UInt16);
+            return true;
+        }
+        else if (name == PropertyName.property_UInt32) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.property_UInt32);
+            return true;
+        }
+        else if (name == PropertyName.property_UInt64) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.property_UInt64);
+            return true;
+        }
+        else if (name == PropertyName.property_Single) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.property_Single);
+            return true;
+        }
+        else if (name == PropertyName.property_Double) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.property_Double);
+            return true;
+        }
+        else if (name == PropertyName.property_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.property_String);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector2) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.property_Vector2);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector2I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.property_Vector2I);
+            return true;
+        }
+        else if (name == PropertyName.property_Rect2) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.property_Rect2);
+            return true;
+        }
+        else if (name == PropertyName.property_Rect2I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.property_Rect2I);
+            return true;
+        }
+        else if (name == PropertyName.property_Transform2D) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.property_Transform2D);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector3) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.property_Vector3);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector3I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.property_Vector3I);
+            return true;
+        }
+        else if (name == PropertyName.property_Basis) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.property_Basis);
+            return true;
+        }
+        else if (name == PropertyName.property_Quaternion) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.property_Quaternion);
+            return true;
+        }
+        else if (name == PropertyName.property_Transform3D) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.property_Transform3D);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector4) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.property_Vector4);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector4I) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.property_Vector4I);
+            return true;
+        }
+        else if (name == PropertyName.property_Projection) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.property_Projection);
+            return true;
+        }
+        else if (name == PropertyName.property_Aabb) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.property_Aabb);
+            return true;
+        }
+        else if (name == PropertyName.property_Color) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.property_Color);
+            return true;
+        }
+        else if (name == PropertyName.property_Plane) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.property_Plane);
+            return true;
+        }
+        else if (name == PropertyName.property_Callable) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.property_Callable);
+            return true;
+        }
+        else if (name == PropertyName.property_Signal) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.property_Signal);
+            return true;
+        }
+        else if (name == PropertyName.property_Enum) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyEnum>(this.property_Enum);
+            return true;
+        }
+        else if (name == PropertyName.property_FlagsEnum) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyFlagsEnum>(this.property_FlagsEnum);
+            return true;
+        }
+        else if (name == PropertyName.property_ByteArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.property_ByteArray);
+            return true;
+        }
+        else if (name == PropertyName.property_Int32Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.property_Int32Array);
+            return true;
+        }
+        else if (name == PropertyName.property_Int64Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.property_Int64Array);
+            return true;
+        }
+        else if (name == PropertyName.property_SingleArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.property_SingleArray);
+            return true;
+        }
+        else if (name == PropertyName.property_DoubleArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.property_DoubleArray);
+            return true;
+        }
+        else if (name == PropertyName.property_StringArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.property_StringArray);
+            return true;
+        }
+        else if (name == PropertyName.property_StringArrayEnum) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.property_StringArrayEnum);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector2Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.property_Vector2Array);
+            return true;
+        }
+        else if (name == PropertyName.property_Vector3Array) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.property_Vector3Array);
+            return true;
+        }
+        else if (name == PropertyName.property_ColorArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.property_ColorArray);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotObjectOrDerivedArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.property_GodotObjectOrDerivedArray);
+            return true;
+        }
+        else if (name == PropertyName.field_StringNameArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.field_StringNameArray);
+            return true;
+        }
+        else if (name == PropertyName.field_NodePathArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.field_NodePathArray);
+            return true;
+        }
+        else if (name == PropertyName.field_RidArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.field_RidArray);
+            return true;
+        }
+        else if (name == PropertyName.property_Variant) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.property_Variant);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotObjectOrDerived) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.property_GodotObjectOrDerived);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotResourceTexture) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.property_GodotResourceTexture);
+            return true;
+        }
+        else if (name == PropertyName.property_StringName) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.property_StringName);
+            return true;
+        }
+        else if (name == PropertyName.property_NodePath) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.property_NodePath);
+            return true;
+        }
+        else if (name == PropertyName.property_Rid) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.property_Rid);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotDictionary) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.property_GodotDictionary);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.property_GodotArray);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotGenericDictionary) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.property_GodotGenericDictionary);
+            return true;
+        }
+        else if (name == PropertyName.property_GodotGenericArray) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.property_GodotGenericArray);
+            return true;
+        }
+        else if (name == PropertyName._notGenerate_Property_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._notGenerate_Property_String);
+            return true;
+        }
+        else if (name == PropertyName._notGenerate_Property_Int) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this._notGenerate_Property_Int);
+            return true;
+        }
+        else if (name == PropertyName._fullProperty_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._fullProperty_String);
+            return true;
+        }
+        else if (name == PropertyName._fullProperty_String_Complex) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._fullProperty_String_Complex);
+            return true;
+        }
+        else if (name == PropertyName._lamdaProperty_String) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this._lamdaProperty_String);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName._notGenerate_Property_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.NotGenerate_Complex_Lamda_Property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.NotGenerate_Lamda_NoField_Property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.NotGenerate_Complex_Return_Property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName._notGenerate_Property_Int, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.NotGenerate_Returns_Property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName._fullProperty_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.FullProperty_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName._fullProperty_String_Complex, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.FullProperty_String_Complex, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName._lamdaProperty_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.LamdaProperty_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.property_Boolean, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_Char, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_SByte, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_Int16, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_Int32, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_Int64, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_Byte, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_UInt16, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_UInt32, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_UInt64, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.property_Single, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.property_Double, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.property_String, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)5, name: PropertyName.property_Vector2, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)6, name: PropertyName.property_Vector2I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)7, name: PropertyName.property_Rect2, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)8, name: PropertyName.property_Rect2I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)11, name: PropertyName.property_Transform2D, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)9, name: PropertyName.property_Vector3, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)10, name: PropertyName.property_Vector3I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)17, name: PropertyName.property_Basis, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)15, name: PropertyName.property_Quaternion, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)18, name: PropertyName.property_Transform3D, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)12, name: PropertyName.property_Vector4, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)13, name: PropertyName.property_Vector4I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)19, name: PropertyName.property_Projection, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)16, name: PropertyName.property_Aabb, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)20, name: PropertyName.property_Color, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)14, name: PropertyName.property_Plane, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)25, name: PropertyName.property_Callable, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)26, name: PropertyName.property_Signal, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_Enum, hint: (global::Godot.PropertyHint)2, hintString: "A,B,C", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.property_FlagsEnum, hint: (global::Godot.PropertyHint)6, hintString: "A:0,B:1,C:2", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)29, name: PropertyName.property_ByteArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)30, name: PropertyName.property_Int32Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)31, name: PropertyName.property_Int64Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)32, name: PropertyName.property_SingleArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)33, name: PropertyName.property_DoubleArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)34, name: PropertyName.property_StringArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)34, name: PropertyName.property_StringArrayEnum, hint: (global::Godot.PropertyHint)23, hintString: "4/2:A,B,C", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)35, name: PropertyName.property_Vector2Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)36, name: PropertyName.property_Vector3Array, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)37, name: PropertyName.property_ColorArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.property_GodotObjectOrDerivedArray, hint: (global::Godot.PropertyHint)23, hintString: "24/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_StringNameArray, hint: (global::Godot.PropertyHint)23, hintString: "21/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_NodePathArray, hint: (global::Godot.PropertyHint)23, hintString: "22/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.field_RidArray, hint: (global::Godot.PropertyHint)23, hintString: "23/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)0, name: PropertyName.property_Variant, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)135174, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.property_GodotObjectOrDerived, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.property_GodotResourceTexture, hint: (global::Godot.PropertyHint)17, hintString: "Texture", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)21, name: PropertyName.property_StringName, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)22, name: PropertyName.property_NodePath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)23, name: PropertyName.property_Rid, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)27, name: PropertyName.property_GodotDictionary, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.property_GodotArray, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)27, name: PropertyName.property_GodotGenericDictionary, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)28, name: PropertyName.property_GodotGenericArray, hint: (global::Godot.PropertyHint)23, hintString: "2/0:", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
@@ -1,0 +1,147 @@
+partial class ExportedProperties
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+#if TOOLS
+    /// <summary>
+    /// Get the default values for all properties declared in this class.
+    /// This method is used by Godot to determine the value that will be
+    /// used by the inspector when resetting properties.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
+    {
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(64);
+        string __NotGenerate_Complex_Lamda_Property_default_value = default;
+        values.Add(PropertyName.NotGenerate_Complex_Lamda_Property, global::Godot.Variant.From<string>(__NotGenerate_Complex_Lamda_Property_default_value));
+        string __NotGenerate_Lamda_NoField_Property_default_value = default;
+        values.Add(PropertyName.NotGenerate_Lamda_NoField_Property, global::Godot.Variant.From<string>(__NotGenerate_Lamda_NoField_Property_default_value));
+        string __NotGenerate_Complex_Return_Property_default_value = default;
+        values.Add(PropertyName.NotGenerate_Complex_Return_Property, global::Godot.Variant.From<string>(__NotGenerate_Complex_Return_Property_default_value));
+        string __NotGenerate_Returns_Property_default_value = default;
+        values.Add(PropertyName.NotGenerate_Returns_Property, global::Godot.Variant.From<string>(__NotGenerate_Returns_Property_default_value));
+        string __FullProperty_String_default_value = "FullProperty_String";
+        values.Add(PropertyName.FullProperty_String, global::Godot.Variant.From<string>(__FullProperty_String_default_value));
+        string __FullProperty_String_Complex_default_value = new string("FullProperty_String_Complex")   + global::System.Convert.ToInt32("1");
+        values.Add(PropertyName.FullProperty_String_Complex, global::Godot.Variant.From<string>(__FullProperty_String_Complex_default_value));
+        string __LamdaProperty_String_default_value = "LamdaProperty_String";
+        values.Add(PropertyName.LamdaProperty_String, global::Godot.Variant.From<string>(__LamdaProperty_String_default_value));
+        bool __property_Boolean_default_value = true;
+        values.Add(PropertyName.property_Boolean, global::Godot.Variant.From<bool>(__property_Boolean_default_value));
+        char __property_Char_default_value = 'f';
+        values.Add(PropertyName.property_Char, global::Godot.Variant.From<char>(__property_Char_default_value));
+        sbyte __property_SByte_default_value = 10;
+        values.Add(PropertyName.property_SByte, global::Godot.Variant.From<sbyte>(__property_SByte_default_value));
+        short __property_Int16_default_value = 10;
+        values.Add(PropertyName.property_Int16, global::Godot.Variant.From<short>(__property_Int16_default_value));
+        int __property_Int32_default_value = 10;
+        values.Add(PropertyName.property_Int32, global::Godot.Variant.From<int>(__property_Int32_default_value));
+        long __property_Int64_default_value = 10;
+        values.Add(PropertyName.property_Int64, global::Godot.Variant.From<long>(__property_Int64_default_value));
+        byte __property_Byte_default_value = 10;
+        values.Add(PropertyName.property_Byte, global::Godot.Variant.From<byte>(__property_Byte_default_value));
+        ushort __property_UInt16_default_value = 10;
+        values.Add(PropertyName.property_UInt16, global::Godot.Variant.From<ushort>(__property_UInt16_default_value));
+        uint __property_UInt32_default_value = 10;
+        values.Add(PropertyName.property_UInt32, global::Godot.Variant.From<uint>(__property_UInt32_default_value));
+        ulong __property_UInt64_default_value = 10;
+        values.Add(PropertyName.property_UInt64, global::Godot.Variant.From<ulong>(__property_UInt64_default_value));
+        float __property_Single_default_value = 10;
+        values.Add(PropertyName.property_Single, global::Godot.Variant.From<float>(__property_Single_default_value));
+        double __property_Double_default_value = 10;
+        values.Add(PropertyName.property_Double, global::Godot.Variant.From<double>(__property_Double_default_value));
+        string __property_String_default_value = "foo";
+        values.Add(PropertyName.property_String, global::Godot.Variant.From<string>(__property_String_default_value));
+        global::Godot.Vector2 __property_Vector2_default_value = new(10f, 10f);
+        values.Add(PropertyName.property_Vector2, global::Godot.Variant.From<global::Godot.Vector2>(__property_Vector2_default_value));
+        global::Godot.Vector2I __property_Vector2I_default_value = global::Godot.Vector2I.Up;
+        values.Add(PropertyName.property_Vector2I, global::Godot.Variant.From<global::Godot.Vector2I>(__property_Vector2I_default_value));
+        global::Godot.Rect2 __property_Rect2_default_value = new(new global::Godot.Vector2(10f, 10f), new global::Godot.Vector2(10f, 10f));
+        values.Add(PropertyName.property_Rect2, global::Godot.Variant.From<global::Godot.Rect2>(__property_Rect2_default_value));
+        global::Godot.Rect2I __property_Rect2I_default_value = new(new global::Godot.Vector2I(10, 10), new global::Godot.Vector2I(10, 10));
+        values.Add(PropertyName.property_Rect2I, global::Godot.Variant.From<global::Godot.Rect2I>(__property_Rect2I_default_value));
+        global::Godot.Transform2D __property_Transform2D_default_value = global::Godot.Transform2D.Identity;
+        values.Add(PropertyName.property_Transform2D, global::Godot.Variant.From<global::Godot.Transform2D>(__property_Transform2D_default_value));
+        global::Godot.Vector3 __property_Vector3_default_value = new(10f, 10f, 10f);
+        values.Add(PropertyName.property_Vector3, global::Godot.Variant.From<global::Godot.Vector3>(__property_Vector3_default_value));
+        global::Godot.Vector3I __property_Vector3I_default_value = global::Godot.Vector3I.Back;
+        values.Add(PropertyName.property_Vector3I, global::Godot.Variant.From<global::Godot.Vector3I>(__property_Vector3I_default_value));
+        global::Godot.Basis __property_Basis_default_value = new global::Godot.Basis(global::Godot.Quaternion.Identity);
+        values.Add(PropertyName.property_Basis, global::Godot.Variant.From<global::Godot.Basis>(__property_Basis_default_value));
+        global::Godot.Quaternion __property_Quaternion_default_value = new global::Godot.Quaternion(global::Godot.Basis.Identity);
+        values.Add(PropertyName.property_Quaternion, global::Godot.Variant.From<global::Godot.Quaternion>(__property_Quaternion_default_value));
+        global::Godot.Transform3D __property_Transform3D_default_value = global::Godot.Transform3D.Identity;
+        values.Add(PropertyName.property_Transform3D, global::Godot.Variant.From<global::Godot.Transform3D>(__property_Transform3D_default_value));
+        global::Godot.Vector4 __property_Vector4_default_value = new(10f, 10f, 10f, 10f);
+        values.Add(PropertyName.property_Vector4, global::Godot.Variant.From<global::Godot.Vector4>(__property_Vector4_default_value));
+        global::Godot.Vector4I __property_Vector4I_default_value = global::Godot.Vector4I.One;
+        values.Add(PropertyName.property_Vector4I, global::Godot.Variant.From<global::Godot.Vector4I>(__property_Vector4I_default_value));
+        global::Godot.Projection __property_Projection_default_value = global::Godot.Projection.Identity;
+        values.Add(PropertyName.property_Projection, global::Godot.Variant.From<global::Godot.Projection>(__property_Projection_default_value));
+        global::Godot.Aabb __property_Aabb_default_value = new global::Godot.Aabb(10f, 10f, 10f, new global::Godot.Vector3(1f, 1f, 1f));
+        values.Add(PropertyName.property_Aabb, global::Godot.Variant.From<global::Godot.Aabb>(__property_Aabb_default_value));
+        global::Godot.Color __property_Color_default_value = global::Godot.Colors.Aquamarine;
+        values.Add(PropertyName.property_Color, global::Godot.Variant.From<global::Godot.Color>(__property_Color_default_value));
+        global::Godot.Plane __property_Plane_default_value = global::Godot.Plane.PlaneXZ;
+        values.Add(PropertyName.property_Plane, global::Godot.Variant.From<global::Godot.Plane>(__property_Plane_default_value));
+        global::Godot.Callable __property_Callable_default_value = new global::Godot.Callable(global::Godot.Engine.GetMainLoop(), "_process");
+        values.Add(PropertyName.property_Callable, global::Godot.Variant.From<global::Godot.Callable>(__property_Callable_default_value));
+        global::Godot.Signal __property_Signal_default_value = new global::Godot.Signal(global::Godot.Engine.GetMainLoop(), "property_list_changed");
+        values.Add(PropertyName.property_Signal, global::Godot.Variant.From<global::Godot.Signal>(__property_Signal_default_value));
+        global::ExportedProperties.MyEnum __property_Enum_default_value = global::ExportedProperties.MyEnum.C;
+        values.Add(PropertyName.property_Enum, global::Godot.Variant.From<global::ExportedProperties.MyEnum>(__property_Enum_default_value));
+        global::ExportedProperties.MyFlagsEnum __property_FlagsEnum_default_value = global::ExportedProperties.MyFlagsEnum.C;
+        values.Add(PropertyName.property_FlagsEnum, global::Godot.Variant.From<global::ExportedProperties.MyFlagsEnum>(__property_FlagsEnum_default_value));
+        byte[] __property_ByteArray_default_value = { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.property_ByteArray, global::Godot.Variant.From<byte[]>(__property_ByteArray_default_value));
+        int[] __property_Int32Array_default_value = { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.property_Int32Array, global::Godot.Variant.From<int[]>(__property_Int32Array_default_value));
+        long[] __property_Int64Array_default_value = { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.property_Int64Array, global::Godot.Variant.From<long[]>(__property_Int64Array_default_value));
+        float[] __property_SingleArray_default_value = { 0f, 1f, 2f, 3f, 4f, 5f, 6f  };
+        values.Add(PropertyName.property_SingleArray, global::Godot.Variant.From<float[]>(__property_SingleArray_default_value));
+        double[] __property_DoubleArray_default_value = { 0d, 1d, 2d, 3d, 4d, 5d, 6d  };
+        values.Add(PropertyName.property_DoubleArray, global::Godot.Variant.From<double[]>(__property_DoubleArray_default_value));
+        string[] __property_StringArray_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.property_StringArray, global::Godot.Variant.From<string[]>(__property_StringArray_default_value));
+        string[] __property_StringArrayEnum_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.property_StringArrayEnum, global::Godot.Variant.From<string[]>(__property_StringArrayEnum_default_value));
+        global::Godot.Vector2[] __property_Vector2Array_default_value = { global::Godot.Vector2.Up, global::Godot.Vector2.Down, global::Godot.Vector2.Left, global::Godot.Vector2.Right   };
+        values.Add(PropertyName.property_Vector2Array, global::Godot.Variant.From<global::Godot.Vector2[]>(__property_Vector2Array_default_value));
+        global::Godot.Vector3[] __property_Vector3Array_default_value = { global::Godot.Vector3.Up, global::Godot.Vector3.Down, global::Godot.Vector3.Left, global::Godot.Vector3.Right   };
+        values.Add(PropertyName.property_Vector3Array, global::Godot.Variant.From<global::Godot.Vector3[]>(__property_Vector3Array_default_value));
+        global::Godot.Color[] __property_ColorArray_default_value = { global::Godot.Colors.Aqua, global::Godot.Colors.Aquamarine, global::Godot.Colors.Azure, global::Godot.Colors.Beige   };
+        values.Add(PropertyName.property_ColorArray, global::Godot.Variant.From<global::Godot.Color[]>(__property_ColorArray_default_value));
+        global::Godot.GodotObject[] __property_GodotObjectOrDerivedArray_default_value = { null  };
+        values.Add(PropertyName.property_GodotObjectOrDerivedArray, global::Godot.Variant.CreateFrom(__property_GodotObjectOrDerivedArray_default_value));
+        global::Godot.StringName[] __field_StringNameArray_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.field_StringNameArray, global::Godot.Variant.From<global::Godot.StringName[]>(__field_StringNameArray_default_value));
+        global::Godot.NodePath[] __field_NodePathArray_default_value = { "foo", "bar"  };
+        values.Add(PropertyName.field_NodePathArray, global::Godot.Variant.From<global::Godot.NodePath[]>(__field_NodePathArray_default_value));
+        global::Godot.Rid[] __field_RidArray_default_value = { default, default, default  };
+        values.Add(PropertyName.field_RidArray, global::Godot.Variant.From<global::Godot.Rid[]>(__field_RidArray_default_value));
+        global::Godot.Variant __property_Variant_default_value = "foo";
+        values.Add(PropertyName.property_Variant, global::Godot.Variant.From<global::Godot.Variant>(__property_Variant_default_value));
+        global::Godot.GodotObject __property_GodotObjectOrDerived_default_value = default;
+        values.Add(PropertyName.property_GodotObjectOrDerived, global::Godot.Variant.From<global::Godot.GodotObject>(__property_GodotObjectOrDerived_default_value));
+        global::Godot.Texture __property_GodotResourceTexture_default_value = default;
+        values.Add(PropertyName.property_GodotResourceTexture, global::Godot.Variant.From<global::Godot.Texture>(__property_GodotResourceTexture_default_value));
+        global::Godot.StringName __property_StringName_default_value = new global::Godot.StringName("foo");
+        values.Add(PropertyName.property_StringName, global::Godot.Variant.From<global::Godot.StringName>(__property_StringName_default_value));
+        global::Godot.NodePath __property_NodePath_default_value = new global::Godot.NodePath("foo");
+        values.Add(PropertyName.property_NodePath, global::Godot.Variant.From<global::Godot.NodePath>(__property_NodePath_default_value));
+        global::Godot.Rid __property_Rid_default_value = default;
+        values.Add(PropertyName.property_Rid, global::Godot.Variant.From<global::Godot.Rid>(__property_Rid_default_value));
+        global::Godot.Collections.Dictionary __property_GodotDictionary_default_value = new()  { { "foo", 10  }, { global::Godot.Vector2.Up, global::Godot.Colors.Chocolate   }  };
+        values.Add(PropertyName.property_GodotDictionary, global::Godot.Variant.From<global::Godot.Collections.Dictionary>(__property_GodotDictionary_default_value));
+        global::Godot.Collections.Array __property_GodotArray_default_value = new()  { "foo", 10, global::Godot.Vector2.Up, global::Godot.Colors.Chocolate   };
+        values.Add(PropertyName.property_GodotArray, global::Godot.Variant.From<global::Godot.Collections.Array>(__property_GodotArray_default_value));
+        global::Godot.Collections.Dictionary<string, bool> __property_GodotGenericDictionary_default_value = new()  { { "foo", true  }, { "bar", false  }  };
+        values.Add(PropertyName.property_GodotGenericDictionary, global::Godot.Variant.CreateFrom(__property_GodotGenericDictionary_default_value));
+        global::Godot.Collections.Array<int> __property_GodotGenericArray_default_value = new()  { 0, 1, 2, 3, 4, 5, 6  };
+        values.Add(PropertyName.property_GodotGenericArray, global::Godot.Variant.CreateFrom(__property_GodotGenericArray_default_value));
+        return values;
+    }
+#endif // TOOLS
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Foo_ScriptPath.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Foo_ScriptPath.generated.cs
@@ -1,0 +1,5 @@
+using Godot;
+[ScriptPathAttribute("res://Foo.cs")]
+partial class Foo
+{
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Generic_ScriptPath.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Generic_ScriptPath.generated.cs
@@ -1,0 +1,5 @@
+using Godot;
+[ScriptPathAttribute("res://Generic.cs")]
+partial class Generic
+{
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
@@ -1,0 +1,61 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class Methods
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the methods contained in this class, for fast lookup.
+    /// </summary>
+    public new class MethodName : global::Godot.GodotObject.MethodName {
+        /// <summary>
+        /// Cached name for the 'MethodWithOverload' method.
+        /// </summary>
+        public new static readonly global::Godot.StringName MethodWithOverload = "MethodWithOverload";
+    }
+    /// <summary>
+    /// Get the method information for all the methods declared in this class.
+    /// This method is used by Godot to register the available methods in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GetGodotMethodList()
+    {
+        var methods = new global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>(3);
+        methods.Add(new(name: MethodName.MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: null, defaultArguments: null));
+        methods.Add(new(name: MethodName.MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)2, name: "a", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        methods.Add(new(name: MethodName.MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)2, name: "a", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), new(type: (global::Godot.Variant.Type)2, name: "b", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        return methods;
+    }
+#pragma warning restore CS0109
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
+    {
+        if (method == MethodName.MethodWithOverload && args.Count == 0) {
+            MethodWithOverload();
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.MethodWithOverload && args.Count == 1) {
+            MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]));
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.MethodWithOverload && args.Count == 2) {
+            MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
+            ret = default;
+            return true;
+        }
+        return base.InvokeGodotClassMethod(method, args, out ret);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool HasGodotClassMethod(in godot_string_name method)
+    {
+        if (method == MethodName.MethodWithOverload) {
+           return true;
+        }
+        return base.HasGodotClassMethod(method);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/MixedReadOnlyWriteOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/MixedReadOnlyWriteOnly_ScriptProperties.generated.cs
@@ -1,0 +1,94 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class MixedReadOnlyWriteOnly
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.GodotObject.PropertyName {
+        /// <summary>
+        /// Cached name for the 'readonly_auto_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName readonly_auto_property = "readonly_auto_property";
+        /// <summary>
+        /// Cached name for the 'readonly_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName readonly_property = "readonly_property";
+        /// <summary>
+        /// Cached name for the 'initonly_auto_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName initonly_auto_property = "initonly_auto_property";
+        /// <summary>
+        /// Cached name for the 'writeonly_property' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName writeonly_property = "writeonly_property";
+        /// <summary>
+        /// Cached name for the 'readonly_field' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName readonly_field = "readonly_field";
+        /// <summary>
+        /// Cached name for the 'writeonly_backing_field' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName writeonly_backing_field = "writeonly_backing_field";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.writeonly_property) {
+            this.writeonly_property = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        else if (name == PropertyName.writeonly_backing_field) {
+            this.writeonly_backing_field = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.readonly_auto_property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.readonly_auto_property);
+            return true;
+        }
+        else if (name == PropertyName.readonly_property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.readonly_property);
+            return true;
+        }
+        else if (name == PropertyName.initonly_auto_property) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.initonly_auto_property);
+            return true;
+        }
+        else if (name == PropertyName.readonly_field) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.readonly_field);
+            return true;
+        }
+        else if (name == PropertyName.writeonly_backing_field) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.writeonly_backing_field);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.readonly_field, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.readonly_auto_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.readonly_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.initonly_auto_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.writeonly_backing_field, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.writeonly_property, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptMethods.generated.cs
@@ -1,0 +1,52 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial struct OuterClass
+{
+partial class NestedClass
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the methods contained in this class, for fast lookup.
+    /// </summary>
+    public new class MethodName : global::Godot.RefCounted.MethodName {
+        /// <summary>
+        /// Cached name for the '_Get' method.
+        /// </summary>
+        public new static readonly global::Godot.StringName _Get = "_Get";
+    }
+    /// <summary>
+    /// Get the method information for all the methods declared in this class.
+    /// This method is used by Godot to register the available methods in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GetGodotMethodList()
+    {
+        var methods = new global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>(1);
+        methods.Add(new(name: MethodName._Get, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)131078, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)21, name: "property", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        return methods;
+    }
+#pragma warning restore CS0109
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
+    {
+        if (method == MethodName._Get && args.Count == 1) {
+            var callRet = _Get(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
+            ret = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(callRet);
+            return true;
+        }
+        return base.InvokeGodotClassMethod(method, args, out ret);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool HasGodotClassMethod(in godot_string_name method)
+    {
+        if (method == MethodName._Get) {
+           return true;
+        }
+        return base.HasGodotClassMethod(method);
+    }
+}
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptProperties.generated.cs
@@ -1,0 +1,15 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial struct OuterClass
+{
+partial class NestedClass
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.RefCounted.PropertyName {
+    }
+}
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptSerialization.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptSerialization.generated.cs
@@ -1,0 +1,21 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial struct OuterClass
+{
+partial class NestedClass
+{
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override void SaveGodotObjectData(global::Godot.Bridge.GodotSerializationInfo info)
+    {
+        base.SaveGodotObjectData(info);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override void RestoreGodotObjectData(global::Godot.Bridge.GodotSerializationInfo info)
+    {
+        base.RestoreGodotObjectData(info);
+    }
+}
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
@@ -1,0 +1,62 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ScriptBoilerplate
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the methods contained in this class, for fast lookup.
+    /// </summary>
+    public new class MethodName : global::Godot.Node.MethodName {
+        /// <summary>
+        /// Cached name for the '_Process' method.
+        /// </summary>
+        public new static readonly global::Godot.StringName _Process = "_Process";
+        /// <summary>
+        /// Cached name for the 'Bazz' method.
+        /// </summary>
+        public new static readonly global::Godot.StringName Bazz = "Bazz";
+    }
+    /// <summary>
+    /// Get the method information for all the methods declared in this class.
+    /// This method is used by Godot to register the available methods in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GetGodotMethodList()
+    {
+        var methods = new global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>(2);
+        methods.Add(new(name: MethodName._Process, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)3, name: "delta", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        methods.Add(new(name: MethodName.Bazz, returnVal: new(type: (global::Godot.Variant.Type)2, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)21, name: "name", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        return methods;
+    }
+#pragma warning restore CS0109
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
+    {
+        if (method == MethodName._Process && args.Count == 1) {
+            _Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.Bazz && args.Count == 1) {
+            var callRet = Bazz(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
+            ret = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(callRet);
+            return true;
+        }
+        return base.InvokeGodotClassMethod(method, args, out ret);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool HasGodotClassMethod(in godot_string_name method)
+    {
+        if (method == MethodName._Process) {
+           return true;
+        }
+        else if (method == MethodName.Bazz) {
+           return true;
+        }
+        return base.HasGodotClassMethod(method);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptPath.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptPath.generated.cs
@@ -1,0 +1,5 @@
+using Godot;
+[ScriptPathAttribute("res://ScriptBoilerplate.cs")]
+partial class ScriptBoilerplate
+{
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptProperties.generated.cs
@@ -1,0 +1,62 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ScriptBoilerplate
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.Node.PropertyName {
+        /// <summary>
+        /// Cached name for the '_nodePath' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _nodePath = "_nodePath";
+        /// <summary>
+        /// Cached name for the '_velocity' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName _velocity = "_velocity";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName._nodePath) {
+            this._nodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            return true;
+        }
+        else if (name == PropertyName._velocity) {
+            this._velocity = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName._nodePath) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this._nodePath);
+            return true;
+        }
+        else if (name == PropertyName._velocity) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this._velocity);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)22, name: PropertyName._nodePath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName._velocity, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptSerialization.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptSerialization.generated.cs
@@ -1,0 +1,24 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ScriptBoilerplate
+{
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override void SaveGodotObjectData(global::Godot.Bridge.GodotSerializationInfo info)
+    {
+        base.SaveGodotObjectData(info);
+        info.AddProperty(PropertyName._nodePath, global::Godot.Variant.From<global::Godot.NodePath>(this._nodePath));
+        info.AddProperty(PropertyName._velocity, global::Godot.Variant.From<int>(this._velocity));
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override void RestoreGodotObjectData(global::Godot.Bridge.GodotSerializationInfo info)
+    {
+        base.RestoreGodotObjectData(info);
+        if (info.TryGetProperty(PropertyName._nodePath, out var _value__nodePath))
+            this._nodePath = _value__nodePath.As<global::Godot.NodePath>();
+        if (info.TryGetProperty(PropertyName._velocity, out var _value__velocity))
+            this._velocity = _value__velocity.As<int>();
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/AllReadOnly.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/AllReadOnly.cs
@@ -1,0 +1,9 @@
+using Godot;
+
+public partial class AllReadOnly : GodotObject
+{
+    public readonly string readonly_field = "foo";
+    public string readonly_auto_property { get; } = "foo";
+    public string readonly_property { get => "foo"; }
+    public string initonly_auto_property { get; init; }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/AllWriteOnly.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/AllWriteOnly.cs
@@ -1,0 +1,7 @@
+using Godot;
+
+public partial class AllWriteOnly : GodotObject
+{
+    bool writeonly_backing_field = false;
+    public bool writeonly_property { set => writeonly_backing_field = value; }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Bar.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Bar.cs
@@ -1,0 +1,14 @@
+using Godot;
+
+partial class Bar : GodotObject
+{
+}
+
+// Foo in another file
+partial class Foo
+{
+}
+
+partial class NotSameNameAsFile : GodotObject
+{
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/EventSignals.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/EventSignals.cs
@@ -1,0 +1,7 @@
+using Godot;
+
+public partial class EventSignals : GodotObject
+{
+    [Signal]
+    public delegate void MySignalEventHandler(string str, int num);
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
@@ -1,0 +1,102 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+public partial class ExportedFields : GodotObject
+{
+    [Export] private Boolean field_Boolean = true;
+    [Export] private Char field_Char = 'f';
+    [Export] private SByte field_SByte = 10;
+    [Export] private Int16 field_Int16 = 10;
+    [Export] private Int32 field_Int32 = 10;
+    [Export] private Int64 field_Int64 = 10;
+    [Export] private Byte field_Byte = 10;
+    [Export] private UInt16 field_UInt16 = 10;
+    [Export] private UInt32 field_UInt32 = 10;
+    [Export] private UInt64 field_UInt64 = 10;
+    [Export] private Single field_Single = 10;
+    [Export] private Double field_Double = 10;
+    [Export] private String field_String = "foo";
+
+    // Godot structs
+    [Export] private Vector2 field_Vector2 = new(10f, 10f);
+    [Export] private Vector2I field_Vector2I = Vector2I.Up;
+    [Export] private Rect2 field_Rect2 = new(new Vector2(10f, 10f), new Vector2(10f, 10f));
+    [Export] private Rect2I field_Rect2I = new(new Vector2I(10, 10), new Vector2I(10, 10));
+    [Export] private Transform2D field_Transform2D = Transform2D.Identity;
+    [Export] private Vector3 field_Vector3 = new(10f, 10f, 10f);
+    [Export] private Vector3I field_Vector3I = Vector3I.Back;
+    [Export] private Basis field_Basis = new Basis(Quaternion.Identity);
+    [Export] private Quaternion field_Quaternion = new Quaternion(Basis.Identity);
+    [Export] private Transform3D field_Transform3D = Transform3D.Identity;
+    [Export] private Vector4 field_Vector4 = new(10f, 10f, 10f, 10f);
+    [Export] private Vector4I field_Vector4I = Vector4I.One;
+    [Export] private Projection field_Projection = Projection.Identity;
+    [Export] private Aabb field_Aabb = new Aabb(10f, 10f, 10f, new Vector3(1f, 1f, 1f));
+    [Export] private Color field_Color = Colors.Aquamarine;
+    [Export] private Plane field_Plane = Plane.PlaneXZ;
+    [Export] private Callable field_Callable = new Callable(Engine.GetMainLoop(), "_process");
+    [Export] private Signal field_Signal = new Signal(Engine.GetMainLoop(), "property_list_changed");
+
+    // Enums
+    enum MyEnum
+    {
+        A,
+        B,
+        C
+    }
+
+    [Export] private MyEnum field_Enum = MyEnum.C;
+
+    [Flags]
+    enum MyFlagsEnum
+    {
+        A,
+        B,
+        C
+    }
+
+    [Export] private MyFlagsEnum field_FlagsEnum = MyFlagsEnum.C;
+
+    // Arrays
+    [Export] private Byte[] field_ByteArray = { 0, 1, 2, 3, 4, 5, 6 };
+    [Export] private Int32[] field_Int32Array = { 0, 1, 2, 3, 4, 5, 6 };
+    [Export] private Int64[] field_Int64Array = { 0, 1, 2, 3, 4, 5, 6 };
+    [Export] private Single[] field_SingleArray = { 0f, 1f, 2f, 3f, 4f, 5f, 6f };
+    [Export] private Double[] field_DoubleArray = { 0d, 1d, 2d, 3d, 4d, 5d, 6d };
+    [Export] private String[] field_StringArray = { "foo", "bar" };
+    [Export(PropertyHint.Enum, "A,B,C")] private String[] field_StringArrayEnum = { "foo", "bar" };
+    [Export] private Vector2[] field_Vector2Array = { Vector2.Up, Vector2.Down, Vector2.Left, Vector2.Right };
+    [Export] private Vector3[] field_Vector3Array = { Vector3.Up, Vector3.Down, Vector3.Left, Vector3.Right };
+    [Export] private Color[] field_ColorArray = { Colors.Aqua, Colors.Aquamarine, Colors.Azure, Colors.Beige };
+    [Export] private GodotObject[] field_GodotObjectOrDerivedArray = { null };
+    [Export] private StringName[] field_StringNameArray = { "foo", "bar" };
+    [Export] private NodePath[] field_NodePathArray = { "foo", "bar" };
+    [Export] private Rid[] field_RidArray = { default, default, default };
+    // Note we use Array and not System.Array. This tests the generated namespace qualification.
+    [Export] private Int32[] field_empty_Int32Array = Array.Empty<Int32>();
+    // Note we use List and not System.Collections.Generic.
+    [Export] private int[] field_array_from_list = new List<int>(Array.Empty<int>()).ToArray();
+
+    // Variant
+    [Export] private Variant field_Variant = "foo";
+
+    // Classes
+    [Export] private GodotObject field_GodotObjectOrDerived;
+    [Export] private Godot.Texture field_GodotResourceTexture;
+    [Export] private StringName field_StringName = new StringName("foo");
+    [Export] private NodePath field_NodePath = new NodePath("foo");
+    [Export] private Rid field_Rid;
+
+    [Export]
+    private Godot.Collections.Dictionary field_GodotDictionary = new() { { "foo", 10 }, { Vector2.Up, Colors.Chocolate } };
+
+    [Export]
+    private Godot.Collections.Array field_GodotArray = new() { "foo", 10, Vector2.Up, Colors.Chocolate };
+
+    [Export]
+    private Godot.Collections.Dictionary<string, bool> field_GodotGenericDictionary = new() { { "foo", true }, { "bar", false } };
+
+    [Export]
+    private Godot.Collections.Array<int> field_GodotGenericArray = new() { 0, 1, 2, 3, 4, 5, 6 };
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
@@ -1,0 +1,186 @@
+using Godot;
+using System;
+
+public partial class ExportedProperties : GodotObject
+{
+    // Do not generate default value
+    private String _notGenerate_Property_String = new string("not generate");
+    [Export]
+    public String NotGenerate_Complex_Lamda_Property
+    {
+        get => _notGenerate_Property_String + Convert.ToInt32("1");
+        set => _notGenerate_Property_String = value;
+    }
+
+    [Export]
+    public String NotGenerate_Lamda_NoField_Property
+    {
+        get => new string("not generate");
+        set => _notGenerate_Property_String = value;
+    }
+
+    [Export]
+    public String NotGenerate_Complex_Return_Property
+    {
+        get
+        {
+            return _notGenerate_Property_String + Convert.ToInt32("1");
+        }
+        set
+        {
+            _notGenerate_Property_String = value;
+        }
+    }
+
+    private int _notGenerate_Property_Int = 1;
+    [Export]
+    public string NotGenerate_Returns_Property
+    {
+        get
+        {
+            if (_notGenerate_Property_Int == 1)
+            {
+                return "a";
+            }
+            else
+            {
+                return "b";
+            }
+        }
+        set
+        {
+            _notGenerate_Property_Int = value == "a" ? 1 : 2;
+        }
+    }
+
+    // Full Property
+    private String _fullProperty_String = "FullProperty_String";
+    [Export]
+    public String FullProperty_String
+    {
+        get
+        {
+            return _fullProperty_String;
+        }
+        set
+        {
+            _fullProperty_String = value;
+        }
+    }
+
+    private String _fullProperty_String_Complex = new string("FullProperty_String_Complex") + Convert.ToInt32("1");
+    [Export]
+    public String FullProperty_String_Complex
+    {
+        get
+        {
+            return _fullProperty_String_Complex;
+        }
+        set
+        {
+            _fullProperty_String_Complex = value;
+        }
+    }
+
+    // Lambda Property
+    private String _lamdaProperty_String = "LamdaProperty_String";
+    [Export]
+    public String LamdaProperty_String
+    {
+        get => _lamdaProperty_String;
+        set => _lamdaProperty_String = value;
+    }
+
+    // Auto Property
+    [Export] private Boolean property_Boolean { get; set; } = true;
+    [Export] private Char property_Char { get; set; } = 'f';
+    [Export] private SByte property_SByte { get; set; } = 10;
+    [Export] private Int16 property_Int16 { get; set; } = 10;
+    [Export] private Int32 property_Int32 { get; set; } = 10;
+    [Export] private Int64 property_Int64 { get; set; } = 10;
+    [Export] private Byte property_Byte { get; set; } = 10;
+    [Export] private UInt16 property_UInt16 { get; set; } = 10;
+    [Export] private UInt32 property_UInt32 { get; set; } = 10;
+    [Export] private UInt64 property_UInt64 { get; set; } = 10;
+    [Export] private Single property_Single { get; set; } = 10;
+    [Export] private Double property_Double { get; set; } = 10;
+    [Export] private String property_String { get; set; } = "foo";
+
+    // Godot structs
+    [Export] private Vector2 property_Vector2 { get; set; } = new(10f, 10f);
+    [Export] private Vector2I property_Vector2I { get; set; } = Vector2I.Up;
+    [Export] private Rect2 property_Rect2 { get; set; } = new(new Vector2(10f, 10f), new Vector2(10f, 10f));
+    [Export] private Rect2I property_Rect2I { get; set; } = new(new Vector2I(10, 10), new Vector2I(10, 10));
+    [Export] private Transform2D property_Transform2D { get; set; } = Transform2D.Identity;
+    [Export] private Vector3 property_Vector3 { get; set; } = new(10f, 10f, 10f);
+    [Export] private Vector3I property_Vector3I { get; set; } = Vector3I.Back;
+    [Export] private Basis property_Basis { get; set; } = new Basis(Quaternion.Identity);
+    [Export] private Quaternion property_Quaternion { get; set; } = new Quaternion(Basis.Identity);
+    [Export] private Transform3D property_Transform3D { get; set; } = Transform3D.Identity;
+    [Export] private Vector4 property_Vector4 { get; set; } = new(10f, 10f, 10f, 10f);
+    [Export] private Vector4I property_Vector4I { get; set; } = Vector4I.One;
+    [Export] private Projection property_Projection { get; set; } = Projection.Identity;
+    [Export] private Aabb property_Aabb { get; set; } = new Aabb(10f, 10f, 10f, new Vector3(1f, 1f, 1f));
+    [Export] private Color property_Color { get; set; } = Colors.Aquamarine;
+    [Export] private Plane property_Plane { get; set; } = Plane.PlaneXZ;
+    [Export] private Callable property_Callable { get; set; } = new Callable(Engine.GetMainLoop(), "_process");
+    [Export] private Signal property_Signal { get; set; } = new Signal(Engine.GetMainLoop(), "property_list_changed");
+
+    // Enums
+    enum MyEnum
+    {
+        A,
+        B,
+        C
+    }
+
+    [Export] private MyEnum property_Enum { get; set; } = MyEnum.C;
+
+    [Flags]
+    enum MyFlagsEnum
+    {
+        A,
+        B,
+        C
+    }
+
+    [Export] private MyFlagsEnum property_FlagsEnum { get; set; } = MyFlagsEnum.C;
+
+    // Arrays
+    [Export] private Byte[] property_ByteArray { get; set; } = { 0, 1, 2, 3, 4, 5, 6 };
+    [Export] private Int32[] property_Int32Array { get; set; } = { 0, 1, 2, 3, 4, 5, 6 };
+    [Export] private Int64[] property_Int64Array { get; set; } = { 0, 1, 2, 3, 4, 5, 6 };
+    [Export] private Single[] property_SingleArray { get; set; } = { 0f, 1f, 2f, 3f, 4f, 5f, 6f };
+    [Export] private Double[] property_DoubleArray { get; set; } = { 0d, 1d, 2d, 3d, 4d, 5d, 6d };
+    [Export] private String[] property_StringArray { get; set; } = { "foo", "bar" };
+    [Export(PropertyHint.Enum, "A,B,C")] private String[] property_StringArrayEnum { get; set; } = { "foo", "bar" };
+    [Export] private Vector2[] property_Vector2Array { get; set; } = { Vector2.Up, Vector2.Down, Vector2.Left, Vector2.Right };
+    [Export] private Vector3[] property_Vector3Array { get; set; } = { Vector3.Up, Vector3.Down, Vector3.Left, Vector3.Right };
+    [Export] private Color[] property_ColorArray { get; set; } = { Colors.Aqua, Colors.Aquamarine, Colors.Azure, Colors.Beige };
+    [Export] private GodotObject[] property_GodotObjectOrDerivedArray { get; set; } = { null };
+    [Export] private StringName[] field_StringNameArray { get; set; } = { "foo", "bar" };
+    [Export] private NodePath[] field_NodePathArray { get; set; } = { "foo", "bar" };
+    [Export] private Rid[] field_RidArray { get; set; } = { default, default, default };
+
+    // Variant
+    [Export] private Variant property_Variant { get; set; } = "foo";
+
+    // Classes
+    [Export] private GodotObject property_GodotObjectOrDerived { get; set; }
+    [Export] private Godot.Texture property_GodotResourceTexture { get; set; }
+    [Export] private StringName property_StringName { get; set; } = new StringName("foo");
+    [Export] private NodePath property_NodePath { get; set; } = new NodePath("foo");
+    [Export] private Rid property_Rid { get; set; }
+
+    [Export]
+    private Godot.Collections.Dictionary property_GodotDictionary { get; set; } = new() { { "foo", 10 }, { Vector2.Up, Colors.Chocolate } };
+
+    [Export]
+    private Godot.Collections.Array property_GodotArray { get; set; } = new() { "foo", 10, Vector2.Up, Colors.Chocolate };
+
+    [Export]
+    private Godot.Collections.Dictionary<string, bool> property_GodotGenericDictionary { get; set; } = new() { { "foo", true }, { "bar", false } };
+
+    [Export]
+    private Godot.Collections.Array<int> property_GodotGenericArray { get; set; } = new() { 0, 1, 2, 3, 4, 5, 6 };
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Foo.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Foo.cs
@@ -1,0 +1,10 @@
+using Godot;
+
+partial class Foo : GodotObject
+{
+}
+
+// Foo again in the same file
+partial class Foo
+{
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Generic.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Generic.cs
@@ -1,0 +1,18 @@
+using Godot;
+
+partial class Generic<T> : GodotObject
+{
+    private int _field;
+}
+
+// Generic again but different generic parameters
+partial class Generic<T, R> : GodotObject
+{
+    private int _field;
+}
+
+// Generic again but without generic parameters
+partial class Generic : GodotObject
+{
+    private int _field;
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Methods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Methods.cs
@@ -1,0 +1,26 @@
+using Godot;
+
+public partial class Methods : GodotObject
+{
+    private void MethodWithOverload()
+    {
+    }
+
+    private void MethodWithOverload(int a)
+    {
+    }
+
+    private void MethodWithOverload(int a, int b)
+    {
+    }
+
+    // Should be ignored. The previous one is picked.
+    private void MethodWithOverload(float a, float b)
+    {
+    }
+
+    // Generic methods should be ignored.
+    private void GenericMethod<T>(T t)
+    {
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/MixedReadOnlyWriteOnly.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/MixedReadOnlyWriteOnly.cs
@@ -1,0 +1,12 @@
+using Godot;
+
+public partial class MixedReadOnlyWriteOnly : GodotObject
+{
+    public readonly string readonly_field = "foo";
+    public string readonly_auto_property { get; } = "foo";
+    public string readonly_property { get => "foo"; }
+    public string initonly_auto_property { get; init; }
+
+    bool writeonly_backing_field = false;
+    public bool writeonly_property { set => writeonly_backing_field = value; }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/MoreExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/MoreExportedFields.cs
@@ -1,0 +1,8 @@
+using Godot;
+using System;
+
+public partial class ExportedFields : GodotObject
+{
+    // Note we use Array and not System.Array. This tests the generated namespace qualification.
+    [Export] private Int64[] field_empty_Int64Array = Array.Empty<Int64>();
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ScriptBoilerplate.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ScriptBoilerplate.cs
@@ -1,0 +1,33 @@
+using Godot;
+
+public partial class ScriptBoilerplate : Node
+{
+    private NodePath _nodePath;
+    private int _velocity;
+
+    public override void _Process(double delta)
+    {
+        _ = delta;
+
+        base._Process(delta);
+    }
+
+    public int Bazz(StringName name)
+    {
+        _ = name;
+        return 1;
+    }
+
+    public void IgnoreThisMethodWithByRefParams(ref int a)
+    {
+        _ = a;
+    }
+}
+
+partial struct OuterClass
+{
+    public partial class NestedClass : RefCounted
+    {
+        public override Variant _Get(StringName property) => default;
+    }
+}


### PR DESCRIPTION
Following the discussions in #64899.  

We want to be able to notice regressions / breaking changes in the C# source generators. The idea would be to base the tests on the current `Godot.SourceGenerators.Sample` project, eventually running them on CI when `Godot.SourceGenerators` is modified. I'm not sure if the sample project would still have a reason to exist once a proper testing pipeline is set up?

Roslyn documentation on the subject can be found [here](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.cookbook.md#unit-testing-of-generators) and [here](https://github.com/dotnet/roslyn-sdk/tree/main/src/Microsoft.CodeAnalysis.Testing#microsoftcodeanalysistesting).

Following is the current list of generators we'd want to have tests for:
- [x] `ScriptMethodsGenerator`
- [x] `ScriptPathAttributeGenerator`
- [x] `ScriptPropertiesGenerator`
- [x] `ScriptPropertyDefValGenerator`
- [x] `ScriptSerializationGenerator`
- [x] `ScriptSignalsGenerator`

The current draft is a simple proof of concept xUnit project that loads the appropriate assemblies and run a couple of (almost) empty tests against our `ScriptPropertiesGenerator`.  
I still need to decide on a good way to load test data and expected results, and avoid the huge string blocks. The less friction there is on writing tests, the better.

__Edit 1:__
Blocks of strings are probably fine, at least for now. I roughly pulled everything that was in the sample project into tests (see list above). A couple still need a bit of work to be usable.

_Production edit: closes godotengine/godot-roadmap#49_