### PR TITLE
Fix description of `Animation::copy_track`

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -257,7 +257,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="to_animation" type="Animation" />
 			<description>
-				Adds a new track that is a copy of the given track from [param to_animation].
+				Adds a new track to [param to_animation] that is a copy of the given track from this animation.
 			</description>
 		</method>
 		<method name="find_track" qualifiers="const">


### PR DESCRIPTION
The documentation stated the track was added to this, instead of `to_animation`

* Fixes: https://github.com/godotengine/godot-docs/issues/8255

As per the code:
https://github.com/godotengine/godot/blob/a60fc7f7c86daad48a8b23c9e4e1fe49cf3a0881/scene/resources/animation.cpp#L3795-L3813

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
