### PR TITLE
GDScript: Don't optimize division and modulo on debug

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -662,6 +662,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				uint32_t op_signature = _code_ptr[ip + 5];
 				uint32_t actual_signature = (a->get_type() << 8) | (b->get_type());
 
+#ifdef DEBUG_ENABLED
+				if (op == Variant::OP_DIVIDE || op == Variant::OP_MODULE) {
+					// Don't optimize division and modulo since there's not check for division by zero with validated calls.
+					op_signature = 0xFFFF;
+					_code_ptr[ip + 5] = op_signature;
+				}
+#endif
+
 				// Check if this is the first run. If so, store the current signature for the optimized path.
 				if (unlikely(op_signature == 0)) {
 					static Mutex initializer_mutex;


### PR DESCRIPTION
Since the validated operators don't have checks for division by zero, use the regular evaluator in debug which has those checks.

Fix #83308
