### PR TITLE
Code Editor: Fix regression with using doc comments for code regions

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -907,6 +907,8 @@ void GDScriptSyntaxHighlighter::add_color_region(const String &p_start_key, cons
 		ERR_FAIL_COND_MSG(color_regions[i].start_key == p_start_key, "color region with start key '" + p_start_key + "' already exists.");
 		if (p_start_key.length() < color_regions[i].start_key.length()) {
 			at++;
+		} else {
+			break;
 		}
 	}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2862,7 +2862,8 @@ void CodeEdit::_update_code_region_tags() {
 		return;
 	}
 
-	for (int i = 0; i < delimiters.size(); i++) {
+	// A shorter delimiter has higher priority.
+	for (int i = delimiters.size() - 1; i >= 0; i--) {
 		if (delimiters[i].type != DelimiterType::TYPE_COMMENT) {
 			continue;
 		}
@@ -3104,6 +3105,8 @@ void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key
 		ERR_FAIL_COND_MSG(delimiters[i].start_key == p_start_key, "delimiter with start key '" + p_start_key + "' already exists.");
 		if (p_start_key.length() < delimiters[i].start_key.length()) {
 			at++;
+		} else {
+			break;
 		}
 	}
 

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2944,15 +2944,15 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		CHECK(code_edit->is_line_code_region_end(2));
 
 		// Update code region delimiter when removing comment delimiter.
-		code_edit->set_text("//region region_name\nline2\n//endregion\n#region region_name\nline2\n#endregion");
+		code_edit->set_text("#region region_name\nline2\n#endregion\n//region region_name\nline2\n//endregion");
 		code_edit->clear_comment_delimiters();
 		code_edit->add_comment_delimiter("//", "");
-		code_edit->add_comment_delimiter("#", "");
+		code_edit->add_comment_delimiter("#", ""); // A shorter delimiter has higher priority.
 		CHECK(code_edit->is_line_code_region_start(0));
 		CHECK(code_edit->is_line_code_region_end(2));
 		CHECK_FALSE(code_edit->is_line_code_region_start(3));
 		CHECK_FALSE(code_edit->is_line_code_region_end(5));
-		code_edit->remove_comment_delimiter("//");
+		code_edit->remove_comment_delimiter("#");
 		CHECK_FALSE(code_edit->is_line_code_region_start(0));
 		CHECK_FALSE(code_edit->is_line_code_region_end(2));
 		CHECK(code_edit->is_line_code_region_start(3));


### PR DESCRIPTION
* #74843 implemented support for code regions like:

```gdscript
#region New Code Region
<code>
#endregion
```

* However, after merge #72751 this changed to:

```gdscript
##region New Code Region
<code>
##endregion
```

This is bad because `##` is used for doc comments.

The reason of the regression is that the code editor selects the first comment delimiter, and the delimiter are sorted internally in descending order of delimiter length. I'm guessing the sorting was implemented incorrectly and was originally intended to be in ascending length order.

**Addition order:** `", ', """, ''', #, ##`

**Storage order (before):** `''', """, ##, #, ', "`

<details>
<summary>Sorting</summary>

```
"
', "
""", ', "
''', """, ', "
''', """, #, ', "
''', """, ##, #, ', "
```

</details>


~**Storage order (after):** `", ', #, ##, """, '''`~

<details>
<summary>Sorting</summary>

```
"
", '
", ', """
", ', """, '''
", ', #, """, '''
", ', #, ##, """, '''
```

</details>

~After changing the sorting, the regression is fixed, the shortest comment delimiter is selected for the region, I see a lot of sense in this. I didn't notice any other regressions due to this change.~

~I also fixed the sorting in a similar highlighter code (originally copied from the code editor).~