### PR TITLE
Document memory layout for RenderingServer::multimesh_set_buffer()

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2427,9 +2427,9 @@
 				    Vector3 row_y; float origin_y;
 				};
 				struct InstanceTransform3D {
-				    Basis basis_x; float origin_x;
-				    Basis basis_y; float origin_y;
-				    Basis basis_z; float origin_z;
+				    Vector3 basis_x; float origin_x;
+				    Vector3 basis_y; float origin_y;
+				    Vector3 basis_z; float origin_z;
 				};
 				2D:
 				  - Position: 8 floats (8 floats for InstanceTransform2D)

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2421,16 +2421,24 @@
 				Set the entire data to use for drawing the [param multimesh] at once to [param buffer] (such as instance transforms and colors). [param buffer]'s size must match the number of instances multiplied by the per-instance data size (which depends on the enabled MultiMesh fields). Otherwise, an error message is printed and nothing is rendered. See also [method multimesh_get_buffer].
 				The per-instance data size and expected data order is:
 				[codeblock]
+				struct InstanceTransform2D {
+				    float[8] undocumented; // differs from Transform2D
+				};
+				struct InstanceTransform3D {
+				    Basis basis_x; float origin_x;
+				    Basis basis_y; float origin_y;
+				    Basis basis_z; float origin_z;
+				};
 				2D:
-				  - Position: 8 floats (8 floats for Transform2D)
-				  - Position + Vertex color: 12 floats (8 floats for Transform2D, 4 floats for Color)
-				  - Position + Custom data: 12 floats (8 floats for Transform2D, 4 floats of custom data)
-				  - Position + Vertex color + Custom data: 16 floats (8 floats for Transform2D, 4 floats for Color, 4 floats of custom data)
+				  - Position: 8 floats (8 floats for InstanceTransform2D)
+				  - Position + Vertex color: 12 floats (8 floats for InstanceTransform2D, 4 floats for Color)
+				  - Position + Custom data: 12 floats (8 floats for InstanceTransform2D, 4 floats of custom data)
+				  - Position + Vertex color + Custom data: 16 floats (8 floats for InstanceTransform2D, 4 floats for Color, 4 floats of custom data)
 				3D:
-				  - Position: 12 floats (12 floats for Transform3D)
-				  - Position + Vertex color: 16 floats (12 floats for Transform3D, 4 floats for Color)
-				  - Position + Custom data: 16 floats (12 floats for Transform3D, 4 floats of custom data)
-				  - Position + Vertex color + Custom data: 20 floats (12 floats for Transform3D, 4 floats for Color, 4 floats of custom data)
+				  - Position: 12 floats (12 floats for InstanceTransform3D)
+				  - Position + Vertex color: 16 floats (12 floats for InstanceTransform3D, 4 floats for Color)
+				  - Position + Custom data: 16 floats (12 floats for InstanceTransform3D, 4 floats of custom data)
+				  - Position + Vertex color + Custom data: 20 floats (12 floats for InstanceTransform3D, 4 floats for Color, 4 floats of custom data)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2422,7 +2422,8 @@
 				The per-instance data size and expected data order is:
 				[codeblock]
 				struct InstanceTransform2D {
-				    float[8] undocumented; // differs from Transform2D
+				    Basis basis_x; float origin_x;
+				    Basis basis_y; float origin_y;
 				};
 				struct InstanceTransform3D {
 				    Basis basis_x; float origin_x;

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2421,9 +2421,10 @@
 				Set the entire data to use for drawing the [param multimesh] at once to [param buffer] (such as instance transforms and colors). [param buffer]'s size must match the number of instances multiplied by the per-instance data size (which depends on the enabled MultiMesh fields). Otherwise, an error message is printed and nothing is rendered. See also [method multimesh_get_buffer].
 				The per-instance data size and expected data order is:
 				[codeblock]
-				struct InstanceTransform2D {
-				    Basis basis_x; float origin_x;
-				    Basis basis_y; float origin_y;
+				    // row_x = Vector3(xf2d.x.x, xf2d.y.x, 0), z is not used.
+    				    // row_y = Vector3(xf2d.x.y, xf2d.y.y, 0)
+				    Vector3 row_x; float origin_x;
+				    Vector3 row_y; float origin_y;
 				};
 				struct InstanceTransform3D {
 				    Basis basis_x; float origin_x;


### PR DESCRIPTION
The documentation for `RenderingServer::multimesh_set_buffer()` seemed to imply that the transform memory layout matches `Transform2D` and `Transform3D`, but that is not correct.  I was able to determine through experimentation that the memory layout for a 3D transform in the call to this method must be ordered as follows:
```cpp
struct InstanceTransform3D {
    Basis basis_x; float origin_x;
    Basis basis_y; float origin_y;
    Basis basis_z; float origin_z;
};
```
I’m uncertain how a similar `InstanceTransform2D` is organized, but it is clearly larger than `Transform2D`, so possibly just the first two rows as above.

Clarification from someone who knows better is very welcome!

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
