### PR TITLE
Replace `sanity` with `safety` for checks

### DIFF
--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2278,7 +2278,7 @@ Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3
 
 	uint32_t edges_copied = 0;
 	for (uint32_t i = 0; i < ch.edges.size(); i++) {
-		ERR_CONTINUE(edge_faces[i] == -1); // Sanity check
+		ERR_CONTINUE(edge_faces[i] == -1); // Safety check.
 
 		uint32_t a = (&ch.edges[i])->get_source_vertex();
 		uint32_t b = (&ch.edges[i])->get_target_vertex();

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -36,7 +36,7 @@
 #include "core/object/script_language.h"
 
 #ifdef DEV_ENABLED
-// Includes sanity checks to ensure that a queue set as a thread singleton override
+// Includes safety checks to ensure that a queue set as a thread singleton override
 // is only ever called from the thread it was set for.
 #define LOCK_MUTEX                                     \
 	if (this != MessageQueue::thread_singleton) {      \
@@ -537,7 +537,7 @@ CallQueue::~CallQueue() {
 	if (!allocator_is_custom) {
 		memdelete(allocator);
 	}
-	// This is done here to avoid a circular dependency between the sanity checks and the thread singleton pointer.
+	// This is done here to avoid a circular dependency between the safety checks and the thread singleton pointer.
 	if (this == MessageQueue::thread_singleton) {
 		MessageQueue::thread_singleton = nullptr;
 	}

--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -144,7 +144,7 @@ public:
 		if (thread_safe) {
 			spin_lock.lock();
 		}
-		ERR_FAIL_COND(page_pool != nullptr); //sanity check
+		ERR_FAIL_COND(page_pool != nullptr); // Safety check.
 		ERR_FAIL_COND(p_page_size == 0);
 		page_size = nearest_power_of_2_templated(p_page_size);
 		page_mask = page_size - 1;

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -182,7 +182,7 @@ class SafeRefCount {
 	SafeNumeric<uint32_t> count;
 
 #ifdef DEV_ENABLED
-	_ALWAYS_INLINE_ void _check_unref_sanity() {
+	_ALWAYS_INLINE_ void _check_unref_safety() {
 		// This won't catch every misuse, but it's better than nothing.
 		CRASH_COND_MSG(count.get() == 0,
 				"Trying to unreference a SafeRefCount which is already zero is wrong and a symptom of it being misused.\n"
@@ -202,14 +202,14 @@ public:
 
 	_ALWAYS_INLINE_ bool unref() { // true if must be disposed of
 #ifdef DEV_ENABLED
-		_check_unref_sanity();
+		_check_unref_safety();
 #endif
 		return count.decrement() == 0;
 	}
 
 	_ALWAYS_INLINE_ uint32_t unrefval() { // 0 if must be disposed of
 #ifdef DEV_ENABLED
-		_check_unref_sanity();
+		_check_unref_safety();
 #endif
 		return count.decrement();
 	}

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -866,7 +866,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		state.instance_data_array[r_index].lights[2] = lights[2];
 		state.instance_data_array[r_index].lights[3] = lights[3];
 
-		state.instance_data_array[r_index].flags = base_flags | (state.instance_data_array[r_index == 0 ? 0 : r_index - 1].flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); //reset on each command for sanity, keep canvastexture binding config
+		state.instance_data_array[r_index].flags = base_flags | (state.instance_data_array[r_index == 0 ? 0 : r_index - 1].flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); // Reset on each command for safety, keep canvastexture binding config.
 
 		Color blend_color = base_color;
 		GLES3::CanvasShaderData::BlendMode blend_mode = p_blend_mode;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4340,7 +4340,7 @@ Error GLTFDocument::_expand_skin(Ref<GLTFState> p_state, Ref<GLTFSkin> p_skin) {
 }
 
 Error GLTFDocument::_verify_skin(Ref<GLTFState> p_state, Ref<GLTFSkin> p_skin) {
-	// This may seem duplicated from expand_skins, but this is really a sanity check! (so it kinda is)
+	// This may seem duplicated from expand_skins, but this is really a safety check! (so it kinda is)
 	// In case additional interpolating logic is added to the skins, this will help ensure that you
 	// do not cause it to self implode into a fiery blaze
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1855,7 +1855,7 @@ void Node::_set_owner_nocheck(Node *p_owner) {
 }
 
 void Node::_release_unique_name_in_owner() {
-	ERR_FAIL_NULL(data.owner); // Sanity check.
+	ERR_FAIL_NULL(data.owner); // Safety check.
 	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.operator String());
 	Node **which = data.owner->data.owned_unique_nodes.getptr(key);
 	if (which == nullptr || *which != this) {
@@ -1865,7 +1865,7 @@ void Node::_release_unique_name_in_owner() {
 }
 
 void Node::_acquire_unique_name_in_owner() {
-	ERR_FAIL_NULL(data.owner); // Sanity check.
+	ERR_FAIL_NULL(data.owner); // Safety check.
 	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.operator String());
 	Node **which = data.owner->data.owned_unique_nodes.getptr(key);
 	if (which != nullptr && *which != this) {
@@ -1938,7 +1938,7 @@ Node *Node::get_owner() const {
 }
 
 void Node::_clean_up_owner() {
-	ERR_FAIL_NULL(data.owner); // Sanity check.
+	ERR_FAIL_NULL(data.owner); // Safety check.
 
 	if (data.unique_name_in_owner) {
 		_release_unique_name_in_owner();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4398,7 +4398,7 @@ struct AnimationCompressionDataState {
 		PacketData packet;
 		packet.frame = p_frame;
 		for (int i = 0; i < 3; i++) {
-			ERR_FAIL_COND_V(p_key[i] > 65535, false); // Sanity check
+			ERR_FAIL_COND_V(p_key[i] > 65535, false); // Safety checks.
 			packet.data[i] = p_key[i];
 		}
 
@@ -4544,7 +4544,7 @@ struct AnimationCompressionDataState {
 				}
 				int32_t delta = _compute_delta16_signed(temp_packets[i - 1].data[j], temp_packets[i].data[j]);
 
-				ERR_FAIL_COND(delta < -32768 || delta > 32767); //sanity check
+				ERR_FAIL_COND(delta < -32768 || delta > 32767); // Safety check.
 
 				uint16_t deltau;
 				if (delta < 0) {
@@ -4556,7 +4556,7 @@ struct AnimationCompressionDataState {
 			}
 		}
 		if (bits_used != 0) {
-			ERR_FAIL_COND(bit_buffer > 0xFF); // Sanity check
+			ERR_FAIL_COND(bit_buffer > 0xFF); // Safety check.
 			data.push_back(bit_buffer);
 		}
 
@@ -4645,7 +4645,7 @@ Vector3i Animation::_compress_key(uint32_t p_track, const AABB &p_bounds, int32_
 			values[0] = CLAMP(int32_t(blend * 65535.0), 0, 65535);
 		} break;
 		default: {
-			ERR_FAIL_V(Vector3i()); //sanity check
+			ERR_FAIL_V(Vector3i()); // Safety check.
 		} break;
 	}
 
@@ -4819,7 +4819,7 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 				break;
 			}
 
-			ERR_FAIL_COND(key_frame < base_page_frame); // Sanity check, should never happen
+			ERR_FAIL_COND(key_frame < base_page_frame); // Safety check, should never happen.
 
 			if (key_frame - base_page_frame >= max_frames_per_page) {
 				// Invalid because beyond the max frames allowed per page
@@ -5260,7 +5260,7 @@ bool Animation::_fetch_compressed(uint32_t p_compressed_track, double p_time, Ve
 			// So, the last frame found still has a time that is less than the required frame,
 			// will have to interpolate with the first frame of the next timekey.
 
-			if ((uint32_t)packet_idx < time_key_count - 1) { // Sanity check but should not matter much, otherwise current next packet is last packet
+			if ((uint32_t)packet_idx < time_key_count - 1) { // Safety check but should not matter much, otherwise current next packet is last packet.
 
 				uint16_t time_key_data_next = time_keys[(packet_idx + 1) * 2 + 1];
 				uint32_t data_offset_next = (time_key_data_next & 0xFFF) * 4; // Lower 12 bits

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1808,7 +1808,7 @@ real_t Curve3D::_sample_baked_tilt(Interval p_interval) const {
 }
 
 // Internal method for getting posture at a baked point. Assuming caller
-// make all sanity checks.
+// make all safety checks.
 Basis Curve3D::_compose_posture(int p_index) const {
 	Vector3 forward = baked_forward_vector_cache[p_index];
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -485,7 +485,7 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 			continue;
 		}
 
-		push_constant.flags = base_flags | (push_constant.flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); //reset on each command for sanity, keep canvastexture binding config
+		push_constant.flags = base_flags | (push_constant.flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); // Reset on each command for safety, keep canvastexture binding config.
 
 		switch (c->type) {
 			case Item::Command::TYPE_RECT: {


### PR DESCRIPTION
More inclusive language and something that has bothered me personally.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
