### PR TITLE
 Fix FindReplaceBar focus problems

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -97,7 +97,7 @@ class FindReplaceBar : public HBoxContainer {
 	void _update_matches_label();
 
 	void _show_search(bool p_focus_replace = false, bool p_show_only = false);
-	void _hide_bar();
+	void _hide_bar(bool p_force_focus = false);
 
 	void _editor_text_changed();
 	void _search_options_changed(bool p_pressed);
@@ -108,6 +108,7 @@ class FindReplaceBar : public HBoxContainer {
 protected:
 	void _notification(int p_what);
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
+	void _focus_lost();
 
 	bool _search(uint32_t p_flags, int p_from_line, int p_from_col);
 


### PR DESCRIPTION
After #81128 and then #82914 the `_unhandled_input` in FindReplaceBar did not work correctly when it was focused.

Fixes #83303