### PR TITLE
Fix StringName leaks in GDExtension, core, and editor themes

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -794,6 +794,8 @@ void register_global_constants() {
 
 void unregister_global_constants() {
 	_global_constants.clear();
+	_global_constants_map.clear();
+	_global_enums.clear();
 }
 
 int CoreConstants::get_global_constant_count() {

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -664,7 +664,7 @@ void GDExtension::_get_library_path(GDExtensionClassLibraryPtr p_library, GDExte
 	memnew_placement(r_path, String(self->library_path));
 }
 
-HashMap<StringName, GDExtensionInterfaceFunctionPtr> gdextension_interface_functions;
+HashMap<StringName, GDExtensionInterfaceFunctionPtr> GDExtension::gdextension_interface_functions;
 
 void GDExtension::register_interface_function(StringName p_function_name, GDExtensionInterfaceFunctionPtr p_function_pointer) {
 	ERR_FAIL_COND_MSG(gdextension_interface_functions.has(p_function_name), "Attempt to register interface function '" + p_function_name + "', which appears to be already registered.");
@@ -834,6 +834,10 @@ void GDExtension::initialize_gdextensions() {
 	register_interface_function("classdb_register_extension_class_signal", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_signal);
 	register_interface_function("classdb_unregister_extension_class", (GDExtensionInterfaceFunctionPtr)&GDExtension::_unregister_extension_class);
 	register_interface_function("get_library_path", (GDExtensionInterfaceFunctionPtr)&GDExtension::_get_library_path);
+}
+
+void GDExtension::finalize_gdextensions() {
+	gdextension_interface_functions.clear();
 }
 
 Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path, Ref<GDExtension> &p_extension) {

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -106,6 +106,8 @@ class GDExtension : public Resource {
 	void clear_instance_bindings();
 #endif
 
+	static HashMap<StringName, GDExtensionInterfaceFunctionPtr> gdextension_interface_functions;
+
 protected:
 	static void _bind_methods();
 
@@ -153,6 +155,7 @@ public:
 	static void register_interface_function(StringName p_function_name, GDExtensionInterfaceFunctionPtr p_function_pointer);
 	static GDExtensionInterfaceFunctionPtr get_interface_function(StringName p_function_name);
 	static void initialize_gdextensions();
+	static void finalize_gdextensions();
 
 	GDExtension();
 	~GDExtension();

--- a/core/extension/gdextension_compat_hashes.cpp
+++ b/core/extension/gdextension_compat_hashes.cpp
@@ -840,4 +840,8 @@ void GDExtensionCompatHashes::initialize() {
 	// clang-format on
 }
 
+void GDExtensionCompatHashes::finalize() {
+	mappings.clear();
+}
+
 #endif // DISABLE_DEPRECATED

--- a/core/extension/gdextension_compat_hashes.h
+++ b/core/extension/gdextension_compat_hashes.h
@@ -48,6 +48,7 @@ class GDExtensionCompatHashes {
 
 public:
 	static void initialize();
+	static void finalize();
 	static bool lookup_current_hash(const StringName &p_class, const StringName &p_method, uint32_t p_legacy_hash, uint32_t *r_current_hash);
 	static bool get_legacy_hashes(const StringName &p_class, const StringName &p_method, Array &r_hashes);
 };

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -293,3 +293,9 @@ GDExtensionManager::GDExtensionManager() {
 	GDExtensionCompatHashes::initialize();
 #endif
 }
+
+GDExtensionManager::~GDExtensionManager() {
+#ifndef DISABLE_DEPRECATED
+	GDExtensionCompatHashes::finalize();
+#endif
+}

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -86,6 +86,7 @@ public:
 	void reload_extensions();
 
 	GDExtensionManager();
+	~GDExtensionManager();
 };
 
 VARIANT_ENUM_CAST(GDExtensionManager::LoadStatus)

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -360,6 +360,7 @@ void unregister_core_extensions() {
 	if (_is_core_extensions_registered) {
 		gdextension_manager->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_CORE);
 	}
+	GDExtension::finalize_gdextensions();
 }
 
 void unregister_core_types() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6951,6 +6951,7 @@ EditorNode::EditorNode() {
 
 	// Exporters might need the theme.
 	EditorColorMap::create();
+	EditorTheme::initialize();
 	theme = create_custom_theme();
 	DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
 
@@ -8038,6 +8039,8 @@ EditorNode::~EditorNode() {
 	memdelete(progress_hb);
 
 	EditorSettings::destroy();
+	EditorColorMap::finish();
+	EditorTheme::finalize();
 
 	GDExtensionEditorPlugins::editor_node_add_plugin = nullptr;
 	GDExtensionEditorPlugins::editor_node_remove_plugin = nullptr;

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -55,7 +55,7 @@ void EditorColorMap::add_conversion_color_pair(const String p_from_color, const 
 	color_conversion_map[Color::html(p_from_color)] = Color::html(p_to_color);
 }
 
-void EditorColorMap::add_conversion_exception(const StringName p_icon_name) {
+void EditorColorMap::add_conversion_exception(const StringName &p_icon_name) {
 	color_conversion_exceptions.insert(p_icon_name);
 }
 
@@ -63,7 +63,7 @@ void EditorColorMap::create() {
 	// Some of the colors below are listed for completeness sake.
 	// This can be a basis for proper palette validation later.
 
-	// Convert:    FROM       TO
+	// Convert:               FROM       TO
 	add_conversion_color_pair("#478cbf", "#478cbf"); // Godot Blue
 	add_conversion_color_pair("#414042", "#414042"); // Godot Gray
 
@@ -215,6 +215,11 @@ void EditorColorMap::create() {
 	add_conversion_exception("Breakpoint");
 }
 
+void EditorColorMap::finish() {
+	color_conversion_map.clear();
+	color_conversion_exceptions.clear();
+}
+
 Vector<StringName> EditorTheme::editor_theme_types;
 
 // TODO: Refactor these and corresponding Theme methods to use the bool get_xxx(r_value) pattern internally.
@@ -301,13 +306,15 @@ Ref<StyleBox> EditorTheme::get_stylebox(const StringName &p_name, const StringNa
 	}
 }
 
-EditorTheme::EditorTheme() {
-	if (editor_theme_types.is_empty()) {
-		editor_theme_types.append(EditorStringName(Editor));
-		editor_theme_types.append(EditorStringName(EditorFonts));
-		editor_theme_types.append(EditorStringName(EditorIcons));
-		editor_theme_types.append(EditorStringName(EditorStyles));
-	}
+void EditorTheme::initialize() {
+	editor_theme_types.append(EditorStringName(Editor));
+	editor_theme_types.append(EditorStringName(EditorFonts));
+	editor_theme_types.append(EditorStringName(EditorIcons));
+	editor_theme_types.append(EditorStringName(EditorStyles));
+}
+
+void EditorTheme::finalize() {
+	editor_theme_types.clear();
 }
 
 // Editor theme generatior.

--- a/editor/editor_themes.h
+++ b/editor/editor_themes.h
@@ -45,12 +45,14 @@ class EditorColorMap {
 	static HashSet<StringName> color_conversion_exceptions;
 
 public:
-	static void create();
 	static void add_conversion_color_pair(const String p_from_color, const String p_to_color);
-	static void add_conversion_exception(const StringName p_icon_name);
+	static void add_conversion_exception(const StringName &p_icon_name);
 
 	static HashMap<Color, Color> &get_color_conversion_map() { return color_conversion_map; };
 	static HashSet<StringName> &get_color_conversion_exceptions() { return color_conversion_exceptions; };
+
+	static void create();
+	static void finish();
 };
 
 class EditorTheme : public Theme {
@@ -66,7 +68,8 @@ public:
 	virtual Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_theme_type) const override;
 	virtual Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_theme_type) const override;
 
-	EditorTheme();
+	static void initialize();
+	static void finalize();
 };
 
 Ref<Theme> create_editor_theme(Ref<Theme> p_theme = nullptr);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2845,6 +2845,7 @@ ProjectManager::ProjectManager() {
 	}
 
 	EditorColorMap::create();
+	EditorTheme::initialize();
 	Ref<Theme> theme = create_custom_theme();
 	DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
 
@@ -3297,6 +3298,9 @@ ProjectManager::~ProjectManager() {
 	if (EditorSettings::get_singleton()) {
 		EditorSettings::destroy();
 	}
+
+	EditorColorMap::finish();
+	EditorTheme::finalize();
 }
 
 void ProjectTag::_notification(int p_what) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/69195. Closes https://github.com/godotengine/godot/issues/73554.

We are currently leaking **1255 string names** (tested by launching the project manager with a verbose flag). All of these occurrences are related to the use of static hashmaps, which do not clear themselves and so don't properly free their references string names. Issues related to my own changes in the editor theme code, to various changes in GDExtension (cc @dsnopek), and to changes in global enums (cc @vnen https://github.com/godotengine/godot/pull/73590).

The proposed solution in the issue is a bit sus, as it creates copies of string names, which somehow circumvents the issue. But it doesn't appear to the a proper solution. Instead I added the necessary code to clear all relevant hashmaps when objects should be finalized/deinitialized/destroyed.

I'm not sure if https://github.com/godotengine/godot/pull/74031 should be redone in a similar fashion, but that one might be correct as is, since it's about one singular static StringName.

-----

A bit of stats :)

#### Base

> StringName: 1255 unclaimed string names at exit.

#### EditorColorMap changes

> StringName: 1219 unclaimed string names at exit.

#### GDExtension changes

> StringName: 1070 unclaimed string names at exit.

#### GDExtensionCompatHashes changes

> StringName: 526 unclaimed string names at exit.

#### CoreConstants changes

> StringName: 4 unclaimed string names at exit.

#### EditorTheme changes

😊

-----

Some of this should be backported to 4.1, but I don't think this would be cherry-pickable.