### PR TITLE
Improve split blending logic for OpenGL

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1628,7 +1628,7 @@ void main() {
 
 #ifdef LIGHT_USE_PSSM_BLEND
 			directional_shadow2 = shadow2;
-			pssm_blend = smoothstep(0.0, light_split_offsets.x, depth_z);
+			pssm_blend = smoothstep(light_split_offsets.x - light_split_offsets.x * 0.1, light_split_offsets.x, depth_z);
 #endif
 		} else {
 			directional_shadow = shadow2;
@@ -1672,7 +1672,7 @@ void main() {
 #ifdef LIGHT_USE_PSSM_BLEND
 				directional_shadow2 = shadow2;
 
-				pssm_blend = smoothstep(0.0, light_split_offsets.x, depth_z);
+				pssm_blend = smoothstep(light_split_offsets.x - light_split_offsets.x * 0.1, light_split_offsets.x, depth_z);
 #endif
 			} else {
 				directional_shadow = shadow2;
@@ -1680,7 +1680,7 @@ void main() {
 #ifdef LIGHT_USE_PSSM_BLEND
 				directional_shadow2 = shadow3;
 
-				pssm_blend = smoothstep(light_split_offsets.x, light_split_offsets.y, depth_z);
+				pssm_blend = smoothstep(light_split_offsets.y - light_split_offsets.y * 0.1, light_split_offsets.y, depth_z);
 #endif
 			}
 		} else {
@@ -1689,7 +1689,7 @@ void main() {
 
 #if defined(LIGHT_USE_PSSM_BLEND)
 				directional_shadow2 = shadow4;
-				pssm_blend = smoothstep(light_split_offsets.y, light_split_offsets.z, depth_z);
+				pssm_blend = smoothstep(light_split_offsets.z - light_split_offsets.z * 0.1, light_split_offsets.z, depth_z);
 #endif
 
 			} else {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
OpenGL version of https://github.com/godotengine/godot/pull/82668

I've made this a separate PR as I don't know what if there might be reasons not to accept this into the compatibility renderer (though I personally don't see why not) while accepting it for the Vulkan renderers.