### PR TITLE
C#: Parameterless constructors for Variant structs

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -819,7 +819,6 @@ namespace Godot
         /// <summary>
         /// The identity basis, with no rotation or scaling applied.
         /// This is used as a replacement for <c>Basis()</c> in GDScript.
-        /// Do not use <c>new Basis()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Back)</c>.</value>
         public static Basis Identity { get { return _identity; } }
@@ -838,6 +837,12 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Forward)</c>.</value>
         public static Basis FlipZ { get { return _flipZ; } }
+
+        /// <summary>
+        /// Constructs a <see cref="Basis"/> set to <see langword="default"/>.
+        /// </summary>
+        /// <remarks>For the GDScript equivalent of <c>Basis()</c>, use <see cref="Identity"/> instead.</remarks>
+        public Basis() => this = default;
 
         /// <summary>
         /// Constructs a pure rotation basis matrix from the given quaternion.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -525,6 +525,12 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a <see cref="Color"/> set to <see langword="default"/>.
+        /// </summary>
+        /// <remarks>For the GDScript equivalent of <c>Color()</c>, use <see cref="Colors.Black"/> instead.</remarks>
+        public Color() => this = default;
+
+        /// <summary>
         /// Constructs a <see cref="Color"/> from RGBA values, typically on the range of 0 to 1.
         /// </summary>
         /// <param name="r">The color's red component, typically on the range of 0 to 1.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -821,10 +821,15 @@ namespace Godot
         /// <summary>
         /// The identity projection, with no distortion applied.
         /// This is used as a replacement for <c>Projection()</c> in GDScript.
-        /// Do not use <c>new Projection()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Projection(new Vector4(1, 0, 0, 0), new Vector4(0, 1, 0, 0), new Vector4(0, 0, 1, 0), new Vector4(0, 0, 0, 1))</c>.</value>
         public static Projection Identity { get { return _identity; } }
+
+        /// <summary>
+        /// Constructs a <see cref="Projection"/> set to <see langword="default"/>.
+        /// </summary>
+        /// <remarks>For the GDScript equivalent of <c>Projection()</c>, use <see cref="Identity"/> instead.</remarks>
+        public Projection() => this = default;
 
         /// <summary>
         /// Constructs a projection from 4 vectors (matrix columns).

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -488,9 +488,16 @@ namespace Godot
         /// The identity quaternion, representing no rotation.
         /// Equivalent to an identity <see cref="Basis"/> matrix. If a vector is transformed by
         /// an identity quaternion, it will not change.
+        /// This is used as a replacement for <c>Quaternion()</c> in GDScript.
         /// </summary>
         /// <value>Equivalent to <c>new Quaternion(0, 0, 0, 1)</c>.</value>
         public static Quaternion Identity { get { return _identity; } }
+
+        /// <summary>
+        /// Constructs a <see cref="Quaternion"/> set to <see langword="default"/>.
+        /// </summary>
+        /// <remarks>For the GDScript equivalent of <c>Quaternion()</c>, use <see cref="Identity"/> instead.</remarks>
+        public Quaternion() => this = default;
 
         /// <summary>
         /// Constructs a <see cref="Quaternion"/> defined by the given values.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -363,7 +363,6 @@ namespace Godot
         /// <summary>
         /// The identity transform, with no translation, rotation, or scaling applied.
         /// This is used as a replacement for <c>Transform2D()</c> in GDScript.
-        /// Do not use <c>new Transform2D()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Down, Vector2.Zero)</c>.</value>
         public static Transform2D Identity { get { return _identity; } }
@@ -377,6 +376,12 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Up, Vector2.Zero)</c>.</value>
         public static Transform2D FlipY { get { return _flipY; } }
+
+        /// <summary>
+        /// Constructs a <see cref="Transform2D"/> set to <see langword="default"/>.
+        /// </summary>
+        /// <remarks>For the GDScript equivalent of <c>Transform2D()</c>, use <see cref="Identity"/> instead.</remarks>
+        public Transform2D() => this = default;
 
         /// <summary>
         /// Constructs a transformation matrix from 3 vectors (matrix columns).

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -304,7 +304,6 @@ namespace Godot
         /// <summary>
         /// The identity transform, with no translation, rotation, or scaling applied.
         /// This is used as a replacement for <c>Transform()</c> in GDScript.
-        /// Do not use <c>new Transform()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Back, Vector3.Zero)</c>.</value>
         public static Transform3D Identity { get { return _identity; } }
@@ -323,6 +322,12 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Forward, Vector3.Zero)</c>.</value>
         public static Transform3D FlipZ { get { return _flipZ; } }
+
+        /// <summary>
+        /// Constructs a <see cref="Transform3D"/> set to <see langword="default"/>.
+        /// </summary>
+        /// <remarks>For the GDScript equivalent of <c>Transform()</c>, use <see cref="Identity"/> instead.</remarks>
+        public Transform3D() => this = default;
 
         /// <summary>
         /// Constructs a transformation matrix from 4 vectors (matrix columns).


### PR DESCRIPTION
Currently, it's documented that one of the differences between GDScript and C# is that certain struct types [shouldn't use their constructors](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_differences.html#basis), instead opting for static readonly equivalents. This was because, at the time of writing, it was impossible for C# to define a parameterless constructor for a struct. However, starting with .NET6 (C#10), we now have that functionality!
<details>
<summary>Old implementation</summary>

This PR provides parity with GDScript by assigning parameterless constructors to the 6 problem types, setting their values to the GDScript equivalents. Theoretically, this shouldn't break compatability, as it's already suggested by the documentation to always avoid these constructors. However, in the case that a zeroed-value is what's desired, the docstrings mention the [relevant C#10 specification](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/parameterless-struct-constructors#default-expression) where providing `default` results in exactly that. The one area where parity is arguable is fields, as their implicit value is `default` rather than `new()`; but in a C# context this is expected behavior (mirrors reference types and nullable value types being null, their default, implicitly)

---
Input:
```cs
GD.Print(new Color());
GD.Print((Color)default);
GD.Print(new Quaternion());
GD.Print((Quaternion)default);
GD.Print(new Transform2D());
GD.Print((Transform2D)default);
GD.Print(new Transform3D());
GD.Print((Transform3D)default);
GD.Print(new Basis());
GD.Print((Basis)default);
GD.Print(new Projection());
GD.Print((Projection)default);
```

Output:
```
(0, 0, 0, 1)
(0, 0, 0, 0)
(0, 0, 0, 1)
(0, 0, 0, 0)
[X: (1, 0), Y: (0, 1), O: (0, 0)]
[X: (0, 0), Y: (0, 0), O: (0, 0)]
[X: (1, 0, 0), Y: (0, 1, 0), Z: (0, 0, 1), O: (0, 0, 0)]
[X: (0, 0, 0), Y: (0, 0, 0), Z: (0, 0, 0), O: (0, 0, 0)]
[X: (1, 0, 0), Y: (0, 1, 0), Z: (0, 0, 1)]
[X: (0, 0, 0), Y: (0, 0, 0), Z: (0, 0, 0)]
1, 0, 0, 0
0, 1, 0, 0
0, 0, 1, 0
0, 0, 0, 1

0, 0, 0, 0
0, 0, 0, 0
0, 0, 0, 0
0, 0, 0, 0
```
</details>

**EDIT:** Change of plans. The parameterless constructor will instead be used as a means of adding further documentation. It'll remain functionally identical to `default`, but with an added note on how to emulate GDScript behavior if used as a constructor. Also removes the portion of documentation that explicitly discourages a plain constructor