### PR TITLE
Fix incorrect vertex data size calculation in `ImmediateMesh`

### DIFF
--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -175,7 +175,7 @@ void ImmediateMesh::surface_end() {
 	AABB aabb;
 
 	{
-		surface_vertex_create_cache.resize(vertex_stride * vertices.size());
+		surface_vertex_create_cache.resize((vertex_stride + normal_tangent_stride) * vertices.size());
 		uint8_t *surface_vertex_ptr = surface_vertex_create_cache.ptrw();
 		for (uint32_t i = 0; i < vertices.size(); i++) {
 			{


### PR DESCRIPTION
Fixes #83083.

From #81138:
> P = Vertex position
> N = normal
> T = tangent
> 
> // After this PR
> PPPPNTNTNTNT

The issue was in ImmediateMesh the buffer was resized only for the `PPPP` part (normals/tangents were written out of the buffer bounds).