### PR TITLE
Add a project setting to control reflection filter mode

### DIFF
--- a/doc/classes/PanoramaSkyMaterial.xml
+++ b/doc/classes/PanoramaSkyMaterial.xml
@@ -15,7 +15,7 @@
 			The sky's overall brightness multiplier. Higher values result in a brighter sky.
 		</member>
 		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
-			A boolean value to determine if the background texture should be filtered or not.
+			If [code]true[/code], uses bilinear filtering to display the background texture. If [code]false[/code], nearest-neighbor filtering is used instead. When [member filter] is set to [code]false[/code], you may want reflections to use nearest-neighbor filtering as well. This can be done by changing [member ProjectSettings.rendering/reflections/filter] to [b]Nearest[/b].
 		</member>
 		<member name="panorama" type="Texture2D" setter="set_panorama" getter="get_panorama">
 			[Texture2D] to be applied to the [PanoramaSkyMaterial].

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3068,6 +3068,10 @@
 			[b]Note:[/b] Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it. Large open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling. Large open scenes generally benefit more from mesh LOD and visibility ranges ([member GeometryInstance3D.visibility_range_begin] and [member GeometryInstance3D.visibility_range_end]) compared to occlusion culling.
 			[b]Note:[/b] Due to memory constraints, occlusion culling is not supported by default in Web export templates. It can be enabled by compiling custom Web export templates with [code]module_raycast_enabled=yes[/code].
 		</member>
+		<member name="rendering/reflections/filter" type="int" setter="" getter="" default="1">
+			The filtering mode to use for [Environment] sky reflections and [ReflectionProbe] nodes. This setting generally does not affect performance, but nearest-neighbor filtering can be used for a retro look. Reflections from [VoxelGI] and SDFGI are not affected by this setting. When using [b]Nearest[/b], you may also want to reduce [member Sky.radiance_size] in [Environment] and [member rendering/reflections/reflection_atlas/reflection_size] to make the pixelation more noticeable. When using [PanoramaSkyMaterial], you may also want to set its [member PanoramaSkyMaterial.filter] property to [code]false[/code] as well.
+			[b]Note:[/b] This property is only read when the project starts. To change the reflection filter mode at run-time, use [method RenderingServer.reflections_set_filter] instead.
+		</member>
 		<member name="rendering/reflections/reflection_atlas/reflection_count" type="int" setter="" getter="" default="64">
 			Number of cubemaps to store in the reflection atlas. The number of [ReflectionProbe]s in a scene will be limited by this amount. A higher number requires more VRAM.
 		</member>
@@ -3280,6 +3284,7 @@
 		</member>
 		<member name="rendering/textures/decals/filter" type="int" setter="" getter="" default="3">
 			The filtering quality to use for [Decal] nodes. When using one of the anisotropic filtering modes, the anisotropic filtering level is controlled by [member rendering/textures/default_filters/anisotropic_filtering_level].
+			[b]Note:[/b] This property is only read when the project starts. To change the decal filter mode at run-time, use [method RenderingServer.decals_set_filter] instead.
 		</member>
 		<member name="rendering/textures/default_filters/anisotropic_filtering_level" type="int" setter="" getter="" default="2">
 			Sets the maximum number of samples to take when using anisotropic filtering on textures (as a power of two). A higher sample count will result in sharper textures at oblique angles, but is more expensive to compute. A value of [code]0[/code] forcibly disables anisotropic filtering, even on materials where it is enabled.
@@ -3299,6 +3304,7 @@
 		</member>
 		<member name="rendering/textures/light_projectors/filter" type="int" setter="" getter="" default="3">
 			The filtering quality to use for [OmniLight3D] and [SpotLight3D] projectors. When using one of the anisotropic filtering modes, the anisotropic filtering level is controlled by [member rendering/textures/default_filters/anisotropic_filtering_level].
+			[b]Note:[/b] This property is only read when the project starts. To change the light projector filter mode at run-time, use [method RenderingServer.light_projectors_set_filter] instead.
 		</member>
 		<member name="rendering/textures/lossless_compression/force_png" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the texture importer will import lossless textures using the PNG format. Otherwise, it will default to using WebP.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1208,7 +1208,7 @@
 			<return type="void" />
 			<param index="0" name="filter" type="int" enum="RenderingServer.DecalFilter" />
 			<description>
-				Sets the texture [param filter] mode to use when rendering decals. This parameter is global and cannot be set on a per-decal basis.
+				Sets the texture [param filter] mode to use when rendering decals. This parameter is global and cannot be set on a per-decal basis. See [member ProjectSettings.rendering/textures/decals/filter].
 			</description>
 		</method>
 		<method name="directional_light_create">
@@ -2107,7 +2107,7 @@
 			<return type="void" />
 			<param index="0" name="filter" type="int" enum="RenderingServer.LightProjectorFilter" />
 			<description>
-				Sets the texture filter mode to use when rendering light projectors. This parameter is global and cannot be set on a per-light basis.
+				Sets the texture filter mode to use when rendering light projectors. This parameter is global and cannot be set on a per-light basis. See [member ProjectSettings.rendering/textures/light_projectors/filter].
 			</description>
 		</method>
 		<method name="light_set_bake_mode">
@@ -3340,6 +3340,13 @@
 			<param index="1" name="mode" type="int" enum="RenderingServer.ReflectionProbeUpdateMode" />
 			<description>
 				Sets how often the reflection probe updates. Can either be once or every frame. See [enum ReflectionProbeUpdateMode] for options.
+			</description>
+		</method>
+		<method name="reflections_set_filter">
+			<return type="void" />
+			<param index="0" name="filter" type="int" enum="RenderingServer.ReflectionFilter" />
+			<description>
+				Sets the texture filter mode to use when rendering sky reflections and reflection probes. This parameter is global and cannot be set on a per-probe basis. See [member ProjectSettings.rendering/reflections/filter].
 			</description>
 		</method>
 		<method name="request_frame_drawn_callback">
@@ -4896,6 +4903,12 @@
 		</constant>
 		<constant name="REFLECTION_PROBE_AMBIENT_COLOR" value="2" enum="ReflectionProbeAmbientMode">
 			Apply custom ambient lighting inside the reflection probe's box defined by its size. See [method reflection_probe_set_ambient_color] and [method reflection_probe_set_ambient_energy].
+		</constant>
+		<constant name="REFLECTION_FILTER_NEAREST" value="0" enum="ReflectionFilter">
+			Nearest-neighbor filter for reflections (use for pixel art reflections).
+		</constant>
+		<constant name="REFLECTION_FILTER_LINEAR" value="1" enum="ReflectionFilter">
+			Linear filter for reflections (use for non-pixel art reflections).
 		</constant>
 		<constant name="DECAL_TEXTURE_ALBEDO" value="0" enum="DecalTexture">
 			Albedo texture slot in a decal ([member Decal.texture_albedo]).

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4140,6 +4140,9 @@ void RasterizerSceneGLES3::update() {
 void RasterizerSceneGLES3::sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) {
 }
 
+void RasterizerSceneGLES3::reflections_set_filter(RS::ReflectionFilter p_filter) {
+}
+
 void RasterizerSceneGLES3::decals_set_filter(RS::DecalFilter p_filter) {
 }
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -869,6 +869,7 @@ public:
 	void update() override;
 	void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) override;
 
+	void reflections_set_filter(RS::ReflectionFilter p_filter) override;
 	void decals_set_filter(RS::DecalFilter p_filter) override;
 	void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) override;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -498,6 +498,7 @@ void EditorNode::_update_from_settings() {
 	float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
 	scene_root->set_mesh_lod_threshold(mesh_lod_threshold);
 
+	RS::get_singleton()->reflections_set_filter(RS::ReflectionFilter(int(GLOBAL_GET("rendering/reflections/filter"))));
 	RS::get_singleton()->decals_set_filter(RS::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
 	RS::get_singleton()->light_projectors_set_filter(RS::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
 	RS::get_singleton()->lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -190,6 +190,7 @@ public:
 	void update() override {}
 	void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) override {}
 
+	virtual void reflections_set_filter(RS::ReflectionFilter p_filter) override {}
 	virtual void decals_set_filter(RS::DecalFilter p_filter) override {}
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override {}
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) override {}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -3436,11 +3436,30 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		uniforms.push_back(u);
 	}
 
-	p_samplers.append_uniforms(uniforms, 12);
+	{
+		RD::Uniform u;
+		u.binding = 12;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+		RID sampler;
+		switch (reflections_get_filter()) {
+			// Mipmaps should always be used to sample reflections. Otherwise, roughness won't apply to reflections.
+			case RS::REFLECTION_FILTER_NEAREST: {
+				sampler = p_samplers.get_sampler(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			} break;
+			case RS::REFLECTION_FILTER_LINEAR: {
+				sampler = p_samplers.get_sampler(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			} break;
+		}
+
+		u.append_id(sampler);
+		uniforms.push_back(u);
+	}
+
+	p_samplers.append_uniforms(uniforms, 13);
 
 	{
 		RD::Uniform u;
-		u.binding = 24;
+		u.binding = 25;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID texture;
 		if (rb.is_valid() && rb->has_texture(RB_SCOPE_BUFFERS, RB_TEX_BACK_DEPTH)) {
@@ -3453,7 +3472,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	}
 	{
 		RD::Uniform u;
-		u.binding = 25;
+		u.binding = 26;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID bbt = rb_data.is_valid() ? rb->get_back_buffer_texture() : RID();
 		RID texture = bbt.is_valid() ? bbt : texture_storage->texture_rd_get_default(is_multiview ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
@@ -3463,7 +3482,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 
 	{
 		RD::Uniform u;
-		u.binding = 26;
+		u.binding = 27;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID texture = rb_data.is_valid() && rb_data->has_normal_roughness() ? rb_data->get_normal_roughness() : texture_storage->texture_rd_get_default(is_multiview ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_NORMAL : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_NORMAL);
 		u.append_id(texture);
@@ -3472,7 +3491,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 
 	{
 		RD::Uniform u;
-		u.binding = 27;
+		u.binding = 28;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID aot = rb.is_valid() && rb->has_texture(RB_SCOPE_SSAO, RB_FINAL) ? rb->get_texture(RB_SCOPE_SSAO, RB_FINAL) : RID();
 		RID texture = aot.is_valid() ? aot : texture_storage->texture_rd_get_default(is_multiview ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
@@ -3482,7 +3501,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 
 	{
 		RD::Uniform u;
-		u.binding = 28;
+		u.binding = 29;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID texture = rb_data.is_valid() && rb->has_texture(RB_SCOPE_GI, RB_TEX_AMBIENT) ? rb->get_texture(RB_SCOPE_GI, RB_TEX_AMBIENT) : texture_storage->texture_rd_get_default(is_multiview ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 		u.append_id(texture);
@@ -3491,7 +3510,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 
 	{
 		RD::Uniform u;
-		u.binding = 29;
+		u.binding = 30;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID texture = rb_data.is_valid() && rb->has_texture(RB_SCOPE_GI, RB_TEX_REFLECTION) ? rb->get_texture(RB_SCOPE_GI, RB_TEX_REFLECTION) : texture_storage->texture_rd_get_default(is_multiview ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 		u.append_id(texture);
@@ -3499,7 +3518,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	}
 	{
 		RD::Uniform u;
-		u.binding = 30;
+		u.binding = 31;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID t;
 		if (rb.is_valid() && rb->has_custom_data(RB_SCOPE_SDFGI)) {
@@ -3514,7 +3533,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	}
 	{
 		RD::Uniform u;
-		u.binding = 31;
+		u.binding = 32;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID t;
 		if (rb.is_valid() && rb->has_custom_data(RB_SCOPE_SDFGI)) {
@@ -3529,7 +3548,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	}
 	{
 		RD::Uniform u;
-		u.binding = 32;
+		u.binding = 33;
 		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 		RID voxel_gi;
 		if (rb.is_valid() && rb->has_custom_data(RB_SCOPE_GI)) {
@@ -3541,7 +3560,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	}
 	{
 		RD::Uniform u;
-		u.binding = 33;
+		u.binding = 34;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID vfog;
 		if (rb_data.is_valid() && rb->has_custom_data(RB_SCOPE_FOG)) {
@@ -3558,7 +3577,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 	}
 	{
 		RD::Uniform u;
-		u.binding = 34;
+		u.binding = 35;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID ssil = rb.is_valid() && rb->has_texture(RB_SCOPE_SSIL, RB_FINAL) ? rb->get_texture(RB_SCOPE_SSIL, RB_FINAL) : RID();
 		RID texture = ssil.is_valid() ? ssil : texture_storage->texture_rd_get_default(is_multiview ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
@@ -3743,28 +3762,28 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 	{
 		RD::Uniform u;
 		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
-		u.binding = 24;
+		u.binding = 25;
 		u.append_id(p_albedo_texture);
 		uniforms.push_back(u);
 	}
 	{
 		RD::Uniform u;
 		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
-		u.binding = 25;
+		u.binding = 26;
 		u.append_id(p_emission_texture);
 		uniforms.push_back(u);
 	}
 	{
 		RD::Uniform u;
 		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
-		u.binding = 26;
+		u.binding = 27;
 		u.append_id(p_emission_aniso_texture);
 		uniforms.push_back(u);
 	}
 	{
 		RD::Uniform u;
 		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
-		u.binding = 27;
+		u.binding = 28;
 		u.append_id(p_geom_facing_texture);
 		uniforms.push_back(u);
 	}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -631,7 +631,26 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		uniforms.push_back(u);
 	}
 
-	p_samplers.append_uniforms(uniforms, 13);
+	{
+		RD::Uniform u;
+		u.binding = 13;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
+		RID sampler;
+		switch (reflections_get_filter()) {
+			// Mipmaps should always be used to sample reflections. Otherwise, roughness won't apply to reflections.
+			case RS::REFLECTION_FILTER_NEAREST: {
+				sampler = p_samplers.get_sampler(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			} break;
+			case RS::REFLECTION_FILTER_LINEAR: {
+				sampler = p_samplers.get_sampler(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+			} break;
+		}
+
+		u.append_id(sampler);
+		uniforms.push_back(u);
+	}
+
+	p_samplers.append_uniforms(uniforms, 14);
 
 	return UniformSetCacheRD::get_singleton()->get_cache_vec(scene_shader.default_shader_rd, RENDER_PASS_UNIFORM_SET, uniforms);
 }

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1067,6 +1067,14 @@ void RendererSceneRenderRD::directional_soft_shadow_filter_set_quality(RS::Shado
 	_update_shader_quality_settings();
 }
 
+void RendererSceneRenderRD::reflections_set_filter(RenderingServer::ReflectionFilter p_filter) {
+	if (reflections_filter == p_filter) {
+		return;
+	}
+	reflections_filter = p_filter;
+	_update_shader_quality_settings();
+}
+
 void RendererSceneRenderRD::decals_set_filter(RenderingServer::DecalFilter p_filter) {
 	if (decals_filter == p_filter) {
 		return;
@@ -1074,6 +1082,7 @@ void RendererSceneRenderRD::decals_set_filter(RenderingServer::DecalFilter p_fil
 	decals_filter = p_filter;
 	_update_shader_quality_settings();
 }
+
 void RendererSceneRenderRD::light_projectors_set_filter(RenderingServer::LightProjectorFilter p_filter) {
 	if (light_projectors_filter == p_filter) {
 		return;
@@ -1541,6 +1550,7 @@ void RendererSceneRenderRD::init() {
 	environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
 	environment_set_volumetric_fog_filter_active(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter"));
 
+	reflections_set_filter(RS::ReflectionFilter(int(GLOBAL_GET("rendering/reflections/filter"))));
 	decals_set_filter(RS::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
 	light_projectors_set_filter(RS::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
 	lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -139,6 +139,7 @@ private:
 	int directional_soft_shadow_samples = 0;
 	int penumbra_shadow_samples = 0;
 	int soft_shadow_samples = 0;
+	RS::ReflectionFilter reflections_filter = RS::REFLECTION_FILTER_LINEAR;
 	RS::DecalFilter decals_filter = RS::DECAL_FILTER_LINEAR_MIPMAPS;
 	RS::LightProjectorFilter light_projectors_filter = RS::LIGHT_PROJECTOR_FILTER_LINEAR_MIPMAPS;
 
@@ -262,6 +263,7 @@ public:
 	virtual void positional_soft_shadow_filter_set_quality(RS::ShadowQuality p_quality) override;
 	virtual void directional_soft_shadow_filter_set_quality(RS::ShadowQuality p_quality) override;
 
+	virtual void reflections_set_filter(RS::ReflectionFilter p_filter) override;
 	virtual void decals_set_filter(RS::DecalFilter p_filter) override;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) override;
@@ -308,6 +310,9 @@ public:
 		return soft_shadow_samples;
 	}
 
+	_FORCE_INLINE_ RS::ReflectionFilter reflections_get_filter() const {
+		return reflections_filter;
+	}
 	_FORCE_INLINE_ RS::LightProjectorFilter light_projectors_get_filter() const {
 		return light_projectors_filter;
 	}

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1576,11 +1576,11 @@ void fragment_shader(in SceneData scene_data) {
 		float lod, blend;
 
 		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
-		specular_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
-		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
+		specular_light = texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod)).rgb;
+		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod + 1)).rgb, blend);
 
 #else
-		specular_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
+		specular_light = textureLod(samplerCube(radiance_cubemap, reflection_sampler), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
 
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= scene_data.IBL_exposure_normalization;
@@ -1632,11 +1632,11 @@ void fragment_shader(in SceneData scene_data) {
 
 		float lod, blend;
 		blend = modf(roughness_lod, lod);
-		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
-		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
+		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod)).rgb;
+		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod + 1)).rgb, blend);
 
 #else
-		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, roughness_lod).rgb;
+		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, reflection_sampler), ref_vec, roughness_lod).rgb;
 
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -369,25 +369,27 @@ layout(set = 1, binding = 10) uniform sampler decal_sampler;
 
 layout(set = 1, binding = 11) uniform sampler light_projector_sampler;
 
-layout(set = 1, binding = 12 + 0) uniform sampler SAMPLER_NEAREST_CLAMP;
-layout(set = 1, binding = 12 + 1) uniform sampler SAMPLER_LINEAR_CLAMP;
-layout(set = 1, binding = 12 + 2) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_CLAMP;
-layout(set = 1, binding = 12 + 3) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
-layout(set = 1, binding = 12 + 4) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
-layout(set = 1, binding = 12 + 5) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
-layout(set = 1, binding = 12 + 6) uniform sampler SAMPLER_NEAREST_REPEAT;
-layout(set = 1, binding = 12 + 7) uniform sampler SAMPLER_LINEAR_REPEAT;
-layout(set = 1, binding = 12 + 8) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_REPEAT;
-layout(set = 1, binding = 12 + 9) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_REPEAT;
-layout(set = 1, binding = 12 + 10) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
-layout(set = 1, binding = 12 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
+layout(set = 1, binding = 12) uniform sampler reflection_sampler;
+
+layout(set = 1, binding = 13 + 0) uniform sampler SAMPLER_NEAREST_CLAMP;
+layout(set = 1, binding = 13 + 1) uniform sampler SAMPLER_LINEAR_CLAMP;
+layout(set = 1, binding = 13 + 2) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_CLAMP;
+layout(set = 1, binding = 13 + 3) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
+layout(set = 1, binding = 13 + 4) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
+layout(set = 1, binding = 13 + 5) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
+layout(set = 1, binding = 13 + 6) uniform sampler SAMPLER_NEAREST_REPEAT;
+layout(set = 1, binding = 13 + 7) uniform sampler SAMPLER_LINEAR_REPEAT;
+layout(set = 1, binding = 13 + 8) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_REPEAT;
+layout(set = 1, binding = 13 + 9) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_REPEAT;
+layout(set = 1, binding = 13 + 10) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
+layout(set = 1, binding = 13 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
 
 #ifdef MODE_RENDER_SDF
 
-layout(r16ui, set = 1, binding = 24) uniform restrict writeonly uimage3D albedo_volume_grid;
-layout(r32ui, set = 1, binding = 25) uniform restrict writeonly uimage3D emission_grid;
-layout(r32ui, set = 1, binding = 26) uniform restrict writeonly uimage3D emission_aniso_grid;
-layout(r32ui, set = 1, binding = 27) uniform restrict uimage3D geom_facing_grid;
+layout(r16ui, set = 1, binding = 25) uniform restrict writeonly uimage3D albedo_volume_grid;
+layout(r32ui, set = 1, binding = 26) uniform restrict writeonly uimage3D emission_grid;
+layout(r32ui, set = 1, binding = 27) uniform restrict writeonly uimage3D emission_aniso_grid;
+layout(r32ui, set = 1, binding = 28) uniform restrict uimage3D geom_facing_grid;
 
 //still need to be present for shaders that use it, so remap them to something
 #define depth_buffer shadow_atlas
@@ -398,24 +400,24 @@ layout(r32ui, set = 1, binding = 27) uniform restrict uimage3D geom_facing_grid;
 #else
 
 #ifdef USE_MULTIVIEW
-layout(set = 1, binding = 24) uniform texture2DArray depth_buffer;
-layout(set = 1, binding = 25) uniform texture2DArray color_buffer;
-layout(set = 1, binding = 26) uniform texture2DArray normal_roughness_buffer;
-layout(set = 1, binding = 27) uniform texture2DArray ao_buffer;
-layout(set = 1, binding = 28) uniform texture2DArray ambient_buffer;
-layout(set = 1, binding = 29) uniform texture2DArray reflection_buffer;
+layout(set = 1, binding = 25) uniform texture2DArray depth_buffer;
+layout(set = 1, binding = 26) uniform texture2DArray color_buffer;
+layout(set = 1, binding = 27) uniform texture2DArray normal_roughness_buffer;
+layout(set = 1, binding = 28) uniform texture2DArray ao_buffer;
+layout(set = 1, binding = 29) uniform texture2DArray ambient_buffer;
+layout(set = 1, binding = 30) uniform texture2DArray reflection_buffer;
 #define multiviewSampler sampler2DArray
 #else // USE_MULTIVIEW
-layout(set = 1, binding = 24) uniform texture2D depth_buffer;
-layout(set = 1, binding = 25) uniform texture2D color_buffer;
-layout(set = 1, binding = 26) uniform texture2D normal_roughness_buffer;
-layout(set = 1, binding = 27) uniform texture2D ao_buffer;
-layout(set = 1, binding = 28) uniform texture2D ambient_buffer;
-layout(set = 1, binding = 29) uniform texture2D reflection_buffer;
+layout(set = 1, binding = 25) uniform texture2D depth_buffer;
+layout(set = 1, binding = 26) uniform texture2D color_buffer;
+layout(set = 1, binding = 27) uniform texture2D normal_roughness_buffer;
+layout(set = 1, binding = 28) uniform texture2D ao_buffer;
+layout(set = 1, binding = 29) uniform texture2D ambient_buffer;
+layout(set = 1, binding = 30) uniform texture2D reflection_buffer;
 #define multiviewSampler sampler2D
 #endif
-layout(set = 1, binding = 30) uniform texture2DArray sdfgi_lightprobe_texture;
-layout(set = 1, binding = 31) uniform texture3D sdfgi_occlusion_cascades;
+layout(set = 1, binding = 31) uniform texture2DArray sdfgi_lightprobe_texture;
+layout(set = 1, binding = 32) uniform texture3D sdfgi_occlusion_cascades;
 
 struct VoxelGIData {
 	mat4 xform; // 64 - 64
@@ -432,17 +434,17 @@ struct VoxelGIData {
 	float exposure_normalization; // 4 - 112
 };
 
-layout(set = 1, binding = 32, std140) uniform VoxelGIs {
+layout(set = 1, binding = 33, std140) uniform VoxelGIs {
 	VoxelGIData data[MAX_VOXEL_GI_INSTANCES];
 }
 voxel_gi_instances;
 
-layout(set = 1, binding = 33) uniform texture3D volumetric_fog_texture;
+layout(set = 1, binding = 34) uniform texture3D volumetric_fog_texture;
 
 #ifdef USE_MULTIVIEW
-layout(set = 1, binding = 34) uniform texture2DArray ssil_buffer;
+layout(set = 1, binding = 35) uniform texture2DArray ssil_buffer;
 #else
-layout(set = 1, binding = 34) uniform texture2D ssil_buffer;
+layout(set = 1, binding = 35) uniform texture2D ssil_buffer;
 #endif // USE_MULTIVIEW
 
 #endif

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1234,11 +1234,11 @@ void main() {
 
 		float lod, blend;
 		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
-		specular_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
-		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
+		specular_light = texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod)).rgb;
+		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod + 1)).rgb, blend);
 
 #else // USE_RADIANCE_CUBEMAP_ARRAY
-		specular_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
+		specular_light = textureLod(samplerCube(radiance_cubemap, reflection_sampler), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
 
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= sc_luminance_multiplier();
@@ -1292,11 +1292,11 @@ void main() {
 
 		float lod, blend;
 		blend = modf(roughness_lod, lod);
-		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
-		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
+		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod)).rgb;
+		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, reflection_sampler), vec4(ref_vec, lod + 1)).rgb, blend);
 
 #else
-		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, roughness_lod).rgb;
+		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, reflection_sampler), ref_vec, roughness_lod).rgb;
 
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -351,18 +351,20 @@ layout(set = 1, binding = 11) uniform sampler decal_sampler;
 
 layout(set = 1, binding = 12) uniform sampler light_projector_sampler;
 
-layout(set = 1, binding = 13 + 0) uniform sampler SAMPLER_NEAREST_CLAMP;
-layout(set = 1, binding = 13 + 1) uniform sampler SAMPLER_LINEAR_CLAMP;
-layout(set = 1, binding = 13 + 2) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_CLAMP;
-layout(set = 1, binding = 13 + 3) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
-layout(set = 1, binding = 13 + 4) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
-layout(set = 1, binding = 13 + 5) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
-layout(set = 1, binding = 13 + 6) uniform sampler SAMPLER_NEAREST_REPEAT;
-layout(set = 1, binding = 13 + 7) uniform sampler SAMPLER_LINEAR_REPEAT;
-layout(set = 1, binding = 13 + 8) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_REPEAT;
-layout(set = 1, binding = 13 + 9) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_REPEAT;
-layout(set = 1, binding = 13 + 10) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
-layout(set = 1, binding = 13 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
+layout(set = 1, binding = 13) uniform sampler reflection_sampler;
+
+layout(set = 1, binding = 14 + 0) uniform sampler SAMPLER_NEAREST_CLAMP;
+layout(set = 1, binding = 14 + 1) uniform sampler SAMPLER_LINEAR_CLAMP;
+layout(set = 1, binding = 14 + 2) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_CLAMP;
+layout(set = 1, binding = 14 + 3) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
+layout(set = 1, binding = 14 + 4) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
+layout(set = 1, binding = 14 + 5) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_CLAMP;
+layout(set = 1, binding = 14 + 6) uniform sampler SAMPLER_NEAREST_REPEAT;
+layout(set = 1, binding = 14 + 7) uniform sampler SAMPLER_LINEAR_REPEAT;
+layout(set = 1, binding = 14 + 8) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_REPEAT;
+layout(set = 1, binding = 14 + 9) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_REPEAT;
+layout(set = 1, binding = 14 + 10) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
+layout(set = 1, binding = 14 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
 
 /* Set 2 Skeleton & Instancing (can change per item) */
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -931,7 +931,7 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 		vec4 reflection;
 		float reflection_blend = max(0.0, blend - reflection_accum.a);
 
-		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_ref_vec, reflections.data[ref_index].index), sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier();
+		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, reflection_sampler), vec4(local_ref_vec, reflections.data[ref_index].index), sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier();
 		reflection.rgb *= reflections.data[ref_index].exposure_normalization;
 		reflection.a = reflection_blend;
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1387,6 +1387,7 @@ public:
 	/* Misc */
 	PASS1(set_debug_draw_mode, RS::ViewportDebugDraw)
 
+	PASS1(reflections_set_filter, RS::ReflectionFilter)
 	PASS1(decals_set_filter, RS::DecalFilter)
 	PASS1(light_projectors_set_filter, RS::LightProjectorFilter)
 	PASS1(lightmaps_set_bicubic_filter, bool)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -339,6 +339,7 @@ public:
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) = 0;
 
+	virtual void reflections_set_filter(RS::ReflectionFilter p_filter) = 0;
 	virtual void decals_set_filter(RS::DecalFilter p_filter) = 0;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) = 0;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) = 0;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -352,6 +352,7 @@ public:
 	virtual void render_probes() = 0;
 	virtual void update_visibility_notifiers() = 0;
 
+	virtual void reflections_set_filter(RS::ReflectionFilter p_filter) = 0;
 	virtual void decals_set_filter(RS::DecalFilter p_filter) = 0;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) = 0;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -838,6 +838,7 @@ public:
 
 	FUNC1(positional_soft_shadow_filter_set_quality, ShadowQuality);
 	FUNC1(directional_soft_shadow_filter_set_quality, ShadowQuality);
+	FUNC1(reflections_set_filter, RS::ReflectionFilter);
 	FUNC1(decals_set_filter, RS::DecalFilter);
 	FUNC1(light_projectors_set_filter, RS::LightProjectorFilter);
 	FUNC1(lightmaps_set_bicubic_filter, bool);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2591,12 +2591,17 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_resolution", "probe", "resolution"), &RenderingServer::reflection_probe_set_resolution);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_mesh_lod_threshold", "probe", "pixels"), &RenderingServer::reflection_probe_set_mesh_lod_threshold);
 
+	ClassDB::bind_method(D_METHOD("reflections_set_filter", "filter"), &RenderingServer::reflections_set_filter);
+
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ONCE);
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ALWAYS);
 
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_AMBIENT_DISABLED);
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_AMBIENT_ENVIRONMENT);
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_AMBIENT_COLOR);
+
+	BIND_ENUM_CONSTANT(REFLECTION_FILTER_NEAREST);
+	BIND_ENUM_CONSTANT(REFLECTION_FILTER_LINEAR);
 
 	/* DECAL */
 
@@ -3623,6 +3628,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug", false);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug.release", true);
 
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/reflections/filter", PROPERTY_HINT_ENUM, "Nearest,Linear"), REFLECTION_FILTER_LINEAR);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/roughness_layers", PROPERTY_HINT_RANGE, "1,32,1"), 8); // Assumes a 256x256 cubemap
 	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/texture_array_reflections", true);
 	GLOBAL_DEF("rendering/reflections/sky_reflections/texture_array_reflections.mobile", false);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -669,6 +669,13 @@ public:
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) = 0;
 	virtual void reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_pixels) = 0;
 
+	enum ReflectionFilter {
+		REFLECTION_FILTER_NEAREST,
+		REFLECTION_FILTER_LINEAR,
+	};
+
+	virtual void reflections_set_filter(ReflectionFilter p_filter) = 0;
+
 	/* DECAL API */
 
 	enum DecalTexture {
@@ -1926,6 +1933,7 @@ VARIANT_ENUM_CAST(RenderingServer::LightDirectionalSkyMode);
 VARIANT_ENUM_CAST(RenderingServer::LightProjectorFilter);
 VARIANT_ENUM_CAST(RenderingServer::ReflectionProbeUpdateMode);
 VARIANT_ENUM_CAST(RenderingServer::ReflectionProbeAmbientMode);
+VARIANT_ENUM_CAST(RenderingServer::ReflectionFilter);
 VARIANT_ENUM_CAST(RenderingServer::VoxelGIQuality);
 VARIANT_ENUM_CAST(RenderingServer::DecalTexture);
 VARIANT_ENUM_CAST(RenderingServer::DecalFilter);


### PR DESCRIPTION
The default is bilinear filtering as before, but nearest-neighbor filtering can now be chosen for a retro look.

This affects sky radiance map and ReflectionProbe specular light.

This also marks additional settings as requiring a restart, as noticed during testing.

- This closes https://github.com/godotengine/godot-proposals/issues/8063.

**Testing project:** [test_reflection_nearest_neighbor.zip](https://github.com/godotengine/godot/files/12875043/test_reflection_nearest_neighbor.zip)

## Preview

### Without ReflectionProbe

#### Linear

https://github.com/godotengine/godot/assets/180032/de5eb236-68eb-4024-8673-8e4d07e8474f

#### Nearest

https://github.com/godotengine/godot/assets/180032/5a63987c-d640-4aee-887c-36f59090cbc3

### With ReflectionProbe

#### Linear

https://github.com/godotengine/godot/assets/180032/40af8661-37f8-4dd0-82da-7cc2529ff1ed

#### Nearest

https://github.com/godotengine/godot/assets/180032/27005638-57f3-40c0-adf8-e964f57c51b0

## TODO

- [ ] Implement in Compatibility.
- [ ] Fix undefined uniform set error in Forward+ when SDFGI is enabled.