### PR TITLE
Fix Android logic for deferred window input events being inverted

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -310,9 +310,9 @@ void DisplayServerAndroid::window_set_drop_files_callback(const Callable &p_call
 void DisplayServerAndroid::_window_callback(const Callable &p_callable, const Variant &p_arg, bool p_deferred) const {
 	if (!p_callable.is_null()) {
 		if (p_deferred) {
-			p_callable.call(p_arg);
-		} else {
 			p_callable.call_deferred(p_arg);
+		} else {
+			p_callable.call(p_arg);
 		}
 	}
 }


### PR DESCRIPTION
Workaround / Fixes https://github.com/godotengine/godot/issues/82396#issuecomment-1761756594  #66318
maybe more: [Github search](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+TouchScreenButton)

*Bugsquad edit:*
- Fixes #66318
- Fixes #82396

`physics_frames` comparison at `TouchScreenButton` is not always possible. [input.cpp#L306](https://github.com/godotengine/godot/blob/51f81e1c88499f04d2ebdcc0be0b34e73f5e90eb/core/input/input.cpp#L306)
`TouchScreenButton::_press` is mostly triggered after `_physics_process`.

The change should have no effect on `Input Map actions`: [input.cpp#L716](https://github.com/godotengine/godot/blob/51f81e1c88499f04d2ebdcc0be0b34e73f5e90eb/core/input/input.cpp#L716)


Minimal test project: [test.zip](https://github.com/godotengine/godot/files/12922291/test.zip)


https://github.com/godotengine/godot/assets/41921395/6f359aef-8aba-4376-9725-5d5245b516e2
