### PR TITLE
Fix enabling NavigationRegion3D saved disabled

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -497,20 +497,18 @@ void NavigationRegion2D::_region_enter_navigation_map() {
 		return;
 	}
 
-	if (enabled) {
-		if (map_override.is_valid()) {
-			NavigationServer2D::get_singleton()->region_set_map(region, map_override);
-			for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
-				if (constrain_avoidance_obstacles[i].is_valid()) {
-					NavigationServer2D::get_singleton()->obstacle_set_map(constrain_avoidance_obstacles[i], map_override);
-				}
+	if (map_override.is_valid()) {
+		NavigationServer2D::get_singleton()->region_set_map(region, map_override);
+		for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
+			if (constrain_avoidance_obstacles[i].is_valid()) {
+				NavigationServer2D::get_singleton()->obstacle_set_map(constrain_avoidance_obstacles[i], map_override);
 			}
-		} else {
-			NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
-			for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
-				if (constrain_avoidance_obstacles[i].is_valid()) {
-					NavigationServer2D::get_singleton()->obstacle_set_map(constrain_avoidance_obstacles[i], get_world_2d()->get_navigation_map());
-				}
+		}
+	} else {
+		NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
+		for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
+			if (constrain_avoidance_obstacles[i].is_valid()) {
+				NavigationServer2D::get_singleton()->obstacle_set_map(constrain_avoidance_obstacles[i], get_world_2d()->get_navigation_map());
 			}
 		}
 	}
@@ -522,6 +520,8 @@ void NavigationRegion2D::_region_enter_navigation_map() {
 			NavigationServer2D::get_singleton()->obstacle_set_position(constrain_avoidance_obstacles[i], get_global_position());
 		}
 	}
+
+	NavigationServer2D::get_singleton()->region_set_enabled(region, enabled);
 
 	queue_redraw();
 }

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -356,16 +356,16 @@ void NavigationRegion3D::_region_enter_navigation_map() {
 		return;
 	}
 
-	if (enabled) {
-		if (map_override.is_valid()) {
-			NavigationServer3D::get_singleton()->region_set_map(region, map_override);
-		} else {
-			NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
-		}
+	if (map_override.is_valid()) {
+		NavigationServer3D::get_singleton()->region_set_map(region, map_override);
+	} else {
+		NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
 	}
 
 	current_global_transform = get_global_transform();
 	NavigationServer3D::get_singleton()->region_set_transform(region, current_global_transform);
+
+	NavigationServer3D::get_singleton()->region_set_enabled(region, enabled);
 
 #ifdef DEBUG_ENABLED
 	if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {


### PR DESCRIPTION
This PR fixes issue #83364 by always registering the region when it enters the tree, and instead using `region_set_enabled` to control whether its enabled. The same logical changes have been applied to NavigationRegion2D.

* *Bugsquad edit, fixes: #83364*
