### PR TITLE
C#: Fallback to the latest SDK

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Locator;
 
 namespace GodotTools.ProjectEditor
 {
@@ -19,15 +21,18 @@ namespace GodotTools.ProjectEditor
 
     public static class ProjectUtils
     {
-        public static void MSBuildLocatorRegisterDefaults(out Version version, out string path)
+        public static void MSBuildLocatorRegisterLatest(out Version version, out string path)
         {
-            var instance = Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults();
+            var instance = MSBuildLocator.QueryVisualStudioInstances()
+                .OrderByDescending(x => x.Version)
+                .First();
+            MSBuildLocator.RegisterInstance(instance);
             version = instance.Version;
             path = instance.MSBuildPath;
         }
 
         public static void MSBuildLocatorRegisterMSBuildPath(string msbuildPath)
-            => Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath(msbuildPath);
+            => MSBuildLocator.RegisterMSBuildPath(msbuildPath);
 
         public static MSBuildProject Open(string path)
         {

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -456,7 +456,7 @@ namespace GodotTools
             var dotNetSdkSearchVersion = Environment.Version;
 
             // First we try to find the .NET Sdk ourselves to make sure we get the
-            // correct version first (`RegisterDefaults` always picks the latest).
+            // correct version first, otherwise pick the latest.
             if (DotNetFinder.TryFindDotNetSdk(dotNetSdkSearchVersion, out var sdkVersion, out string sdkPath))
             {
                 if (Godot.OS.IsStdOutVerbose())
@@ -468,7 +468,7 @@ namespace GodotTools
             {
                 try
                 {
-                    ProjectUtils.MSBuildLocatorRegisterDefaults(out sdkVersion, out sdkPath);
+                    ProjectUtils.MSBuildLocatorRegisterLatest(out sdkVersion, out sdkPath);
                     if (Godot.OS.IsStdOutVerbose())
                         Console.WriteLine($"Found .NET Sdk version '{sdkVersion}': {sdkPath}");
                 }


### PR DESCRIPTION
When trying to find the .NET SDK, we were using `MSBuildLocator.RegisterDefaults` as a fallback assuming it was picking the latest one. That's not correct, it uses the first one it finds (see https://github.com/microsoft/MSBuildLocator/issues/81).

- The new implementation picks the latest version so it should fix https://github.com/godotengine/godot/issues/81133. But I don't have a Windows machine to test this.