### PR TITLE
Re-add close button for nodes in `AnimationNodeBlendTree` editor

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -2046,12 +2046,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	graphn_sb_panel_selected->set_corner_radius_individual(0, 0, corner_radius * EDSCALE, corner_radius * EDSCALE);
 	graphn_sb_panel_selected->set_expand_margin(SIDE_TOP, 17 * EDSCALE);
 
-	const int gn_titlebar_margin_side = 12;
-	Ref<StyleBoxFlat> graphn_sb_titlebar = make_flat_stylebox(graphnode_bg, gn_titlebar_margin_side, gn_margin_top, gn_titlebar_margin_side, 0, corner_width);
+	const int gn_titlebar_margin_left = 12;
+	const int gn_titlebar_margin_right = 4; // The rest is for the close button.
+	Ref<StyleBoxFlat> graphn_sb_titlebar = make_flat_stylebox(graphnode_bg, gn_titlebar_margin_left, gn_margin_top, gn_titlebar_margin_right, 0, corner_width);
 	graphn_sb_titlebar->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
 	graphn_sb_titlebar->set_corner_radius_individual(corner_radius * EDSCALE, corner_radius * EDSCALE, 0, 0);
 
-	Ref<StyleBoxFlat> graphn_sb_titlebar_selected = make_flat_stylebox(graph_node_selected_border_color, gn_titlebar_margin_side, gn_margin_top, gn_titlebar_margin_side, 0, corner_width);
+	Ref<StyleBoxFlat> graphn_sb_titlebar_selected = make_flat_stylebox(graph_node_selected_border_color, gn_titlebar_margin_left, gn_margin_top, gn_titlebar_margin_right, 0, corner_width);
 	graphn_sb_titlebar_selected->set_corner_radius_individual(corner_radius * EDSCALE, corner_radius * EDSCALE, 0, 0);
 	graphn_sb_titlebar_selected->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
 	Ref<StyleBoxEmpty> graphn_sb_slot = make_empty_stylebox(12, 0, 12, 0);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -170,7 +170,15 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			name->connect("text_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_rename_lineedit_changed), CONNECT_DEFERRED);
 			base = 1;
 			agnode->set_closable(true);
-			node->connect("delete_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_node_request).bind(E), CONNECT_DEFERRED);
+
+			if (!read_only) {
+				Button *delete_button = memnew(Button);
+				delete_button->set_flat(true);
+				delete_button->set_focus_mode(FOCUS_NONE);
+				delete_button->set_icon(get_editor_theme_icon(SNAME("Close")));
+				delete_button->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_delete_node_request).bind(E), CONNECT_DEFERRED);
+				node->get_titlebar_hbox()->add_child(delete_button);
+			}
 		}
 
 		for (int i = 0; i < agnode->get_input_count(); i++) {


### PR DESCRIPTION
Closes #82501

The close/delete button was removed [intentionally](https://github.com/godotengine/godot/pull/79311#issuecomment-1701027224) from these editors. Users are supposed to use context menu delete option or the `DEL` key. However, there was no "Delete" option in `AnimationNodeBlendTree` editor's context menu. The only way to delete a node was using `DEL` key, but it's hard to discover.

My initial thought was to add the missing "Delete" option. But the right click menu in this editor was actually not a standalone context menu. Right clicking triggers the "Add Node" menu option. So this PR readds the button instead.

![Peek 2023-10-17 23-26](https://github.com/godotengine/godot/assets/372476/881ebc73-78fb-40d4-a9e0-bc843c4d75dc)

I have to adjust the editor theme so that the button's position looks right. Otherwise it looks too far away from the right edge. This is the only place in the editor that uses `get_titlebar_hbox()`, so I think the modification won't affect others.