### PR TITLE
[XR] Replace `OpenXRInterface.session_focussed` with `session_focused`

### DIFF
--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -148,9 +148,15 @@
 				Informs our OpenXR session has been started.
 			</description>
 		</signal>
-		<signal name="session_focussed">
+		<signal name="session_focused">
 			<description>
 				Informs our OpenXR session now has focus.
+			</description>
+		</signal>
+		<signal name="session_focussed" is_deprecated="true">
+			<description>
+				Informs our OpenXR session now has focus.
+				[i]Deprecated.[/i] Use [signal session_focused] instead.
 			</description>
 		</signal>
 		<signal name="session_stopping">

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -40,7 +40,10 @@ void OpenXRInterface::_bind_methods() {
 	// lifecycle signals
 	ADD_SIGNAL(MethodInfo("session_begun"));
 	ADD_SIGNAL(MethodInfo("session_stopping"));
+	ADD_SIGNAL(MethodInfo("session_focused"));
+#ifndef DISABLE_DEPRECATED
 	ADD_SIGNAL(MethodInfo("session_focussed"));
+#endif // DISABLE_DEPRECATED
 	ADD_SIGNAL(MethodInfo("session_visible"));
 	ADD_SIGNAL(MethodInfo("pose_recentered"));
 
@@ -1177,7 +1180,10 @@ void OpenXRInterface::on_state_visible() {
 }
 
 void OpenXRInterface::on_state_focused() {
+	emit_signal(SNAME("session_focused"));
+#ifndef DISABLE_DEPRECATED
 	emit_signal(SNAME("session_focussed"));
+#endif // DISABLE_DEPRECATED
 }
 
 void OpenXRInterface::on_state_stopping() {


### PR DESCRIPTION
Deprecate old misspelled signal.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
