### PR TITLE
Optimize cubic hermite algorithm in AudioStreamPlaybackResampled

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -173,12 +173,12 @@ int AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, 
 		}
 
 		float mu2 = mu * mu;
-		AudioFrame a0 = 3 * y1 - 3 * y2 + y3 - y0;
-		AudioFrame a1 = 2 * y0 - 5 * y1 + 4 * y2 - y3;
-		AudioFrame a2 = y2 - y0;
-		AudioFrame a3 = 2 * y1;
+		float h11 = mu2 * (mu - 1);
+		float z = mu2 - h11;
+		float h01 = z - h11;
+		float h10 = mu - z;
 
-		p_buffer[i] = (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3) / 2;
+		p_buffer[i] = y1 + (y2 - y1) * h01 + ((y2 - y0) * h10 + (y3 - y1) * h11) * 0.5;
 
 		mix_offset += mix_increment;
 


### PR DESCRIPTION
Replace the algorithm with one that performs fewer multiplications. The variable names use the nomenclature from [the wikipedia page](https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Representations).

Benchmarked with this test file: https://gist.github.com/wareya/2b6183176fa95d391399722f09fd75cb

Compiled something like: `g++ fptest.cpp -Wall -O3 -msse2 -I ../godot/godot4/ -I ../godot/godot4/platform/windows/ -o resample_new_cubic.exe -D MODE_NEW_CUBIC`

Benchmark results (lower is better, zero order hold and linear shown for reference):

```
wareya@Toriaezu MSYS /c/users/wareya/dev/scrap
$ ./resample_zoh.exe
0.503047

wareya@Toriaezu MSYS /c/users/wareya/dev/scrap
$ ./resample_linear.exe
0.692028

wareya@Toriaezu MSYS /c/users/wareya/dev/scrap
$ ./resample_new_cubic.exe
1.262155

wareya@Toriaezu MSYS /c/users/wareya/dev/scrap
$ ./resample_old_cubic.exe
1.420782
```