### PR TITLE
[MP] Fix synchronizer init and reset

### DIFF
--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -107,6 +107,9 @@ void MultiplayerSynchronizer::reset() {
 	net_id = 0;
 	last_sync_usec = 0;
 	last_inbound_sync = 0;
+	last_watch_usec = 0;
+	sync_started = false;
+	watchers.clear();
 }
 
 uint32_t MultiplayerSynchronizer::get_net_id() const {
@@ -131,7 +134,9 @@ bool MultiplayerSynchronizer::update_outbound_sync_time(uint64_t p_usec) {
 }
 
 bool MultiplayerSynchronizer::update_inbound_sync_time(uint16_t p_network_time) {
-	if (p_network_time <= last_inbound_sync && last_inbound_sync - p_network_time < 32767) {
+	if (!sync_started) {
+		sync_started = true;
+	} else if (p_network_time <= last_inbound_sync && last_inbound_sync - p_network_time < 32767) {
 		return false;
 	}
 	last_inbound_sync = p_network_time;
@@ -343,6 +348,9 @@ void MultiplayerSynchronizer::update_visibility(int p_for_peer) {
 }
 
 void MultiplayerSynchronizer::set_root_path(const NodePath &p_path) {
+	if (p_path == root_path) {
+		return;
+	}
 	_stop();
 	root_path = p_path;
 	_start();
@@ -353,15 +361,12 @@ NodePath MultiplayerSynchronizer::get_root_path() const {
 }
 
 void MultiplayerSynchronizer::set_multiplayer_authority(int p_peer_id, bool p_recursive) {
-	Node *node = is_inside_tree() ? get_node_or_null(root_path) : nullptr;
-	if (!node || get_multiplayer_authority() == p_peer_id) {
-		Node::set_multiplayer_authority(p_peer_id, p_recursive);
+	if (get_multiplayer_authority() == p_peer_id) {
 		return;
 	}
-
-	get_multiplayer()->object_configuration_remove(node, this);
+	_stop();
 	Node::set_multiplayer_authority(p_peer_id, p_recursive);
-	get_multiplayer()->object_configuration_add(node, this);
+	_start();
 }
 
 Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -66,6 +66,7 @@ private:
 	uint64_t last_sync_usec = 0;
 	uint16_t last_inbound_sync = 0;
 	uint32_t net_id = 0;
+	bool sync_started = false;
 
 	static Object *_get_prop_target(Object *p_obj, const NodePath &p_prop);
 	void _start();


### PR DESCRIPTION
Fix set_multiplayer_authority not resetting the synchronizer (fixes #83112).

Fix the reset function not clearing the watchers state.

Skip wrap around check for the first sync packet after reset.