### PR TITLE
C#: Enable nullable environment for GodotSharp

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -66,6 +66,7 @@ StringBuilder &operator<<(StringBuilder &r_sb, const char *p_cstring) {
 
 #define OPEN_BLOCK "{\n"
 #define CLOSE_BLOCK "}\n"
+#define EMPTY_BLOCK " { }\n"
 
 #define OPEN_BLOCK_L1 INDENT1 OPEN_BLOCK
 #define OPEN_BLOCK_L2 INDENT2 OPEN_BLOCK
@@ -1136,6 +1137,7 @@ void BindingsGenerator::_append_xml_method(StringBuilder &p_xml_output, const Ty
 					if (iarg.def_param_mode == ArgumentInterface::NULLABLE_VAL) {
 						p_xml_output.append("}");
 					}
+					// Documentation accounts for nullable refs automatically, no need to append "?"
 				}
 				p_xml_output.append(")\"/>");
 			} else {
@@ -1512,7 +1514,7 @@ void BindingsGenerator::_generate_array_extensions(StringBuilder &p_output) {
 	p_output.append(INDENT1 "public static bool IsEmpty(this " #m_type "[] instance)\n");               \
 	p_output.append(OPEN_BLOCK_L1);                                                                     \
 	p_output.append(INDENT2 "return instance == null || instance.Length == 0;\n");                      \
-	p_output.append(INDENT1 CLOSE_BLOCK);
+	p_output.append(CLOSE_BLOCK_L1);
 
 #define ARRAY_JOIN(m_type)                                                                                          \
 	p_output.append("\n" INDENT1 "/// <summary>\n");                                                                \
@@ -1523,8 +1525,8 @@ void BindingsGenerator::_generate_array_extensions(StringBuilder &p_output) {
 	p_output.append(INDENT1 "/// <returns>A single string with all items.</returns>\n");                            \
 	p_output.append(INDENT1 "public static string Join(this " #m_type "[] instance, string delimiter = \", \")\n"); \
 	p_output.append(OPEN_BLOCK_L1);                                                                                 \
-	p_output.append(INDENT2 "return String.Join(delimiter, instance);\n");                                          \
-	p_output.append(INDENT1 CLOSE_BLOCK);
+	p_output.append(INDENT2 "return String.Join(delimiter, instance ?? Array.Empty<" #m_type ">());\n");            \
+	p_output.append(CLOSE_BLOCK_L1);
 
 #define ARRAY_STRINGIFY(m_type)                                                                          \
 	p_output.append("\n" INDENT1 "/// <summary>\n");                                                     \
@@ -1535,7 +1537,7 @@ void BindingsGenerator::_generate_array_extensions(StringBuilder &p_output) {
 	p_output.append(INDENT1 "public static string Stringify(this " #m_type "[] instance)\n");            \
 	p_output.append(OPEN_BLOCK_L1);                                                                      \
 	p_output.append(INDENT2 "return \"[\" + instance.Join() + \"]\";\n");                                \
-	p_output.append(INDENT1 CLOSE_BLOCK);
+	p_output.append(CLOSE_BLOCK_L1);
 
 #define ARRAY_ALL(m_type)  \
 	ARRAY_IS_EMPTY(m_type) \
@@ -1978,9 +1980,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	output.append("using System;\n"); // IntPtr
 	output.append("using System.ComponentModel;\n"); // EditorBrowsable
 	output.append("using System.Diagnostics;\n"); // DebuggerBrowsable
-	output.append("using Godot.NativeInterop;\n");
-
-	output.append("\n#nullable disable\n");
+	output.append("using Godot.NativeInterop;\n\n");
 
 	const DocData::ClassDoc *class_doc = itype.class_doc;
 
@@ -2162,7 +2162,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 			instance_type_name = itype.proxy_name;
 		}
 
-		output.append(MEMBER_BEGIN "private static " + instance_type_name + " singleton;\n");
+		output.append(MEMBER_BEGIN "private static " + instance_type_name + "? singleton;\n");
 
 		output << MEMBER_BEGIN "public static " + instance_type_name + " " CS_PROPERTY_SINGLETON " =>\n"
 			   << INDENT2 "singleton \?\?= (" + instance_type_name + ")"
@@ -2187,29 +2187,19 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 		if (is_derived_type) {
 			// Add default constructor
-			if (itype.is_instantiable) {
-				output << MEMBER_BEGIN "public " << itype.proxy_name << "() : this("
-					   << (itype.memory_own ? "true" : "false") << ")\n" OPEN_BLOCK_L1
-					   << INDENT2 "unsafe\n" INDENT2 OPEN_BLOCK
-					   << INDENT3 "ConstructAndInitialize(" CS_STATIC_FIELD_NATIVE_CTOR ", "
-					   << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
-					   << (itype.is_ref_counted ? "true" : "false") << ");\n"
-					   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
-			} else {
-				// Hide the constructor
-				output << MEMBER_BEGIN "internal " << itype.proxy_name << "() : this("
-					   << (itype.memory_own ? "true" : "false") << ")\n" OPEN_BLOCK_L1
-					   << INDENT2 "unsafe\n" INDENT2 OPEN_BLOCK
-					   << INDENT3 "ConstructAndInitialize(null, "
-					   << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
-					   << (itype.is_ref_counted ? "true" : "false") << ");\n"
-					   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
-			}
+			output << MEMBER_BEGIN << (itype.is_instantiable ? "public" : "internal") << " "
+				   << itype.proxy_name << "() : this(" << (itype.memory_own ? "true" : "false")
+				   << ")\n" OPEN_BLOCK_L1 INDENT2 "unsafe\n"
+				   << INDENT2 OPEN_BLOCK INDENT3 "ConstructAndInitialize("
+				   << (itype.is_instantiable ? CS_STATIC_FIELD_NATIVE_CTOR : "null")
+				   << ", " << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
+				   << (itype.is_ref_counted ? "true" : "false") << ");\n"
+				   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
 
 			// Add.. em.. trick constructor. Sort of.
 			output.append(MEMBER_BEGIN "internal ");
 			output.append(itype.proxy_name);
-			output.append("(bool " CS_PARAM_MEMORYOWN ") : base(" CS_PARAM_MEMORYOWN ") { }\n");
+			output.append("(bool " CS_PARAM_MEMORYOWN ") : base(" CS_PARAM_MEMORYOWN ")" EMPTY_BLOCK);
 		}
 	}
 
@@ -2594,14 +2584,13 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 	String prop_cs_type = prop_itype->cs_type + _get_generic_type_parameters(*prop_itype, proptype_name.generic_type_parameters);
 
 	p_output.append(prop_cs_type);
-	p_output.append(" ");
+	p_output.append(prop_itype->is_object_type ? "? " : " ");
 	p_output.append(p_iprop.proxy_name);
 	p_output.append("\n" OPEN_BLOCK_L1);
 
 	if (getter) {
-		p_output.append(INDENT2 "get\n" OPEN_BLOCK_L2 INDENT3);
+		p_output.append(INDENT2 "get => ");
 
-		p_output.append("return ");
 		p_output.append(getter->proxy_name + "(");
 		if (p_iprop.index != -1) {
 			const ArgumentInterface &idx_arg = getter->arguments.front()->get();
@@ -2614,11 +2603,11 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 				p_output.append(itos(p_iprop.index));
 			}
 		}
-		p_output.append(");\n" CLOSE_BLOCK_L2);
+		p_output.append(");\n");
 	}
 
 	if (setter) {
-		p_output.append(INDENT2 "set\n" OPEN_BLOCK_L2 INDENT3);
+		p_output.append(INDENT2 "set => ");
 
 		p_output.append(setter->proxy_name + "(");
 		if (p_iprop.index != -1) {
@@ -2632,7 +2621,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 				p_output.append(itos(p_iprop.index) + ", ");
 			}
 		}
-		p_output.append("value);\n" CLOSE_BLOCK_L2);
+		p_output.append("value);\n");
 	}
 
 	p_output.append(CLOSE_BLOCK_L1);
@@ -2714,6 +2703,8 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 			if (iarg.def_param_mode == ArgumentInterface::NULLABLE_VAL) {
 				arguments_sig += "> ";
+			} else if (iarg.def_param_mode == ArgumentInterface::NULLABLE_REF || arg_type->is_object_type) {
+				arguments_sig += "? ";
 			} else {
 				arguments_sig += " ";
 			}
@@ -2731,27 +2722,13 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 		icall_params += ", ";
 
-		if (iarg.default_argument.size() && iarg.def_param_mode != ArgumentInterface::CONSTANT) {
+		if (iarg.default_argument.size() && iarg.def_param_mode != ArgumentInterface::CONSTANT && iarg.default_argument != "null") {
 			// The default value of an argument must be constant. Otherwise we make it Nullable and do the following:
-			// Type arg_in = arg.HasValue ? arg.Value : <non-const default value>;
+			// Type arg_in = arg ?? <non-const default value>;
 			String arg_or_defval_local = iarg.name;
 			arg_or_defval_local += "OrDefVal";
 
-			cs_in_statements << INDENT2 << arg_cs_type << " " << arg_or_defval_local << " = " << iarg.name;
-
-			if (iarg.def_param_mode == ArgumentInterface::NULLABLE_VAL) {
-				cs_in_statements << ".HasValue ? ";
-			} else {
-				cs_in_statements << " != null ? ";
-			}
-
-			cs_in_statements << iarg.name;
-
-			if (iarg.def_param_mode == ArgumentInterface::NULLABLE_VAL) {
-				cs_in_statements << ".Value : ";
-			} else {
-				cs_in_statements << " : ";
-			}
+			cs_in_statements << INDENT2 << arg_cs_type << " " << arg_or_defval_local << " = " << iarg.name << " ?? ";
 
 			String cs_type = arg_cs_type;
 			if (cs_type.ends_with("[]")) {
@@ -2778,7 +2755,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 			// Escape < and > in the attribute default value
 			String param_def_arg = def_arg.replacen("<", "&lt;").replacen(">", "&gt;");
 
-			default_args_doc.append(MEMBER_BEGIN "/// <param name=\"" + param_tag_name + "\">If the parameter is null, then the default value is <c>" + param_def_arg + "</c>.</param>");
+			default_args_doc.append(MEMBER_BEGIN "/// <param name=\"" + param_tag_name + "\">If the parameter is <see langword=\"null\"/>, then the default value is <c>" + param_def_arg + "</c>.</param>");
 		} else {
 			if (arg_type->cs_in.size()) {
 				cs_in_statements << sformat(arg_type->cs_in, arg_type->c_type, iarg.name,
@@ -2858,22 +2835,29 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		}
 
 		String return_cs_type = return_type->cs_type + _get_generic_type_parameters(*return_type, p_imethod.return_type.generic_type_parameters);
+		if (return_type->is_object_type) {
+			return_cs_type += "?";
+		}
 
 		p_output.append(return_cs_type + " ");
 		p_output.append(p_imethod.proxy_name + "(");
-		p_output.append(arguments_sig + ")\n" OPEN_BLOCK_L1);
+		p_output.append(arguments_sig + ")");
 
 		if (p_imethod.is_virtual) {
 			// Godot virtual method must be overridden, therefore we return a default value by default.
 
 			if (return_type->cname == name_cache.type_void) {
-				p_output.append(CLOSE_BLOCK_L1);
+				p_output << EMPTY_BLOCK;
 			} else {
-				p_output.append(INDENT2 "return default;\n" CLOSE_BLOCK_L1);
+				p_output << "\n" OPEN_BLOCK_L1
+						 << INDENT2 "return " << return_type->cs_default << ";\n"
+						 << CLOSE_BLOCK_L1;
 			}
 
 			return OK; // Won't increment method bind count
 		}
+
+		p_output << "\n" OPEN_BLOCK_L1;
 
 		if (p_imethod.requires_object_call) {
 			// Fallback to Godot's object.Call(string, params)
@@ -2954,7 +2938,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 		}
 
 		arguments_sig += arg_type->cs_type;
-		arguments_sig += " ";
+		arguments_sig += arg_type->is_object_type ? "? " : " ";
 		arguments_sig += iarg.name;
 
 		delegate_type_params += arg_type->cs_type;
@@ -3392,6 +3376,9 @@ const String BindingsGenerator::_get_generic_type_parameters(const TypeInterface
 		}
 
 		params += param_itype->cs_type;
+		if (param_itype->is_object_type) {
+			params += "?";
+		}
 		if (i < p_generic_type_parameters.size() - 1) {
 			params += ", ";
 		}
@@ -3630,7 +3617,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		itype.c_arg_in = "&%s";
 		itype.c_type = "IntPtr";
 		itype.c_type_in = itype.c_type;
-		itype.c_type_out = "GodotObject";
+		itype.c_type_out = "GodotObject?";
 
 		// Populate properties
 
@@ -4156,11 +4143,11 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 			if (r_iarg.type.cname == name_cache.type_StringName || r_iarg.type.cname == name_cache.type_NodePath) {
 				if (r_iarg.default_argument.length() > 0) {
 					r_iarg.default_argument = "(%s)\"" + r_iarg.default_argument + "\"";
-					r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
 				} else {
 					// No need for a special `in` statement to change `null` to `""`. Marshaling takes care of this already.
 					r_iarg.default_argument = "null";
 				}
+				r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
 			} else {
 				CRASH_COND(r_iarg.type.cname != name_cache.type_String);
 				r_iarg.default_argument = "\"" + r_iarg.default_argument + "\"";
@@ -4191,9 +4178,6 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 		case Variant::VECTOR2I:
 		case Variant::VECTOR3:
 		case Variant::VECTOR3I:
-			r_iarg.default_argument = "new %s" + r_iarg.default_argument;
-			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
-			break;
 		case Variant::VECTOR4:
 		case Variant::VECTOR4I:
 			r_iarg.default_argument = "new %s" + r_iarg.default_argument;
@@ -4204,13 +4188,14 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 					"Parameter of type '" + String(r_iarg.type.cname) + "' can only have null/zero as the default value.");
 
 			r_iarg.default_argument = "null";
+			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
 			break;
 		case Variant::DICTIONARY:
 			ERR_FAIL_COND_V_MSG(!p_val.operator Dictionary().is_empty(), false,
 					"Default value of type 'Dictionary' must be an empty dictionary.");
 			// The [cs_in] expression already interprets null values as empty dictionaries.
 			r_iarg.default_argument = "null";
-			r_iarg.def_param_mode = ArgumentInterface::CONSTANT;
+			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
 			break;
 		case Variant::RID:
 			ERR_FAIL_COND_V_MSG(r_iarg.type.cname != name_cache.type_RID, false,
@@ -4226,7 +4211,7 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 					"Default value of type 'Array' must be an empty array.");
 			// The [cs_in] expression already interprets null values as empty arrays.
 			r_iarg.default_argument = "null";
-			r_iarg.def_param_mode = ArgumentInterface::CONSTANT;
+			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
 			break;
 		case Variant::PACKED_BYTE_ARRAY:
 		case Variant::PACKED_INT32_ARRAY:
@@ -4430,6 +4415,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.cname = itype.name;
 	itype.proxy_name = "string";
 	itype.cs_type = itype.proxy_name;
+	itype.cs_default = "string.Empty";
 	itype.c_in = "%5using %0 %1_in = " C_METHOD_MONOSTR_TO_GODOT "(%1);\n";
 	itype.c_out = "%5return " C_METHOD_MONOSTR_FROM_GODOT "(%1);\n";
 	itype.c_arg_in = "&%s_in";
@@ -4446,6 +4432,9 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.cname = itype.name;
 	itype.proxy_name = "StringName";
 	itype.cs_type = itype.proxy_name;
+	itype.cs_variant_to_managed += "!";
+	itype.cs_managed_to_variant += "!";
+	itype.cs_default = "new()";
 	itype.cs_in_expr = "(%1)(%0?.NativeValue ?? default)";
 	// Cannot pass null StringName to ptrcall
 	itype.c_out = "%5return %0.CreateTakingOwnershipOfDisposableValue(%1);\n";
@@ -4464,6 +4453,9 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.cname = itype.name;
 	itype.proxy_name = "NodePath";
 	itype.cs_type = itype.proxy_name;
+	itype.cs_variant_to_managed += "!";
+	itype.cs_managed_to_variant += "!";
+	itype.cs_default = "new()";
 	itype.cs_in_expr = "(%1)(%0?.NativeValue ?? default)";
 	// Cannot pass null NodePath to ptrcall
 	itype.c_out = "%5return %0.CreateTakingOwnershipOfDisposableValue(%1);\n";
@@ -4551,6 +4543,9 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 		itype.cname = itype.name;                                                   \
 		itype.proxy_name = #m_proxy_t "[]";                                         \
 		itype.cs_type = itype.proxy_name;                                           \
+		itype.cs_variant_to_managed += "!";                                         \
+		itype.cs_managed_to_variant += "!";                                         \
+		itype.cs_default = "Array.Empty<" #m_proxy_t ">()";                         \
 		itype.c_in = "%5using %0 %1_in = " C_METHOD_MONOARRAY_TO(m_type) "(%1);\n"; \
 		itype.c_out = "%5return " C_METHOD_MONOARRAY_FROM(m_type) "(%1);\n";        \
 		itype.c_arg_in = "&%s_in";                                                  \
@@ -4585,6 +4580,9 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.proxy_name = itype.name;
 	itype.type_parameter_count = 1;
 	itype.cs_type = BINDINGS_NAMESPACE_COLLECTIONS "." + itype.proxy_name;
+	itype.cs_variant_to_managed += "!";
+	itype.cs_managed_to_variant += "!";
+	itype.cs_default = "new()";
 	itype.cs_in_expr = "(%1)(%0 ?? new()).NativeValue";
 	itype.c_out = "%5return %0.CreateTakingOwnershipOfDisposableValue(%1);\n";
 	itype.c_arg_in = "&%s";
@@ -4603,6 +4601,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	// For generic Godot collections, Variant.From<T>/As<T> is slower, so we need this special case
 	itype.cs_variant_to_managed = "VariantUtils.ConvertToArray(%0)";
 	itype.cs_managed_to_variant = "VariantUtils.CreateFromArray(%0)";
+	itype.cs_default = "new()";
 	builtin_types.insert(itype.cname, itype);
 
 	// Dictionary
@@ -4612,6 +4611,9 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.proxy_name = itype.name;
 	itype.type_parameter_count = 2;
 	itype.cs_type = BINDINGS_NAMESPACE_COLLECTIONS "." + itype.proxy_name;
+	itype.cs_variant_to_managed += "!";
+	itype.cs_managed_to_variant += "!";
+	itype.cs_default = "new()";
 	itype.cs_in_expr = "(%1)(%0 ?? new()).NativeValue";
 	itype.c_out = "%5return %0.CreateTakingOwnershipOfDisposableValue(%1);\n";
 	itype.c_arg_in = "&%s";
@@ -4630,6 +4632,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	// For generic Godot collections, Variant.From<T>/As<T> is slower, so we need this special case
 	itype.cs_variant_to_managed = "VariantUtils.ConvertToDictionary(%0)";
 	itype.cs_managed_to_variant = "VariantUtils.CreateFromDictionary(%0)";
+	itype.cs_default = "new()";
 	builtin_types.insert(itype.cname, itype);
 
 	// void (fictitious type to represent the return type of methods that do not return anything)

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -416,6 +416,11 @@ class BindingsGenerator {
 		String cs_type;
 
 		/**
+		 * Value used when returning a default argument. Usually 'default'.
+		 */
+		String cs_default;
+
+		/**
 		 * Formatting elements:
 		 * %0: input expression of type `in godot_variant`
 		 * %1: [cs_type] of this type
@@ -600,8 +605,10 @@ class BindingsGenerator {
 		TypeInterface() {
 			static String default_cs_variant_to_managed = "VariantUtils.ConvertTo<%1>(%0)";
 			static String default_cs_managed_to_variant = "VariantUtils.CreateFrom<%1>(%0)";
+			static String default_cs_default = "default";
 			cs_variant_to_managed = default_cs_variant_to_managed;
 			cs_managed_to_variant = default_cs_managed_to_variant;
+			cs_default = default_cs_default;
 		}
 	};
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
@@ -70,7 +70,7 @@ partial class CodeEdit
 {
     /// <inheritdoc cref="AddCodeCompletionOption(CodeCompletionKind, string, string, Nullable{Color}, Resource, Variant, int)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void AddCodeCompletionOption(CodeCompletionKind type, string displayText, string insertText, Nullable<Color> textColor, Resource icon, Nullable<Variant> value)
+    public void AddCodeCompletionOption(CodeCompletionKind type, string displayText, string insertText, Nullable<Color> textColor, Resource? icon, Nullable<Variant> value)
     {
         AddCodeCompletionOption(type, displayText, insertText, textColor, icon, value, location: 1024);
     }
@@ -98,7 +98,7 @@ partial class GraphEdit
 
     /// <inheritdoc cref="GetMenuHBox()"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public HBoxContainer GetZoomHBox()
+    public HBoxContainer? GetZoomHBox()
     {
         return GetMenuHBox();
     }
@@ -134,7 +134,7 @@ partial class ImporterMesh
 {
     /// <inheritdoc cref="AddSurface(Mesh.PrimitiveType, Godot.Collections.Array, Godot.Collections.Array{Godot.Collections.Array}, Godot.Collections.Dictionary, Material, string, ulong)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void AddSurface(Mesh.PrimitiveType primitive, Godot.Collections.Array arrays, Godot.Collections.Array<Godot.Collections.Array> blendShapes, Godot.Collections.Dictionary lods, Material material, string name, uint flags)
+    public void AddSurface(Mesh.PrimitiveType primitive, Godot.Collections.Array arrays, Godot.Collections.Array<Godot.Collections.Array>? blendShapes, Godot.Collections.Dictionary? lods, Material? material, string name, uint flags)
     {
         AddSurface(primitive, arrays, blendShapes, lods, material, name, (ulong)flags);
     }
@@ -172,9 +172,9 @@ partial class RenderingDevice
 {
     /// <inheritdoc cref="DrawListBegin(Rid, InitialAction, FinalAction, InitialAction, FinalAction, Color[], float, uint, Nullable{Rect2}, Godot.Collections.Array{Rid})"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public long DrawListBegin(Rid framebuffer, InitialAction initialColorAction, FinalAction finalColorAction, InitialAction initialDepthAction, FinalAction finalDepthAction, Color[] clearColorValues, float clearDepth, uint clearStencil, Nullable<Rect2> region, Godot.Collections.Array storageTextures)
+    public long DrawListBegin(Rid framebuffer, InitialAction initialColorAction, FinalAction finalColorAction, InitialAction initialDepthAction, FinalAction finalDepthAction, Color[]? clearColorValues, float clearDepth, uint clearStencil, Nullable<Rect2> region, Godot.Collections.Array? storageTextures)
     {
-        return DrawListBegin(framebuffer, initialColorAction, finalColorAction, initialDepthAction, finalDepthAction, clearColorValues, clearDepth, clearStencil, region, new Godot.Collections.Array<Rid>(storageTextures));
+        return DrawListBegin(framebuffer, initialColorAction, finalColorAction, initialDepthAction, finalDepthAction, clearColorValues, clearDepth, clearStencil, region, new Godot.Collections.Array<Rid>(storageTextures ?? new()));
     }
 }
 
@@ -199,14 +199,14 @@ partial class SurfaceTool
 {
     /// <inheritdoc cref="AddTriangleFan(Vector3[], Vector2[], Color[], Vector2[], Vector3[], Godot.Collections.Array{Plane})"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void AddTriangleFan(Vector3[] vertices, Vector2[] uvs, Color[] colors, Vector2[] uv2S, Vector3[] normals, Godot.Collections.Array tangents)
+    public void AddTriangleFan(Vector3[] vertices, Vector2[]? uvs, Color[]? colors, Vector2[]? uv2S, Vector3[]? normals, Godot.Collections.Array? tangents)
     {
-        AddTriangleFan(vertices, uvs, colors, uv2S, normals, new Godot.Collections.Array<Plane>(tangents));
+        AddTriangleFan(vertices, uvs, colors, uv2S, normals, new Godot.Collections.Array<Plane>(tangents ?? new()));
     }
 
     /// <inheritdoc cref="Commit(ArrayMesh, ulong)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public ArrayMesh Commit(ArrayMesh existing, uint flags)
+    public ArrayMesh? Commit(ArrayMesh existing, uint flags)
     {
         return Commit(existing, (ulong)flags);
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot.Collections
 {
     /// <summary>
@@ -158,7 +156,7 @@ namespace Godot.Collections
         /// The <paramref name="array"/> is <see langword="null"/>.
         /// </exception>
         /// <returns>A new Godot Array.</returns>
-        public Array(ReadOnlySpan<GodotObject> array)
+        public Array(ReadOnlySpan<GodotObject?> array)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
@@ -1049,7 +1047,7 @@ namespace Godot.Collections
         IEnumerable<T>,
         IGenericGodotArray
     {
-        private static godot_variant ToVariantFunc(in Array<T> godotArray) =>
+        private static godot_variant ToVariantFunc(in Array<T>? godotArray) =>
             VariantUtils.CreateFromArray(godotArray);
 
         private static Array<T> FromVariantFunc(in godot_variant variant) =>
@@ -1194,7 +1192,7 @@ namespace Godot.Collections
         /// is returned.
         /// </summary>
         /// <returns>The maximum value contained in the array.</returns>
-        public T Max()
+        public T? Max()
         {
             godot_variant resVariant;
             var self = (godot_array)_underlyingArray.NativeValue;
@@ -1208,7 +1206,7 @@ namespace Godot.Collections
         /// is returned.
         /// </summary>
         /// <returns>The minimum value contained in the array.</returns>
-        public T Min()
+        public T? Min()
         {
             godot_variant resVariant;
             var self = (godot_array)_underlyingArray.NativeValue;
@@ -1231,7 +1229,7 @@ namespace Godot.Collections
             godot_variant resVariant;
             var self = (godot_array)_underlyingArray.NativeValue;
             NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
-            return VariantUtils.ConvertTo<T>(resVariant);
+            return VariantUtils.ConvertTo<T>(resVariant)!;
         }
 
         /// <summary>
@@ -1410,7 +1408,7 @@ namespace Godot.Collections
             get
             {
                 _underlyingArray.GetVariantBorrowElementAt(index, out godot_variant borrowElem);
-                return VariantUtils.ConvertTo<T>(borrowElem);
+                return VariantUtils.ConvertTo<T>(borrowElem)!;
             }
             set
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>
@@ -46,5 +44,3 @@ namespace Godot
         }
     }
 }
-
-#nullable restore

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -16,14 +16,14 @@ namespace Godot
         /// <summary>
         /// Optional string that can contain additional metadata for the <see cref="Hint"/>.
         /// </summary>
-        public string HintString { get; }
+        public string? HintString { get; }
 
         /// <summary>
         /// Constructs a new ExportAttribute Instance.
         /// </summary>
         /// <param name="hint">The hint for the exported property.</param>
         /// <param name="hintString">A string that may contain additional metadata for the hint.</param>
-        public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
+        public ExportAttribute(PropertyHint hint = PropertyHint.None, string? hintString = null)
         {
             Hint = hint;
             HintString = hintString;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
@@ -1,7 +1,5 @@
 using System;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>
@@ -25,7 +23,7 @@ namespace Godot
         /// </summary>
         /// <param name="name">The name of the group.</param>
         /// <param name="prefix">If provided, the group would make group to only consider properties that have this prefix.</param>
-        public ExportGroupAttribute(string name, string prefix = "")
+        public ExportGroupAttribute(string name, string? prefix = null)
         {
             Name = name;
             Prefix = prefix;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
@@ -1,7 +1,5 @@
 using System;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>
@@ -25,7 +23,7 @@ namespace Godot
         /// </summary>
         /// <param name="name">The name of the subgroup.</param>
         /// <param name="prefix">If provided, the subgroup would make group to only consider properties that have this prefix.</param>
-        public ExportSubgroupAttribute(string name, string prefix = "")
+        public ExportSubgroupAttribute(string name, string? prefix = null)
         {
             Name = name;
             Prefix = prefix;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalClassAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalClassAttribute.cs
@@ -1,7 +1,5 @@
 using System;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -12,7 +12,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
                 {
@@ -49,7 +49,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
                     throw new InvalidOperationException();
@@ -79,7 +79,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
                     throw new InvalidOperationException();
@@ -134,7 +134,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (okIfNull.ToBool())
                     godotObject?.Dispose();
@@ -152,7 +152,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var self = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var self = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (self == null)
                 {
@@ -186,7 +186,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
                     return godot_bool.False;
@@ -209,7 +209,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
                     return;
@@ -242,7 +242,7 @@ namespace Godot.Bridge
         {
             try
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+                var godotObject = (GodotObject?)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
                     return;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GCHandleBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GCHandleBridge.cs
@@ -31,7 +31,7 @@ namespace Godot.Bridge
                 if (target is Delegate @delegate)
                     return DelegateUtils.IsDelegateCollectible(@delegate).ToGodotBool();
 
-                return target.GetType().IsCollectible.ToGodotBool();
+                return target!.GetType().IsCollectible.ToGodotBool();
             }
             catch (Exception e)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/MethodInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/MethodInfo.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 
 namespace Godot.Bridge;
 
-#nullable enable
-
 public readonly struct MethodInfo
 {
     public StringName Name { get; init; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
@@ -1,7 +1,5 @@
 namespace Godot.Bridge;
 
-#nullable enable
-
 public readonly struct PropertyInfo
 {
     public Variant.Type Type { get; init; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 
 namespace Godot.Bridge;
 
-#nullable enable
-
 public static partial class ScriptManagerBridge
 {
     private class ScriptTypeBiMap

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
@@ -28,25 +28,25 @@ namespace Godot
     /// </example>
     public readonly partial struct Callable
     {
-        private readonly GodotObject _target;
-        private readonly StringName _method;
-        private readonly Delegate _delegate;
+        private readonly GodotObject? _target;
+        private readonly StringName? _method;
+        private readonly Delegate? _delegate;
         private readonly unsafe delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> _trampoline;
 
         /// <summary>
         /// Object that contains the method.
         /// </summary>
-        public GodotObject Target => _target;
+        public GodotObject? Target => _target;
 
         /// <summary>
         /// Name of the method that will be called.
         /// </summary>
-        public StringName Method => _method;
+        public StringName? Method => _method;
 
         /// <summary>
         /// Delegate of the method that will be called.
         /// </summary>
-        public Delegate Delegate => _delegate;
+        public Delegate? Delegate => _delegate;
 
         /// <summary>
         /// Trampoline function pointer for dynamically invoking <see cref="Callable.Delegate"/>.
@@ -60,7 +60,7 @@ namespace Godot
         /// </summary>
         /// <param name="target">Object that contains the method.</param>
         /// <param name="method">Name of the method that will be called.</param>
-        public unsafe Callable(GodotObject target, StringName method)
+        public unsafe Callable(GodotObject? target, StringName method)
         {
             _target = target;
             _method = method;
@@ -68,7 +68,7 @@ namespace Godot
             _trampoline = null;
         }
 
-        private unsafe Callable(Delegate @delegate,
+        private unsafe Callable(Delegate? @delegate,
             delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> trampoline)
         {
             _target = @delegate?.Target as GodotObject;
@@ -197,7 +197,7 @@ namespace Godot
         /// <param name="delegate">Delegate method that will be called.</param>
         /// <param name="trampoline">Trampoline function pointer for invoking the delegate.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Callable CreateWithUnsafeTrampoline(Delegate @delegate,
+        public static unsafe Callable CreateWithUnsafeTrampoline(Delegate? @delegate,
             delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> trampoline)
             => new(@delegate, trampoline);
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.generics.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.generics.cs
@@ -4,8 +4,6 @@ using Godot.NativeInterop;
 
 namespace Godot;
 
-#nullable enable
-
 public readonly partial struct Callable
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -53,7 +51,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 1);
 
-            ((Action<T0>)delegateObj)(
+            ((Action<T0?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0])
             );
 
@@ -72,7 +70,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 2);
 
-            ((Action<T0, T1>)delegateObj)(
+            ((Action<T0?, T1?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1])
             );
@@ -92,7 +90,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 3);
 
-            ((Action<T0, T1, T2>)delegateObj)(
+            ((Action<T0?, T1?, T2?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2])
@@ -113,7 +111,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 4);
 
-            ((Action<T0, T1, T2, T3>)delegateObj)(
+            ((Action<T0?, T1?, T2?, T3?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -135,7 +133,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 5);
 
-            ((Action<T0, T1, T2, T3, T4>)delegateObj)(
+            ((Action<T0?, T1?, T2?, T3?, T4?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -158,7 +156,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 6);
 
-            ((Action<T0, T1, T2, T3, T4, T5>)delegateObj)(
+            ((Action<T0?, T1?, T2?, T3?, T4?, T5?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -182,7 +180,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 7);
 
-            ((Action<T0, T1, T2, T3, T4, T5, T6>)delegateObj)(
+            ((Action<T0?, T1?, T2?, T3?, T4?, T5?, T6?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -207,7 +205,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 8);
 
-            ((Action<T0, T1, T2, T3, T4, T5, T6, T7>)delegateObj)(
+            ((Action<T0?, T1?, T2?, T3?, T4?, T5?, T6?, T7?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -233,7 +231,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 9);
 
-            ((Action<T0, T1, T2, T3, T4, T5, T6, T7, T8>)delegateObj)(
+            ((Action<T0?, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -263,7 +261,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 0);
 
-            TResult res = ((Func<TResult>)delegateObj)();
+            TResult? res = ((Func<TResult?>)delegateObj)();
 
             ret = VariantUtils.CreateFrom(res);
         }
@@ -280,7 +278,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 1);
 
-            TResult res = ((Func<T0, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0])
             );
 
@@ -299,7 +297,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 2);
 
-            TResult res = ((Func<T0, T1, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1])
             );
@@ -319,7 +317,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 3);
 
-            TResult res = ((Func<T0, T1, T2, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2])
@@ -340,7 +338,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 4);
 
-            TResult res = ((Func<T0, T1, T2, T3, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, T3?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -362,7 +360,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 5);
 
-            TResult res = ((Func<T0, T1, T2, T3, T4, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, T3?, T4?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -385,7 +383,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 6);
 
-            TResult res = ((Func<T0, T1, T2, T3, T4, T5, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, T3?, T4?, T5?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -409,7 +407,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 7);
 
-            TResult res = ((Func<T0, T1, T2, T3, T4, T5, T6, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, T3?, T4?, T5?, T6?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -434,7 +432,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 8);
 
-            TResult res = ((Func<T0, T1, T2, T3, T4, T5, T6, T7, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),
@@ -460,7 +458,7 @@ public readonly partial struct Callable
         {
             ThrowIfArgCountMismatch(args, 9);
 
-            TResult res = ((Func<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>)delegateObj)(
+            TResult? res = ((Func<T0?, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult?>)delegateObj)(
                 VariantUtils.ConvertTo<T0>(args[0]),
                 VariantUtils.ConvertTo<T1>(args[1]),
                 VariantUtils.ConvertTo<T2>(args[2]),

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -4,8 +4,6 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/CustomGCHandle.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/CustomGCHandle.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
@@ -6,8 +6,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     internal static class DebuggingUtils

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -803,13 +801,13 @@ namespace Godot
 
                 if (typeof(GodotObject[]).IsAssignableFrom(type))
                 {
-                    static GodotObject[] ConvertToSystemArrayOfGodotObject(in godot_array nativeArray, Type type)
+                    static GodotObject?[] ConvertToSystemArrayOfGodotObject(in godot_array nativeArray, Type type)
                     {
                         var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
                             NativeFuncs.godotsharp_array_new_copy(nativeArray));
 
                         int length = array.Count;
-                        var ret = (GodotObject[])Activator.CreateInstance(type, length)!;
+                        var ret = (GodotObject?[])Activator.CreateInstance(type, length)!;
 
                         for (int i = 0; i < length; i++)
                             ret[i] = array[i].AsGodotObject();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -5,8 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot.Collections
 {
     /// <summary>
@@ -485,7 +483,7 @@ namespace Godot.Collections
         IReadOnlyDictionary<TKey, TValue>,
         IGenericGodotDictionary
     {
-        private static godot_variant ToVariantFunc(in Dictionary<TKey, TValue> godotDictionary) =>
+        private static godot_variant ToVariantFunc(in Dictionary<TKey, TValue>? godotDictionary) =>
             VariantUtils.CreateFromDictionary(godotDictionary);
 
         private static Dictionary<TKey, TValue> FromVariantFunc(in godot_variant variant) =>
@@ -640,7 +638,7 @@ namespace Godot.Collections
                         variantKey, out godot_variant value).ToBool())
                 {
                     using (value)
-                        return VariantUtils.ConvertTo<TValue>(value);
+                        return VariantUtils.ConvertTo<TValue>(value)!;
                 }
                 else
                 {
@@ -701,8 +699,8 @@ namespace Godot.Collections
             using (value)
             {
                 return new KeyValuePair<TKey, TValue>(
-                    VariantUtils.ConvertTo<TKey>(key),
-                    VariantUtils.ConvertTo<TValue>(value));
+                    VariantUtils.ConvertTo<TKey>(key)!,
+                    VariantUtils.ConvertTo<TValue>(value)!);
             }
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
@@ -6,7 +6,7 @@ namespace Godot
 {
     public static class Dispatcher
     {
-        internal static GodotTaskScheduler DefaultGodotTaskScheduler;
+        internal static GodotTaskScheduler? DefaultGodotTaskScheduler;
 
         internal static void InitializeDefaultGodotTaskScheduler()
         {
@@ -14,6 +14,6 @@ namespace Godot
             DefaultGodotTaskScheduler = new GodotTaskScheduler();
         }
 
-        public static GodotSynchronizationContext SynchronizationContext => DefaultGodotTaskScheduler.Context;
+        public static GodotSynchronizationContext? SynchronizationContext => DefaultGodotTaskScheduler?.Context;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DisposablesTracker.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DisposablesTracker.cs
@@ -3,8 +3,6 @@ using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     internal static class DisposablesTracker

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/GodotObjectExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/GodotObjectExtensions.cs
@@ -1,7 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
-
-#nullable enable
 
 namespace Godot
 {
@@ -51,7 +50,7 @@ namespace Godot
         /// </summary>
         /// <param name="instance">The instance to check.</param>
         /// <returns>If the instance is a valid object.</returns>
-        public static bool IsInstanceValid(GodotObject? instance)
+        public static bool IsInstanceValid([NotNullWhen(true)] GodotObject? instance)
         {
             return instance != null && instance.NativeInstance != IntPtr.Zero;
         }
@@ -81,7 +80,7 @@ namespace Godot
                 if (weakRef.IsNull)
                     return null;
 
-                return (WeakRef)InteropUtils.UnmanagedGetManaged(weakRef.Reference);
+                return (WeakRef?)InteropUtils.UnmanagedGetManaged(weakRef.Reference);
             }
         }
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -42,9 +42,9 @@ namespace Godot
         /// <returns>
         /// The <see cref="Node"/> at the given <paramref name="path"/>.
         /// </returns>
-        public T GetNode<T>(NodePath path) where T : class
+        public T? GetNode<T>(NodePath path) where T : class?
         {
-            return (T)(object)GetNode(path);
+            return (T?)(object?)GetNode(path);
         }
 
         /// <summary>
@@ -73,11 +73,14 @@ namespace Godot
         /// </example>
         /// <seealso cref="GetNode{T}(NodePath)"/>
         /// <param name="path">The path to the node to fetch.</param>
+        /// <exception cref="InvalidCastException">
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
         /// The <see cref="Node"/> at the given <paramref name="path"/>, or <see langword="null"/> if not found.
         /// </returns>
-        public T GetNodeOrNull<T>(NodePath path) where T : class
+        public T? GetNodeOrNull<T>(NodePath path) where T : class?
         {
             return GetNodeOrNull(path) as T;
         }
@@ -101,9 +104,9 @@ namespace Godot
         /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>.
         /// </returns>
-        public T GetChild<T>(int idx, bool includeInternal = false) where T : class
+        public T? GetChild<T>(int idx, bool includeInternal = false) where T : class?
         {
-            return (T)(object)GetChild(idx, includeInternal);
+            return (T?)(object?)GetChild(idx, includeInternal);
         }
 
         /// <summary>
@@ -118,11 +121,14 @@ namespace Godot
         /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
         /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
         /// </param>
+        /// <exception cref="InvalidCastException">
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>, or <see langword="null"/> if not found.
         /// </returns>
-        public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class
+        public T? GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class?
         {
             int count = GetChildCount(includeInternal);
             return idx >= -count && idx < count ? GetChild(idx, includeInternal) as T : null;
@@ -143,9 +149,9 @@ namespace Godot
         /// <returns>
         /// The owner <see cref="Node"/>.
         /// </returns>
-        public T GetOwner<T>() where T : class
+        public T? GetOwner<T>() where T : class?
         {
-            return (T)(object)Owner;
+            return (T?)(object?)Owner;
         }
 
         /// <summary>
@@ -156,11 +162,14 @@ namespace Godot
         /// with instancing and subinstancing.
         /// </summary>
         /// <seealso cref="GetOwner{T}"/>
+        /// <exception cref="InvalidCastException">
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
         /// The owner <see cref="Node"/>, or <see langword="null"/> if there is no owner.
         /// </returns>
-        public T GetOwnerOrNull<T>() where T : class
+        public T? GetOwnerOrNull<T>() where T : class?
         {
             return Owner as T;
         }
@@ -177,9 +186,9 @@ namespace Godot
         /// <returns>
         /// The parent <see cref="Node"/>.
         /// </returns>
-        public T GetParent<T>() where T : class
+        public T? GetParent<T>() where T : class?
         {
-            return (T)(object)GetParent();
+            return (T?)(object?)GetParent();
         }
 
         /// <summary>
@@ -187,11 +196,14 @@ namespace Godot
         /// if the node lacks a parent.
         /// </summary>
         /// <seealso cref="GetParent{T}"/>
+        /// <exception cref="InvalidCastException">
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
         /// The parent <see cref="Node"/>, or <see langword="null"/> if the node has no parent.
         /// </returns>
-        public T GetParentOrNull<T>() where T : class
+        public T? GetParentOrNull<T>() where T : class?
         {
             return GetParent() as T;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
@@ -15,9 +15,9 @@ namespace Godot
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>The instantiated scene.</returns>
-        public T Instantiate<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        public T? Instantiate<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class?
         {
-            return (T)(object)Instantiate(editState);
+            return (T?)(object?)Instantiate(editState);
         }
 
         /// <summary>
@@ -26,9 +26,12 @@ namespace Godot
         /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
         /// </summary>
         /// <seealso cref="Instantiate{T}(GenEditState)"/>
+        /// <exception cref="InvalidCastException">
+        /// The instantiated node can't be casted to the given type <typeparamref name="T"/>.
+        /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>The instantiated scene.</returns>
-        public T InstantiateOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        public T? InstantiateOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class?
         {
             return Instantiate(editState) as T;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
@@ -22,9 +22,9 @@ namespace Godot
         /// The loaded resource can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class
+        public static T? Load<T>(string path, string? typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class?
         {
-            return (T)(object)Load(path, typeHint, cacheMode);
+            return (T?)(object?)Load(path, typeHint, cacheMode);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -97,7 +97,7 @@ namespace Godot
         /// </example>
         /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
         /// <returns>The loaded <see cref="Resource"/>.</returns>
-        public static Resource Load(string path)
+        public static Resource? Load(string path)
         {
             return ResourceLoader.Load(path);
         }
@@ -123,13 +123,16 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
+        /// <exception cref="InvalidCastException">
+        /// The loaded resource can't be casted to the given type <typeparamref name="T"/>.
+        /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path) where T : class
+        public static T? Load<T>(string path) where T : class?
         {
             return ResourceLoader.Load<T>(path);
         }
 
-        private static string AppendPrintParams(object[] parameters)
+        private static string AppendPrintParams(object?[] parameters)
         {
             if (parameters == null)
             {
@@ -144,7 +147,7 @@ namespace Godot
             return sb.ToString();
         }
 
-        private static string AppendPrintParams(char separator, object[] parameters)
+        private static string AppendPrintParams(char separator, object?[] parameters)
         {
             if (parameters == null)
             {
@@ -192,7 +195,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        public static void Print(params object[] what)
+        public static void Print(params object?[] what)
         {
             Print(AppendPrintParams(what));
         }
@@ -245,7 +248,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintRich(params object[] what)
+        public static void PrintRich(params object?[] what)
         {
             PrintRich(AppendPrintParams(what));
         }
@@ -269,7 +272,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintErr(params object[] what)
+        public static void PrintErr(params object?[] what)
         {
             PrintErr(AppendPrintParams(what));
         }
@@ -298,7 +301,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintRaw(params object[] what)
+        public static void PrintRaw(params object?[] what)
         {
             PrintRaw(AppendPrintParams(what));
         }
@@ -312,7 +315,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintS(params object[] what)
+        public static void PrintS(params object?[] what)
         {
             string message = AppendPrintParams(' ', what);
             using var godotStr = Marshaling.ConvertStringToNative(message);
@@ -328,7 +331,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintT(params object[] what)
+        public static void PrintT(params object?[] what)
         {
             string message = AppendPrintParams('\t', what);
             using var godotStr = Marshaling.ConvertStringToNative(message);
@@ -339,8 +342,8 @@ namespace Godot
         private static void ErrPrintError(string message, godot_error_handler_type type = godot_error_handler_type.ERR_HANDLER_ERROR)
         {
             // Skip 1 frame to avoid current method.
-            var stackFrame = DebuggingUtils.GetCurrentStackFrame(skipFrames: 1);
-            string callerFilePath = ProjectSettings.LocalizePath(stackFrame.GetFileName());
+            var stackFrame = DebuggingUtils.GetCurrentStackFrame(skipFrames: 1)!;
+            string callerFilePath = ProjectSettings.LocalizePath(stackFrame.GetFileName()!);
             DebuggingUtils.GetStackFrameMethodDecl(stackFrame, out string callerName);
             int callerLineNumber = stackFrame.GetFileLineNumber();
 
@@ -377,7 +380,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that form the error message.</param>
-        public static void PushError(params object[] what)
+        public static void PushError(params object?[] what)
         {
             ErrPrintError(AppendPrintParams(what));
         }
@@ -405,7 +408,7 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that form the warning message.</param>
-        public static void PushWarning(params object[] what)
+        public static void PushWarning(params object?[] what)
         {
             ErrPrintError(AppendPrintParams(what), type: godot_error_handler_type.ERR_HANDLER_WARNING);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -4,8 +4,6 @@ using System.Runtime.InteropServices;
 using Godot.Bridge;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     public partial class GodotObject : IDisposable

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.exceptions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.exceptions.cs
@@ -2,8 +2,6 @@ using System;
 using System.Globalization;
 using System.Text;
 
-#nullable enable
-
 namespace Godot
 {
     public partial class GodotObject
@@ -137,6 +135,25 @@ namespace Godot
 
                     return sb.ToString();
                 }
+            }
+        }
+
+        public class InvalidNullReturnException : NullReferenceException
+        {
+            // ReSharper disable once InconsistentNaming
+            private const string Arg_InvalidNullReturnException = "A method attempted to return null in a non-nullable context.";
+
+            public InvalidNullReturnException() : base(Arg_InvalidNullReturnException)
+            {
+            }
+
+            public InvalidNullReturnException(string? message) : base(message)
+            {
+            }
+
+            public InvalidNullReturnException(string? message, Exception? innerException)
+                : base(message, innerException)
+            {
             }
         }
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
@@ -7,9 +7,9 @@ namespace Godot
 {
     public sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
     {
-        private readonly BlockingCollection<(SendOrPostCallback Callback, object State)> _queue = new();
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = new();
 
-        public override void Send(SendOrPostCallback d, object state)
+        public override void Send(SendOrPostCallback d, object? state)
         {
             // Shortcut if we're already on this context
             // Also necessary to avoid a deadlock, since Send is blocking
@@ -36,7 +36,7 @@ namespace Godot
             source.Task.Wait();
         }
 
-        public override void Post(SendOrPostCallback d, object state)
+        public override void Post(SendOrPostCallback d, object? state)
         {
             _queue.Add((d, state));
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
@@ -90,7 +90,7 @@ namespace Godot
                 {
                     if (_tasks.Any())
                     {
-                        task = _tasks.First.Value;
+                        task = _tasks.First!.Value;
                         _tasks.RemoveFirst();
                     }
                     else

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
@@ -4,17 +4,17 @@ namespace Godot
 {
     internal class GodotTraceListener : TraceListener
     {
-        public override void Write(string message)
+        public override void Write(string? message)
         {
-            GD.PrintRaw(message);
+            GD.PrintRaw(message!);
         }
 
-        public override void WriteLine(string message)
+        public override void WriteLine(string? message)
         {
-            GD.Print(message);
+            GD.Print(message!);
         }
 
-        public override void Fail(string message, string detailMessage)
+        public override void Fail(string? message, string? detailMessage)
         {
             GD.PrintErr("Assertion failed: ", message);
             GD.PrintErr("  Details: ", detailMessage);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -20,6 +20,6 @@ namespace Godot
     {
         bool IsCompleted { get; }
 
-        TResult GetResult();
+        TResult? GetResult();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -4,8 +4,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-#nullable enable
-
 namespace Godot.NativeInterop
 {
     internal static class ExceptionUtils
@@ -223,7 +221,7 @@ namespace Godot.NativeInterop
         {
             if (variant->Type == Variant.Type.Object)
             {
-                GodotObject obj = VariantUtils.ConvertToGodotObject(*variant);
+                GodotObject? obj = VariantUtils.ConvertToGodotObject(*variant);
                 if (obj == null)
                 {
                     return "null instance";

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/GodotDllImportResolver.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/GodotDllImportResolver.cs
@@ -2,8 +2,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot.NativeInterop
 {
     public class GodotDllImportResolver

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -571,7 +571,7 @@ namespace Godot.NativeInterop
             return _data == other._data;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is StringName s && s.Equals(this);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Godot.Bridge;
 
@@ -8,7 +9,7 @@ namespace Godot.NativeInterop
 {
     internal static class InteropUtils
     {
-        public static GodotObject UnmanagedGetManaged(IntPtr unmanaged)
+        public static GodotObject? UnmanagedGetManaged(IntPtr unmanaged)
         {
             // The native pointer may be null
             if (unmanaged == IntPtr.Zero)
@@ -23,7 +24,7 @@ namespace Godot.NativeInterop
                 unmanaged, out hasCsScriptInstance);
 
             if (gcHandlePtr != IntPtr.Zero)
-                return (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target;
+                return (GodotObject?)GCHandle.FromIntPtr(gcHandlePtr).Target;
 
             // Otherwise, if the object has a CSharpInstance script instance, return null
 
@@ -34,7 +35,7 @@ namespace Godot.NativeInterop
 
             gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_get_instance_binding_managed(unmanaged);
 
-            object target = gcHandlePtr != IntPtr.Zero ? GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+            object? target = gcHandlePtr != IntPtr.Zero ? GCHandle.FromIntPtr(gcHandlePtr).Target : null;
 
             if (target != null)
                 return (GodotObject)target;
@@ -44,7 +45,7 @@ namespace Godot.NativeInterop
             gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_instance_binding_create_managed(
                 unmanaged, gcHandlePtr);
 
-            return gcHandlePtr != IntPtr.Zero ? (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+            return gcHandlePtr != IntPtr.Zero ? (GodotObject?)GCHandle.FromIntPtr(gcHandlePtr).Target : null;
         }
 
         public static void TieManagedToUnmanaged(GodotObject managed, IntPtr unmanaged,
@@ -90,7 +91,9 @@ namespace Godot.NativeInterop
         public static GodotObject EngineGetSingleton(string name)
         {
             using godot_string src = Marshaling.ConvertStringToNative(name);
-            return UnmanagedGetManaged(NativeFuncs.godotsharp_engine_get_singleton(src));
+            var singleton = UnmanagedGetManaged(NativeFuncs.godotsharp_engine_get_singleton(src));
+            Debug.Assert(singleton is not null, "Valid singleton name must be passed.");
+            return singleton;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -10,8 +10,6 @@ using Array = System.Array;
 // We want to use full name qualifiers here even if redundant for clarity
 // ReSharper disable RedundantNameQualifier
 
-#nullable enable
-
 namespace Godot.NativeInterop
 {
     public static class Marshaling
@@ -294,7 +292,7 @@ namespace Godot.NativeInterop
 
         public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
         {
-            ulong ownerId = p_managed_signal.Owner.GetInstanceId();
+            ulong ownerId = p_managed_signal.Owner?.GetInstanceId() ?? default;
             godot_string_name name;
 
             if (p_managed_signal.Name != null && !p_managed_signal.Name.IsEmpty)
@@ -320,17 +318,17 @@ namespace Godot.NativeInterop
 
         // Array
 
-        internal static T[] ConvertNativeGodotArrayToSystemArrayOfGodotObjectType<T>(in godot_array p_array)
+        internal static T?[] ConvertNativeGodotArrayToSystemArrayOfGodotObjectType<T>(in godot_array p_array)
             where T : GodotObject
         {
             var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
                 NativeFuncs.godotsharp_array_new_copy(p_array));
 
             int length = array.Count;
-            var ret = new T[length];
+            var ret = new T?[length];
 
             for (int i = 0; i < length; i++)
-                ret[i] = (T)array[i].AsGodotObject();
+                ret[i] = (T?)array[i].AsGodotObject();
 
             return ret;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -7,8 +7,6 @@ using System.Runtime.CompilerServices;
 using Godot.Collections;
 
 
-#nullable enable
-
 namespace Godot.NativeInterop
 {
     public static partial class VariantUtils
@@ -258,7 +256,7 @@ namespace Godot.NativeInterop
             return CreateFromArray((godot_array)fromGodot.NativeValue);
         }
 
-        public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject[]? from)
+        public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject?[]? from)
         {
             if (from == null)
                 return default; // Nil
@@ -475,7 +473,7 @@ namespace Godot.NativeInterop
             => p_var.Type == Variant.Type.Object ? p_var.Object : IntPtr.Zero;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static GodotObject ConvertToGodotObject(in godot_variant p_var)
+        public static GodotObject? ConvertToGodotObject(in godot_variant p_var)
             => InteropUtils.UnmanagedGetManaged(ConvertToGodotObjectPtr(p_var));
 
         public static string ConvertToString(in godot_variant p_var)
@@ -629,7 +627,7 @@ namespace Godot.NativeInterop
             return Marshaling.ConvertNativeGodotArrayToSystemArrayOfRid(godotArray);
         }
 
-        public static T[] ConvertToSystemArrayOfGodotObject<T>(in godot_variant p_var)
+        public static T?[] ConvertToSystemArrayOfGodotObject<T>(in godot_variant p_var)
             where T : GodotObject
         {
             using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -3,8 +3,6 @@ using System.Runtime.CompilerServices;
 
 namespace Godot.NativeInterop;
 
-#nullable enable
-
 public partial class VariantUtils
 {
     private static Exception UnsupportedType<T>() => new InvalidOperationException(
@@ -12,17 +10,17 @@ public partial class VariantUtils
 
     internal static class GenericConversion<T>
     {
-        public static unsafe godot_variant ToVariant(in T from) =>
+        public static unsafe godot_variant ToVariant(in T? from) =>
             ToVariantCb != null ? ToVariantCb(from) : throw UnsupportedType<T>();
 
-        public static unsafe T FromVariant(in godot_variant variant) =>
+        public static unsafe T? FromVariant(in godot_variant variant) =>
             FromVariantCb != null ? FromVariantCb(variant) : throw UnsupportedType<T>();
 
         // ReSharper disable once StaticMemberInGenericType
-        internal static unsafe delegate*<in T, godot_variant> ToVariantCb;
+        internal static unsafe delegate*<in T?, godot_variant> ToVariantCb;
 
         // ReSharper disable once StaticMemberInGenericType
-        internal static unsafe delegate*<in godot_variant, T> FromVariantCb;
+        internal static unsafe delegate*<in godot_variant, T?> FromVariantCb;
 
         static GenericConversion()
         {
@@ -31,10 +29,10 @@ public partial class VariantUtils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static godot_variant CreateFrom<[MustBeVariant] T>(in T from)
+    public static godot_variant CreateFrom<[MustBeVariant] T>(in T? from)
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static TTo UnsafeAs<TTo>(in T f) => Unsafe.As<T, TTo>(ref Unsafe.AsRef(f));
+        static TTo UnsafeAs<TTo>(in T? f) => Unsafe.As<T, TTo>(ref Unsafe.AsRef(f)!);
 
         // `typeof(T) == typeof(X)` is optimized away. We cannot cache `typeof(T)` in a local variable, as it's not optimized when done like that.
 
@@ -221,7 +219,7 @@ public partial class VariantUtils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static T ConvertTo<[MustBeVariant] T>(in godot_variant variant)
+    public static T? ConvertTo<[MustBeVariant] T>(in godot_variant variant)
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static T UnsafeAsT<TFrom>(TFrom f) => Unsafe.As<TFrom, T>(ref Unsafe.AsRef(f));
@@ -378,7 +376,7 @@ public partial class VariantUtils
         // `typeof(X).IsAssignableFrom(typeof(T))` is optimized away
 
         if (typeof(GodotObject).IsAssignableFrom(typeof(T)))
-            return (T)(object)ConvertToGodotObject(variant);
+            return (T?)(object?)ConvertToGodotObject(variant);
 
         // `typeof(T).IsValueType` is optimized away
         // `typeof(T).IsEnum` is NOT optimized away: https://github.com/dotnet/runtime/issues/67113

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq;
 
-#nullable enable
-
 namespace Godot;
 
 internal class ReflectionUtils

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
@@ -5,13 +5,13 @@ namespace Godot
     /// </summary>
     public readonly struct Signal : IAwaitable<Variant[]>
     {
-        private readonly GodotObject _owner;
+        private readonly GodotObject? _owner;
         private readonly StringName _signalName;
 
         /// <summary>
         /// Object that contains the signal.
         /// </summary>
-        public GodotObject Owner => _owner;
+        public GodotObject? Owner => _owner;
 
         /// <summary>
         /// Name of the signal.
@@ -24,7 +24,7 @@ namespace Godot
         /// </summary>
         /// <param name="owner">Object that contains the signal.</param>
         /// <param name="name">Name of the signal.</param>
-        public Signal(GodotObject owner, StringName name)
+        public Signal(GodotObject? owner, StringName name)
         {
             _owner = owner;
             _signalName = name;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
@@ -7,10 +8,10 @@ namespace Godot
     public class SignalAwaiter : IAwaiter<Variant[]>, IAwaitable<Variant[]>
     {
         private bool _completed;
-        private Variant[] _result;
-        private Action _continuation;
+        private Variant[]? _result;
+        private Action? _continuation;
 
-        public SignalAwaiter(GodotObject source, StringName signal, GodotObject target)
+        public SignalAwaiter(GodotObject? source, StringName signal, GodotObject? target)
         {
             var awaiterGcHandle = CustomGCHandle.AllocStrong(this);
             using godot_string_name signalSrc = NativeFuncs.godotsharp_string_name_new_copy(
@@ -26,7 +27,7 @@ namespace Godot
             _continuation = continuation;
         }
 
-        public Variant[] GetResult() => _result;
+        public Variant[]? GetResult() => _result;
 
         public IAwaiter<Variant[]> GetAwaiter() => this;
 
@@ -36,7 +37,7 @@ namespace Godot
         {
             try
             {
-                var awaiter = (SignalAwaiter)GCHandle.FromIntPtr(awaiterGCHandlePtr).Target;
+                var awaiter = (SignalAwaiter?)GCHandle.FromIntPtr(awaiterGCHandlePtr).Target;
 
                 if (awaiter == null)
                 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -7,8 +7,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -4,8 +4,6 @@ using Godot.NativeInterop;
 
 namespace Godot;
 
-#nullable enable
-
 // TODO: Disabled because it is a false positive, see https://github.com/dotnet/roslyn-analyzers/issues/6151
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
 public partial struct Variant : IDisposable
@@ -156,11 +154,11 @@ public partial struct Variant : IDisposable
         };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Variant From<[MustBeVariant] T>(in T from) =>
+    public static Variant From<[MustBeVariant] T>(in T? from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFrom(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public T As<[MustBeVariant] T>() =>
+    public T? As<[MustBeVariant] T>() =>
         VariantUtils.ConvertTo<T>(NativeVar.DangerousSelfRef);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -324,7 +322,7 @@ public partial struct Variant : IDisposable
         VariantUtils.ConvertAsPackedColorArrayToSystemArray((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public T[] AsGodotObjectArray<T>()
+    public T?[] AsGodotObjectArray<T>()
         where T : GodotObject =>
         VariantUtils.ConvertToSystemArrayOfGodotObject<T>((godot_variant)NativeVar);
 
@@ -349,7 +347,7 @@ public partial struct Variant : IDisposable
         VariantUtils.ConvertToSystemArrayOfRid((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public GodotObject AsGodotObject() =>
+    public GodotObject? AsGodotObject() =>
         VariantUtils.ConvertToGodotObject((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -504,7 +502,7 @@ public partial struct Variant : IDisposable
     public static explicit operator Rid[](Variant from) => from.AsSystemArrayOfRid();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static explicit operator GodotObject(Variant from) => from.AsGodotObject();
+    public static explicit operator GodotObject?(Variant from) => from.AsGodotObject();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator StringName(Variant from) => from.AsStringName();
@@ -645,7 +643,7 @@ public partial struct Variant : IDisposable
     public static Variant CreateFrom(Span<Color> from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Variant CreateFrom(GodotObject[] from) => from;
+    public static Variant CreateFrom(GodotObject?[] from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom<[MustBeVariant] TKey, [MustBeVariant] TValue>(Collections.Dictionary<TKey, TValue> from) =>
@@ -665,7 +663,7 @@ public partial struct Variant : IDisposable
     public static Variant CreateFrom(Span<Rid> from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Variant CreateFrom(GodotObject from) => from;
+    public static Variant CreateFrom(GodotObject? from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(StringName from) => from;
@@ -845,7 +843,7 @@ public partial struct Variant : IDisposable
         (Variant)from.AsSpan();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator Variant(GodotObject[] from) =>
+    public static implicit operator Variant(GodotObject?[] from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfGodotObject(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -909,7 +907,7 @@ public partial struct Variant : IDisposable
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfRid(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator Variant(GodotObject from) =>
+    public static implicit operator Variant(GodotObject? from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromGodotObject(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Godot
 {
     /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -9,7 +9,7 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>10</LangVersion>
-
+    <Nullable>enable</Nullable>
     <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
   <PropertyGroup>

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/Compat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/Compat.cs
@@ -14,7 +14,7 @@ partial class EditorUndoRedoManager
 {
     /// <inheritdoc cref="CreateAction(string, UndoRedo.MergeMode, GodotObject, bool)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void CreateAction(string name, UndoRedo.MergeMode mergeMode, GodotObject customContext)
+    public void CreateAction(string name, UndoRedo.MergeMode mergeMode, GodotObject? customContext)
     {
         CreateAction(name, mergeMode, customContext, backwardUndoOps: false);
     }

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -9,6 +9,7 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Godot C# Editor API.</Description>


### PR DESCRIPTION
This PR showcases a GodotSharp environment where nullability is enabled. While [initially conceived](https://github.com/godotengine/godot/pull/82983#issuecomment-1752047518) as a means to centralize changes which can be branched off into standalone PRs (eg: #82980, #82983), it also showcases the consequences of trying to retrofit the concept without first undergoing significant refactoring

The biggest culprit is `GodotObject`, and how it's uniquely a reference type that Godot allows for nullability. While this draft explores the idea of returning GodotObject fields as nullable, I'm not convinced that makes for the best approach, because it floods almost every existing method/field with an added nullability check. It might be worth considering an approach similar to [Unity Objects](https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Scripting/UnityEngineObject.bindings.cs#L103), where there's operator overloads & behind-the-scenes null checks to better handle `null` in the context of that environment. Or it could even be as simple as throwing in a bunch of `[AllowNull]/[MaybeNull]` annotations in the generation for object files

While the majority of areas have warnings accounted for, there's still a handful that have them. This is mainly those that I'm not entirely sure yet how to handle, or areas that feel particularly sensitive to adjustment. It's also entirely possible that many of these warnings/cases simply wouldn't be a thing with future core additions (particularly, some means of knowing if an object return value *can* be null). Either way, this is provided as-is for discussion and so potential areas can be cherrypicked for implementation as needed