### PR TITLE
Filter nodes selection on bone rename notification

### DIFF
--- a/editor/import/post_import_plugin_skeleton_renamer.cpp
+++ b/editor/import/post_import_plugin_skeleton_renamer.cpp
@@ -128,7 +128,7 @@ void PostImportPluginSkeletonRenamer::_internal_process(InternalImportCategory p
 		}
 		vargs.push_back(rename_map_dict);
 
-		TypedArray<Node> nodes = p_base_scene->find_children("*");
+		TypedArray<Node> nodes = p_base_scene->find_children("*", "BoneAttachment3D");
 		while (nodes.size()) {
 			Node *nd = Object::cast_to<Node>(nodes.pop_back());
 			nd->callv("_notify_skeleton_bones_renamed", vargs);


### PR DESCRIPTION
It seems this error appears ever since #79341 got merged. Since BoneAttachment3D is the only consumer of this notification, I made the find_children call more restrictive in its parameters. 

Fixes #83148
