### PR TITLE
GDExtension: Prevent issues with the editor trying to reload GDExtensions through its usual mechanism

### DIFF
--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -112,6 +112,8 @@ protected:
 public:
 	HashMap<String, String> class_icon_paths;
 
+	virtual bool editor_can_reload_from_file() override { return false; } // Reloading is handled in a special way.
+
 	static String get_extension_list_config_file();
 	static String find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags = nullptr);
 


### PR DESCRIPTION
This attempts to fix the bug described in PR https://github.com/godotengine/godot/pull/83260 in a slightly different way

Basically, we can't ever have multiple `GDExtension` resource objects that loaded the same library, because it affects global data on both the Godot and GDExtension side. Also, I don't think the editor should be trying to reload GDExtensions through the usual mechanism, because they need to be handled in a special way.

~~This is a draft presently, because I want to also uncomment the `editor_can_reload_from_file()` that's added here, but I'd like @Klaim to test if this fixes their issue, and I think that line will make it so they can't reproduce the conditions that led to the crash in their testing. If they can confirm this fix, then I'll uncomment that line and take this out of draft.~~