### PR TITLE
[3.x] Fix vertex color looks darker in GLES2

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -621,7 +621,12 @@ void SpatialMaterial::_update_shader() {
 		code += "\tif (!OUTPUT_IS_SRGB) {\n";
 		code += "\t\tCOLOR.rgb = mix(pow((COLOR.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), COLOR.rgb * (1.0 / 12.92), lessThan(COLOR.rgb, vec3(0.04045)));\n";
 		code += "\t}\n";
+	} else {
+		code += "\tif (OUTPUT_IS_SRGB) {\n";
+		code += "\t\tCOLOR.rgb = mix((vec3(1.055)) * pow(COLOR.rgb, vec3(1.0 / 2.4)) - vec3(0.055), 12.92 * COLOR.rgb, lessThan(COLOR.rgb, vec3(0.0031308)));\n";
+		code += "\t}\n";
 	}
+
 	if (flags[FLAG_USE_POINT_SIZE]) {
 		code += "\tPOINT_SIZE=point_size;\n";
 	}


### PR DESCRIPTION
Add auto convert to srgb code in material
related to https://github.com/godotengine/godot/issues/82994, https://github.com/godotengine/godot/issues/30701

Add material color correction in gles2.
![image](https://github.com/godotengine/godot/assets/9168814/3d806893-8f96-4883-9bc0-0f7aab460d28)

GLES2 import before fix(upper fbx. lower gltf)
![image](https://github.com/godotengine/godot/assets/9168814/886d02b7-538b-4cdb-b0ac-4d1c8a806566)

GLES2 import after fix((upper fbx. lower gltf, color looks same as in GLES3)
![image](https://github.com/godotengine/godot/assets/9168814/8a740da1-9b20-4309-b48d-437afe261e32)

fbx looks brighter cause blender export fbx vertex color in srgb space, check the is_srgb vertex color in material will fix this.

This fix wont change GLES3 fbx/gltf import behavior(already correct), only change the material code auto generation so it makes the vertex looks correct on gles2.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
