### PR TITLE
Document `AudioStreamGeneratorPlayback.get_skips()`

### DIFF
--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -33,6 +33,7 @@
 		<method name="get_skips" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the number of times the playback skipped due to a buffer underrun in the audio sample data. This value is reset at the start of the playback.
 			</description>
 		</method>
 		<method name="push_buffer">


### PR DESCRIPTION
>Does anyone know what the `get_skips()` method is used for? I'd like to get 100% documentation completion on this class :slightly_smiling_face:

_Originally posted by @Calinou in https://github.com/godotengine/godot/pull/48682#discussion_r631488773_
            