### PR TITLE
GDScript: Highlight code region comments

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -39,6 +39,15 @@ class GDScriptSyntaxHighlighter : public EditorSyntaxHighlighter {
 
 private:
 	struct ColorRegion {
+		enum Type {
+			TYPE_NONE,
+			TYPE_STRING, // `"` and `'`, optional prefix `&`, `^`, or `r`.
+			TYPE_MULTILINE_STRING, // `"""` and `'''`, optional prefix `r`.
+			TYPE_COMMENT, // `#` and `##`.
+			TYPE_CODE_REGION, // `#region` and `#endregion`.
+		};
+
+		Type type = TYPE_NONE;
 		Color color;
 		String start_key;
 		String end_key;
@@ -94,7 +103,7 @@ private:
 	Color comment_marker_colors[COMMENT_MARKER_MAX];
 	HashMap<String, CommentMarkerLevel> comment_markers;
 
-	void add_color_region(const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false);
+	void add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false);
 
 public:
 	virtual void _update_cache() override;


### PR DESCRIPTION
![](https://github.com/godotengine/godot/assets/47700418/89243794-3f67-48ff-942a-f6db20235136)

Also optimizes color region type checking by using an enum instead of string comparison.