### PR TITLE
Allow coexistence of GDScript and GDExtension virtual methods in the same object

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -47,8 +47,8 @@ _FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
 }\\
 _FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const { \\
 	ScriptInstance *_script_instance = ((Object*)(this))->get_script_instance();\\
-	if (_script_instance) {\\
-	    return _script_instance->has_method(_gdvirtual_##m_name##_sn);\\
+	if (_script_instance && _script_instance->has_method(_gdvirtual_##m_name##_sn)) {\\
+		return true;\\
 	}\\
     if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
          _gdvirtual_##m_name = nullptr;\\


### PR DESCRIPTION
…same object

Resolves https://github.com/godotengine/godot-cpp/issues/1224

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
