### PR TITLE
Project setting for Joypad on unfocused Window

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1407,6 +1407,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations_pot_files", PackedStringArray());
 
+	GLOBAL_DEF("input_devices/config/ignore_joypad_on_unfocused_window", false);
 	ProjectSettings::get_singleton()->add_hidden_prefix("input/");
 }
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -34,6 +34,7 @@
 #include "core/input/default_controller_mappings.h"
 #include "core/input/input_map.h"
 #include "core/os/os.h"
+#include "servers/display_server.h"
 
 #ifdef DEV_ENABLED
 #include "core/os/thread.h"
@@ -268,6 +269,19 @@ bool Input::is_key_label_pressed(Key p_keycode) const {
 bool Input::is_mouse_button_pressed(MouseButton p_button) const {
 	_THREAD_SAFE_METHOD_
 	return mouse_button_mask.has_flag(mouse_button_to_mask(p_button));
+}
+
+void Input::_project_settings_changed() {
+	ignore_joypad_on_unfocused = bool(GLOBAL_GET("input_devices/config/ignore_joypad_on_unfocused_window"));
+}
+
+bool Input::_config_ignore_joypad_on_unfocused_window() {
+	if (ignore_joypad_on_unfocused) {
+		if (!DisplayServer::get_singleton()->window_is_focused(DisplayServer::MAIN_WINDOW_ID)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static JoyAxis _combine_device(JoyAxis p_value, int p_device) {
@@ -1053,6 +1067,9 @@ void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 
 void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	_THREAD_SAFE_METHOD_;
+	if (_config_ignore_joypad_on_unfocused_window()) {
+		return;
+	}
 	Joypad &joy = joy_names[p_device];
 	ERR_FAIL_INDEX((int)p_button, (int)JoyButton::MAX);
 
@@ -1080,7 +1097,9 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_THREAD_SAFE_METHOD_;
-
+	if (_config_ignore_joypad_on_unfocused_window()) {
+		return;
+	}
 	ERR_FAIL_INDEX((int)p_axis, (int)JoyAxis::MAX);
 
 	Joypad &joy = joy_names[p_device];
@@ -1147,6 +1166,10 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 
 void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 	_THREAD_SAFE_METHOD_;
+	if (_config_ignore_joypad_on_unfocused_window()) {
+		return;
+	}
+
 	const Joypad &joy = joy_names[p_device];
 
 	JoyEvent map[(size_t)HatDir::MAX];
@@ -1616,6 +1639,8 @@ Input::Input() {
 		// Always use standard behavior in the editor.
 		legacy_just_pressed_behavior = false;
 	}
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Input::_project_settings_changed));
 }
 
 Input::~Input() {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -97,6 +97,7 @@ private:
 	Vector2 mouse_pos;
 	int64_t mouse_window = 0;
 	bool legacy_just_pressed_behavior = false;
+	bool ignore_joypad_on_unfocused = false;
 
 	struct Action {
 		uint64_t pressed_physics_frame = UINT64_MAX;
@@ -246,6 +247,9 @@ private:
 	static void (*set_custom_mouse_cursor_func)(const Ref<Resource> &, CursorShape, const Vector2 &);
 
 	EventDispatchFunc event_dispatch_function = nullptr;
+
+	bool _config_ignore_joypad_on_unfocused_window();
+	void _project_settings_changed();
 
 protected:
 	static void _bind_methods();

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1302,6 +1302,9 @@
 			If [code]false[/code], no input will be lost.
 			[b]Note:[/b] You should in nearly all cases prefer the [code]false[/code] setting. The legacy behavior is to enable supporting old projects that rely on the old logic, without changes to script.
 		</member>
+		<member name="input_devices/config/ignore_joypad_on_unfocused_window" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], joypad input will be ignored when the window is not focused.
+		</member>
 		<member name="input_devices/pen_tablet/driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 			[b]Note:[/b] The driver in use can be overridden at runtime via the [code]--tablet-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].


### PR DESCRIPTION
Project setting to prevent handling from joypad input when the window is not focused.

Closes https://github.com/godotengine/godot/issues/16832
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
