### PR TITLE
Update `triangulate_delaunay()` to avoid needless reallocations

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -306,10 +306,12 @@ public:
 		Vector<Delaunay2D::Triangle> tr = Delaunay2D::triangulate(p_points);
 		Vector<int> triangles;
 
+		triangles.resize(3 * tr.size());
+		int *ptr = triangles.ptrw();
 		for (int i = 0; i < tr.size(); i++) {
-			triangles.push_back(tr[i].points[0]);
-			triangles.push_back(tr[i].points[1]);
-			triangles.push_back(tr[i].points[2]);
+			*ptr++ = tr[i].points[0];
+			*ptr++ = tr[i].points[1];
+			*ptr++ = tr[i].points[2];
 		}
 		return triangles;
 	}


### PR DESCRIPTION
During the review process of the #83353 PR a certain optimization was proposed by one of the members of the Godot team; said optimization can be applied to a related function, which is what this PR accomplishes.
