### PR TITLE
Prevent clicks when looping in AudioStreamWAV

### DIFF
--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -61,7 +61,9 @@ class AudioStreamPlaybackWAV : public AudioStreamPlayback {
 	Ref<AudioStreamWAV> base;
 
 	template <class Depth, bool is_stereo, bool is_ima_adpcm>
-	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &p_offset, int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm);
+	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &p_offset,
+			int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm, int64_t p_limit,
+			int64_t p_border) const;
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;


### PR DESCRIPTION
Partially fixes #64775 (namely, the WAV part. OGG is addressed by #80452).

`AudioStreamWAV` supports resampling and variable playback speeds by using sub-sample accuracy in the playback position and linear interpolation between two neighboring samples.

When forward or backward looping is enabled between samples _s_ and _e_ (inclusive) and the playback pointer is between samples _e_ and _e + 1_, interpolation is done between samples _e_ and _e + 1_. The next/previous sample to be played after/before _e_, however, is _s_, so interpolation should instead be done between _e_ and _s_ to prevent discontinuities/clicks in the signal. For pingpong looping, interpolation in that same case should be done between _e_ and _e - 1_, because the stream is essentially mirrored at the end.

Ensuring this border condition requires one additional check per output sample. I don't know how performance sensitive we are in the audio thread so just to be sure, I added one more template parameter to the `do_resample` method so that there's a separate code path for mixing blocks near the end of the loop region. That produces quite the cascade of function calls, but allows skipping the border checks for the vast majority of blocks.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
