### PR TITLE
C#: Add better support for generic class types

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/GenericExports.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/GenericExports.cs
@@ -1,0 +1,60 @@
+using Godot.Collections;
+
+namespace Godot.SourceGenerators.Sample;
+
+public partial class GenericExports<[MustBeVariant] T> : GodotObject
+{
+    [Export] public T RegularField;
+    [Export] public T RegularProperty { get; set; }
+
+    [Export] public Array<T> ArrayProperty { get; set; }
+
+    [Signal]
+    public delegate T GenericEventHandler(T var);
+
+    public T GenericMethod(T var)
+    {
+        return var;
+    }
+}
+
+public partial class GenericExports : GenericExports<Vector2>
+{
+}
+
+public partial class GenericExportsRect2 : GenericExports<Rect2>
+{
+}
+
+public partial class GenericExports<TSome, [MustBeVariant] TOther> : GodotObject
+{
+    [Export] public Array<TOther> ArrayExport { get; set; }
+
+    // This is not valid because TSome is not [MustBeVariant]
+    // [Export] public TSome AnotherArray { get; set; }
+
+    // You can still use TSome, just not exported.
+    public TSome NonExportField;
+}
+
+public partial class GenericArrayExport<[MustBeVariant] T> : GodotObject
+{
+    [Export] public T[] ArrayOfT;
+}
+
+public partial class GenericArrayExportInt : GenericArrayExport<int>
+{
+}
+
+// This is not valid because it results in attempting to export a Plane[], which is not a valid Variant type.
+// An error is generated suggesting to use a Godot array instead of a C# array.
+// public partial class GenericArrayExportPlane : GenericArrayExport<Plane>
+// {
+// }
+
+// Doesn't require the [MustBeVariant] attribute because T is constrained to GodotObject already.
+public partial class InferredVariantCompatible<T> : Resource
+    where T : GodotObject
+{
+    [Export] public T Exported;
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalType.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalType.cs
@@ -69,5 +69,9 @@ namespace Godot.SourceGenerators
         GodotArray,
         GodotGenericDictionary,
         GodotGenericArray,
+
+        // For things using generic type parameters
+        GenericType,
+        GenericSystemArrayType,
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,115 +15,339 @@ namespace Godot.SourceGenerators
             => ImmutableArray.Create(
                 Common.GenericTypeArgumentMustBeVariantRule,
                 Common.GenericTypeParameterMustBeVariantAnnotatedRule,
-                Common.TypeArgumentParentSymbolUnhandledRule);
+                Common.TypeArgumentParentSymbolUnhandledRule,
+                Common.InvalidMustBeGenericTypeParameterUsageRule);
 
         public override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.TypeArgumentList);
-        }
 
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
-        {
-            // Ignore syntax inside comments
-            if (IsInsideDocumentation(context.Node))
-                return;
+            context.RegisterSyntaxNodeAction(AnalyzeExportedProperties, SyntaxKind.FieldDeclaration,
+                SyntaxKind.PropertyDeclaration);
+            context.RegisterSyntaxNodeAction(AnalyzeSignals, SyntaxKind.DelegateDeclaration);
 
-            var typeArgListSyntax = (TypeArgumentListSyntax)context.Node;
-
-            // Method invocation or variable declaration that contained the type arguments
-            var parentSyntax = context.Node.Parent;
-            Debug.Assert(parentSyntax != null);
-
-            var sm = context.SemanticModel;
-
-            var typeCache = new MarshalUtils.TypeCache(context.Compilation);
-
-            for (int i = 0; i < typeArgListSyntax.Arguments.Count; i++)
-            {
-                var typeSyntax = typeArgListSyntax.Arguments[i];
-
-                // Ignore omitted type arguments, e.g.: List<>, Dictionary<,>, etc
-                if (typeSyntax is OmittedTypeArgumentSyntax)
-                    continue;
-
-                var typeSymbol = sm.GetSymbolInfo(typeSyntax).Symbol as ITypeSymbol;
-                Debug.Assert(typeSymbol != null);
-
-                var parentSymbol = sm.GetSymbolInfo(parentSyntax).Symbol;
-
-                if (!ShouldCheckTypeArgument(context, parentSyntax, parentSymbol, typeSyntax, typeSymbol, i))
-                {
-                    return;
-                }
-
-                if (typeSymbol is ITypeParameterSymbol typeParamSymbol)
-                {
-                    if (!typeParamSymbol.GetAttributes().Any(a => a.AttributeClass?.IsGodotMustBeVariantAttribute() ?? false))
-                    {
-                        Common.ReportGenericTypeParameterMustBeVariantAnnotated(context, typeSyntax, typeSymbol);
-                    }
-                    continue;
-                }
-
-                var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(typeSymbol, typeCache);
-
-                if (marshalType == null)
-                {
-                    Common.ReportGenericTypeArgumentMustBeVariant(context, typeSyntax, typeSymbol);
-                    continue;
-                }
-            }
+            // Has to include IdentifierName because calls to methods with the type arguments inferred aren't 'GenericName' syntax.
+            context.RegisterSyntaxNodeAction(AnalyzeGenericTypeUsage, SyntaxKind.GenericName,
+                SyntaxKind.IdentifierName);
         }
 
         /// <summary>
-        /// Check if the syntax node is inside a documentation syntax.
+        /// If a generic type is used in an exported field or property, make sure it is [MustBeVariant]
         /// </summary>
-        /// <param name="syntax">Syntax node to check.</param>
-        /// <returns><see langword="true"/> if the syntax node is inside a documentation syntax.</returns>
-        private bool IsInsideDocumentation(SyntaxNode? syntax)
+        /// <param name="context"></param>
+        private void AnalyzeExportedProperties(SyntaxNodeAnalysisContext context)
         {
-            while (syntax != null)
+            SemanticModel sm = context.SemanticModel;
+            var member = (MemberDeclarationSyntax)context.Node;
+
+            if (!member.GetAllAttributes().Any(a => a.GetTypeSymbol(sm).IsGodotExportAttribute())) return;
+
+            TypeSyntax typeSyntax = member switch
             {
-                if (syntax is DocumentationCommentTriviaSyntax)
-                {
-                    return true;
-                }
-
-                syntax = syntax.Parent;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Check if the given type argument is being used in a type parameter that contains
-        /// the <c>MustBeVariantAttribute</c>; otherwise, we ignore the attribute.
-        /// </summary>
-        /// <param name="context">Context for a syntax node action.</param>
-        /// <param name="parentSyntax">The parent node syntax that contains the type node syntax.</param>
-        /// <param name="parentSymbol">The symbol retrieved for the parent node syntax.</param>
-        /// <param name="typeArgumentSyntax">The type node syntax of the argument type to check.</param>
-        /// <param name="typeArgumentSymbol">The symbol retrieved for the type node syntax.</param>
-        /// <returns><see langword="true"/> if the type must be variant and must be analyzed.</returns>
-        private bool ShouldCheckTypeArgument(SyntaxNodeAnalysisContext context, SyntaxNode parentSyntax, ISymbol parentSymbol, TypeSyntax typeArgumentSyntax, ITypeSymbol typeArgumentSymbol, int typeArgumentIndex)
-        {
-            var typeParamSymbol = parentSymbol switch
-            {
-                IMethodSymbol methodSymbol => methodSymbol.TypeParameters[typeArgumentIndex],
-                INamedTypeSymbol typeSymbol => typeSymbol.TypeParameters[typeArgumentIndex],
-                _ => null,
+                FieldDeclarationSyntax field => field.Declaration.Type,
+                PropertyDeclarationSyntax property => property.Type,
+                _ => throw new ArgumentException() // Shouldn't happen
             };
 
-            if (typeParamSymbol == null)
+            ITypeSymbol typeSymbol = (ITypeSymbol)ModelExtensions.GetSymbolInfo(sm, typeSyntax).Symbol!;
+
+            if (typeSymbol is ITypeParameterSymbol typeParam && !typeParam.IsVariantCompatible())
             {
-                Common.ReportTypeArgumentParentSymbolUnhandled(context, typeArgumentSyntax, parentSymbol);
+                Common.ReportGenericTypeParameterMustBeVariantAnnotated(context, typeParam);
+            }
+        }
+
+        /// <summary>
+        /// If a generic type is used in a signal delegate, make sure it is [MustBeVariant]
+        /// </summary>
+        /// <param name="context"></param>
+        private void AnalyzeSignals(SyntaxNodeAnalysisContext context)
+        {
+            SemanticModel sm = context.SemanticModel;
+            var delegateSyntax = (DelegateDeclarationSyntax)context.Node;
+
+            if (!delegateSyntax.GetAllAttributes().Any(a => a.GetTypeSymbol(sm).IsGodotSignalAttribute()))
+                return;
+
+            foreach (var param in delegateSyntax.ParameterList.Parameters)
+            {
+                if (param.Type == null) continue;
+
+                var paramType = (ITypeSymbol)ModelExtensions.GetSymbolInfo(sm, param.Type).Symbol!;
+
+                if (paramType is ITypeParameterSymbol typeParam && !typeParam.IsVariantCompatible())
+                {
+                    Common.ReportGenericTypeParameterMustBeVariantAnnotated(context, typeParam);
+                }
+            }
+
+            var retType = (ITypeSymbol)ModelExtensions.GetSymbolInfo(sm, delegateSyntax.ReturnType).Symbol!;
+            if (retType is ITypeParameterSymbol retTypeParam && !retTypeParam.IsVariantCompatible())
+            {
+                Common.ReportGenericTypeParameterMustBeVariantAnnotated(context, retTypeParam);
+            }
+        }
+
+        /// <summary>
+        /// Any time a generic name (type, method) is referenced, check to make sure all of the type arguments
+        /// that need to be [MustBeVariant] are Variant-compatible.
+        /// </summary>
+        private void AnalyzeGenericTypeUsage(SyntaxNodeAnalysisContext context)
+        {
+            SemanticModel sm = context.SemanticModel;
+            MarshalUtils.TypeCache typeCache = new MarshalUtils.TypeCache(context.Compilation);
+
+            // Get both the type arguments and type parameters for the generic name
+            ISymbol? genericName = sm.GetSymbolInfo(context.Node).Symbol;
+            var (typeArguments, typeParameters) = genericName switch
+            {
+                INamedTypeSymbol typeSymbol => (typeSymbol.TypeArguments, typeSymbol.TypeParameters),
+                IMethodSymbol methodSymbol => (methodSymbol.TypeArguments, methodSymbol.TypeParameters),
+                _ => (ImmutableArray<ITypeSymbol>.Empty, ImmutableArray<ITypeParameterSymbol>.Empty)
+            };
+
+            // Nothing to check.
+            if (genericName == null || typeArguments.Length == 0) return;
+
+            // Check each type argument
+            for (int i = 0; i < typeParameters.Length; i++)
+            {
+                // This type parameter isn't [MustBeVariant] so we don't care
+                if (!typeParameters[i].IsVariantCompatible()) continue;
+
+                // Check what the provided type argument is
+                ITypeSymbol argument = typeArguments[i];
+                if (argument is ITypeParameterSymbol typeParam && !typeParam.IsVariantCompatible())
+                {
+                    // Another type parameter took its place but it isn't also [MustBeVariant]
+                    Common.ReportGenericTypeParameterMustBeVariantAnnotated(context, typeParam);
+                    continue;
+                }
+
+                if (MarshalUtils.ConvertManagedTypeToMarshalType(typeArguments[i], typeCache) == null)
+                {
+                    // An explicit type was specified but we can't marshal it to a variant type
+                    Common.ReportGenericTypeArgumentMustBeVariant(context, context.Node, argument);
+                    continue;
+                }
+
+                // Now that we know the type arguments used with this generic type we can try to find invalid usage
+                CheckForInvalidGenericVariantUsage(context, genericName, typeParameters[i], typeArguments[i],
+                    context.Node, typeCache);
+            }
+        }
+
+        /// <summary>
+        /// There are a few edge cases where we might not know for sure if the usage of a [MustBeGeneric] type parameter
+        /// is valid until we know the type argument that replaces it. Here we check for that. This isn't perfect, but
+        /// hopefully it will catch the majority of invalid uses.
+        ///
+        /// Consider the class:
+        /// <code>
+        /// public partial class GenericObject&lt;[MustBeGeneric] T&gt; : Node
+        /// {
+        ///     [Export] public T SomeField;
+        ///     [Export] public T[] SomeArray;
+        /// }
+        /// </code>
+        ///
+        /// The above class is perfectly valid provided that both T and T[] are Variant-compatible, which is the case
+        /// with several types such as int, float, Vector2, Color, StringName, etc. However, there are also some types
+        /// where this isn't the case, such as Rect2, Plane, Callable, and more. A system array of any of these types
+        /// is not Variant-compatible and they cannot be marshaled, instead they need to use a Godot.Collections.Array.
+        ///
+        /// Additionally, any array of a GodotObject-derived type is considered Variant-compatible but it isn't really
+        /// as it is always marshalled to/from a Godot array first, and the Variant.From and Variant.ConvertTo methods
+        /// don't support them so there's no way to marshal them in an entirely generic context. For these reasons,
+        /// this is also considered invalid usage and should also use a Godot.Collections.Array.
+        ///
+        /// Note on the above; exporting a system array of GodotObject-derived types should still be fine as long as
+        /// it isn't generic. There's a special case in the source generator to handle this provided it knows the type
+        /// ahead of time, which is not the case when using type parameters.
+        /// </summary>
+        private void CheckForInvalidGenericVariantUsage(SyntaxNodeAnalysisContext context, ISymbol genericName,
+            ITypeParameterSymbol typeParameter, ITypeSymbol typeArgument, SyntaxNode location,
+            MarshalUtils.TypeCache typeCache)
+        {
+            ITypeSymbol? invalidType = null;
+            ISymbol? source = null;
+
+            if (typeArgument is not INamedTypeSymbol) return;
+
+            if (genericName is INamedTypeSymbol typeSymbol)
+                IsValidType(typeParameter, typeSymbol, typeSymbol.OriginalDefinition, typeCache, out invalidType,
+                    ref source);
+            else if (genericName is IMethodSymbol methodSymbol)
+                CheckMethodSymbol(typeParameter, methodSymbol, methodSymbol.OriginalDefinition, typeCache,
+                    out invalidType, out source);
+
+            if (invalidType != null && source != null)
+            {
+                Common.ReportInvalidMustBeGenericTypeParameterUsage(context, typeParameter, typeArgument,
+                    invalidType, source, location);
+            }
+        }
+
+        private bool IsValidType(ITypeParameterSymbol typeParameter, ITypeSymbol type, ITypeSymbol originalType,
+            MarshalUtils.TypeCache typeCache, out ITypeSymbol? invalidType, ref ISymbol? source)
+        {
+            // If the type itself is not valid then no
+            MarshalType? marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(type, typeCache);
+            if (marshalType == null || marshalType == MarshalType.GodotObjectOrDerivedArray)
+            {
+                invalidType = originalType;
                 return false;
             }
 
-            return typeParamSymbol.GetAttributes()
-                .Any(a => a.AttributeClass?.IsGodotMustBeVariantAttribute() ?? false);
+            // If this type is also generic we need to go deeper still
+            if (type is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.Arity > 0)
+            {
+                // Check all of the type members to see if any of them are invalid
+                INamedTypeSymbol originalNamedType = (INamedTypeSymbol)originalType;
+                if (!CheckTypeMembers(typeParameter, namedTypeSymbol, originalNamedType, typeCache, out invalidType,
+                        out source))
+                    return false;
+
+                INamedTypeSymbol? baseType = type.BaseType;
+                if (baseType != null && baseType.Arity > 0)
+                {
+                    // If the type parameter was passed into a parent generic type, we can check those too
+                    INamedTypeSymbol originalBaseType = originalNamedType.BaseType!;
+                    for (int i = 0; i < namedTypeSymbol.TypeArguments.Length; i++)
+                    {
+                        if (!UsesTypeParameter(typeParameter, baseType, originalBaseType))
+                            continue;
+
+                        if (!IsValidType(typeParameter, baseType, originalBaseType, typeCache, out invalidType, ref source))
+                            return false;
+                    }
+                }
+            }
+
+            invalidType = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Checks a method's argument types and return type for non Variant-compatible types
+        /// </summary>
+        private bool CheckMethodSymbol(ITypeParameterSymbol typeParameter, IMethodSymbol methodSymbol,
+            IMethodSymbol originalMethodSymbol, MarshalUtils.TypeCache typeCache, out ITypeSymbol? invalidType,
+            out ISymbol? source)
+        {
+            source = methodSymbol.OriginalDefinition;
+
+            // Check each parameter and the return type
+            for (int i = 0; i < methodSymbol.Parameters.Length; i++)
+            {
+                // Only check parameters that originally used this specific type parameter
+                ITypeSymbol paramType = methodSymbol.Parameters[i].Type;
+                ITypeSymbol originalParamType = originalMethodSymbol.Parameters[i].Type;
+                if (!UsesTypeParameter(typeParameter, paramType, originalParamType)) continue;
+
+                // Warn if new type is no longer valid
+                if (!IsValidType(typeParameter, paramType, originalParamType, typeCache, out invalidType, ref source))
+                    return false;
+            }
+
+            // Same but for return type
+            ITypeSymbol originalRetType = originalMethodSymbol.ReturnType;
+            if (UsesTypeParameter(typeParameter, methodSymbol.ReturnType, originalRetType))
+            {
+                if (!IsValidType(typeParameter, methodSymbol.ReturnType, originalRetType, typeCache,
+                        out invalidType, ref source))
+                    return false;
+            }
+
+            invalidType = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Check a generic type for non Variant-compatible members
+        /// </summary>
+        private bool CheckTypeMembers(ITypeParameterSymbol typeParameter, INamedTypeSymbol typeSymbol,
+            INamedTypeSymbol originalType, MarshalUtils.TypeCache typeCache, out ITypeSymbol? invalidType,
+            out ISymbol? source)
+        {
+            source = originalType;
+
+            ImmutableArray<ISymbol> members = typeSymbol.GetMembers();
+            ImmutableArray<ISymbol> originalMembers = originalType.GetMembers();
+            for (int i = 0; i < members.Length; i++)
+            {
+                ISymbol member = members[i];
+                if (member is IPropertySymbol property && property.HasGodotExportAttribute())
+                {
+                    ITypeSymbol originalPropertyType = ((IPropertySymbol)originalMembers[i]).OriginalDefinition.Type;
+                    if (!IsValidType(typeParameter, property.Type, originalPropertyType, typeCache, out invalidType,
+                            ref source))
+                        return false;
+                }
+                else if (member is IFieldSymbol field && field.HasGodotExportAttribute())
+                {
+                    ITypeSymbol originalFieldType = ((IFieldSymbol)originalMembers[i]).OriginalDefinition.Type;
+                    if (!IsValidType(typeParameter, field.Type, originalFieldType, typeCache, out invalidType,
+                            ref source))
+                        return false;
+                }
+                else if (member is IMethodSymbol)
+                {
+                    // TODO: Do we want to analyze and error on methods...?
+                }
+                else if (member is INamedTypeSymbol namedType && namedType.HasGodotSignalAttribute())
+                {
+                    IMethodSymbol? methodSymbol = namedType.DelegateInvokeMethod;
+                    if (methodSymbol == null) continue;
+                    IMethodSymbol originalMethodSymbol = ((INamedTypeSymbol)originalMembers[i]).DelegateInvokeMethod!;
+
+                    if (!CheckMethodSymbol(typeParameter, methodSymbol, originalMethodSymbol, typeCache,
+                            out invalidType, out source))
+                    {
+                        source = originalMembers[i];
+                        return false;
+                    }
+                }
+            }
+
+            invalidType = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the given symbol used the given type parameter in any part of itself
+        /// </summary>
+        private bool UsesTypeParameter(ITypeParameterSymbol typeParamSymbol, ITypeSymbol currentTypeSymbol,
+            ITypeSymbol originalTypeSymbol)
+        {
+            static bool CompareSymbols(ISymbol a, ISymbol b) => SymbolEqualityComparer.Default.Equals(a, b);
+
+            // If it hasn't changed then no
+            if (CompareSymbols(originalTypeSymbol, currentTypeSymbol)) return false;
+
+            // If the type previously was just the generic type itself, yes
+            if (CompareSymbols(originalTypeSymbol, typeParamSymbol)) return true;
+
+            // If the type was an array of the generic type, yes
+            if (originalTypeSymbol is IArrayTypeSymbol array && CompareSymbols(array.ElementType, typeParamSymbol))
+                return true;
+
+            // If the symbol used the generic type in another type argument list, yes
+            if (currentTypeSymbol is INamedTypeSymbol currentNamedType && currentNamedType.Arity > 0)
+            {
+                var originalNamedType = (INamedTypeSymbol)originalTypeSymbol;
+                for (int i = 0; i < currentNamedType.TypeArguments.Length; i++)
+                {
+                    // If the nested type used our type parameter, yes.
+                    if (UsesTypeParameter(typeParamSymbol, currentNamedType.TypeArguments[i],
+                            originalNamedType.TypeArguments[i]))
+                        return true;
+                }
+            }
+
+            // Otherwise probably no? Can't think of anything else.
+            return false;
         }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/PropertyInfo.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/PropertyInfo.cs
@@ -1,15 +1,18 @@
+using Microsoft.CodeAnalysis;
+
 namespace Godot.SourceGenerators
 {
     internal readonly struct PropertyInfo
     {
-        public PropertyInfo(VariantType type, string name, PropertyHint hint,
+        public PropertyInfo(VariantType? variantType, ITypeSymbol? propertyType, string name, PropertyHint hint,
             string? hintString, PropertyUsageFlags usage, bool exported)
-            : this(type, name, hint, hintString, usage, className: null, exported) { }
+            : this(variantType, propertyType, name, hint, hintString, usage, className: null, exported) { }
 
-        public PropertyInfo(VariantType type, string name, PropertyHint hint,
+        public PropertyInfo(VariantType? variantType, ITypeSymbol? propertyType, string name, PropertyHint hint,
             string? hintString, PropertyUsageFlags usage, string? className, bool exported)
         {
-            Type = type;
+            VariantType = variantType;
+            PropertyType = propertyType;
             Name = name;
             Hint = hint;
             HintString = hintString;
@@ -18,7 +21,8 @@ namespace Godot.SourceGenerators
             Exported = exported;
         }
 
-        public VariantType Type { get; }
+        public VariantType? VariantType { get; }
+        public ITypeSymbol? PropertyType { get; }
         public string Name { get; }
         public PropertyHint Hint { get; }
         public string? HintString { get; }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -292,7 +292,7 @@ namespace Godot.SourceGenerators
                 .Append(methodInfo.Name)
                 .Append(", returnVal: ");
 
-            AppendPropertyInfo(source, methodInfo.ReturnVal);
+            source.AppendPropertyInfo(methodInfo.ReturnVal, "\"{0}\"");
 
             source.Append(", flags: (global::Godot.MethodFlags)")
                 .Append((int)methodInfo.Flags)
@@ -304,7 +304,7 @@ namespace Godot.SourceGenerators
 
                 foreach (var param in methodInfo.Arguments)
                 {
-                    AppendPropertyInfo(source, param);
+                    source.AppendPropertyInfo(param, "\"{0}\"");
 
                     // C# allows colon after the last element
                     source.Append(", ");
@@ -320,29 +320,6 @@ namespace Godot.SourceGenerators
             source.Append(", defaultArguments: null));\n");
         }
 
-        private static void AppendPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)
-        {
-            source.Append("new(type: (global::Godot.Variant.Type)")
-                .Append((int)propertyInfo.Type)
-                .Append(", name: \"")
-                .Append(propertyInfo.Name)
-                .Append("\", hint: (global::Godot.PropertyHint)")
-                .Append((int)propertyInfo.Hint)
-                .Append(", hintString: \"")
-                .Append(propertyInfo.HintString)
-                .Append("\", usage: (global::Godot.PropertyUsageFlags)")
-                .Append((int)propertyInfo.Usage)
-                .Append(", exported: ")
-                .Append(propertyInfo.Exported ? "true" : "false");
-            if (propertyInfo.ClassName != null)
-            {
-                source.Append(", className: new global::Godot.StringName(\"")
-                    .Append(propertyInfo.ClassName)
-                    .Append("\")");
-            }
-            source.Append(")");
-        }
-
         private static MethodInfo DetermineMethodInfo(GodotMethodData method)
         {
             PropertyInfo returnVal;
@@ -355,7 +332,7 @@ namespace Godot.SourceGenerators
             }
             else
             {
-                returnVal = new PropertyInfo(VariantType.Nil, string.Empty, PropertyHint.None,
+                returnVal = new PropertyInfo(VariantType.Nil, null, string.Empty, PropertyHint.None,
                     hintString: null, PropertyUsageFlags.Default, exported: false);
             }
 
@@ -392,20 +369,23 @@ namespace Godot.SourceGenerators
 
         private static PropertyInfo DeterminePropertyInfo(MarshalType marshalType, ITypeSymbol typeSymbol, string name)
         {
-            var memberVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(marshalType)!.Value;
+            var memberVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(marshalType);
 
             var propUsage = PropertyUsageFlags.Default;
-
-            if (memberVariantType == VariantType.Nil)
-                propUsage |= PropertyUsageFlags.NilIsVariant;
-
             string? className = null;
-            if (memberVariantType == VariantType.Object && typeSymbol is INamedTypeSymbol namedTypeSymbol)
+
+            if (memberVariantType.HasValue)
             {
-                className = namedTypeSymbol.GetGodotScriptNativeClassName();
+                if (memberVariantType == VariantType.Nil)
+                    propUsage |= PropertyUsageFlags.NilIsVariant;
+
+                if (memberVariantType == VariantType.Object && typeSymbol is INamedTypeSymbol namedTypeSymbol)
+                {
+                    className = namedTypeSymbol.GetGodotScriptNativeClassName();
+                }
             }
 
-            return new PropertyInfo(memberVariantType, name,
+            return new PropertyInfo(memberVariantType, typeSymbol, name,
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GenericUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GenericUtils.cs
@@ -1,0 +1,174 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Text;
+using Godot.NativeInterop;
+
+namespace Godot.Bridge;
+
+// ReSharper disable UnusedMember.Global
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class GenericUtils
+{
+    public static PropertyInfo PropertyInfoFromGenericType<[MustBeVariant] T>(StringName name, PropertyHint hint,
+        string hintString, PropertyUsageFlags usage, bool exported)
+    {
+        Variant.Type variantType = VariantUtils.TypeOf<T>();
+
+        // If we're not in an editor build, don't bother with the hint string.
+        // It's likely not AOT safe and we don't need it anyway.
+        if (!OS.HasFeature("editor"))
+        {
+            hint = PropertyHint.None;
+            hintString = "";
+        }
+        else GetPropertyHintString(typeof(T), variantType, hint, hintString, out hint, out hintString);
+
+        return new PropertyInfo(variantType, name, hint, hintString, usage, exported);
+    }
+
+    /// <summary>
+    /// Determines what editor hint and hint string to use for a given managed type.
+    /// This function shares its logic with ScriptPropertiesGenerator.TryGetMemberExportHint so if you update
+    /// anything here, check if it needs updating over there too!
+    /// </summary>
+    private static bool GetPropertyHintString(Type type, Variant.Type variantType, PropertyHint exportHint,
+        string exportHintString, out PropertyHint hint, out string hintString)
+    {
+        hint = PropertyHint.None;
+        hintString = "";
+
+        if (variantType == Variant.Type.Nil) return true;
+
+        if (variantType == Variant.Type.Int && typeof(Enum).IsAssignableFrom(type))
+        {
+            hint = type.GetCustomAttribute<FlagsAttribute>() != null ? PropertyHint.Flags : PropertyHint.Enum;
+
+            // Build a string of all the enum names and values, e.g:
+            // Foo:0,Bar:1,Baz:2
+            StringBuilder sb = new StringBuilder();
+            foreach (FieldInfo enumField in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                sb.Append(enumField.Name).Append(':').Append(enumField.GetRawConstantValue()).Append(',');
+            }
+
+            // Remove trailing comma
+            sb.Length -= 1;
+            hintString = sb.ToString();
+            return true;
+        }
+
+        if (variantType == Variant.Type.Object)
+        {
+            if (typeof(Resource).IsAssignableFrom(type))
+            {
+                hint = PropertyHint.ResourceType;
+                hintString = GetTypeName(type);
+                return true;
+            }
+
+            if (typeof(Node).IsAssignableFrom(type))
+            {
+                hint = PropertyHint.NodeType;
+                hintString = GetTypeName(type);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (variantType == Variant.Type.Array)
+        {
+            // No hint needed for generic arrays
+            if (typeof(Godot.Collections.Array) == type)
+            {
+                return true;
+            }
+
+            // Lets find out what the elements should be hinted as
+            Type elementType = type!.GetGenericArguments()[0];
+            Variant.Type elementVariantType = GetVariantType(elementType);
+            bool hasElementHint = GetPropertyHintString(elementType, elementVariantType, exportHint,
+                exportHintString, out var elementHint, out var elementHintString);
+
+            // Special case for string arrays
+            hint = PropertyHint.TypeString;
+            if (!GetStringArrayEnumHint(exportHint, exportHintString, elementVariantType, ref hintString))
+            {
+                hintString = hasElementHint
+                    ? $"{(int)elementVariantType}/{(int)elementHint}:{elementHintString}"
+                    : $"{(int)elementVariantType}/{(int)PropertyHint.None}:";
+            }
+
+            return true;
+        }
+
+        if (variantType == Variant.Type.PackedStringArray)
+        {
+            if (GetStringArrayEnumHint(exportHint, exportHintString, Variant.Type.String, ref hintString))
+            {
+                hint = PropertyHint.TypeString;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (variantType == Variant.Type.Dictionary)
+        {
+            // TODO: Dictionaries are not supported in the editor.
+            return false;
+        }
+
+        return false;
+    }
+
+    private static string GetTypeName(Type type)
+    {
+        // If this is a global class, we use the class name
+        if (type.GetCustomAttribute<GlobalClassAttribute>() != null)
+        {
+            return type.Name;
+        }
+
+        // Otherwise we find the first Godot type and use its name.
+        Type nativeType = type;
+        while (nativeType != null)
+        {
+            if (nativeType.Namespace == "Godot")
+            {
+                var classNameAttribute = nativeType.GetCustomAttribute<GodotClassNameAttribute>(false);
+                return classNameAttribute != null ? classNameAttribute.Name : nativeType.Name;
+            }
+
+            nativeType = nativeType.BaseType;
+        }
+
+        // This shouldn't happen
+        return "";
+    }
+
+    private static bool GetStringArrayEnumHint(PropertyHint hint, string hintString, Variant.Type elementVariantType,
+        ref string newHint)
+    {
+        if (hint == PropertyHint.Enum)
+        {
+            newHint = $"{(int)elementVariantType}/{(int)PropertyHint.Enum}:{hintString}";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static Variant.Type GetVariantType(Type type)
+    {
+        // There's no non-generic overload for VariantUtils.TypeOf
+        // But because this is only used for hints and the editor will never be AOT, this is fine.
+        return (Variant.Type)typeof(VariantUtils)
+            .GetMethod(nameof(VariantUtils.TypeOf),
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)!
+            .MakeGenericMethod(type).Invoke(null, null)!;
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -411,4 +411,69 @@ public partial class VariantUtils
 
         return GenericConversion<T>.FromVariant(variant);
     }
+
+    public static Variant.Type TypeOf<[MustBeVariant] T>()
+    {
+        if (typeof(T) == typeof(bool)) return Variant.Type.Bool;
+        if (typeof(T) == typeof(char)) return Variant.Type.Int;
+        if (typeof(T) == typeof(sbyte)) return Variant.Type.Int;
+        if (typeof(T) == typeof(short)) return Variant.Type.Int;
+        if (typeof(T) == typeof(int)) return Variant.Type.Int;
+        if (typeof(T) == typeof(long)) return Variant.Type.Int;
+        if (typeof(T) == typeof(byte)) return Variant.Type.Int;
+        if (typeof(T) == typeof(ushort)) return Variant.Type.Int;
+        if (typeof(T) == typeof(uint)) return Variant.Type.Int;
+        if (typeof(T) == typeof(ulong)) return Variant.Type.Int;
+        if (typeof(T) == typeof(float)) return Variant.Type.Float;
+        if (typeof(T) == typeof(double)) return Variant.Type.Float;
+        if (typeof(T) == typeof(Vector2)) return Variant.Type.Vector2;
+        if (typeof(T) == typeof(Vector2I)) return Variant.Type.Vector2I;
+        if (typeof(T) == typeof(Rect2)) return Variant.Type.Rect2;
+        if (typeof(T) == typeof(Rect2I)) return Variant.Type.Rect2I;
+        if (typeof(T) == typeof(Transform2D)) return Variant.Type.Transform2D;
+        if (typeof(T) == typeof(Projection)) return Variant.Type.Projection;
+        if (typeof(T) == typeof(Vector3)) return Variant.Type.Vector3;
+        if (typeof(T) == typeof(Vector3I)) return Variant.Type.Vector3I;
+        if (typeof(T) == typeof(Basis)) return Variant.Type.Basis;
+        if (typeof(T) == typeof(Quaternion)) return Variant.Type.Quaternion;
+        if (typeof(T) == typeof(Transform3D)) return Variant.Type.Transform3D;
+        if (typeof(T) == typeof(Vector4)) return Variant.Type.Vector4;
+        if (typeof(T) == typeof(Vector4I)) return Variant.Type.Vector4I;
+        if (typeof(T) == typeof(Aabb)) return Variant.Type.Aabb;
+        if (typeof(T) == typeof(Color)) return Variant.Type.Color;
+        if (typeof(T) == typeof(Plane)) return Variant.Type.Plane;
+        if (typeof(T) == typeof(Callable)) return Variant.Type.Callable;
+        if (typeof(T) == typeof(Signal)) return Variant.Type.Signal;
+        if (typeof(T) == typeof(string)) return Variant.Type.String;
+        if (typeof(T) == typeof(byte[])) return Variant.Type.PackedByteArray;
+        if (typeof(T) == typeof(int[])) return Variant.Type.PackedInt32Array;
+        if (typeof(T) == typeof(long[])) return Variant.Type.PackedInt64Array;
+        if (typeof(T) == typeof(float[])) return Variant.Type.PackedFloat32Array;
+        if (typeof(T) == typeof(double[])) return Variant.Type.PackedFloat64Array;
+        if (typeof(T) == typeof(string[])) return Variant.Type.PackedStringArray;
+        if (typeof(T) == typeof(Vector2[])) return Variant.Type.PackedVector2Array;
+        if (typeof(T) == typeof(Vector3[])) return Variant.Type.PackedVector3Array;
+        if (typeof(T) == typeof(Color[])) return Variant.Type.PackedColorArray;
+        if (typeof(T) == typeof(StringName[])) return Variant.Type.Array;
+        if (typeof(T) == typeof(NodePath[])) return Variant.Type.Array;
+        if (typeof(T) == typeof(Rid[])) return Variant.Type.Array;
+        if (typeof(T) == typeof(StringName)) return Variant.Type.StringName;
+        if (typeof(T) == typeof(NodePath)) return Variant.Type.NodePath;
+        if (typeof(T) == typeof(Rid)) return Variant.Type.Rid;
+        if (typeof(T) == typeof(Godot.Collections.Dictionary)) return Variant.Type.Dictionary;
+        if (typeof(T) == typeof(Godot.Collections.Array)) return Variant.Type.Array;
+        if (typeof(T) == typeof(Variant)) return Variant.Type.Nil;
+        if (typeof(GodotObject).IsAssignableFrom(typeof(T))) return Variant.Type.Object;
+        if (typeof(T).IsValueType && typeof(System.Enum).IsAssignableFrom(typeof(T))) return Variant.Type.Int;
+
+        if (typeof(T).IsGenericType)
+        {
+            // I think this is OK to do w/ AOT?
+            Type genericTypeDef = typeof(T).GetGenericTypeDefinition();
+            if (typeof(Collections.Array<>) == genericTypeDef) return Variant.Type.Array;
+            if (typeof(Collections.Dictionary<,>) == genericTypeDef) return Variant.Type.Dictionary;
+        }
+
+        return Variant.Type.Nil;
+    }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -47,6 +47,7 @@
   <!-- Sources -->
   <ItemGroup>
     <Compile Include="Core\Aabb.cs" />
+    <Compile Include="Core\Bridge\GenericUtils.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />
     <Compile Include="Core\Callable.generics.cs" />


### PR DESCRIPTION
This allows the usage of C# generic type parameters in exported properties, methods, and signals, and fixes a couple issues with the existing generic analyzer. The behavior of these generic members should match with if you had exported them non-generically, so they work with all Variant types, exports and signals show up in the editor, GDScript scripts can call your generic methods, etc.

The biggest change is to the analyzer itself as lifting the restriction on generic usage opened the doors for some problematic edge cases. I left a big comment in the MustBeVariantAnalyzer file explaining it all, but basically it's just that some Variant types support being marshaled as a C# array `T[]` and others don't. It's not possible to know if an exported property of `T[]` is valid until we know what type replaces `T`, so that's what the analyzer now does.

* Fixes #74960 
* Fixes #82939
* Fixes a bug where the MustBeVariantAnalyzer would miss enforcing the attribute on generic method calls when the type argument is inferred
