### PR TITLE
Expose a method to compute gravity for any physics body

### DIFF
--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -17,6 +17,12 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="compute_gravity" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the gravity vector computed from all sources that can affect the body, including all gravity overrides from [Area2D] nodes and the global world gravity.
+			</description>
+		</method>
 		<method name="get_collision_exceptions">
 			<return type="PhysicsBody2D[]" />
 			<description>

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -18,6 +18,12 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="compute_gravity" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the gravity vector computed from all sources that can affect the body, including all gravity overrides from [Area3D] nodes and the global world gravity.
+			</description>
+		</method>
 		<method name="get_axis_lock" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -366,6 +366,13 @@
 				Removes all shapes from the body. This does not delete the shapes themselves, so they can continue to be used elsewhere or added back later.
 			</description>
 		</method>
+		<method name="body_compute_gravity" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the gravity vector computed from all sources that can affect the body, including all gravity overrides from [Area2D] nodes and the global world gravity.
+			</description>
+		</method>
 		<method name="body_create">
 			<return type="RID" />
 			<description>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -348,6 +348,13 @@
 				Removes all shapes from a body.
 			</description>
 		</method>
+		<method name="body_compute_gravity" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the gravity vector computed from all sources that can affect the body, including all gravity overrides from [Area3D] nodes and the global world gravity.
+			</description>
+		</method>
 		<method name="body_create">
 			<return type="RID" />
 			<description>

--- a/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
@@ -6,14 +6,11 @@ extends _BASE_
 const SPEED = 300.0
 const JUMP_VELOCITY = -400.0
 
-# Get the gravity from the project settings to be synced with RigidBody nodes.
-var gravity: int = ProjectSettings.get_setting("physics/2d/default_gravity")
-
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
 	if not is_on_floor():
-		velocity.y += gravity * delta
+		velocity += compute_gravity() * delta
 
 	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():

--- a/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
@@ -6,14 +6,11 @@ extends _BASE_
 const SPEED = 5.0
 const JUMP_VELOCITY = 4.5
 
-# Get the gravity from the project settings to be synced with RigidBody nodes.
-var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
-
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
 	if not is_on_floor():
-		velocity.y -= gravity * delta
+		velocity += compute_gravity() * delta
 
 	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():

--- a/modules/mono/editor/script_templates/CharacterBody2D/basic_movement.cs
+++ b/modules/mono/editor/script_templates/CharacterBody2D/basic_movement.cs
@@ -8,16 +8,13 @@ public partial class _CLASS_ : _BASE_
     public const float Speed = 300.0f;
     public const float JumpVelocity = -400.0f;
 
-    // Get the gravity from the project settings to be synced with RigidBody nodes.
-    public float gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
-
     public override void _PhysicsProcess(double delta)
     {
         Vector2 velocity = Velocity;
 
         // Add the gravity.
         if (!IsOnFloor())
-            velocity.Y += gravity * (float)delta;
+            velocity.Y += ComputeGravity() * (float)delta;
 
         // Handle Jump.
         if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())

--- a/modules/mono/editor/script_templates/CharacterBody3D/basic_movement.cs
+++ b/modules/mono/editor/script_templates/CharacterBody3D/basic_movement.cs
@@ -8,16 +8,13 @@ public partial class _CLASS_ : _BASE_
     public const float Speed = 5.0f;
     public const float JumpVelocity = 4.5f;
 
-    // Get the gravity from the project settings to be synced with RigidBody nodes.
-    public float gravity = ProjectSettings.GetSetting("physics/3d/default_gravity").AsSingle();
-
     public override void _PhysicsProcess(double delta)
     {
         Vector3 velocity = Velocity;
 
         // Add the gravity.
         if (!IsOnFloor())
-            velocity.Y -= gravity * (float)delta;
+            velocity.Y += ComputeGravity() * (float)delta;
 
         // Handle Jump.
         if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -35,6 +35,7 @@
 void PhysicsBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::_move, DEFVAL(false), DEFVAL(0.08), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "motion", "collision", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::test_move, DEFVAL(Variant()), DEFVAL(0.08), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("compute_gravity"), &PhysicsBody2D::compute_gravity);
 
 	ClassDB::bind_method(D_METHOD("get_collision_exceptions"), &PhysicsBody2D::get_collision_exceptions);
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &PhysicsBody2D::add_collision_exception_with);
@@ -143,6 +144,10 @@ bool PhysicsBody2D::test_move(const Transform2D &p_from, const Vector2 &p_motion
 	parameters.recovery_as_collision = p_recovery_as_collision;
 
 	return PhysicsServer2D::get_singleton()->body_test_motion(get_rid(), parameters, r);
+}
+
+Vector2 PhysicsBody2D::compute_gravity() const {
+	return PhysicsServer2D::get_singleton()->body_compute_gravity(get_rid());
 }
 
 TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -52,6 +52,7 @@ protected:
 public:
 	bool move_and_collide(const PhysicsServer2D::MotionParameters &p_parameters, PhysicsServer2D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
 	bool test_move(const Transform2D &p_from, const Vector2 &p_motion, const Ref<KinematicCollision2D> &r_collision = Ref<KinematicCollision2D>(), real_t p_margin = 0.08, bool p_recovery_as_collision = false);
+	Vector2 compute_gravity() const;
 
 	TypedArray<PhysicsBody2D> get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -35,6 +35,7 @@
 void PhysicsBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::_move, DEFVAL(false), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "motion", "collision", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::test_move, DEFVAL(Variant()), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("compute_gravity"), &PhysicsBody3D::compute_gravity);
 
 	ClassDB::bind_method(D_METHOD("set_axis_lock", "axis", "lock"), &PhysicsBody3D::set_axis_lock);
 	ClassDB::bind_method(D_METHOD("get_axis_lock", "axis"), &PhysicsBody3D::get_axis_lock);
@@ -184,6 +185,10 @@ bool PhysicsBody3D::test_move(const Transform3D &p_from, const Vector3 &p_motion
 	parameters.recovery_as_collision = p_recovery_as_collision;
 
 	return PhysicsServer3D::get_singleton()->body_test_motion(get_rid(), parameters, r);
+}
+
+Vector3 PhysicsBody3D::compute_gravity() const {
+	return PhysicsServer3D::get_singleton()->body_compute_gravity(get_rid());
 }
 
 void PhysicsBody3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock) {

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -55,6 +55,7 @@ protected:
 public:
 	bool move_and_collide(const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
 	bool test_move(const Transform3D &p_from, const Vector3 &p_motion, const Ref<KinematicCollision3D> &r_collision = Ref<KinematicCollision3D>(), real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1);
+	Vector3 compute_gravity() const;
 
 	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock);
 	bool get_axis_lock(PhysicsServer3D::BodyAxis p_axis) const;

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -388,6 +388,8 @@ public:
 
 	GDVIRTUAL7RC(bool, _body_test_motion, RID, const Transform2D &, const Vector2 &, real_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionMotionResult>)
 
+	EXBIND1RC(Vector2, body_compute_gravity, RID)
+
 	thread_local static const HashSet<RID> *exclude_bodies;
 	thread_local static const HashSet<ObjectID> *exclude_objects;
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -385,6 +385,8 @@ public:
 
 	GDVIRTUAL8RC(bool, _body_test_motion, RID, const Transform3D &, const Vector3 &, real_t, int, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionMotionResult>)
 
+	EXBIND1RC(Vector3, body_compute_gravity, RID)
+
 	thread_local static const HashSet<RID> *exclude_bodies;
 	thread_local static const HashSet<ObjectID> *exclude_objects;
 

--- a/servers/physics_2d/godot_area_2d.h
+++ b/servers/physics_2d/godot_area_2d.h
@@ -188,4 +188,16 @@ void GodotArea2D::remove_area_from_query(GodotArea2D *p_area, uint32_t p_area_sh
 	}
 }
 
+struct Area2DCMP {
+	GodotArea2D *area = nullptr;
+	int refCount = 0;
+	_FORCE_INLINE_ bool operator==(const Area2DCMP &p_cmp) const { return area->get_self() == p_cmp.area->get_self(); }
+	_FORCE_INLINE_ bool operator<(const Area2DCMP &p_cmp) const { return area->get_priority() < p_cmp.area->get_priority(); }
+	_FORCE_INLINE_ Area2DCMP() {}
+	_FORCE_INLINE_ Area2DCMP(GodotArea2D *p_area) {
+		area = p_area;
+		refCount = 1;
+	}
+};
+
 #endif // GODOT_AREA_2D_H

--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -440,7 +440,7 @@ void GodotBody2D::integrate_forces(real_t p_step) {
 	// Combine gravity and damping from overlapping areas in priority order.
 	if (ac) {
 		areas.sort();
-		const AreaCMP *aa = &areas[0];
+		const Area2DCMP *aa = &areas[0];
 		for (int i = ac - 1; i >= 0 && !stopped; i--) {
 			if (!gravity_done) {
 				PhysicsServer2D::AreaSpaceOverrideMode area_gravity_mode = (PhysicsServer2D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer2D::AREA_PARAM_GRAVITY_OVERRIDE_MODE);
@@ -740,7 +740,7 @@ GodotPhysicsDirectBodyState2D *GodotBody2D::get_direct_state() {
 }
 
 GodotBody2D::GodotBody2D() :
-		GodotCollisionObject2D(TYPE_BODY),
+		GodotSolidObject2D(TYPE_BODY),
 		active_list(this),
 		mass_properties_update_list(this),
 		direct_state_query_list(this) {

--- a/servers/physics_2d/godot_body_2d.h
+++ b/servers/physics_2d/godot_body_2d.h
@@ -32,7 +32,7 @@
 #define GODOT_BODY_2D_H
 
 #include "godot_area_2d.h"
-#include "godot_collision_object_2d.h"
+#include "godot_solid_object_2d.h"
 
 #include "core/templates/list.h"
 #include "core/templates/pair.h"
@@ -41,7 +41,7 @@
 class GodotConstraint2D;
 class GodotPhysicsDirectBodyState2D;
 
-class GodotBody2D : public GodotCollisionObject2D {
+class GodotBody2D : public GodotSolidObject2D {
 	PhysicsServer2D::BodyMode mode = PhysicsServer2D::BODY_MODE_RIGID;
 
 	Vector2 biased_linear_velocity;
@@ -108,20 +108,6 @@ class GodotBody2D : public GodotCollisionObject2D {
 
 	List<Pair<GodotConstraint2D *, int>> constraint_list;
 
-	struct AreaCMP {
-		GodotArea2D *area = nullptr;
-		int refCount = 0;
-		_FORCE_INLINE_ bool operator==(const AreaCMP &p_cmp) const { return area->get_self() == p_cmp.area->get_self(); }
-		_FORCE_INLINE_ bool operator<(const AreaCMP &p_cmp) const { return area->get_priority() < p_cmp.area->get_priority(); }
-		_FORCE_INLINE_ AreaCMP() {}
-		_FORCE_INLINE_ AreaCMP(GodotArea2D *p_area) {
-			area = p_area;
-			refCount = 1;
-		}
-	};
-
-	Vector<AreaCMP> areas;
-
 	struct Contact {
 		Vector2 local_pos;
 		Vector2 local_normal;
@@ -163,16 +149,16 @@ public:
 	GodotPhysicsDirectBodyState2D *get_direct_state();
 
 	_FORCE_INLINE_ void add_area(GodotArea2D *p_area) {
-		int index = areas.find(AreaCMP(p_area));
+		int index = areas.find(Area2DCMP(p_area));
 		if (index > -1) {
 			areas.write[index].refCount += 1;
 		} else {
-			areas.ordered_insert(AreaCMP(p_area));
+			areas.ordered_insert(Area2DCMP(p_area));
 		}
 	}
 
 	_FORCE_INLINE_ void remove_area(GodotArea2D *p_area) {
-		int index = areas.find(AreaCMP(p_area));
+		int index = areas.find(Area2DCMP(p_area));
 		if (index > -1) {
 			areas.write[index].refCount -= 1;
 			if (areas[index].refCount < 1) {

--- a/servers/physics_2d/godot_physics_server_2d.cpp
+++ b/servers/physics_2d/godot_physics_server_2d.cpp
@@ -1002,6 +1002,13 @@ bool GodotPhysicsServer2D::body_test_motion(RID p_body, const MotionParameters &
 	return body->get_space()->test_body_motion(body, p_parameters, r_result);
 }
 
+Vector2 GodotPhysicsServer2D::body_compute_gravity(RID p_body) const {
+	GodotSolidObject2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, Vector2());
+
+	return body->compute_gravity();
+}
+
 PhysicsDirectBodyState2D *GodotPhysicsServer2D::body_get_direct_state(RID p_body) {
 	ERR_FAIL_COND_V_MSG((using_threads && !doing_sync), nullptr, "Body state is inaccessible right now, wait for iteration or physics process notification.");
 

--- a/servers/physics_2d/godot_physics_server_2d.h
+++ b/servers/physics_2d/godot_physics_server_2d.h
@@ -256,6 +256,8 @@ public:
 
 	virtual bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override;
 
+	virtual Vector2 body_compute_gravity(RID p_body) const override;
+
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override;
 

--- a/servers/physics_2d/godot_solid_object_2d.cpp
+++ b/servers/physics_2d/godot_solid_object_2d.cpp
@@ -1,0 +1,31 @@
+/**************************************************************************/
+/*  godot_solid_object_2d.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "godot_solid_object_2d.h"

--- a/servers/physics_2d/godot_solid_object_2d.h
+++ b/servers/physics_2d/godot_solid_object_2d.h
@@ -39,6 +39,9 @@ protected:
 	Vector<Area2DCMP> areas;
 	GodotSolidObject2D(GodotCollisionObject2D::Type p_type) :
 			GodotCollisionObject2D(p_type) {}
+
+public:
+	Vector2 compute_gravity();
 };
 
 #endif // GODOT_SOLID_OBJECT_2D_H

--- a/servers/physics_2d/godot_solid_object_2d.h
+++ b/servers/physics_2d/godot_solid_object_2d.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  godot_solid_object_2d.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GODOT_SOLID_OBJECT_2D_H
+#define GODOT_SOLID_OBJECT_2D_H
+
+#include "godot_area_2d.h"
+#include "godot_collision_object_2d.h"
+
+class GodotSolidObject2D : public GodotCollisionObject2D {
+protected:
+	Vector<Area2DCMP> areas;
+	GodotSolidObject2D(GodotCollisionObject2D::Type p_type) :
+			GodotCollisionObject2D(p_type) {}
+};
+
+#endif // GODOT_SOLID_OBJECT_2D_H

--- a/servers/physics_3d/godot_area_3d.h
+++ b/servers/physics_3d/godot_area_3d.h
@@ -225,13 +225,13 @@ void GodotArea3D::remove_area_from_query(GodotArea3D *p_area, uint32_t p_area_sh
 	}
 }
 
-struct AreaCMP {
+struct Area3DCMP {
 	GodotArea3D *area = nullptr;
 	int refCount = 0;
-	_FORCE_INLINE_ bool operator==(const AreaCMP &p_cmp) const { return area->get_self() == p_cmp.area->get_self(); }
-	_FORCE_INLINE_ bool operator<(const AreaCMP &p_cmp) const { return area->get_priority() < p_cmp.area->get_priority(); }
-	_FORCE_INLINE_ AreaCMP() {}
-	_FORCE_INLINE_ AreaCMP(GodotArea3D *p_area) {
+	_FORCE_INLINE_ bool operator==(const Area3DCMP &p_cmp) const { return area->get_self() == p_cmp.area->get_self(); }
+	_FORCE_INLINE_ bool operator<(const Area3DCMP &p_cmp) const { return area->get_priority() < p_cmp.area->get_priority(); }
+	_FORCE_INLINE_ Area3DCMP() {}
+	_FORCE_INLINE_ Area3DCMP(GodotArea3D *p_area) {
 		area = p_area;
 		refCount = 1;
 	}

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -481,43 +481,21 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 
 	int ac = areas.size();
 
-	bool gravity_done = false;
 	bool linear_damp_done = false;
 	bool angular_damp_done = false;
 
 	bool stopped = false;
 
-	gravity = Vector3(0, 0, 0);
+	gravity = compute_gravity();
 
 	total_linear_damp = 0.0;
 	total_angular_damp = 0.0;
 
-	// Combine gravity and damping from overlapping areas in priority order.
+	// Combine damping from overlapping areas in priority order.
 	if (ac) {
 		areas.sort();
 		const Area3DCMP *aa = &areas[0];
 		for (int i = ac - 1; i >= 0 && !stopped; i--) {
-			if (!gravity_done) {
-				PhysicsServer3D::AreaSpaceOverrideMode area_gravity_mode = (PhysicsServer3D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE);
-				if (area_gravity_mode != PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED) {
-					Vector3 area_gravity;
-					aa[i].area->compute_gravity(get_transform().get_origin(), area_gravity);
-					switch (area_gravity_mode) {
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE:
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE_REPLACE: {
-							gravity += area_gravity;
-							gravity_done = area_gravity_mode == PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE_REPLACE;
-						} break;
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE:
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE_COMBINE: {
-							gravity = area_gravity;
-							gravity_done = area_gravity_mode == PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE;
-						} break;
-						default: {
-						}
-					}
-				}
-			}
 			if (!linear_damp_done) {
 				PhysicsServer3D::AreaSpaceOverrideMode area_linear_damp_mode = (PhysicsServer3D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer3D::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE);
 				if (area_linear_damp_mode != PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED) {
@@ -558,20 +536,14 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 					}
 				}
 			}
-			stopped = gravity_done && linear_damp_done && angular_damp_done;
+			stopped = linear_damp_done && angular_damp_done;
 		}
 	}
 
-	// Add default gravity and damping from space area.
+	// Add default damping from space area.
 	if (!stopped) {
 		GodotArea3D *default_area = get_space()->get_default_area();
 		ERR_FAIL_NULL(default_area);
-
-		if (!gravity_done) {
-			Vector3 default_gravity;
-			default_area->compute_gravity(get_transform().get_origin(), default_gravity);
-			gravity += default_gravity;
-		}
 
 		if (!linear_damp_done) {
 			total_linear_damp += default_area->get_linear_damp();

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -495,7 +495,7 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 	// Combine gravity and damping from overlapping areas in priority order.
 	if (ac) {
 		areas.sort();
-		const AreaCMP *aa = &areas[0];
+		const Area3DCMP *aa = &areas[0];
 		for (int i = ac - 1; i >= 0 && !stopped; i--) {
 			if (!gravity_done) {
 				PhysicsServer3D::AreaSpaceOverrideMode area_gravity_mode = (PhysicsServer3D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE);
@@ -819,7 +819,7 @@ GodotPhysicsDirectBodyState3D *GodotBody3D::get_direct_state() {
 }
 
 GodotBody3D::GodotBody3D() :
-		GodotCollisionObject3D(TYPE_BODY),
+		GodotSolidObject3D(TYPE_BODY),
 		active_list(this),
 		mass_properties_update_list(this),
 		direct_state_query_list(this) {

--- a/servers/physics_3d/godot_body_3d.h
+++ b/servers/physics_3d/godot_body_3d.h
@@ -32,14 +32,14 @@
 #define GODOT_BODY_3D_H
 
 #include "godot_area_3d.h"
-#include "godot_collision_object_3d.h"
+#include "godot_solid_object_3d.h"
 
 #include "core/templates/vset.h"
 
 class GodotConstraint3D;
 class GodotPhysicsDirectBodyState3D;
 
-class GodotBody3D : public GodotCollisionObject3D {
+class GodotBody3D : public GodotSolidObject3D {
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
 
 	Vector3 linear_velocity;
@@ -114,8 +114,6 @@ class GodotBody3D : public GodotCollisionObject3D {
 
 	HashMap<GodotConstraint3D *, int> constraint_map;
 
-	Vector<AreaCMP> areas;
-
 	struct Contact {
 		Vector3 local_pos;
 		Vector3 local_normal;
@@ -157,16 +155,16 @@ public:
 	GodotPhysicsDirectBodyState3D *get_direct_state();
 
 	_FORCE_INLINE_ void add_area(GodotArea3D *p_area) {
-		int index = areas.find(AreaCMP(p_area));
+		int index = areas.find(Area3DCMP(p_area));
 		if (index > -1) {
 			areas.write[index].refCount += 1;
 		} else {
-			areas.ordered_insert(AreaCMP(p_area));
+			areas.ordered_insert(Area3DCMP(p_area));
 		}
 	}
 
 	_FORCE_INLINE_ void remove_area(GodotArea3D *p_area) {
-		int index = areas.find(AreaCMP(p_area));
+		int index = areas.find(Area3DCMP(p_area));
 		if (index > -1) {
 			areas.write[index].refCount -= 1;
 			if (areas[index].refCount < 1) {

--- a/servers/physics_3d/godot_physics_server_3d.cpp
+++ b/servers/physics_3d/godot_physics_server_3d.cpp
@@ -920,6 +920,13 @@ bool GodotPhysicsServer3D::body_test_motion(RID p_body, const MotionParameters &
 	return body->get_space()->test_body_motion(body, p_parameters, r_result);
 }
 
+Vector3 GodotPhysicsServer3D::body_compute_gravity(RID p_body) const {
+	GodotSolidObject3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, Vector3());
+
+	return body->compute_gravity();
+}
+
 PhysicsDirectBodyState3D *GodotPhysicsServer3D::body_get_direct_state(RID p_body) {
 	ERR_FAIL_COND_V_MSG((using_threads && !doing_sync), nullptr, "Body state is inaccessible right now, wait for iteration or physics process notification.");
 

--- a/servers/physics_3d/godot_physics_server_3d.h
+++ b/servers/physics_3d/godot_physics_server_3d.h
@@ -252,6 +252,8 @@ public:
 
 	virtual bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override;
 
+	virtual Vector3 body_compute_gravity(RID p_body) const override;
+
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override;
 

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -55,7 +55,7 @@ subject to the following restrictions:
 ///btSoftBody implementation by Nathanael Presson
 
 GodotSoftBody3D::GodotSoftBody3D() :
-		GodotCollisionObject3D(TYPE_SOFT_BODY),
+		GodotSolidObject3D(TYPE_SOFT_BODY),
 		active_list(this) {
 	_set_static(false);
 }
@@ -977,7 +977,7 @@ void GodotSoftBody3D::predict_motion(real_t p_delta) {
 	int ac = areas.size();
 	if (ac) {
 		areas.sort();
-		const AreaCMP *aa = &areas[0];
+		const Area3DCMP *aa = &areas[0];
 		for (int i = ac - 1; i >= 0; i--) {
 			if (!gravity_done) {
 				PhysicsServer3D::AreaSpaceOverrideMode area_gravity_mode = (PhysicsServer3D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE);

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -969,52 +969,19 @@ void GodotSoftBody3D::predict_motion(real_t p_delta) {
 
 	ERR_FAIL_NULL(get_space());
 
-	bool gravity_done = false;
-	Vector3 gravity;
+	Vector3 gravity = compute_gravity();
 
+	// Gather wind areas from the list of areas.
 	LocalVector<GodotArea3D *> wind_areas;
-
 	int ac = areas.size();
 	if (ac) {
 		areas.sort();
 		const Area3DCMP *aa = &areas[0];
 		for (int i = ac - 1; i >= 0; i--) {
-			if (!gravity_done) {
-				PhysicsServer3D::AreaSpaceOverrideMode area_gravity_mode = (PhysicsServer3D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE);
-				if (area_gravity_mode != PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED) {
-					Vector3 area_gravity;
-					aa[i].area->compute_gravity(get_transform().get_origin(), area_gravity);
-					switch (area_gravity_mode) {
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE:
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE_REPLACE: {
-							gravity += area_gravity;
-							gravity_done = area_gravity_mode == PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE_REPLACE;
-						} break;
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE:
-						case PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE_COMBINE: {
-							gravity = area_gravity;
-							gravity_done = area_gravity_mode == PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE;
-						} break;
-						default: {
-						}
-					}
-				}
-			}
-
 			if (aa[i].area->get_wind_force_magnitude() > CMP_EPSILON) {
 				wind_areas.push_back(aa[i].area);
 			}
 		}
-	}
-
-	// Add default gravity and damping from space area.
-	if (!gravity_done) {
-		GodotArea3D *default_area = get_space()->get_default_area();
-		ERR_FAIL_NULL(default_area);
-
-		Vector3 default_gravity;
-		default_area->compute_gravity(get_transform().get_origin(), default_gravity);
-		gravity += default_gravity;
 	}
 
 	// Apply forces.

--- a/servers/physics_3d/godot_soft_body_3d.h
+++ b/servers/physics_3d/godot_soft_body_3d.h
@@ -32,7 +32,7 @@
 #define GODOT_SOFT_BODY_3D_H
 
 #include "godot_area_3d.h"
-#include "godot_collision_object_3d.h"
+#include "godot_solid_object_3d.h"
 
 #include "core/math/aabb.h"
 #include "core/math/dynamic_bvh.h"
@@ -43,7 +43,7 @@
 
 class GodotConstraint3D;
 
-class GodotSoftBody3D : public GodotCollisionObject3D {
+class GodotSoftBody3D : public GodotSolidObject3D {
 	RID soft_mesh;
 
 	struct Node {
@@ -105,8 +105,6 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 
 	HashSet<GodotConstraint3D *> constraints;
 
-	Vector<AreaCMP> areas;
-
 	VSet<RID> exceptions;
 
 	uint64_t island_step = 0;
@@ -135,16 +133,16 @@ public:
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
 
 	_FORCE_INLINE_ void add_area(GodotArea3D *p_area) {
-		int index = areas.find(AreaCMP(p_area));
+		int index = areas.find(Area3DCMP(p_area));
 		if (index > -1) {
 			areas.write[index].refCount += 1;
 		} else {
-			areas.ordered_insert(AreaCMP(p_area));
+			areas.ordered_insert(Area3DCMP(p_area));
 		}
 	}
 
 	_FORCE_INLINE_ void remove_area(GodotArea3D *p_area) {
-		int index = areas.find(AreaCMP(p_area));
+		int index = areas.find(Area3DCMP(p_area));
 		if (index > -1) {
 			areas.write[index].refCount -= 1;
 			if (areas[index].refCount < 1) {

--- a/servers/physics_3d/godot_solid_object_3d.cpp
+++ b/servers/physics_3d/godot_solid_object_3d.cpp
@@ -1,0 +1,31 @@
+/**************************************************************************/
+/*  godot_solid_object_3d.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "godot_solid_object_3d.h"

--- a/servers/physics_3d/godot_solid_object_3d.cpp
+++ b/servers/physics_3d/godot_solid_object_3d.cpp
@@ -29,3 +29,47 @@
 /**************************************************************************/
 
 #include "godot_solid_object_3d.h"
+
+#include "godot_space_3d.h"
+
+Vector3 GodotSolidObject3D::compute_gravity() {
+	Vector3 gravity;
+	// Add gravity from areas in order of priority.
+	int area_count = areas.size();
+	if (area_count) {
+		areas.sort();
+		const Area3DCMP *aa = &areas[0];
+		for (int i = area_count - 1; i >= 0; i--) {
+			PhysicsServer3D::AreaSpaceOverrideMode area_gravity_mode = (PhysicsServer3D::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE);
+			if (area_gravity_mode != PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED) {
+				Vector3 area_gravity;
+				aa[i].area->compute_gravity(get_transform().get_origin(), area_gravity);
+				switch (area_gravity_mode) {
+					case PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE:
+					case PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE_REPLACE: {
+						gravity += area_gravity;
+						if (area_gravity_mode == PhysicsServer3D::AREA_SPACE_OVERRIDE_COMBINE_REPLACE) {
+							return gravity;
+						}
+					} break;
+					case PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE:
+					case PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE_COMBINE: {
+						gravity = area_gravity;
+						if (area_gravity_mode == PhysicsServer3D::AREA_SPACE_OVERRIDE_REPLACE) {
+							return gravity;
+						}
+					} break;
+					case PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED: {
+					}
+				}
+			}
+		}
+	}
+	// Add global world gravity from the space's default area.
+	GodotArea3D *default_area = get_space()->get_default_area();
+	ERR_FAIL_NULL_V(default_area, gravity);
+	Vector3 global_default_gravity;
+	default_area->compute_gravity(get_transform().get_origin(), global_default_gravity);
+	gravity += global_default_gravity;
+	return gravity;
+}

--- a/servers/physics_3d/godot_solid_object_3d.h
+++ b/servers/physics_3d/godot_solid_object_3d.h
@@ -39,6 +39,9 @@ protected:
 	Vector<Area3DCMP> areas;
 	GodotSolidObject3D(GodotCollisionObject3D::Type p_type) :
 			GodotCollisionObject3D(p_type) {}
+
+public:
+	Vector3 compute_gravity();
 };
 
 #endif // GODOT_SOLID_OBJECT_3D_H

--- a/servers/physics_3d/godot_solid_object_3d.h
+++ b/servers/physics_3d/godot_solid_object_3d.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  godot_solid_object_3d.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GODOT_SOLID_OBJECT_3D_H
+#define GODOT_SOLID_OBJECT_3D_H
+
+#include "godot_area_3d.h"
+#include "godot_collision_object_3d.h"
+
+class GodotSolidObject3D : public GodotCollisionObject3D {
+protected:
+	Vector<Area3DCMP> areas;
+	GodotSolidObject3D(GodotCollisionObject3D::Type p_type) :
+			GodotCollisionObject3D(p_type) {}
+};
+
+#endif // GODOT_SOLID_OBJECT_3D_H

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -757,6 +757,7 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_force_integration_callback", "body", "callable", "userdata"), &PhysicsServer2D::body_set_force_integration_callback, DEFVAL(Variant()));
 
 	ClassDB::bind_method(D_METHOD("body_test_motion", "body", "parameters", "result"), &PhysicsServer2D::_body_test_motion, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("body_compute_gravity", "body"), &PhysicsServer2D::body_compute_gravity);
 
 	ClassDB::bind_method(D_METHOD("body_get_direct_state", "body"), &PhysicsServer2D::body_get_direct_state);
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -522,6 +522,7 @@ public:
 	};
 
 	virtual bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) = 0;
+	virtual Vector2 body_compute_gravity(RID p_body) const = 0;
 
 	/* JOINT API */
 

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -266,6 +266,8 @@ public:
 		return physics_server_2d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
+	FUNC1RC(Vector2, body_compute_gravity, RID);
+
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -830,6 +830,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_ray_pickable", "body", "enable"), &PhysicsServer3D::body_set_ray_pickable);
 
 	ClassDB::bind_method(D_METHOD("body_test_motion", "body", "parameters", "result"), &PhysicsServer3D::_body_test_motion, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("body_compute_gravity", "body"), &PhysicsServer3D::body_compute_gravity);
 
 	ClassDB::bind_method(D_METHOD("body_get_direct_state", "body"), &PhysicsServer3D::body_get_direct_state);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -566,6 +566,7 @@ public:
 	};
 
 	virtual bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) = 0;
+	virtual Vector3 body_compute_gravity(RID p_body) const = 0;
 
 	/* SOFT BODY */
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -265,6 +265,8 @@ public:
 		return physics_server_3d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
+	FUNC1RC(Vector3, body_compute_gravity, RID);
+
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/8054 see the proposal for the justification.

Minimal test project: [character_gravity.zip](https://github.com/godotengine/godot/files/12853155/character_gravity.zip)

I split this PR into 3 commits for easy reviewing:

* First commit: In 3D we have both rigid and soft bodies, but currently a lot of the logic is duplicated between these two. I made a new class `GodotSolidObject3D` that can hold the logic shared by both. For 2D we don't have soft bodies yet, but I made the same change for consistency.
    * In just this commit, the classes are empty. More shared code can be moved here in the future.
    * This commit also renames the AreaCMP classes to Area2DCMP and Area3DCMP, which is necessary to fix a name conflict after moving the 2D AreaCMP to `godot_area_2d.h` for consistency with 3D.
* Second commit: Move the shared code for computing gravity into the GodotSolidObject classes.
* Third commit: Expose the compute gravity method on the physics nodes and physics server. Due to both 2D and 3D physics and all the different physics server classes for Godot physics, GDExtension, etc, this commit touches a lot of files, but it's only a few lines per file so it's not a lot of code.
    * This commit also uses the new methods in the script templates, which replaces the long `var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")` line with just `compute_gravity()`, and now the code no longer needs to care which direction the gravity is.