### PR TITLE
Fix vertex color looks darker in gles2

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -975,6 +975,11 @@ void BaseMaterial3D::_update_shader() {
 		code += "		COLOR.rgb = mix(pow((COLOR.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), COLOR.rgb * (1.0 / 12.92), lessThan(COLOR.rgb, vec3(0.04045)));\n";
 		code += "	}\n";
 	}
+	else {
+		code += "\tif (OUTPUT_IS_SRGB) {\n";
+		code += "\t\tCOLOR.rgb = mix((vec3(1.0f) + vec3(0.055f)) * pow(COLOR.rgb, vec3(1.0f / 2.4f)) - vec3(0.055f), 12.92f * COLOR.rgb, lessThan(COLOR.rgb, vec3(0.0031308f)));\n";
+		code += "\t}\n";
+	}
 	if (flags[FLAG_USE_POINT_SIZE]) {
 		code += "	POINT_SIZE=point_size;\n";
 	}


### PR DESCRIPTION
Add auto convert to srgb code in material
related to https://github.com/godotengine/godot/issues/82994, https://github.com/godotengine/godot/issues/30701

GLES2 gltf before fix
![image](https://github.com/godotengine/godot/assets/9168814/c1d67f6c-299f-42bf-b17d-13659c491274)

GLES2 gltf after fix(looks same as GLES3)
![image](https://github.com/godotengine/godot/assets/9168814/3bf66fd0-dce6-4f68-92be-ae8b41767363)
 fbx looks brighter cause blender export fbx vertex color in srgb space, check the is_srgb vertex color in material will fix this.

GLES3 fbx/gltf not changed(already correct).
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
