### PR TITLE
Fix: An attempt to fix missing link. issue #82495

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,8 @@ feature, *please* edit the commit title to something meaningful. Commits named
 You can contribute to Godot's translation from the [Hosted
 Weblate](https://hosted.weblate.org/projects/godot-engine/godot), an open
 source and web-based translation platform. Please refer to the [translation
-readme](editor/translations/README.md) for more information.
+readme](https://github.com/godotengine/godot/blob/3.5/editor/translations/README.md)
+for more information.
 
 You can also help translate [Godot's
 documentation](https://hosted.weblate.org/projects/godot-engine/godot-docs/)


### PR DESCRIPTION
I added a link to the README in version 3.5 because it seems clear and to the point. Although I think adding a README to the newer versions would be better

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
