### PR TITLE
Add a Disable 2D property to Viewport (reverted)

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -258,8 +258,11 @@
 		<member name="debug_draw" type="int" setter="set_debug_draw" getter="get_debug_draw" enum="Viewport.DebugDraw" default="0">
 			The overlay mode for test rendered geometry in debug purposes.
 		</member>
+		<member name="disable_2d" type="bool" setter="set_disable_2d" getter="is_2d_disabled" default="false">
+			If [code]true[/code], disables 2D rendering while keeping 3D rendering. See also [member disable_3d].
+		</member>
 		<member name="disable_3d" type="bool" setter="set_disable_3d" getter="is_3d_disabled" default="false">
-			Disable 3D rendering (but keep 2D rendering).
+			If [code]true[/code], disables 3D rendering while keeping 2D rendering. See also [member disable_2d].
 		</member>
 		<member name="fsr_sharpness" type="float" setter="set_fsr_sharpness" getter="get_fsr_sharpness" default="0.2">
 			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4019,6 +4019,17 @@ void Viewport::set_camera_3d_override_orthogonal(real_t p_size, real_t p_z_near,
 	}
 }
 
+void Viewport::set_disable_2d(bool p_disable) {
+	ERR_MAIN_THREAD_GUARD;
+	disable_2d = p_disable;
+	RenderingServer::get_singleton()->viewport_set_disable_2d(viewport, disable_2d);
+}
+
+bool Viewport::is_2d_disabled() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return disable_2d;
+}
+
 void Viewport::set_disable_3d(bool p_disable) {
 	ERR_MAIN_THREAD_GUARD;
 	disable_3d = p_disable;
@@ -4461,6 +4472,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_3d", "enable"), &Viewport::set_as_audio_listener_3d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_3d"), &Viewport::is_audio_listener_3d);
 
+	ClassDB::bind_method(D_METHOD("set_disable_2d", "disable"), &Viewport::set_disable_2d);
+	ClassDB::bind_method(D_METHOD("is_2d_disabled"), &Viewport::is_2d_disabled);
+
 	ClassDB::bind_method(D_METHOD("set_disable_3d", "disable"), &Viewport::set_disable_3d);
 	ClassDB::bind_method(D_METHOD("is_3d_disabled"), &Viewport::is_3d_disabled);
 
@@ -4485,6 +4499,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vrs_texture", "texture"), &Viewport::set_vrs_texture);
 	ClassDB::bind_method(D_METHOD("get_vrs_texture"), &Viewport::get_vrs_texture);
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_2d"), "set_disable_2d", "is_2d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_xr"), "set_use_xr", "is_using_xr");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -283,6 +283,7 @@ private:
 
 	void _update_audio_listener_2d();
 
+	bool disable_2d = false;
 	bool disable_3d = false;
 
 	void _propagate_viewport_notification(Node *p_node, int p_what);
@@ -737,6 +738,9 @@ public:
 
 	void set_camera_3d_override_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
 	void set_camera_3d_override_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
+
+	void set_disable_2d(bool p_disable);
+	bool is_2d_disabled() const;
 
 	void set_disable_3d(bool p_disable);
 	bool is_3d_disabled() const;


### PR DESCRIPTION
This is the 2D counterpart to the existing Disable 3D property. Its functionality is already internally implemented and used, but it wasn't exposed.

- This closes https://github.com/godotengine/godot-proposals/issues/8020.

**Testing project:** [test_disable_2d.zip](https://github.com/godotengine/godot/files/12838088/test_disable_2d.zip)

## Preview

https://github.com/godotengine/godot/assets/180032/6074af67-dbb8-43e8-824d-f26cb86e63a2