### PR TITLE
Store and display custom Git branch name in version information

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -206,6 +206,7 @@ def version_hash_builder(target, source, env):
 #include "core/version.h"
 
 const char *const VERSION_HASH = "{git_hash}";
+const char *const VERSION_GIT_BRANCH = "{git_branch}";
 const uint64_t VERSION_TIMESTAMP = {git_timestamp};
 """.format(**env.version_info)
         )

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -122,6 +122,9 @@ Dictionary Engine::get_version_info() const {
 	dict["status"] = VERSION_STATUS;
 	dict["build"] = VERSION_BUILD;
 
+	String branch = String::utf8(VERSION_GIT_BRANCH);
+	dict["branch"] = branch.is_empty() ? String("unknown") : branch;
+
 	String hash = String(VERSION_HASH);
 	dict["hash"] = hash.is_empty() ? String("unknown") : hash;
 

--- a/core/version.h
+++ b/core/version.h
@@ -77,10 +77,16 @@
 #define VERSION_FULL_NAME VERSION_NAME " v" VERSION_FULL_BUILD
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
+// If the `.git` folder isn't available at build time, this is an empty string.
 extern const char *const VERSION_HASH;
 
 // Git commit date UNIX timestamp (in seconds), generated at build time in `core/version_hash.gen.cpp`.
 // Set to 0 if unknown.
 extern const uint64_t VERSION_TIMESTAMP;
+
+// Git commit branch, generated at build time in `core/version_hash.gen.cpp`.
+// Only stored for non-default branch names. For default branch names, this is an empty string.
+// If the `.git` folder isn't available at build time, this is an empty string.
+extern const char *const VERSION_GIT_BRANCH;
 
 #endif // VERSION_H

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -179,7 +179,8 @@
 				- [code]hex[/code] - Full version encoded as a hexadecimal int with one byte (2 hex digits) per number (see example below);
 				- [code]status[/code] - Status (such as "beta", "rc1", "rc2", "stable", etc.) as a String;
 				- [code]build[/code] - Build name (e.g. "custom_build") as a String;
-				- [code]hash[/code] - Full Git commit hash as a String;
+				- [code]branch[/code] - Git commit branch name as a String (or "unknown" if not using a custom branch, or if the [code].git/[/code] folder isn't present at build-time);
+				- [code]hash[/code] - Full Git commit hash as a String (or "unknown" if the [code].git/[/code] folder isn't present at build-time);
 				- [code]timestamp[/code] - Holds the Git commit date UNIX timestamp in seconds as an int, or [code]0[/code] if unavailable;
 				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], [code]status[/code], and [code]build[/code] in a single String.
 				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code].

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -179,7 +179,6 @@ EditorAbout::EditorAbout() {
 	hbc->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	hbc->add_theme_constant_override("separation", 30 * EDSCALE);
 	vbc->add_child(hbc);
-
 	_logo = memnew(TextureRect);
 	_logo->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 	hbc->add_child(_logo);

--- a/editor/gui/editor_version_button.cpp
+++ b/editor/gui/editor_version_button.cpp
@@ -34,16 +34,23 @@
 #include "core/version.h"
 
 String _get_version_string(EditorVersionButton::VersionFormat p_format) {
+	String branch = String::utf8(VERSION_GIT_BRANCH);
+	if (branch.length() != 0) {
+		// Trim branch name display if it's too long.
+		constexpr int MAX_BRANCH_NAME_LENGTH = 20;
+		branch = " " + vformat((branch.length() > MAX_BRANCH_NAME_LENGTH) ? "(%s...)" : "(%s)", branch.left(MAX_BRANCH_NAME_LENGTH));
+	}
+
 	String main;
 	switch (p_format) {
 		case EditorVersionButton::FORMAT_BASIC: {
-			return VERSION_FULL_CONFIG;
+			return VERSION_FULL_CONFIG + branch;
 		} break;
 		case EditorVersionButton::FORMAT_WITH_BUILD: {
-			main = "v" VERSION_FULL_BUILD;
+			main = "v" VERSION_FULL_BUILD + branch;
 		} break;
 		case EditorVersionButton::FORMAT_WITH_NAME_AND_BUILD: {
-			main = VERSION_FULL_NAME;
+			main = VERSION_FULL_NAME + branch;
 		} break;
 		default: {
 			ERR_FAIL_V_MSG(VERSION_FULL_NAME, "Unexpected format: " + itos(p_format));
@@ -54,6 +61,7 @@ String _get_version_string(EditorVersionButton::VersionFormat p_format) {
 	if (!hash.is_empty()) {
 		hash = vformat(" [%s]", hash.left(9));
 	}
+
 	return main + hash;
 }
 

--- a/editor/gui/editor_version_button.h
+++ b/editor/gui/editor_version_button.h
@@ -38,11 +38,11 @@ class EditorVersionButton : public LinkButton {
 
 public:
 	enum VersionFormat {
-		// 4.3.2.stable
+		// 4.3.2.stable (branch)
 		FORMAT_BASIC,
-		// v4.3.2.stable.mono [HASH]
+		// v4.3.2.stable.mono (branch) [HASH]
 		FORMAT_WITH_BUILD,
-		// Godot Engine v4.3.2.stable.mono.official [HASH]
+		// Godot Engine v4.3.2.stable.mono.official (branch) [HASH]
 		FORMAT_WITH_NAME_AND_BUILD,
 	};
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -281,11 +281,15 @@ static String unescape_cmdline(const String &p_str) {
 }
 
 static String get_full_version_string() {
+	String branch = String::utf8(VERSION_GIT_BRANCH);
+	if (!branch.is_empty()) {
+		branch = "." + branch;
+	}
 	String hash = String(VERSION_HASH);
 	if (!hash.is_empty()) {
 		hash = "." + hash.left(9);
 	}
-	return String(VERSION_FULL_BUILD) + hash;
+	return String(VERSION_FULL_BUILD) + branch + hash;
 }
 
 #if defined(TOOLS_ENABLED) && defined(MODULE_GDSCRIPT_ENABLED)


### PR DESCRIPTION
This information is visible in the project manager, editor, command line help and About dialog (trimmed to 20 characters in places where it's displayed in the editor). It can also be queried using `Engine.get_version_info()["branch"]`.

This helps avoid mistakes when testing multiple builds from various branches.

Internally, the constant is `VERSION_GIT_BRANCH` as `VERSION_BRANCH` is already used to store the `major.minor` version number.

If the branch name is a standard Godot maintenance branch (such as `master` or `4.1`), the branch name is an empty string (or `unknown` in `Engine.get_version_info()`'s return value).

## Preview

![Screenshot_20231016_005945](https://github.com/godotengine/godot/assets/180032/8ba60362-d9aa-4fd3-92af-bd7ba758f60e)