### PR TITLE
Automatic reconnection of nodes in blend tree.

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -447,6 +447,11 @@ void AnimationNodeBlendTreeEditor::_connection_request(const String &p_from, int
 
 	AnimationNodeBlendTree::ConnectionError err = blend_tree->can_connect_node(p_to, p_to_index, p_from);
 
+	if (err == AnimationNodeBlendTree::CONNECTION_ERROR_CONNECTION_EXISTS) {
+		blend_tree->disconnect_node(p_to, p_to_index);
+		err = blend_tree->can_connect_node(p_to, p_to_index, p_from);
+	}
+
 	if (err != AnimationNodeBlendTree::CONNECTION_OK) {
 		EditorNode::get_singleton()->show_warning(TTR("Unable to connect, port may be in use or connection may be invalid."));
 		return;


### PR DESCRIPTION
If a blend tree node is connected to an already-connected port and a new connection is made to that port, it will now attempt to disconnect that node and connect the new one rather than simply throwing up a generic error message.
![godot windows editor dev x86_64_KPC8Rfdexb](https://github.com/godotengine/godot/assets/12756047/e88b2221-48b0-4b61-b23d-d899b15dc245)
