### PR TITLE
Fix modifying base script exports not propagating to derived scripts

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -163,13 +163,14 @@ class GDScript : public Script {
 	HashSet<PlaceHolderScriptInstance *> placeholders;
 	//void _update_placeholder(PlaceHolderScriptInstance *p_placeholder);
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) override;
+	void _update_exports_down(bool p_base_exports_changed);
 #endif
 
 #ifdef DEBUG_ENABLED
 	HashMap<ObjectID, List<Pair<StringName, Variant>>> pending_reload_state;
 #endif
 
-	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr);
+	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr, bool p_base_exports_changed = false);
 
 	void _save_orphaned_subclasses(GDScript::ClearData *p_clear_data);
 


### PR DESCRIPTION
Fixes issue #82998 by triggering an update in derived scripts if an export changes on of the base scripts in the hierarchy. Tested over three levels of inheritance with editing the default value and adding / removing exports.

_Bugsquad edit: fixes https://github.com/godotengine/godot/issues/82998_