### PR TITLE
Add support for 'external' AnimationNode type.

### DIFF
--- a/doc/classes/AnimationNodeExternal.xml
+++ b/doc/classes/AnimationNodeExternal.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeExternal" inherits="AnimationRootNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1214,6 +1214,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("BlendSpace1D", "AnimationNodeBlendSpace1D"));
 	add_options.push_back(AddOption("BlendSpace2D", "AnimationNodeBlendSpace2D"));
 	add_options.push_back(AddOption("StateMachine", "AnimationNodeStateMachine"));
+	add_options.push_back(AddOption("External", "AnimationNodeExternal"));
 	_update_options_menu();
 
 	error_panel = memnew(PanelContainer);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -785,6 +785,18 @@ void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<A
 	List<AnimationNode::ChildNode> children;
 	p_node->get_child_nodes(&children);
 
+	Ref<AnimationNodeExternal> external = p_node;
+	if (external.is_valid()) {
+		String external_node_path = p_base_path + "external_node";
+		external_properties.push_back(external_node_path);
+		if (property_map.has(external_node_path)) {
+			Ref<AnimationRootNode> external_node = property_map[external_node_path].first;
+			if (external_node.is_valid()) {
+				_update_properties_for_node(p_base_path, external_node);
+			}
+		}
+	}
+
 	for (const AnimationNode::ChildNode &E : children) {
 		_update_properties_for_node(p_base_path + E.name + "/", E.node);
 	}
@@ -796,6 +808,7 @@ void AnimationTree::_update_properties() {
 	}
 
 	properties.clear();
+	external_properties.clear();
 	property_reference_map.clear();
 	property_parent_map.clear();
 	input_activity_map.clear();
@@ -909,6 +922,13 @@ bool AnimationTree::_set(const StringName &p_name, const Variant &p_value) {
 			return false; // Prevent to set property by user.
 		}
 		property_map[p_name].first = p_value;
+
+		for (int i = 0; i < external_properties.size(); i++) {
+			if (external_properties.get(i) == p_name) {
+				properties_dirty = true;
+			}
+		}
+
 		return true;
 	}
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -511,6 +511,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeBlendSpace2D);
 	GDREGISTER_CLASS(AnimationNodeStateMachine);
 	GDREGISTER_CLASS(AnimationNodeStateMachinePlayback);
+	GDREGISTER_CLASS(AnimationNodeExternal);
 
 	GDREGISTER_CLASS(AnimationNodeSync);
 	GDREGISTER_CLASS(AnimationNodeStateMachineTransition);


### PR DESCRIPTION
This PR introduces a new node derived from AnimationNodeRoot which can store another AnimationNodeRoot in the tree's parameter data. This facilitates the ability to have dynamic per-instance composible animation graphs which can be useful for games making use of smart objects or other forms of extensive dynamically loaded bespoke animations such as emotes.

Implements the proposal described here: https://github.com/godotengine/godot-proposals/issues/8162