### PR TITLE
GDScript DocGen: Fix regression with return metatypes

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -304,7 +304,8 @@ void GDScriptDocGen::generate_docs(GDScript *p_script, const GDP::ClassNode *p_c
 				method_doc.qualifiers = m_func->is_static ? "static" : "";
 
 				if (m_func->return_type) {
-					_doctype_from_gdtype(m_func->return_type->get_datatype(), method_doc.return_type, method_doc.return_enum, true);
+					// `m_func->return_type->get_datatype()` is a metatype.
+					_doctype_from_gdtype(m_func->get_datatype(), method_doc.return_type, method_doc.return_enum, true);
 				} else if (!m_func->body->has_return) {
 					// If no `return` statement, then return type is `void`, not `Variant`.
 					method_doc.return_type = "void";


### PR DESCRIPTION
* Fix a bug that was appeared after #82067.

`function->return_type->get_datatype()` and `function->get_datatype()` have different values:

https://github.com/godotengine/godot/blob/42425baa59956dc9d1e22341fe5e5d7f8fad5067/modules/gdscript/gdscript_analyzer.cpp#L1654

Since DocGen previously did not take metatypes into account, this bug did not appear.