### PR TITLE
GDExtension: Fix incorrect error message about vararg methods

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -218,7 +218,7 @@ public:
 #ifdef TOOLS_ENABLED
 		ERR_FAIL_COND_MSG(!valid, vformat("Cannot call invalid GDExtension method bind '%s'. It's probably cached - you may need to restart Godot.", name));
 #endif
-		ERR_FAIL_COND_MSG(vararg, "Validated methods don't have ptrcall support. This is most likely an engine bug.");
+		ERR_FAIL_COND_MSG(vararg, "Vararg methods don't have validated call support. This is most likely an engine bug.");
 		GDExtensionClassInstancePtr extension_instance = is_static() ? nullptr : p_object->_get_extension_instance();
 
 		if (validated_call_func) {


### PR DESCRIPTION
I noticed this while working on PR https://github.com/godotengine/godot/pull/83054

I assume this was a copy-paste and modify error. There's a similar line in `ptrcall()` below, and it looks like "Vararg" was incorrectly changed to "Validated", and this PR simply changes that back, and does the correct modification.

(Note: I actually suspect these checks might not be necessary anymore, because in PR https://github.com/godotengine/godot/pull/76047 we added ptrcall support for at least some vararg methods - but that can be explored and fixed in a future PR.)