### PR TITLE
Fix forces integrated before pre-solve

### DIFF
--- a/servers/physics_2d/godot_step_2d.cpp
+++ b/servers/physics_2d/godot_step_2d.cpp
@@ -137,30 +137,9 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 
 	const SelfList<GodotBody2D>::List *body_list = &p_space->get_active_body_list();
 
-	/* INTEGRATE FORCES */
-
+	// Setup profile
 	uint64_t profile_begtime = OS::get_singleton()->get_ticks_usec();
 	uint64_t profile_endtime = 0;
-
-	int active_count = 0;
-
-	const SelfList<GodotBody2D> *b = body_list->first();
-	while (b) {
-		b->self()->integrate_forces(p_delta);
-		b = b->next();
-		active_count++;
-	}
-
-	p_space->set_active_objects(active_count);
-
-	// Update the broadphase to register collision pairs.
-	p_space->update();
-
-	{ //profile
-		profile_endtime = OS::get_singleton()->get_ticks_usec();
-		p_space->set_elapsed_time(GodotSpace2D::ELAPSED_TIME_INTEGRATE_FORCES, profile_endtime - profile_begtime);
-		profile_begtime = profile_endtime;
-	}
 
 	/* GENERATE CONSTRAINT ISLANDS FOR MOVING AREAS */
 
@@ -192,10 +171,9 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 
 	/* GENERATE CONSTRAINT ISLANDS FOR ACTIVE RIGID BODIES */
 
-	b = body_list->first();
-
 	uint32_t body_island_count = 0;
 
+	const SelfList<GodotBody2D> *b = body_list->first();
 	while (b) {
 		GodotBody2D *body = b->self();
 
@@ -254,6 +232,28 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 	// Warning: This doesn't run on threads, because it involves thread-unsafe processing.
 	for (uint32_t island_index = 0; island_index < island_count; ++island_index) {
 		_pre_solve_island(constraint_islands[island_index]);
+	}
+
+	/* INTEGRATE FORCES */
+
+	int active_count = 0;
+
+	b = body_list->first();
+	while (b) {
+		b->self()->integrate_forces(p_delta);
+		b = b->next();
+		active_count++;
+	}
+
+	p_space->set_active_objects(active_count);
+
+	// Update the broadphase to register collision pairs.
+	p_space->update();
+
+	{ //profile
+		profile_endtime = OS::get_singleton()->get_ticks_usec();
+		p_space->set_elapsed_time(GodotSpace2D::ELAPSED_TIME_INTEGRATE_FORCES, profile_endtime - profile_begtime);
+		profile_begtime = profile_endtime;
 	}
 
 	/* SOLVE CONSTRAINT ISLANDS */


### PR DESCRIPTION
This PR solves the issue #81347.

I changed the method GodotStep3D::step() at line godot_step_3d.cpp:185 by putting the "integrate forces" loop between "pre-solve islands" and "solve islands".

Closes #81347 
