### PR TITLE
Implement abstract methods in GDScript

### DIFF
--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -150,7 +150,7 @@
 		<method name="_is_abstract" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the script is an abstract script. An abstract script does not have a constructor and cannot be instantiated.
+				Returns [code]true[/code] if the script is an abstract script. Abstract scripts are not intended to be used directly, instead other scripts should inherit them. An abstract script does not have a constructor and cannot be instantiated by itself. They will be either unselectable or hidden in the Create New Node dialog (unselectable if there are non-abstract classes inheriting it, otherwise hidden).
 			</description>
 		</method>
 		<method name="_is_placeholder_fallback_enabled" qualifiers="virtual const">

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -164,6 +164,10 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 				return true; // Plugin is not enabled.
 			}
 		}
+		// Abstract scripts cannot be instantiated.
+		String path = ScriptServer::get_global_class_path(p_type);
+		Ref<Script> scr = ResourceLoader::load(path, "Script");
+		return scr->is_abstract();
 	}
 
 	return false;

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -280,6 +280,12 @@
 		</constant>
 	</constants>
 	<annotations>
+		<annotation name="@abstract">
+			<return type="void" />
+			<description>
+				Mark the current class as abstract. Abstract classes are not intended to be used directly, instead other scripts should inherit them. They will be either unselectable or hidden in the Create New Node dialog (unselectable if there are non-abstract classes inheriting it, otherwise hidden).
+			</description>
+		</annotation>
 		<annotation name="@export">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -63,6 +63,7 @@ class GDScript : public Script {
 	bool tool = false;
 	bool valid = false;
 	bool reloading = false;
+	bool _is_abstract = false;
 
 	struct MemberInfo {
 		int index = 0;
@@ -200,7 +201,6 @@ public:
 	void clear(GDScript::ClearData *p_clear_data = nullptr);
 
 	virtual bool is_valid() const override { return valid; }
-	virtual bool is_abstract() const override { return false; } // GDScript does not support abstract classes.
 
 	bool inherits_script(const Ref<Script> &p_script) const override;
 
@@ -227,6 +227,7 @@ public:
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override;
 
 	bool is_tool() const override { return tool; }
+	bool is_abstract() const override { return _is_abstract; }
 	Ref<GDScript> get_base() const;
 
 	const HashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2635,6 +2635,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 	p_script->clearing = false;
 
 	p_script->tool = parser->is_tool();
+	p_script->_is_abstract = p_class->is_abstract;
 
 	if (p_script->local_name != StringName()) {
 		if (ClassDB::class_exists(p_script->local_name) && ClassDB::is_class_exposed(p_script->local_name)) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -93,6 +93,7 @@ GDScriptParser::GDScriptParser() {
 	register_annotation(MethodInfo("@tool"), AnnotationInfo::SCRIPT, &GDScriptParser::tool_annotation);
 	register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 	register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
+	register_annotation(MethodInfo("@abstract"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS, &GDScriptParser::abstract_annotation);
 
 	register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 	// Export annotations.
@@ -515,7 +516,7 @@ void GDScriptParser::parse_program() {
 				if (annotation->applies_to(AnnotationInfo::SCRIPT)) {
 					// `@icon` needs to be applied in the parser. See GH-72444.
 					if (annotation->name == SNAME("@icon")) {
-						annotation->apply(this, head, nullptr);
+						annotation->apply(this, head, nullptr); // The root class is not in any class.
 					} else {
 						head->annotations.push_back(annotation);
 					}
@@ -3884,6 +3885,18 @@ bool GDScriptParser::icon_annotation(const AnnotationNode *p_annotation, Node *p
 	return true;
 }
 
+bool GDScriptParser::abstract_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::CLASS, false, R"("@abstract" annotation can only be applied to classes.)");
+	// Note: Use `p_target`, **not** `p_class`, because when `p_target` is a class then `p_class` refers to the parent class.
+	ClassNode *class_node = static_cast<ClassNode *>(p_target);
+	if (class_node->is_abstract) {
+		push_error(R"("@abstract" annotation can only be used once per class.)", p_annotation);
+		return false;
+	}
+	class_node->is_abstract = true;
+	return true;
+}
+
 bool GDScriptParser::onready_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@onready" annotation can only be applied to class variables.)");
 
@@ -5411,12 +5424,15 @@ void GDScriptParser::TreePrinter::print_tree(const GDScriptParser &p_parser) {
 	if (p_parser.is_tool()) {
 		push_line("@tool");
 	}
-	if (!p_parser.get_tree()->icon_path.is_empty()) {
+	if (class_tree->is_abstract) {
+		push_line("@abstract");
+	}
+	if (!class_tree->icon_path.is_empty()) {
 		push_text(R"(@icon (")");
-		push_text(p_parser.get_tree()->icon_path);
+		push_text(class_tree->icon_path);
 		push_line("\")");
 	}
-	print_class(p_parser.get_tree());
+	print_class(class_tree);
 
 	print_line(String(printed));
 }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -840,6 +840,7 @@ public:
 		TypeNode *return_type = nullptr;
 		SuiteNode *body = nullptr;
 		bool is_static = false;
+		bool is_abstract = false;
 		bool is_coroutine = false;
 		Variant rpc_config;
 		MethodInfo info;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -733,6 +733,7 @@ public:
 		ClassNode *outer = nullptr;
 		bool extends_used = false;
 		bool onready_used = false;
+		bool is_abstract = false;
 		bool has_static_data = false;
 		bool annotated_static_unload = false;
 		String extends_path;
@@ -1463,6 +1464,7 @@ private:
 	void clear_unused_annotations();
 	bool tool_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool abstract_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.gd
@@ -1,0 +1,8 @@
+extends RefCounted
+
+@abstract
+class A:
+	pass
+
+func test():
+	var _a := A.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot call constructor on abstract class "A".

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.gd
@@ -1,0 +1,4 @@
+const A = preload("./construct_abstract_script.notest.gd")
+
+func test():
+	var _a := A.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.notest.gd
@@ -1,0 +1,2 @@
+@abstract
+class_name TestConstructAbstractScriptNotest

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot call constructor on abstract class "TestConstructAbstractScriptNotest".

--- a/modules/gdscript/tests/scripts/analyzer/errors/duplicate_abstract.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/duplicate_abstract.gd
@@ -1,0 +1,9 @@
+extends RefCounted
+
+@abstract
+@abstract
+class A:
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/duplicate_abstract.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/duplicate_abstract.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+"@abstract" annotation can only be used once per class.

--- a/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
@@ -8,5 +8,13 @@ class B extends A:
 class C extends CanvasItem:
 	pass
 
+@abstract
+class X:
+	pass
+
+class Y extends X:
+	func test() -> String:
+		return "ok"
+
 func test():
-	print('ok')
+	print(Y.new().test())


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot/pull/67777 .

This PR allows the `@abstract` annotation defined in the PR above to be used on methods. Abstract methods have the following properties:

* They must exist inside an abstract class:
![image](https://github.com/godotengine/godot/assets/56272643/97013f8e-c027-4090-9f40-6afecd3d7628)

* They cannot have an implementation
![image](https://github.com/godotengine/godot/assets/56272643/6d30d1d6-39a8-4425-bdb8-c95264121f9d)

* They MUST be implemented by subclasses
![image](https://github.com/godotengine/godot/assets/56272643/60e0671f-e0b5-46ce-87de-e1a5709d4c91)

Please test this and let me know your thoughts!

Below is a simple example project to use in testing:

[test_project_abstract_methods.zip](https://github.com/godotengine/godot/files/12839926/test_project_abstract_methods.zip)

* _Bugsquad edit:_ Closes godotengine/godot-proposals#1631.
* _Production edit: closes godotengine/godot-roadmap#66_