### PR TITLE
C#: Fix lookup for singleton instance types.

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -280,7 +280,7 @@ namespace Godot.Bridge
             if (wrapperType != null && IsStatic(wrapperType))
             {
                 // A static class means this is a Godot singleton class. Try to get the Instance proxy type.
-                wrapperType = TypeGetProxyClass($"{nativeTypeNameStr}Instance");
+                wrapperType = TypeGetProxyClass($"{wrapperType.Name}Instance");
                 if (wrapperType == null)
                 {
                     // Otherwise, fallback to GodotObject.


### PR DESCRIPTION
Fixes #83237

Use `{ProxyName}Instance` to find correct types. (Like `ResourceUidInstance` instead of `ResourceUIDInstance`) 