### PR TITLE
Input - prevent action missed input on Android

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -98,6 +98,13 @@ private:
 	int64_t mouse_window = 0;
 	bool legacy_just_pressed_behavior = false;
 
+	// Input can come in AFTER the user has had the opportunity to poll input for the
+	// frame or tick, and thus the input "clocks" are kept one ahead of the regular
+	// engine clocks, and syncing immediately prior to process() and physics_process()
+	// in order to minimize latency.
+	uint64_t input_curr_tick = 0;
+	uint64_t input_curr_process_frame = 0;
+
 	struct Action {
 		uint64_t pressed_physics_frame = UINT64_MAX;
 		uint64_t pressed_process_frame = UINT64_MAX;
@@ -346,6 +353,9 @@ public:
 	void release_pressed_events();
 
 	void set_event_dispatch_function(EventDispatchFunc p_function);
+
+	void set_curr_tick(uint64_t p_tick) { input_curr_tick = p_tick; }
+	void set_curr_process_frame(uint64_t p_frame) { input_curr_process_frame = p_frame; }
 
 	Input();
 	~Input();

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -456,6 +456,8 @@ bool SceneTree::physics_process(double p_time) {
 
 	flush_transform_notifications();
 
+	Input::get_singleton()->set_curr_tick(Engine::get_singleton()->get_physics_frames() + 1);
+
 	if (MainLoop::physics_process(p_time)) {
 		_quit = true;
 	}
@@ -485,6 +487,8 @@ bool SceneTree::physics_process(double p_time) {
 
 bool SceneTree::process(double p_time) {
 	root_lock++;
+
+	Input::get_singleton()->set_curr_process_frame(Engine::get_singleton()->get_process_frames() + 1);
 
 	if (MainLoop::process(p_time)) {
 		_quit = true;


### PR DESCRIPTION
On Android, if input came in on a tick or frame after the physics_process or process, it could be missed when relying on `is_action_just_pressed()`. This is because by the time the action got around to being checked, the action's tick or frame would have passed.

This PR changes the timestamp for the action to be for the next tick or next frame (preventing missed input), but only immediately prior to `process` and `physics_process`, in order to minimize latency.

Alternative to #83301
Fixes #66318

## Discussion
There's likely several ways of fixing this (and different ways of doing the sync, e.g. `MainLoop` versus `Main::iteration()` versus `SceneTree` etc). There might be some better way of protecting people making custom `MainLoop` - welcome suggestions here, I've just used some `DEV_ASSERTS` here, which (rightly or wrongly) is assuming they are building from source, as a custom `MainLoop` seems to be _here there be dragons_ territory. Custom `MainLoop` is really difficult in general once you get down to the subtleties of timing I guess.

I was originally unsure about #83301 but it's actually not a bad approach, as essentially we want to pass any input that is occurring after the "read point" to the next tick / frame. But the latency is a bit of a downside, especially for input that could unnecessarily be shifted to the next tick which might be on a later frame. 

I first experimented with storing a read tick on each action, such that if it had not been read so far on that tick, the registered tick would be placed on the current tick, but if it had been read, it would be `tick+1`. This would make latency pretty minimal, but I wasn't keen on the haphazard / stochastic nature, so am now of the opinion a fixed sync point might be better.

Here I've placed the sync point just before the calls to `physics_process` and `process`. It may not gain a massive amount over just using `tick+1` everywhere (particularly for idle frame), but it seems slightly better for reducing latency, which is something we should strive for.

## Notes
* #83301 has the downside that it seems likely to unnecessarily introduced extra latency on non-Android platforms, whereas this PR should not have effects on other platforms.
* Compared to #83301 this additionally fixes input on the frame as well as physics tick, as the frame also seems to share the vulnerability (although may occur less in practice).
* This area can probably be improved in future if we proceed with #77062, as that makes the input timing slicing a bit more sensible. In fact that PR may also already fix the problem, it's been a while since I worked on it. However these PRs are good for interim fix.
* We discuss Android here, but really the problem is common to platforms that have separate thread for input. That may be more platforms in future.
* I also haven't tested this yet, it would be great to get some confirmation it works (the theory is sound).
* `input_curr_tick` and `input_curr_process_frame` could possibly be atomic, I'll defer to @RandomShaper 's opinion on this.
 
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
