### PR TITLE
Fix body leaving area gravity influence

### DIFF
--- a/servers/physics_2d/godot_area_pair_2d.cpp
+++ b/servers/physics_2d/godot_area_pair_2d.cpp
@@ -66,6 +66,7 @@ bool GodotAreaPair2D::pre_solve(real_t p_step) {
 
 	if (colliding) {
 		if (has_space_override) {
+			body_has_attached_area = true;
 			body->add_area(area);
 		}
 
@@ -74,6 +75,7 @@ bool GodotAreaPair2D::pre_solve(real_t p_step) {
 		}
 	} else {
 		if (has_space_override) {
+			body_has_attached_area = false;
 			body->remove_area(area);
 		}
 
@@ -103,7 +105,8 @@ GodotAreaPair2D::GodotAreaPair2D(GodotBody2D *p_body, int p_body_shape, GodotAre
 
 GodotAreaPair2D::~GodotAreaPair2D() {
 	if (colliding) {
-		if (has_space_override) {
+		if (body_has_attached_area) {
+			body_has_attached_area = false;
 			body->remove_area(area);
 		}
 		if (area->has_monitor_callback()) {

--- a/servers/physics_2d/godot_area_pair_2d.h
+++ b/servers/physics_2d/godot_area_pair_2d.h
@@ -43,6 +43,7 @@ class GodotAreaPair2D : public GodotConstraint2D {
 	bool colliding = false;
 	bool has_space_override = false;
 	bool process_collision = false;
+	bool body_has_attached_area = false;
 
 public:
 	virtual bool setup(real_t p_step) override;

--- a/servers/physics_3d/godot_area_pair_3d.cpp
+++ b/servers/physics_3d/godot_area_pair_3d.cpp
@@ -67,6 +67,7 @@ bool GodotAreaPair3D::pre_solve(real_t p_step) {
 
 	if (colliding) {
 		if (has_space_override) {
+			body_has_attached_area = true;
 			body->add_area(area);
 		}
 
@@ -75,6 +76,7 @@ bool GodotAreaPair3D::pre_solve(real_t p_step) {
 		}
 	} else {
 		if (has_space_override) {
+			body_has_attached_area = false;
 			body->remove_area(area);
 		}
 
@@ -104,7 +106,8 @@ GodotAreaPair3D::GodotAreaPair3D(GodotBody3D *p_body, int p_body_shape, GodotAre
 
 GodotAreaPair3D::~GodotAreaPair3D() {
 	if (colliding) {
-		if (has_space_override) {
+		if (body_has_attached_area) {
+			body_has_attached_area = false;
 			body->remove_area(area);
 		}
 		if (area->has_monitor_callback()) {
@@ -242,6 +245,7 @@ bool GodotAreaSoftBodyPair3D::pre_solve(real_t p_step) {
 
 	if (colliding) {
 		if (has_space_override) {
+			body_has_attached_area = true;
 			soft_body->add_area(area);
 		}
 
@@ -250,6 +254,7 @@ bool GodotAreaSoftBodyPair3D::pre_solve(real_t p_step) {
 		}
 	} else {
 		if (has_space_override) {
+			body_has_attached_area = false;
 			soft_body->remove_area(area);
 		}
 
@@ -276,7 +281,8 @@ GodotAreaSoftBodyPair3D::GodotAreaSoftBodyPair3D(GodotSoftBody3D *p_soft_body, i
 
 GodotAreaSoftBodyPair3D::~GodotAreaSoftBodyPair3D() {
 	if (colliding) {
-		if (has_space_override) {
+		if (body_has_attached_area) {
+			body_has_attached_area = false;
 			soft_body->remove_area(area);
 		}
 		if (area->has_monitor_callback()) {

--- a/servers/physics_3d/godot_area_pair_3d.h
+++ b/servers/physics_3d/godot_area_pair_3d.h
@@ -44,6 +44,7 @@ class GodotAreaPair3D : public GodotConstraint3D {
 	bool colliding = false;
 	bool process_collision = false;
 	bool has_space_override = false;
+	bool body_has_attached_area = false;
 
 public:
 	virtual bool setup(real_t p_step) override;
@@ -83,6 +84,7 @@ class GodotAreaSoftBodyPair3D : public GodotConstraint3D {
 	bool colliding = false;
 	bool process_collision = false;
 	bool has_space_override = false;
+	bool body_has_attached_area = false;
 
 public:
 	virtual bool setup(real_t p_step) override;


### PR DESCRIPTION
This pull request fixes and closes issue [Area3D gravity problem in Godot 4 #77682](https://github.com/godotengine/godot/issues/77682)

We solve this issue with [@Wiltof](https://github.com/Wiltof) by adding a check in the destructor of `GodotAreaPair3D` ; if the area has a gravity override then we remove the area from the body so it is not influenced by it anymore.

This solves the cases where we have a `Rigidbody3D` inside an `Area3D` with a gravity override mode, when the `RigidBody3D` is teleported outside the Area using its `Tranform`, or when the `Area3D` is disabled or deleted. The `RigidBody3D` is no longer subject to the `Area3D` gravity.

* *Bugsquad edit, fixes: #77682*
* *Bugsquad edit, fixes: #81550*
* *fixes: #77449*