### PR TITLE
Fix shortcut input for `EditorSceneTabs`

### DIFF
--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -341,6 +341,8 @@ void EditorSceneTabs::_bind_methods() {
 EditorSceneTabs::EditorSceneTabs() {
 	singleton = this;
 
+	set_process_shortcut_input(true);
+
 	tabbar_panel = memnew(PanelContainer);
 	add_child(tabbar_panel);
 	tabbar_container = memnew(HBoxContainer);


### PR DESCRIPTION
Seems like an oversight from when the tab was split off into its own component (in #80490)

* Fixes: #83500

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
