### PR TITLE
[.NET] Fix serialization of delegates capturing variables

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -207,7 +207,7 @@ namespace Godot
 
                             foreach (FieldInfo field in fields)
                             {
-                                Type fieldType = field.GetType();
+                                Type fieldType = field.FieldType;
 
                                 Variant.Type variantType = GD.TypeToVariantType(fieldType);
 
@@ -216,7 +216,7 @@ namespace Godot
 
                                 static byte[] VarToBytes(in godot_variant var)
                                 {
-                                    NativeFuncs.godotsharp_var_to_bytes(var, false.ToGodotBool(), out var varBytes);
+                                    NativeFuncs.godotsharp_var_to_bytes(var, godot_bool.True, out var varBytes);
                                     using (varBytes)
                                         return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
                                 }
@@ -483,7 +483,7 @@ namespace Godot
 
                             if (fieldInfo != null)
                             {
-                                var variantValue = GD.BytesToVar(valueBuffer);
+                                var variantValue = GD.BytesToVarWithObjects(valueBuffer);
                                 object? managedValue = RuntimeTypeConversionHelper.ConvertToObjectOfType(
                                     (godot_variant)variantValue.NativeVar, fieldInfo.FieldType);
                                 fieldInfo.SetValue(recreatedTarget, managedValue);
@@ -799,7 +799,7 @@ namespace Godot
                     return func(variant);
 
                 if (typeof(GodotObject).IsAssignableFrom(type))
-                    return Convert.ChangeType(VariantUtils.ConvertTo<GodotObject>(variant), type, CultureInfo.InvariantCulture);
+                    return VariantUtils.ConvertTo<GodotObject>(variant);
 
                 if (typeof(GodotObject[]).IsAssignableFrom(type))
                 {
@@ -818,7 +818,7 @@ namespace Godot
                     }
 
                     using var godotArray = NativeFuncs.godotsharp_variant_as_array(variant);
-                    return Convert.ChangeType(ConvertToSystemArrayOfGodotObject(godotArray, type), type, CultureInfo.InvariantCulture);
+                    return ConvertToSystemArrayOfGodotObject(godotArray, type);
                 }
 
                 if (type.IsEnum)


### PR DESCRIPTION
WIP fix for #81903.

Let's use a similar example to the one described in the issue.  

```cs
[Tool]
public partial class Scene : VBoxContainer
{
    public override void _Ready()
    {
        for (var i = 0; i < 4; ++i)
        {
            var button = new Button { Text = $"Click me!" };

            var buttonIndex = i;

            // Case 1
            button.Connect(Button.SignalName.Pressed, Callable.From(() => GD.Print($"Button #{buttonIndex} was clicked!"));
            // Case 2
            button.Connect(Button.SignalName.Pressed, Callable.From(() => WhenButtonClicked(buttonIndex)));

            AddChild(button);
        }
    }

    private void WhenButtonClicked(int buttonIndex)
    {
        GD.Print($"Button #{buttonIndex} was clicked!");
    }
}
```

As of right now, this PR completely fixes case 1 (crudely: captured variables aren't `GodotObject`).  

On my way to fixing case 2 (here, we also capture `this`). I had to switch the serialization and call `godotsharp_var_to_bytes()` with `p_full_objects = true`. I'm not entirely sure about it, there might be security concerns? Everything now serializes fine (and thus, is properly unloaded). But once we try to deserialize the delegate back, `this` (in the example above) is considered as a `VBoxContainer` instead of the actual concrete class, resulting in an `ArgumentException` when we try to use its value. I kinda imagine it's because of the script being unloaded in between, but I can't really think of any good/simple solution here.

Hoping for someone to have a stroke of genius, or to rubber duck me in the right direction ❤️ 

I've also been wondering on and off if serializing these when reloading is actually something we want to do in this case.

- _Bugsquad edit, closes: https://github.com/godotengine/godot/issues/81903_