### PR TITLE
Fix BaseMaterial3D update with certain material settings

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -3079,6 +3079,8 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	flags[FLAG_ALBEDO_TEXTURE_MSDF] = false;
 	flags[FLAG_USE_TEXTURE_REPEAT] = true;
 
+	current_key.invalid_key = 1;
+
 	_mark_initialized(callable_mp(this, &BaseMaterial3D::_queue_shader_change));
 }
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -325,6 +325,7 @@ private:
 		uint64_t emission_op : get_num_bits(EMISSION_OP_MAX - 1);
 		uint64_t distance_fade : get_num_bits(DISTANCE_FADE_MAX - 1);
 		// booleans
+		uint64_t invalid_key : 1;
 		uint64_t deep_parallax : 1;
 		uint64_t grow : 1;
 		uint64_t proximity_fade : 1;


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/81082

Certain `BaseMaterial3D` settings result in a material key that is all zeros while still being a valid material. This causes the material update to be skipped when the material is created and a default material will be used instead.

This PR adds `invalid_key` member to the material key (`BaseMaterial3D::MaterialKey`) which can be used to mark the material invalid and force an update. This same idiom is already used in `ParticleProcessMaterial` and `CanvasItemMaterial`.