### PR TITLE
Fix C# ScriptManagerBridge duplicate key Type

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
@@ -20,7 +20,10 @@ public static partial class ScriptManagerBridge
             // TODO: What if this is called while unloading a load context, but after we already did cleanup in preparation for unloading?
 
             _scriptTypeMap.Add(scriptPtr, scriptType);
-            _typeScriptMap.Add(scriptType, scriptPtr);
+            
+            // Due to generic classes, more than one class can point to the same type, so
+            // there could be duplicate keys in this case. We only add a type as key once.
+            _typeScriptMap.TryAdd(scriptType, scriptPtr);
 
             if (AlcReloadCfg.IsAlcReloadingEnabled)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
@@ -20,7 +20,6 @@ public static partial class ScriptManagerBridge
             // TODO: What if this is called while unloading a load context, but after we already did cleanup in preparation for unloading?
 
             _scriptTypeMap.Add(scriptPtr, scriptType);
-            
             // Due to generic classes, more than one class can point to the same type, so
             // there could be duplicate keys in this case. We only add a type as key once.
             _typeScriptMap.TryAdd(scriptType, scriptPtr);


### PR DESCRIPTION
### Issue

This PR is related to fix #79519.

### Summary

When the same key is added in `ScriptManagerBridge`, throws an Exception and breaks Unload.

Here is a minimal project example with the issue: https://github.com/taylorhadden/godot-csharp-generic-assembly-reload-error

This PR only adds the key if not exist, fixing the problem but sometimes the `Missing class qualified name for reloading script` happens.

https://github.com/godotengine/godot/blob/b1371806ad3907c009458ea939bd4b810f9deb21/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs#L558

I didn't figure out how to prevent that message Error.
