### PR TITLE
Warning header should be in debug mode!?

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -35,7 +35,10 @@
 #include "gdscript_compiler.h"
 #include "gdscript_parser.h"
 #include "gdscript_rpc_callable.h"
+
+#ifdef DEBUG_ENABLED
 #include "gdscript_warning.h"
+#endif
 
 #ifdef TOOLS_ENABLED
 #include "editor/gdscript_docgen.h"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The ``#include "gdscript_warning.h"`` isn't wrapped by ``DEBUG_ENABLED`` macro here. I don't know if this is a required enhancement but I tested it and working fine.
