### PR TITLE
Fix crash when generating mono glue

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -900,6 +900,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(I->next()->get());
 			}
 		}
+		// --generate-mono-glue has to be run with 'project_manager = true' or bad things happen:
+		// 1. Crash due to the EditorPaths singleton being null.
+		// 2. Hangs and doesn't shut down after generating the glue.
+		if (I->get() == "--generate-mono-glue") {
+			project_manager = true;
+		}
 #endif
 
 		if (adding_user_args) {


### PR DESCRIPTION
This PR fixes this issue here: https://github.com/godotengine/godot/issues/83128

I'm not actually sure if this check should go inside the ``#ifdef TOOLS_ENABLED`` or outside of it.  I'll let someone more familiar with the code base comment on that and let me know if I need to change it.

We are currently maintaining our own fork as we port from Unity to Godot!  Its so nice to be able to fix bugs ourselves as we uncover them! :)  Feel free to reject or accept any PRs from us.  We won't be offended.