### PR TITLE
Set new SkeletonRestFixer tracks as imported

### DIFF
--- a/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
@@ -242,6 +242,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 						if (rot_track == -1) {
 							int track = anim->add_track(Animation::TYPE_ROTATION_3D);
 							anim->track_set_path(track, insert_path);
+							anim->track_set_imported(track, true);
 							anim->rotation_track_insert_key(track, 0, src_skeleton->get_bone_rest(src_idx).basis.get_rotation_quaternion());
 						}
 					}


### PR DESCRIPTION
This makes sure that the default rotation tracks generated by the SkeletonRestFixer plugin will be flagged as 'imported', which prevents them duplicating repeatedly on reimport.

Closes https://github.com/godotengine/godot/issues/83075