### PR TITLE
Add a setting to disable import hints from scene importer

### DIFF
--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -62,6 +62,9 @@
 		<member name="nodes/root_type" type="String" setter="" getter="" default="&quot;&quot;">
 			Override for the root node type. If empty, the root node will use what the scene specifies, or [Node3D] if the scene does not specify a root type. Using a node type that inherits from [Node3D] is recommended. Otherwise, you'll lose the ability to position the node directly in the 3D editor.
 		</member>
+		<member name="nodes/use_node_type_customization" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables the use of node type customization. Disable when automatic transformations based on naming conventions are not desired. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.html]ImportNode type customization using name suffixes[/url] for more information.
+		</member>
 		<member name="skins/use_named_skins" type="bool" setter="" getter="" default="true">
 			If checked, use named [Skin]s for animation. The [MeshInstance3D] node contains 3 properties of relevance here: a skeleton [NodePath] pointing to the [Skeleton3D] node (usually [code]..[/code]), a mesh, and a skin:
 			- The [Skeleton3D] node contains a list of bones with names, their pose and rest, a name and a parent bone.

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1930,6 +1930,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/apply_root_scale"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/use_node_type_customization"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/ensure_tangents"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/generate_lods"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/create_shadow_meshes"), true));
@@ -2386,7 +2387,9 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 
 	HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> collision_map;
 	List<Pair<NodePath, Node *>> node_renames;
-	_pre_fix_node(scene, scene, collision_map, nullptr, node_renames);
+	if (p_options["nodes/use_node_type_customization"]) {
+		_pre_fix_node(scene, scene, collision_map, nullptr, node_renames);
+	}
 
 	return scene;
 }
@@ -2489,7 +2492,9 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	Pair<PackedVector3Array, PackedInt32Array> occluder_arrays;
 	List<Pair<NodePath, Node *>> node_renames;
 
-	_pre_fix_node(scene, scene, collision_map, &occluder_arrays, node_renames);
+	if (p_options["nodes/use_node_type_customization"]) {
+		_pre_fix_node(scene, scene, collision_map, &occluder_arrays, node_renames);
+	}
 
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
 		post_importer_plugins.write[i]->pre_process(scene, p_options);


### PR DESCRIPTION
In certain cases, import hints may not be desired for use in a project. In our case, we had existing model files, one of which contained an object ending in "_Wheel". This automatically turns the node into a vehicle wheel, which is not desired behavior. As it stands, it's impossible to disable this functionality. The only fix would be to modify the source model and rename the object, which is not always easy to do, or desired.

This pull request adds a simple setting to disable import hints for the Scene importer.