### PR TITLE
Use Rect2 instead of Rect2i to get char size from TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -464,7 +464,7 @@
 			</description>
 		</method>
 		<method name="get_pos_at_line_column" qualifiers="const">
-			<return type="Vector2i" />
+			<return type="Vector2" />
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
@@ -473,7 +473,7 @@
 			</description>
 		</method>
 		<method name="get_rect_at_line_column" qualifiers="const">
-			<return type="Rect2i" />
+			<return type="Rect2" />
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -288,8 +288,17 @@ Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/commit/argume
 
 Surface format was increased to 64 bits from 32 bits. Compatibility methods registered. 
 
+
 GH-79527
 --------
 Validate extension JSON: Error: Field 'classes/ParticleProcessMaterial/properties/orbit_velocity_curve': type changed value in new API, from "CurveTexture" to "CurveTexture,CurveXYZTexture".
 
 Added accepted curve type from only CurveTexture to CurveXYZTexture.
+
+
+GH-83312
+--------
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_pos_at_line_column/return_value': type changed value in new API, from "Vector2i" to "Vector2".
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_rect_at_line_column/return_value': type changed value in new API, from "Rect2i" to "Rect2".
+
+Keep floating point char widths. Compatibility methods registered.

--- a/scene/gui/text_edit.compat.inc
+++ b/scene/gui/text_edit.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  text_edit.compat.inc                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Point2i TextEdit::_get_pos_at_line_column_83312(int p_line, int p_column) const {
+	return get_pos_at_line_column(p_line, p_column);
+}
+
+Rect2i TextEdit::_get_rect_at_line_column_83312(int p_line, int p_column) const {
+	return get_rect_at_line_column(p_line, p_column);
+}
+
+void TextEdit::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_pos_at_line_column", "line", "column"), &TextEdit::_get_pos_at_line_column_83312);
+	ClassDB::bind_compatibility_method(D_METHOD("get_rect_at_line_column", "line", "column"), &TextEdit::_get_rect_at_line_column_83312);
+}
+
+#endif

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "text_edit.h"
+#include "text_edit.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
@@ -4314,41 +4315,41 @@ Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_allow_out_
 	return Point2i(col, row);
 }
 
-Point2i TextEdit::get_pos_at_line_column(int p_line, int p_column) const {
-	Rect2i rect = get_rect_at_line_column(p_line, p_column);
-	return rect.position.x == -1 ? rect.position : rect.position + Vector2i(0, get_line_height());
+Point2 TextEdit::get_pos_at_line_column(int p_line, int p_column) const {
+	Rect2 rect = get_rect_at_line_column(p_line, p_column);
+	return rect.position.x == -1 ? rect.position : rect.position + Vector2(0, get_line_height());
 }
 
-Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
-	ERR_FAIL_INDEX_V(p_line, text.size(), Rect2i(-1, -1, 0, 0));
-	ERR_FAIL_COND_V(p_column < 0, Rect2i(-1, -1, 0, 0));
-	ERR_FAIL_COND_V(p_column > text[p_line].length(), Rect2i(-1, -1, 0, 0));
+Rect2 TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
+	ERR_FAIL_INDEX_V(p_line, text.size(), Rect2(-1, -1, 0, 0));
+	ERR_FAIL_COND_V(p_column < 0, Rect2(-1, -1, 0, 0));
+	ERR_FAIL_COND_V(p_column > text[p_line].length(), Rect2(-1, -1, 0, 0));
 
 	if (text.size() == 1 && text[0].length() == 0) {
 		// The TextEdit is empty.
-		return Rect2i();
+		return Rect2();
 	}
 
 	if (line_drawing_cache.size() == 0 || !line_drawing_cache.has(p_line)) {
 		// Line is not in the cache, which means it's outside of the viewing area.
-		return Rect2i(-1, -1, 0, 0);
+		return Rect2(-1, -1, 0, 0);
 	}
 	LineDrawingCache cache_entry = line_drawing_cache[p_line];
 
 	int wrap_index = get_line_wrap_index_at_column(p_line, p_column);
 	if (wrap_index >= cache_entry.first_visible_chars.size()) {
 		// Line seems to be wrapped beyond the viewable area.
-		return Rect2i(-1, -1, 0, 0);
+		return Rect2(-1, -1, 0, 0);
 	}
 
 	int first_visible_char = cache_entry.first_visible_chars[wrap_index];
 	int last_visible_char = cache_entry.last_visible_chars[wrap_index];
 	if (p_column < first_visible_char || p_column > last_visible_char) {
 		// Character is outside of the viewing area, no point calculating its position.
-		return Rect2i(-1, -1, 0, 0);
+		return Rect2(-1, -1, 0, 0);
 	}
 
-	Point2i pos, size;
+	Point2 pos, size;
 	pos.y = cache_entry.y_offset + get_line_height() * wrap_index;
 	pos.x = get_total_gutter_width() + theme_cache.style_normal->get_margin(SIDE_LEFT) - get_h_scroll();
 
@@ -4359,7 +4360,7 @@ Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 
 	size.y = get_line_height();
 
-	return Rect2i(pos, size);
+	return Rect2(pos, size);
 }
 
 int TextEdit::get_minimap_line_at_pos(const Point2i &p_pos) const {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -624,6 +624,12 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Point2i _get_pos_at_line_column_83312(int p_line, int p_column) const;
+	Rect2i _get_rect_at_line_column_83312(int p_line, int p_column) const;
+	static void _bind_compatibility_methods();
+#endif
+
 	virtual void _update_theme_item_cache() override;
 
 	/* Internal API for CodeEdit, pending public API. */
@@ -808,8 +814,8 @@ public:
 	String get_word_at_pos(const Vector2 &p_pos) const;
 
 	Point2i get_line_column_at_pos(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
-	Point2i get_pos_at_line_column(int p_line, int p_column) const;
-	Rect2i get_rect_at_line_column(int p_line, int p_column) const;
+	Point2 get_pos_at_line_column(int p_line, int p_column) const;
+	Rect2 get_rect_at_line_column(int p_line, int p_column) const;
 
 	int get_minimap_line_at_pos(const Point2i &p_pos) const;
 

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -948,8 +948,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == 13);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
-			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
+			Point2 line_0 = text_edit->get_pos_at_line_column(0, 0);
+			line_0.y /= 2.0;
 			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 
@@ -980,8 +980,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
 
-			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
+			Point2 line_0 = text_edit->get_pos_at_line_column(0, 0);
+			line_0.y /= 2.0;
 			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 
@@ -1147,8 +1147,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->grab_click_focus();
 			MessageQueue::get_singleton()->flush();
 
-			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
+			Point2 line_0 = text_edit->get_pos_at_line_column(0, 0);
+			line_0.y /= 2.0;
 			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
@@ -1156,7 +1156,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag me");
 
 			line_0 = target_text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
+			line_0.y /= 2.0;
 			line_0.x += 401; // As empty add one.
 			SEND_GUI_MOUSE_MOTION_EVENT(line_0, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
@@ -3247,11 +3247,11 @@ TEST_CASE("[SceneTree][TextEdit] mouse") {
 
 	text_edit->set_size(Size2(800, 200));
 
-	CHECK(text_edit->get_rect_at_line_column(0, 0).get_position() == Point2i(0, 0));
+	CHECK(text_edit->get_rect_at_line_column(0, 0).get_position() == Point2(0, 0));
 
 	text_edit->set_line(0, "A");
 	MessageQueue::get_singleton()->flush();
-	CHECK(text_edit->get_rect_at_line_column(0, 1).get_position().x > 0);
+	CHECK(text_edit->get_rect_at_line_column(0, 1).get_position().x > 0.0);
 
 	text_edit->clear(); // Necessary, otherwise the following test cases fail.
 
@@ -3262,21 +3262,21 @@ TEST_CASE("[SceneTree][TextEdit] mouse") {
 	CHECK(text_edit->get_word_at_pos(text_edit->get_pos_at_line_column(0, 9)) == "ipsum");
 
 	ERR_PRINT_OFF;
-	CHECK(text_edit->get_pos_at_line_column(0, -1) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(-1, 0) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(-1, -1) == Point2i(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(0, -1) == Point2(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(-1, 0) == Point2(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(-1, -1) == Point2(-1, -1));
 
-	CHECK(text_edit->get_pos_at_line_column(0, 500) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(2, 0) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(2, 500) == Point2i(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(0, 500) == Point2(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(2, 0) == Point2(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(2, 500) == Point2(-1, -1));
 
 	// Out of view.
-	CHECK(text_edit->get_pos_at_line_column(0, text_edit->get_line(0).length() - 1) == Point2i(-1, -1));
+	CHECK(text_edit->get_pos_at_line_column(0, text_edit->get_line(0).length() - 1) == Point2(-1, -1));
 	ERR_PRINT_ON;
 
 	// Add method to get drawn column count?
-	Point2i start_pos = text_edit->get_pos_at_line_column(0, 0);
-	Point2i end_pos = text_edit->get_pos_at_line_column(0, 105);
+	Point2 start_pos = text_edit->get_pos_at_line_column(0, 0);
+	Point2 end_pos = text_edit->get_pos_at_line_column(0, 105);
 
 	CHECK(text_edit->get_line_column_at_pos(Point2i(start_pos.x, start_pos.y)) == Point2i(0, 0));
 	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y)) == Point2i(104, 0));


### PR DESCRIPTION
Fixes #83311

While the text size, and therefore the height, is an integer, the same does not apply to the resulting char width which can be a float.