### PR TITLE
Optimize lightmapper using triangle clusters on the acceleration structure.

### DIFF
--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -42,15 +42,22 @@ struct Triangle {
 	uint pad1;
 };
 
+struct ClusterAABB {
+	vec3 min_bounds;
+	uint pad0;
+	vec3 max_bounds;
+	uint pad1;
+};
+
 layout(set = 0, binding = 2, std430) restrict readonly buffer Triangles {
 	Triangle data[];
 }
 triangles;
 
-layout(set = 0, binding = 3, std430) restrict readonly buffer GridIndices {
+layout(set = 0, binding = 3, std430) restrict readonly buffer TriangleIndices {
 	uint data[];
 }
-grid_indices;
+triangle_indices;
 
 #define LIGHT_TYPE_DIRECTIONAL 0
 #define LIGHT_TYPE_OMNI 1
@@ -103,6 +110,16 @@ layout(set = 0, binding = 8) uniform texture2DArray albedo_tex;
 layout(set = 0, binding = 9) uniform texture2DArray emission_tex;
 
 layout(set = 0, binding = 10) uniform sampler linear_sampler;
+
+layout(set = 0, binding = 11, std430) restrict readonly buffer ClusterIndices {
+	uint data[];
+}
+cluster_indices;
+
+layout(set = 0, binding = 12, std430) restrict readonly buffer ClusterAABBs {
+	ClusterAABB data[];
+}
+cluster_aabbs;
 
 // Fragment action constants
 const uint FA_NONE = 0;


### PR DESCRIPTION
Originally suggested by @reduz in this [post](https://gist.github.com/reduz/3e3a129cf4f17be1ea97cd14c9add542).

Add an additional layer of indirection to the grid used by the lightmapper to store fixed-size triangle clusters. Greatly speeds up baking times on scenes with high triangle density, as the clusters will help to avoid unnecessary checks when the triangle density is high on the scene.

Unreal Sun Temple (from https://github.com/godotengine/godot/issues/75440).
```
Master: Done baking lightmaps in 00:04:39.
PR: Done baking lightmaps in 00:01:10.
```

Sponza
```
Master: Done baking lightmaps in 00:00:56.
PR: Done baking lightmaps in 00:00:37.
```

So far I haven't been able to see if this introduces any errors as the results look identical to me (which is good news as the results would be invalidated otherwise). We should double check as much as possible that nothing breaks before we're sure we want this merged.

Feel free to test it out if you get similar reductions in baking speed and ensuring nothing breaks. Don't expect much gains in scenes with low geometry density, as the optimizations are oriented entirely around reducing ray-triangle intersections in scenes where there was a significant amount of triangles per cell.