### PR TITLE
Fix `GDScriptCache::get_full_script` eating parsing errors because of early exit

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -287,7 +287,8 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 
 	if (script.is_null()) {
 		script = get_shallow_script(p_path, r_error);
-		if (r_error) {
+		// Only exit early if script failed to load, otherwise let reload report errors.
+		if (script.is_null()) {
 			return script;
 		}
 	}


### PR DESCRIPTION
Historically and up through Godot 4.0-beta4, parse errors in a malformed GDScript will be printed to output and reported to the debugger at runtime to interrupt execution. In 4.0-beta5 and later, parse errors for most scripts are no longer reported, and the debugger does not stop execution. (I say most because scripts used as named classes or preloads, e.g., still fail to resolve or load as a resource). Up through 4.1.1-stable, there is no indication at all in the editor that a script has failed to be run because of a parsing error, which is potentially quite confusing. In 4.1.2-stable, the addition of https://github.com/godotengine/godot/pull/78540/ at least prints an error when `ResourceFormatLoaderGDScript::load` fails, which a user can see in the debug panel. However, it is easily missed as execution is still not interrupted, and it does not show the actual parsing error anyway.

The root cause is a change in the responsiblity and logic of `GDScriptCache::get_shallow_script` introduced in https://github.com/godotengine/godot/pull/68374. Prior to that, `get_shallow_script` only loaded and cached the source code of a script. `GDScriptCache::get_full_script` would exit early if `get_shallow_script` failed because there would have been no script to call `GDScript::reload` on (which does the actual parsing and error reporting). Since the changes in the above PR, however, `get_shallow_script` now also parses the source code and passes along any errors. But `get_full_script` still exits early if `get_shallow_script` fails for any reason. This means that a script that loads sucessfully but hits an error during parsing will not make it to the `reload` call. Thus, the errors are never printed and never reported to the debugger.

The simplest fix is to exit from `get_full_script` early only when `get_shallow_script` returns a null `Ref`, indicating that the script simply failed to load. Actual parsing errors are ignored at that point so that `reload` will always be called on a script that loads. Then parsing errors will not be silently lost. Note that `get_shallow_script` will not have called `GDScriptCompiler::make_scripts` in the case of a parsing error, but this is fine because `get_shallow_script` is only called here for scripts that are not in the `full_gdscript_cache` and therefore were never compiled, and `reload` will exit after finding the same error during its own call of `GDScriptParser::parse`, well before compilation is attempted. 

Other callers of `get_shallow_script` of course still retain the ability to error out if that initial parsing fails.

Fixes https://github.com/godotengine/godot/issues/75545.