### PR TITLE
Fix TextEdit column index out of bound if column length changes during selection

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3445,6 +3445,7 @@ void TextEdit::set_line(int p_line, const String &p_new_text) {
 
 		if (has_selection(i) && p_line == get_selection_to_line(i) && get_selection_to_column(i) > text[p_line].length()) {
 			carets.write[i].selection.to_column = text[p_line].length();
+			carets.write[i].selection.selecting_column = CLAMP(carets[i].selection.selecting_column, 0, text[p_line].length());
 		}
 	}
 	end_complex_operation();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #83410 