### PR TITLE
Make AudioStreamPlaybackWAV inherit from AudioStreamPlaybackResampled

### DIFF
--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -35,14 +35,8 @@
 
 class AudioStreamWAV;
 
-class AudioStreamPlaybackWAV : public AudioStreamPlayback {
-	GDCLASS(AudioStreamPlaybackWAV, AudioStreamPlayback);
-	enum {
-		MIX_FRAC_BITS = 13,
-		MIX_FRAC_LEN = (1 << MIX_FRAC_BITS),
-		MIX_FRAC_MASK = MIX_FRAC_LEN - 1,
-	};
-
+class AudioStreamPlaybackWAV : public AudioStreamPlaybackResampled {
+	GDCLASS(AudioStreamPlaybackWAV, AudioStreamPlaybackResampled);
 	struct IMA_ADPCM_State {
 		int16_t step_index = 0;
 		int32_t predictor = 0;
@@ -54,14 +48,18 @@ class AudioStreamPlaybackWAV : public AudioStreamPlayback {
 		int32_t window_ofs = 0;
 	} ima_adpcm[2];
 
-	int64_t offset = 0;
+	int32_t offset = 0;
 	int sign = 1;
 	bool active = false;
 	friend class AudioStreamWAV;
 	Ref<AudioStreamWAV> base;
 
 	template <class Depth, bool is_stereo, bool is_ima_adpcm>
-	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &p_offset, int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm);
+	void do_mix(const Depth *p_src, AudioFrame *p_dst, int32_t &p_offset, int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm);
+
+protected:
+	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
+	virtual float get_stream_sampling_rate() override;
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;
@@ -72,8 +70,6 @@ public:
 
 	virtual double get_playback_position() const override;
 	virtual void seek(double p_time) override;
-
-	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	virtual void tag_used_streams() override;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/58216 by removing resampling-related code from AudioStreamPlaybackWAV and making it inherit from AudioStreamPlaybackResampled.

I only tested this at a basic level, not extensively. Requires testing with a wide variety of audio files, with all kinds of looping set up. Performance testing is needed, too. The cubic hermite resampling that AudioStreamPlaybackResampled does is extremely cheap in theory, but I'm not sure it's been battle tested by running several dozen instances of it at once.

This has the added bonus of bypassing the issue the ADPCM decoder has of not doing interpolation; before this patch, low sample rate ADPCM audio has nasty aliasing artifacts that you can even see with your eyes. By relying entirely on AudioStreamPlaybackResampled, that issue is avoided. I'm not sure if an issue is already open for this or not.

![Audacity_2023-10-17_04-10-42](https://github.com/godotengine/godot/assets/585488/7ad6e6c4-0fad-491c-930b-f72a24d2e177)
