### PR TITLE
Convert Nodepath properties to Object if "node_type" property hint has been set

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1233,8 +1233,9 @@ int SceneState::_find_base_scene_node_remap_key(int p_idx) const {
 	return -1;
 }
 
-Variant SceneState::get_property_value(int p_node, const StringName &p_property, bool &found) const {
+Variant SceneState::get_property_value(int p_node, const StringName &p_property, bool &found, bool &is_path_node) const {
 	found = false;
+	is_path_node = false;
 
 	ERR_FAIL_COND_V(p_node < 0, Variant());
 
@@ -1246,6 +1247,9 @@ Variant SceneState::get_property_value(int p_node, const StringName &p_property,
 		const NodeData::Property *p = nodes[p_node].properties.ptr();
 		for (int i = 0; i < pc; i++) {
 			if (p_property == namep[p[i].name & FLAG_PROP_NAME_MASK]) {
+				if (p[i].name & FLAG_PATH_PROPERTY_IS_NODE) {
+					is_path_node = true;
+				}
 				found = true;
 				return variants[p[i].value];
 			}
@@ -1255,7 +1259,7 @@ Variant SceneState::get_property_value(int p_node, const StringName &p_property,
 	//property not found, try on instance
 
 	if (base_scene_node_remap.has(p_node)) {
-		return get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found);
+		return get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found, is_path_node);
 	}
 
 	return Variant();

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -139,7 +139,7 @@ public:
 	static Ref<Resource> get_remap_resource(const Ref<Resource> &p_resource, HashMap<Ref<Resource>, Ref<Resource>> &remap_cache, const Ref<Resource> &p_fallback, Node *p_for_scene);
 
 	int find_node_by_path(const NodePath &p_node) const;
-	Variant get_property_value(int p_node, const StringName &p_property, bool &found) const;
+	Variant get_property_value(int p_node, const StringName &p_property, bool &found, bool &is_path_node) const;
 	bool is_node_in_group(int p_node, const StringName &p_group) const;
 	bool is_connection(int p_node, const StringName &p_signal, int p_to_node, const StringName &p_to_method) const;
 


### PR DESCRIPTION
This fixes an issue when instantiating a scene, script's properties that have "node_type" hint set are read as a nodepath causing "revert" button to popup due variant mismatch.

before pr:

https://github.com/godotengine/godot/assets/33091666/39213a90-db67-458a-8cd5-3e9d6b2c67da

pr: 

https://github.com/godotengine/godot/assets/33091666/930f3fa5-030a-4fd2-a61b-b182950765c8
