### PR TITLE
On Linux, favor local symbols when loading a shared library

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -81,6 +81,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifndef RTLD_DEEPBIND
+#define RTLD_DEEPBIND 0
+#endif
+
 #if defined(MACOS_ENABLED) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 28)
 // Random location for getentropy. Fitting.
 #include <sys/random.h>
@@ -646,7 +650,7 @@ Error OS_Unix::open_dynamic_library(const String p_path, void *&p_library_handle
 		path = get_executable_path().get_base_dir().path_join("../lib").path_join(p_path.get_file());
 	}
 
-	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
+	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW | RTLD_DEEPBIND);
 	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, dlerror()));
 
 	if (r_resolved_path != nullptr) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/82812

Myself and the reporter of that issue, are seeing a strange situation where a GDExtension will use a class defined by the engine with the same name, rather than the class defined in the GDExtension.

Passing `RTLD_DEEPBIND` to `dlopen()` when loading the GDExtension seems to fix it in my testing!

About `RTLD_DEEPBIND`, the man page says:

> Place  the  lookup  scope  of the symbols in this shared object ahead of the global scope.  This means that a self-contained object will use its own symbols in preference to global symbols with the same name contained in objects that have already been loaded.

I'm definitely not an expert on platform-level stuff, so I don't know if this flag has any limitations or caveats associated with it.

### Downloading pre-compiled binaries:

1. Login into github
2. Click the "checks" tab of this PR
3. On the right there's an "artifacts" button.
4. Download the appropriate build for your plaform

![image](https://github.com/godotengine/godot/assets/7917475/ba40d17f-8ba7-46cc-8dea-fc9758e383fb)
