### PR TITLE
Add connection related functionality to VisualShader (deleting, dropping/inserting a node)

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -34,13 +34,13 @@
 #include "editor/editor_plugin.h"
 #include "editor/editor_properties.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
+#include "scene/gui/graph_edit.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/visual_shader.h"
 
 class CodeEdit;
 class ColorPicker;
 class CurveEditor;
-class GraphEdit;
 class GraphElement;
 class MenuButton;
 class PopupPanel;
@@ -203,6 +203,7 @@ class VisualShaderEditor : public VBoxContainer {
 	VisualShaderNode::PortType members_input_port_type = VisualShaderNode::PORT_TYPE_MAX;
 	VisualShaderNode::PortType members_output_port_type = VisualShaderNode::PORT_TYPE_MAX;
 	PopupMenu *popup_menu = nullptr;
+	PopupMenu *connection_popup_menu = nullptr;
 	PopupMenu *constants_submenu = nullptr;
 	MenuButton *tools = nullptr;
 
@@ -280,6 +281,11 @@ class VisualShaderEditor : public VBoxContainer {
 		SEPARATOR3, // ignore
 		SET_COMMENT_TITLE,
 		SET_COMMENT_DESCRIPTION,
+	};
+
+	enum ConnectionMenuOptions {
+		INSERT_NEW_NODE,
+		DISCONNECT,
 	};
 
 	enum class VaryingMenuOptions {
@@ -397,6 +403,9 @@ class VisualShaderEditor : public VBoxContainer {
 	int from_node = -1;
 	int from_slot = -1;
 
+	Ref<GraphEdit::Connection> clicked_connection;
+	bool connection_node_insert_requested = false;
+
 	HashSet<int> selected_constants;
 	HashSet<int> selected_parameters;
 	int selected_comment = -1;
@@ -409,6 +418,8 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _connection_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_position);
 	void _connection_from_empty(const String &p_to, int p_to_slot, const Vector2 &p_release_position);
+	bool _check_node_drop_on_connection(const Vector2 &p_position, Ref<GraphEdit::Connection> *r_closest_connection, int *r_node_id = nullptr, int *r_to_port = nullptr);
+	void _handle_node_drop_on_connection();
 
 	void _comment_title_popup_show(const Point2 &p_position, int p_node_id);
 	void _comment_title_popup_hide();
@@ -501,6 +512,7 @@ class VisualShaderEditor : public VBoxContainer {
 
 	Vector2 menu_point;
 	void _node_menu_id_pressed(int p_idx);
+	void _connection_menu_id_pressed(int p_idx);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1365,7 +1365,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<Theme> &p_theme, Th
 		}
 		p_theme->set_color("selection_fill", "GraphEdit", p_theme->get_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
 		p_theme->set_color("selection_stroke", "GraphEdit", p_theme->get_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)));
-		p_theme->set_color("activity", "GraphEdit", p_config.accent_color);
+		p_theme->set_color("activity", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0));
 
 		p_theme->set_color("connection_hover_tint_color", "GraphEdit", p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3));
 		p_theme->set_color("connection_valid_target_tint_color", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4));

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -246,6 +246,20 @@ void VisualShaderNode::set_input_port_connected(int p_port, bool p_connected) {
 	connected_input_ports[p_port] = p_connected;
 }
 
+bool VisualShaderNode::is_any_port_connected() const {
+	for (const KeyValue<int, bool> &E : connected_input_ports) {
+		if (E.value) {
+			return true;
+		}
+	}
+	for (const KeyValue<int, int> &E : connected_output_ports) {
+		if (E.value > 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool VisualShaderNode::is_generate_input_var(int p_port) const {
 	return true;
 }

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -314,6 +314,7 @@ public:
 	void set_output_port_connected(int p_port, bool p_connected);
 	bool is_input_port_connected(int p_port) const;
 	void set_input_port_connected(int p_port, bool p_connected);
+	bool is_any_port_connected() const;
 	virtual bool is_generate_input_var(int p_port) const;
 
 	virtual bool has_output_port_preview(int p_port) const;


### PR DESCRIPTION
![VS Connections](https://github.com/godotengine/godot/assets/50084500/2be25d06-b947-4204-a945-e1cbfbff162a)
To demonstrate the new connection functionality, I went ahead and implemented some UX improvements for VS.

Depends on #86158 [merged] ~~#83508~~.
- Add a context menu for connections in the VisualShader editor consisting of
	- Disconnect: Deletes the connection
	- Insert New Node: Opens the "Create Shader Node" dialog and inserts the chosen node by splitting the original connection.

TODO:
- [x] Allow dragging fully unconnected nodes on connections to insert them
- [x] Polish