### PR TITLE
Fix bug where TileMap wouldn't update material correctly on assignment

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -407,6 +407,7 @@ void TileMapLayer::_rendering_update() {
 		// Updates on TileMap changes.
 		if (dirty.flags[DIRTY_FLAGS_TILE_MAP_LIGHT_MASK] ||
 				dirty.flags[DIRTY_FLAGS_TILE_MAP_USE_PARENT_MATERIAL] ||
+				dirty.flags[DIRTY_FLAGS_TILE_MAP_MATERIAL] ||
 				dirty.flags[DIRTY_FLAGS_TILE_MAP_TEXTURE_FILTER] ||
 				dirty.flags[DIRTY_FLAGS_TILE_MAP_TEXTURE_REPEAT]) {
 			for (KeyValue<Vector2i, Ref<RenderingQuadrant>> &kv : rendering_quadrant_map) {


### PR DESCRIPTION
This seemed to be a simple case of a missing condition in an if statement with a few different flags. I'm not super familiar with the tilemap code but hopefully this is the correct place to add this check.

Fixes #83474


### Testing Procedure

- Download the example project in issue #83474 and test it on master. Upon running the game, press the space key to toggle the material and observe that no visual change occurs.
- Checkout this Pull Request and recompile.
- Test the project again. It should work as expected. 