### PR TITLE
Fix VoxelGI bake memory leak

### DIFF
--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -884,6 +884,8 @@ Vector<uint8_t> Voxelizer::get_sdf_3d_image() const {
 		}
 	}
 
+	memdelete_arr(work_memory);
+
 	return image3d;
 }
 


### PR DESCRIPTION
Currently, every time you bake a VoxelGI node it leaks the temporary 3D SDF data. Depending on voxel configuration this is often 20 to 30 megabytes in size, so it adds up quicky.

This PR simply frees the temporary memory allocation at the end of the function, which fixes the leak.