### PR TITLE
Add documentation on which buttons JOY_BUTTON_START corresponds to

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2449,7 +2449,7 @@
 			Game controller SDL guide button. Corresponds to the Sony PS, Xbox Home button.
 		</constant>
 		<constant name="JOY_BUTTON_START" value="6" enum="JoyButton">
-			Game controller SDL start button. Corresponds to the Nintendo + button.
+			Game controller SDL start button. Corresponds to the Sony Options, Xbox Menu, Nintendo + button.
 		</constant>
 		<constant name="JOY_BUTTON_LEFT_STICK" value="7" enum="JoyButton">
 			Game controller SDL left stick button. Corresponds to the Sony L3, Xbox L/LS button.


### PR DESCRIPTION
The existing documentation for  `JoyButton.JOY_BUTTON_START` only mentions the Nintendo button it corresponds to, that being:

> Game controller SDL start button. Corresponds to the Nintendo + button.

This PR updates it to also include the PlayStation and Xbox buttons it corresponds to, the names for the updated documentation are taken from the corresponding manuals at:

- https://manuals.playstation.net/document/en/ps4/basic/pn_controller.html
- https://support.xbox.com/en-US/help/hardware-network/controller/xbox-one-wireless-controller

