### PR TITLE
Fix missing editor singletons when dumping extension api

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2960,6 +2960,7 @@ bool Main::start() {
 	}
 
 	if (dump_extension_api) {
+		Engine::get_singleton()->set_editor_hint(true); // "extension_api.json" should always contains editor singletons.
 		GDExtensionAPIDump::generate_extension_json_file("extension_api.json", include_docs_in_extension_api_dump);
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fix missing editor singletons (`EditorInterface`) when dumping extension api after [#80962](https://github.com/godotengine/godot/pull/80962).