### PR TITLE
Expose `reload_scripts` as `reload_open_files`

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -86,6 +86,14 @@
 				[b]Note:[/b] Does not apply to scripts that are already opened.
 			</description>
 		</method>
+		<method name="reload_open_files">
+			<return type="void" />
+			<param index="0" name="refresh_only" type="bool" default="false" />
+			<description>
+				Reload all currently opened files if [param refresh_only] is [code]false[/code]. When [param refresh_only] is [code]true[/code], only modified files are reloaded.
+				[b]Note:[/b] This method has no effect if an external editor is currently active.
+			</description>
+		</method>
 		<method name="unregister_syntax_highlighter">
 			<return type="void" />
 			<param index="0" name="syntax_highlighter" type="EditorSyntaxHighlighter" />

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3975,6 +3975,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
+	ClassDB::bind_method(D_METHOD("reload_open_files", "refresh_only"), &ScriptEditor::reload_scripts, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
 

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -478,6 +478,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "region_bake_navmesh", "region_bake_navigation_mesh" }, // Navigation3DServer
 	{ "region_set_navmesh", "region_set_navigation_mesh" }, // Navigation3DServer
 	{ "region_set_navpoly", "region_set_navigation_polygon" }, // Navigation2DServer
+	{ "reload_scripts", "reload_open_files" }, // ScriptEditor
 	{ "remove_animation", "remove_animation_library" }, // AnimationPlayer
 	{ "remove_color_override", "remove_theme_color_override" }, // Control
 	{ "remove_constant_override", "remove_theme_constant_override" }, // Control


### PR DESCRIPTION
Expose the `reload_scripts` method to match the current state of the 3.x branch.

As described in #83118, it is possible to replicate this method with GDScript:

```gdscript
static func reload_script(text_edit: TextEdit, source_code: String) -> void:
	var column := text_edit.get_caret_column()
	var row := text_edit.get_caret_line()
	var scroll_position_h := text_edit.get_h_scroll_bar().value
	var scroll_position_v := text_edit.get_v_scroll_bar().value

	text_edit.text = source_code
	text_edit.set_caret_column(column)
	text_edit.set_caret_line(row)
	text_edit.scroll_horizontal = scroll_position_h
	text_edit.scroll_vertical = scroll_position_v

	text_edit.tag_saved_version()
```

and set the `text_editor/behavior/files/auto_reload_scripts_on_external_change` setting to `true`.

Personally, I would prefer calling `EditorInterface.get_script_editor().reload_scripts()`, but I might not be aware of possible pitfalls caused by exposing this method.

This would also improve the porting of existing 3.5 plugins.

 
closes https://github.com/godotengine/godot-proposals/issues/8111