### PR TITLE
Support consistent sub resource ID

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -124,6 +124,26 @@ String Resource::generate_scene_unique_id() {
 	return id;
 }
 
+String Resource::generate_consistent_scene_unique_id(String name) {
+	String result;
+
+	uint32_t hash = name.hash();
+	static constexpr uint32_t characters = 5;
+	static constexpr uint32_t char_count = ('z' - 'a') + 1;
+	static constexpr uint32_t base = char_count + ('9' - '0') + 1;
+	for (uint32_t i = 0; i < characters; i++) {
+		uint32_t c = hash % base;
+		if (c < char_count) {
+			result += String::chr('a' + c);
+		} else {
+			result += String::chr('0' + (c - char_count));
+		}
+		hash /= base;
+	}
+
+	return result;
+}
+
 void Resource::set_scene_unique_id(const String &p_id) {
 	scene_unique_id = p_id;
 }

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -107,6 +107,7 @@ public:
 	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.contains("::") || path_cache.begins_with("local://"); }
 
 	static String generate_scene_unique_id();
+	static String generate_consistent_scene_unique_id(String name);
 	void set_scene_unique_id(const String &p_id);
 	String get_scene_unique_id() const;
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2246,12 +2246,19 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		if (r->is_built_in()) {
 			if (r->get_scene_unique_id().is_empty()) {
 				String new_id;
-
+				int attempt = 0;
 				while (true) {
-					new_id = _resource_get_class(r) + "_" + Resource::generate_scene_unique_id();
+					String long_name = _resource_get_class(r) + "_" + r->get_name() + "_" + itos(res_index);
+					if (attempt != 0) {
+						long_name += "_" + itos(attempt);
+					}
+
+					new_id = Resource::generate_consistent_scene_unique_id(long_name);
+
 					if (!used_unique_ids.has(new_id)) {
 						break;
 					}
+					attempt++;
 				}
 
 				r->set_scene_unique_id(new_id);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2110,6 +2110,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 		}
 	}
 
+	int sub_res_index = 0;
 	for (List<Ref<Resource>>::Element *E = saved_resources.front(); E; E = E->next()) {
 		Ref<Resource> res = E->get();
 		ERR_CONTINUE(!resource_set.has(res));
@@ -2125,12 +2126,19 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			String line = "[sub_resource ";
 			if (res->get_scene_unique_id().is_empty()) {
 				String new_id;
+				int attempt = 0;
 				while (true) {
-					new_id = _resource_get_class(res) + "_" + Resource::generate_scene_unique_id();
+					String long_name = _resource_get_class(res) + "_" + res->get_name() + "_" + itos(sub_res_index);
+					if (attempt != 0) {
+						long_name += "_" + itos(attempt);
+					}
+
+					new_id = Resource::generate_consistent_scene_unique_id(long_name);
 
 					if (!used_unique_ids.has(new_id)) {
 						break;
 					}
+					attempt++;
 				}
 
 				res->set_scene_unique_id(new_id);
@@ -2203,6 +2211,8 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 		if (E->next()) {
 			f->store_line(String());
 		}
+
+		sub_res_index++;
 	}
 
 	if (packed_scene.is_valid()) {


### PR DESCRIPTION
Try an idea of consistent sub-resource id
Fixes #82702

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
