### PR TITLE
Fix dragging in mesh preview will create a "drag and drop" action

### DIFF
--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -49,7 +49,7 @@ void MeshEditor::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void MeshEditor::_update_theme_item_cache() {
-	SubViewportContainer::_update_theme_item_cache();
+	Control::_update_theme_item_cache();
 
 	theme_cache.light_1_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight1"));
 	theme_cache.light_2_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight2"));
@@ -102,14 +102,19 @@ void MeshEditor::_on_light_2_switch_pressed() {
 }
 
 MeshEditor::MeshEditor() {
+	vc = memnew(SubViewportContainer);
+	vc->set_stretch(true);
+	vc->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	add_child(vc);
+
 	viewport = memnew(SubViewport);
 	Ref<World3D> world_3d;
 	world_3d.instantiate();
 	viewport->set_world_3d(world_3d); // Use own world.
-	add_child(viewport);
+	vc->add_child(viewport);
+
 	viewport->set_disable_input(true);
 	viewport->set_msaa_3d(Viewport::MSAA_4X);
-	set_stretch(true);
 	camera = memnew(Camera3D);
 	camera->set_transform(Transform3D(Basis(), Vector3(0, 0, 1.1)));
 	camera->set_perspective(45, 0.1, 10);

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -43,12 +43,13 @@
 class SubViewport;
 class Button;
 
-class MeshEditor : public SubViewportContainer {
-	GDCLASS(MeshEditor, SubViewportContainer);
+class MeshEditor : public Control {
+	GDCLASS(MeshEditor, Control);
 
 	float rot_x;
 	float rot_y;
 
+	SubViewportContainer *vc = nullptr;
 	SubViewport *viewport = nullptr;
 	MeshInstance3D *mesh_instance = nullptr;
 	Node3D *rotation = nullptr;


### PR DESCRIPTION
MaterialEditor doesn't have this problem. Did some check and found they have different parent class that caused the behaviour difference. So I change MeshEditor's parent from SubViewportContainer to Control. Tested locally, it worked. 

I would appreciate any feedback or alternative suggestions.

Fixes #83171

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
