### PR TITLE
Improve performance of single light scene

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -850,6 +850,10 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 			if (p_render_data->directional_light_soft_shadows) {
 				spec_constant_base_flags |= 1 << SPEC_CONSTANT_USING_DIRECTIONAL_SOFT_SHADOWS;
 			}
+
+			if (p_render_data->directional_light_count == 1) {
+				spec_constant_base_flags |= 1 << SPEC_CONSTANT_SINGLE_DIRECTIONAL_LIGHT;
+			}
 		} else {
 			spec_constant_base_flags |= 1 << SPEC_CONSTANT_DISABLE_DIRECTIONAL_LIGHTS;
 		}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -83,6 +83,9 @@ private:
 		SPEC_CONSTANT_DISABLE_DECALS = 13,
 		SPEC_CONSTANT_DISABLE_FOG = 14,
 
+		// 15 is used by sc_luminance_multiplier
+		SPEC_CONSTANT_SINGLE_DIRECTIONAL_LIGHT = 16,
+
 	};
 
 	enum {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -513,6 +513,7 @@ layout(constant_id = 9) const bool sc_disable_omni_lights = false;
 layout(constant_id = 10) const bool sc_disable_spot_lights = false;
 layout(constant_id = 11) const bool sc_disable_reflection_probes = false;
 layout(constant_id = 12) const bool sc_disable_directional_lights = false;
+layout(constant_id = 16) const bool sc_single_directional_light = false;
 
 #endif //!MODE_UNSHADED
 
@@ -1284,13 +1285,14 @@ void main() {
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 	if (!sc_disable_directional_lights) { //directional light
+		const uint max_directional_lights = sc_single_directional_light ? 1u : 8u;
 #ifndef SHADOWS_DISABLED
 		// Do shadow and lighting in two passes to reduce register pressure
 		uint shadow0 = 0;
 		uint shadow1 = 0;
 
-		for (uint i = 0; i < 8; i++) {
-			if (i >= scene_data.directional_light_count) {
+		for (uint i = 0; i < max_directional_lights; i++) {
+			if (!sc_single_directional_light && i >= scene_data.directional_light_count) {
 				break;
 			}
 
@@ -1561,8 +1563,8 @@ void main() {
 
 #endif // SHADOWS_DISABLED
 
-		for (uint i = 0; i < 8; i++) {
-			if (i >= scene_data.directional_light_count) {
+		for (uint i = 0; i < max_directional_lights; i++) {
+			if (!sc_single_directional_light && i >= scene_data.directional_light_count) {
 				break;
 			}
 


### PR DESCRIPTION
On pixel shader bound scenarios, use a specialization constant to generate a variant that uses one single directional light; which is the most common use case.

This improves framerate of Adreno 505 by 33%

**NOTE:** For Adreno 505 performance improvements to actually appear this PR also needs #82805 to workaround a driver bug.

**NOTE:** This PR _can_ be merged without having to merge #82805.