### PR TITLE
Sanitize tangents when creating mesh surfaces to avoid triggering the compressed mesh path in the shader

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -206,6 +206,11 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		uint32_t value = 0;
 		value |= (uint16_t)CLAMP(res.x * 65535, 0, 65535);
 		value |= (uint16_t)CLAMP(res.y * 65535, 0, 65535) << 16;
+		if (value == 4294901760) {
+			// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+			// So we sanitize here.
+			value = 4294967295;
+		}
 
 		v_tangent = value;
 	}

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -208,6 +208,11 @@ void ImmediateMesh::surface_end() {
 				uint32_t value = 0;
 				value |= (uint16_t)CLAMP(t.x * 65535, 0, 65535);
 				value |= (uint16_t)CLAMP(t.y * 65535, 0, 65535) << 16;
+				if (value == 4294901760) {
+					// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+					// So we sanitize here.
+					value = 4294967295;
+				}
 
 				*tangent = value;
 			}

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1156,6 +1156,11 @@ void _fix_array_compatibility(const Vector<uint8_t> &p_src, uint64_t p_old_forma
 							uint16_t *dst = (uint16_t *)&dst_vertex_ptr[i * dst_normal_tangent_stride + dst_offsets[Mesh::ARRAY_NORMAL]];
 							dst[0] = (uint16_t)CLAMP(res.x * 65535, 0, 65535);
 							dst[1] = (uint16_t)CLAMP(res.y * 65535, 0, 65535);
+							if (dst[0] == 0 && dst[1] == 65535) {
+								// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+								// So we sanitize here.
+								dst[0] = 65535;
+							}
 						}
 						src_offset += sizeof(uint8_t) * 4;
 					} else {
@@ -1167,6 +1172,11 @@ void _fix_array_compatibility(const Vector<uint8_t> &p_src, uint64_t p_old_forma
 							uint16_t *dst = (uint16_t *)&dst_vertex_ptr[i * dst_normal_tangent_stride + dst_offsets[Mesh::ARRAY_NORMAL]];
 							dst[0] = (uint16_t)CLAMP(res.x * 65535, 0, 65535);
 							dst[1] = (uint16_t)CLAMP(res.y * 65535, 0, 65535);
+							if (dst[0] == 0 && dst[1] == 65535) {
+								// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+								// So we sanitize here.
+								dst[0] = 65535;
+							}
 						}
 						src_offset += sizeof(float) * 4;
 					}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -612,6 +612,12 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 							};
 
+							if (vector[0] == 0 && vector[1] == 65535) {
+								// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+								// So we sanitize here.
+								vector[0] = 65535;
+							}
+
 							memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
 						}
 					} else { // PACKED_FLOAT64_ARRAY
@@ -626,6 +632,12 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								(uint16_t)CLAMP(res.x * 65535, 0, 65535),
 								(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 							};
+
+							if (vector[0] == 0 && vector[1] == 65535) {
+								// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+								// So we sanitize here.
+								vector[0] = 65535;
+							}
 
 							memcpy(&vw[p_offsets[ai] + i * p_normal_stride], vector, 4);
 						}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/83175

This was a fun one to track down. 

In the shader we check if (tangent.x > 0 || tangent.y < 1.0), to see if we should run the uncompressed path. I wrongly assumed that we would never send (0, 1) to the shader because (0, 1) maps to a tangent of (0, 0, -1, 1), but a tangent of (0, 0, -1, 1) maps to (1, 1). _However_, (-1e8, 0, -1, 1) maps to (0, 1) and sometimes we create tangents that are (-1e8, 0, -1, 1). We can't represent (-1e8, 0, -1, 1) in octahedral tangents anyway, so its fine to just force all cases of (0, 1) to (1, 1) 