### PR TITLE
Display a log message when using Reload Saved Scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3243,6 +3243,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			}
 
 			_discard_changes();
+
+			EditorNode::get_log()->add_message(vformat("--- Scene reloaded: %s ---", scene_filename), EditorLog::MSG_TYPE_EDITOR);
 		} break;
 
 		case EditorSceneTabs::SCENE_SHOW_IN_FILESYSTEM: {


### PR DESCRIPTION
This makes it easier to know what's going on when using `print()` in a `@tool` script.

- See https://github.com/godotengine/godot-proposals/issues/8153.

## Preview

![Screenshot_20231017_235109](https://github.com/godotengine/godot/assets/180032/cc2dca93-b29f-4aa1-a03f-748ddd652bba)
