### PR TITLE
Fix outdated link to translation docs in CONTRIBUTING.md #83043

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,8 @@ feature, *please* edit the commit title to something meaningful. Commits named
 You can contribute to Godot's translation from the [Hosted
 Weblate](https://hosted.weblate.org/projects/godot-engine/godot), an open
 source and web-based translation platform. Please refer to the [translation
-readme](editor/translations/README.md) for more information.
+readme](https://docs.godotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
+ for more information.
 
 You can also help translate [Godot's
 documentation](https://hosted.weblate.org/projects/godot-engine/godot-docs/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,8 +153,7 @@ feature, *please* edit the commit title to something meaningful. Commits named
 
 You can contribute to Godot's translation from the [Hosted
 Weblate](https://hosted.weblate.org/projects/godot-engine/godot), an open
-source and web-based translation platform. Please refer to the [translation
-readme](https://github.com/godotengine/godot-editor-l10n) for more information.
+source and web-based translation platform. Please refer to the [documentation](https://docs.godotengine.org/en/stable/contributing/documentation/editor_and_docs_localization.html) for more information.
 
 You can also help translate [Godot's
 documentation](https://hosted.weblate.org/projects/godot-engine/godot-docs/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ feature, *please* edit the commit title to something meaningful. Commits named
 You can contribute to Godot's translation from the [Hosted
 Weblate](https://hosted.weblate.org/projects/godot-engine/godot), an open
 source and web-based translation platform. Please refer to the [translation
-readme](https://docs.godotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
+readme](https://github.com/godotengine/godot-editor-l10n)
  for more information.
 
 You can also help translate [Godot's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,8 +154,7 @@ feature, *please* edit the commit title to something meaningful. Commits named
 You can contribute to Godot's translation from the [Hosted
 Weblate](https://hosted.weblate.org/projects/godot-engine/godot), an open
 source and web-based translation platform. Please refer to the [translation
-readme](https://github.com/godotengine/godot-editor-l10n)
- for more information.
+readme](https://github.com/godotengine/godot-editor-l10n) for more information.
 
 You can also help translate [Godot's
 documentation](https://hosted.weblate.org/projects/godot-engine/godot-docs/)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->