### PR TITLE
C#: Allow exporting games without C#

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -121,16 +121,16 @@ void CSharpLanguage::init() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "dotnet/project/assembly_reload_attempts", PROPERTY_HINT_RANGE, "1,16,1,or_greater"), 3);
 #endif
 
-	gdmono = memnew(GDMono);
-	gdmono->initialize();
-
 #ifdef TOOLS_ENABLED
-	if (gdmono->is_runtime_initialized()) {
-		gdmono->initialize_load_assemblies();
-	}
-
 	EditorNode::add_init_callback(&_editor_init_callback);
 #endif
+
+	gdmono = memnew(GDMono);
+
+	// Initialize only if the project uses C#.
+	if (gdmono->should_initialize()) {
+		gdmono->initialize();
+	}
 }
 
 void CSharpLanguage::finish() {

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -20,6 +20,19 @@ namespace GodotTools.Export
 
         private List<string> _tempFolders = new List<string>();
 
+        private static bool ProjectContainsDotNet()
+        {
+            return File.Exists(GodotSharpDirs.ProjectSlnPath);
+        }
+
+        public override string[] _GetExportFeatures(EditorExportPlatform platform, bool debug)
+        {
+            if (!ProjectContainsDotNet())
+                return Array.Empty<string>();
+
+            return new string[] { "dotnet" };
+        }
+
         public override Godot.Collections.Array<Godot.Collections.Dictionary> _GetExportOptions(EditorExportPlatform platform)
         {
             return new Godot.Collections.Array<Godot.Collections.Dictionary>()
@@ -119,7 +132,7 @@ namespace GodotTools.Export
         {
             _ = flags; // Unused.
 
-            if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
+            if (!ProjectContainsDotNet())
                 return;
 
             if (!DeterminePlatformFromFeatures(features, out string platform))

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -348,6 +348,15 @@ godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle)
 
 } // namespace
 
+bool GDMono::should_initialize() {
+#ifdef TOOLS_ENABLED
+	// The editor always needs to initialize the .NET module for now.
+	return true;
+#else
+	return OS::get_singleton()->has_feature("dotnet");
+#endif
+}
+
 static bool _on_core_api_assembly_loaded() {
 	if (!GDMonoCache::godot_api_cache_updated) {
 		return false;
@@ -435,11 +444,15 @@ void GDMono::initialize() {
 
 	_on_core_api_assembly_loaded();
 
+#ifdef TOOLS_ENABLED
+	_try_load_project_assembly();
+#endif
+
 	initialized = true;
 }
 
 #ifdef TOOLS_ENABLED
-void GDMono::initialize_load_assemblies() {
+void GDMono::_try_load_project_assembly() {
 	if (Engine::get_singleton()->is_project_manager_hint()) {
 		return;
 	}

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -72,6 +72,7 @@ class GDMono {
 
 #ifdef TOOLS_ENABLED
 	bool _load_project_assembly();
+	void _try_load_project_assembly();
 #endif
 
 	uint64_t api_core_hash = 0;
@@ -149,10 +150,9 @@ public:
 	Error reload_project_assemblies();
 #endif
 
+	bool should_initialize();
+
 	void initialize();
-#ifdef TOOLS_ENABLED
-	void initialize_load_assemblies();
-#endif
 
 	GDMono();
 	~GDMono();


### PR DESCRIPTION
When exporting a game that contains a C# solution, a feature is added so the exported game can check if it should initialize the .NET module. Otherwise, the module initialization is skipped so games without C# won't check for the assemblies and won't show alerts when they're missing.

- Fixes https://github.com/godotengine/godot/issues/81852.