### PR TITLE
Add semicolon to OS documentation case statement.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -334,7 +334,7 @@
 				    case "Linux":
 				    case "FreeBSD":
 				    case "NetBSD":
-				    case "OpenBSD"
+				    case "OpenBSD":
 				    case "BSD":
 				        GD.Print("Linux/BSD");
 				        break;


### PR DESCRIPTION
PR to fix Issue #https://github.com/godotengine/godot-docs/issues/8208
