### PR TITLE
Fix `trace_ray()` function in the lightmapper missing hits with large triangles.

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -205,6 +205,14 @@ uint trace_ray(vec3 p_from, vec3 p_to
 					return RAY_ANY; //any hit good
 #endif
 
+					vec3 position = p_from + dir * distance;
+					vec3 hit_cell = (position - params.to_cell_offset) * params.to_cell_size;
+					if (icell != ivec3(hit_cell)) {
+						// It's possible for the ray to hit a triangle in a position outside the bounds of the cell
+						// if it's large enough to cover multiple ones. The hit must be ignored if this is the case.
+						continue;
+					}
+
 #if defined(MODE_UNOCCLUDE) || defined(MODE_BOUNCE_LIGHT) || defined(MODE_LIGHT_PROBES)
 					if (!backface) {
 						// the case of meshes having both a front and back face in the same plane is more common than


### PR DESCRIPTION
The DDA traversal had a conceptual error where it did an early termination of the search if it hit a triangle, but it didn't check if the hit position was inside the bounds of the cell being traversed. This can aid to fix light leaks such as the ones found in issue #75440.

I don't have much in the way of good comparison pics as the effectiveness of this fix is better observed with another change I'll introduce in my indirect bounces PR, which is the possibility of tracing lights on each bounce. In that scenario there's leaks that are impossible to fix otherwise that this PR will address.

What I did notice however is an increase in baking times as expected.

```
Unreal Sun Temple:
Before: Done baking lightmaps in 00:04:20.
After: Done baking lightmaps in 00:04:41.

Sponza:
Before: Done baking lightmaps in 00:00:56.
After: Done baking lightmaps in 00:01:02.
```

That's around ~10% slower bake times for what might not be a very noticeable fix right now, but it's hard to deny the fact the algorithm itself is wrong and can cause errors. The slower bake times are easily explained by the fact it's not doing early termination anymore. The fact the difference shows up means there was a significant amount of cases where the light mapper was _not_ finding the actual closest hit but something further away.

So in short, there might be not be easy to find scenarios where we can confirm this fixes something right now, but it'd be for the best for the code to not work incorrectly.