### PR TITLE
Generated light probes avoid StaticBody3Ds

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -52,6 +52,10 @@
 			[b]Note:[/b] Automatically generated [LightmapProbe]s are not visible as nodes in the Scene tree dock, and cannot be modified this way after they are generated.
 			[b]Note:[/b] Regardless of [member generate_probes_subdiv], direct lighting on dynamic objects is always applied using [Light3D] nodes in real-time.
 		</member>
+		<member name="generate_probes_ignore_layer" type="int" setter="set_probes_ignore_layer" getter="get_probes_ignore_layer" default="0">
+			By default, generated [LightmapProbe]s will not be placed inside of [StaticBody3D]s. If a layer is specified here, any [StaticBody3D]s in that layer will be ignored and generated [LightmapProbe]s will be placed inside of it. This is useful for things like invisible walls. If set to -1, all layers will be ignored and generated [LightmapProbe]s will not avoid [StaticBody3D]s at all.
+			[b]Note:[/b] This does not affect manually placed [LightmapProbe]s.
+		</member>
 		<member name="interior" type="bool" setter="set_interior" getter="is_interior" default="false">
 			If [code]true[/code], ignore environment lighting when baking lightmaps.
 		</member>

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -39,6 +39,8 @@
 #include "scene/resources/environment.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/sky.h"
+#include "scene/3d/physics_body_3d.h"
+#include "servers/physics_server_3d.h"
 
 void LightmapGIData::add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance) {
 	User user;
@@ -698,9 +700,36 @@ void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, f
 			const Vector3 *pp = probe_positions.ptr();
 			bool exists = false;
 			for (int j = 0; j < ppcount; j++) {
-				if (pp[j].is_equal_approx(real_pos)) {
+				if (pp[j].distance_to(real_pos) < (p_cell_size * 0.5f)) {
 					exists = true;
 					break;
+				}
+			}
+
+			// check for collision with static geo, unless we're ignoring all layers
+			if (probes_ignore_layer != -1) {
+				auto space_state = get_world_3d()->get_direct_space_state();
+				auto point_params = PhysicsDirectSpaceState3D::PointParameters();
+				point_params.position = real_pos;
+				point_params.collide_with_areas = false;
+				PhysicsDirectSpaceState3D::ShapeResult results[10];
+				int intersect_count = space_state->intersect_point(point_params, results, 10);
+				if (intersect_count > 0) {
+					for (int j = 0; j < intersect_count; j++) {
+						auto shape_result = results[j];
+						StaticBody3D *static_body = cast_to<StaticBody3D>(shape_result.collider);
+						if (static_body) {
+							// if there are is no ignore layer, just continue
+							if (probes_ignore_layer == 0) {
+								exists = true;
+							} else {
+								CollisionObject3D *collision_obj = cast_to<CollisionObject3D>(static_body);
+								if ((collision_obj->get_collision_layer() & (1 << (probes_ignore_layer - 1))) == 0) {
+									exists = true;
+								}
+							}
+						}
+					}
 				}
 			}
 
@@ -1482,6 +1511,16 @@ LightmapGI::GenerateProbes LightmapGI::get_generate_probes() const {
 	return gen_probes;
 }
 
+void LightmapGI::set_probes_ignore_layer(int p_layer) {
+	ERR_FAIL_COND_MSG(p_layer < -1, "Layer number must be between -1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer > 32, "Layer number must be between -1 and 32 inclusive.");
+	probes_ignore_layer = p_layer;
+}
+
+int LightmapGI::get_probes_ignore_layer() const {
+	return probes_ignore_layer;
+}
+
 void LightmapGI::set_camera_attributes(const Ref<CameraAttributes> &p_camera_attributes) {
 	camera_attributes = p_camera_attributes;
 }
@@ -1568,6 +1607,9 @@ void LightmapGI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "camera_attributes"), &LightmapGI::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &LightmapGI::get_camera_attributes);
 
+	ClassDB::bind_method(D_METHOD("set_probes_ignore_layer", "ignore_layers"), &LightmapGI::set_probes_ignore_layer);
+	ClassDB::bind_method(D_METHOD("get_probes_ignore_layer"), &LightmapGI::get_probes_ignore_layer);
+
 	//	ClassDB::bind_method(D_METHOD("bake", "from_node"), &LightmapGI::bake, DEFVAL(Variant()));
 
 	ADD_GROUP("Tweaks", "");
@@ -1589,6 +1631,7 @@ void LightmapGI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
 	ADD_GROUP("Gen Probes", "generate_probes_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "generate_probes_subdiv", PROPERTY_HINT_ENUM, "Disabled,4,8,16,32"), "set_generate_probes", "get_generate_probes");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "generate_probes_ignore_layer", PROPERTY_HINT_RANGE, "-1,32,1"), "set_probes_ignore_layer", "get_probes_ignore_layer");
 	ADD_GROUP("Data", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "light_data", PROPERTY_HINT_RESOURCE_TYPE, "LightmapGIData"), "set_light_data", "get_light_data");
 

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -158,6 +158,7 @@ private:
 	bool directional = false;
 	bool use_texture_for_bounces = true;
 	GenerateProbes gen_probes = GENERATE_PROBES_SUBDIV_8;
+	int probes_ignore_layer = 0;
 	Ref<CameraAttributes> camera_attributes;
 
 	Ref<LightmapGIData> light_data;
@@ -280,6 +281,9 @@ public:
 
 	void set_generate_probes(GenerateProbes p_generate_probes);
 	GenerateProbes get_generate_probes() const;
+
+	void set_probes_ignore_layer(int p_layer);
+	int get_probes_ignore_layer() const;
 
 	void set_camera_attributes(const Ref<CameraAttributes> &p_camera_attributes);
 	Ref<CameraAttributes> get_camera_attributes() const;


### PR DESCRIPTION
### Problem

When the LightmapGI generates light probes, a lot of those light probes end up inside objects and obscured from any light at all. This used to be a huge problem because they would glitch and end up with odd colored lighting, [but this was fixed recently, and now they just end up totally black](https://github.com/godotengine/godot/pull/82068).

This is still not ideal though, having lots of black light probes in your scene produces very weird lighting especially when they are close to the edges of objects:

![black_probes](https://github.com/godotengine/godot/assets/18580013/e745d3b6-1ef1-4ebc-945a-8ebd5b62ca8a)
![black_probes_2](https://github.com/godotengine/godot/assets/18580013/050daa47-c3c5-4591-9d63-37117eb5f869)

https://github.com/godotengine/godot/assets/18580013/48960377-9158-44a5-b90a-0bcd94340345

### Solution

It's not perfect, but we can make an assumption that probably `StaticBody3D`s are usually objects that are visually solid and blocking light, like walls and floors, and do an `intersect_point` check against them when deciding whether to place a generated light probe. In my case this solved the problem entirely:

![black_probes_gone](https://github.com/godotengine/godot/assets/18580013/f3cbea5f-3696-4540-8e29-cfabf80802ae)
![black_probes_gone_2](https://github.com/godotengine/godot/assets/18580013/4f05a6ba-e22c-4aa0-bdd1-1f45bad2866f)

https://github.com/godotengine/godot/assets/18580013/818c5960-b78f-4dd1-ac7d-744a6eb3e4af

Still, there might be situations where you don't want a static body to block generated light probes, like if you have invisible walls. For that case, I added a `probe_ignore_layer` variable that defaults to 0. If it's set to a layer number 1-32, any static bodies in that layer will _not_ block generated light probes. If it is set to -1, then all layers are ignored and the current behavior will remain.

Additionally, while poking around in `lightmap_gi`, I noticed there is code to avoid generating probes too close to manually placed probes, but it was doing an `is_equal_approx` check against the two positions instead of a distance check, so this was never being triggered. I changed it to a distance check so the behavior is as expected now:

![probes_by_approx](https://github.com/godotengine/godot/assets/18580013/a59c6a67-7ea2-4d8a-a8fe-db85ea2bee32)
![probes_by_dist_good](https://github.com/godotengine/godot/assets/18580013/619a9aad-c68d-41ea-9c6b-c3003f8b7003)
