### PR TITLE
Add deprecation notice to a duplicate method of class `Window`

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -357,10 +357,11 @@
 				Centers a native window on the current screen and an embedded window on its embedder [Viewport].
 			</description>
 		</method>
-		<method name="move_to_foreground">
+		<method name="move_to_foreground" is_deprecated="true">
 			<return type="void" />
 			<description>
 				Moves the [Window] on top of other windows and focuses it.
+				[i]Deprecated.[/i] Use [method Window.grab_focus] instead.
 			</description>
 		</method>
 		<method name="popup">

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2350,7 +2350,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		line = line.replace("OS.is_window_focused", "get_window().has_focus");
 	}
 	if (line.contains("OS.move_window_to_foreground")) {
-		line = line.replace("OS.move_window_to_foreground", "get_window().move_to_foreground");
+		line = line.replace("OS.move_window_to_foreground", "get_window().grab_focus");
 	}
 	if (line.contains("OS.request_attention")) {
 		line = line.replace("OS.request_attention", "get_window().request_attention");

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -520,15 +520,12 @@ void Window::request_attention() {
 	}
 }
 
+#ifndef DISABLE_DEPRECATED
 void Window::move_to_foreground() {
-	ERR_MAIN_THREAD_GUARD;
-	if (embedder) {
-		embedder->_sub_window_grab_focus(this);
-
-	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-		DisplayServer::get_singleton()->window_move_to_foreground(window_id);
-	}
+	WARN_DEPRECATED_MSG(R"*(The "move_to_foreground()" method is deprecated, use "grab_focus()" instead.)*");
+	grab_focus();
 }
+#endif // DISABLE_DEPRECATED
 
 bool Window::can_draw() const {
 	ERR_READ_THREAD_GUARD_V(false);
@@ -2745,7 +2742,9 @@ void Window::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("request_attention"), &Window::request_attention);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("move_to_foreground"), &Window::move_to_foreground);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &Window::set_visible);
 	ClassDB::bind_method(D_METHOD("is_visible"), &Window::is_visible);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -301,7 +301,9 @@ public:
 	bool is_maximize_allowed() const;
 
 	void request_attention();
+#ifndef DISABLE_DEPRECATED
 	void move_to_foreground();
+#endif // DISABLE_DEPRECATED
 
 	virtual void set_visible(bool p_visible);
 	bool is_visible() const;


### PR DESCRIPTION
- Fixes #82936.
- Closes #87093.

This pull request adds a deprecation warning to the `Window::move_to_foreground()` method, as internally it contains the same code as the `Window::grab_focus()` method.

In a future version of Godot (*4.3*? *4.4*? ***5.x***?) said method ought to be removed, however, to maintain compatibility a deprecation warning should suffice for now.

**Note**: If this is not the right way to purge duplicates from the codebase I am more than willing to re-do it once I've been shown the proper way.
