### PR TITLE
Remove vertical scrollbar padding from line width calc

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7340,7 +7340,7 @@ void TextEdit::_update_scrollbars() {
 	}
 
 	int visible_width = size.width - theme_cache.style_normal->get_minimum_size().width;
-	int total_width = (draw_placeholder ? placeholder_max_width : text.get_max_width()) + vmin.x + gutters_width + gutter_padding;
+	int total_width = (draw_placeholder ? placeholder_max_width : text.get_max_width()) + gutters_width + gutter_padding;
 
 	if (draw_minimap) {
 		total_width += minimap_width;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3913,7 +3913,8 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_h_scroll() == 0);
 
 	text_edit->set_h_scroll(10000000);
-	CHECK(text_edit->get_h_scroll() == 314);
+	CHECK(text_edit->get_h_scroll() == 306);
+	CHECK(text_edit->get_h_scroll_bar()->get_combined_minimum_size().x == 8);
 
 	text_edit->set_h_scroll(-100);
 	CHECK(text_edit->get_h_scroll() == 0);


### PR DESCRIPTION
Hello 👋

Fix for text edits occasionally rendering a horizontal scrollbar when not necessary, causing what I can only describe as a jitter: sometimes it appears, sometimes not—depending on the text edit's width.

This appears to be caused by the calculation to determine if the max line width exceeds the visible area also accounting for the presence of the vertical scrollbar. As I understand it, this isn't necessary since if the text area wraps, the `_update_wrap_at_column` function will ensure the line stays within the visible area (which includes the vertical scrollbar, if visible).

And for text fields with no wrapping (specifically I'm thinking of the script editor), ignoring the vertical scrollbar width in this calculation doesn't cause clipped text because lines already are given some extra space on [L7283](https://github.com/bronsonholden/godot/blob/ed16df1807ec6b0ba4d0ade99a101ebedcf244dd/scene/gui/text_edit.cpp#L7283)

## Before

https://github.com/godotengine/godot/assets/25910730/76a17f34-84e1-455c-bcfd-082e72ae6030

## After

https://github.com/godotengine/godot/assets/25910730/53322ec0-2129-4f2d-a08f-16927d23f043


Closes #83186 