### PR TITLE
[macOS] Use occlusionState instead of isOnActiveSpace to determine when window is drawable.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -119,6 +119,7 @@ public:
 		bool is_popup = false;
 		bool mpass = false;
 		bool focused = false;
+		bool is_visible = true;
 
 		Rect2i parent_safe_rect;
 	};

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3562,14 +3562,14 @@ bool DisplayServerMacOS::window_is_focused(WindowID p_window) const {
 }
 
 bool DisplayServerMacOS::window_can_draw(WindowID p_window) const {
-	return (window_get_mode(p_window) != WINDOW_MODE_MINIMIZED) && [windows[p_window].window_object isOnActiveSpace];
+	return windows[p_window].is_visible;
 }
 
 bool DisplayServerMacOS::can_any_window_draw() const {
 	_THREAD_SAFE_METHOD_
 
 	for (const KeyValue<WindowID, WindowData> &E : windows) {
-		if ((window_get_mode(E.key) != WINDOW_MODE_MINIMIZED) && [E.value.window_object isOnActiveSpace]) {
+		if (E.value.is_visible) {
 			return true;
 		}
 	}

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -356,4 +356,13 @@
 	}
 }
 
+- (void)windowDidChangeOcclusionState:(NSNotification *)notification {
+	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	if (!ds || !ds->has_window(window_id)) {
+		return;
+	}
+	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
+	wd.is_visible = ([wd.window_object occlusionState] & NSWindowOcclusionStateVisible) && [wd.window_object isVisible];
+}
+
 @end


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/82769

Might fix this one as well, but I can't reproduce the issue - https://github.com/godotengine/godot/issues/64708
*Bugsquad edit:* Closes #64708