### PR TITLE
Fix OpenGL directional shadow last split fading

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1615,7 +1615,6 @@ void main() {
 	float directional_shadow = 1.0;
 
 	if (depth_z < light_split_offsets.y) {
-		float pssm_fade = 0.0;
 
 #ifdef LIGHT_USE_PSSM_BLEND
 		float directional_shadow2 = 1.0;
@@ -1623,7 +1622,6 @@ void main() {
 		bool use_blend = true;
 #endif
 		if (depth_z < light_split_offsets.x) {
-			float pssm_fade = 0.0;
 			directional_shadow = shadow1;
 
 #ifdef LIGHT_USE_PSSM_BLEND
@@ -1632,7 +1630,6 @@ void main() {
 #endif
 		} else {
 			directional_shadow = shadow2;
-			pssm_fade = smoothstep(light_split_offsets.x, light_split_offsets.y, depth_z);
 #ifdef LIGHT_USE_PSSM_BLEND
 			use_blend = false;
 #endif
@@ -1642,7 +1639,6 @@ void main() {
 			directional_shadow = mix(directional_shadow, directional_shadow2, pssm_blend);
 		}
 #endif
-		directional_shadow = mix(directional_shadow, 1.0, pssm_fade);
 	}
 
 #endif //LIGHT_USE_PSSM2
@@ -1658,7 +1654,6 @@ void main() {
 	float directional_shadow = 1.0;
 
 	if (depth_z < light_split_offsets.w) {
-		float pssm_fade = 0.0;
 
 #ifdef LIGHT_USE_PSSM_BLEND
 		float directional_shadow2 = 1.0;
@@ -1694,7 +1689,6 @@ void main() {
 
 			} else {
 				directional_shadow = shadow4;
-				pssm_fade = smoothstep(light_split_offsets.z, light_split_offsets.w, depth_z);
 
 #if defined(LIGHT_USE_PSSM_BLEND)
 				use_blend = false;
@@ -1706,7 +1700,6 @@ void main() {
 			directional_shadow = mix(directional_shadow, directional_shadow2, pssm_blend);
 		}
 #endif
-		directional_shadow = mix(directional_shadow, 1.0, pssm_fade);
 	}
 
 #endif //LIGHT_USE_PSSM4


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes https://github.com/godotengine/godot/issues/82505

I have no ideas what pssm fade was ment to do, however based on the shader code my guess is that it was an attempt to apply the fading controlled by fade start that got scrapped halfway through the implementation and replaced with a proper implementation, given that I cannot see anything of the sort in the Vulkan Renderer to indicate some other specific feature.