### PR TITLE
Add helper class for joypad UI navigation

### DIFF
--- a/scene/gui/joypad_helper.cpp
+++ b/scene/gui/joypad_helper.cpp
@@ -1,0 +1,142 @@
+/**************************************************************************/
+/*  joypad_helper.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "joypad_helper.h"
+
+#include "core/input/input.h"
+#include "scene/main/node.h"
+
+bool JoypadHelper::_check_initial_action(const Ref<InputEvent> &p_event, const StringName &p_action_name) {
+	if (!p_event->is_pressed()) {
+		return false;
+	}
+
+	if (!p_event->is_action(p_action_name, true)) {
+		return false;
+	}
+
+	if (!Input::get_singleton()->is_action_just_pressed(p_action_name, true)) {
+		return false;
+	}
+	return true;
+}
+
+void JoypadHelper::_set_active(bool p_active) {
+	active = p_active;
+	if (toggle_process) {
+		owner->set_process_internal(active);
+	}
+	if (!active) {
+		gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
+	}
+}
+
+void JoypadHelper::setup(Node *p_owner, bool p_use_horizontal_axis, bool p_use_vertical_axis) {
+	owner = p_owner;
+	use_horizontal_axis = p_use_horizontal_axis;
+	use_vertical_axis = p_use_vertical_axis;
+}
+
+void JoypadHelper::set_move_callback(const Callable &p_callback) {
+	move_callback = p_callback;
+}
+
+void JoypadHelper::disable_process_toggle() {
+	toggle_process = false;
+}
+
+bool JoypadHelper::process_event(const Ref<InputEvent> &p_event) {
+	if (!Object::cast_to<InputEventJoypadMotion>(p_event.ptr()) && !Object::cast_to<InputEventJoypadButton>(p_event.ptr())) {
+		return false;
+	}
+
+	if (use_horizontal_axis) {
+		if (_check_initial_action(p_event, SNAME("ui_left")) || _check_initial_action(p_event, SNAME("ui_right"))) {
+			_set_active(true);
+			return false;
+		}
+	}
+
+	if (use_vertical_axis) {
+		if (_check_initial_action(p_event, SNAME("ui_down")) || _check_initial_action(p_event, SNAME("ui_up"))) {
+			_set_active(true);
+			return false;
+		}
+	}
+	return true;
+}
+
+void JoypadHelper::process_internal(double p_delta) {
+	if (!active) {
+		return;
+	}
+
+	Input *input = Input::get_singleton();
+	if (use_horizontal_axis) {
+		if (input->is_action_just_released(SNAME("ui_right")) || input->is_action_just_released(SNAME("ui_left"))) {
+			_set_active(false);
+			return;
+		}
+	}
+
+	if (use_vertical_axis) {
+		if (input->is_action_just_released(SNAME("ui_down")) || input->is_action_just_released(SNAME("ui_up"))) {
+			_set_active(false);
+			return;
+		}
+	}
+	gamepad_event_delay_ms -= p_delta;
+
+	if (gamepad_event_delay_ms <= 0) {
+		if (use_horizontal_axis) {
+			if (input->is_action_pressed(SNAME("ui_right"))) {
+				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
+				move_callback.call(Vector2i(1, 0));
+			}
+
+			if (input->is_action_pressed(SNAME("ui_left"))) {
+				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
+				move_callback.call(Vector2i(-1, 0));
+			}
+		}
+
+		if (use_vertical_axis) {
+			if (input->is_action_pressed(SNAME("ui_down"))) {
+				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
+				move_callback.call(Vector2i(0, 1));
+			}
+
+			if (input->is_action_pressed(SNAME("ui_up"))) {
+				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
+				move_callback.call(Vector2i(0, -1));
+			}
+		}
+	}
+}

--- a/scene/gui/joypad_helper.h
+++ b/scene/gui/joypad_helper.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  slider.h                                                              */
+/*  joypad_helper.h                                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,90 +28,40 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef SLIDER_H
-#define SLIDER_H
+#ifndef JOYPAD_HELPER_H
+#define JOYPAD_HELPER_H
 
-#include "scene/gui/range.h"
+#include "core/object/ref_counted.h"
 
-class JoypadHelper;
+class InputEvent;
+class Node;
 
-class Slider : public Range {
-	GDCLASS(Slider, Range);
+class JoypadHelper : public RefCounted {
+	GDCLASS(JoypadHelper, RefCounted);
 
-	struct Grab {
-		int pos = 0;
-		double uvalue = 0.0; // Value at `pos`.
-		double value_before_dragging = 0.0;
-		bool active = false;
-	} grab;
+private:
+	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
+	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
+	float gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
 
-	int ticks = 0;
-	bool mouse_inside = false;
-	Orientation orientation;
-	double custom_step = -1.0;
-	bool editable = true;
-	bool scrollable = true;
+	Node *owner = nullptr;
+	bool use_horizontal_axis = false;
+	bool use_vertical_axis = false;
 
-	Ref<JoypadHelper> joypad_helper;
-	void _value_move(const Vector2i &p_movement);
+	Callable move_callback;
+	bool toggle_process = true;
+	bool active = false;
 
-	struct ThemeCache {
-		Ref<StyleBox> slider_style;
-		Ref<StyleBox> grabber_area_style;
-		Ref<StyleBox> grabber_area_hl_style;
-
-		Ref<Texture2D> grabber_icon;
-		Ref<Texture2D> grabber_hl_icon;
-		Ref<Texture2D> grabber_disabled_icon;
-		Ref<Texture2D> tick_icon;
-
-		bool center_grabber = false;
-		int grabber_offset = 0;
-	} theme_cache;
-
-protected:
-	bool ticks_on_borders = false;
-
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-	void _notification(int p_what);
-	static void _bind_methods();
+	bool _check_initial_action(const Ref<InputEvent> &p_event, const StringName &p_action_name);
+	void _set_active(bool p_active);
 
 public:
-	virtual Size2 get_minimum_size() const override;
+	void setup(Node *p_owner, bool p_use_horizontal_axis, bool p_use_vertical_axis);
+	void set_move_callback(const Callable &p_callback);
+	void disable_process_toggle();
 
-	void set_custom_step(double p_custom_step);
-	double get_custom_step() const;
-
-	void set_ticks(int p_count);
-	int get_ticks() const;
-
-	void set_ticks_on_borders(bool);
-	bool get_ticks_on_borders() const;
-
-	void set_editable(bool p_editable);
-	bool is_editable() const;
-
-	void set_scrollable(bool p_scrollable);
-	bool is_scrollable() const;
-
-	Slider(Orientation p_orientation = VERTICAL);
-	~Slider();
+	bool process_event(const Ref<InputEvent> &p_event);
+	void process_internal(double p_delta);
 };
 
-class HSlider : public Slider {
-	GDCLASS(HSlider, Slider);
-
-public:
-	HSlider() :
-			Slider(HORIZONTAL) { set_v_size_flags(0); }
-};
-
-class VSlider : public Slider {
-	GDCLASS(VSlider, Slider);
-
-public:
-	VSlider() :
-			Slider(VERTICAL) { set_h_size_flags(0); }
-};
-
-#endif // SLIDER_H
+#endif // JOYPAD_HELPER_H

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -35,6 +35,7 @@
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
+#include "scene/gui/joypad_helper.h"
 #include "scene/gui/menu_bar.h"
 #include "scene/gui/panel_container.h"
 #include "scene/resources/style_box_flat.h"
@@ -478,87 +479,14 @@ void PopupMenu::_input_from_window(const Ref<InputEvent> &p_event) {
 
 void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 	if (!items.is_empty()) {
-		Input *input = Input::get_singleton();
-		Ref<InputEventJoypadMotion> joypadmotion_event = p_event;
-		Ref<InputEventJoypadButton> joypadbutton_event = p_event;
-		bool is_joypad_event = (joypadmotion_event.is_valid() || joypadbutton_event.is_valid());
+		if (joypad_helper->process_event(p_event)) {
+			return;
+		}
 
 		if (p_event->is_action("ui_down", true) && p_event->is_pressed()) {
-			if (is_joypad_event) {
-				if (!input->is_action_just_pressed("ui_down", true)) {
-					return;
-				}
-				set_process_internal(true);
-			}
-			int search_from = mouse_over + 1;
-			if (search_from >= items.size()) {
-				search_from = 0;
-			}
-
-			bool match_found = false;
-			for (int i = search_from; i < items.size(); i++) {
-				if (!items[i].separator && !items[i].disabled) {
-					mouse_over = i;
-					emit_signal(SNAME("id_focused"), items[i].id);
-					scroll_to_item(i);
-					control->queue_redraw();
-					set_input_as_handled();
-					match_found = true;
-					break;
-				}
-			}
-
-			if (!match_found) {
-				// If the last item is not selectable, try re-searching from the start.
-				for (int i = 0; i < search_from; i++) {
-					if (!items[i].separator && !items[i].disabled) {
-						mouse_over = i;
-						emit_signal(SNAME("id_focused"), items[i].id);
-						scroll_to_item(i);
-						control->queue_redraw();
-						set_input_as_handled();
-						break;
-					}
-				}
-			}
+			_cursor_move(Vector2(0, 1));
 		} else if (p_event->is_action("ui_up", true) && p_event->is_pressed()) {
-			if (is_joypad_event) {
-				if (!input->is_action_just_pressed("ui_up", true)) {
-					return;
-				}
-				set_process_internal(true);
-			}
-			int search_from = mouse_over - 1;
-			if (search_from < 0) {
-				search_from = items.size() - 1;
-			}
-
-			bool match_found = false;
-			for (int i = search_from; i >= 0; i--) {
-				if (!items[i].separator && !items[i].disabled) {
-					mouse_over = i;
-					emit_signal(SNAME("id_focused"), items[i].id);
-					scroll_to_item(i);
-					control->queue_redraw();
-					set_input_as_handled();
-					match_found = true;
-					break;
-				}
-			}
-
-			if (!match_found) {
-				// If the first item is not selectable, try re-searching from the end.
-				for (int i = items.size() - 1; i >= search_from; i--) {
-					if (!items[i].separator && !items[i].disabled) {
-						mouse_over = i;
-						emit_signal(SNAME("id_focused"), items[i].id);
-						scroll_to_item(i);
-						control->queue_redraw();
-						set_input_as_handled();
-						break;
-					}
-				}
-			}
+			_cursor_move(Vector2(0, -1));
 		} else if (p_event->is_action("ui_left", true) && p_event->is_pressed()) {
 			Node *n = get_parent();
 			if (n) {
@@ -1178,83 +1106,10 @@ void PopupMenu::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			Input *input = Input::get_singleton();
-
-			if (input->is_action_just_released("ui_up") || input->is_action_just_released("ui_down")) {
-				gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
-				set_process_internal(false);
-				return;
-			}
-			gamepad_event_delay_ms -= get_process_delta_time();
-			if (gamepad_event_delay_ms <= 0) {
-				if (input->is_action_pressed("ui_down")) {
-					gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
-					int search_from = mouse_over + 1;
-					if (search_from >= items.size()) {
-						search_from = 0;
-					}
-
-					bool match_found = false;
-					for (int i = search_from; i < items.size(); i++) {
-						if (!items[i].separator && !items[i].disabled) {
-							mouse_over = i;
-							emit_signal(SNAME("id_focused"), items[i].id);
-							scroll_to_item(i);
-							control->queue_redraw();
-							match_found = true;
-							break;
-						}
-					}
-
-					if (!match_found) {
-						// If the last item is not selectable, try re-searching from the start.
-						for (int i = 0; i < search_from; i++) {
-							if (!items[i].separator && !items[i].disabled) {
-								mouse_over = i;
-								emit_signal(SNAME("id_focused"), items[i].id);
-								scroll_to_item(i);
-								control->queue_redraw();
-								break;
-							}
-						}
-					}
-				}
-
-				if (input->is_action_pressed("ui_up")) {
-					gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
-					int search_from = mouse_over - 1;
-					if (search_from < 0) {
-						search_from = items.size() - 1;
-					}
-
-					bool match_found = false;
-					for (int i = search_from; i >= 0; i--) {
-						if (!items[i].separator && !items[i].disabled) {
-							mouse_over = i;
-							emit_signal(SNAME("id_focused"), items[i].id);
-							scroll_to_item(i);
-							control->queue_redraw();
-							match_found = true;
-							break;
-						}
-					}
-
-					if (!match_found) {
-						// If the first item is not selectable, try re-searching from the end.
-						for (int i = items.size() - 1; i >= search_from; i--) {
-							if (!items[i].separator && !items[i].disabled) {
-								mouse_over = i;
-								emit_signal(SNAME("id_focused"), items[i].id);
-								scroll_to_item(i);
-								control->queue_redraw();
-								break;
-							}
-						}
-					}
-				}
-			}
+			joypad_helper->process_internal(get_process_delta_time());
 
 			// Only used when using operating system windows.
+			// FIXME: Joypad controls interfere with this code by overwriting internal process.
 			if (!activated_by_keyboard && !is_embedded() && autohide_areas.size()) {
 				Point2 mouse_pos = DisplayServer::get_singleton()->mouse_get_position();
 				mouse_pos -= get_position();
@@ -2653,6 +2508,76 @@ void PopupMenu::_shortcut_changed() {
 	control->queue_redraw();
 }
 
+void PopupMenu::_cursor_move(const Vector2i &p_movement) {
+	if (p_movement.y > 0) {
+		int search_from = mouse_over + 1;
+		if (search_from >= items.size()) {
+			search_from = 0;
+		}
+
+		bool match_found = false;
+		for (int i = search_from; i < items.size(); i++) {
+			const Item &item = items[i];
+			if (item.separator || item.disabled) {
+				continue;
+			}
+			mouse_over = i;
+			emit_signal(SNAME("id_focused"), item.id);
+			scroll_to_item(i);
+			control->queue_redraw();
+			match_found = true;
+			break;
+		}
+
+		if (!match_found) {
+			// If the last item is not selectable, try re-searching from the start.
+			for (int i = 0; i < search_from; i++) {
+				const Item &item = items[i];
+				if (item.separator || item.disabled) {
+					continue;
+				}
+				mouse_over = i;
+				emit_signal(SNAME("id_focused"), item.id);
+				scroll_to_item(i);
+				control->queue_redraw();
+				break;
+			}
+		}
+	}
+
+	if (p_movement.y < 0) {
+		int search_from = mouse_over - 1;
+		if (search_from < 0) {
+			search_from = items.size() - 1;
+		}
+
+		bool match_found = false;
+		for (int i = search_from; i >= 0; i--) {
+			if (!items[i].separator && !items[i].disabled) {
+				mouse_over = i;
+				emit_signal(SNAME("id_focused"), i);
+				scroll_to_item(i);
+				control->queue_redraw();
+				match_found = true;
+				break;
+			}
+		}
+
+		if (!match_found) {
+			// If the first item is not selectable, try re-searching from the end.
+			for (int i = items.size() - 1; i >= search_from; i--) {
+				if (!items[i].separator && !items[i].disabled) {
+					mouse_over = i;
+					emit_signal(SNAME("id_focused"), i);
+					scroll_to_item(i);
+					control->queue_redraw();
+					break;
+				}
+			}
+		}
+	}
+}
+
 // Hide on item selection determines whether or not the popup will close after item selection
 void PopupMenu::set_hide_on_item_selection(bool p_enabled) {
 	hide_on_item_selection = p_enabled;
@@ -3039,6 +2964,11 @@ PopupMenu::PopupMenu() {
 	add_child(minimum_lifetime_timer, false, INTERNAL_MODE_FRONT);
 
 	property_helper.setup_for_instance(base_property_helper, this);
+
+	joypad_helper.instantiate();
+	joypad_helper->setup(this, false, true);
+	joypad_helper->set_move_callback(callable_mp(this, &PopupMenu::_cursor_move));
+	joypad_helper->disable_process_toggle();
 
 #ifdef TOOLS_ENABLED
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp((Node *)this, &Node::update_configuration_warnings));

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -37,6 +37,7 @@
 #include "scene/property_list_helper.h"
 #include "scene/resources/text_line.h"
 
+class JoypadHelper;
 class PanelContainer;
 
 class PopupMenu : public Popup {
@@ -158,9 +159,8 @@ class PopupMenu : public Popup {
 	ScrollContainer *scroll_container = nullptr;
 	Control *control = nullptr;
 
-	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
-	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
-	float gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
+	Ref<JoypadHelper> joypad_helper;
+	void _cursor_move(const Vector2i &p_movement);
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -35,6 +35,8 @@
 #include "scene/property_list_helper.h"
 #include "scene/resources/text_line.h"
 
+class JoypadHelper;
+
 class TabBar : public Control {
 	GDCLASS(TabBar, Control);
 
@@ -121,9 +123,8 @@ private:
 	bool initialized = false;
 	int queued_current = CURRENT_TAB_UNINITIALIZED;
 
-	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
-	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
-	float gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
+	Ref<JoypadHelper> joypad_helper;
+	void _tab_cursor_move(const Vector2i &p_movement);
 
 	struct ThemeCache {
 		int h_separation = 0;


### PR DESCRIPTION
Slider, PopupMenu and TabBar had a duplicated code that handled joypad navigation. This PR adds a helper class that removes the duplication. This allows to easily modify the various constants and also add better joypad handling to more classes.

Usage:
- Add JoypadHelper to the class
- Setup it with `setup()` and `set_move_callback()`
  - setup takes "owner", the helper will automatically toggle internal process (unless you use `disable_process_toggle()`). It also determines whether the helper works in horizontal or vertical mode (or both)
  - callback is a Callable that takes Vector2i
- Call `joypad_helper->process_event(p_event)` in `gui_input`. If it returns `true`, return from the method.
- In `NOTIFICIATION_INTERNAL_PROCESS` call `joypad_helper->process_internal(delta)`
  - it will call the move callback when appropriate, with the argument specifying how the value should change

The new class uses `SNAME()` for actions, so it should be a little bit more performant too.

Also fixes #90288