### PR TITLE
Close shader in Shader Editor tab when deleting shader file in FileSystem panel

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -64,6 +64,11 @@ void ShaderEditorPlugin::_update_shader_list() {
 			}
 		}
 
+		// When shader is deleted in filesystem dock, need this to correctly close shader editor.
+		if (!path.is_empty()) {
+			shader->set_meta("_edit_res_path", path);
+		}
+
 		bool unsaved = false;
 		if (edited_shader.shader_editor) {
 			unsaved = edited_shader.shader_editor->is_unsaved();
@@ -571,10 +576,20 @@ void ShaderEditorPlugin::_window_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
 }
 
+void ShaderEditorPlugin::_file_removed(const String &p_removed_file) {
+	for (uint32_t i = 0; i < edited_shaders.size(); i++) {
+		const Ref<Shader> &shader = edited_shaders[i].shader;
+		if (shader->get_meta("_edit_res_path") == p_removed_file) {
+			_close_shader(i);
+		}
+	}
+}
+
 void ShaderEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &ShaderEditorPlugin::_close_builtin_shaders_from_scene));
+			FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &ShaderEditorPlugin::_file_removed));
 		} break;
 	}
 }

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -87,6 +87,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	void _resource_saved(Object *obj);
 	void _close_shader(int p_index);
 	void _close_builtin_shaders_from_scene(const String &p_scene);
+	void _file_removed(const String &p_removed_file);
 
 	void _shader_created(Ref<Shader> p_shader);
 	void _shader_include_created(Ref<ShaderInclude> p_shader_inc);


### PR DESCRIPTION
Fixes #72595

It works as the same with built-in script editor, when you delete the file in the filesystem panel, the editor should close the relating tab.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
