### PR TITLE
Expose 3D Delaunay tetrahedralization in `Geometry3D`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1039,6 +1039,10 @@ Vector<Vector3> Geometry3D::clip_polygon(const Vector<Vector3> &p_points, const 
 	return ::Geometry3D::clip_polygon(p_points, p_plane);
 }
 
+Vector<int32_t> Geometry3D::tetrahedralize_delaunay(const Vector<Vector3> &p_points) {
+	return ::Geometry3D::tetrahedralize_delaunay(p_points);
+}
+
 void Geometry3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("compute_convex_mesh_points", "planes"), &Geometry3D::compute_convex_mesh_points);
 	ClassDB::bind_method(D_METHOD("build_box_planes", "extents"), &Geometry3D::build_box_planes);
@@ -1060,6 +1064,7 @@ void Geometry3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("segment_intersects_convex", "from", "to", "planes"), &Geometry3D::segment_intersects_convex);
 
 	ClassDB::bind_method(D_METHOD("clip_polygon", "points", "plane"), &Geometry3D::clip_polygon);
+	ClassDB::bind_method(D_METHOD("tetrahedralize_delaunay", "points"), &Geometry3D::tetrahedralize_delaunay);
 }
 
 ////// Marshalls //////

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -336,6 +336,7 @@ public:
 	Vector<Vector3> segment_intersects_convex(const Vector3 &p_from, const Vector3 &p_to, const TypedArray<Plane> &p_planes);
 
 	Vector<Vector3> clip_polygon(const Vector<Vector3> &p_points, const Plane &p_plane);
+	Vector<int32_t> tetrahedralize_delaunay(const Vector<Vector3> &p_points);
 
 	Geometry3D() { singleton = this; }
 };

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -31,6 +31,7 @@
 #ifndef GEOMETRY_3D_H
 #define GEOMETRY_3D_H
 
+#include "core/math/delaunay_3d.h"
 #include "core/math/face3.h"
 #include "core/object/object.h"
 #include "core/templates/local_vector.h"
@@ -530,6 +531,21 @@ public:
 		}
 
 		return clipped;
+	}
+
+	static Vector<int32_t> tetrahedralize_delaunay(const Vector<Vector3> &p_points) {
+		Vector<Delaunay3D::OutputSimplex> tetr = Delaunay3D::tetrahedralize(p_points);
+		Vector<int32_t> tetrahedrons;
+
+		tetrahedrons.resize(4 * tetr.size());
+		int32_t *ptr = tetrahedrons.ptrw();
+		for (int i = 0; i < tetr.size(); i++) {
+			*ptr++ = tetr[i].points[0];
+			*ptr++ = tetr[i].points[1];
+			*ptr++ = tetr[i].points[2];
+			*ptr++ = tetr[i].points[3];
+		}
+		return tetrahedrons;
 	}
 
 	// Create a "wrap" that encloses the given geometry.

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -142,5 +142,12 @@
 				Tests if the segment ([param from], [param to]) intersects the triangle [param a], [param b], [param c]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
+		<method name="tetrahedralize_delaunay">
+			<return type="PackedInt32Array" />
+			<param index="0" name="points" type="PackedVector3Array" />
+			<description>
+				Tetrahedralizes the volume specified by a discrete set of [param points] in 3D space, ensuring that no point lies within the circumsphere of any resulting tetrahedron. The method returns a [PackedInt32Array] where each tetrahedron consists of four consecutive point indices into the [param points] array (resulting in an array with [code]n * 4[/code] elements, where [code]n[/code] is the number of tetrahedra found). If the tetrahedralization is unsuccessful, an empty [PackedInt32Array] is returned.
+			</description>
+		</method>
 	</methods>
 </class>


### PR DESCRIPTION
Whilst working on a [benchmark test](https://github.com/godotengine/godot-benchmarks/pull/39) for the `godot-benchmarks` suite I have come to the realization that there is no way to access `Delaunay3D` in GDScript (even though the functionality itself is implemented in Godot [here](https://github.com/godotengine/godot/blob/a574c0296b38d5f786f249b12e6251e562c528cc/core/math/delaunay_3d.h#L215) - to be used only by the `LightmapGI`'s `bake` method).

If merged, you'll be able to use the method via scripting as `Geometry3D.tetrahedralize_delaunay(points)`.

The interface is the same as in other related methods, returning indices into tetrahedralized points.
