### PR TITLE
CI: Remove kisak mesa PPA, setup fails sporadically

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -87,14 +87,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Need newer mesa for lavapipe to work properly.
-      - name: Linux dependencies for tests
-        if: ${{ matrix.proj-test }}
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo add-apt-repository ppa:kisak/turtle
-          sudo apt-get install -qq mesa-vulkan-drivers
-
       - name: Free disk space on runner
         run: |
           echo "Disk usage before:" && df -h


### PR DESCRIPTION
Let's see if our tests can now pass with Ubuntu 20.04's Mesa.
If not, we'll have to find another solution to upgrade Mesa (or move the build with Vulkan/GLES3 tests to Ubuntu 22.04).

Follow-up to #83147, which didn't help.

GitHub bug report: https://github.com/orgs/community/discussions/69720