### PR TITLE
Allow to load multiple animation/libraries at once in the animation manager

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -137,7 +137,7 @@ void AnimationLibraryEditor::_load_library() {
 		file_dialog->add_filter("*." + K);
 	}
 
-	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
 	file_dialog->set_current_file("");
 	file_dialog->popup_centered_ratio();
 
@@ -299,85 +299,9 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 		} break;
 	}
 }
+
 void AnimationLibraryEditor::_load_file(String p_path) {
 	switch (file_dialog_action) {
-		case FILE_DIALOG_ACTION_OPEN_LIBRARY: {
-			Ref<AnimationLibrary> al = ResourceLoader::load(p_path);
-			if (al.is_null()) {
-				error_dialog->set_text(TTR("Invalid AnimationLibrary file."));
-				error_dialog->popup_centered();
-				return;
-			}
-
-			List<StringName> libs;
-			mixer->get_animation_library_list(&libs);
-			for (const StringName &K : libs) {
-				Ref<AnimationLibrary> al2 = mixer->get_animation_library(K);
-				if (al2 == al) {
-					error_dialog->set_text(TTR("This library is already added to the mixer."));
-					error_dialog->popup_centered();
-
-					return;
-				}
-			}
-
-			String name = AnimationLibrary::validate_library_name(p_path.get_file().get_basename());
-
-			int attempt = 1;
-
-			while (bool(mixer->has_animation_library(name))) {
-				attempt++;
-				name = p_path.get_file().get_basename() + " " + itos(attempt);
-			}
-
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-
-			undo_redo->create_action(vformat(TTR("Add Animation Library: %s"), name));
-			undo_redo->add_do_method(mixer, "add_animation_library", name, al);
-			undo_redo->add_undo_method(mixer, "remove_animation_library", name);
-			undo_redo->add_do_method(this, "_update_editor", mixer);
-			undo_redo->add_undo_method(this, "_update_editor", mixer);
-			undo_redo->commit_action();
-		} break;
-		case FILE_DIALOG_ACTION_OPEN_ANIMATION: {
-			Ref<Animation> anim = ResourceLoader::load(p_path);
-			if (anim.is_null()) {
-				error_dialog->set_text(TTR("Invalid Animation file."));
-				error_dialog->popup_centered();
-				return;
-			}
-
-			Ref<AnimationLibrary> al = mixer->get_animation_library(adding_animation_to_library);
-			List<StringName> anims;
-			al->get_animation_list(&anims);
-			for (const StringName &K : anims) {
-				Ref<Animation> a2 = al->get_animation(K);
-				if (a2 == anim) {
-					error_dialog->set_text(TTR("This animation is already added to the library."));
-					error_dialog->popup_centered();
-					return;
-				}
-			}
-
-			String name = p_path.get_file().get_basename();
-
-			int attempt = 1;
-
-			while (al->has_animation(name)) {
-				attempt++;
-				name = p_path.get_file().get_basename() + " " + itos(attempt);
-			}
-
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-
-			undo_redo->create_action(vformat(TTR("Load Animation into Library: %s"), name));
-			undo_redo->add_do_method(al.ptr(), "add_animation", name, anim);
-			undo_redo->add_undo_method(al.ptr(), "remove_animation", name);
-			undo_redo->add_do_method(this, "_update_editor", mixer);
-			undo_redo->add_undo_method(this, "_update_editor", mixer);
-			undo_redo->commit_action();
-		} break;
-
 		case FILE_DIALOG_ACTION_SAVE_LIBRARY: {
 			Ref<AnimationLibrary> al = mixer->get_animation_library(file_dialog_library);
 			String prev_path = al->get_path();
@@ -415,6 +339,121 @@ void AnimationLibraryEditor::_load_file(String p_path) {
 				undo_redo->commit_action();
 			}
 		} break;
+		default: {
+		}
+	}
+}
+
+void AnimationLibraryEditor::_load_files(const PackedStringArray &p_paths) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	bool has_created_action = false;
+	bool show_error_diag = false;
+	List<String> name_list;
+
+	switch (file_dialog_action) {
+		case FILE_DIALOG_ACTION_OPEN_LIBRARY: {
+			for (const String &path : p_paths) {
+				Ref<AnimationLibrary> al = ResourceLoader::load(path);
+				if (al.is_null()) {
+					show_error_diag = true;
+					error_dialog->set_text(TTR("Some AnimationLibrary files were invalid."));
+					continue;
+				}
+
+				List<StringName> libs;
+				mixer->get_animation_library_list(&libs);
+				bool is_already_added = false;
+				for (const StringName &K : libs) {
+					if (mixer->get_animation_library(K) == al) {
+						// Prioritize the "invalid" error message.
+						if (!show_error_diag) {
+							show_error_diag = true;
+							error_dialog->set_text(TTR("Some of the selected libraries were already added to the mixer."));
+						}
+
+						is_already_added = true;
+						break;
+					}
+				}
+
+				if (is_already_added) {
+					continue;
+				}
+
+				String name = AnimationLibrary::validate_library_name(path.get_file().get_basename());
+				int attempt = 1;
+				while (bool(mixer->has_animation_library(name)) || name_list.find(name)) {
+					attempt++;
+					name = path.get_file().get_basename() + " " + itos(attempt);
+				}
+				name_list.push_back(name);
+
+				if (!has_created_action) {
+					has_created_action = true;
+					undo_redo->create_action(p_paths.size() > 1 ? TTR("Add Animation Libraries") : vformat(TTR("Add Animation Library: %s"), name));
+				}
+				undo_redo->add_do_method(mixer, "add_animation_library", name, al);
+				undo_redo->add_undo_method(mixer, "remove_animation_library", name);
+			}
+		} break;
+		case FILE_DIALOG_ACTION_OPEN_ANIMATION: {
+			Ref<AnimationLibrary> al = mixer->get_animation_library(adding_animation_to_library);
+			for (const String &path : p_paths) {
+				Ref<Animation> anim = ResourceLoader::load(path);
+				if (anim.is_null()) {
+					show_error_diag = true;
+					error_dialog->set_text(TTR("Some Animation files were invalid."));
+					continue;
+				}
+
+				List<StringName> anims;
+				al->get_animation_list(&anims);
+				bool is_already_added = false;
+				for (const StringName &K : anims) {
+					if (al->get_animation(K) == anim) {
+						// Prioritize the "invalid" error message.
+						if (!show_error_diag) {
+							show_error_diag = true;
+							error_dialog->set_text(TTR("Some of the selected animations were already added to the library."));
+						}
+
+						is_already_added = true;
+						break;
+					}
+				}
+
+				if (is_already_added) {
+					continue;
+				}
+
+				String name = path.get_file().get_basename();
+				int attempt = 1;
+				while (al->has_animation(name) || name_list.find(name)) {
+					attempt++;
+					name = path.get_file().get_basename() + " " + itos(attempt);
+				}
+				name_list.push_back(name);
+
+				if (!has_created_action) {
+					has_created_action = true;
+					undo_redo->create_action(p_paths.size() > 1 ? TTR("Load Animations into Library") : vformat(TTR("Load Animation into Library: %s"), name));
+				}
+				undo_redo->add_do_method(al.ptr(), "add_animation", name, anim);
+				undo_redo->add_undo_method(al.ptr(), "remove_animation", name);
+			}
+		} break;
+		default: {
+		}
+	}
+
+	if (has_created_action) {
+		undo_redo->add_do_method(this, "_update_editor", mixer);
+		undo_redo->add_undo_method(this, "_update_editor", mixer);
+		undo_redo->commit_action();
+	}
+
+	if (show_error_diag) {
+		error_dialog->popup_centered();
 	}
 }
 
@@ -506,7 +545,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 				}
 
 				file_dialog->set_title(TTR("Load Animation"));
-				file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+				file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
 				file_dialog->set_current_file("");
 				file_dialog->popup_centered_ratio();
 
@@ -673,12 +712,12 @@ void AnimationLibraryEditor::update_tree() {
 		libitem->set_metadata(0, K);
 		libitem->set_icon(0, get_editor_theme_icon("AnimationLibrary"));
 
-		libitem->add_button(0, get_editor_theme_icon("Add"), LIB_BUTTON_ADD, animation_library_is_foreign, TTR("Add Animation to Library"));
-		libitem->add_button(0, get_editor_theme_icon("Load"), LIB_BUTTON_LOAD, animation_library_is_foreign, TTR("Load animation from file and add to library"));
-		libitem->add_button(0, get_editor_theme_icon("ActionPaste"), LIB_BUTTON_PASTE, animation_library_is_foreign, TTR("Paste Animation to Library from clipboard"));
+		libitem->add_button(0, get_editor_theme_icon("Add"), LIB_BUTTON_ADD, animation_library_is_foreign, TTR("Add animation to library."));
+		libitem->add_button(0, get_editor_theme_icon("Load"), LIB_BUTTON_LOAD, animation_library_is_foreign, TTR("Load animation from file and add to library."));
+		libitem->add_button(0, get_editor_theme_icon("ActionPaste"), LIB_BUTTON_PASTE, animation_library_is_foreign, TTR("Paste animation to library from clipboard."));
 
-		libitem->add_button(1, get_editor_theme_icon("Save"), LIB_BUTTON_FILE, false, TTR("Save animation library to resource on disk"));
-		libitem->add_button(1, get_editor_theme_icon("Remove"), LIB_BUTTON_DELETE, false, TTR("Remove animation library"));
+		libitem->add_button(1, get_editor_theme_icon("Save"), LIB_BUTTON_FILE, false, TTR("Save animation library to resource on disk."));
+		libitem->add_button(1, get_editor_theme_icon("Remove"), LIB_BUTTON_DELETE, false, TTR("Remove animation library."));
 
 		libitem->set_custom_bg_color(0, ss_color);
 
@@ -690,7 +729,7 @@ void AnimationLibraryEditor::update_tree() {
 			anitem->set_editable(0, !animation_library_is_foreign);
 			anitem->set_metadata(0, L);
 			anitem->set_icon(0, get_editor_theme_icon("Animation"));
-			anitem->add_button(0, get_editor_theme_icon("ActionCopy"), ANIM_BUTTON_COPY, animation_library_is_foreign, TTR("Copy animation to clipboard"));
+			anitem->add_button(0, get_editor_theme_icon("ActionCopy"), ANIM_BUTTON_COPY, animation_library_is_foreign, TTR("Copy animation to clipboard."));
 
 			Ref<Animation> anim = al->get_animation(L);
 			String anim_path = anim->get_path();
@@ -717,8 +756,8 @@ void AnimationLibraryEditor::update_tree() {
 					anitem->set_text(1, anim_path.get_file());
 				}
 			}
-			anitem->add_button(1, get_editor_theme_icon("Save"), ANIM_BUTTON_FILE, animation_library_is_foreign, TTR("Save animation to resource on disk"));
-			anitem->add_button(1, get_editor_theme_icon("Remove"), ANIM_BUTTON_DELETE, animation_library_is_foreign, TTR("Remove animation from Library"));
+			anitem->add_button(1, get_editor_theme_icon("Save"), ANIM_BUTTON_FILE, animation_library_is_foreign, TTR("Save animation to resource on disk."));
+			anitem->add_button(1, get_editor_theme_icon("Remove"), ANIM_BUTTON_DELETE, animation_library_is_foreign, TTR("Remove animation from Library."));
 		}
 	}
 }
@@ -743,6 +782,7 @@ AnimationLibraryEditor::AnimationLibraryEditor() {
 	file_dialog = memnew(EditorFileDialog);
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", callable_mp(this, &AnimationLibraryEditor::_load_file));
+	file_dialog->connect("files_selected", callable_mp(this, &AnimationLibraryEditor::_load_files));
 
 	add_library_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *dialog_vb = memnew(VBoxContainer);

--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -98,6 +98,7 @@ class AnimationLibraryEditor : public AcceptDialog {
 	void _add_library_confirm();
 	void _load_library();
 	void _load_file(String p_path);
+	void _load_files(const PackedStringArray &p_paths);
 
 	void _item_renamed();
 	void _button_pressed(TreeItem *p_item, int p_column, int p_id, MouseButton p_button);


### PR DESCRIPTION
Currently, you can only load animations and animation libraries one-by-one in the "Edit Animation Libraries" dialog. This PR allows the user to now pick multiple ones at once to load.