### PR TITLE
gdextension: fixes double loading of gdextension followed by usage of destroyed object after each hot-reloading

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -37,7 +37,6 @@
 #include "core/version.h"
 #include "gdextension_manager.h"
 
-
 extern void gdextension_setup_interface();
 extern GDExtensionInterfaceFunctionPtr gdextension_get_proc_address(const char *p_name);
 
@@ -951,14 +950,12 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 }
 
 Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
-
 	GDExtensionManager *manager = GDExtensionManager::get_singleton();
 	Ref<GDExtension> maybe_lib = manager->get_extension(p_path);
 
 	const bool must_load = maybe_lib.is_null() || (maybe_lib->is_reloadable() && maybe_lib->has_library_changed());
 
-	if (must_load)
-	{
+	if (must_load) {
 		Ref<GDExtension> lib;
 		Error err = load_gdextension_resource(p_path, lib);
 		if (err != OK && r_error) {


### PR DESCRIPTION
This is a "hotfix" for a bug I tracked, **I believe this is not the right solution but I need guidance** to reach a more reasonable solution.  After debugging the issue I found the reason but I am not knowledgeable about Godot's architecture so I just hacked something that makes sense that does fix the issue for me, at least for that bug. That's why I'm setting this as a Draft for now.

## The Problem

Context: 
```
Godot v4.2.beta1 - Windows 10.0.22621 - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 3080 Ti (NVIDIA; 31.0.15.1694) - AMD Ryzen 9 5900X 12-Core Processor (24 Threads)
```

I found random problems happening after hot-reloading my GDExtension. The second time I hot-reload I would find errors like this:
```
Attempt to unregister unexisting extension class 'GDExample'.
Attempt to register extension class 'GDExample', which appears to be already registered.
```
Here `GDExample` is a C++ class copy-pasted from the GDExtension hello-world, that I put in my GDExtension to remove any of my other code from the equation.

I would also get similar error reports when clicking on the related node, and sometimes instead of these errors I would get crashes in code relaetd to gdextension access.

After the second hot-reloading, I was getting an access violation in the code destroying the GDExtension instance, at almost every time, but not every time.

## How To Reproduce The Problem

1. Setup a project using any GDExtension that you can modify the binary of and open that project in Godot Editor.
2. Make sure a scene is open with a node using a type from that GDExtension. I used `GDExample` from the doc to reduce the possibilities, just replacing it's `_process` impl by `rotation(sin(delta))`,
3. Just hot reload several times that GDExtension: modify something visible, build+install, focus on the editor.
4. At some point a random crash, access violation, godot error report or something else might or not happen. That's unfortunately UB so anything is possible.

## What's Happening

After debugging Godot using a debug build from `master` (ee118e7ffd97f478de73f4b344fddc0203ef7cca) with `godot-cpp` at ef2f63a00c5496cc325e8546acd743787e87a83d
I found that the heart of the issue is that **after the end of the first hot-reloading** (not the first loading), the pointer [`internal::library` in `godot-cpp`](https://github.com/godotengine/godot-cpp/blob/ef2f63a00c5496cc325e8546acd743787e87a83d/src/godot.cpp#L47) is now pointing at a destroyed object. From that point, any usage of that pointer is UB and leads to the other issues.


Why this pointer is pointing to a destroyed object? The sequence I observe is as follows:
1. After changing the extension binary file and focus on the editor, hot-reloading check is triggered, we call [`GDExtensionManager::reload_extensions` which checks if it needs to reload](https://github.com/godotengine/godot/blob/37ee293be82e625e68704a78477b841d0ba17b8f/core/extension/gdextension_manager.cpp#L249-L252).
2. We do need to reload, so we call [`GDExtensionManager::reload_extension`](https://github.com/godotengine/godot/blob/37ee293be82e625e68704a78477b841d0ba17b8f/core/extension/gdextension_manager.cpp#L89) which calls `GDExtension::close_library` on our current `GDExtension` instance for that binary file path.
3. Then we call [`GDExtensionResourceLoader::load_gdextension_resource`](https://github.com/godotengine/godot/blob/37ee293be82e625e68704a78477b841d0ba17b8f/core/extension/gdextension_manager.cpp#L120) which ultimately [calls `GDExtension::open_library` on that same `GDExtension` instance](https://github.com/godotengine/godot/blob/master/core/extension/gdextension.cpp#L918),which leads to [`godot::GDExtensionBinding::init` which will store the pointer to the `GDExtension` into `internal::library`](https://github.com/godotengine/godot-cpp/blob/c4d3f019dab87aff7b36acc5071e1c9adf76f6dd/src/godot.cpp#L246). At this point, all seems OK (to me).
5. **After all this, a signal "_resource_changed" is emitted** from the scene (not sure which node but I suspect it's the one of the type which is from the GDExtension) which leads to this call stack:
```
godot.windows.editor.dev.x86_64.exe!GDExtensionResourceLoader::load_gdextension_resource
godot.windows.editor.dev.x86_64.exe!GDExtensionResourceLoader::load
godot.windows.editor.dev.x86_64.exe!ResourceLoader::_load
godot.windows.editor.dev.x86_64.exe!ResourceLoader::_thread_load_function
godot.windows.editor.dev.x86_64.exe!ResourceLoader::_load_start
godot.windows.editor.dev.x86_64.exe!ResourceLoader::load
godot.windows.editor.dev.x86_64.exe!Resource::reload_from_file
godot.windows.editor.dev.x86_64.exe!EditorNode::_resources_changed
..... [stripped the rest but see below for details]
```
Here we can see that `GDExtensionResourceLoader::load_gdextension_resource` is called again, with the same path we just already reloaded. When it is called this time it [creates a new `GDExtension` instance](...) which, after calling `GDExtension::open_library`  on it -> then `GDExtensionBinding::init` -> it's address set to `interal::library` and then it is returned to `Resource::reload_from_file`.
6. **In[ `Resource::reload_from_file` we do not keep alive the `Ref<Resource>` which holds the `GDExtension`](https://github.com/godotengine/godot/blob/37ee293be82e625e68704a78477b841d0ba17b8f/core/io/resource.cpp#L194), which leads to it's destruction, which also leads to `GDExtension::close_library`.**
7. At this point, `internal::library` is still pointing to that destroyed `GDExtension` object. Any future usage of it is UB.
Also note that the initial `GDExtension` instance is still alive somewhere (no destructor calls in my call stack trace below), so something is still referring to it (maybe the node instance using it's type?) and keeps it alive, but `internal::library` is not pointing to it.


Here is the sequence of events as a sequence of prints of callstacks (using tracepoints in VS to not change the code): https://pastebin.com/MgtrUHeD
I made the tracepoints print also the GDExtension objects addresses when calling it's  members so that you see that there is indeed 2 GDExtension instances, the second one being destroyed just after being created.

I also was debugging live when I started to understand the issue, I can provide a video but I dont think it's necessary. Ask if that helps.

## What this hotfix attempts do

This hotfix prevents step 5 and following from happening by adding in `GDExtensionResourceLoader::load` [the same check from `GDExtensionManager::reload_extensions`](https://github.com/godotengine/godot/blob/37ee293be82e625e68704a78477b841d0ba17b8f/core/extension/gdextension_manager.cpp#L249-L252) that the GDExtension binary file at the given path have changed since last load. Because step 5 happens always in reaction to the previous steps which have already re-loaded, it will usually just do nothing if my hotfix is applied.

## Why I think this hotfix might not be right and I need guidance

- `GDExtensionResourceManager` did not have any access to `GDExtensionManager` before this patch, which adds coupling (with a singleton, so tricky) which makes my intuition tell me this is not how one knowledgeable of the architecture of this system would have done this.
- It is not clear to me why the signal emitted leads to a reload, so maybe some wiring is wrong there and should be fixed instead of doing this?
- It is not clear to me who should handle the lifetime of `GDEXtension` objects: `GDExtensionManager` ? `GDExtensionResourceManager`?
- I suspect part of teh right solution might be to make `internal::library` a `Ref<GDExtension>` instead of a `void*`, but I dont know if the binding system allows that.
- I suspect my hotfix to prevent the resource system to work correctly after hot-reloading, but I couldnt test further yet to check what's broken or not.

Finally an important additional note:
My GDExtension is using `build2` as build-system and package manager, so my build of `godot-cpp` library is from my packaging for `build2`. While it should not affect this bug, I didnt yet attempt to reproduce using a GDExtension built with CMake with `godot-cpp` built with CMake too. I dont think it's necessary as the issue is not related to the build and I think I got the packaging right, but just in case and for context.
   
   