### PR TITLE
C#: Fix MSVC dotnet `dev_mode` regression

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1927,20 +1927,19 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 }
 
 bool EditorExportPlatformIOS::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
-#ifdef MODULE_MONO_ENABLED
-#ifdef MACOS_ENABLED
-	// iOS export is still a work in progress, keep a message as a warning.
-	r_error += TTR("Exporting to iOS when using C#/.NET is experimental.") + "\n";
-#else
+#if defined(MODULE_MONO_ENABLED) && !defined(MACOS_ENABLED)
 	// TODO: Remove this restriction when we don't rely on macOS tools to package up the native libraries anymore.
 	r_error += TTR("Exporting to iOS when using C#/.NET is experimental and requires macOS.") + "\n";
 	return false;
-#endif
-#endif
+#else
 
 	String err;
 	bool valid = false;
 
+#if defined(MODULE_MONO_ENABLED)
+	// iOS export is still a work in progress, keep a message as a warning.
+	err += TTR("Exporting to iOS when using C#/.NET is experimental.") + "\n";
+#endif
 	// Look for export templates (first official, and if defined custom templates).
 
 	bool dvalid = exists_export_template("ios.zip", &err);
@@ -1967,6 +1966,7 @@ bool EditorExportPlatformIOS::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
+#endif // !(MODULE_MONO_ENABLED && !MACOS_ENABLED)
 }
 
 bool EditorExportPlatformIOS::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {


### PR DESCRIPTION
A regression by #82729 brings back the erroneous behavior found in #79351. This is fixed by reimplementing the `#else` check in the ios `export_plugin` script