### PR TITLE
Use global cache directory to store shader cache

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -537,7 +537,6 @@ void EditorFileSystem::_save_filesystem_cache() {
 	group_file_cache.clear();
 
 	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().path_join(CACHE_FILE_NAME);
-
 	Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + fscache + "'. Check user write permissions.");
 

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -252,10 +252,7 @@ EditorPaths::EditorPaths() {
 
 	// Validate or create project-specific editor data dir,
 	// including shader cache subdir.
-	if (Engine::get_singleton()->is_project_manager_hint() || (Main::is_cmdline_tool() && !ProjectSettings::get_singleton()->is_project_loaded())) {
-		// Nothing to create, use shared editor data dir for shader cache.
-		Engine::get_singleton()->set_shader_cache_path(data_dir);
-	} else {
+	if (!Engine::get_singleton()->is_project_manager_hint() && !(Main::is_cmdline_tool() && !ProjectSettings::get_singleton()->is_project_loaded())) {
 		Ref<DirAccess> dir_res = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (dir_res->change_dir(project_data_dir) != OK) {
 			dir_res->make_dir_recursive(project_data_dir);
@@ -277,8 +274,6 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
-		Engine::get_singleton()->set_shader_cache_path(project_data_dir);
-
 		// Editor metadata dir.
 		if (!dir_res->dir_exists("editor")) {
 			dir_res->make_dir("editor");
@@ -289,4 +284,6 @@ EditorPaths::EditorPaths() {
 			dir_res->make_dir(imported_files_path);
 		}
 	}
+
+	Engine::get_singleton()->set_shader_cache_path(cache_dir);
 }

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -252,7 +252,9 @@ EditorPaths::EditorPaths() {
 
 	// Validate or create project-specific editor data dir,
 	// including shader cache subdir.
-	if (!Engine::get_singleton()->is_project_manager_hint() && !(Main::is_cmdline_tool() && !ProjectSettings::get_singleton()->is_project_loaded())) {
+	if (Engine::get_singleton()->is_project_manager_hint() || (Main::is_cmdline_tool() && !ProjectSettings::get_singleton()->is_project_loaded())) {
+		// Nothing to create, use shared editor data dir for shader cache.
+		Engine::get_singleton()->set_shader_cache_path(cache_dir);
 		Ref<DirAccess> dir_res = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (dir_res->change_dir(project_data_dir) != OK) {
 			dir_res->make_dir_recursive(project_data_dir);
@@ -274,6 +276,10 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
+		// Use the same shader cache location for the editor and running project,
+		// so that the cache can be reused when running the project from the editor.
+		Engine::get_singleton()->set_shader_cache_path("user://");
+
 		// Editor metadata dir.
 		if (!dir_res->dir_exists("editor")) {
 			dir_res->make_dir("editor");
@@ -284,6 +290,4 @@ EditorPaths::EditorPaths() {
 			dir_res->make_dir(imported_files_path);
 		}
 	}
-
-	Engine::get_singleton()->set_shader_cache_path(cache_dir);
 }


### PR DESCRIPTION
This has several upsides:

- `.godot/` is no longer bloated with shader cache, making ZIP archives of projects several megabytes larger when MRPs are uploaded to GitHub.
- Shader cache is shared across projects, which benefits startup times when you edit several projects.
- Shader cache is shared between the editor and running project, which benefits initial project startup times after opening the editor.

Given the potential implications of this change, I suggest not cherry-picking it until it's been thoroughly tested.

___

- This closes https://github.com/godotengine/godot/issues/73174.
