### PR TITLE
Fix crash on recovered orphaned nodes.

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -450,7 +450,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			}
 
 			if (!old_parent_path.is_empty()) {
-				node->_set_name_nocheck(old_parent_path + "@" + node->get_name());
+				node->set_name(old_parent_path + "#" + node->get_name());
 			}
 
 			if (n.owner >= 0) {


### PR DESCRIPTION
There are a lot of issues in regards to how Godot recovers nodes from situations where an instanced or inherited node has its overall composition changed, resulting in nodes which might no longer reference a valid parent. However, the most notable issue right now is that if this happens, the scene will become corrupted to the point that it will crash if you attempt to close any scene containining one or more of these orphaned nodes. This is due to the default recover mechanism first extracting the nodes's path, then prepending it to the nodes name between an @ symbol. However, @ is a reserved character, so it sets it with the nocheck name, which subsequently updates the name, but does NOT update its parent's cache, resulting in failure if the node is referenced by path, and subsequently leads to crashes. The scene is essentially corrupted now beyond repair without manual text editing.

While there's a lot more that can be done in regards to recovering scenes with orphaned nodes (I recommend the next step should be constructing dummy nodes to recreate the original path composition as close as possible rather than shoving them in the root), I've changed from the reserved @ symbol to the ~ symbol and used the set_name command which does checks. This should at least now give users an oppertunity to manually repair their scene if nodes become orphaned, but may also be considering an editor-only UID system for scenes, which should more or less completely eliminate scene breakage like this.

Closes https://github.com/godotengine/godot/issues/83595