### PR TITLE
Main: Fix freezing after disabling VSync

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3486,6 +3486,7 @@ bool Main::start() {
 uint64_t Main::last_ticks = 0;
 uint32_t Main::frames = 0;
 uint32_t Main::hide_print_fps_attempts = 3;
+bool Main::delay_frame = true;
 uint32_t Main::frame = 0;
 bool Main::force_redraw_requested = false;
 int Main::iterating = 0;
@@ -3684,6 +3685,7 @@ bool Main::iteration() {
 	}
 
 	OS::get_singleton()->add_frame_delay(DisplayServer::get_singleton()->window_can_draw());
+	if (last_ticks == 1) OS::get_singleton()->delay_usec(10000);
 
 #ifdef TOOLS_ENABLED
 	if (auto_build_solutions) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Here comes another PR, this time, it fixes freezing issue after disabling VSync and loading intense-enough scene before the first render frame.
Not sure if this solves the problem or not, please let me know.

* *Bugsquad edit, fixes: #83390*