### PR TITLE
Add `path` option to `ScriptLanguageExtension::_validate`

### DIFF
--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -313,6 +313,9 @@ public:
 				ERR_CONTINUE(!err.has("message"));
 
 				ScriptError serr;
+				if (err.has("path")) {
+					serr.path = err["path"];
+				}
 				serr.line = err["line"];
 				serr.column = err["column"];
 				serr.message = err["message"];


### PR DESCRIPTION
Currently, `_validate` works for warnings but not errors. This should fix it.