### PR TITLE
Keep focus on floating window when showing ProgressDialog

### DIFF
--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -147,6 +147,13 @@ void ProgressDialog::_popup() {
 	main->set_offset(SIDE_BOTTOM, -style->get_margin(SIDE_BOTTOM));
 
 	if (!is_inside_tree()) {
+		for (Window *window : host_windows) {
+			if (window->has_focus()) {
+				popup_exclusive_centered(window, ms);
+				return;
+			}
+		}
+		// No host window found, use main window.
 		EditorInterface::get_singleton()->popup_dialog_centered(this, ms);
 	}
 }
@@ -224,6 +231,11 @@ void ProgressDialog::end_task(const String &p_task) {
 	} else {
 		_popup();
 	}
+}
+
+void ProgressDialog::add_host_window(Window *p_window) {
+	ERR_FAIL_NULL(p_window);
+	host_windows.push_back(p_window);
 }
 
 void ProgressDialog::_cancel_pressed() {

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -81,6 +81,8 @@ class ProgressDialog : public PopupPanel {
 	VBoxContainer *main = nullptr;
 	uint64_t last_progress_tick;
 
+	LocalVector<Window *> host_windows;
+
 	static ProgressDialog *singleton;
 	void _popup();
 
@@ -95,6 +97,8 @@ public:
 	void add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
 	bool task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_redraw = true);
 	void end_task(const String &p_task);
+
+	void add_host_window(Window *p_window);
 
 	ProgressDialog();
 };

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
+#include "editor/progress_dialog.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"
@@ -332,6 +333,8 @@ WindowWrapper::WindowWrapper() {
 	window_background = memnew(Panel);
 	window_background->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 	window->add_child(window_background);
+
+	ProgressDialog::get_singleton()->add_host_window(window);
 }
 
 // ScreenSelect


### PR DESCRIPTION
Fixes #78672 

This uses the first approach described in https://github.com/godotengine/godot/issues/78672#issuecomment-1646848253

I tested this only on Linux (KDE neon 5.27 22.04 - X11 - Vulkan (Forward+) - dedicated AMD Radeon Graphics (RADV NAVI23) - AMD Ryzen 5 5600 6-Core Processor (12 Threads)). 
Other OSes should be tested as well, just in case any of them doesn't like quick focus changes.

<hr>

I have done this patch  ~2 months ago, but I never get to publish it 🙈. 
Initially, I want to base this PR to #79261, but it's not merged.