### PR TITLE
Project Manager: Open project when "Enter" is pressed when the search box is focused

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2731,6 +2731,14 @@ void ProjectManager::_on_search_term_changed(const String &p_term) {
 	_update_project_buttons();
 }
 
+void ProjectManager::_on_search_term_submitted(const String &p_text) {
+	if (tabs->get_current_tab() != 0) {
+		return;
+	}
+
+	_open_selected_projects_ask();
+}
+
 void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_update_project_buttons", &ProjectManager::_update_project_buttons);
 	ClassDB::bind_method("_version_button_pressed", &ProjectManager::_version_button_pressed);
@@ -2899,6 +2907,7 @@ ProjectManager::ProjectManager() {
 		search_box->set_tooltip_text(TTR("This field filters projects by name and last path component.\nTo filter projects by name and full path, the query must contain at least one `/` character."));
 		search_box->set_clear_button_enabled(true);
 		search_box->connect("text_changed", callable_mp(this, &ProjectManager::_on_search_term_changed));
+		search_box->connect("text_submitted", callable_mp(this, &ProjectManager::_on_search_term_submitted));
 		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		hb->add_child(search_box);
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -440,6 +440,7 @@ class ProjectManager : public Control {
 	void _on_order_option_changed(int p_idx);
 	void _on_tab_changed(int p_tab);
 	void _on_search_term_changed(const String &p_term);
+	void _on_search_term_submitted(const String &p_text);
 
 	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);
 	static Ref<Texture2D> _file_dialog_get_thumbnail(const String &p_path);


### PR DESCRIPTION
In the project manager, when the Search Box is focused, the `Key::Enter` event is not being handled by `ProjectManager::shortcut_input`. So added a dedicated handler for the search box with the signal `gui_input`. Now when Enter is pressed, the highlighted project is opened.

Fixes and closes #73768. 
