### PR TITLE
C#: Documentation on supporting C# scripts in the Godot editor.

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2274,6 +2274,10 @@ bool EditorFileSystem::_should_reload_script(const String &p_path) {
 		return false;
 	}
 
+	if (scr->get_language()->get_name() == "C#") {
+		return false;
+	}
+
 	// Scripts are reloaded via the script editor if they are currently opened.
 	if (ScriptEditor::get_singleton()->get_open_scripts().has(scr)) {
 		return false;

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1496,7 +1496,6 @@ void ConnectionsDock::update_tree() {
 	}
 
 	TreeItem *root = tree->create_item();
-	DocTools *doc_data = EditorHelp::get_doc_data();
 	EditorData &editor_data = EditorNode::get_editor_data();
 	StringName native_base = selected_node->get_class();
 	Ref<Script> script_base = selected_node->get_script();
@@ -1513,12 +1512,12 @@ void ConnectionsDock::update_tree() {
 				class_name = script_base->get_path().get_file();
 			}
 
-			doc_class_name = script_base->get_global_name();
+			doc_class_name = script_base->get_doc_class_name();
 			if (doc_class_name.is_empty()) {
-				doc_class_name = script_base->get_path().trim_prefix("res://").quote();
-			}
-			if (!doc_class_name.is_empty() && !doc_data->class_list.find(doc_class_name)) {
-				doc_class_name = String();
+				doc_class_name = script_base->get_global_name();
+				if (doc_class_name.is_empty()) {
+					doc_class_name = script_base->get_path().trim_prefix("res://").quote();
+				}
 			}
 
 			class_icon = editor_data.get_script_icon(script_base->get_path());
@@ -1550,10 +1549,6 @@ void ConnectionsDock::update_tree() {
 		} else {
 			class_name = native_base;
 			doc_class_name = native_base;
-
-			if (!doc_data->class_list.find(doc_class_name)) {
-				doc_class_name = String();
-			}
 
 			if (has_theme_icon(native_base, EditorStringName(EditorIcons))) {
 				class_icon = get_editor_theme_icon(native_base);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1044,6 +1044,10 @@ Error CSharpLanguage::open_in_external_editor(const Ref<Script> &p_script, int p
 bool CSharpLanguage::overrides_external_editor() {
 	return get_godotsharp_editor()->call("OverridesExternalEditor");
 }
+
+bool CSharpLanguage::supports_documentation() const {
+	return true;
+}
 #endif
 
 bool CSharpLanguage::debug_break_parse(const String &p_file, int p_line, const String &p_error) {
@@ -2080,9 +2084,15 @@ void GD_CLR_STDCALL CSharpScript::_add_property_info_list_callback(CSharpScript 
 	GDMonoCache::godotsharp_property_info *props = (GDMonoCache::godotsharp_property_info *)p_props;
 
 #ifdef TOOLS_ENABLED
-	p_script->exported_members_cache.push_back(PropertyInfo(
-			Variant::NIL, p_script->type_info.class_name, PROPERTY_HINT_NONE,
-			p_script->get_path(), PROPERTY_USAGE_CATEGORY));
+	if (p_script->get_path().is_empty()) {
+		p_script->exported_members_cache.push_back(PropertyInfo(
+				Variant::NIL, p_script->type_info.class_name, PROPERTY_HINT_NONE,
+				String("res://") + String(p_script->doc_class_name).lstrip("\"").rstrip("\""), PROPERTY_USAGE_CATEGORY));
+	} else {
+		p_script->exported_members_cache.push_back(PropertyInfo(
+				Variant::NIL, p_script->type_info.class_name, PROPERTY_HINT_NONE,
+				p_script->get_path(), PROPERTY_USAGE_CATEGORY));
+	}
 #endif
 
 	for (int i = 0; i < p_count; i++) {
@@ -2119,6 +2129,38 @@ void GD_CLR_STDCALL CSharpScript::_add_property_default_values_callback(CSharpSc
 
 		p_script->exported_members_defval_cache[name] = value;
 	}
+}
+
+void CSharpScript::get_docs(Ref<CSharpScript> p_script) {
+	Dictionary class_doc_dict;
+	class_doc_dict.~Dictionary();
+
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_GetDocs(p_script.ptr(), &class_doc_dict);
+
+	p_script->docs.clear();
+
+	if (class_doc_dict.is_empty()) {
+		// Script has no docs.
+		return;
+	}
+
+	String inherits;
+	Ref<CSharpScript> base = p_script->get_base_script();
+	if (base.is_null()) {
+		// Must be a native base type.
+		inherits = p_script->get_instance_base_type();
+	} else {
+		inherits = base->get_global_name();
+		if (inherits == StringName()) {
+			inherits = base->get_path().trim_prefix("res://").quote();
+		}
+	}
+
+	DocData::ClassDoc class_doc = DocData::ClassDoc().from_dict(class_doc_dict);
+	class_doc.inherits = inherits;
+
+	p_script->doc_class_name = class_doc.name;
+	p_script->docs.append(class_doc);
 }
 #endif
 
@@ -2344,6 +2386,10 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	}
 
 	p_script->base_script = base_script;
+
+#ifdef TOOLS_ENABLED
+	get_docs(p_script);
+#endif
 }
 
 bool CSharpScript::can_instantiate() const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -197,6 +197,8 @@ private:
 	bool exports_invalidated = true;
 	void _update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames);
 	void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) override;
+	StringName doc_class_name;
+	Vector<DocData::ClassDoc> docs;
 #endif
 
 #if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
@@ -210,6 +212,7 @@ private:
 	static void GD_CLR_STDCALL _add_property_info_list_callback(CSharpScript *p_script, const String *p_current_class_name, void *p_props, int32_t p_count);
 #ifdef TOOLS_ENABLED
 	static void GD_CLR_STDCALL _add_property_default_values_callback(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
+	static void get_docs(Ref<CSharpScript> p_script);
 #endif
 	bool _update_exports(PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
@@ -242,10 +245,8 @@ public:
 	void set_source_code(const String &p_code) override;
 
 #ifdef TOOLS_ENABLED
-	virtual StringName get_doc_class_name() const override { return StringName(); } // TODO
+	virtual StringName get_doc_class_name() const override { return doc_class_name; }
 	virtual Vector<DocData::ClassDoc> get_documentation() const override {
-		// TODO
-		Vector<DocData::ClassDoc> docs;
 		return docs;
 	}
 	virtual String get_class_icon_path() const override {
@@ -572,6 +573,7 @@ public:
 #ifdef TOOLS_ENABLED
 	Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) override;
 	bool overrides_external_editor() override;
+	virtual bool supports_documentation() const override;
 #endif
 
 	RBMap<Object *, CSharpScriptBinding>::Element *insert_script_binding(Object *p_object, const CSharpScriptBinding &p_script_binding);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ClassDoc.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ClassDoc.cs
@@ -1,0 +1,30 @@
+namespace Godot.SourceGenerators.Sample;
+
+/// <summary>
+/// class description
+/// test
+/// </summary>
+public partial class ClassDoc : GodotObject
+{
+    /// <summary>
+    /// field description
+    /// test
+    /// </summary>
+    [Export]
+    private int _fieldDocTest = 1;
+
+    /// <summary>
+    /// property description
+    /// test
+    /// </summary>
+    [Export]
+    public int PropertyDocTest { get; set; }
+
+    /// <summary>
+    /// signal description
+    /// test
+    /// </summary>
+    /// <param name="num"></param>
+    [Signal]
+    public delegate void SignalDocTestEventHandler(int num);
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptDocsGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptDocsGeneratorTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class ScriptDocsGeneratorTests
+{
+    [Fact]
+    public async void Docs()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptDocsGenerator>.Verify(
+            "ClassDoc.cs",
+            "ClassDoc_ScriptDocs.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void AllDocs()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptDocsGenerator>.Verify(
+            "ClassAllDoc.cs",
+            "ClassAllDoc_ScriptDocs.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ClassAllDoc_ScriptDocs.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ClassAllDoc_ScriptDocs.generated.cs
@@ -1,0 +1,31 @@
+partial class ClassAllDoc
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+#if TOOLS
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::Godot.Collections.Dictionary GetGodotClassDocs()
+    {
+        var docs = new global::Godot.Collections.Dictionary();
+        docs.Add("name","\"ClassAllDoc.cs\"");
+        docs.Add("brief_description",@"class description test");
+        docs.Add("description",@"class description test");
+
+        var propertyDocs = new global::Godot.Collections.Array();
+        propertyDocs.Add(new global::Godot.Collections.Dictionary { { "name", PropertyName.PropertyDocTest }, { @"type", @"int" }, { "description", @"property description test [code]ClassAllDoc[/code]" }});
+        propertyDocs.Add(new global::Godot.Collections.Dictionary { { "name", PropertyName._fieldDocTest }, { @"type", @"int" }, { "description", @"field description [code]true[/code] test [code]ClassAllDoc[/code]" }});
+        docs.Add("properties", propertyDocs);
+
+        var signalDocs  = new global::Godot.Collections.Array();
+        signalDocs.Add(new global::Godot.Collections.Dictionary { { "name", SignalName.SignalDocTest }, { "description", @"signal description ~!@#$%^*()_+{}| test [code]ClassAllDoc[/code][br][br][b]Parameters:[/b][br] • [b]num[/b]:" }});
+        docs.Add("signals", signalDocs);
+
+        docs.Add("is_script_doc", true);
+
+        docs.Add("script_path", "ClassAllDoc.cs");
+
+        return docs;
+    }
+
+#endif // TOOLS
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ClassDoc_ScriptDocs.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ClassDoc_ScriptDocs.generated.cs
@@ -1,0 +1,26 @@
+partial class ClassDoc
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+#if TOOLS
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::Godot.Collections.Dictionary GetGodotClassDocs()
+    {
+        var docs = new global::Godot.Collections.Dictionary();
+        docs.Add("name","\"ClassDoc.cs\"");
+        docs.Add("brief_description",@"This is the class documentation.");
+        docs.Add("description",@"This is the class documentation.");
+
+        var propertyDocs = new global::Godot.Collections.Array();
+        propertyDocs.Add(new global::Godot.Collections.Dictionary { { "name", PropertyName.MyProperty }, { @"type", @"int" }, { "description", @"There is currently no description for this property." }});
+        docs.Add("properties", propertyDocs);
+
+        docs.Add("is_script_doc", true);
+
+        docs.Add("script_path", "ClassDoc.cs");
+
+        return docs;
+    }
+
+#endif // TOOLS
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ClassAllDoc.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ClassAllDoc.cs
@@ -1,0 +1,30 @@
+using Godot;
+
+/// <summary>
+/// class description
+/// test
+/// </summary>
+public partial class ClassAllDoc : GodotObject
+{
+    /// <summary>
+    /// field description <c>true</c>
+    /// test <see cref="ClassAllDoc"/>
+    /// </summary>
+    [Export]
+    private int _fieldDocTest = 1;
+
+    /// <summary>
+    /// property description
+    /// test <see cref="ClassAllDoc"/>
+    /// </summary>
+    [Export]
+    public int PropertyDocTest { get; set; }
+
+    /// <summary>
+    /// signal description ~!@#$%^*()_+{}|
+    /// test <see cref="ClassAllDoc"/>
+    /// </summary>
+    /// <param name="num"></param>
+    [Signal]
+    public delegate void SignalDocTestEventHandler(int num);
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ClassDoc.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ClassDoc.cs
@@ -1,0 +1,10 @@
+using Godot;
+
+/// <summary>
+/// This is the class documentation.
+/// </summary>
+public partial class ClassDoc : GodotObject
+{
+    [Export]
+    public int MyProperty { get; set; }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/BBCodeRenderer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/BBCodeRenderer.cs
@@ -1,0 +1,542 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Godot.SourceGenerators
+{
+    internal static class BBCodeRenderer
+    {
+        private static readonly Regex SanitizeXmlDocumentationRegex = new(@" *\/\/\/ *", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Render the specified raw C# XML documentation comment to BBCode.
+        /// </summary>
+        /// <returns>The rendered BBCode string.</returns>
+        /// <exception cref="FormatException">Raised if the XML documentation is malformed.</exception>
+        public static void RenderXmlDocumentationToBBCode(string xmlDocumentation, out string briefDescription,
+            out string fullDescription)
+        {
+            var sanitizedDocumentation =
+                SanitizeXmlDocumentationRegex
+                .Replace(xmlDocumentation, string.Empty)
+                .Replace("<c>", "[code]")
+                .Replace("</c>", "[/code]");
+
+            XmlNodeCollection root;
+            try
+            {
+                root = Parse(sanitizedDocumentation);
+            }
+            catch (Exception e)
+            {
+                throw new FormatException("Failed to parse XML documentation.", e);
+            }
+
+            var briefDescriptionBuilder = new StringBuilder();
+            root.RenderBriefBbCode(briefDescriptionBuilder);
+            var fullDescriptionBuilder = new StringBuilder();
+            root.RenderBbCode(fullDescriptionBuilder);
+
+            briefDescription = briefDescriptionBuilder.ToString().Trim().ReplaceLineEndings("[br]").Replace("\"", "\"\"");
+            fullDescription = fullDescriptionBuilder.ToString().Trim().ReplaceLineEndings("[br]").Replace("\"", "\"\"");
+        }
+
+        private enum NodeType
+        {
+            Root,
+            Text,
+            Summary,
+            Remarks,
+            Para,
+            See,
+            Code,
+            Param,
+            Returns,
+            ParamRef,
+            Exception,
+            TypeParam,
+            TypeParamRef,
+            Unknown,
+        }
+
+        private class UnknownTypeXmlNode : XmlNode
+        {
+            public UnknownTypeXmlNode(string content) : base(NodeType.Unknown)
+            {
+                Content = content;
+            }
+
+            public override string ToString() => $"[Unknown: {Content}]";
+            public override void RenderBbCode(StringBuilder builder) => builder.Append(Content);
+            public string Content { get; }
+        }
+
+        private class TypeParamRefXmlNode : XmlNode
+        {
+            public TypeParamRefXmlNode(string name) : base(NodeType.TypeParamRef)
+            {
+                Name = name;
+            }
+
+            public override string ToString() => $"[TypeParamRef: {Name}]";
+            public override void RenderBbCode(StringBuilder builder) => builder.Append($"[code]{Name}[/code]");
+            public string Name { get; }
+        }
+
+        private class ParamRefXmlNode : XmlNode
+        {
+            public ParamRefXmlNode(string name) : base(NodeType.ParamRef)
+            {
+                Name = name;
+            }
+
+            public override string ToString() => $"[ParamRef: {Name}]";
+            public override void RenderBbCode(StringBuilder builder) => builder.Append($"[param {Name}]");
+            public string Name { get; }
+        }
+
+        private class TypeParamXmlNode : XmlNodeCollection
+        {
+            public TypeParamXmlNode(string name, List<XmlNode> nodes) : base(NodeType.TypeParam, nodes)
+            {
+                Name = name;
+            }
+
+            public override string ToString() => $"TypeParam: {Name} {string.Join(" ", Nodes)}";
+
+            public override void RenderBbCode(StringBuilder builder)
+            {
+                builder.Append($"[b]{Name}[/b]: ");
+                base.RenderBbCode(builder);
+            }
+
+            public string Name { get; }
+        }
+
+        private class ParamXmlNode : XmlNodeCollection
+        {
+            public ParamXmlNode(string name, List<XmlNode> nodes) : base(NodeType.Param, nodes)
+            {
+                Name = name;
+            }
+
+            public override string ToString() => $"Param: {Name} {string.Join(" ", Nodes)}";
+
+            public override void RenderBbCode(StringBuilder builder)
+            {
+                builder.Append($"[b]{Name}[/b]: ");
+                base.RenderBbCode(builder);
+            }
+
+            public string Name { get; }
+        }
+
+        private class ExceptionXmlNode : XmlNodeCollection
+        {
+            public ExceptionXmlNode(string cref, List<XmlNode> nodes) : base(NodeType.Exception, nodes)
+            {
+                Cref = cref;
+            }
+
+            public override string ToString() => $"Exception: {Cref} {string.Join(" ", Nodes)}";
+
+            public override void RenderBbCode(StringBuilder builder)
+            {
+                builder.Append($"[b]{Cref}[/b]: ");
+                base.RenderBbCode(builder);
+            }
+
+            public string Cref { get; }
+        }
+
+        private class CrefXmlNode : SeeXmlNode
+        {
+            public CrefXmlNode(string cref)
+            {
+                Cref = cref;
+            }
+
+            private string ToCleanCref() => Cref.Replace('{', '<').Replace('}', '>');
+            public override string ToString() => $"[Cref: {ToCleanCref()}]";
+            public override void RenderBbCode(StringBuilder builder) => builder.Append($"[code]{ToCleanCref()}[/code]");
+            public string Cref { get; }
+        }
+
+        private class HrefXmlNode : SeeXmlNode
+        {
+            public HrefXmlNode(string href, string text)
+            {
+                Href = href;
+                Text = text;
+            }
+
+            public override string ToString() => $"[Href: {Href} - {Text}]";
+            public override void RenderBbCode(StringBuilder builder) => builder.Append($"[url={Href}]{Text}[/url]");
+            public string Href { get; }
+            public string Text { get; }
+        }
+
+        private abstract class SeeXmlNode : XmlNode
+        {
+            protected SeeXmlNode() : base(NodeType.See)
+            {
+            }
+        }
+
+        private class TextXmlNode : XmlNode
+        {
+            public TextXmlNode(string text) : base(NodeType.Text)
+            {
+                Text = text;
+            }
+
+            public override string ToString() => Text;
+            public override void RenderBbCode(StringBuilder builder) => builder.Append(Text);
+            public string Text { get; }
+        }
+
+        private class XmlNodeCollection : XmlNode
+        {
+            public XmlNodeCollection(NodeType type, List<XmlNode> nodes) : base(type)
+            {
+                Nodes = nodes;
+            }
+
+            public override string ToString()
+            {
+                var builder = new StringBuilder();
+                builder.Append("--- ").Append(Type).AppendLine(" ---");
+                var isFirst = true;
+                foreach (var node in Nodes)
+                {
+                    if (Type == NodeType.Root) builder.AppendLine(node.ToString());
+                    else
+                    {
+                        if (isFirst) isFirst = false;
+                        else builder.Append(' ');
+                        builder.Append(node);
+                    }
+                }
+
+                return builder.ToString();
+            }
+
+            private enum RenderMode
+            {
+                Paragraph,
+                List,
+            }
+
+            private void RenderCollection(StringBuilder builder, RenderMode renderMode) =>
+                RenderCollectionCore(builder, Nodes, renderMode);
+
+            private static void RenderCollectionCore(StringBuilder builder, IEnumerable<XmlNode> nodes, RenderMode renderMode, string prefix = "")
+            {
+                switch (renderMode)
+                {
+                    case RenderMode.Paragraph:
+                    {
+                        var isFirst = true;
+                        builder.Append(prefix);
+                        foreach (var node in nodes)
+                        {
+                            if (isFirst) isFirst = false;
+                            else
+                            {
+                                if (node is not TextXmlNode textXmlNode || !textXmlNode.Text.StartsWith("."))
+                                    builder.Append(' ');
+                            }
+
+                            node.RenderBbCode(builder);
+                        }
+
+                        break;
+                    }
+                    case RenderMode.List:
+                    {
+                        var isFirst = true;
+                        foreach (var node in nodes)
+                        {
+                            if (isFirst) isFirst = false;
+                            else builder.AppendLine();
+                            builder.Append(prefix);
+                            node.RenderBbCode(builder);
+                        }
+
+                        break;
+                    }
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(renderMode), renderMode, null);
+                }
+            }
+
+            public void RenderBriefBbCode(StringBuilder builder)
+            {
+                RenderCollectionCore(builder, Nodes.Where(x => x.Type == NodeType.Summary), RenderMode.List);
+            }
+
+            public override void RenderBbCode(StringBuilder builder)
+            {
+                switch (Type)
+                {
+                    case NodeType.Root:
+                        var ordered = Nodes.GroupBy(x => x.Type).ToDictionary(x => x.Key);
+                        if (ordered.TryGetValue(NodeType.Summary, out var summary))
+                        {
+                            RenderCollectionCore(builder, summary, RenderMode.List);
+                            builder.AppendLine();
+                        }
+
+                        if (ordered.TryGetValue(NodeType.Param, out var para))
+                        {
+                            builder.AppendLine().AppendLine("[b]Parameters:[/b]");
+                            RenderCollectionCore(builder, para, RenderMode.List, " • ");
+                            builder.AppendLine();
+                        }
+
+                        if (ordered.TryGetValue(NodeType.Returns, out var returns))
+                        {
+                            builder.AppendLine().AppendLine("[b]Returns:[/b]");
+                            RenderCollectionCore(builder, returns, RenderMode.List, " • ");
+                            builder.AppendLine();
+                        }
+
+                        if (ordered.TryGetValue(NodeType.Exception, out var exception))
+                        {
+                            builder.AppendLine().AppendLine("[b]Exceptions:[/b]");
+                            RenderCollectionCore(builder, exception, RenderMode.List, " • ");
+                            builder.AppendLine();
+                        }
+
+                        if (ordered.TryGetValue(NodeType.Remarks, out var remarks))
+                        {
+                            builder.AppendLine().AppendLine("[b]Note:[/b]");
+                            RenderCollectionCore(builder, remarks, RenderMode.List);
+                            builder.AppendLine();
+                        }
+
+                        break;
+                    case NodeType.Para:
+                        builder.AppendLine();
+                        RenderCollection(builder, RenderMode.Paragraph);
+                        builder.AppendLine();
+                        break;
+                    case NodeType.Code:
+                        builder.Append("[codeblocks][csharp]");
+                        RenderCollection(builder, RenderMode.List);
+                        builder.Append("[/csharp][/codeblocks]");
+                        break;
+                    default:
+                        RenderCollection(builder, RenderMode.Paragraph);
+                        break;
+                }
+            }
+
+            public List<XmlNode> Nodes { get; }
+        }
+
+        private abstract class XmlNode
+        {
+            protected XmlNode(NodeType type)
+            {
+                Type = type;
+            }
+
+            public abstract void RenderBbCode(StringBuilder builder);
+            public NodeType Type { get; }
+        }
+
+        private static XmlNodeCollection Parse(string documentation)
+        {
+            var root = new XmlNodeCollection(NodeType.Root, new List<XmlNode>());
+            ParseNodes(documentation, false, root.Nodes);
+            return root;
+        }
+
+        private static string ConditionalFormat(string sourceString, bool replaceLineEndings)
+        {
+            return (replaceLineEndings ? sourceString.ReplaceLineEndings(" ") : sourceString)
+                .Replace("<br/>", "\n")
+                .Trim();
+        }
+
+        private static string ReplaceLineEndings(this string input, string replacement)
+        {
+            return input.Replace("\r\n", replacement)
+                       .Replace("\r", replacement)
+                       .Replace("\n", replacement);
+        }
+
+        private static void ParseNodes(string content, bool replaceLineEndings, List<XmlNode> nodes)
+        {
+            var position = 0;
+
+            while (position < content.Length)
+            {
+                var tagStart = content.IndexOf('<', position);
+
+                if (tagStart == -1)
+                {
+                    // No more tags, add remaining text
+                    var remainingText = content.Substring(position).Trim();
+                    if (!string.IsNullOrEmpty(remainingText))
+                    {
+                        nodes.Add(new TextXmlNode(ConditionalFormat(remainingText, replaceLineEndings)));
+                    }
+
+                    break;
+                }
+
+                // Add text before tag
+                if (tagStart > position)
+                {
+                    var textBefore = content.Substring(position, tagStart - position).Trim();
+                    if (!string.IsNullOrEmpty(textBefore))
+                    {
+                        nodes.Add(new TextXmlNode(ConditionalFormat(textBefore, replaceLineEndings)));
+                    }
+                }
+
+                var tagEnd = content.IndexOf('>', tagStart);
+                if (tagEnd == -1) break;
+
+                var tagContent = content.Substring(tagStart + 1, tagEnd - tagStart - 1);
+
+                // Check if it's a self-closing tag or see tag
+                if (tagContent.EndsWith("/") || tagContent.StartsWith("see ") || tagContent.StartsWith("paramref ") ||
+                    tagContent.StartsWith("typeparamref "))
+                {
+                    if (tagContent.StartsWith("see "))
+                    {
+                        var crefMatch = ExtractCrefRegex.Match(tagContent);
+                        if (crefMatch.Success)
+                        {
+                            nodes.Add(new CrefXmlNode(ConditionalFormat(crefMatch.Groups[1].Value, true)));
+                        }
+                    }
+                    else if (tagContent.StartsWith("paramref "))
+                    {
+                        var nameMatch = ExtractNameRegex.Match(tagContent);
+                        if (nameMatch.Success)
+                        {
+                            nodes.Add(new ParamRefXmlNode(ConditionalFormat(nameMatch.Groups[1].Value, true)));
+                        }
+                    }
+                    else if (tagContent.StartsWith("typeparamref "))
+                    {
+                        var nameMatch = ExtractNameRegex.Match(tagContent);
+                        if (nameMatch.Success)
+                        {
+                            nodes.Add(new TypeParamRefXmlNode(ConditionalFormat(nameMatch.Groups[1].Value, true)));
+                        }
+                    }
+                    else
+                    {
+                        // Handle unknown self-closing tags
+                        nodes.Add(new UnknownTypeXmlNode($"<{tagContent}>"));
+                    }
+
+                    position = tagEnd + 1;
+                    continue;
+                }
+
+                var tagName = tagContent.Split(' ')[0];
+                var nodeType = tagName switch
+                {
+                    "summary" => NodeType.Summary,
+                    "remarks" => NodeType.Remarks,
+                    "para" => NodeType.Para,
+                    "code" => NodeType.Code,
+                    "param" => NodeType.Param,
+                    "returns" => NodeType.Returns,
+                    "exception" => NodeType.Exception,
+                    "typeparam" => NodeType.TypeParam,
+                    "a" => NodeType.See,
+                    _ => NodeType.Unknown
+                };
+
+                // Find closing tag
+                var closingTag = $"</{tagName}>";
+                var closingTagStart = content.IndexOf(closingTag, tagEnd + 1, StringComparison.Ordinal);
+
+                if (closingTagStart == -1)
+                {
+                    position = tagEnd + 1;
+                    continue;
+                }
+
+                var innerContent = content.Substring(tagEnd + 1, closingTagStart - tagEnd - 1);
+                var childNodes = new List<XmlNode>();
+
+                // Recursively parse inner content
+                ParseNodes(innerContent, nodeType switch
+                {
+                    NodeType.Summary => true,
+                    NodeType.Remarks => true,
+                    NodeType.Para => true,
+                    NodeType.Code => false,
+                    NodeType.Param => true,
+                    NodeType.Returns => true,
+                    NodeType.Exception => true,
+                    NodeType.TypeParam => true,
+                    NodeType.See => true,
+                    _ => false
+                }, childNodes);
+
+                switch (nodeType)
+                {
+                    case NodeType.Param:
+                    {
+                        var nameMatch = ExtractNameRegex.Match(tagContent);
+                        var paramName = nameMatch.Success ? nameMatch.Groups[1].Value : string.Empty;
+                        nodes.Add(new ParamXmlNode(paramName, childNodes));
+                        break;
+                    }
+                    case NodeType.Exception:
+                    {
+                        var crefMatch = ExtractCrefRegex.Match(tagContent);
+                        var crefValue = crefMatch.Success ? crefMatch.Groups[1].Value : string.Empty;
+                        nodes.Add(new ExceptionXmlNode(crefValue, childNodes));
+                        break;
+                    }
+                    case NodeType.TypeParam:
+                    {
+                        var nameMatch = ExtractNameRegex.Match(tagContent);
+                        var paramName = nameMatch.Success ? nameMatch.Groups[1].Value : string.Empty;
+                        nodes.Add(new TypeParamXmlNode(paramName, childNodes));
+                        break;
+                    }
+                    case NodeType.See when tagName == "a":
+                    {
+                        var hrefMatch = ExtractHrefRegex.Match(tagContent);
+                        var hrefValue = hrefMatch.Success ? hrefMatch.Groups[1].Value : string.Empty;
+                        var linkText = innerContent.Trim();
+                        nodes.Add(new HrefXmlNode(hrefValue, linkText));
+                        break;
+                    }
+                    case NodeType.Unknown:
+                    {
+                        // Handle unknown tags - store the full tag with content
+                        var fullTag = content.Substring(tagStart, closingTagStart + closingTag.Length - tagStart);
+                        nodes.Add(new UnknownTypeXmlNode(fullTag));
+                        break;
+                    }
+                    default:
+                        nodes.Add(new XmlNodeCollection(nodeType, childNodes));
+                        break;
+                }
+
+                position = closingTagStart + closingTag.Length;
+            }
+        }
+
+        private static readonly Regex ExtractCrefRegex = new(@"cref=""([^""]+)""");
+
+        private static readonly Regex ExtractNameRegex = new(@"name=""([^""]+)""");
+
+        private static readonly Regex ExtractHrefRegex = new(@"href=""([^""]+)""");
+
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptDocsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptDocsGenerator.cs
@@ -1,0 +1,596 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using static Godot.SourceGenerators.MarshalUtils;
+
+namespace Godot.SourceGenerators
+{
+    [Generator]
+    public class ScriptDocsGenerator : ISourceGenerator
+    {
+        public void Initialize(GeneratorInitializationContext context)
+        {
+        }
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            if (context.IsGodotSourceGeneratorDisabled("ScriptDocs"))
+                return;
+
+            if (context.IsGodotToolsProject())
+                return;
+
+            // NOTE: NotNullWhen diagnostics don't work on projects targeting .NET Standard 2.0
+            // ReSharper disable once ReplaceWithStringIsNullOrEmpty
+            if (!context.TryGetGlobalAnalyzerProperty("GodotProjectDirBase64", out string? godotProjectDir) || godotProjectDir!.Length == 0)
+            {
+                if (!context.TryGetGlobalAnalyzerProperty("GodotProjectDir", out godotProjectDir) || godotProjectDir!.Length == 0)
+                {
+                    throw new InvalidOperationException("Property 'GodotProjectDir' is null or empty.");
+                }
+            }
+            else
+            {
+                // Workaround for https://github.com/dotnet/roslyn/issues/51692
+                godotProjectDir = Encoding.UTF8.GetString(Convert.FromBase64String(godotProjectDir));
+            }
+
+            INamedTypeSymbol[] godotClasses = context
+                .Compilation.SyntaxTrees
+                .SelectMany(tree =>
+                    tree.GetRoot().DescendantNodes()
+                        .OfType<ClassDeclarationSyntax>()
+                        .SelectGodotScriptClasses(context.Compilation)
+                        // Report and skip non-partial classes
+                        .Where(x =>
+                        {
+                            if (x.cds.IsPartial())
+                            {
+                                if (x.cds.IsNested() && !x.cds.AreAllOuterTypesPartial(out _))
+                                {
+                                    return false;
+                                }
+
+                                return true;
+                            }
+
+                            return false;
+                        })
+                        .Select(x => x.symbol)
+                )
+                .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
+                .ToArray();
+
+            if (godotClasses.Length > 0)
+            {
+                var typeCache = new MarshalUtils.TypeCache(context.Compilation);
+
+                foreach (var godotClass in godotClasses)
+                {
+                    VisitGodotScriptClass(context, typeCache, godotClass, godotProjectDir);
+                }
+            }
+        }
+
+        private static void VisitGodotScriptClass(
+            GeneratorExecutionContext context,
+            MarshalUtils.TypeCache typeCache,
+            INamedTypeSymbol symbol,
+            string godotProjectDir
+        )
+        {
+            symbol.GetDocumentationSummaryText(out string? briefDescription, out string? classDescription);
+
+            StringBuilder docPropertyString = new StringBuilder();
+
+            var members = symbol.GetMembers();
+
+            var exportedProperties = members
+                .Where(s => s.Kind == SymbolKind.Property)
+                .Cast<IPropertySymbol>()
+                .Where(s => s.GetAttributes()
+                    .Any(a => a.AttributeClass?.IsGodotExportAttribute() ?? false))
+                .ToArray();
+
+            var exportedFields = members
+                .Where(s => s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
+                .Cast<IFieldSymbol>()
+                .Where(s => s.GetAttributes()
+                    .Any(a => a.AttributeClass?.IsGodotExportAttribute() ?? false))
+                .ToArray();
+
+            var enumRegistration = new HashSet<ITypeSymbol>();
+
+            foreach (var property in exportedProperties)
+            {
+                GeneratePropertyDoc(docPropertyString, property, typeCache, symbol, enumRegistration);
+            }
+
+            foreach (var field in exportedFields)
+            {
+                GeneratePropertyDoc(docPropertyString, field, typeCache, symbol, enumRegistration);
+            }
+
+            StringBuilder docSignalString = new StringBuilder();
+
+            var signalDelegateSymbols = members
+                .Where(s => s.Kind == SymbolKind.NamedType)
+                .Cast<INamedTypeSymbol>()
+                .Where(namedTypeSymbol => namedTypeSymbol.TypeKind == TypeKind.Delegate)
+                .Where(s => s.GetAttributes()
+                    .Any(a => a.AttributeClass?.IsGodotSignalAttribute() ?? false))
+                .ToArray();
+
+            foreach (var signalDelegateSymbol in signalDelegateSymbols)
+            {
+                GenerateSignalDoc(docSignalString, signalDelegateSymbol);
+            }
+
+            StringBuilder docEnumString = new StringBuilder();
+            StringBuilder docConstantString = new StringBuilder();
+
+            foreach (var enumType in enumRegistration)
+            {
+                GenerateEnumRegistration(docEnumString, docConstantString, enumType);
+            }
+
+            if (string.IsNullOrWhiteSpace(classDescription) && docPropertyString.Length == 0 && docSignalString.Length == 0 && docEnumString.Length == 0 && docConstantString.Length == 0)
+            {
+                // Script has no doc.
+                return;
+            }
+
+            INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
+            string classNs = namespaceSymbol is { IsGlobalNamespace: false }
+                ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+                : string.Empty;
+            bool hasNamespace = classNs.Length != 0;
+
+            bool isInnerClass = symbol.ContainingType != null;
+
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
+                                + "_ScriptDocs.generated";
+
+            var source = new StringBuilder();
+
+            if (hasNamespace)
+            {
+                source.Append("namespace ");
+                source.Append(classNs);
+                source.Append(" {\n\n");
+            }
+
+            if (isInnerClass)
+            {
+                var containingType = symbol.ContainingType;
+                AppendPartialContainingTypeDeclarations(containingType);
+
+                void AppendPartialContainingTypeDeclarations(INamedTypeSymbol? containingType)
+                {
+                    if (containingType == null)
+                        return;
+
+                    AppendPartialContainingTypeDeclarations(containingType.ContainingType);
+
+                    source.Append("partial ");
+                    source.Append(containingType.GetDeclarationKeyword());
+                    source.Append(" ");
+                    source.Append(containingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                    source.Append("\n{\n");
+                }
+            }
+
+            source.Append("partial class ");
+            source.Append(symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            source.Append("\n{\n");
+
+            source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
+            source.Append("#if TOOLS\n");
+
+            source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+            source.Append("    internal new static global::Godot.Collections.Dictionary GetGodotClassDocs()\n    {\n");
+            source.Append("        var docs = new global::Godot.Collections.Dictionary();\n");
+            source.Append("        docs.Add(\"name\",\"");
+
+            string scriptPath = ScriptPathAttributeGenerator.RelativeToDir(symbol.DeclaringSyntaxReferences.First().SyntaxTree.FilePath, godotProjectDir);
+
+            if (symbol.GetAttributes().Any(a => a.AttributeClass?.IsGodotGlobalClassAttribute() ?? false))
+            {
+                source.Append(symbol.Name);
+            }
+            else
+            {
+                source.Append($"\\\"{scriptPath}\\\"");
+                if (isInnerClass)
+                {
+                    source.Append($".{symbol.Name}");
+                }
+            }
+            source.Append("\");\n");
+            source.Append("        docs.Add(\"brief_description\",@\"");
+            source.Append(briefDescription);
+            source.Append("\");\n");
+            source.Append("        docs.Add(\"description\",@\"");
+            source.Append(classDescription);
+            source.Append("\");\n\n");
+
+            if (docPropertyString.Length > 0)
+            {
+                source.Append("        var propertyDocs = new global::Godot.Collections.Array();\n");
+                source.Append(docPropertyString);
+                source.Append("        docs.Add(\"properties\", propertyDocs);\n\n");
+            }
+
+            if (docSignalString.Length > 0)
+            {
+                source.Append("        var signalDocs  = new global::Godot.Collections.Array();\n");
+                source.Append(docSignalString);
+                source.Append("        docs.Add(\"signals\", signalDocs);\n\n");
+            }
+
+            if (docEnumString.Length > 0)
+            {
+                source.Append("        var enumDocs = new global::Godot.Collections.Dictionary();\n");
+                source.Append(docEnumString);
+                source.Append("        docs.Add(\"enums\", enumDocs);\n\n");
+            }
+
+            if (docConstantString.Length > 0)
+            {
+                source.Append("        var constantDocs = new global::Godot.Collections.Array();\n");
+                source.Append(docConstantString);
+                source.Append("        docs.Add(\"constants\", constantDocs);\n\n");
+            }
+
+            source.Append("        docs.Add(\"is_script_doc\", true);\n\n");
+            source.Append("        docs.Add(\"script_path\", \"").Append(scriptPath).Append("\");\n\n");
+
+            source.Append("        return docs;\n    }\n\n");
+
+            source.Append("#endif // TOOLS\n");
+
+            source.Append("#pragma warning restore CS0109\n");
+
+            source.Append("}\n"); // partial class
+
+            if (isInnerClass)
+            {
+                var containingType = symbol.ContainingType;
+
+                while (containingType != null)
+                {
+                    source.Append("}\n"); // outer class
+
+                    containingType = containingType.ContainingType;
+                }
+            }
+
+            if (hasNamespace)
+            {
+                source.Append("\n}\n");
+            }
+
+            context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
+        }
+
+        private const string FallbackDoc = "There is currently no description for this property.";
+
+        private static void GeneratePropertyDoc(StringBuilder docPropertyString, ISymbol symbol, TypeCache typeCache, ITypeSymbol containingType, HashSet<ITypeSymbol> enumRegistration)
+        {
+            var propertySymbol = symbol as IPropertySymbol;
+            var fieldSymbol = symbol as IFieldSymbol;
+            var memberType = propertySymbol?.Type ?? fieldSymbol!.Type;
+            var typeInfo = new Dictionary<string, string>();
+            ConvertManagedTypeToDocTypeString(memberType, typeCache, containingType, enumRegistration, typeInfo);
+            docPropertyString.Append("        propertyDocs.Add(new global::Godot.Collections.Dictionary { { \"name\", PropertyName.")
+                .Append(symbol.Name).Append(" }");
+            foreach (var info in typeInfo)
+            {
+                docPropertyString.Append(", { @\"").Append(info.Key).Append("\", @\"").Append(info.Value).Append("\" }");
+            }
+
+            symbol.GetDocumentationSummaryText(out _, out string? text);
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                docPropertyString.Append(", { \"description\", @\"").Append(text).Append("\" }");
+            }
+            else
+            {
+                docPropertyString.Append(", { \"description\", @\"").Append(FallbackDoc).Append("\" }");
+            }
+
+            docPropertyString.Append("});\n");
+        }
+
+        private static void GenerateEnumRegistration(StringBuilder enumRegistrationString, StringBuilder constantRegistrationString, ITypeSymbol enumType)
+        {
+            enumRegistrationString.Append("        enumDocs.Add(").Append("\"").Append(enumType.Name).Append("\", new global::Godot.Collections.Dictionary {");
+            bool isFlags = enumType.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == "System.FlagsAttribute");
+
+            enumType.GetDocumentationSummaryText(out _, out string? text);
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                enumRegistrationString.Append("{ \"description\", @\"").Append(text).Append("\" }");
+            }
+            else
+            {
+                enumRegistrationString.Append("{ \"description\", @\"").Append(FallbackDoc).Append("\" }");
+            }
+
+            enumRegistrationString.Append("});\n");
+
+            var enumMembers = enumType.GetMembers().Where(m => m.Kind == SymbolKind.Field).Cast<IFieldSymbol>().Where(f => f.ConstantValue != null);
+            foreach (var member in enumMembers)
+            {
+                constantRegistrationString.Append("        constantDocs.Add(new global::Godot.Collections.Dictionary {")
+                    .Append(" { \"name\", @\"").Append(member.Name).Append("\" }, ")
+                    .Append("{ \"value\", @\"").Append(member.ConstantValue).Append("\" }, ")
+                    .Append("{ \"enumeration\", @\"").Append(enumType.Name).Append("\" }");
+
+                if (isFlags)
+                {
+                    constantRegistrationString.Append(", { \"isFlags\", @\"true\" }");
+                }
+
+                member.GetDocumentationSummaryText(out _, out string? memberSummary);
+                if (!string.IsNullOrWhiteSpace(memberSummary))
+                {
+                    constantRegistrationString.Append(", { \"description\", @\"").Append(memberSummary).Append("\" }");
+                }
+                else
+                {
+                    constantRegistrationString.Append(", { \"description\", @\"").Append(FallbackDoc).Append("\" }");
+                }
+
+                constantRegistrationString.Append("});\n");
+            }
+        }
+
+        private static void GenerateSignalDoc(StringBuilder docSignalString, ISymbol symbol)
+        {
+            string signalName = symbol.Name;
+            const string SignalDelegateSuffix = "EventHandler";
+            signalName = signalName.Substring(0, signalName.Length - SignalDelegateSuffix.Length);
+            docSignalString.Append("        signalDocs.Add(new global::Godot.Collections.Dictionary { { \"name\", SignalName.")
+                .Append(signalName).Append(" }");
+            symbol.GetDocumentationSummaryText(out _, out string? text);
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                docSignalString.Append(", { \"description\", @\"").Append(text).Append("\" }");
+            }
+            else
+            {
+                docSignalString.Append(", { \"description\", @\"").Append(FallbackDoc).Append("\" }");
+            }
+            docSignalString.Append("});\n");
+        }
+
+        private static void ConvertManagedTypeToDocTypeString(ITypeSymbol typeSymbol, TypeCache typeCache,
+            ITypeSymbol containingType, HashSet<ITypeSymbol> enumRegistration, Dictionary<string, string> typeInfo)
+        {
+            typeInfo["type"] = "Variant";
+            var marshalType = ConvertManagedTypeToMarshalType(typeSymbol, typeCache);
+            if (!marshalType.HasValue)
+            {
+                return;
+            }
+
+            var marshalTypeValue = marshalType.Value;
+            string typeString;
+
+            switch (marshalTypeValue)
+            {
+                case MarshalType.Boolean:
+                    typeString = "bool";
+                    break;
+                case MarshalType.Char:
+                case MarshalType.SByte:
+                case MarshalType.Int16:
+                case MarshalType.Int32:
+                case MarshalType.Int64:
+                case MarshalType.Byte:
+                case MarshalType.UInt16:
+                case MarshalType.UInt32:
+                case MarshalType.UInt64:
+                    typeString = "int";
+                    break;
+                case MarshalType.Single:
+                case MarshalType.Double:
+                    typeString = "float";
+                    break;
+                case MarshalType.String:
+                    typeString = "String";
+                    break;
+                case MarshalType.Vector2:
+                    typeString = "Vector2";
+                    break;
+                case MarshalType.Vector2I:
+                    typeString = "Vector2i";
+                    break;
+                case MarshalType.Rect2:
+                    typeString = "Rect2";
+                    break;
+                case MarshalType.Rect2I:
+                    typeString = "Rect2i";
+                    break;
+                case MarshalType.Transform2D:
+                    typeString = "Transform2D";
+                    break;
+                case MarshalType.Vector3:
+                    typeString = "Vector3";
+                    break;
+                case MarshalType.Vector3I:
+                    typeString = "Vector3i";
+                    break;
+                case MarshalType.Basis:
+                    typeString = "Basis";
+                    break;
+                case MarshalType.Quaternion:
+                    typeString = "Quaternion";
+                    break;
+                case MarshalType.Transform3D:
+                    typeString = "Transform3D";
+                    break;
+                case MarshalType.Vector4:
+                    typeString = "Vector4";
+                    break;
+                case MarshalType.Vector4I:
+                    typeString = "Vector4i";
+                    break;
+                case MarshalType.Projection:
+                    typeString = "Projection";
+                    break;
+                case MarshalType.Aabb:
+                    typeString = "AABB";
+                    break;
+                case MarshalType.Color:
+                    typeString = "Color";
+                    break;
+                case MarshalType.Plane:
+                    typeString = "Plane";
+                    break;
+                case MarshalType.Callable:
+                    typeString = "Callable";
+                    break;
+                case MarshalType.Signal:
+                    typeString = "Signal";
+                    break;
+                case MarshalType.ByteArray:
+                    typeString = "PackedByteArray";
+                    break;
+                case MarshalType.Int32Array:
+                    typeString = "PackedInt32Array";
+                    break;
+                case MarshalType.Int64Array:
+                    typeString = "PackedInt64Array";
+                    break;
+                case MarshalType.Float32Array:
+                    typeString = "PackedFloat32Array";
+                    break;
+                case MarshalType.Float64Array:
+                    typeString = "PackedFloat64Array";
+                    break;
+                case MarshalType.StringArray:
+                    typeString = "PackedStringArray";
+                    break;
+                case MarshalType.Vector2Array:
+                    typeString = "PackedVector2Array";
+                    break;
+                case MarshalType.Vector3Array:
+                    typeString = "PackedVector3Array";
+                    break;
+                case MarshalType.Vector4Array:
+                    typeString = "PackedVector4Array";
+                    break;
+                case MarshalType.ColorArray:
+                    typeString = "PackedColorArray";
+                    break;
+                case MarshalType.Variant:
+                    typeString = "Variant";
+                    break;
+                case MarshalType.StringName:
+                    typeString = "StringName";
+                    break;
+                case MarshalType.NodePath:
+                    typeString = "NodePath";
+                    break;
+                case MarshalType.Rid:
+                    typeString = "RID";
+                    break;
+                case MarshalType.GodotDictionary:
+                    typeString = "Dictionary";
+                    break;
+                case MarshalType.GodotArray:
+                    typeString = "Array";
+                    break;
+                case MarshalType.SystemArrayOfStringName:
+                    typeString = "StringName[]";
+                    break;
+                case MarshalType.SystemArrayOfNodePath:
+                    typeString = "NodePath[]";
+                    break;
+                case MarshalType.SystemArrayOfRid:
+                    typeString = "RID[]";
+                    break;
+                case MarshalType.GodotObjectOrDerived:
+                    typeString = typeSymbol.Name;
+                    break;
+                case MarshalType.GodotObjectOrDerivedArray:
+                {
+                    var arrayType = (IArrayTypeSymbol)typeSymbol;
+                    var elementType = arrayType.ElementType;
+                    typeString = $"{elementType.Name}[]";
+                    break;
+                }
+                case MarshalType.GodotGenericArray:
+                {
+                    var innerType = ((INamedTypeSymbol)typeSymbol).TypeArguments[0];
+                    if (innerType.TypeKind == TypeKind.Enum)
+                    {
+                        enumRegistration.Add(innerType);
+                        typeString = $"{containingType.Name}.{innerType.Name}[]";
+                    }
+                    else
+                    {
+                        var innerTypeInfo = new Dictionary<string, string>();
+                        ConvertManagedTypeToDocTypeString(innerType, typeCache, containingType, enumRegistration, innerTypeInfo);
+                        typeString = $"{innerTypeInfo["type"]}[]";
+                    }
+                    break;
+                }
+                case MarshalType.GodotGenericDictionary:
+                {
+                    var namedTypeSymbol = (INamedTypeSymbol)typeSymbol;
+                    var keyType = namedTypeSymbol.TypeArguments[0];
+                    var valueType = namedTypeSymbol.TypeArguments[1];
+                    string keyTypeName;
+                    string valueTypeName;
+                    if (keyType.TypeKind == TypeKind.Enum)
+                    {
+                        enumRegistration.Add(keyType);
+                        keyTypeName = $"{containingType.Name}.{keyType.Name}";
+                    }
+                    else
+                    {
+                        var innerTypeInfo = new Dictionary<string, string>();
+                        ConvertManagedTypeToDocTypeString(keyType, typeCache, containingType, enumRegistration, innerTypeInfo);
+                        keyTypeName = innerTypeInfo["type"];
+                    }
+                    if (valueType.TypeKind == TypeKind.Enum)
+                    {
+                        enumRegistration.Add(valueType);
+                        valueTypeName = $"{containingType.Name}.{valueType.Name}";
+                    }
+                    else
+                    {
+                        var innerTypeInfo = new Dictionary<string, string>();
+                        ConvertManagedTypeToDocTypeString(valueType, typeCache, containingType, enumRegistration, innerTypeInfo);
+                        valueTypeName = innerTypeInfo["type"];
+                    }
+                    typeString = $"Dictionary[{keyTypeName}, {valueTypeName}]";
+                    break;
+                }
+                case MarshalType.Enum:
+                {
+                    typeString = "int";
+                    typeInfo["enumeration"] = $"{containingType.Name}.{typeSymbol.Name}";
+                    enumRegistration.Add(typeSymbol);
+                    var isFlags = typeSymbol.GetAttributes()
+                        .Any(a => a.AttributeClass?.ToDisplayString() == "System.FlagsAttribute");
+                    if (isFlags)
+                    {
+                        typeInfo["is_bitfield"] = "true";
+                    }
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            typeInfo["type"] = typeString;
+        }
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
@@ -185,7 +185,7 @@ namespace Godot.SourceGenerators
         {
         }
 
-        private static string RelativeToDir(string path, string dir)
+        public static string RelativeToDir(string path, string dir)
         {
             // Make sure the directory ends with a path separator
             dir = Path.Combine(dir, " ").TrimEnd();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -28,6 +28,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
         public delegate* unmanaged<IntPtr, godot_csharp_type_info*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
+        public delegate* unmanaged<IntPtr, godot_dictionary*, void> ScriptManagerBridge_GetDocs;
         public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;
@@ -72,6 +73,7 @@ namespace Godot.Bridge
                 ScriptManagerBridge_RemoveScriptBridge = &ScriptManagerBridge.RemoveScriptBridge,
                 ScriptManagerBridge_TryReloadRegisteredScriptWithClass = &ScriptManagerBridge.TryReloadRegisteredScriptWithClass,
                 ScriptManagerBridge_UpdateScriptClassInfo = &ScriptManagerBridge.UpdateScriptClassInfo,
+                ScriptManagerBridge_GetDocs = &ScriptManagerBridge.GetDocs,
                 ScriptManagerBridge_SwapGCHandleForType = &ScriptManagerBridge.SwapGCHandleForType,
                 ScriptManagerBridge_GetPropertyInfoList = &ScriptManagerBridge.GetPropertyInfoList,
                 ScriptManagerBridge_GetPropertyDefaultValues = &ScriptManagerBridge.GetPropertyDefaultValues,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -943,6 +943,38 @@ namespace Godot.Bridge
             }
         }
 
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetDocs(IntPtr scriptPtr, godot_dictionary* outClassDocDest)
+        {
+            try
+            {
+                var scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
+
+                var getGetGodotClassDocsMethod = scriptType.GetMethod(
+                    "GetGodotClassDocs",
+                    BindingFlags.DeclaredOnly | BindingFlags.Static |
+                    BindingFlags.NonPublic | BindingFlags.Public);
+                if (getGetGodotClassDocsMethod == null)
+                {
+                    *outClassDocDest = NativeFuncs.godotsharp_dictionary_new();
+                    return;
+                }
+                else
+                {
+                    using Collections.Dictionary? classDocsObj = (Collections.Dictionary?)getGetGodotClassDocsMethod.Invoke(null, null);
+                    if (classDocsObj != null)
+                    {
+                        *outClassDocDest = NativeFuncs.godotsharp_dictionary_new_copy((godot_dictionary)classDocsObj.NativeValue);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                *outClassDocDest = NativeFuncs.godotsharp_dictionary_new();
+            }
+        }
+
         private static List<MethodInfo>? GetSignalListForType(Type type)
         {
             var getGodotSignalListMethod = type.GetMethod(

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -69,6 +69,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, RemoveScriptBridge);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, TryReloadRegisteredScriptWithClass);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, UpdateScriptClassInfo);
+	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetDocs);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, SwapGCHandleForType);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyInfoList);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyDefaultValues);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -91,6 +91,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_RemoveScriptBridge = void(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass = bool(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, CSharpScript::TypeInfo *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
+	using FuncScriptManagerBridge_GetDocs = void(GD_CLR_STDCALL *)(const CSharpScript *, Dictionary *);
 	using FuncScriptManagerBridge_SwapGCHandleForType = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr *, bool);
 	using FuncScriptManagerBridge_GetPropertyInfoList = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyInfoList_Add);
 	using FuncScriptManagerBridge_GetPropertyDefaultValues = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add);
@@ -129,6 +130,7 @@ struct ManagedCallbacks {
 	FuncScriptManagerBridge_RemoveScriptBridge ScriptManagerBridge_RemoveScriptBridge;
 	FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
 	FuncScriptManagerBridge_UpdateScriptClassInfo ScriptManagerBridge_UpdateScriptClassInfo;
+	FuncScriptManagerBridge_GetDocs ScriptManagerBridge_GetDocs;
 	FuncScriptManagerBridge_SwapGCHandleForType ScriptManagerBridge_SwapGCHandleForType;
 	FuncScriptManagerBridge_GetPropertyInfoList ScriptManagerBridge_GetPropertyInfoList;
 	FuncScriptManagerBridge_GetPropertyDefaultValues ScriptManagerBridge_GetPropertyDefaultValues;


### PR DESCRIPTION
``` cs
    /// <summary>
    /// tip text
    /// </summary>
    [Export]
    string s1 = "AAAA";
```

![image](https://github.com/godotengine/godot/assets/14800320/a37f0c6c-b1fb-417b-8a4f-07d8df8d0b99)
![30N9OK8 7{39{)BWG@C(%RN](https://github.com/godotengine/godot/assets/14800320/1a69e052-a5a6-48ae-937e-28e3a82a4ed0)
![C D4LHV%8UP8 G)VKY_VUE](https://github.com/godotengine/godot/assets/14800320/9e25090a-1d84-4ebd-95ae-bbab014db438)

resolve godotengine/godot-proposals#8269

---
https://github.com/godotengine/godot/pull/118210 PR moves the implementation logic into GodotTools.dll instead of using a source generator.