### PR TITLE
[3.x] Fix `glGet` overflows by using 64 bit versions

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -134,6 +134,15 @@ void RasterizerStorageGLES2::GLWrapper::reset() {
 	texture_unit_table.blank();
 }
 
+int32_t RasterizerStorageGLES2::safe_gl_get_integer(unsigned int p_gl_param_name, int32_t p_max_accepted) {
+	// There is no glGetInteger64v in the base GLES2 spec as far as I can see.
+	// So we will just have a capped 32 bit version for GLES2.
+	int32_t temp;
+	glGetIntegerv(p_gl_param_name, &temp);
+	temp = MIN(temp, p_max_accepted);
+	return temp;
+}
+
 void RasterizerStorageGLES2::bind_quad_array() const {
 	glBindBuffer(GL_ARRAY_BUFFER, resources.quadie);
 	glVertexAttribPointer(VS::ARRAY_VERTEX, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, nullptr);
@@ -6316,7 +6325,7 @@ void RasterizerStorageGLES2::initialize() {
 	config.depth_type = GL_UNSIGNED_INT;
 
 	// Initialize GLWrapper early on, as required for any calls to glActiveTexture.
-	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &config.max_texture_image_units);
+	config.max_texture_image_units = safe_gl_get_integer(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, Config::max_desired_texture_image_units);
 	gl_wrapper.initialize(config.max_texture_image_units);
 
 #ifdef GLES_OVER_GL

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -65,6 +65,7 @@ public:
 
 		int max_vertex_texture_image_units;
 		int max_texture_image_units;
+		static const int32_t max_desired_texture_image_units = 64;
 		int max_texture_size;
 		int max_cubemap_texture_size;
 		int max_viewport_dimensions[2];
@@ -1389,6 +1390,8 @@ public:
 	virtual uint64_t get_render_info(VS::RenderInfo p_info);
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
+
+	static int32_t safe_gl_get_integer(unsigned int p_gl_param_name, int32_t p_max_accepted = INT32_MAX);
 
 	// NOTE : THESE SIZES ARE IN BYTES. BUFFER SIZES MAY NOT BE SPECIFIED IN BYTES SO REMEMBER TO CONVERT THEM WHEN CALLING.
 	void buffer_orphan_and_upload(unsigned int p_buffer_size_bytes, unsigned int p_offset_bytes, unsigned int p_data_size_bytes, const void *p_data, GLenum p_target = GL_ARRAY_BUFFER, GLenum p_usage = GL_DYNAMIC_DRAW, bool p_optional_orphan = false) const;

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -558,7 +558,8 @@ void ShaderGLES2::setup(
 		}
 	}
 
-	glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_image_units);
+	// The upper limit must match the version used in storage.
+	max_image_units = RasterizerStorageGLES2::safe_gl_get_integer(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, RasterizerStorageGLES2::Config::max_desired_texture_image_units);
 }
 
 void ShaderGLES2::finish() {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -97,6 +97,7 @@ public:
 		float anisotropic_level;
 
 		int max_texture_image_units;
+		static const int32_t max_desired_texture_image_units = 64;
 		int max_texture_size;
 		int max_cubemap_texture_size;
 
@@ -1529,6 +1530,8 @@ public:
 
 	void initialize();
 	void finalize();
+
+	static int32_t safe_gl_get_integer(unsigned int p_gl_param_name, int32_t p_max_accepted = INT32_MAX);
 
 	virtual bool has_os_feature(const String &p_feature) const;
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -34,6 +34,7 @@
 #include "core/os/os.h"
 #include "core/print_string.h"
 #include "core/threaded_callable_queue.h"
+#include "drivers/gles3/rasterizer_storage_gles3.h"
 #include "drivers/gles3/shader_cache_gles3.h"
 #include "servers/visual_server.h"
 
@@ -1216,7 +1217,8 @@ void ShaderGLES3::setup(const char **p_conditional_defines, int p_conditional_co
 		}
 	}
 
-	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &max_image_units);
+	// The upper limit must match the version used in storage.
+	max_image_units = RasterizerStorageGLES3::safe_gl_get_integer(GL_MAX_TEXTURE_IMAGE_UNITS, RasterizerStorageGLES3::Config::max_desired_texture_image_units);
 }
 
 void ShaderGLES3::init_async_compilation() {


### PR DESCRIPTION
Certain glGet operations require 64 bit versions according to the GLES spec. The previous code was susceptible to overflow bugs,  especially running under ANGLE.

May fix #75913

## Notes
* Supersedes #82921
* Also fixes a theoretical bug in `gl_wrapper` by placing an upper limit on texture image units.
* Is basically a slightly more in depth version of #80909 .

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
