### PR TITLE
Show AnimationMixer warning for non-numeric types only when relevant

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -871,21 +871,23 @@ bool AnimationMixer::_update_caches() {
 				// TODO: Currently, misc type cannot be blended. In the future,
 				// it should have a separate blend weight, just as bool is converted to 0 and 1.
 				// Then, it should provide the correct precedence value.
-				switch (track_value->init_value.get_type()) {
-					case Variant::NIL:
-					case Variant::STRING_NAME:
-					case Variant::NODE_PATH:
-					case Variant::RID:
-					case Variant::OBJECT:
-					case Variant::CALLABLE:
-					case Variant::SIGNAL:
-					case Variant::DICTIONARY:
-					case Variant::ARRAY: {
-						WARN_PRINT_ONCE_ED("AnimationMixer: '" + String(E) + "', Value Track: '" + String(path) + "' uses a non-numeric type as key value with UpdateMode.UPDATE_CONTINUOUS. This will not be blended correctly, so it is forced to UpdateMode.UPDATE_DISCRETE.");
-						track_value->is_continuous = false;
-						break;
-					}
-					default: {
+				if (track_value->is_continuous) {
+					switch (track_value->init_value.get_type()) {
+						case Variant::NIL:
+						case Variant::STRING_NAME:
+						case Variant::NODE_PATH:
+						case Variant::RID:
+						case Variant::OBJECT:
+						case Variant::CALLABLE:
+						case Variant::SIGNAL:
+						case Variant::DICTIONARY:
+						case Variant::ARRAY: {
+							WARN_PRINT_ONCE_ED("AnimationMixer: '" + String(E) + "', Value Track: '" + String(path) + "' uses a non-numeric type as key value with UpdateMode.UPDATE_CONTINUOUS. This will not be blended correctly, so it is forced to UpdateMode.UPDATE_DISCRETE.");
+							track_value->is_continuous = false;
+							break;
+						}
+						default: {
+						}
 					}
 				}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Without this patch, the warning will show regardless of whether the non-numeric tracks in the animation were set to `UpdateMode.UPDATE_DISCRETE` by the user.