### PR TITLE
Fix Basis `is_orthogonal` and `is_rotation` methods, add `is_orthonormal`

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -89,13 +89,26 @@ Basis Basis::orthogonalized() const {
 	return c;
 }
 
+// Returns true if the basis vectors are orthogonal (perpendicular), so it has no skew or shear, and can be decomposed into rotation and scale.
+// See https://en.wikipedia.org/wiki/Orthogonal_basis
 bool Basis::is_orthogonal() const {
-	Basis identity;
-	Basis m = (*this) * transposed();
-
-	return m.is_equal_approx(identity);
+	const Vector3 x = get_column(0);
+	const Vector3 y = get_column(1);
+	const Vector3 z = get_column(2);
+	return Math::is_zero_approx(x.dot(y)) && Math::is_zero_approx(x.dot(z)) && Math::is_zero_approx(y.dot(z));
 }
 
+// Returns true if the basis vectors are orthonormal (orthogonal and normalized), so it has no scale, skew, or shear.
+// See https://en.wikipedia.org/wiki/Orthonormal_basis
+bool Basis::is_orthonormal() const {
+	const Vector3 x = get_column(0);
+	const Vector3 y = get_column(1);
+	const Vector3 z = get_column(2);
+	return Math::is_equal_approx(x.length_squared(), 1) && Math::is_equal_approx(y.length_squared(), 1) && Math::is_equal_approx(z.length_squared(), 1) && Math::is_zero_approx(x.dot(y)) && Math::is_zero_approx(x.dot(z)) && Math::is_zero_approx(y.dot(z));
+}
+
+// Returns true if the basis is conformal (orthogonal, uniform scale, preserves angles and distance ratios).
+// See https://en.wikipedia.org/wiki/Conformal_linear_transformation
 bool Basis::is_conformal() const {
 	const Vector3 x = get_column(0);
 	const Vector3 y = get_column(1);
@@ -104,6 +117,7 @@ bool Basis::is_conformal() const {
 	return Math::is_equal_approx(x_len_sq, y.length_squared()) && Math::is_equal_approx(x_len_sq, z.length_squared()) && Math::is_zero_approx(x.dot(y)) && Math::is_zero_approx(x.dot(z)) && Math::is_zero_approx(y.dot(z));
 }
 
+// Returns true if the basis only has diagonal elements, so it may only have scale or flip, but no rotation, skew, or shear.
 bool Basis::is_diagonal() const {
 	return (
 			Math::is_zero_approx(rows[0][1]) && Math::is_zero_approx(rows[0][2]) &&
@@ -111,8 +125,9 @@ bool Basis::is_diagonal() const {
 			Math::is_zero_approx(rows[2][0]) && Math::is_zero_approx(rows[2][1]));
 }
 
+// Returns true if the basis is a pure rotation matrix, so it has no scale, skew, shear, or flip.
 bool Basis::is_rotation() const {
-	return Math::is_equal_approx(determinant(), 1, (real_t)UNIT_EPSILON) && is_orthogonal();
+	return is_conformal() && Math::is_equal_approx(determinant(), 1, (real_t)UNIT_EPSILON);
 }
 
 #ifdef MATH_CHECKS

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -138,6 +138,7 @@ struct _NO_DISCARD_ Basis {
 	_FORCE_INLINE_ Basis operator*(const real_t p_val) const;
 
 	bool is_orthogonal() const;
+	bool is_orthonormal() const;
 	bool is_conformal() const;
 	bool is_diagonal() const;
 	bool is_rotation() const;

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -324,6 +324,100 @@ TEST_CASE("[Basis] Is conformal checks") {
 	CHECK_FALSE_MESSAGE(
 			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_conformal(),
 			"Basis with the X axis skewed 45 degrees should not be conformal.");
+
+	CHECK_MESSAGE(
+			Basis(0, 0, 0, 0, 0, 0, 0, 0, 0).is_conformal(),
+			"Edge case: Basis with all zeroes should return true for is_conformal (because a 0 scale is uniform).");
+}
+
+TEST_CASE("[Basis] Is orthogonal checks") {
+	CHECK_MESSAGE(
+			Basis().is_orthogonal(),
+			"Identity Basis should be orthogonal.");
+
+	CHECK_MESSAGE(
+			Basis::from_euler(Vector3(1.2, 3.4, 5.6)).is_orthogonal(),
+			"Basis with only rotation should be orthogonal.");
+
+	CHECK_MESSAGE(
+			Basis::from_scale(Vector3(-1, -1, -1)).is_orthogonal(),
+			"Basis with only a flip should be orthogonal.");
+
+	CHECK_MESSAGE(
+			Basis::from_scale(Vector3(1.2, 3.4, 5.6)).is_orthogonal(),
+			"Basis with only scale should be orthogonal.");
+
+	CHECK_MESSAGE(
+			Basis(Vector3(3, 4, 0), Vector3(4, -3, 0), Vector3(0, 0, 5)).is_orthogonal(),
+			"Basis with a flip, rotation, and uniform scale should be orthogonal.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_orthogonal(),
+			"Basis with the X axis skewed 45 degrees should not be orthogonal.");
+
+	CHECK_MESSAGE(
+			Basis(0, 0, 0, 0, 0, 0, 0, 0, 0).is_orthogonal(),
+			"Edge case: Basis with all zeroes should return true for is_orthogonal, since zero vectors are orthogonal to all vectors.");
+}
+
+TEST_CASE("[Basis] Is orthonormal checks") {
+	CHECK_MESSAGE(
+			Basis().is_orthonormal(),
+			"Identity Basis should be orthonormal.");
+
+	CHECK_MESSAGE(
+			Basis::from_euler(Vector3(1.2, 3.4, 5.6)).is_orthonormal(),
+			"Basis with only rotation should be orthonormal.");
+
+	CHECK_MESSAGE(
+			Basis::from_scale(Vector3(-1, -1, -1)).is_orthonormal(),
+			"Basis with only a flip should be orthonormal.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis::from_scale(Vector3(1.2, 3.4, 5.6)).is_orthonormal(),
+			"Basis with only scale should not be orthonormal.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(Vector3(3, 4, 0), Vector3(4, -3, 0), Vector3(0, 0, 5)).is_orthonormal(),
+			"Basis with a flip, rotation, and uniform scale should not be orthonormal.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_orthonormal(),
+			"Basis with the X axis skewed 45 degrees should not be orthonormal.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(0, 0, 0, 0, 0, 0, 0, 0, 0).is_orthonormal(),
+			"Edge case: Basis with all zeroes should return false for is_orthonormal, since the vectors do not have a length of 1.");
+}
+
+TEST_CASE("[Basis] Is rotation checks") {
+	CHECK_MESSAGE(
+			Basis().is_rotation(),
+			"Identity Basis should be a rotation (a rotation of zero).");
+
+	CHECK_MESSAGE(
+			Basis::from_euler(Vector3(1.2, 3.4, 5.6)).is_rotation(),
+			"Basis with only rotation should be a rotation.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis::from_scale(Vector3(-1, -1, -1)).is_rotation(),
+			"Basis with only a flip should not be a rotation.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis::from_scale(Vector3(1.2, 3.4, 5.6)).is_rotation(),
+			"Basis with only scale should not be a rotation.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(Vector3(2, 0, 0), Vector3(0, 0.5, 0), Vector3(0, 0, 1)).is_rotation(),
+			"Basis with a squeeze should not be a rotation.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(Vector3(Math_SQRT12, Math_SQRT12, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)).is_rotation(),
+			"Basis with the X axis skewed 45 degrees should not be a rotation.");
+
+	CHECK_FALSE_MESSAGE(
+			Basis(0, 0, 0, 0, 0, 0, 0, 0, 0).is_rotation(),
+			"Edge case: Basis with all zeroes should return false for is_rotation, because it is not just a rotation (has a scale of 0).");
 }
 
 } // namespace TestBasis


### PR DESCRIPTION
I noticed that the behavior of these methods was not correct for all inputs. This PR adds unit tests for these methods and fixes the methods. If desired, I could expose them and write docs too.

The `is_orthogonal` method was not working for scaled inputs. The new changes also greatly simplify the code, we only need 3 dot products to check if the Basis is orthogonal, because the dot product of orthogonal vectors is zero. Without these changes, these unit tests would fail:

```
./tests/core/math/test_basis.h:340: ERROR: CHECK( Basis::from_scale(Vector3(1.2, 3.4, 5.6)).is_orthogonal() ) is NOT correct!
  values: CHECK( false )
  logged: Basis with only scale should be orthogonal.

./tests/core/math/test_basis.h:348: ERROR: CHECK( Basis(Vector3(3, 4, 0), Vector3(4, -3, 0), Vector3(0, 0, 5)).is_orthogonal() ) is NOT correct!
  values: CHECK( false )
  logged: Basis with a flip, rotation, and uniform scale should be orthogonal.
```

The `is_rotation` method was not taking into account squeeze matrices (a special form of non-uniform scale where the volume is preserved but the scale changes). Admittedly this was an edge case, but still, now it's fixed. Without this fix, this unit test would fail:

```
./tests/core/math/test_basis.h:374: ERROR: CHECK_FALSE( Basis(Vector3(2, 0, 0), Vector3(0, 0.5, 0), Vector3(0, 0, 1)).is_rotation() ) is NOT correct!
  values: CHECK_FALSE( true )
  logged: Basis with a squeeze should not be a rotation.
```

If anyone is wondering, here is the truth table of the Basis validation methods as of this PR:

| Basis has...      | is_rotation | is_orthonormal | is_conformal | is_orthogonal | is_diagonal |
|-------------------|-------------|----------------|--------------|---------------|-------------|
| Rotation          | ✅ true      | ✅ true         | ✅ true       | ✅ true        | ❌ false     |
| Flip              | ❌ false     | ✅ true         | ✅ true       | ✅ true        | ✅ true      |
| Uniform Scale     | ❌ false     | ❌ false        | ✅ true       | ✅ true        | ✅ true      |
| Non-Uniform Scale | ❌ false     | ❌ false        | ❌ false      | ✅ true        | ✅ true      |
| Skew/Shear        | ❌ false     | ❌ false        | ❌ false      | ❌ false       | ❌ false     |
| Nothing/Identity  | ✅ true      | ✅ true         | ✅ true       | ✅ true        | ✅ true      |
