### PR TITLE
[3.x] [macOS] Use occlusionState to determine when window is drawable.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -135,6 +135,7 @@ public:
 	bool resizable;
 	bool window_focused;
 	bool on_top;
+	bool is_visible;
 
 	Size2 window_size;
 	Rect2 restore_rect;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -463,6 +463,10 @@ static NSCursor *cursorFromSelector(SEL selector, SEL fallback = nil) {
 	OS_OSX::singleton->window_focused = true;
 };
 
+- (void)windowDidChangeOcclusionState:(NSNotification *)notification {
+	OS_OSX::singleton->is_visible = ([OS_OSX::singleton->window_object occlusionState] & NSWindowOcclusionStateVisible) && [OS_OSX::singleton->window_object isVisible];
+}
+
 @end
 
 @interface GodotContentView : NSOpenGLView <NSTextInputClient> {
@@ -2410,7 +2414,7 @@ String OS_OSX::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
 }
 
 bool OS_OSX::can_draw() const {
-	return true;
+	return is_visible;
 }
 
 void OS_OSX::set_clipboard(const String &p_text) {
@@ -3568,6 +3572,7 @@ OS_OSX::OS_OSX() {
 	im_position = Point2();
 	layered_window = false;
 	autoreleasePool = [[NSAutoreleasePool alloc] init];
+	is_visible = true;
 
 	eventSource = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 	ERR_FAIL_COND(!eventSource);


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/83096 for 3.x
