### PR TITLE
Automatically load specific resource packs when the project starts

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1308,6 +1308,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/project_settings_override", "");
 
 	GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "application/run/additional_packs"), "");
 	GLOBAL_DEF("application/config/auto_accept_quit", true);
 	GLOBAL_DEF("application/config/quit_on_go_back", true);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -304,6 +304,9 @@
 		<member name="application/config/windows_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
+		<member name="application/run/additional_packs" type="PackedStringArray" setter="" getter="" default="">
+			Specifies the additional .pck or .zip to load. For example, if [code]graphics.pck[/code] was added, the engine will attempt to load [code]graphics.pck[/code] after the main pack has successfully loaded, then after also successfully loaded that, it will also attempt to load [code]audio.pck[/code] but if they can't find audio.pck because it's missing in executable directory, it will fail and show the error message.
+		</member>
 		<member name="application/run/delta_smoothing" type="bool" setter="" getter="" default="true">
 			Time samples for frame deltas are subject to random variation introduced by the platform, even when frames are displayed at regular intervals thanks to V-Sync. This can lead to jitter. Delta smoothing can often give a better result by filtering the input deltas to correct for minor fluctuations from the refresh rate.
 			[b]Note:[/b] Delta smoothing is only attempted when [member display/window/vsync/vsync_mode] is set to [code]enabled[/code], as it does not work well without V-Sync.

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -47,6 +47,7 @@ void EditorExport::_save() {
 		config->set_value(section, "name", preset->get_name());
 		config->set_value(section, "platform", preset->get_platform()->get_name());
 		config->set_value(section, "runnable", preset->is_runnable());
+		config->set_value(section, "pure", preset->is_pure());
 		config->set_value(section, "dedicated_server", preset->is_dedicated_server());
 		config->set_value(section, "custom_features", preset->get_custom_features());
 
@@ -227,6 +228,7 @@ void EditorExport::load_config() {
 
 		preset->set_name(config->get_value(section, "name"));
 		preset->set_runnable(config->get_value(section, "runnable"));
+		preset->set_pure(config->get_value(section, "pure"));
 		preset->set_dedicated_server(config->get_value(section, "dedicated_server", false));
 
 		if (config->has_section_key(section, "custom_features")) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1356,6 +1356,10 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		}
 	}
 
+	if (p_preset->is_pure()) {
+		return OK;
+	}
+
 	Vector<String> forced_export = get_forced_export_files();
 	for (int i = 0; i < forced_export.size(); i++) {
 		Vector<uint8_t> array = FileAccess::get_file_as_bytes(forced_export[i]);

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -187,6 +187,15 @@ bool EditorExportPreset::is_runnable() const {
 	return runnable;
 }
 
+void EditorExportPreset::set_pure(bool p_enable) {
+	pure = p_enable;
+	EditorExport::singleton->save_presets();
+}
+
+bool EditorExportPreset::is_pure() const {
+	return pure;
+}
+
 void EditorExportPreset::set_dedicated_server(bool p_enable) {
 	dedicated_server = p_enable;
 	EditorExport::singleton->save_presets();

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -65,6 +65,7 @@ private:
 	HashSet<String> selected_files;
 	HashMap<String, FileExportMode> customized_files;
 	bool runnable = false;
+	bool pure = false;
 	bool dedicated_server = false;
 
 	friend class EditorExport;
@@ -118,6 +119,9 @@ public:
 
 	void set_runnable(bool p_enable);
 	bool is_runnable() const;
+
+	void set_pure(bool p_enable);
+	bool is_pure() const;
 
 	void set_dedicated_server(bool p_enable);
 	bool is_dedicated_server() const;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -241,6 +241,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		name->set_editable(false);
 		export_path->hide();
 		runnable->set_disabled(true);
+		pure->set_disabled(true);
 		parameters->edit(nullptr);
 		presets->deselect_all();
 		duplicate_preset->set_disabled(true);
@@ -276,6 +277,8 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	export_path->update_property();
 	runnable->set_disabled(false);
 	runnable->set_pressed(current->is_runnable());
+	pure->set_disabled(false);
+	pure->set_pressed(current->is_pure());
 	parameters->set_object_class(current->get_platform()->get_class_name());
 	parameters->edit(current.ptr());
 
@@ -461,6 +464,18 @@ void ProjectExportDialog::_runnable_pressed() {
 	} else {
 		current->set_runnable(false);
 	}
+
+	_update_presets();
+}
+
+void ProjectExportDialog::_pure_pressed() {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+	current->set_pure(pure->is_pressed());
 
 	_update_presets();
 }
@@ -1190,6 +1205,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	runnable->set_tooltip_text(TTR("If checked, the preset will be available for use in one-click deploy.\nOnly one preset per platform may be marked as runnable."));
 	runnable->connect("pressed", callable_mp(this, &ProjectExportDialog::_runnable_pressed));
 	settings_vb->add_child(runnable);
+	pure = memnew(CheckButton);
+	pure->set_text(TTR("Pure"));
+	pure->set_tooltip_text(TTR("If checked, it will not export forced files."));
+	pure->connect("pressed", callable_mp(this, &ProjectExportDialog::_pure_pressed));
+	settings_vb->add_child(pure);
 
 	export_path = memnew(EditorPropertyPath);
 	settings_vb->add_child(export_path);

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -82,6 +82,7 @@ private:
 	EditorPropertyPath *export_path = nullptr;
 	EditorInspector *parameters = nullptr;
 	CheckButton *runnable = nullptr;
+	CheckButton *pure = nullptr;
 
 	Button *button_export = nullptr;
 	bool updating = false;
@@ -119,6 +120,7 @@ private:
 	String default_filename;
 
 	void _runnable_pressed();
+	void _pure_pressed();
 	void _update_parameters(const String &p_edited_property);
 	void _name_changed(const String &p_string);
 	void _export_path_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1599,6 +1599,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (globals->setup(project_path, main_pack, upwards, editor) == OK) {
 #ifdef TOOLS_ENABLED
 		found_project = true;
+#else
+		PackedStringArray packs = GLOBAL_GET("application/run/additional_packs");
+		if (!packs.is_empty()) {
+			for (int i = 0; i < packs.size(); i++) {
+				if (PackedData::get_singleton()->add_pack(packs[i], true, 0) != OK) {
+					const String error_msg = "Error: Couldn't load additional pack at path \"" + project_path + "\". Is the .pck file missing?\n";
+					OS::get_singleton()->print("%s", error_msg.utf8().get_data());
+					OS::get_singleton()->alert(error_msg);
+
+					goto error;
+				}
+			}
+		}
 #endif
 	} else {
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR adds ability to load multiple PCKs and/or ZIPs by adding whatever you want into `Additional Packs` in `Project Settings > Application > Run`
![2023-10-17_19-02](https://github.com/godotengine/godot/assets/132811907/d5913e63-458f-4a8e-996b-6af771c7ffc5)
*From my modified version of Godot. That's why they are .spk instead of .pck*
![2023-10-17_19-50](https://github.com/godotengine/godot/assets/132811907/a8ec8804-2311-4f97-ba79-fd6df750ce46)

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8172.*