### PR TITLE
Fix "Navigation map synchronization error" when using NavigationRegion2D

### DIFF
--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -503,6 +503,4 @@ void NavigationPolygon::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-NavigationPolygon::NavigationPolygon() {
-	navigation_mesh.instantiate();
-}
+NavigationPolygon::NavigationPolygon() {}


### PR DESCRIPTION
The constructor of `NavigationPolygon` instantiates its `navigation_mesh` variable, preventing the `NavigationPolygon::get_navigation_mesh()` function from initializing the `navigation_mesh` object correctly, leading to this error:
```
modules/navigation/nav_region.cpp:128 - Navigation map synchronization error. Attempted to update a navigation region with a navigation mesh that uses a `cell_size` of 1 while assigned to a navigation map set to a `cell_size` of 0.25. The cell size for navigation maps can be changed by using the NavigationServer map_set_cell_size() function. The cell size for default navigation maps can also be changed in the ProjectSettings.
```

The instantiation of `navigation_mesh` in the constructor is not even needed, since that variable is only accessed through `NavigationPolygon::get_navigation_mesh()` where `navigation_mesh` is instantiated lazily, if necessary.

fixes https://github.com/godotengine/godot/issues/83570