### PR TITLE
Editor: Fix some issues with `EditorHelpTooltip`

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2264,7 +2264,12 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 			p_rt->push_strikethrough();
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
-
+		} else if (tag == "lb") {
+			p_rt->add_text("[");
+			pos = brk_end + 1;
+		} else if (tag == "rb") {
+			p_rt->add_text("]");
+			pos = brk_end + 1;
 		} else if (tag == "url") {
 			int end = bbcode.find("[", brk_end);
 			if (end == -1) {
@@ -2850,7 +2855,7 @@ void EditorHelpTooltip::_notification(int p_what) {
 // `p_text` is expected to be something like these:
 // - `class|Control||`;
 // - `property|Control|size|`;
-// - `signal|Control|gui_input|(event: InputEvent)`
+// - `signal|Control|gui_input|(event: InputEvent)`.
 void EditorHelpTooltip::parse_tooltip(const String &p_text) {
 	tooltip_text = p_text;
 
@@ -2895,7 +2900,7 @@ void EditorHelpTooltip::parse_tooltip(const String &p_text) {
 	}
 
 	// Metadata special handling replaces "Property:" with "Metadata": above.
-	formatted_text += " [u][b]" + title.trim_prefix("metadata/") + "[/b][/u]" + property_args + "\n";
+	formatted_text += " [u][b]" + title.trim_prefix("metadata/") + "[/b][/u]" + property_args.replace("[", "[lb]") + "\n";
 	formatted_text += description.is_empty() ? "[i]" + TTR("No description available.") + "[/i]" : description;
 	set_text(formatted_text);
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -74,6 +74,7 @@ private:
 	StringName property;
 	String property_path;
 	String doc_path;
+	bool has_doc_tooltip = false;
 
 	int property_usage;
 


### PR DESCRIPTION
* Fixes #82934.

```gdscript
@export_category("class|test")
@export var d: Dictionary = {key = 123}
signal s2(a: Array[int])
```

1. Fix tooltips for dictionary keys.
2. Fix tooltips for categories starting with `class|`.
3. Add BBCode markup escaping for signal parameters.