### PR TITLE
AnimationMixer: Fix non-numeric misc type (`Resource`, `Dictionary` & etc.) values cannot be blended with `UpdateMode.UPDATE_CONTINUOUS`

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -868,6 +868,27 @@ bool AnimationMixer::_update_caches() {
 				track_value->is_continuous |= anim->value_track_get_update_mode(i) != Animation::UPDATE_DISCRETE;
 				track_value->is_using_angle |= anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_LINEAR_ANGLE || anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_CUBIC_ANGLE;
 
+				// TODO: Currently, misc type cannot be blended. In the future,
+				// it should have a separate blend weight, just as bool is converted to 0 and 1.
+				// Then, it should provide the correct precedence value.
+				switch (track_value->init_value.get_type()) {
+					case Variant::NIL:
+					case Variant::STRING_NAME:
+					case Variant::NODE_PATH:
+					case Variant::RID:
+					case Variant::OBJECT:
+					case Variant::CALLABLE:
+					case Variant::SIGNAL:
+					case Variant::DICTIONARY:
+					case Variant::ARRAY: {
+						WARN_PRINT_ONCE_ED("AnimationMixer: '" + String(E) + "', Value Track: '" + String(path) + "' uses a non-numeric type as key value with UpdateMode.UPDATE_CONTINUOUS. This will not be blended correctly, so it is forced to UpdateMode.UPDATE_DISCRETE.");
+						track_value->is_continuous = false;
+						break;
+					}
+					default: {
+					}
+				}
+
 				if (was_continuous != track_value->is_continuous) {
 					WARN_PRINT_ONCE_ED("Value Track: " + String(path) + " has different update modes between some animations may be blended. Blending prioritizes UpdateMode.UPDATE_CONTINUOUS, so the process treat UpdateMode.UPDATE_DISCRETE as UpdateMode.UPDATE_CONTINUOUS with InterpolationType.INTERPOLATION_NEAREST.");
 				}


### PR DESCRIPTION
Closes #82949
Closes #82905

If you try to use `UpdateMode.UPDATE_CONTINUOUS` with a non-numeric Misc Type value, it will fail to apply the value because there is currently no way to blend using `UpdateMode.UPDATE_CONTINUOUS`.

I believe that in the future we should convert them to have weight as `Pair<Variant value, float weight>` in the similar way that `bool` values are converted to `0` or `1` and blended, but for now it will force `UpdateMode.UPDATE_DISCRETE` instead of `UpdateMode.UPDATE_CONTINUOUS` since it is useless now.