### PR TITLE
C#: Untyped to typed `ArgumentNullException`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -36,6 +36,9 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new <see cref="Array"/> from the given collection's elements.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="collection"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="collection">The collection of elements to construct from.</param>
         /// <returns>A new Godot Array.</returns>
         public Array(IEnumerable<Variant> collection) : this()
@@ -50,6 +53,9 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new <see cref="Array"/> from the given objects.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="array">The objects to put in the new array.</param>
         /// <returns>A new Godot Array.</returns>
         public Array(Variant[] array)
@@ -68,6 +74,13 @@ namespace Godot.Collections
                 this[i] = array[i];
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given span's elements.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <returns>A new Godot Array.</returns>
         public Array(Span<StringName> array)
         {
             if (array == null)
@@ -84,6 +97,13 @@ namespace Godot.Collections
                 this[i] = array[i];
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given span's elements.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <returns>A new Godot Array.</returns>
         public Array(Span<NodePath> array)
         {
             if (array == null)
@@ -100,6 +120,13 @@ namespace Godot.Collections
                 this[i] = array[i];
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given span's elements.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <returns>A new Godot Array.</returns>
         public Array(Span<Rid> array)
         {
             if (array == null)
@@ -121,6 +148,13 @@ namespace Godot.Collections
         // fine as long as the array is not mutated. However, Span does this type checking at
         // instantiation, so it's not possible to use it even when not mutating anything.
         // ReSharper disable once RedundantNameQualifier
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given ReadOnlySpan's elements.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <returns>A new Godot Array.</returns>
         public Array(ReadOnlySpan<GodotObject> array)
         {
             if (array == null)
@@ -861,8 +895,14 @@ namespace Godot.Collections
         /// Copies the elements of this <see cref="Array"/> to the given
         /// <see cref="Variant"/> C# array, starting at the given index.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The destination array was not long enough.
         /// </exception>
         /// <param name="array">The array to copy to.</param>
         /// <param name="arrayIndex">The index to start at.</param>
@@ -1031,6 +1071,7 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new empty <see cref="Array{T}"/>.
         /// </summary>
+        /// <returns>A new Godot Array.</returns>
         public Array()
         {
             _underlyingArray = new Array();
@@ -1039,6 +1080,9 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new <see cref="Array{T}"/> from the given collection's elements.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="collection"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="collection">The collection of elements to construct from.</param>
         /// <returns>A new Godot Array.</returns>
         public Array(IEnumerable<T> collection)
@@ -1055,6 +1099,9 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new <see cref="Array{T}"/> from the given items.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="array">The items to put in the new array.</param>
         /// <returns>A new Godot Array.</returns>
         public Array(T[] array)
@@ -1071,9 +1118,16 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a typed <see cref="Array{T}"/> from an untyped <see cref="Array"/>.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="array">The untyped array to construct from.</param>
+        /// <returns>A new Godot Array.</returns>
         public Array(Array array)
         {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+
             _underlyingArray = array;
         }
 
@@ -1085,6 +1139,7 @@ namespace Godot.Collections
         /// Converts this typed <see cref="Array{T}"/> to an untyped <see cref="Array"/>.
         /// </summary>
         /// <param name="from">The typed array to convert.</param>
+        /// <returns>A new Godot Array, or <see langword="null"/> if <see paramref="from"/> was null.</returns>
         public static explicit operator Array(Array<T> from)
         {
             return from?._underlyingArray;
@@ -1695,8 +1750,14 @@ namespace Godot.Collections
         /// Copies the elements of this <see cref="Array{T}"/> to the given
         /// C# array, starting at the given index.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The destination array was not long enough.
         /// </exception>
         /// <param name="array">The C# array to copy to.</param>
         /// <param name="arrayIndex">The index to start at.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -385,6 +385,15 @@ namespace Godot.Collections
         /// Copies the elements of this <see cref="Dictionary"/> to the given untyped
         /// <see cref="KeyValuePair{TKey, TValue}"/> array, starting at the given index.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The destination array was not long enough.
+        /// </exception>
         /// <param name="array">The array to copy to.</param>
         /// <param name="arrayIndex">The index to start at.</param>
         void ICollection<KeyValuePair<Variant, Variant>>.CopyTo(KeyValuePair<Variant, Variant>[] array, int arrayIndex)
@@ -499,6 +508,7 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new empty <see cref="Dictionary{TKey, TValue}"/>.
         /// </summary>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary()
         {
             _underlyingDict = new Dictionary();
@@ -507,6 +517,9 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="dictionary"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="dictionary">The dictionary to construct from.</param>
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(IDictionary<TKey, TValue> dictionary)
@@ -523,10 +536,16 @@ namespace Godot.Collections
         /// <summary>
         /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="dictionary"/> is <see langword="null"/>.
+        /// </exception>
         /// <param name="dictionary">The dictionary to construct from.</param>
         /// <returns>A new Godot Dictionary.</returns>
         public Dictionary(Dictionary dictionary)
         {
+            if (dictionary == null)
+                throw new ArgumentNullException(nameof(dictionary));
+
             _underlyingDict = dictionary;
         }
 
@@ -539,6 +558,7 @@ namespace Godot.Collections
         /// Converts this typed <see cref="Dictionary{TKey, TValue}"/> to an untyped <see cref="Dictionary"/>.
         /// </summary>
         /// <param name="from">The typed dictionary to convert.</param>
+        /// <returns>A new Godot Dictionary, or <see langword="null"/> if <see paramref="from"/> was null.</returns>
         public static explicit operator Dictionary(Dictionary<TKey, TValue> from)
         {
             return from?._underlyingDict;
@@ -555,6 +575,8 @@ namespace Godot.Collections
         /// elements will be shallow copied regardless of the <paramref name="deep"/>
         /// setting.
         /// </summary>
+        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+        /// <returns>A new Godot Dictionary.</returns>
         public Dictionary<TKey, TValue> Duplicate(bool deep = false)
         {
             return new Dictionary<TKey, TValue>(_underlyingDict.Duplicate(deep));
@@ -688,6 +710,9 @@ namespace Godot.Collections
         /// <exception cref="InvalidOperationException">
         /// The dictionary is read-only.
         /// </exception>
+        /// <exception cref="ArgumentException">
+        /// An element with the same <paramref name="key"/> already exists.
+        /// </exception>
         /// <param name="key">The key at which to add the object.</param>
         /// <param name="value">The object to add.</param>
         public void Add(TKey key, TValue value)
@@ -810,6 +835,15 @@ namespace Godot.Collections
         /// Copies the elements of this <see cref="Dictionary{TKey, TValue}"/> to the given
         /// untyped C# array, starting at the given index.
         /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The destination array was not long enough.
+        /// </exception>
         /// <param name="array">The array to copy to.</param>
         /// <param name="arrayIndex">The index to start at.</param>
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)


### PR DESCRIPTION
Originally part of #82983, before one of the [discussions](https://github.com/godotengine/godot/pull/82983#discussion_r1350189988) prompted me to check if adding `ArgumentNullException` to the untyped→typed constructors would break compatability. As it turns out, it would not, because they always expect the underlying collection to be valid. However, this *does* mean that it wasn't throwing an exception earlier, only when an actual function is called, so the exception in the constructor is warranted

In addition, this adds missing exception/returns documentation for the two files. It was already warranted for the constructors having a new exception, but this ensures similar relevant functions have appropriate documentation if it was similarly missing

---
Test case::
```cs
var array = (Godot.Collections.Array)null;
var intArray = new Godot.Collections.Array<int>(array);
intArray.Add(123);
```
Old behavior log, caught on line 3:
```log
Array.cs:1514 @ Boolean Godot.Collections.Array`1.get_IsReadOnly(): System.NullReferenceException: Object reference not set to an instance of an object.
```
New behavior log, caught on line 2:
```log
Array.cs:1129 @ Godot.Collections.Array`1..ctor(Godot.Collections.Array): System.ArgumentNullException: Value cannot be null. (Parameter 'array')
```