### PR TITLE
Add missing double-precision flag for Vector4 & Projection in `encode_variant`

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1155,10 +1155,12 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 #ifdef REAL_T_IS_DOUBLE
 		case Variant::VECTOR2:
 		case Variant::VECTOR3:
+		case Variant::VECTOR4:
 		case Variant::PACKED_VECTOR2_ARRAY:
 		case Variant::PACKED_VECTOR3_ARRAY:
 		case Variant::TRANSFORM2D:
 		case Variant::TRANSFORM3D:
+		case Variant::PROJECTION:
 		case Variant::QUATERNION:
 		case Variant::PLANE:
 		case Variant::BASIS:


### PR DESCRIPTION
Applies the same double-precision fixes found in #58205 to Vector4 & Projection, which were added after this fix was initially implemented