### PR TITLE
Fix external editor hot reload for GDScript

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -987,7 +987,7 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 	}
 
 	_update_script_names();
-	_trigger_live_script_reload();
+	trigger_live_script_reload();
 }
 
 void ScriptEditor::_scene_saved_callback(const String &p_path) {
@@ -1015,7 +1015,7 @@ void ScriptEditor::_scene_saved_callback(const String &p_path) {
 	}
 }
 
-void ScriptEditor::_trigger_live_script_reload() {
+void ScriptEditor::trigger_live_script_reload() {
 	if (!pending_auto_reload && auto_reload_running_scripts) {
 		call_deferred(SNAME("_live_auto_reload_running_scripts"));
 		pending_auto_reload = true;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -378,7 +378,6 @@ class ScriptEditor : public PanelContainer {
 
 	bool pending_auto_reload;
 	bool auto_reload_running_scripts;
-	void _trigger_live_script_reload();
 	void _live_auto_reload_running_scripts();
 
 	void _update_selected_editor_menu();
@@ -537,6 +536,8 @@ public:
 	void update_doc(const String &p_name);
 	void clear_docs_from_script(const Ref<Script> &p_script);
 	void update_docs_from_script(const Ref<Script> &p_script);
+
+	void trigger_live_script_reload();
 
 	bool can_take_away_focus() const;
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -809,7 +809,7 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 			scr->set_last_modified_time(rel_scr->get_last_modified_time());
 			scr->update_exports();
 
-			_trigger_live_script_reload();
+			trigger_live_script_reload();
 		}
 	}
 }

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -110,9 +110,11 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 		} else {
 			scr->reload(true);
 		}
+
 		scr->update_exports();
 		ScriptEditor::get_singleton()->reload_scripts(true);
 		ScriptEditor::get_singleton()->update_docs_from_script(scr);
+		ScriptEditor::get_singleton()->trigger_live_script_reload();
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/72825 by adding a call to:

```
ScriptEditor::get_singleton()->trigger_live_script_reload();
```

in the `GDScriptTextDocument::didSave` callback. I tested this using the VSCode Godot extension, when connected to the language server, in `master` saving the file in VSCode does NOT trigger an update. An update only happens when you focus in the editor, which goes through the flow: `ScriptEditor::_notification` -> `_update_modified_scripts_for_external_editor()`.

https://github.com/godotengine/godot/blob/6916349697a4339216469e9bf5899b983d78db07/editor/plugins/script_editor_plugin.cpp#L1677C4-L1677C48

For reference, the normal flow of updating a script file while the game is running goes through `ScriptEditor::_res_saved_callback()` -> `_trigger_live_script_reload()`