### PR TITLE
CI: Workaround recently broken add-apt-repository on GHA

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -92,7 +92,8 @@ jobs:
         if: ${{ matrix.proj-test }}
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo add-apt-repository ppa:kisak/turtle
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB8B81E14DA65431D7504EA8F63F0F2B90935439
+          sudo add-apt-repository "deb https://ppa.launchpadcontent.net/kisak/turtle/ubuntu focal main"
           sudo apt-get install -qq mesa-vulkan-drivers
 
       - name: Free disk space on runner


### PR DESCRIPTION
Hopefully adding the sources manually still works.

Follow-up to https://github.com/godotengine/godot/pull/83147, which didn't help.

Another attempt at working around https://github.com/orgs/community/discussions/69720.