### PR TITLE
Fix Animation Timeline Go to Next Step / Prev Step which triggered wrong animation display

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1262,9 +1262,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool 
 
 	if (!p_timeline_only) {
 		if (player->is_valid() && !p_set) {
-			double delta = player->get_current_animation_position();
 			player->seek(pos, true, true);
-			player->seek(pos + delta, true, true);
 		} else {
 			player->stop();
 			player->seek(pos, true, true);


### PR DESCRIPTION
[FIX] Fix by unifying the behaviours of mouse / command key triggering player->seek: Animation Timeline Go to Next Step / Prev Step is triggering the wrong player->seek


This fix is to tackle with the issue:


### Expected result: animation goes smoothly

https://github.com/godotengine/godot/assets/1129695/c24c498c-7f77-4cc9-a1c9-a1627d89c58b



### Actual result: animation jumps crazily


https://github.com/godotengine/godot/assets/1129695/947bf5b4-a0ab-42d4-bb5b-201800b4bdc6


https://github.com/godotengine/godot/assets/1129695/65303cd0-8c2d-4a35-9d16-c94752ac2e3a



For details, please refer to this issue item:
* fixes: https://github.com/godotengine/godot/issues/83394




I am not sure if my fix will break any other thing though (e.g. the most recent onion-skinning capability revival, AnimationMixer). I need you to help me verify.

This fix has the following related merges as the most recent ones:
https://github.com/godotengine/godot/pull/80813
https://github.com/godotengine/godot/pull/80939

_Bugsquad Edited:_
Fixes #85129