### PR TITLE
Ability to disable pen tablet

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -186,6 +186,7 @@ opts.Add(BoolVariable("production", "Set defaults to build Godot for use in prod
 # Components
 opts.Add(BoolVariable("deprecated", "Enable compatibility code for deprecated and removed features", True))
 opts.Add(EnumVariable("precision", "Set the floating-point precision level", "single", ("single", "double")))
+opts.Add(BoolVariable("tablet", "Enable pen tablet support", True))
 opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable("brotli", "Enable Brotli for decompresson and WOFF2 fonts support", True))
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
@@ -913,6 +914,8 @@ if selected_platform in platform_list:
             Exit(255)
         else:
             env.Append(CPPDEFINES=["ADVANCED_GUI_DISABLED"])
+    if env["tablet"]:
+        env.Append(CPPDEFINES=["TABLET_ENABLED"])
     if env["minizip"]:
         env.Append(CPPDEFINES=["MINIZIP_ENABLED"])
     if env["brotli"]:

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -157,7 +157,9 @@ static bool _start_success = false;
 
 // Drivers
 
+#if TABLET_ENABLED
 String tablet_driver = "";
+#endif
 String text_driver = "";
 String rendering_driver = "";
 String rendering_method = "";
@@ -448,7 +450,9 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --rendering-driver <driver>       Rendering driver (depends on display driver).\n");
 	OS::get_singleton()->print("  --gpu-index <device_index>        Use a specific GPU (run with --verbose to get available device list).\n");
 	OS::get_singleton()->print("  --text-driver <driver>            Text driver (Fonts, BiDi, shaping).\n");
+#if TABLET_ENABLED
 	OS::get_singleton()->print("  --tablet-driver <driver>          Pen tablet input driver.\n");
+#endif
 	OS::get_singleton()->print("  --headless                        Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
 	OS::get_singleton()->print("  --write-movie <file>              Writes a video to the specified path (usually with .avi or .png extension).\n");
 	OS::get_singleton()->print("                                    --fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
@@ -1054,6 +1058,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif
 		} else if (I->get() == "--generate-spirv-debug-info") {
 			Engine::singleton->generate_spirv_debug_info = true;
+#if TABLET_ENABLED
 		} else if (I->get() == "--tablet-driver") {
 			if (I->next()) {
 				tablet_driver = I->next()->get();
@@ -1062,6 +1067,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing tablet driver argument, aborting.\n");
 				goto error;
 			}
+#endif
 		} else if (I->get() == "--delta-smoothing") {
 			if (I->next()) {
 				String string = I->next()->get();
@@ -2159,7 +2165,9 @@ error:
 	text_driver = "";
 	display_driver = "";
 	audio_driver = "";
+#if TABLET_ENABLED
 	tablet_driver = "";
+#endif
 	Engine::get_singleton()->set_write_movie_path(String());
 	project_path = "";
 
@@ -2392,6 +2400,7 @@ Error Main::setup2() {
 
 	/* Initialize Pen Tablet Driver */
 
+#ifdef TABLET_ENABLED
 	{
 		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "wintab,winink"), "");
@@ -2416,6 +2425,7 @@ Error Main::setup2() {
 	}
 
 	print_verbose("Using \"" + tablet_driver + "\" pen tablet driver...");
+#endif
 
 	/* Initialize Rendering Server */
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -295,6 +295,7 @@ class DisplayServerWindows : public DisplayServer {
 	static GetImmersiveColorTypeFromNamePtr GetImmersiveColorTypeFromName;
 	static GetImmersiveUserColorSetPreferencePtr GetImmersiveUserColorSetPreference;
 
+#ifdef TABLET_ENABLED
 	// WinTab API
 	static bool wintab_available;
 	static WTOpenPtr wintab_WTOpen;
@@ -307,14 +308,17 @@ class DisplayServerWindows : public DisplayServer {
 	static bool winink_available;
 	static GetPointerTypePtr win8p_GetPointerType;
 	static GetPointerPenInfoPtr win8p_GetPointerPenInfo;
+#endif
 
 	// DPI conversion API
 	static LogicalToPhysicalPointForPerMonitorDPIPtr win81p_LogicalToPhysicalPointForPerMonitorDPI;
 	static PhysicalToLogicalPointForPerMonitorDPIPtr win81p_PhysicalToLogicalPointForPerMonitorDPI;
 
+#ifdef TABLET_ENABLED
 	void _update_tablet_ctx(const String &p_old_driver, const String &p_new_driver);
 	String tablet_driver;
 	Vector<String> tablet_drivers;
+#endif
 
 	enum {
 		KEY_EVENT_BUFFER_SIZE = 512


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR adds `tablet` SConst option that allows it to disable by appending `tablet=no` in command line or build profile