### PR TITLE
Fix cannot update remote after disabling `use_global_coordinates` in `RemoteTransform2D`

### DIFF
--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -114,6 +114,7 @@ void RemoteTransform2D::_notification(int p_what) {
 			_update_cache();
 		} break;
 
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				break;
@@ -127,6 +128,10 @@ void RemoteTransform2D::_notification(int p_what) {
 }
 
 void RemoteTransform2D::set_remote_node(const NodePath &p_remote_node) {
+	if (remote_node == p_remote_node) {
+		return;
+	}
+
 	remote_node = p_remote_node;
 	if (is_inside_tree()) {
 		_update_cache();
@@ -141,7 +146,13 @@ NodePath RemoteTransform2D::get_remote_node() const {
 }
 
 void RemoteTransform2D::set_use_global_coordinates(const bool p_enable) {
+	if (use_global_coordinates == p_enable) {
+		return;
+	}
+
 	use_global_coordinates = p_enable;
+	set_notify_transform(use_global_coordinates);
+	set_notify_local_transform(!use_global_coordinates);
 	_update_remote();
 }
 
@@ -150,6 +161,9 @@ bool RemoteTransform2D::get_use_global_coordinates() const {
 }
 
 void RemoteTransform2D::set_update_position(const bool p_update) {
+	if (update_remote_position == p_update) {
+		return;
+	}
 	update_remote_position = p_update;
 	_update_remote();
 }
@@ -159,6 +173,9 @@ bool RemoteTransform2D::get_update_position() const {
 }
 
 void RemoteTransform2D::set_update_rotation(const bool p_update) {
+	if (update_remote_rotation == p_update) {
+		return;
+	}
 	update_remote_rotation = p_update;
 	_update_remote();
 }
@@ -168,6 +185,9 @@ bool RemoteTransform2D::get_update_rotation() const {
 }
 
 void RemoteTransform2D::set_update_scale(const bool p_update) {
+	if (update_remote_scale == p_update) {
+		return;
+	}
 	update_remote_scale = p_update;
 	_update_remote();
 }
@@ -215,6 +235,7 @@ void RemoteTransform2D::_bind_methods() {
 }
 
 RemoteTransform2D::RemoteTransform2D() {
-	set_notify_transform(true);
+	set_notify_transform(use_global_coordinates);
+	set_notify_local_transform(!use_global_coordinates);
 	set_hide_clip_children(true);
 }

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -113,6 +113,7 @@ void RemoteTransform3D::_notification(int p_what) {
 			_update_cache();
 		} break;
 
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				break;
@@ -126,6 +127,10 @@ void RemoteTransform3D::_notification(int p_what) {
 }
 
 void RemoteTransform3D::set_remote_node(const NodePath &p_remote_node) {
+	if (remote_node == p_remote_node) {
+		return;
+	}
+
 	remote_node = p_remote_node;
 	if (is_inside_tree()) {
 		_update_cache();
@@ -140,7 +145,15 @@ NodePath RemoteTransform3D::get_remote_node() const {
 }
 
 void RemoteTransform3D::set_use_global_coordinates(const bool p_enable) {
+	if (use_global_coordinates == p_enable) {
+		return;
+	}
+
 	use_global_coordinates = p_enable;
+
+	set_notify_transform(use_global_coordinates);
+	set_notify_local_transform(!use_global_coordinates);
+	_update_remote();
 }
 
 bool RemoteTransform3D::get_use_global_coordinates() const {
@@ -148,6 +161,9 @@ bool RemoteTransform3D::get_use_global_coordinates() const {
 }
 
 void RemoteTransform3D::set_update_position(const bool p_update) {
+	if (update_remote_position == p_update) {
+		return;
+	}
 	update_remote_position = p_update;
 	_update_remote();
 }
@@ -157,6 +173,9 @@ bool RemoteTransform3D::get_update_position() const {
 }
 
 void RemoteTransform3D::set_update_rotation(const bool p_update) {
+	if (update_remote_rotation == p_update) {
+		return;
+	}
 	update_remote_rotation = p_update;
 	_update_remote();
 }
@@ -166,6 +185,9 @@ bool RemoteTransform3D::get_update_rotation() const {
 }
 
 void RemoteTransform3D::set_update_scale(const bool p_update) {
+	if (update_remote_scale == p_update) {
+		return;
+	}
 	update_remote_scale = p_update;
 	_update_remote();
 }
@@ -213,5 +235,6 @@ void RemoteTransform3D::_bind_methods() {
 }
 
 RemoteTransform3D::RemoteTransform3D() {
-	set_notify_transform(true);
+	set_notify_transform(use_global_coordinates);
+	set_notify_local_transform(!use_global_coordinates);
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Due to the optimization in `CanvasItem`, `global_transform` is only updated when `get_global_transform()` is called, and then notify `NOTIFICATION_TRANSFORM_CHANGED`. That is, in the case where `global_transform` is not obtained, the notification `NOTIFICATION_TRANSFORM_CHANGED` will not be sent.

So we use `NOTIFICATION_LOCAL_TRANSFORM_CHANGED` in this case. Use in combination to prevent certain optimizations.

Fix https://github.com/godotengine/godot/issues/83297#issuecomment-1762815741.

Same change for `RemoteTransform3D`, to prevent the same optimization from being used in Node3D in the future.