### PR TITLE
Show warning on AnimationTree for invalid advance expression

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -84,7 +84,15 @@ void AnimationNodeStateMachineTransition::set_advance_expression(const String &p
 		expression.instantiate();
 	}
 
-	ERR_FAIL_COND_MSG(expression->parse(advance_expression_stripped) != OK, "Failed to parse advance expression '" + advance_expression_stripped + "': " + expression->get_error_text());
+#ifdef TOOLS_ENABLED
+	Error err = expression->parse(advance_expression_stripped);
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		// This error is already shown in the scene tree editor.
+		ERR_FAIL_COND_MSG(err != OK, "Failed to parse advance expression '" + advance_expression_stripped + "': " + expression->get_error_text());
+	}
+#else
+	expression->parse(advance_expression_stripped);
+#endif
 }
 
 String AnimationNodeStateMachineTransition::get_advance_expression() const {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -144,7 +144,12 @@ PackedStringArray AnimationNodeStateMachineTransition::get_configuration_warning
 		// been executed, clearing its error.
 		Expression test_expression;
 		if (test_expression.parse(advance_expression_stripped) != OK) {
-			warnings.push_back("Invalid advance expression: " + advance_expression_stripped);
+			String error_text = test_expression.get_error_text();
+			if (error_text == "Expected '='") {
+				warnings.push_back("Invalid advance expression '" + advance_expression_stripped + "': " + test_expression.get_error_text() + " (maybe '=' should be '=='?)");
+			} else {
+				warnings.push_back("Invalid advance expression '" + advance_expression_stripped + "': " + test_expression.get_error_text());
+			}
 		}
 	}
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -72,6 +72,8 @@ StringName AnimationNodeStateMachineTransition::get_advance_condition_name() con
 void AnimationNodeStateMachineTransition::set_advance_expression(const String &p_expression) {
 	advance_expression = p_expression;
 
+	emit_changed();
+
 	String advance_expression_stripped = advance_expression.strip_edges();
 	if (advance_expression_stripped == String()) {
 		expression.unref();
@@ -82,7 +84,7 @@ void AnimationNodeStateMachineTransition::set_advance_expression(const String &p
 		expression.instantiate();
 	}
 
-	expression->parse(advance_expression_stripped);
+	ERR_FAIL_COND_MSG(expression->parse(advance_expression_stripped) != OK, "Failed to parse advance expression '" + advance_expression_stripped + "': " + expression->get_error_text());
 }
 
 String AnimationNodeStateMachineTransition::get_advance_expression() const {
@@ -123,6 +125,22 @@ void AnimationNodeStateMachineTransition::set_priority(int p_priority) {
 
 int AnimationNodeStateMachineTransition::get_priority() const {
 	return priority;
+}
+
+PackedStringArray AnimationNodeStateMachineTransition::get_configuration_warnings() const {
+	PackedStringArray warnings;
+
+	String advance_expression_stripped = advance_expression.strip_edges();
+	if (!advance_expression_stripped.is_empty()) {
+		// We can't use this transition's expression as it may have already
+		// been executed, clearing its error.
+		Expression test_expression;
+		if (test_expression.parse(advance_expression_stripped) != OK) {
+			warnings.push_back("Invalid advance expression: " + advance_expression_stripped);
+		}
+	}
+
+	return warnings;
 }
 
 void AnimationNodeStateMachineTransition::_bind_methods() {
@@ -1140,7 +1158,11 @@ bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<Anima
 		if (expression_base) {
 			Ref<Expression> exp = transition->expression;
 			bool ret = exp->execute(Array(), expression_base, false, Engine::get_singleton()->is_editor_hint()); // Avoids allowing the user to crash the system with an expression by only allowing const calls.
-			if (exp->has_execute_failed() || !ret) {
+			if (exp->has_execute_failed()) {
+				ERR_PRINT("Failed to execute transition advance expression '" + transition->advance_expression + "': " + exp->get_error_text());
+				return false;
+			}
+			if (!ret) {
 				return false;
 			}
 		} else {
@@ -1547,6 +1569,7 @@ void AnimationNodeStateMachine::add_transition(const StringName &p_from, const S
 	tr.transition = p_transition;
 
 	tr.transition->connect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), CONNECT_REFERENCE_COUNTED);
+	tr.transition->connect_changed(callable_mp((Resource *)this, &Resource::emit_changed), CONNECT_REFERENCE_COUNTED);
 
 	transitions.push_back(tr);
 
@@ -1595,6 +1618,7 @@ void AnimationNodeStateMachine::remove_transition_by_index(const int p_transitio
 	ERR_FAIL_INDEX(p_transition, transitions.size());
 	Transition tr = transitions[p_transition];
 	transitions.write[p_transition].transition->disconnect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
+	transitions.write[p_transition].transition->disconnect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
 	transitions.remove_at(p_transition);
 
 	Vector<String> path_from = String(tr.from).split("/");
@@ -1791,6 +1815,22 @@ void AnimationNodeStateMachine::_animation_node_renamed(const ObjectID &p_oid, c
 
 void AnimationNodeStateMachine::_animation_node_removed(const ObjectID &p_oid, const StringName &p_node) {
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
+}
+
+PackedStringArray AnimationNodeStateMachine::get_configuration_warnings() const {
+	PackedStringArray warnings;
+
+	for (int i = 0; i < transitions.size(); i++) {
+		PackedStringArray transition_warnings = transitions[i].transition->get_configuration_warnings();
+		String from = transitions[i].from;
+		String to = transitions[i].to;
+		for (int j = 0; j < transition_warnings.size(); j++) {
+			// Prefix each warning with the transition for easy identification.
+			warnings.append(from + " -> " + to + ": " + transition_warnings[j]);
+		}
+	}
+
+	return warnings;
 }
 
 void AnimationNodeStateMachine::_bind_methods() {

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -94,6 +94,8 @@ public:
 	void set_priority(int p_priority);
 	int get_priority() const;
 
+	PackedStringArray get_configuration_warnings() const;
+
 	AnimationNodeStateMachineTransition();
 };
 
@@ -142,6 +144,8 @@ private:
 	void _remove_transition(const Ref<AnimationNodeStateMachineTransition> p_transition);
 	void _rename_transitions(const StringName &p_name, const StringName &p_new_name);
 	bool _can_connect(const StringName &p_name);
+
+	PackedStringArray get_configuration_warnings() const override;
 
 protected:
 	static void _bind_methods();

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -504,6 +504,10 @@ void AnimationRootNode::_animation_node_removed(const ObjectID &p_oid, const Str
 	emit_signal(SNAME("animation_node_removed"), p_oid, p_node);
 }
 
+PackedStringArray AnimationRootNode::get_configuration_warnings() const {
+	return PackedStringArray();
+}
+
 ////////////////////
 
 void AnimationTree::set_root_animation_node(const Ref<AnimationRootNode> &p_animation_node) {
@@ -511,6 +515,7 @@ void AnimationTree::set_root_animation_node(const Ref<AnimationRootNode> &p_anim
 		root_animation_node->disconnect(SNAME("tree_changed"), callable_mp(this, &AnimationTree::_tree_changed));
 		root_animation_node->disconnect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationTree::_animation_node_renamed));
 		root_animation_node->disconnect(SNAME("animation_node_removed"), callable_mp(this, &AnimationTree::_animation_node_removed));
+		root_animation_node->disconnect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings));
 	}
 
 	root_animation_node = p_animation_node;
@@ -519,6 +524,7 @@ void AnimationTree::set_root_animation_node(const Ref<AnimationRootNode> &p_anim
 		root_animation_node->connect(SNAME("tree_changed"), callable_mp(this, &AnimationTree::_tree_changed));
 		root_animation_node->connect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationTree::_animation_node_renamed));
 		root_animation_node->connect(SNAME("animation_node_removed"), callable_mp(this, &AnimationTree::_animation_node_removed));
+		root_animation_node->connect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings));
 	}
 
 	properties_dirty = true;
@@ -607,7 +613,9 @@ uint64_t AnimationTree::get_last_process_pass() const {
 
 PackedStringArray AnimationTree::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
-	if (!root_animation_node.is_valid()) {
+	if (root_animation_node.is_valid()) {
+		warnings.append_array(root_animation_node->get_configuration_warnings());
+	} else {
 		warnings.push_back(RTR("No root AnimationNode for the graph is set."));
 	}
 	return warnings;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -170,6 +170,8 @@ protected:
 
 public:
 	AnimationRootNode() {}
+
+	virtual PackedStringArray get_configuration_warnings() const;
 };
 
 class AnimationNodeStartState : public AnimationRootNode {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR makes the engine display a warning in the scene tree editor against AnimationTrees which have a `AnimationNodeStateMachineTransition` with an invalid expression (i.e. one that can't be parsed):

![Configuration warning for invalid advance expression](https://github.com/godotengine/godot/assets/1843197/b30bd624-a746-46a9-96ff-f4b6bf6f198e)

It also adds some error reporting to `set_advance_expression`, which shows up in the editor's output (and debugger for running projects):

![Error in output](https://github.com/godotengine/godot/assets/1843197/d1ccc65a-9e9c-40ea-b06a-8ac46d96d085)

![Error in debugger](https://github.com/godotengine/godot/assets/1843197/b1e7a88f-c497-421a-bb6e-6546ec9f59a0)

One downside to adding this error reporting to the setter is that there is no debouncing when editing the expression via the inspector, causing every keystroke to report an error in the output (unless the expression is valid):

![Errors reported whilst typing "value == 3 + 4"](https://github.com/godotengine/godot/assets/1843197/8720fba6-576a-4c39-b7de-5609424b6b57)

I'm happy to remove this error reporting if need be, as it is only really useful when setting `advance_expression` at runtime, which I can't imagine is done very often.

This PR also adds error reporting to transition execution, catching cases where variables may not exist:
![Error at runtime](https://github.com/godotengine/godot/assets/1843197/4f97b533-4140-4fc8-9ed7-7822ed336d50)
There's a similar downside to this error reporting too - it ends up being output every frame that the expression is invalid (which is usually indefinitely), both in-editor and whilst the project is running. This could be changed to use `ERR_PRINT_ONCE`, but it seems like that would cause it to only be printed once per engine run, which seems less than ideal.