### PR TITLE
Implement `Vector2i/3i/4i` methods: `distance_to` and `distance_squared_to`

### DIFF
--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -85,6 +85,14 @@ struct _NO_DISCARD_ Vector2i {
 		return Vector2i(MAX(x, p_vector2i.x), MAX(y, p_vector2i.y));
 	}
 
+	double distance_to(const Vector2i &p_to) const {
+		return (p_to - *this).length();
+	}
+
+	int64_t distance_squared_to(const Vector2i &p_to) const {
+		return (p_to - *this).length_squared();
+	}
+
 	Vector2i operator+(const Vector2i &p_v) const;
 	void operator+=(const Vector2i &p_v);
 	Vector2i operator-(const Vector2i &p_v) const;

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -87,6 +87,9 @@ struct _NO_DISCARD_ Vector3i {
 	Vector3i clamp(const Vector3i &p_min, const Vector3i &p_max) const;
 	Vector3i snapped(const Vector3i &p_step) const;
 
+	_FORCE_INLINE_ double distance_to(const Vector3i &p_to) const;
+	_FORCE_INLINE_ int64_t distance_squared_to(const Vector3i &p_to) const;
+
 	/* Operators */
 
 	_FORCE_INLINE_ Vector3i &operator+=(const Vector3i &p_v);
@@ -141,6 +144,14 @@ Vector3i Vector3i::abs() const {
 
 Vector3i Vector3i::sign() const {
 	return Vector3i(SIGN(x), SIGN(y), SIGN(z));
+}
+
+double Vector3i::distance_to(const Vector3i &p_to) const {
+	return (p_to - *this).length();
+}
+
+int64_t Vector3i::distance_squared_to(const Vector3i &p_to) const {
+	return (p_to - *this).length_squared();
 }
 
 /* Operators */

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -84,6 +84,9 @@ struct _NO_DISCARD_ Vector4i {
 
 	_FORCE_INLINE_ void zero();
 
+	_FORCE_INLINE_ double distance_to(const Vector4i &p_to) const;
+	_FORCE_INLINE_ int64_t distance_squared_to(const Vector4i &p_to) const;
+
 	_FORCE_INLINE_ Vector4i abs() const;
 	_FORCE_INLINE_ Vector4i sign() const;
 	Vector4i clamp(const Vector4i &p_min, const Vector4i &p_max) const;
@@ -137,6 +140,14 @@ int64_t Vector4i::length_squared() const {
 
 double Vector4i::length() const {
 	return Math::sqrt((double)length_squared());
+}
+
+double Vector4i::distance_to(const Vector4i &p_to) const {
+	return (p_to - *this).length();
+}
+
+int64_t Vector4i::distance_squared_to(const Vector4i &p_to) const {
+	return (p_to - *this).length_squared();
 }
 
 Vector4i Vector4i::abs() const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1796,6 +1796,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2i, aspect, sarray(), varray());
 	bind_method(Vector2i, max_axis_index, sarray(), varray());
 	bind_method(Vector2i, min_axis_index, sarray(), varray());
+	bind_method(Vector2i, distance_to, sarray("to"), varray());
+	bind_method(Vector2i, distance_squared_to, sarray("to"), varray());
 	bind_method(Vector2i, length, sarray(), varray());
 	bind_method(Vector2i, length_squared, sarray(), varray());
 	bind_method(Vector2i, sign, sarray(), varray());
@@ -1886,6 +1888,8 @@ static void _register_variant_builtin_methods() {
 
 	bind_method(Vector3i, min_axis_index, sarray(), varray());
 	bind_method(Vector3i, max_axis_index, sarray(), varray());
+	bind_method(Vector3i, distance_to, sarray("to"), varray());
+	bind_method(Vector3i, distance_squared_to, sarray("to"), varray());
 	bind_method(Vector3i, length, sarray(), varray());
 	bind_method(Vector3i, length_squared, sarray(), varray());
 	bind_method(Vector3i, sign, sarray(), varray());
@@ -1932,6 +1936,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector4i, abs, sarray(), varray());
 	bind_method(Vector4i, clamp, sarray("min", "max"), varray());
 	bind_method(Vector4i, snapped, sarray("step"), varray());
+	bind_method(Vector4i, distance_to, sarray("to"), varray());
+	bind_method(Vector4i, distance_squared_to, sarray("to"), varray());
 
 	/* Plane */
 

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -64,6 +64,21 @@
 				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
+		<method name="distance_squared_to" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="to" type="Vector2i" />
+			<description>
+				Returns the squared distance between this vector and [param to].
+				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
+			</description>
+		</method>
+		<method name="distance_to" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="to" type="Vector2i" />
+			<description>
+				Returns the distance between this vector and [param to].
+			</description>
+		</method>
 		<method name="length" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -59,6 +59,21 @@
 				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
+		<method name="distance_squared_to" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="to" type="Vector3i" />
+			<description>
+				Returns the squared distance between this vector and [param to].
+				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
+			</description>
+		</method>
+		<method name="distance_to" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="to" type="Vector3i" />
+			<description>
+				Returns the distance between this vector and [param to].
+			</description>
+		</method>
 		<method name="length" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -57,6 +57,21 @@
 				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
+		<method name="distance_squared_to" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="to" type="Vector4i" />
+			<description>
+				Returns the squared distance between this vector and [param to].
+				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
+			</description>
+		</method>
+		<method name="distance_to" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="to" type="Vector4i" />
+			<description>
+				Returns the distance between this vector and [param to].
+			</description>
+		</method>
 		<method name="length" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -121,6 +121,29 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the squared distance between this vector and <paramref name="to"/>.
+        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
+        /// you need to compare vectors or need the squared distance for some formula.
+        /// </summary>
+        /// <param name="to">The other vector to use.</param>
+        /// <returns>The squared distance between the two vectors.</returns>
+        public readonly int DistanceSquaredTo(Vector2I to)
+        {
+            return (to - this).LengthSquared();
+        }
+
+        /// <summary>
+        /// Returns the distance between this vector and <paramref name="to"/>.
+        /// </summary>
+        /// <seealso cref="DistanceSquaredTo(Vector2I)"/>
+        /// <param name="to">The other vector to use.</param>
+        /// <returns>The distance between the two vectors.</returns>
+        public readonly real_t DistanceTo(Vector2I to)
+        {
+            return (to - this).Length();
+        }
+
+        /// <summary>
         /// Returns the length (magnitude) of this vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -129,6 +129,29 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the squared distance between this vector and <paramref name="to"/>.
+        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
+        /// you need to compare vectors or need the squared distance for some formula.
+        /// </summary>
+        /// <param name="to">The other vector to use.</param>
+        /// <returns>The squared distance between the two vectors.</returns>
+        public readonly int DistanceSquaredTo(Vector3I to)
+        {
+            return (to - this).LengthSquared();
+        }
+
+        /// <summary>
+        /// Returns the distance between this vector and <paramref name="to"/>.
+        /// </summary>
+        /// <seealso cref="DistanceSquaredTo(Vector3I)"/>
+        /// <param name="to">The other vector to use.</param>
+        /// <returns>The distance between the two vectors.</returns>
+        public readonly real_t DistanceTo(Vector3I to)
+        {
+            return (to - this).Length();
+        }
+
+        /// <summary>
         /// Returns the length (magnitude) of this vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -146,6 +146,29 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the squared distance between this vector and <paramref name="to"/>.
+        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
+        /// you need to compare vectors or need the squared distance for some formula.
+        /// </summary>
+        /// <param name="to">The other vector to use.</param>
+        /// <returns>The squared distance between the two vectors.</returns>
+        public readonly int DistanceSquaredTo(Vector4I to)
+        {
+            return (to - this).LengthSquared();
+        }
+
+        /// <summary>
+        /// Returns the distance between this vector and <paramref name="to"/>.
+        /// </summary>
+        /// <seealso cref="DistanceSquaredTo(Vector4I)"/>
+        /// <param name="to">The other vector to use.</param>
+        /// <returns>The distance between the two vectors.</returns>
+        public readonly real_t DistanceTo(Vector4I to)
+        {
+            return (to - this).Length();
+        }
+
+        /// <summary>
         /// Returns the length (magnitude) of this vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>

--- a/tests/core/math/test_vector2i.h
+++ b/tests/core/math/test_vector2i.h
@@ -87,6 +87,12 @@ TEST_CASE("[Vector2i] Length methods") {
 	CHECK_MESSAGE(
 			vector2.length() == doctest::Approx(36.05551275463989293119),
 			"Vector2i length should work as expected.");
+	CHECK_MESSAGE(
+			vector1.distance_squared_to(vector2) == 500,
+			"Vector2i distance_squared_to should work as expected and return exact result.");
+	CHECK_MESSAGE(
+			vector1.distance_to(vector2) == doctest::Approx(22.36067977499789696409),
+			"Vector2i distance_to should work as expected.");
 }
 
 TEST_CASE("[Vector2i] Operators") {

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -90,6 +90,12 @@ TEST_CASE("[Vector3i] Length methods") {
 	CHECK_MESSAGE(
 			vector2.length() == doctest::Approx(53.8516480713450403125),
 			"Vector3i length should work as expected.");
+	CHECK_MESSAGE(
+			vector1.distance_squared_to(vector2) == 1400,
+			"Vector3i distance_squared_to should work as expected and return exact result.");
+	CHECK_MESSAGE(
+			vector1.distance_to(vector2) == doctest::Approx(37.41657386773941385584),
+			"Vector3i distance_to should work as expected.");
 }
 
 TEST_CASE("[Vector3i] Operators") {

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -90,6 +90,12 @@ TEST_CASE("[Vector4i] Length methods") {
 	CHECK_MESSAGE(
 			vector2.length() == doctest::Approx(73.4846922835),
 			"Vector4i length should work as expected.");
+	CHECK_MESSAGE(
+			vector1.distance_squared_to(vector2) == 3000,
+			"Vector4i distance_squared_to should work as expected.");
+	CHECK_MESSAGE(
+			vector1.distance_to(vector2) == doctest::Approx(54.772255750517),
+			"Vector4i distance_to should work as expected.");
 }
 
 TEST_CASE("[Vector4i] Operators") {


### PR DESCRIPTION
This pull request implements `distance_to` and `distance_squared_to` methods for `Vector2i`, `Vector3i` and `Vector4i`.

Partially implements [#2297](https://github.com/godotengine/godot-proposals/issues/2297), closes [#7983](https://github.com/godotengine/godot-proposals/issues/7983).
