### PR TITLE
GDExtension: Use correct return pointer for validated calls that return `Variant`

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -234,7 +234,7 @@ public:
 			void *ret_opaque = nullptr;
 			if (r_ret) {
 				VariantInternal::initialize(r_ret, return_value_info.type);
-				ret_opaque = VariantInternal::get_opaque_pointer(r_ret);
+				ret_opaque = r_ret->get_type() == Variant::NIL ? r_ret : VariantInternal::get_opaque_pointer(r_ret);
 			}
 
 			ptrcall(p_object, argptrs, ret_opaque);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/83016
Fixes https://github.com/godotengine/godot/issues/83097

~~Since I don't presently have a way to reproduce the bug, this will need some testing.~~