### PR TITLE
Enable new addon after hiding ProjectSettings

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -819,12 +819,12 @@ void EditorNode::_on_plugin_ready(Object *p_script, const String &p_activate_nam
 	if (scr.is_null()) {
 		return;
 	}
-	if (p_activate_name.length()) {
-		set_addon_plugin_enabled(p_activate_name, true);
-	}
 	project_settings_editor->update_plugins();
 	project_settings_editor->hide();
 	push_item(scr.operator->());
+	if (p_activate_name.length()) {
+		set_addon_plugin_enabled(p_activate_name, true);
+	}
 }
 
 void EditorNode::_remove_plugin_from_enabled(const String &p_name) {
@@ -7336,10 +7336,6 @@ EditorNode::EditorNode() {
 	project_menu->add_separator();
 	project_menu->add_item(TTR("Customize Engine Build Configuration..."), TOOLS_BUILD_PROFILE_MANAGER);
 	project_menu->add_separator();
-
-	plugin_config_dialog = memnew(PluginConfigDialog);
-	plugin_config_dialog->connect("plugin_ready", callable_mp(this, &EditorNode::_on_plugin_ready));
-	gui_base->add_child(plugin_config_dialog);
 
 	tool_menu = memnew(PopupMenu);
 	tool_menu->set_name("Tools");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -355,8 +355,6 @@ private:
 
 	uint64_t started_timestamp = 0;
 
-	PluginConfigDialog *plugin_config_dialog = nullptr;
-
 	RichTextLabel *load_errors = nullptr;
 	AcceptDialog *load_error_dialog = nullptr;
 


### PR DESCRIPTION
- Enabling newly created addons can show a warning dialog, doing so before hiding the `ProjectSettingsEditor` dialog causes rendering glitches.
	- Fixes https://github.com/godotengine/godot/issues/80883.
	- I've found other issues when opening new windows before hiding another one before (see https://github.com/godotengine/godot/pull/80260#issuecomment-1743209488).
- Remove unused `PuginConfigDialog` in `EditorNode`. The one actually being used is an instance in `EditorPluginSettings`.
