### PR TITLE
Fix phantom tab right button

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -567,6 +567,8 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 		rb->draw(ci, Point2i(rb_rect.position.x + style->get_margin(SIDE_LEFT), rb_rect.position.y + style->get_margin(SIDE_TOP)));
 
 		p_x = rtl ? rb_rect.position.x : rb_rect.position.x + rb_rect.size.width;
+	} else {
+		tabs.write[p_index].rb_rect = Rect2();
 	}
 
 	// Draw and calculate rect of the close button.


### PR DESCRIPTION
Fixes #83232

Was caused by only updating the right button `rb_rect` of a tab if the texture was valid. Therefore, it would never be updated when texture is `null` and so keep its size forever.

Solved by adding a branch to its update logic in `TabBar::_draw_tab()` to set `rb_rect` to an empty `Rect2`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
