### PR TITLE
Fix a few cases where surface format is still 32 bits

### DIFF
--- a/scene/resources/immediate_mesh.h
+++ b/scene/resources/immediate_mesh.h
@@ -63,7 +63,7 @@ class ImmediateMesh : public Mesh {
 		Ref<Material> material;
 		bool vertex_2d = false;
 		int array_len = 0;
-		uint32_t format = 0;
+		uint64_t format = 0;
 		AABB aabb;
 	};
 

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -301,7 +301,7 @@ class ArrayMesh : public Mesh {
 
 private:
 	struct Surface {
-		uint32_t format = 0;
+		uint64_t format = 0;
 		int array_length = 0;
 		int index_array_length = 0;
 		PrimitiveType primitive = PrimitiveType::PRIMITIVE_MAX;


### PR DESCRIPTION
May help: https://github.com/godotengine/godot/issues/82890

While debugging https://github.com/godotengine/godot/issues/82890 I noticed that some of the importers set surfaces in the mesh and then read back using "mesh_get_format" which returns the Surface.format, not SurfaceData.format. When converting to Surface.format, we are losing the upper bits which contain the version. Which leads to the mesh version getting lost. 

I'm not sure that it will fix https://github.com/godotengine/godot/issues/82890, but it is a necessary change.
