### PR TITLE
Show revert button for MeshInstance3D blendshape values

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -493,6 +493,23 @@ void MeshInstance3D::create_debug_tangents() {
 	}
 }
 
+bool MeshInstance3D::_property_can_revert(const StringName &p_name) const {
+	HashMap<StringName, int>::ConstIterator E = blend_shape_properties.find(p_name);
+	if (E) {
+		return true;
+	}
+	return false;
+}
+
+bool MeshInstance3D::_property_get_revert(const StringName &p_name, Variant &r_property) const {
+	HashMap<StringName, int>::ConstIterator E = blend_shape_properties.find(p_name);
+	if (E) {
+		r_property = 0.0f;
+		return true;
+	}
+	return false;
+}
+
 void MeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &MeshInstance3D::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &MeshInstance3D::get_mesh);

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -62,6 +62,9 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;


### PR DESCRIPTION
Shows revert button for MeshInstance3D blendshape values.

![revert_blendshapes](https://github.com/godotengine/godot/assets/52464204/6d1eadfd-e227-4ac5-afd3-a305d801f90e)

... because having to enter `0.0` manually all the time because the slider steps make it impossible to hit zero needs to stop.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
