### PR TITLE
Fix C# docs to use the proper XML

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -239,7 +239,7 @@ namespace Godot
 
         /// <summary>
         /// Returns the basis's rotation in the form of Euler angles.
-        /// The Euler order depends on the [param order] parameter,
+        /// The Euler order depends on the <paramref name="order"/> parameter,
         /// by default it uses the YXZ convention: when decomposing,
         /// first Z, then X, and Y last. The returned vector contains
         /// the rotation angles in the format (X angle, Y angle, Z angle).

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -906,7 +906,7 @@ namespace Godot
 
         /// <summary>
         /// Returns a Vector4 transformed (multiplied) by the transpose of the projection.
-        /// For transforming by inverse of a projection [code]projection.Inverse() * vector[/code] can be used instead. See <see cref="Inverse"/>.
+        /// For transforming by inverse of a projection <c>projection.Inverse() * vector</c> can be used instead. See <see cref="Inverse"/>.
         /// </summary>
         /// <param name="proj">The projection to apply.</param>
         /// <param name="vector">A Vector4 to transform.</param>


### PR DESCRIPTION
Replaces some BBCode that was accidentally left in the C# documentation with the proper XML syntax.

This documentation is usually copied from the Godot documentation which uses BBCode, and I must've missed these in the PR reviews.