### PR TITLE
Expose enetpacketpeer get packet

### DIFF
--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -43,6 +43,12 @@
 				Returns the requested [param statistic] for this peer. See [enum PeerStatistic].
 			</description>
 		</method>
+		<method name="get_packet">
+			<return type="PackedByteArray" />
+			<description>
+				Returns the last packet received by this peer. If no packet has been received at all, or since the last call to [method ENetPacketPeer.get_packet], an empty [PackedByteArray] is returned.
+			</description>
+		</method>
 		<method name="is_active" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/modules/enet/enet_packet_peer.h
+++ b/modules/enet/enet_packet_peer.h
@@ -45,6 +45,7 @@ private:
 
 	static void _bind_methods();
 	Error _send(int p_channel, PackedByteArray p_packet, int p_flags);
+	PackedByteArray _get_packet();
 
 protected:
 	friend class ENetConnection;


### PR DESCRIPTION
This exposes `get_packet` in `ENetPacketPeer` to scripting, and implements https://github.com/godotengine/godot-proposals/issues/8175