### PR TITLE
C#: Fix converting default Callables to native

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -259,7 +259,7 @@ namespace Godot.NativeInterop
                 }
 
                 return new godot_callable(method /* Takes ownership of disposable */,
-                    p_managed_callable.Target.GetInstanceId());
+                    p_managed_callable.Target?.GetInstanceId() ?? 0);
             }
         }
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/83349

When marshaling Callables, we need to check if the `Target` property is null. For a "null" or `default` Callable, the target will be null.