### PR TITLE
Docs: Fix link to Android Gradle build tutorial

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -7,7 +7,7 @@
 	</description>
 	<tutorials>
 		<link title="Exporting for Android">$DOCS_URL/tutorials/export/exporting_for_android.html</link>
-		<link title="Custom builds for Android">$DOCS_URL/tutorials/export/android_custom_build.html</link>
+		<link title="Gradle builds for Android">$DOCS_URL/tutorials/export/android_gradle_build.html</link>
 		<link title="Android plugins documentation index">$DOCS_URL/tutorials/platform/index.html</link>
 	</tutorials>
 	<members>


### PR DESCRIPTION
https://github.com/godotengine/godot-docs/pull/7884 on the docs changed the URL for this page referenced in the Android platform class reference; the change is live in `master`/4.2 and was backported to 4.1 in https://github.com/godotengine/godot-docs/pull/8217, which will be cherrypicked to 4.0 soon.

In-editor/on the web this will be fine, as the page will be redirected. The outdated link in the class reference breaks docs CI currently though, so we still need to adapt the link in the main repo. :)

Until then, I've made that change temporarily on the docs side in https://github.com/godotengine/godot-docs/pull/8244.