### PR TITLE
Fix `EditorFileSystemDirectory::get_file_deps()` may return wrong result

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -261,7 +261,8 @@ void EditorFileSystem::_scan_filesystem() {
 					cpath = name;
 
 				} else {
-					Vector<String> split = l.split("::");
+					// The last section (deps) may contain the same splitter, so limit the maxsplit to 8 to get the complete deps.
+					Vector<String> split = l.split("::", true, 8);
 					ERR_CONTINUE(split.size() < 9);
 					String name = split[0];
 					String file;


### PR DESCRIPTION
Limit the max split to `8` to get complete `deps`.

`deps` caches the return value of `ResourceLoader::get_dependencies()`, which is also separated by "::" (eg `uid://dnl1wt40gvcuu::::res://icon.svg`). 
"::" is quite popular as a splitter.

Reference: Code for storing information

https://github.com/godotengine/godot/blob/6b727ebdd298bdfad8b5c5ea78100bfb6a537d79/editor/editor_file_system.cpp#L1326-L1335

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
