### PR TITLE
Make Label `characters visible` dominant property for `visible_ratio` calculation

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -748,9 +748,13 @@ void Label::set_text(const String &p_string) {
 	text = p_string;
 	xl_text = atr(p_string);
 	dirty = true;
-	if (visible_ratio < 1) {
-		visible_chars = get_total_character_count() * visible_ratio;
+
+	if (visible_chars > -1 && get_total_character_count() > 0) {
+		visible_ratio = (float)visible_chars / (float)get_total_character_count();
+	} else {
+		visible_ratio = 1.0;
 	}
+
 	queue_redraw();
 	update_minimum_size();
 	update_configuration_warnings();


### PR DESCRIPTION
A minor beaviour change that pegs the visible character count, rather than the visible ratio, to be the authoritative property of the Label when `set_text` is called.

The issue is discussed in the comments of https://github.com/godotengine/godot/issues/83387

It recalculates the ratio on the fly, instead of the previous behaviour, which would calculate the visible characters on the fly.

So if you set visible characters to 5, and your text is "Jason St", when you complete the last name by appending "atham", the label will still display the 5 first characters "Jason" ✅, and the ratio will decrease from 1 accordingly.

Previously, the label would adjust its visible characters, with a fixed ratio of 0.625, resulting in 8 characters being shown, i.e. "Jason Stath" ❌

It is unlikely that user intent is to keep the ratio.

The PR is an extension of https://github.com/godotengine/godot/pull/83392 , since it changes instead of just fixing behaviour, I made it a sparate PR.

