### PR TITLE
Fix generated light probes placing too close to manual light probes

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -698,7 +698,7 @@ void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, f
 			const Vector3 *pp = probe_positions.ptr();
 			bool exists = false;
 			for (int j = 0; j < ppcount; j++) {
-				if (pp[j].is_equal_approx(real_pos)) {
+				if (pp[j].distance_to(real_pos) < (p_cell_size * 0.5f)) {
 					exists = true;
 					break;
 				}


### PR DESCRIPTION
This is extracted from a conversation here: https://github.com/godotengine/godot/pull/83420.

While poking around in `lightmap_gi`, I noticed there is code to avoid generating probes too close to manually placed probes, but it was doing an `is_equal_approx` check against the two positions instead of a distance check, so this was never being triggered. I changed it to a distance check so the behavior is as expected now:

![probes_by_approx](https://github.com/godotengine/godot/assets/18580013/a59c6a67-7ea2-4d8a-a8fe-db85ea2bee32)
![probes_by_dist_good](https://github.com/godotengine/godot/assets/18580013/619a9aad-c68d-41ea-9c6b-c3003f8b7003)

