### PR TITLE
[MP] Fix "on change" indexed properties

### DIFF
--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -382,7 +382,7 @@ Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 		bool valid = false;
 		const Object *obj = _get_prop_target(node, prop);
 		ERR_CONTINUE_MSG(!obj, vformat("Node not found for property '%s'.", prop));
-		Variant v = obj->get(prop.get_concatenated_subnames(), &valid);
+		Variant v = obj->get_indexed(prop.get_subnames(), &valid);
 		ERR_CONTINUE_MSG(!valid, vformat("Property '%s' not found.", prop));
 		Watcher &w = ptr[idx];
 		if (w.prop != prop) {


### PR DESCRIPTION
Watchers were still using Object::get instead of Object::get_indexed.

Follow up of #79479 .

Note for reviewers: There is no `set_indexed` counterpart because "setting" shares the same code path of "Always" variables (addressed in the aforementioned PR).