### PR TITLE
Swap TileMap and TileSet buttons

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -413,7 +413,9 @@ bool TileMapEditorPlugin::is_editor_visible() const {
 }
 
 TileMapEditorPlugin::TileMapEditorPlugin() {
-	memnew(TilesEditorUtils);
+	if (!TilesEditorUtils::get_singleton()) {
+		memnew(TilesEditorUtils);
+	}
 	tile_map_plugin_singleton = this;
 
 	editor = memnew(TileMapEditor);
@@ -462,7 +464,9 @@ ObjectID TileSetEditorPlugin::get_edited_tileset() const {
 }
 
 TileSetEditorPlugin::TileSetEditorPlugin() {
-	DEV_ASSERT(tile_map_plugin_singleton);
+	if (!TilesEditorUtils::get_singleton()) {
+		memnew(TilesEditorUtils);
+	}
 	tile_set_plugin_singleton = this;
 
 	editor = memnew(TileSetEditor);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -257,8 +257,8 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<Cast2DEditorPlugin>();
 	EditorPlugins::add_by_type<Skeleton2DEditorPlugin>();
 	EditorPlugins::add_by_type<Sprite2DEditorPlugin>();
-	EditorPlugins::add_by_type<TileMapEditorPlugin>();
 	EditorPlugins::add_by_type<TileSetEditorPlugin>();
+	EditorPlugins::add_by_type<TileMapEditorPlugin>();
 
 	// For correct doc generation.
 	GLOBAL_DEF("editor/run/main_run_args", "");


### PR DESCRIPTION
Closes #83228
I changed TilesEditorUtils to be initialized by the first editor that appears, so now they can be freely swapped.