### PR TITLE
Identify pull request builds from GitHub Actions with the PR number

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -31,6 +31,18 @@ runs:
           SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
       run: |
         echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
-        if [ "${{ inputs.target }}" != "editor" ]; then rm -rf editor; fi  # Ensure we don't include editor code.
+
+        if [ "${{ inputs.target }}" != "editor" ]; then
+          # Ensure we don't include editor code in export template builds.
+          rm -rf editor
+        fi
+
+        if [ "${{ github.event.number }}" != "" ]; then
+          # Set build identifier with pull request number if available. This is displayed throughout the editor.
+          export BUILD_NAME="gh-${{ github.event.number }}"
+        else
+          export BUILD_NAME="gh"
+        fi
+
         scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
         ls -l bin/


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/83445 (can be merged independently).

This makes it easier to go back to the pull request the build was made from. The build name is displayed in the Project Manager, editor About dialog and editor version tooltip (at the bottom of the editor). It's also copied within the Copy System Information text.

## Preview

### GitHub Actions build from a push

![Screenshot_20231016_062303](https://github.com/godotengine/godot/assets/180032/cea45ac2-9410-497a-b260-81785c1b8581)

### GitHub Actions build from a pull request

*PR number is `11` in this example (I was testing on my fork).*

![Screenshot_20231016_062321](https://github.com/godotengine/godot/assets/180032/9bb34f93-c548-4653-ae14-447e6caef2ee)
