### PR TITLE
C#: Fix typed arrays not saving properly

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -679,7 +679,7 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                hint = PropertyHint.TypeString;
+                hint = PropertyHint.ArrayType;
 
                 return hintString != null;
             }


### PR DESCRIPTION
Fixes a typo in `ScriptPropertiesGenerator.cs` that was making the passed hint `TypeString` instead of `ArrayType`. While I'm not certain of the full ramifications of fixing this error, one immediate benefit is having resources correctly save arrays as typed if they're exported as such (like GDScript)

---
Example file to save a single "`123`" entry
```cs
public partial class Main : Node2D
{
    [Export]
    private Godot.Collections.Array<int> _array;
}
```

Before:
```gd
_array = [123]
```
After:
```gd
_array = Array[int]([123])
```