### PR TITLE
Remove AnimationMixer bindings only bound in the editor

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1857,7 +1857,6 @@ Vector3 AnimationMixer::get_root_motion_scale_accumulator() const {
 	return root_motion_scale_accumulator;
 }
 
-#ifdef TOOLS_ENABLED
 void AnimationMixer::set_reset_on_save_enabled(bool p_enabled) {
 	reset_on_save = p_enabled;
 }
@@ -1866,6 +1865,7 @@ bool AnimationMixer::is_reset_on_save_enabled() const {
 	return reset_on_save;
 }
 
+#ifdef TOOLS_ENABLED
 bool AnimationMixer::can_apply_reset() const {
 	return has_animation(SceneStringNames::get_singleton()->RESET);
 }
@@ -2095,14 +2095,10 @@ void AnimationMixer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "is_active");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deterministic"), "set_deterministic", "is_deterministic");
 
-#ifdef TOOLS_ENABLED
-	ClassDB::bind_method(D_METHOD("_reset"), &AnimationMixer::reset);
-	ClassDB::bind_method(D_METHOD("_restore", "backup"), &AnimationMixer::restore);
 	ClassDB::bind_method(D_METHOD("set_reset_on_save_enabled", "enabled"), &AnimationMixer::set_reset_on_save_enabled);
 	ClassDB::bind_method(D_METHOD("is_reset_on_save_enabled"), &AnimationMixer::is_reset_on_save_enabled);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_on_save", PROPERTY_HINT_NONE, ""), "set_reset_on_save_enabled", "is_reset_on_save_enabled");
 	ADD_SIGNAL(MethodInfo("mixer_updated")); // For updating dummy player.
-#endif // TOOLS_ENABLED
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_node"), "set_root_node", "get_root_node");
 

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -46,10 +46,11 @@ class AnimationMixer : public Node {
 	GDCLASS(AnimationMixer, Node);
 #ifdef TOOLS_ENABLED
 	friend AnimatedValuesBackup;
-	bool reset_on_save = true;
 	bool editing = false;
 	bool dummy = false;
 #endif // TOOLS_ENABLED
+
+	bool reset_on_save = true;
 
 public:
 	enum AnimationCallbackModeProcess {
@@ -346,6 +347,9 @@ public:
 	virtual void advance(double p_time);
 	virtual void clear_caches(); ///< must be called by hand if an animation was modified after added
 
+	void set_reset_on_save_enabled(bool p_enabled);
+	bool is_reset_on_save_enabled() const;
+
 #ifdef TOOLS_ENABLED
 	void set_editing(bool p_editing);
 	bool is_editing() const;
@@ -353,8 +357,6 @@ public:
 	void set_dummy(bool p_dummy);
 	bool is_dummy() const;
 
-	void set_reset_on_save_enabled(bool p_enabled);
-	bool is_reset_on_save_enabled() const;
 	bool can_apply_reset() const;
 	void _build_backup_track_cache();
 	Ref<AnimatedValuesBackup> make_backup();


### PR DESCRIPTION
Removes bindings inside `#ifdef TOOL_ENABLED` that would only be bound in the editor and break the C# bindings in exported games.

- Fixes https://github.com/godotengine/godot/issues/82993.