### PR TITLE
Fix creating and updating plugin with dot in folder name

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -62,7 +62,7 @@ void PluginConfigDialog::_on_confirmed() {
 	int lang_idx = script_option_edit->get_selected();
 	String ext = ScriptServer::get_language(lang_idx)->get_extension();
 	String script_name = script_edit->get_text().is_empty() ? _get_subfolder() : script_edit->get_text();
-	if (script_name.get_extension().is_empty()) {
+	if (script_name.get_extension() != ext) {
 		script_name += "." + ext;
 	}
 	String script_path = path.path_join(script_name);
@@ -152,7 +152,7 @@ void PluginConfigDialog::config(const String &p_config_path) {
 		ERR_FAIL_COND_MSG(err != OK, "Cannot load config file from path '" + p_config_path + "'.");
 
 		name_edit->set_text(cf->get_value("plugin", "name", ""));
-		subfolder_edit->set_text(p_config_path.get_base_dir().get_basename().get_file());
+		subfolder_edit->set_text(p_config_path.get_base_dir().get_file());
 		desc_edit->set_text(cf->get_value("plugin", "description", ""));
 		author_edit->set_text(cf->get_value("plugin", "author", ""));
 		version_edit->set_text(cf->get_value("plugin", "version", ""));


### PR DESCRIPTION
This fixes a problem when creating a plugin with a dot in the name from the project settings or updating an existing plugin with a dot in the folder name will fail.

Test project: [plugin_config_dialog.zip](https://github.com/godotengine/godot/files/12905418/plugin_config_dialog.zip)

---

At the moment, when creating a plugin with a dot in the name and leaving "Script Name" empty, creating the initial plugin script fails as it doesn't add the correct extension.

![create-with-dot](https://github.com/godotengine/godot/assets/4883379/a4fcef27-8f27-4de3-bd24-82152147966d)

Also, when a plugin folder is added via file system which contains a dot, information for that plugin cannot be be updated in the project settings as it won’t  use the correct plugin folder name. Updating the author, for example, will silently fail.

![update-with-dot](https://github.com/godotengine/godot/assets/4883379/93efe554-7535-4ae3-b857-edeb34866d06)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/83332*