### PR TITLE
[Linux] Implement `DirAccess.is_case_sensitive` for EXT4 and F2FS.

### DIFF
--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -209,7 +209,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns [code]true[/code] if the file system or directory use case sensitive file names.
-				[b]Note:[/b] This method is implemented on macOS and Windows. On other platforms, it always returns [code]true[/code].
+				[b]Note:[/b] This method is implemented on macOS, Linux (for EXT4 and F2FS filesystems only) and Windows. On other platforms, it always returns [code]true[/code].
 			</description>
 		</method>
 		<method name="list_dir_begin">

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -82,6 +82,8 @@ public:
 	virtual String read_link(String p_file) override;
 	virtual Error create_link(String p_source, String p_target) override;
 
+	virtual bool is_case_sensitive(const String &p_path) const override;
+
 	virtual uint64_t get_space_left() override;
 
 	virtual String get_filesystem_type() const override;


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/82957, implements case sensitivity check for EXT4 and F2FS partitions.
