### PR TITLE
Add optional warnings when accessing properties and methods whose name starts with an underscore from other scripts.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -445,6 +445,12 @@
 		<member name="debug/gdscript/warnings/confusable_local_usage" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an identifier that will be shadowed below in the block is used.
 		</member>
+		<member name="debug/gdscript/warnings/private_property_access" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when accessing a property whose name begins with an underscore from another script.
+		</member>
+		<member name="debug/gdscript/warnings/private_method_access" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when accessing a method whose name begins with an underscore from another script.
+		</member>
 		<member name="debug/gdscript/warnings/constant_used_as_function" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a constant is used as a function.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -445,12 +445,6 @@
 		<member name="debug/gdscript/warnings/confusable_local_usage" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an identifier that will be shadowed below in the block is used.
 		</member>
-		<member name="debug/gdscript/warnings/private_property_access" type="int" setter="" getter="" default="0">
-			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when accessing a property whose name begins with an underscore from another script.
-		</member>
-		<member name="debug/gdscript/warnings/private_method_access" type="int" setter="" getter="" default="0">
-			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when accessing a method whose name begins with an underscore from another script.
-		</member>
 		<member name="debug/gdscript/warnings/constant_used_as_function" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a constant is used as a function.
 		</member>
@@ -499,6 +493,12 @@
 		</member>
 		<member name="debug/gdscript/warnings/onready_with_export" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the [code]@onready[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.
+		</member>
+		<member name="debug/gdscript/warnings/private_method_access" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when accessing a method whose name begins with an underscore from another script.
+		</member>
+		<member name="debug/gdscript/warnings/private_property_access" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when accessing a property whose name begins with an underscore from another script.
 		</member>
 		<member name="debug/gdscript/warnings/property_used_as_function" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using a property as if it is a function.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3347,8 +3347,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			parser->push_warning(p_call, GDScriptWarning::STATIC_CALLED_ON_INSTANCE, p_call->function_name, caller_type);
 		}
 
-		if (String(p_call->function_name).begins_with("_")) {
-			parser->push_warning(p_call, GDScriptWarning::PRIVATE_METHOD_ACCESS, p_call->function_name);
+		if (!is_self && String(p_call->function_name).begins_with("_") && !method_flags.has_flag(METHOD_FLAG_STATIC)) {
+			parser->push_warning(p_call, GDScriptWarning::PRIVATE_METHOD_ACCESS, String(p_call->function_name));
 		}
 #endif // DEBUG_ENABLED
 
@@ -4226,7 +4226,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				p_subscript->is_constant = p_subscript->attribute->is_constant;
 				p_subscript->reduced_value = p_subscript->attribute->reduced_value;
 #ifdef DEBUG_ENABLED
-				if (String(p_subscript->attribute->name).begins_with("_")) {
+				if (p_subscript->base->type != GDScriptParser::Node::SELF && String(p_subscript->attribute->name).begins_with("_")) {
 					parser->push_warning(p_subscript, GDScriptWarning::PRIVATE_PROPERTY_ACCESS, p_subscript->attribute->name);
 				}
 #endif

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3347,7 +3347,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			parser->push_warning(p_call, GDScriptWarning::STATIC_CALLED_ON_INSTANCE, p_call->function_name, caller_type);
 		}
 
-		if (((String) p_call->function_name).begins_with("_")) {
+		if (String(p_call->function_name).begins_with("_")) {
 			parser->push_warning(p_call, GDScriptWarning::PRIVATE_METHOD_ACCESS, p_call->function_name);
 		}
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4221,6 +4221,11 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				result_type = attr_type;
 				p_subscript->is_constant = p_subscript->attribute->is_constant;
 				p_subscript->reduced_value = p_subscript->attribute->reduced_value;
+#ifdef DEBUG_ENABLED
+				if(((String) p_subscript->attribute->name).begins_with("_")) {
+					parser->push_warning(p_subscript, GDScriptWarning::PRIVATE_PROPERTY_ACCESS, p_subscript->attribute->name);
+				}
+#endif
 			} else if (!base_type.is_meta_type || !base_type.is_constant) {
 				valid = base_type.kind != GDScriptParser::DataType::BUILTIN;
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4226,7 +4226,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				p_subscript->is_constant = p_subscript->attribute->is_constant;
 				p_subscript->reduced_value = p_subscript->attribute->reduced_value;
 #ifdef DEBUG_ENABLED
-				if (((String) p_subscript->attribute->name).begins_with("_")) {
+				if (String(p_subscript->attribute->name).begins_with("_")) {
 					parser->push_warning(p_subscript, GDScriptWarning::PRIVATE_PROPERTY_ACCESS, p_subscript->attribute->name);
 				}
 #endif

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3346,6 +3346,10 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 			parser->push_warning(p_call, GDScriptWarning::STATIC_CALLED_ON_INSTANCE, p_call->function_name, caller_type);
 		}
+
+		if (((String) p_call->function_name).begins_with("_")) {
+			parser->push_warning(p_call, GDScriptWarning::PRIVATE_METHOD_ACCESS, p_call->function_name);
+		}
 #endif // DEBUG_ENABLED
 
 		call_type = return_type;
@@ -4222,7 +4226,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				p_subscript->is_constant = p_subscript->attribute->is_constant;
 				p_subscript->reduced_value = p_subscript->attribute->reduced_value;
 #ifdef DEBUG_ENABLED
-				if(((String) p_subscript->attribute->name).begins_with("_")) {
+				if (((String) p_subscript->attribute->name).begins_with("_")) {
 					parser->push_warning(p_subscript, GDScriptWarning::PRIVATE_PROPERTY_ACCESS, p_subscript->attribute->name);
 				}
 #endif

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -151,6 +151,12 @@ String GDScriptWarning::get_message() const {
 		case CONFUSABLE_LOCAL_USAGE:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The identifier "%s" will be shadowed below in the block.)", symbols[0]);
+		case PRIVATE_PROPERTY_ACCESS:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The property "%s" begins with an underscore and is considered by convention to be private)", symbols[0]);
+		case PRIVATE_METHOD_ACCESS:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The method "%s" begins with an underscore and is considered by convention to be private)", symbols[0]);
 		case INFERENCE_ON_VARIANT:
 			CHECK_SYMBOLS(1);
 			return vformat("The %s type is being inferred from a Variant value, so it will be typed as Variant.", symbols[0]);
@@ -232,6 +238,8 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"CONFUSABLE_IDENTIFIER",
 		"CONFUSABLE_LOCAL_DECLARATION",
 		"CONFUSABLE_LOCAL_USAGE",
+		"PRIVATE_PROPERTY_ACCESS",
+		"PRIVATE_METHOD_ACCESS",
 		"INFERENCE_ON_VARIANT",
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -87,6 +87,8 @@ public:
 		CONFUSABLE_IDENTIFIER, // The identifier contains misleading characters that can be confused. E.g. "usеr" (has Cyrillic "е" instead of Latin "e").
 		CONFUSABLE_LOCAL_DECLARATION, // The parent block declares an identifier with the same name below.
 		CONFUSABLE_LOCAL_USAGE, // The identifier will be shadowed below in the block.
+		PRIVATE_PROPERTY_ACCESS, // Accessing a property whose name begins with '_'.
+		PRIVATE_METHOD_ACCESS, // Accessing a method whose name begins with '_'.
 		INFERENCE_ON_VARIANT, // The declaration uses type inference but the value is typed as Variant.
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
@@ -136,6 +138,8 @@ public:
 		WARN, // CONFUSABLE_IDENTIFIER
 		WARN, // CONFUSABLE_LOCAL_DECLARATION
 		WARN, // CONFUSABLE_LOCAL_USAGE
+		IGNORE, // PRIVATE_PROPERTY_ACCESS
+		IGNORE, // PRIVATE_METHOD_ACCESS
 		ERROR, // INFERENCE_ON_VARIANT // Most likely done by accident, usually inference is trying for a particular type.
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_method_access.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_method_access.gd
@@ -1,0 +1,13 @@
+func test():
+    var instance := TestClass.new()
+    instance.public()
+    instance._private()
+
+
+class TestClass:
+
+    func public():
+        pass
+    
+    func _private():
+        pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_method_access.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_method_access.gd
@@ -1,13 +1,13 @@
 func test():
-    var instance := TestClass.new()
-    instance.public()
-    instance._private()
+	var instance := TestClass.new()
+	instance.public()
+	instance._private()
 
 
 class TestClass:
 
-    func public():
-        pass
-    
-    func _private():
-        pass
+	func public():
+		pass
+
+	func _private():
+		pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_method_access.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_method_access.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+>> WARNING
+>> Line: 4
+>> PRIVATE_METHOD_ACCESS
+>> The method "_private" begins with an underscore and is considered by convention to be private

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_property_access.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_property_access.gd
@@ -1,0 +1,10 @@
+func test():
+    var instance := TestClass.new()
+    instance.public += 1
+    instance._private += 1
+
+
+class TestClass:
+
+    var public := 1
+    var _private := 1

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_property_access.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_property_access.gd
@@ -1,10 +1,10 @@
 func test():
-    var instance := TestClass.new()
-    instance.public += 1
-    instance._private += 1
+	var instance := TestClass.new()
+	instance.public += 1
+	instance._private += 1
 
 
 class TestClass:
 
-    var public := 1
-    var _private := 1
+	var public := 1
+	var _private := 1

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_property_access.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_property_access.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+>> WARNING
+>> Line: 4
+>> PRIVATE_PROPERTY_ACCESS
+>> The property "_private" begins with an underscore and is considered by convention to be private


### PR DESCRIPTION
Whether GDScript should have access modifiers or not is a matter that has been discussed for a long time. Up to now, the convention has been to use identifier names starting with an underscore for private variables and functions, so I suggest to implement an optional warning (ignored by default) that triggers when an attribute or method whose name starts with an underscore is accessed from another script.

For example, this will trigger the warning:
```gdscript
class_name MyScript
extends Node

var _private: int = 1

func _private_func():
    pass
```
```gdscript
extends Node

@onready var _my_script: MyScript = $MyScript

func _ready():
    _my_script._private += 1
    _my_script._private_func()
```

I believe this should help to enforce the convention.

I should also mention that accessing the same variables and function from a child script will not trigger the warning, so technically they wouldn't be private, but protected. For example, this will not trigger the warning.

```gdscript
class_name OtherScript
extends MyScript

func _ready():
    _private += 1
    _private_func()
```

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8095*