### PR TITLE
Display multiplayer authority ID in remote debugger

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -336,6 +336,12 @@ SceneDebuggerObject::SceneDebuggerObject(ObjectID p_id) {
 	}
 
 	if (Node *node = Object::cast_to<Node>(obj)) {
+		// For debugging multiplayer.
+		{
+			PropertyInfo pi(Variant::INT, String("Node/multiplayer_authority"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);
+			properties.push_back(SceneDebuggerProperty(pi, node->get_multiplayer_authority()));
+		}
+
 		// Add specialized NodePath info (if inside tree).
 		if (node->is_inside_tree()) {
 			PropertyInfo pi(Variant::NODE_PATH, String("Node/path"));


### PR DESCRIPTION
Adds the multiplayer_authority ID value to the remote node debugger.
![NVIDIA_Share_5BaKgFmKIn](https://github.com/godotengine/godot/assets/12756047/12586780-7135-47ba-b855-4e4563776ad0)
