### PR TITLE
Avoid caching a specific instance for Object* property defaults

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1678,6 +1678,10 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 				if (E.usage & (PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR)) {
 					if (!default_values[p_class].has(E.name)) {
 						Variant v = c->get(E.name);
+						if (v.get_type() == Variant::OBJECT && v.get_validated_object() != nullptr) {
+							// Skip non-null objects, caching a specific instance causes unexpected behavior.
+							continue;
+						}
 						default_values[p_class][E.name] = v;
 					}
 				}
@@ -1708,24 +1712,7 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 	if (r_valid != nullptr) {
 		*r_valid = true;
 	}
-
-	Variant var = default_values[p_class][p_property];
-
-#ifdef DEBUG_ENABLED
-	// Some properties may have an instantiated Object as default value,
-	// (like Path2D's `curve` used to have), but that's not a good practice.
-	// Instead, those properties should use PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT
-	// to be auto-instantiated when created in the editor with the following method:
-	// EditorNode::get_editor_data().instantiate_object_properties(obj);
-	if (var.get_type() == Variant::OBJECT) {
-		Object *obj = var.get_validated_object();
-		if (obj) {
-			WARN_PRINT(vformat("Instantiated %s used as default value for %s's \"%s\" property.", obj->get_class(), p_class, p_property));
-		}
-	}
-#endif
-
-	return var;
+	return default_values[p_class][p_property];
 }
 
 void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {


### PR DESCRIPTION
Avoids a bug with native types and GDExtension types using something other than null as the initial value for an Object* property. Previously, reverting a property like that in the editor would revert to a specific static Object instance shared across instances of the containing type. Now, reverting is disabled for Object properties that default to something other than null, unless the type implements property_can_revert and property_get_revert to specify a default.

Not currently an issue for native types because of a convention to default to null, past issue for some native types was #36372. GDScript types also seem to have some special case that returns null as a default value even if they have a non-null default. So this really only affects GDExtension and future changes to native types.

_Production edit: Fixes https://github.com/godotengine/godot/issues/83108_