### PR TITLE
Utility Functions should return INVALID_ARGUMENT on error

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -128,7 +128,8 @@ Variant VariantUtilityFunctions::floor(Variant x, Callable::CallError &r_error) 
 			return VariantInternalAccessor<Vector4>::get(&x).floor();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::FLOAT;
 			return Variant();
 		}
 	}
@@ -161,7 +162,8 @@ Variant VariantUtilityFunctions::ceil(Variant x, Callable::CallError &r_error) {
 			return VariantInternalAccessor<Vector4>::get(&x).ceil();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::INT;
 			return Variant();
 		}
 	}
@@ -194,7 +196,8 @@ Variant VariantUtilityFunctions::round(Variant x, Callable::CallError &r_error) 
 			return VariantInternalAccessor<Vector4>::get(&x).round();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::INT;
 			return Variant();
 		}
 	}
@@ -236,7 +239,8 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 			return VariantInternalAccessor<Vector4i>::get(&x).abs();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::INT;
 			return Variant();
 		}
 	}
@@ -278,7 +282,8 @@ Variant VariantUtilityFunctions::sign(const Variant &x, Callable::CallError &r_e
 			return VariantInternalAccessor<Vector4i>::get(&x).sign();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::INT;
 			return Variant();
 		}
 	}
@@ -367,7 +372,8 @@ Variant VariantUtilityFunctions::snapped(const Variant &x, const Variant &step, 
 			return VariantInternalAccessor<Vector4i>::get(&x).snapped(VariantInternalAccessor<Vector4i>::get(&step));
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::INT;
 			return Variant();
 		}
 	}
@@ -416,7 +422,8 @@ Variant VariantUtilityFunctions::lerp(const Variant &from, const Variant &to, do
 			return VariantInternalAccessor<Color>::get(&from).lerp(VariantInternalAccessor<Color>::get(&to), weight);
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = Variant::INT;
 			return Variant();
 		}
 	}


### PR DESCRIPTION
This changes various utility functions to use `CALL_ERROR_INVALID_ARGUMENT` when encountering an unexpected argument instead of `CALL_ERROR_INVALID_METHOD`.

`CALL_ERROR_INVALID_METHOD` provides a confusing user experience by telling the user the function does not exist. For example passing `null` to `abs` will provide the error:

> Invalid Call. Nonexistent utility function 'abs'.

With this update the error now says the following:

> Invalid type in utility function 'abs'. Cannot convert argument 1 from Nil to int.

=========

The main thing I'm uncertain about here is the most appropriate `expected` value to use here. INT or FLOAT seemed safest to assume and went with INT though I'm open to the option of also plumbing through a different error that ignores expected and only mentioned to invalid argument type.
