### PR TITLE
Improve `RenderingServer::canvas_set_item_mirroring` interface

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -854,11 +854,10 @@
 		</method>
 		<method name="canvas_set_item_mirroring">
 			<return type="void" />
-			<param index="0" name="canvas" type="RID" />
-			<param index="1" name="item" type="RID" />
-			<param index="2" name="mirroring" type="Vector2" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="mirroring" type="Vector2" />
 			<description>
-				A copy of the canvas item will be drawn with a local offset of the mirroring [Vector2].
+				A copy of the canvas item will be drawn with a local offset of the mirroring [Vector2]. The item must be a direct child of parent canvas. The item will be mirrored three times based on mirroring's x, y, x and y.
 			</description>
 		</method>
 		<method name="canvas_set_modulate">

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -69,10 +69,9 @@ void ParallaxLayer::_update_mirroring() {
 
 	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb) {
-		RID c = pb->get_canvas();
 		RID ci = get_canvas_item();
 		Point2 mirrorScale = mirroring * get_scale();
-		RenderingServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirrorScale);
+		RenderingServer::get_singleton()->canvas_set_item_mirroring(ci, mirrorScale);
 	}
 }
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -415,14 +415,15 @@ void RendererCanvasCull::canvas_initialize(RID p_rid) {
 	canvas_owner.initialize_rid(p_rid);
 }
 
-void RendererCanvasCull::canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring) {
-	Canvas *canvas = canvas_owner.get_or_null(p_canvas);
-	ERR_FAIL_NULL(canvas);
+void RendererCanvasCull::canvas_set_item_mirroring(RID p_item, const Point2 &p_mirroring) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);
 
+	RID parent = canvas_item->parent;
+	Canvas *canvas = canvas_owner.get_or_null(parent);
+	ERR_FAIL_NULL_MSG(canvas, "Item must be a direct child of Canvas.");
+
 	int idx = canvas->find_item(canvas_item);
-	ERR_FAIL_COND(idx == -1);
 	canvas->child_items.write[idx].mirror = p_mirroring;
 }
 

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -200,7 +200,7 @@ public:
 	RID canvas_allocate();
 	void canvas_initialize(RID p_rid);
 
-	void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring);
+	void canvas_set_item_mirroring(RID p_item, const Point2 &p_mirroring);
 	void canvas_set_modulate(RID p_canvas, const Color &p_color);
 	void canvas_set_parent(RID p_canvas, RID p_parent, float p_scale);
 	void canvas_set_disable_scale(bool p_disable);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -823,7 +823,7 @@ public:
 	/* CANVAS (2D) */
 
 	FUNCRIDSPLIT(canvas)
-	FUNC3(canvas_set_item_mirroring, RID, RID, const Point2 &)
+	FUNC2(canvas_set_item_mirroring, RID, const Point2 &)
 	FUNC2(canvas_set_modulate, RID, const Color &)
 	FUNC3(canvas_set_parent, RID, RID, float)
 	FUNC1(canvas_set_disable_scale, bool)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3016,7 +3016,7 @@ void RenderingServer::_bind_methods() {
 	/* CANVAS (2D) */
 
 	ClassDB::bind_method(D_METHOD("canvas_create"), &RenderingServer::canvas_create);
-	ClassDB::bind_method(D_METHOD("canvas_set_item_mirroring", "canvas", "item", "mirroring"), &RenderingServer::canvas_set_item_mirroring);
+	ClassDB::bind_method(D_METHOD("canvas_set_item_mirroring", "item", "mirroring"), &RenderingServer::canvas_set_item_mirroring);
 	ClassDB::bind_method(D_METHOD("canvas_set_modulate", "canvas", "color"), &RenderingServer::canvas_set_modulate);
 	ClassDB::bind_method(D_METHOD("canvas_set_disable_scale", "disable"), &RenderingServer::canvas_set_disable_scale);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1317,7 +1317,7 @@ public:
 	/* CANVAS (2D) */
 
 	virtual RID canvas_create() = 0;
-	virtual void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring) = 0;
+	virtual void canvas_set_item_mirroring(RID p_item, const Point2 &p_mirroring) = 0;
 	virtual void canvas_set_modulate(RID p_canvas, const Color &p_color) = 0;
 	virtual void canvas_set_parent(RID p_canvas, RID p_parent, float p_scale) = 0;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8107

I changed `canvas_set_item_mirroring` to take only the item rid because the canvas can be derived and most of the author's proposal. However I did not change the api name as it does not seems very urgent. But I would appreciate any feedback or alternative suggestions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
