### PR TITLE
Set exit code to `EXIT_SUCCESS` when using `--quit`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3676,6 +3676,7 @@ bool Main::iteration() {
 	}
 
 	if ((quit_after > 0) && (Engine::get_singleton()->_process_frames >= quit_after)) {
+		OS::get_singleton()->set_exit_code(EXIT_SUCCESS);
 		exit = true;
 	}
 


### PR DESCRIPTION
The default exit code is EXIT_FAILURE. When using --quit and there is no failure, it should be EXIT_SUCCESS.

Fixes https://github.com/godotengine/godot/issues/83449

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
