### PR TITLE
Add an option to ignore whitespace characters to XMLParser, similar to Irrlicht Engine's implementation

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -38,11 +38,10 @@ static inline bool _is_white_space(char c) {
 	return (c == ' ' || c == '\t' || c == '\n' || c == '\r');
 }
 
-//! sets the state that text was found. Returns true if set should be set
+//! Sets the state that text was found. Returns true if set should be set.
 bool XMLParser::_set_text(const char *start, const char *end) {
-	// check if text is more than 2 characters, and if not, check if there is
-	// only white space, so that this text won't be reported
-	if (end - start < 3) {
+	// Drop all whitespace by default.
+	if (ignore_whitespace_text) {
 		const char *p = start;
 		for (; p != end; ++p) {
 			if (!_is_white_space(*p)) {
@@ -55,11 +54,11 @@ bool XMLParser::_set_text(const char *start, const char *end) {
 		}
 	}
 
-	// set current text to the parsed text, and replace xml special characters
+	// Set current text to the parsed text, and replace xml special characters.
 	String s = String::utf8(start, (int)(end - start));
 	node_name = s.xml_unescape();
 
-	// current XML node type is text
+	// Current XML node type is text.
 	node_type = NODE_TEXT;
 
 	return true;
@@ -91,7 +90,7 @@ void XMLParser::_ignore_definition() {
 	node_type = NODE_UNKNOWN;
 
 	const char *F = P;
-	// move until end marked with '>' reached
+	// Move until end marked with '>' reached.
 	while (*P && *P != '>') {
 		next_char();
 	}
@@ -109,7 +108,7 @@ bool XMLParser::_parse_cdata() {
 
 	node_type = NODE_CDATA;
 
-	// skip '<![CDATA['
+	// Skip '<![CDATA['.
 	int count = 0;
 	while (*P && count < 8) {
 		next_char();
@@ -124,7 +123,7 @@ bool XMLParser::_parse_cdata() {
 	const char *cDataBegin = P;
 	const char *cDataEnd = nullptr;
 
-	// find end of CDATA
+	// Find end of CDATA.
 	while (*P && !cDataEnd) {
 		if (*P == '>' &&
 				(*(P - 1) == ']') &&
@@ -199,25 +198,25 @@ void XMLParser::_parse_opening_xml_element() {
 	node_empty = false;
 	attributes.clear();
 
-	// find name
+	// Find name.
 	const char *startName = P;
 
-	// find end of element
+	// Find end of element.
 	while (*P && *P != '>' && !_is_white_space(*P)) {
 		next_char();
 	}
 
 	const char *endName = P;
 
-	// find attributes
+	// Find attributes.
 	while (*P && *P != '>') {
 		if (_is_white_space(*P)) {
 			next_char();
 		} else {
 			if (*P != '/') {
-				// we've got an attribute
+				// We've got an attribute.
 
-				// read the attribute names
+				// Read the attribute names.
 				const char *attributeNameBegin = P;
 
 				while (*P && !_is_white_space(*P) && *P != '=') {
@@ -231,13 +230,13 @@ void XMLParser::_parse_opening_xml_element() {
 				const char *attributeNameEnd = P;
 				next_char();
 
-				// read the attribute value
-				// check for quotes and single quotes, thx to murphy
+				// Read the attribute value.
+				// Check for quotes and single quotes, thx to murphy.
 				while ((*P != '\"') && (*P != '\'') && *P) {
 					next_char();
 				}
 
-				if (!*P) { // malformatted xml file
+				if (!*P) { // Malformatted xml file.
 					break;
 				}
 
@@ -265,7 +264,7 @@ void XMLParser::_parse_opening_xml_element() {
 				attr.value = s.xml_unescape();
 				attributes.push_back(attr);
 			} else {
-				// tag is closed directly
+				// Tag is closed directly.
 				next_char();
 				node_empty = true;
 				break;
@@ -273,9 +272,9 @@ void XMLParser::_parse_opening_xml_element() {
 		}
 	}
 
-	// check if this tag is closing directly
+	// Check if this tag is closing directly.
 	if (endName > startName && *(endName - 1) == '/') {
-		// directly closing tag
+		// Directly closing tag.
 		node_empty = true;
 		endName--;
 	}
@@ -290,29 +289,32 @@ void XMLParser::_parse_opening_xml_element() {
 	}
 }
 
-void XMLParser::_parse_current_node() {
+// Reads the current xml node.
+// Return false if no further node is found.
+bool XMLParser::_parse_current_node() {
 	const char *start = P;
 	node_offset = P - data;
 
-	// more forward until '<' found
+	// More forward until '<' found.
 	while (*P != '<' && *P) {
 		next_char();
 	}
 
 	if (P - start > 0) {
-		// we found some text, store it
+		// We found some text, store it.
 		if (_set_text(start, P)) {
-			return;
+			return true;
 		}
 	}
 
+	// Not a node, so return false.
 	if (!*P) {
-		return;
+		return false;
 	}
 
 	next_char();
 
-	// based on current token, parse and report next element
+	// Based on current token, parse and report next element.
 	switch (*P) {
 		case '/':
 			_parse_closing_xml_element();
@@ -329,6 +331,7 @@ void XMLParser::_parse_current_node() {
 			_parse_opening_xml_element();
 			break;
 	}
+	return true;
 }
 
 uint64_t XMLParser::get_node_offset() const {
@@ -362,6 +365,8 @@ void XMLParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("seek", "position"), &XMLParser::seek);
 	ClassDB::bind_method(D_METHOD("open", "file"), &XMLParser::open);
 	ClassDB::bind_method(D_METHOD("open_buffer", "buffer"), &XMLParser::open_buffer);
+	ClassDB::bind_method(D_METHOD("get_ignore_whitespace_text"), &XMLParser::get_ignore_whitespace_text);
+	ClassDB::bind_method(D_METHOD("set_ignore_whitespace_text", "ignore"), &XMLParser::set_ignore_whitespace_text);
 
 	BIND_ENUM_CONSTANT(NODE_NONE);
 	BIND_ENUM_CONSTANT(NODE_ELEMENT);
@@ -373,12 +378,13 @@ void XMLParser::_bind_methods() {
 }
 
 Error XMLParser::read() {
-	// if end not reached, parse the node
+	// If end not reached, parse the node.
+	// Return EOF if the text has only one character left.
 	if (P && (P - data) < (int64_t)length - 1 && *P != 0) {
-		_parse_current_node();
-		return OK;
+		if (_parse_current_node()) {
+			return OK;
+		}
 	}
-
 	return ERR_FILE_EOF;
 }
 
@@ -514,12 +520,12 @@ Error XMLParser::open(const String &p_path) {
 }
 
 void XMLParser::skip_section() {
-	// skip if this element is empty anyway.
+	// Skip if this element is empty anyway.
 	if (is_empty()) {
 		return;
 	}
 
-	// read until we've reached the last element in this section
+	// Read until we've reached the last element in this section.
 	int tagcount = 1;
 
 	while (tagcount && read() == OK) {
@@ -547,6 +553,14 @@ void XMLParser::close() {
 
 int XMLParser::get_current_line() const {
 	return current_line;
+}
+
+void XMLParser::set_ignore_whitespace_text(bool p_ignore) {
+	ignore_whitespace_text = p_ignore;
+}
+
+bool XMLParser::get_ignore_whitespace_text() {
+	return ignore_whitespace_text;
 }
 
 XMLParser::~XMLParser() {

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -44,7 +44,7 @@ class XMLParser : public RefCounted {
 	GDCLASS(XMLParser, RefCounted);
 
 public:
-	//! Enumeration of all supported source text file formats
+	//! Enumeration of all supported source text file formats.
 	enum SourceFormat {
 		SOURCE_ASCII,
 		SOURCE_UTF8,
@@ -74,6 +74,7 @@ private:
 	bool node_empty = false;
 	NodeType node_type = NODE_NONE;
 	uint64_t node_offset = 0;
+	bool ignore_whitespace_text = true; // Do not return EXN_TEXT nodes for pure whitespace.
 
 	struct Attribute {
 		String name;
@@ -88,7 +89,7 @@ private:
 	bool _parse_cdata();
 	void _parse_comment();
 	void _parse_opening_xml_element();
-	void _parse_current_node();
+	bool _parse_current_node();
 
 	_FORCE_INLINE_ void next_char() {
 		if (*P == '\n') {
@@ -110,9 +111,11 @@ public:
 	String get_attribute_value(int p_idx) const;
 	bool has_attribute(const String &p_name) const;
 	String get_named_attribute_value(const String &p_name) const;
-	String get_named_attribute_value_safe(const String &p_name) const; // do not print error if doesn't exist
+	String get_named_attribute_value_safe(const String &p_name) const; // Do not print error if it doesn't exist.
 	bool is_empty() const;
 	int get_current_line() const;
+	void set_ignore_whitespace_text(bool p_ignore);
+	bool get_ignore_whitespace_text();
 
 	void skip_section();
 	Error seek(uint64_t p_pos);

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -68,6 +68,12 @@
 				Returns the current line in the parsed file, counting from 0.
 			</description>
 		</method>
+		<method name="get_ignore_whitespace_text">
+			<return type="bool" />
+			<description>
+				Returns whether the parser is set to ignore whitespace text nodes.
+			</description>
+		</method>
 		<method name="get_named_attribute_value" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="name" type="String" />
@@ -144,6 +150,13 @@
 			<param index="0" name="position" type="int" />
 			<description>
 				Moves the buffer cursor to a certain offset (since the beginning) and reads the next node there. This method returns an error code.
+			</description>
+		</method>
+		<method name="set_ignore_whitespace_text">
+			<return type="void" />
+			<param index="0" name="ignore" type="bool" />
+			<description>
+				Sets whether the parser should ignore whitespace text nodes. If set to [code]true[/code], the parser will skip text nodes that contain only whitespace characters.
 			</description>
 		</method>
 		<method name="skip_section">

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -230,6 +230,86 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
 	CHECK_EQ(parser.get_node_name(), "a");
 }
+
+TEST_CASE("[XMLParser] Whitespace") {
+	constexpr int CASES = 5;
+	String inputs[CASES] = {
+		"<xml><element /></xml>",
+		"<xml>\t<element /></xml>",
+		"<xml>\t\t<element /></xml>",
+		"<xml>\t\t\t<element /></xml>",
+		"<xml>\t\t\t\t<element /></xml>"
+	};
+
+	String results[CASES] = {
+		"", "\t", "\t\t", "\t\t\t", "\t\t\t\t"
+	};
+
+	String trails[CASES] = {
+		"<p>abc</p>",
+		"<p>abc</p>\t",
+		"<p>abc</p>\t\t",
+		"<p>abc</p>\t\t\t",
+		"<p>abc</p>\t\t\t\t"
+	};
+
+	SUBCASE("Ignore Whitespace") {
+		XMLParser parser;
+		for (int i = 0; i < CASES; i++) {
+			REQUIRE_EQ(parser.open_buffer(inputs[i].to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			CHECK_NE(parser.get_node_type(), XMLParser::NodeType::NODE_TEXT);
+		}
+	}
+
+	SUBCASE("Not Ignore Whitespace") {
+		XMLParser parser;
+		parser.set_ignore_whitespace_text(false);
+		for (int i = 0; i < CASES; i++) {
+			REQUIRE_EQ(parser.open_buffer(inputs[i].to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			if (i == 0) {
+				CHECK_NE(parser.get_node_type(), XMLParser::NodeType::NODE_TEXT);
+			} else {
+				CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_TEXT);
+				CHECK_EQ(parser.get_node_data(), results[i]);
+			}
+		}
+	}
+
+	SUBCASE("Ignore Trailing Whitespace") {
+		XMLParser parser;
+		for (int i = 0; i < CASES; i++) {
+			REQUIRE_EQ(parser.open_buffer(trails[i].to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), ERR_FILE_EOF);
+		}
+	}
+
+	SUBCASE("Not Ignore Trailing Whitespace") {
+		XMLParser parser;
+		parser.set_ignore_whitespace_text(false);
+		for (int i = 0; i < CASES; i++) {
+			REQUIRE_EQ(parser.open_buffer(trails[i].to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			REQUIRE_EQ(parser.read(), OK);
+			if (i < 2) {
+				// Return EOF if the text has only one character left.
+				REQUIRE_EQ(parser.read(), ERR_FILE_EOF);
+			} else {
+				REQUIRE_EQ(parser.read(), OK);
+				REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_TEXT);
+				CHECK_EQ(parser.get_node_data(), results[i]);
+			}
+		}
+	}
+}
+
 } // namespace TestXMLParser
 
 #endif // TEST_XML_PARSER_H


### PR DESCRIPTION
fix #51380 XMLParser handles white space outside tags incorrectly/inconsistently
fix #81896 XMLParser incorrectly treats two '\n' as NODE_ELEMENT_END

### Add an option to ignore whitespace characters
```cpp
XMLParser parser;
parser.set_ignore_whitespace_text(false); // default true
```

 ### [Irrlicht Engine's implementation](https://sourceforge.net/p/irrlicht/code/HEAD/tree/trunk/source/Irrlicht/CXMLReaderImpl.h#l267) 

```cpp
//[...]
// By default xml preserves all whitespace. But Irrlicht dropped some whitespace by default
// in the past which did lead to OS dependent behavior. We just ignore all whitespace for now
// as it's the closest to fixing behavior without breaking downward compatibility too much.
if ( IgnoreWhitespaceText )
{
	char_type* p = start;
	for(; p != end; ++p)
		if (!isWhiteSpace(*p))
			break;

	if (p == end)
		return false;
}
//[...]
```

### Unit Test
#### Ignore White

| Input | Expected |
|------|----------|
| `<xml><element /></xml>` | no text |
| `<xml>\t<element /></xml>` | no text | 
| `<xml>\t\t<element /></xml>` | no text | 
| `<xml>\t\t\t<element /></xml>` | no text | 
| `<xml>\t\t\t\t<element /></xml>` | no text | 

#### Not Ignore White

| Input | Expected |
|------|----------|
| `<xml><element /></xml>` | no text |
| `<xml>\t<element /></xml>` | text(0x09) | 
| `<xml>\t\t<element /></xml>` | text(0x09 0x09) | 
| `<xml>\t\t\t<element /></xml>` | text(0x09 0x09 0x09) | 
| `<xml>\t\t\t\t<element /></xml>` | text(0x09 0x09 0x09 0x09) | 

#### Ignore Trailing White
| Input | Expected |
|------|----------|
| `<p>abc</p>` | EOF |
| `<p>abc</p>\t` | EOF | 
| `<p>abc</p>\t\t` | EOF | 
| `<p>abc</p>\t\t\t` | EOF | 
| `<p>abc</p>\t\t\t\t` | EOF | 

#### Not Ignore Trailing White
| Input | Expected |
|------|----------|
| `<p>abc</p>` | EOF |
| `<p>abc</p>\t` | EOF \*| 
| `<p>abc</p>\t\t` | text(0x09 0x09) | 
| `<p>abc</p>\t\t\t` | text(0x09 0x09 0x09) | 
| `<p>abc</p>\t\t\t\t` | text(0x09 0x09 0x09 0x09) | 

\* *XMLParser::read() return EOF if the text has only one character left*


### Minimal reproduction project
```
extends Node2D

var s1 = "<p>abc</p>\n"
var s2 = "<p>abc</p>\n\n"
var s3 = "<p>abc</p>\n\n\n"

func parse_xml(test_xml_buffer, ignore) -> void:

	print("-".repeat(40))
	print("buffer content: \"%s\"" % test_xml_buffer)

	var xml_parser: XMLParser = XMLParser.new()
	xml_parser.set_ignore_whitespace_text(ignore)
	print(xml_parser.get_ignore_whitespace_text())

	var err = xml_parser.open_buffer(test_xml_buffer.to_utf8_buffer())
	if err != OK:
		push_error("error: %s" % err)
		return


	while true:

		err = xml_parser.read()
		if err != OK:
			push_error("error: %s" % err)
			return

		var node_type = xml_parser.get_node_type()
		var node_type_str = ""
		var node_name = ""
		var node_data = ""

		prints("node type:", node_type)

		node_type_str = [
			"XMLParser.NODE_NONE",
			"XMLParser.NODE_ELEMENT",
			"XMLParser.NODE_ELEMENT_END",
			"XMLParser.NODE_TEXT",
			# ...
			][node_type]

		prints("          ", node_type_str)

		match node_type:

			XMLParser.NODE_ELEMENT, XMLParser.NODE_ELEMENT_END:
				node_name = xml_parser.get_node_name()
				prints("          ", "'%s'" % node_name)

			XMLParser.NODE_TEXT:
				node_data = xml_parser.get_node_data()

				for i in range(node_data.length()):
					prints("          ", "%s" % (node_data.substr(i,1)))

			_:
				push_error("Unhandled node type.")

		print()


# Called when the node enters the scene tree for the first time.
func _ready():
	var version = Engine.get_version_info()
	print(version.major) 
	print(version.minor) 
	print(version.patch) 
	print(version.status) 

	parse_xml(s1, true)
	parse_xml(s2, true)
	parse_xml(s3, true)
	
	parse_xml(s1, false)
	parse_xml(s2, false)
	parse_xml(s3, false)

```

### Observe output
```
Godot Engine v4.2.beta.custom_build.c5e41ddeb - https://godotengine.org
Vulkan API 1.2.261 - Forward Mobile - Using Vulkan Device #0: AMD - AMD Radeon Pro 5300M
 
4
2
0
beta
----------------------------------------
buffer content: "<p>abc</p>
"
true
node type: 1
           XMLParser.NODE_ELEMENT
           'p'

node type: 3
           XMLParser.NODE_TEXT
           a
           b
           c

node type: 2
           XMLParser.NODE_ELEMENT_END
           'p'

----------------------------------------
buffer content: "<p>abc</p>

"
true
node type: 1
           XMLParser.NODE_ELEMENT
           'p'

node type: 3
           XMLParser.NODE_TEXT
           a
           b
           c

node type: 2
           XMLParser.NODE_ELEMENT_END
           'p'

----------------------------------------
buffer content: "<p>abc</p>


"
true
node type: 1
           XMLParser.NODE_ELEMENT
           'p'

node type: 3
           XMLParser.NODE_TEXT
           a
           b
           c

node type: 2
           XMLParser.NODE_ELEMENT_END
           'p'

----------------------------------------
buffer content: "<p>abc</p>
"
false
node type: 1
           XMLParser.NODE_ELEMENT
           'p'

node type: 3
           XMLParser.NODE_TEXT
           a
           b
           c

node type: 2
           XMLParser.NODE_ELEMENT_END
           'p'

----------------------------------------
buffer content: "<p>abc</p>

"
false
node type: 1
           XMLParser.NODE_ELEMENT
           'p'

node type: 3
           XMLParser.NODE_TEXT
           a
           b
           c

node type: 2
           XMLParser.NODE_ELEMENT_END
           'p'

node type: 3
           XMLParser.NODE_TEXT
           

           


----------------------------------------
buffer content: "<p>abc</p>


"
false
node type: 1
           XMLParser.NODE_ELEMENT
           'p'

node type: 3
           XMLParser.NODE_TEXT
           a
           b
           c

node type: 2
           XMLParser.NODE_ELEMENT_END
           'p'

node type: 3
           XMLParser.NODE_TEXT
           

           

           


--- Debugging process stopped ---

```