### PR TITLE
[Web] Improve Emscripten `locateFile` glue.

### DIFF
--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -292,7 +292,9 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 				return {};
 			},
 			'locateFile': function (path) {
-				if (path.endsWith('.worker.js')) {
+				if (!path.startsWith('godot.')) {
+					return path;
+				} else if (path.endsWith('.worker.js')) {
 					return `${loadPath}.worker.js`;
 				} else if (path.endsWith('.audio.worklet.js')) {
 					return `${loadPath}.audio.worklet.js`;


### PR DESCRIPTION
Be more selective on what we rewrite, since in recent emscripten versions loading dynamic libraries relies on it.

Partially solve #82865 (tested working with 3.1.29, needs testing with latest)