### PR TITLE
GraphEdit connection rework (API & optimizations)

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -119,6 +119,10 @@ public:
 		}
 	}
 
+	static real_t get_distance_to_segment(const Vector2 &p_point, const Vector2 *p_segment) {
+		return p_point.distance_to(get_closest_point_to_segment(p_point, p_segment));
+	}
+
 	static bool is_point_in_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) {
 		Vector2 an = a - s;
 		Vector2 bn = b - s;
@@ -247,6 +251,28 @@ public:
 			return res2;
 		}
 		return -1;
+	}
+
+	static bool segment_intersects_rect(const Vector2 &p_from, const Vector2 &p_to, const Rect2 &p_rect) {
+		if (p_rect.has_point(p_from) || p_rect.has_point(p_to)) {
+			return true;
+		}
+
+		const Vector2 rect_points[4] = {
+			p_rect.position,
+			p_rect.position + Vector2(p_rect.size.x, 0),
+			p_rect.position + p_rect.size,
+			p_rect.position + Vector2(0, p_rect.size.y)
+		};
+
+		// Check if any of the rect's edges intersect the segment.
+		for (int i = 0; i < 4; i++) {
+			if (segment_intersects_segment(p_from, p_to, rect_points[i], rect_points[(i + 1) % 4], nullptr)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	enum PolyBooleanOperation {

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -143,6 +143,21 @@
 				[b]Note:[/b] This method suppresses any other connection request signals apart from [signal connection_drag_ended].
 			</description>
 		</method>
+		<method name="get_closest_connection_at_point">
+			<return type="Dictionary" />
+			<param index="0" name="point" type="Vector2" />
+			<param index="1" name="max_distance" type="float" default="4.0" />
+			<description>
+				Returns the closest connection to the given point in screen space. If no connection is found within [param max_distance] pixels, an empty [Dictionary] is returned.
+				A connection consists in a structure of the form [code]{ from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }[/code].
+				For example, getting a connection at a given mouse position can be achieved like this:
+				[codeblocks]
+				[gdscript]
+				var connection = get_closest_connection_at_point(mouse_event.get_position())
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_connection_line">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from_node" type="Vector2" />
@@ -154,7 +169,14 @@
 		<method name="get_connection_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
-				Returns an Array containing the list of connections. A connection consists in a structure of the form [code]{ from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }[/code].
+				Returns an [Array] containing the list of connections. A connection consists in a structure of the form [code]{ from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }[/code].
+			</description>
+		</method>
+		<method name="get_connections_intersecting_with_rect">
+			<return type="Dictionary[]" />
+			<param index="0" name="rect" type="Rect2" />
+			<description>
+				Returns an [Array] containing the list of connections that intersect with the given [Rect2]. A connection consists in a structure of the form [code]{ from_port: 0, from: "GraphNode name 0", to_port: 1, to: "GraphNode name 1" }[/code].
 			</description>
 		</method>
 		<method name="get_menu_hbox">
@@ -408,7 +430,13 @@
 	</constants>
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
-			Color of the connection's activity (see [method set_connection_activity]).
+			Color the connection line is interpolated to based on the activity value of a connection (see [method set_connection_activity]).
+		</theme_item>
+		<theme_item name="connection_hover_tint_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.3)">
+			Color which is blended with the connection line when the mouse is hovering over it.
+		</theme_item>
+		<theme_item name="connection_valid_target_tint_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.4)">
+			Color which is blended with the connection line when the currently dragged connection is hovering over a valid target port.
 		</theme_item>
 		<theme_item name="grid_major" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">
 			Color of major grid lines.

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1981,7 +1981,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("selection_fill", "GraphEdit", theme->get_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
 	theme->set_color("selection_stroke", "GraphEdit", theme->get_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)));
 	theme->set_color("activity", "GraphEdit", accent_color);
-
+	theme->set_color("connection_hover_tint_color", "GraphEdit", dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3));
+	theme->set_color("connection_valid_target_tint_color", "GraphEdit", dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4));
 	theme->set_icon("zoom_out", "GraphEdit", theme->get_icon(SNAME("ZoomLess"), EditorStringName(EditorIcons)));
 	theme->set_icon("zoom_in", "GraphEdit", theme->get_icon(SNAME("ZoomMore"), EditorStringName(EditorIcons)));
 	theme->set_icon("zoom_reset", "GraphEdit", theme->get_icon(SNAME("ZoomReset"), EditorStringName(EditorIcons)));

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1156,6 +1156,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("selection_fill", "GraphEdit", Color(1, 1, 1, 0.3));
 	theme->set_color("selection_stroke", "GraphEdit", Color(1, 1, 1, 0.8));
 	theme->set_color("activity", "GraphEdit", Color(1, 1, 1));
+	theme->set_color("connection_hover_tint_color", "GraphEdit", Color(0, 0, 0, 0.3));
+	theme->set_color("connection_valid_target_tint_color", "GraphEdit", Color(1, 1, 1, 0.4));
 
 	// Visual Node Ports
 


### PR DESCRIPTION
![GE Connections](https://github.com/godotengine/godot/assets/50084500/35f9e768-f854-4e2f-b861-30129e4a8ad2)

**Detailed changes:**
- Add `get_closest_connection_at_point` which return the closest connection at a given point in GraphEdit's local screen space (with the given maximum search distance). See the docs for a usage example.
- Optimize connection drawing/handling
	- Introduce connections HashMap (node -> its connections)
		- The old logic iterated over all connections for every GraphNode, now only the relevant connections are checked where possible.
	 - Each connection now caches the line, the start and end positions (in screen space) as well as an AABB. This allows for updating/drawing only those connections visible on the screen (this had a huge performance impact for large graphs). It's also used to accelerate fetching the connection from a screen position which is introduced in this PR.
- Adjust theming/visual appearance
	- hovering a connection now highlights it (theme item `connection_hover_tint_color`)
	- the highlight color when dragging a connection onto a valid port is now a theme item (theme item `connection_valid_target_tint_color`)
- Change signature of `get_connection_list` (now returns the list instead of using a return parameter) [only used internally]

For a demonstration of these new features see #83510.
