### PR TITLE
Fix screen center position returned for rotated Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -209,8 +209,6 @@ Transform2D Camera2D::get_camera_transform() {
 		screen_rect.position += offset;
 	}
 
-	camera_screen_center = screen_rect.get_center();
-
 	Transform2D xform;
 	xform.scale_basis(zoom_scale);
 	if (!ignore_rotation) {
@@ -218,7 +216,9 @@ Transform2D Camera2D::get_camera_transform() {
 	}
 	xform.set_origin(screen_rect.position);
 
-	return (xform).affine_inverse();
+	camera_screen_center = xform.xform(0.5 * screen_size);
+
+	return xform.affine_inverse();
 }
 
 void Camera2D::_notification(int p_what) {


### PR DESCRIPTION
Fixes #44358 (needs a cherry-pick for 3.x) and #83372 which was is a duplicate.

MRP from #83372 (a little tweaked):
| v4.2.beta1.official [b1371806a] | This PR | This PR<br>with added camera animation + drag enabled<br>(aka target_position != screen_center)|
|--------|--------|-|
|![XNdH2YWkSD](https://github.com/godotengine/godot/assets/9283098/62bdbdf8-e44c-481d-b598-4edfcb029b57)|![citRceaTDX](https://github.com/godotengine/godot/assets/9283098/6e4f33d2-07f1-4236-8086-4128002c99d4)|![K2KxTERgo6](https://github.com/godotengine/godot/assets/9283098/7b17b30b-58d7-4739-9bbe-2a63db906699)|
|![ZHc3sFZF44](https://github.com/godotengine/godot/assets/9283098/15654497-c4ec-4296-a192-c4c60fdf1bfd)|![utZBsnAlUG](https://github.com/godotengine/godot/assets/9283098/c23c4cf2-9bf3-4cbe-8cb7-0e4d70a3273d)|![VhQwH1Fwzs](https://github.com/godotengine/godot/assets/9283098/da755db9-5694-4bd8-b6be-80995a71f585)|



Basically within the Camera2D calculations the position ("top right" corner) of the screen rect is calculated taking the rotation into account but the screen rect itself is considered in an unrotated space. Simpler to visualize, the red rect (the green rect is what camera would actually show):
![DcjCCeMo2o](https://github.com/godotengine/godot/assets/9283098/38119cff-c3fd-41aa-8039-d6fdc3a28386)

Note this PR fixes only the returned screen center position. The incorrectly calculated screen rect (red bounds) is still what is taken into account e.g. when limiting position with `limit_smoothed == false` and `position_smoothing_enabled == false` (orange lines = camera limits):
| v4.2.beta1.official [b1371806a] | This PR |
|--------|--------|
|![wS3H39lKsK](https://github.com/godotengine/godot/assets/9283098/704bd509-f258-48cb-b3af-2ffa28512874)|![N9YiCM6A25](https://github.com/godotengine/godot/assets/9283098/12568133-5db4-4def-80fb-34ce5b993532)|


Wanted to keep this PR super simple as there are many other strange/suspicious things in the Camera2D logic (see #63773). It's kinda domino-like. :upside_down_face:
