### PR TITLE
Add an extra backbuffer color texture that can be used when an upscaler is in use.

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2137,6 +2137,12 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		RD::get_singleton()->draw_list_end();
 	}
 
+	if (rb_data.is_valid() && using_fsr2) {
+		// Make sure the upscaled texture is initialized, but not necessarily filled, before running screen copies
+		// so it properly detect if a dedicated copy texture should be used.
+		rb->ensure_upscaled();
+	}
+
 	if (scene_state.used_screen_texture) {
 		RENDER_TIMESTAMP("Copy Screen Texture");
 
@@ -2200,7 +2206,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	if (rb_data.is_valid() && (using_fsr2 || using_taa)) {
 		if (using_fsr2) {
-			rb->ensure_upscaled();
 			rb_data->ensure_fsr2(fsr2_effect);
 
 			RID exposure;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
@@ -58,6 +58,7 @@
 #define RB_TEX_BLUR_1 SNAME("blur_1")
 #define RB_TEX_HALF_BLUR SNAME("half_blur") // only for raster!
 
+#define RB_TEX_BACK_COLOR SNAME("back_color")
 #define RB_TEX_BACK_DEPTH SNAME("back_depth")
 
 class RenderSceneBuffersRD : public RenderSceneBuffers {
@@ -267,7 +268,16 @@ public:
 	}
 
 	// back buffer (color)
-	RID get_back_buffer_texture() const { return has_texture(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0) ? get_texture(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0) : RID(); } // We (re)use our blur texture here.
+	RID get_back_buffer_texture() const {
+		// Prefer returning the dedicated backbuffer color texture if it was created. Return the reused blur texture otherwise.
+		if (has_texture(RB_SCOPE_BUFFERS, RB_TEX_BACK_COLOR)) {
+			return get_texture(RB_SCOPE_BUFFERS, RB_TEX_BACK_COLOR);
+		} else if (has_texture(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0)) {
+			return get_texture(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0);
+		} else {
+			return RID();
+		}
+	}
 
 	// Upscaled.
 	void ensure_upscaled();


### PR DESCRIPTION
Fixes #83152. Due to how BLUR_0 is reused for multiple purposes and requires being at native resolution for some post-processing effects to work, FSR2 will use an alternate texture at internal size to use as the screen texture read by shaders instead. The rendering pipeline will prefer using this texture if it exists.

Anything that used screen textures inside a custom shader was affected when FSR2 was enabled with a resolution scale below 1.0.