### PR TITLE
C#: Implement `IFormattable` for `Variant` structs

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Aabb : IEquatable<Aabb>
+    public struct Aabb : IEquatable<Aabb>, IFormattable
     {
         private Vector3 _position;
         private Vector3 _size;
@@ -733,18 +733,22 @@ namespace Godot
         /// Converts this <see cref="Aabb"/> to a string.
         /// </summary>
         /// <returns>A string representation of this AABB.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_position}, {_size}";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Aabb"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this AABB.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Aabb"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this AABB.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return $"{_position.ToString(format)}, {_size.ToString(format)}";
+            string separator = formatProvider.GetListSeparator();
+            return $"{_position.ToString(format, formatProvider)}{separator} {_size.ToString(format, formatProvider)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -1,7 +1,7 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.ComponentModel;
 
 #nullable enable
 
@@ -23,7 +23,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Basis : IEquatable<Basis>
+    public struct Basis : IEquatable<Basis>, IFormattable
     {
         // NOTE: x, y and z are public-only. Use Column0, Column1 and Column2 internally.
 
@@ -1134,18 +1134,22 @@ namespace Godot
         /// Converts this <see cref="Basis"/> to a string.
         /// </summary>
         /// <returns>A string representation of this basis.</returns>
-        public override readonly string ToString()
-        {
-            return $"[X: {X}, Y: {Y}, Z: {Z}]";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Basis"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this basis.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Basis"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this basis.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return $"[X: {X.ToString(format)}, Y: {Y.ToString(format)}, Z: {Z.ToString(format)}]";
+            string separator = formatProvider.GetListSeparator();
+            return $"[X: {X.ToString(format, formatProvider)}{separator} Y: {Y.ToString(format, formatProvider)}{separator} Z: {Z.ToString(format, formatProvider)}]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
@@ -20,7 +19,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Color : IEquatable<Color>
+    public struct Color : IEquatable<Color>, IFormattable
     {
         /// <summary>
         /// The color's red component, typically on the range of 0 to 1.
@@ -1329,20 +1328,22 @@ namespace Godot
         /// Converts this <see cref="Color"/> to a string.
         /// </summary>
         /// <returns>A string representation of this color.</returns>
-        public override readonly string ToString()
-        {
-            return $"({R}, {G}, {B}, {A})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Color"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this color.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Color"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this color.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({R.ToString(format)}, {G.ToString(format)}, {B.ToString(format)}, {A.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({R.ToString(format, formatProvider)}{separator} {G.ToString(format, formatProvider)}{separator} {B.ToString(format, formatProvider)}{separator} {A.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -13,7 +13,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Plane : IEquatable<Plane>
+    public struct Plane : IEquatable<Plane>, IFormattable
     {
         private Vector3 _normal;
         private real_t _d;
@@ -424,20 +424,22 @@ namespace Godot
         /// Converts this <see cref="Plane"/> to a string.
         /// </summary>
         /// <returns>A string representation of this plane.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_normal}, {_d}";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Plane"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this plane.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Plane"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this plane.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"{_normal.ToString(format)}, {_d.ToString(format)}";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"{_normal.ToString(format, formatProvider)}{separator} {_d.ToString(format, formatProvider)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -16,7 +16,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Projection : IEquatable<Projection>
+    public struct Projection : IEquatable<Projection>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the planes.
@@ -1012,23 +1012,25 @@ namespace Godot
         /// Converts this <see cref="Projection"/> to a string.
         /// </summary>
         /// <returns>A string representation of this projection.</returns>
-        public override readonly string ToString()
-        {
-            return $"{X.X}, {X.Y}, {X.Z}, {X.W}\n{Y.X}, {Y.Y}, {Y.Z}, {Y.W}\n{Z.X}, {Z.Y}, {Z.Z}, {Z.W}\n{W.X}, {W.Y}, {W.Z}, {W.W}\n";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Projection"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this projection.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Projection"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this projection.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"{X.X.ToString(format)}, {X.Y.ToString(format)}, {X.Z.ToString(format)}, {X.W.ToString(format)}\n" +
-                $"{Y.X.ToString(format)}, {Y.Y.ToString(format)}, {Y.Z.ToString(format)}, {Y.W.ToString(format)}\n" +
-                $"{Z.X.ToString(format)}, {Z.Y.ToString(format)}, {Z.Z.ToString(format)}, {Z.W.ToString(format)}\n" +
-                $"{W.X.ToString(format)}, {W.Y.ToString(format)}, {W.Z.ToString(format)}, {W.W.ToString(format)}\n";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"{X.X.ToString(format, formatProvider)}{separator} {X.Y.ToString(format, formatProvider)}{separator} {X.Z.ToString(format, formatProvider)}{separator} {X.W.ToString(format, formatProvider)}\n" +
+                $"{Y.X.ToString(format, formatProvider)}{separator} {Y.Y.ToString(format, formatProvider)}{separator} {Y.Z.ToString(format, formatProvider)}{separator} {Y.W.ToString(format, formatProvider)}\n" +
+                $"{Z.X.ToString(format, formatProvider)}{separator} {Z.Y.ToString(format, formatProvider)}{separator} {Z.Z.ToString(format, formatProvider)}{separator} {Z.W.ToString(format, formatProvider)}\n" +
+                $"{W.X.ToString(format, formatProvider)}{separator} {W.Y.ToString(format, formatProvider)}{separator} {W.Z.ToString(format, formatProvider)}{separator} {W.W.ToString(format, formatProvider)}\n";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -21,7 +21,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Quaternion : IEquatable<Quaternion>
+    public struct Quaternion : IEquatable<Quaternion>, IFormattable
     {
         /// <summary>
         /// X component of the quaternion (imaginary <c>i</c> axis part).
@@ -811,20 +811,22 @@ namespace Godot
         /// Converts this <see cref="Quaternion"/> to a string.
         /// </summary>
         /// <returns>A string representation of this quaternion.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z}, {W})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Quaternion"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this quaternion.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Quaternion"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this quaternion.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)}{separator} {Z.ToString(format, formatProvider)}{separator} {W.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Rect2 : IEquatable<Rect2>
+    public struct Rect2 : IEquatable<Rect2>, IFormattable
     {
         private Vector2 _position;
         private Vector2 _size;
@@ -469,18 +469,22 @@ namespace Godot
         /// Converts this <see cref="Rect2"/> to a string.
         /// </summary>
         /// <returns>A string representation of this rect.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_position}, {_size}";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Rect2"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this rect.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Rect2"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this rect.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return $"{_position.ToString(format)}, {_size.ToString(format)}";
+            string separator = formatProvider.GetListSeparator();
+            return $"{_position.ToString(format, formatProvider)}{separator} {_size.ToString(format, formatProvider)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Rect2I : IEquatable<Rect2I>
+    public struct Rect2I : IEquatable<Rect2I>, IFormattable
     {
         private Vector2I _position;
         private Vector2I _size;
@@ -429,18 +429,22 @@ namespace Godot
         /// Converts this <see cref="Rect2I"/> to a string.
         /// </summary>
         /// <returns>A string representation of this rect.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_position}, {_size}";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Rect2I"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this rect.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Rect2I"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this rect.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return $"{_position.ToString(format)}, {_size.ToString(format)}";
+            string separator = formatProvider.GetListSeparator();
+            return $"{_position.ToString(format, formatProvider)}{separator} {_size.ToString(format, formatProvider)}";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1877,5 +1877,31 @@ namespace Godot
         {
             return SecurityElement.FromString(instance)?.Text;
         }
+
+        /// <summary>
+        /// Returns the list separator of this <see cref="IFormatProvider"/> as a string.
+        /// </summary>
+        /// <param name="provider">The format provider to pull from.</param>
+        /// <returns>The list separator of this IFormatProvider, or the current culture's if
+        /// <paramref name="provider"/> is <see langword="null"/> or cannot be converted.</returns>
+        public static string GetListSeparator(this IFormatProvider? provider)
+        {
+            if (provider is CultureInfo cultureInfo)
+            {
+                return cultureInfo.TextInfo.ListSeparator;
+            }
+
+            if (provider is NumberFormatInfo numberFormatInfo)
+            {
+                if (numberFormatInfo == NumberFormatInfo.InvariantInfo)
+                {
+                    return CultureInfo.InvariantCulture.TextInfo.ListSeparator;
+                }
+                // TODO: Figure out if there's a way of backtracing CultureInfo from NumberFormatInfo
+                return CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+            }
+
+            return CultureInfo.CurrentCulture.TextInfo.ListSeparator;
+        }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -17,7 +17,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Transform2D : IEquatable<Transform2D>
+    public struct Transform2D : IEquatable<Transform2D>, IFormattable
     {
         /// <summary>
         /// The basis matrix's X vector (column 0). Equivalent to array index <c>[0]</c>.
@@ -650,18 +650,22 @@ namespace Godot
         /// Converts this <see cref="Transform2D"/> to a string.
         /// </summary>
         /// <returns>A string representation of this transform.</returns>
-        public override readonly string ToString()
-        {
-            return $"[X: {X}, Y: {Y}, O: {Origin}]";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Transform2D"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this transform.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Transform2D"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this transform.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return $"[X: {X.ToString(format)}, Y: {Y.ToString(format)}, O: {Origin.ToString(format)}]";
+            string separator = formatProvider.GetListSeparator();
+            return $"[X: {X.ToString(format, formatProvider)}{separator} Y: {Y.ToString(format, formatProvider)}{separator} O: {Origin.ToString(format, formatProvider)}]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -1,7 +1,7 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.ComponentModel;
 
 #nullable enable
 
@@ -18,7 +18,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Transform3D : IEquatable<Transform3D>
+    public struct Transform3D : IEquatable<Transform3D>, IFormattable
     {
         /// <summary>
         /// The <see cref="Godot.Basis"/> of this transform. Contains the X, Y, and Z basis
@@ -674,18 +674,22 @@ namespace Godot
         /// Converts this <see cref="Transform3D"/> to a string.
         /// </summary>
         /// <returns>A string representation of this transform.</returns>
-        public override readonly string ToString()
-        {
-            return $"[X: {Basis.X}, Y: {Basis.Y}, Z: {Basis.Z}, O: {Origin}]";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Transform3D"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this transform.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Transform3D"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this transform.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-            return $"[X: {Basis.X.ToString(format)}, Y: {Basis.Y.ToString(format)}, Z: {Basis.Z.ToString(format)}, O: {Origin.ToString(format)}]";
+            string separator = formatProvider.GetListSeparator();
+            return $"[X: {Basis.X.ToString(format, formatProvider)}{separator} Y: {Basis.Y.ToString(format, formatProvider)}{separator} Z: {Basis.Z.ToString(format, formatProvider)}{separator} O: {Origin.ToString(format, formatProvider)}]";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -11,7 +11,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2 : IEquatable<Vector2>
+    public struct Vector2 : IEquatable<Vector2>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the axes.
@@ -1016,20 +1016,22 @@ namespace Godot
         /// Converts this <see cref="Vector2"/> to a string.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Vector2"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Vector2"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this vector.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -11,7 +11,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2I : IEquatable<Vector2I>
+    public struct Vector2I : IEquatable<Vector2I>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the axes.
@@ -589,20 +589,22 @@ namespace Godot
         /// Converts this <see cref="Vector2I"/> to a string.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Vector2I"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Vector2I"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this vector.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -11,7 +11,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3 : IEquatable<Vector3>
+    public struct Vector3 : IEquatable<Vector3>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the axes.
@@ -1118,20 +1118,22 @@ namespace Godot
         /// Converts this <see cref="Vector3"/> to a string.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Vector3"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Vector3"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this vector.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)}{separator} {Z.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -11,7 +11,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3I : IEquatable<Vector3I>
+    public struct Vector3I : IEquatable<Vector3I>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the axes.
@@ -644,20 +644,22 @@ namespace Godot
         /// Converts this <see cref="Vector3I"/> to a string.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Vector3I"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Vector3I"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this vector.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)}{separator} {Z.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -11,7 +11,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4 : IEquatable<Vector4>
+    public struct Vector4 : IEquatable<Vector4>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the axes.
@@ -894,20 +894,22 @@ namespace Godot
         /// Converts this <see cref="Vector4"/> to a string.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public override string ToString()
-        {
-            return $"({X}, {Y}, {Z}, {W})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Vector4"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Vector4"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this vector.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)}{separator} {Z.ToString(format, formatProvider)}{separator} {W.ToString(format, formatProvider)})";
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -11,7 +11,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4I : IEquatable<Vector4I>
+    public struct Vector4I : IEquatable<Vector4I>, IFormattable
     {
         /// <summary>
         /// Enumerated index values for the axes.
@@ -665,20 +665,22 @@ namespace Godot
         /// Converts this <see cref="Vector4I"/> to a string.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z}, {W})";
-        }
+        public override readonly string ToString() => ToString(null, null);
 
         /// <summary>
         /// Converts this <see cref="Vector4I"/> to a string with the given <paramref name="format"/>.
         /// </summary>
         /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string? format)
+        public readonly string ToString(string? format) => ToString(format, null);
+
+        /// <summary>
+        /// Converts this <see cref="Vector4I"/> to a string with the given <paramref name="format"/> and <paramref name="formatProvider"/>.
+        /// </summary>
+        /// <returns>A string representation of this vector.</returns>
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
-#pragma warning disable CA1305 // Disable warning: "Specify IFormatProvider"
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
-#pragma warning restore CA1305
+            string separator = formatProvider.GetListSeparator();
+            return $"({X.ToString(format, formatProvider)}{separator} {Y.ToString(format, formatProvider)}{separator} {Z.ToString(format, formatProvider)}{separator} {W.ToString(format, formatProvider)})";
         }
     }
 }


### PR DESCRIPTION
Implements the `IFormattable` interface to the Variant structs (more specifically, the structs that already had an associated `ToString()` function). This will allow these structs to return strings from a different culture and/or strings with an invariant culture. Because these are two new functions (one with just an `IFormatProvider` argument) that would share syntax with the existing two functions (just one for Rid), the code has been simplified by having everything direct to the `IFormattable` function