### PR TITLE
Make Editor dock resizing consistent

### DIFF
--- a/doc/classes/SplitContainer.xml
+++ b/doc/classes/SplitContainer.xml
@@ -24,6 +24,13 @@
 		<member name="dragger_visibility" type="int" setter="set_dragger_visibility" getter="get_dragger_visibility" enum="SplitContainer.DraggerVisibility" default="0">
 			Determines the dragger's visibility. See [enum DraggerVisibility] for details.
 		</member>
+		<member name="push_nested" type="bool" setter="set_push_nested" getter="is_pushing_nested" default="false">
+			If [code]true[/code], the [SplitContainer] will adjust its parent's [member split_offset] when dragging has reached the child's minimum size so dragging can continue. This can be chained in multiple [SplitContainer]s.
+			[b]Note:[/b] If the parent [SplitContainer] is not aligned with [member vertical], its parent will be used instead. If the parent is not a [SplitContainer], nothing happens.
+		</member>
+		<member name="resize_separately" type="bool" setter="set_resize_separately" getter="is_resizing_separately" default="false">
+			If [code]true[/code], the [SplitContainer] will adjust its child's [member split_offset] when dragging so only the closest split gets resized, until prevented by the child's minimum size. If [member push_nested] is [code]false[/code], dragging cannot continue past its descendent [SplitContainer]s [member split_offset] if it is in the same [member vertical] direction.
+		</member>
 		<member name="split_offset" type="int" setter="set_split_offset" getter="get_split_offset" default="0">
 			The initial offset of the splitting between the two [Control]s, with [code]0[/code] being at the end of the first [Control].
 		</member>

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1871,11 +1871,15 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		vbc->add_child(parent_sc);
 		parent_sc->set_v_size_flags(SIZE_EXPAND_FILL);
 		parent_sc->set_split_offset(500 * EDSCALE);
+		parent_sc->set_push_nested(true);
+		parent_sc->set_resize_separately(true);
 
 		HSplitContainer *sc = memnew(HSplitContainer);
 		sc->set_v_size_flags(SIZE_EXPAND_FILL);
 		sc->set_h_size_flags(SIZE_EXPAND_FILL);
 		parent_sc->add_child(sc);
+		sc->set_push_nested(true);
+		sc->set_resize_separately(true);
 
 		VBoxContainer *stack_vb = memnew(VBoxContainer);
 		stack_vb->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -657,11 +657,15 @@ bool EditorDockManager::are_docks_visible() const {
 void EditorDockManager::add_vsplit(DockSplitContainer *p_split) {
 	vsplits.push_back(p_split);
 	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
+	p_split->set_push_nested(true);
+	p_split->set_resize_separately(true);
 }
 
 void EditorDockManager::add_hsplit(DockSplitContainer *p_split) {
 	hsplits.push_back(p_split);
 	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
+	p_split->set_push_nested(true);
+	p_split->set_resize_separately(true);
 }
 
 void EditorDockManager::register_dock_slot(DockSlot p_dock_slot, TabContainer *p_tab_container) {

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -48,14 +48,30 @@ void SplitContainerDragger::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) {
 		if (mb->get_button_index() == MouseButton::LEFT) {
 			if (mb->is_pressed()) {
-				sc->_compute_middle_sep(true);
+				Control *first = sc->get_containable_child(0);
+				Control *second = sc->get_containable_child(1);
+				if (!first || !second) {
+					return;
+				}
+				bool first_expanded = (sc->vertical ? first->get_v_size_flags() : first->get_h_size_flags()) & SIZE_EXPAND;
+				bool second_expanded = (sc->vertical ? second->get_v_size_flags() : second->get_h_size_flags()) & SIZE_EXPAND;
+				float ratio = first->get_stretch_ratio() / (first->get_stretch_ratio() + second->get_stretch_ratio());
+				if (first_expanded && second_expanded) {
+					expand_multiplier = ratio;
+				} else if (first_expanded) {
+					expand_multiplier = 1;
+				} else {
+					expand_multiplier = 0;
+				}
+				if (!sc->vertical && is_layout_rtl()) {
+					expand_multiplier = 1 - expand_multiplier;
+				}
+
+				sc->_on_drag_start();
 				dragging = true;
 				drag_ofs = sc->split_offset;
-				if (sc->vertical) {
-					drag_from = get_transform().xform(mb->get_position()).y;
-				} else {
-					drag_from = get_transform().xform(mb->get_position()).x;
-				}
+				drag_from = get_transform().xform(mb->get_position())[sc->vertical ? 1 : 0];
+				drag_from -= sc->get_size()[sc->vertical ? 1 : 0] * expand_multiplier;
 			} else {
 				dragging = false;
 				queue_redraw();
@@ -70,13 +86,14 @@ void SplitContainerDragger::gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		Vector2i in_parent_pos = get_transform().xform(mm->get_position());
+		int drag_to = get_transform().xform(mm->get_position())[sc->vertical ? 1 : 0];
+		drag_to -= sc->get_size()[sc->vertical ? 1 : 0] * expand_multiplier;
+		int drag_delta = drag_to - drag_from;
 		if (!sc->vertical && is_layout_rtl()) {
-			sc->split_offset = drag_ofs - (in_parent_pos.x - drag_from);
-		} else {
-			sc->split_offset = drag_ofs + ((sc->vertical ? in_parent_pos.y : in_parent_pos.x) - drag_from);
+			drag_delta *= -1;
 		}
-		sc->_compute_middle_sep(true);
+		sc->split_offset = drag_ofs + drag_delta;
+		sc->_compute_middle_sep(true, true);
 		sc->queue_sort();
 		sc->emit_signal(SNAME("dragged"), sc->get_split_offset());
 	}
@@ -90,6 +107,10 @@ Control::CursorShape SplitContainerDragger::get_cursor_shape(const Point2 &p_pos
 	}
 
 	return Control::get_cursor_shape(p_pos);
+}
+
+bool SplitContainerDragger::is_dragging() const {
+	return dragging;
 }
 
 void SplitContainerDragger::_notification(int p_what) {
@@ -110,6 +131,19 @@ void SplitContainerDragger::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_FOCUS_EXIT: {
+			if (dragging) {
+				dragging = false;
+				queue_redraw();
+			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (dragging && !is_visible_in_tree()) {
+				dragging = false;
+			}
+		} break;
+
 		case NOTIFICATION_DRAW: {
 			SplitContainer *sc = Object::cast_to<SplitContainer>(get_parent());
 			if (!dragging && !mouse_inside && sc->theme_cache.autohide) {
@@ -123,6 +157,7 @@ void SplitContainerDragger::_notification(int p_what) {
 }
 
 Control *SplitContainer::get_containable_child(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, 2, nullptr, "SplitContainer can only have 2 splits.");
 	int idx = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
@@ -156,7 +191,163 @@ Ref<Texture2D> SplitContainer::_get_grabber_icon() const {
 	}
 }
 
-void SplitContainer::_compute_middle_sep(bool p_clamp) {
+void SplitContainer::_on_drag_start() {
+	if (get_containable_child(0) && get_containable_child(1)) {
+		_compute_middle_sep(true);
+	}
+	if (!resize_separately) {
+		return;
+	}
+	// Recursively clamp all children SplitContainers so they can be resized properly.
+	for (int i = 0; i < 2; i++) {
+		Control *split = get_containable_child(i);
+		if (!split) {
+			continue;
+		}
+		SplitContainer *sc = Object::cast_to<SplitContainer>(split);
+		if (!sc) {
+			continue;
+		}
+		sc->_on_drag_start();
+	}
+}
+
+int SplitContainer::_get_separate_combined_minimum_size(bool p_minimize_first_side, int p_axis) const {
+	if (!resize_separately) {
+		return get_combined_minimum_size()[p_axis];
+	}
+	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? _get_grabber_icon()->get_height() : _get_grabber_icon()->get_width()) : 0;
+	int min_size_sum = sep;
+	Control *near_split = get_containable_child(p_minimize_first_side ? 0 : 1);
+	Control *far_split = get_containable_child(p_minimize_first_side ? 1 : 0);
+	if (near_split) {
+		// Use the minimum size for the closest split.
+		SplitContainer *split_sc = Object::cast_to<SplitContainer>(near_split);
+		if (split_sc) {
+			min_size_sum += split_sc->_get_separate_combined_minimum_size(p_minimize_first_side, p_axis);
+		} else {
+			min_size_sum += near_split->get_combined_minimum_size()[p_axis];
+		}
+	}
+	if (far_split) {
+		if (vertical == (p_axis == 1)) {
+			// Use the full size of the other split to prevent dragging past that point.
+			min_size_sum += far_split->get_size()[p_axis];
+		} else {
+			// If we are not aligned in the same direction, use our children's minimum size.
+			SplitContainer *split_sc = Object::cast_to<SplitContainer>(far_split);
+			if (split_sc) {
+				min_size_sum = MAX(min_size_sum - sep, split_sc->_get_separate_combined_minimum_size(p_minimize_first_side, p_axis));
+			} else {
+				min_size_sum = MAX(min_size_sum - sep, near_split->get_combined_minimum_size()[p_axis]);
+			}
+		}
+	}
+	return min_size_sum;
+}
+
+void SplitContainer::_push_parent(int p_delta) {
+	if (p_delta == 0) {
+		return;
+	}
+	// Change the split offset of the first valid parent SplitContainer.
+	Control *last_parent = this;
+	Control *parent;
+	while (last_parent) {
+		parent = last_parent->get_parent_control();
+		if (!parent || !parent->is_inside_tree() || parent->is_set_as_top_level()) {
+			break;
+		}
+		SplitContainer *sc = Object::cast_to<SplitContainer>(parent);
+		if (!sc || !sc->is_visible()) {
+			break;
+		}
+		if (sc->get_containable_child(0) && sc->get_containable_child(1) && sc->is_vertical() == vertical) {
+			// If we are moving towards the divisor.
+			if (sc->get_containable_child(p_delta < 0 ? 1 : 0) == last_parent) {
+				// Clamp the parent before trying to push it.
+				sc->_compute_middle_sep(true, false);
+				sc->split_offset += p_delta;
+				sc->_compute_middle_sep(true, true);
+				sc->queue_sort();
+				break;
+			}
+		}
+		last_parent = parent;
+	}
+}
+
+void SplitContainer::_adjust_child_split(bool p_adjust_first, bool p_vertical, int p_delta) {
+	if (!resize_separately || collapsed || !is_visible()) {
+		return;
+	}
+	Control *first = get_containable_child(0);
+	Control *second = get_containable_child(1);
+	int first_delta = p_delta;
+	int second_delta = p_delta;
+	if (vertical == p_vertical && first && second) {
+		// Move our split_offset before resizing so our far split stays the same size.
+		bool first_expanded = (vertical ? first->get_v_size_flags() : first->get_h_size_flags()) & SIZE_EXPAND;
+		bool second_expanded = (vertical ? second->get_v_size_flags() : second->get_h_size_flags()) & SIZE_EXPAND;
+		int size = get_size()[vertical ? 1 : 0];
+		int targ_split_offset = split_offset;
+
+		if (first_expanded && second_expanded) {
+			Ref<Texture2D> g = _get_grabber_icon();
+			int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? g->get_height() : g->get_width()) : 0;
+			float ratio = first->get_stretch_ratio() / (first->get_stretch_ratio() + second->get_stretch_ratio());
+			if (p_adjust_first) {
+				int split_size = Math::round(size * (1 - ratio) - sep / 2);
+				targ_split_offset += Math::round((size + p_delta) * (1 - ratio) - sep / 2) - split_size;
+				targ_split_offset -= p_delta;
+			} else {
+				int split_size = Math::round(size * ratio - sep / 2);
+				targ_split_offset += Math::round((size + p_delta) * ratio - sep / 2) - split_size;
+			}
+		} else if (first_expanded) {
+			if (!p_adjust_first) {
+				targ_split_offset += p_delta;
+			}
+		} else {
+			if (p_adjust_first) {
+				targ_split_offset -= p_delta;
+			}
+		}
+
+		int target_mid_step = middle_sep - p_delta;
+		split_offset = targ_split_offset;
+		// Clamp the split offset with updated size.
+		_compute_middle_sep(true, false, size - p_delta);
+		queue_sort();
+		int moved_delta = middle_sep - target_mid_step;
+		if (moved_delta == 0) {
+			// Finished adjusting.
+			return;
+		}
+		if (!vertical && is_layout_rtl()) {
+			moved_delta *= -1;
+		}
+		// Adjustment was clamped, continue to children SplitContainers.
+		first_delta = -moved_delta;
+		second_delta = -first_delta;
+	}
+
+	// Propagate to children SplitContainers.
+	if (first) {
+		SplitContainer *first_sc = Object::cast_to<SplitContainer>(first);
+		if (first_sc) {
+			first_sc->_adjust_child_split(p_adjust_first, p_vertical, first_delta);
+		}
+	}
+	if (second) {
+		SplitContainer *second_sc = Object::cast_to<SplitContainer>(second);
+		if (second_sc) {
+			second_sc->_adjust_child_split(p_adjust_first, p_vertical, second_delta);
+		}
+	}
+}
+
+void SplitContainer::_compute_middle_sep(bool p_clamp, bool p_affect_nested, int p_override_size) {
 	Control *first = get_containable_child(0);
 	Control *second = get_containable_child(1);
 
@@ -166,7 +357,7 @@ void SplitContainer::_compute_middle_sep(bool p_clamp) {
 
 	// Compute the minimum size.
 	int axis = vertical ? 1 : 0;
-	int size = get_size()[axis];
+	int size = p_override_size > 0 ? p_override_size : get_size()[axis];
 	int ms_first = first->get_combined_minimum_size()[axis];
 	int ms_second = second->get_combined_minimum_size()[axis];
 
@@ -189,12 +380,59 @@ void SplitContainer::_compute_middle_sep(bool p_clamp) {
 		wished_middle_sep = split_offset_with_collapse;
 	}
 
+	if (resize_separately && !push_nested && dragging_area_control->is_dragging()) {
+		// Prevent dragging past child's split.
+		bool moving_towards_first = wished_middle_sep < middle_sep;
+		if (!vertical && is_layout_rtl()) {
+			moving_towards_first = wished_middle_sep < size - middle_sep - sep;
+		}
+		if (moving_towards_first) {
+			SplitContainer *first_sc = Object::cast_to<SplitContainer>(first);
+			if (first_sc) {
+				ms_first = MAX(ms_first, first_sc->_get_separate_combined_minimum_size(false, axis));
+			}
+		} else {
+			SplitContainer *second_sc = Object::cast_to<SplitContainer>(second);
+			if (second_sc) {
+				ms_second = MAX(ms_second, second_sc->_get_separate_combined_minimum_size(true, axis));
+			}
+		}
+	}
+	int last_sep = middle_sep;
+
 	// Clamp the middle sep to acceptatble values.
-	middle_sep = CLAMP(wished_middle_sep, ms_first, size - sep - ms_second);
+	int clamped_middle_sep = CLAMP(wished_middle_sep, ms_first, size - sep - ms_second);
+	middle_sep = clamped_middle_sep;
+	if (!vertical && is_layout_rtl()) {
+		middle_sep = size - clamped_middle_sep - sep;
+	}
 
 	// Clamp the split_offset if requested.
 	if (p_clamp) {
-		split_offset -= wished_middle_sep - middle_sep;
+		int sep_delta = wished_middle_sep - clamped_middle_sep;
+		split_offset -= sep_delta;
+
+		if (resize_separately && p_affect_nested) {
+			_resort();
+			// Adjust child split offsets so that only the nearest splits change size.
+			int moved_delta = middle_sep - last_sep;
+			if (!vertical && is_layout_rtl()) {
+				moved_delta *= -1;
+			}
+			if (moved_delta != 0) {
+				SplitContainer *first_sc = Object::cast_to<SplitContainer>(first);
+				if (first_sc) {
+					first_sc->_adjust_child_split(false, vertical, -moved_delta);
+				}
+				SplitContainer *second_sc = Object::cast_to<SplitContainer>(second);
+				if (second_sc) {
+					second_sc->_adjust_child_split(true, vertical, moved_delta);
+				}
+			}
+		}
+		if (push_nested && p_affect_nested) {
+			_push_parent(sep_delta);
+		}
 	}
 }
 
@@ -227,7 +465,6 @@ void SplitContainer::_resort() {
 		fit_child_in_rect(second, Rect2(Point2(0, sofs), Size2(get_size().width, get_size().height - sofs)));
 	} else {
 		if (is_layout_rtl()) {
-			middle_sep = get_size().width - middle_sep - sep;
 			fit_child_in_rect(second, Rect2(Point2(0, 0), Size2(middle_sep, get_size().height)));
 			int sofs = middle_sep + sep;
 			fit_child_in_rect(first, Rect2(Point2(sofs, 0), Size2(get_size().width - sofs, get_size().height)));
@@ -342,6 +579,36 @@ void SplitContainer::set_collapsed(bool p_collapsed) {
 	queue_sort();
 }
 
+bool SplitContainer::is_collapsed() const {
+	return collapsed;
+}
+
+void SplitContainer::set_push_nested(bool p_push_nested) {
+	if (push_nested == p_push_nested) {
+		return;
+	}
+
+	push_nested = p_push_nested;
+	queue_sort();
+}
+
+bool SplitContainer::is_pushing_nested() const {
+	return push_nested;
+}
+
+void SplitContainer::set_resize_separately(bool p_resize_separately) {
+	if (resize_separately == p_resize_separately) {
+		return;
+	}
+
+	resize_separately = p_resize_separately;
+	queue_sort();
+}
+
+bool SplitContainer::is_resizing_separately() const {
+	return resize_separately;
+}
+
 void SplitContainer::set_dragger_visibility(DraggerVisibility p_visibility) {
 	if (dragger_visibility == p_visibility) {
 		return;
@@ -353,10 +620,6 @@ void SplitContainer::set_dragger_visibility(DraggerVisibility p_visibility) {
 
 SplitContainer::DraggerVisibility SplitContainer::get_dragger_visibility() const {
 	return dragger_visibility;
-}
-
-bool SplitContainer::is_collapsed() const {
-	return collapsed;
 }
 
 void SplitContainer::set_vertical(bool p_vertical) {
@@ -408,12 +671,19 @@ void SplitContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vertical", "vertical"), &SplitContainer::set_vertical);
 	ClassDB::bind_method(D_METHOD("is_vertical"), &SplitContainer::is_vertical);
 
+	ClassDB::bind_method(D_METHOD("is_pushing_nested"), &SplitContainer::is_pushing_nested);
+	ClassDB::bind_method(D_METHOD("set_push_nested", "push_nested"), &SplitContainer::set_push_nested);
+	ClassDB::bind_method(D_METHOD("is_resizing_separately"), &SplitContainer::is_resizing_separately);
+	ClassDB::bind_method(D_METHOD("set_resize_separately", "resize_separately"), &SplitContainer::set_resize_separately);
+
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::INT, "offset")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "split_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_split_offset", "get_split_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collapsed"), "set_collapsed", "is_collapsed");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "dragger_visibility", PROPERTY_HINT_ENUM, "Visible,Hidden,Hidden and Collapsed"), "set_dragger_visibility", "get_dragger_visibility");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "push_nested"), "set_push_nested", "is_pushing_nested");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resize_separately"), "set_resize_separately", "is_resizing_separately");
 
 	BIND_ENUM_CONSTANT(DRAGGER_VISIBLE);
 	BIND_ENUM_CONSTANT(DRAGGER_HIDDEN);

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -45,8 +45,11 @@ private:
 	int drag_from = 0;
 	int drag_ofs = 0;
 	bool mouse_inside = false;
+	float expand_multiplier = 0;
 
 public:
+	bool is_dragging() const;
+
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 };
 
@@ -66,6 +69,8 @@ private:
 	int middle_sep = 0;
 	bool vertical = false;
 	bool collapsed = false;
+	bool push_nested = false;
+	bool resize_separately = false;
 	DraggerVisibility dragger_visibility = DRAGGER_VISIBLE;
 
 	SplitContainerDragger *dragging_area_control = nullptr;
@@ -80,7 +85,11 @@ private:
 	} theme_cache;
 
 	Ref<Texture2D> _get_grabber_icon() const;
-	void _compute_middle_sep(bool p_clamp);
+	void _on_drag_start();
+	int _get_separate_combined_minimum_size(bool p_minimize_first_side, int p_axis) const;
+	void _push_parent(int p_delta);
+	void _adjust_child_split(bool p_first, bool p_vertical, int p_delta);
+	void _compute_middle_sep(bool p_clamp, bool p_affect_nested = false, int p_override_size = -1);
 	void _resort();
 
 protected:
@@ -99,6 +108,10 @@ public:
 
 	void set_collapsed(bool p_collapsed);
 	bool is_collapsed() const;
+	void set_push_nested(bool p_push_nested);
+	bool is_pushing_nested() const;
+	void set_resize_separately(bool p_resize_separately);
+	bool is_resizing_separately() const;
 
 	void set_dragger_visibility(DraggerVisibility p_visibility);
 	DraggerVisibility get_dragger_visibility() const;


### PR DESCRIPTION
- fixes #83348
- related https://github.com/godotengine/godot-proposals/issues/7233#issuecomment-1625898356. This pr offers an alternative to get the same behavior a `SplitContainer` with multiple children would have.
- related https://github.com/godotengine/godot-proposals/issues/4033 
- related https://github.com/godotengine/godot/issues/55686 - only if its inside an aligned `SplitContainer` and `push_parent` is set
- related to any proposal about more Editor Dock flexibility - this is needed for most of those, since a more flexible layout will have more UX issues without this.

When adjusting the split between docks it will now only adjust the areas to the immediate sides of it, unless the minimum size is reached, then it affects the next area over until it cannot move anymore.

![godot_dock_resizing_issue_fix](https://github.com/godotengine/godot/assets/10054226/a1ff1b3f-d393-4402-a064-453161f4f65f)

Implementation details:
Added `push_parent` bool in `SplitContainer`
 - When dragging has hit the minimum size, try to push its parent `SplitContainer`s so that dragging can continue in them.
 - If the parent does not have 2 splits or is not the same orientation, then its parent is checked. This allows for more complex hierarchies.
 - Pushing the parent will emit the `dragged` signal in the parent.
 
Added `resize_separately` bool in `SplitContainer`
 - This adjusts the split offset of its children when dragging, so splits not immediately next to the drag area do not get resized.
 - If `push_parent` is false, resizing does move past the opposite split, even if could otherwise.

Also fixed dragging not stopping when focus is lost, and dragging while in a moving SplitContainer that has its child's size flag set.

With only `resize_separately` the  `SplitContainer`s work like Blender's dock system does when moving splits.
With both `push_ancestors` and `resize_separately` enabled, the `SplitContainer` hierarchy works together to have a better experience when resizing.

edit: fixed minimum size not handled correctly
edit: fixed rtl layout, scaling issue, dragging with both expand flags set, and other problems