### PR TITLE
Fix referring to ResourceImporterScene static importers via instances

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6924,15 +6924,15 @@ EditorNode::EditorNode() {
 		{
 			Ref<EditorSceneFormatImporterCollada> import_collada;
 			import_collada.instantiate();
-			ResourceImporterScene::add_importer(import_collada);
+			ResourceImporterScene::add_scene_importer(import_collada);
 
 			Ref<EditorOBJImporter> import_obj2;
 			import_obj2.instantiate();
-			ResourceImporterScene::add_importer(import_obj2);
+			ResourceImporterScene::add_scene_importer(import_obj2);
 
 			Ref<EditorSceneFormatImporterESCN> import_escn;
 			import_escn.instantiate();
-			ResourceImporterScene::add_importer(import_escn);
+			ResourceImporterScene::add_scene_importer(import_escn);
 		}
 
 		Ref<ResourceImporterBitMap> import_bitmap;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -443,12 +443,12 @@ void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 
 void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(!p_importer.is_valid());
-	ResourceImporterScene::add_importer(p_importer, p_first_priority);
+	ResourceImporterScene::add_scene_importer(p_importer, p_first_priority);
 }
 
 void EditorPlugin::remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer) {
 	ERR_FAIL_COND(!p_importer.is_valid());
-	ResourceImporterScene::remove_importer(p_importer);
+	ResourceImporterScene::remove_scene_importer(p_importer);
 }
 
 void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -47,7 +47,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_dir_dialog.h"
 #include "editor/gui/editor_scene_tabs.h"
-#include "editor/import/resource_importer_scene.h"
+#include "editor/import/scene_import_settings.h"
 #include "editor/import_dock.h"
 #include "editor/plugins/editor_resource_tooltip_plugins.h"
 #include "editor/scene_create_dialog.h"
@@ -1192,12 +1192,12 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 		String resource_type = ResourceLoader::get_resource_type(fpath);
 
-		if (resource_type == "PackedScene") {
+		if (resource_type == "PackedScene" || resource_type == "AnimationLibrary") {
 			bool is_imported = false;
 
 			{
 				List<String> importer_exts;
-				ResourceImporterScene::get_scene_singleton()->get_recognized_extensions(&importer_exts);
+				ResourceImporterScene::get_scene_importer_extensions(&importer_exts);
 				String extension = fpath.get_extension();
 				for (const String &E : importer_exts) {
 					if (extension.nocasecmp_to(E) == 0) {
@@ -1208,27 +1208,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			}
 
 			if (is_imported) {
-				ResourceImporterScene::get_scene_singleton()->show_advanced_options(fpath);
-			} else {
-				EditorNode::get_singleton()->open_request(fpath);
-			}
-		} else if (resource_type == "AnimationLibrary") {
-			bool is_imported = false;
-
-			{
-				List<String> importer_exts;
-				ResourceImporterScene::get_animation_singleton()->get_recognized_extensions(&importer_exts);
-				String extension = fpath.get_extension();
-				for (const String &E : importer_exts) {
-					if (extension.nocasecmp_to(E) == 0) {
-						is_imported = true;
-						break;
-					}
-				}
-			}
-
-			if (is_imported) {
-				ResourceImporterScene::get_animation_singleton()->show_advanced_options(fpath);
+				SceneImportSettingsDialog::get_singleton()->open_settings(p_path, resource_type == "AnimationLibrary");
 			} else {
 				EditorNode::get_singleton()->open_request(fpath);
 			}

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -250,9 +250,7 @@ String ResourceImporterScene::get_visible_name() const {
 }
 
 void ResourceImporterScene::get_recognized_extensions(List<String> *p_extensions) const {
-	for (Ref<EditorSceneFormatImporter> importer_elem : importers) {
-		importer_elem->get_extensions(p_extensions);
-	}
+	get_scene_importer_extensions(p_extensions);
 }
 
 String ResourceImporterScene::get_save_extension() const {
@@ -294,7 +292,7 @@ bool ResourceImporterScene::get_option_visibility(const String &p_path, const St
 		}
 	}
 
-	for (Ref<EditorSceneFormatImporter> importer : importers) {
+	for (Ref<EditorSceneFormatImporter> importer : scene_importers) {
 		Variant ret = importer->get_option_visibility(p_path, animation_importer, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
 			return ret;
@@ -1951,13 +1949,13 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 		post_importer_plugins.write[i]->get_import_options(p_path, r_options);
 	}
 
-	for (Ref<EditorSceneFormatImporter> importer_elem : importers) {
+	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->get_import_options(p_path, r_options);
 	}
 }
 
 void ResourceImporterScene::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
-	for (Ref<EditorSceneFormatImporter> importer_elem : importers) {
+	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->handle_compatibility_options(p_import_params);
 	}
 }
@@ -2360,7 +2358,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	EditorProgress progress("pre-import", TTR("Pre-Import Scene"), 0);
 	progress.step(TTR("Importing Scene..."), 0);
 
-	for (Ref<EditorSceneFormatImporter> importer_elem : importers) {
+	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		List<String> extensions;
 		importer_elem->get_extensions(&extensions);
 
@@ -2402,7 +2400,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	EditorProgress progress("import", TTR("Import Scene"), 104);
 	progress.step(TTR("Importing Scene..."), 0);
 
-	for (Ref<EditorSceneFormatImporter> importer_elem : importers) {
+	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		List<String> extensions;
 		importer_elem->get_extensions(&extensions);
 
@@ -2665,12 +2663,13 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 ResourceImporterScene *ResourceImporterScene::scene_singleton = nullptr;
 ResourceImporterScene *ResourceImporterScene::animation_singleton = nullptr;
 
-Vector<Ref<EditorSceneFormatImporter>> ResourceImporterScene::importers;
+Vector<Ref<EditorSceneFormatImporter>> ResourceImporterScene::scene_importers;
 Vector<Ref<EditorScenePostImportPlugin>> ResourceImporterScene::post_importer_plugins;
 
 bool ResourceImporterScene::has_advanced_options() const {
 	return true;
 }
+
 void ResourceImporterScene::show_advanced_options(const String &p_path) {
 	SceneImportSettingsDialog::get_singleton()->open_settings(p_path, animation_importer);
 }
@@ -2697,12 +2696,12 @@ ResourceImporterScene::~ResourceImporterScene() {
 	}
 }
 
-void ResourceImporterScene::add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {
+void ResourceImporterScene::add_scene_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(p_importer.is_null());
 	if (p_first_priority) {
-		importers.insert(0, p_importer);
+		scene_importers.insert(0, p_importer);
 	} else {
-		importers.push_back(p_importer);
+		scene_importers.push_back(p_importer);
 	}
 }
 
@@ -2719,13 +2718,19 @@ void ResourceImporterScene::add_post_importer_plugin(const Ref<EditorScenePostIm
 	}
 }
 
-void ResourceImporterScene::remove_importer(Ref<EditorSceneFormatImporter> p_importer) {
-	importers.erase(p_importer);
+void ResourceImporterScene::remove_scene_importer(Ref<EditorSceneFormatImporter> p_importer) {
+	scene_importers.erase(p_importer);
 }
 
 void ResourceImporterScene::clean_up_importer_plugins() {
-	importers.clear();
+	scene_importers.clear();
 	post_importer_plugins.clear();
+}
+
+void ResourceImporterScene::get_scene_importer_extensions(List<String> *p_extensions) {
+	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
+		importer_elem->get_extensions(p_extensions);
+	}
 }
 
 ///////////////////////////////////////

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -159,7 +159,7 @@ VARIANT_ENUM_CAST(EditorScenePostImportPlugin::InternalImportCategory)
 class ResourceImporterScene : public ResourceImporter {
 	GDCLASS(ResourceImporterScene, ResourceImporter);
 
-	static Vector<Ref<EditorSceneFormatImporter>> importers;
+	static Vector<Ref<EditorSceneFormatImporter>> scene_importers;
 	static Vector<Ref<EditorScenePostImportPlugin>> post_importer_plugins;
 
 	static ResourceImporterScene *scene_singleton;
@@ -243,10 +243,10 @@ public:
 	static void add_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority = false);
 	static void remove_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin);
 
-	const Vector<Ref<EditorSceneFormatImporter>> &get_importers() const { return importers; }
-
-	static void add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority = false);
-	static void remove_importer(Ref<EditorSceneFormatImporter> p_importer);
+	const Vector<Ref<EditorSceneFormatImporter>> &get_scene_importers() const { return scene_importers; }
+	static void add_scene_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority = false);
+	static void remove_scene_importer(Ref<EditorSceneFormatImporter> p_importer);
+	static void get_scene_importer_extensions(List<String> *p_extensions);
 
 	static void clean_up_importer_plugins();
 

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -51,7 +51,7 @@
 static void _editor_init() {
 	Ref<EditorSceneFormatImporterGLTF> import_gltf;
 	import_gltf.instantiate();
-	ResourceImporterScene::add_importer(import_gltf);
+	ResourceImporterScene::add_scene_importer(import_gltf);
 
 	// Blend to glTF importer.
 
@@ -66,7 +66,7 @@ static void _editor_init() {
 		} else {
 			Ref<EditorSceneFormatImporterBlend> importer;
 			importer.instantiate();
-			ResourceImporterScene::add_importer(importer);
+			ResourceImporterScene::add_scene_importer(importer);
 
 			Ref<EditorFileSystemImportFormatSupportQueryBlend> blend_import_query;
 			blend_import_query.instantiate();
@@ -82,7 +82,7 @@ static void _editor_init() {
 	if (fbx_enabled) {
 		Ref<EditorSceneFormatImporterFBX> importer;
 		importer.instantiate();
-		ResourceImporterScene::get_scene_singleton()->add_importer(importer);
+		ResourceImporterScene::add_scene_importer(importer);
 
 		Ref<EditorFileSystemImportFormatSupportQueryFBX> fbx_import_query;
 		fbx_import_query.instantiate();


### PR DESCRIPTION
(Note: This will conflict with #82899. We can merge in either order, I will rebase the other PR).

In a small number of places (once in the glTF module and multiple times in the filesystem dock), static data in the `ResourceImporterScene` class was being referred to by the singleton instance when it did not need to be. This PR fixes those places.

Part of the problem is the confusion between the parent class `ResourceImporter` working with "importer"s and this class `ResourceImporterScene` working with "importer"s. This PR includes a rename of the `ResourceImporterScene` importer methods to "scene_importer" to avoid confusion with `ResourceImporter`'s "importer".

This PR also reduces code duplication in the filesystem dock, previously it was choosing between the different singletons but now that is no longer necessary. `ResourceImporterScene::get_scene_importer_extensions` is accessing static data so we don't need to use the singletons. The `show_advanced_options` method is just a shortcut for accessing the scene import dialog and passing along with a bool for if this is the animation dialog or not, so instead of using the singletons of the importer we should just have this part of the editor UI talk to the other part of the editor UI.