### PR TITLE
Extend MultiplayerSynchronizer 'synchronized' signal

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -79,8 +79,9 @@
 			</description>
 		</signal>
 		<signal name="synchronized">
+			<param index="0" name="updates_skipped" type="int" />
 			<description>
-				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated.
+				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated. The argument [param updates_skipped] is the update timestamp relative to the last received update.
 			</description>
 		</signal>
 		<signal name="visibility_changed">

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -89,7 +89,7 @@ public:
 	void set_net_id(uint32_t p_net_id);
 
 	bool update_outbound_sync_time(uint64_t p_usec);
-	bool update_inbound_sync_time(uint16_t p_network_time);
+	int16_t update_inbound_sync_time(uint16_t p_network_time);
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -145,11 +145,11 @@ void SceneReplicationInterface::on_network_process() {
 	// Process syncs.
 	uint64_t usec = OS::get_singleton()->get_ticks_usec();
 	for (KeyValue<int, PeerInfo> &E : peers_info) {
+		uint16_t sync_net_time = ++E.value.last_sent_sync;
 		const HashSet<ObjectID> to_sync = E.value.sync_nodes;
 		if (to_sync.is_empty()) {
 			continue; // Nothing to sync
 		}
-		uint16_t sync_net_time = ++E.value.last_sent_sync;
 		_send_sync(E.key, to_sync, sync_net_time, usec);
 		_send_delta(E.key, to_sync, usec, E.value.last_watch_usecs);
 	}
@@ -878,7 +878,9 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 			ofs += size;
 			ERR_CONTINUE_MSG(true, "Ignoring sync data from non-authority or for missing node.");
 		}
-		if (!sync->update_inbound_sync_time(time)) {
+
+		short sync_time_offset = sync->update_inbound_sync_time(time);
+		if (sync_time_offset <= 0) {
 			// State is too old.
 			ofs += size;
 			continue;
@@ -892,7 +894,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		err = MultiplayerSynchronizer::set_state(props, node, vars);
 		ERR_FAIL_COND_V(err, err);
 		ofs += size;
-		sync->emit_signal(SNAME("synchronized"));
+		sync->emit_signal(SNAME("synchronized"), sync_time_offset - 1);
 #ifdef DEBUG_ENABLED
 		_profile_node_data("sync_in", sync->get_instance_id(), size);
 #endif


### PR DESCRIPTION
WIP draft for extension for Multiplayer API based on ongoing discussions in RocketChat.

Add an additional argument to the MultiplayerSynchronizer 'synchronized' signal meant to show how many sync updates were missing (due to either packet loss or intentional filtering) since the last update by extrapolating the result from the previous 16bit timestamp. This information may allow the ability to extend the multiplayer system with more advance visual latency compensation methods such as delayed interpolation or extrapolation of state snapshots.