### PR TITLE
Remove unnecessary include in `GDScriptWorkspace`

### DIFF
--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -31,7 +31,6 @@
 #include "gdscript_workspace.h"
 
 #include "../gdscript.h"
-#include "../gdscript_parser.h"
 #include "gdscript_language_protocol.h"
 
 #include "core/config/project_settings.h"

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -31,7 +31,6 @@
 #ifndef GDSCRIPT_WORKSPACE_H
 #define GDSCRIPT_WORKSPACE_H
 
-#include "../gdscript_parser.h"
 #include "gdscript_extend_parser.h"
 #include "godot_lsp.h"
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The ``gdscript_parser.h`` is already included inside ``gdscript_extend_parser.h`` so no need to include it multiple times.
