### PR TITLE
Add option to sort script list by last opened

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1311,6 +1311,9 @@
 		<member name="text_editor/script_list/group_help_pages" type="bool" setter="" getter="">
 			If [code]true[/code], class reference pages are grouped together at the bottom of the Script Editor's script list.
 		</member>
+		<member name="text_editor/script_list/last_opened_script_threshold" type="int" setter="" getter="">
+			If [member text_editor/script_list/sort_scripts_by] is set to [b]Last Opened[/b], this defines how many scripts, counting from the top of the list, won't be pushed up when opened.
+		</member>
 		<member name="text_editor/script_list/list_script_names_as" type="int" setter="" getter="">
 			Specifies how script paths should be displayed in Script Editor's script list. If using the "Name" option and some scripts share the same file name, more parts of their paths are revealed to avoid conflicts.
 		</member>
@@ -1328,7 +1331,12 @@
 			[b]Note:[/b] Only effective if [member text_editor/script_list/show_members_overview] is [code]true[/code].
 		</member>
 		<member name="text_editor/script_list/sort_scripts_by" type="int" setter="" getter="">
-			Specifies sorting used for Script Editor's open script list.
+			Specifies sorting used for the Script Editor's list of opened scripts and documentation.
+			- [b]Name:[/b] Scripts will be sorted alphabetically by their file name.
+			- [b]Path:[/b] Scripts will be sorted alphabetically by their file path.
+			- [b]None:[/b] Scripts and documentation won't be sorted in any particular order. They can be dragged around manually.
+			- [b]Last Opened:[/b] Opening a script or documentation page will push it to the top of the list, unless it's already near the top. The threshold for what's considered "near the top" is defined in [member text_editor/script_list/last_opened_script_threshold].
+			If set to [b]Name[/b] or [b]Path[/b], documentation will be sorted alphabetically at the bottom of the list.
 		</member>
 		<member name="text_editor/theme/color_theme" type="String" setter="" getter="">
 			The syntax theme to use in the script editor.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -704,8 +704,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false, true);
 	_initial_set("text_editor/script_list/script_temperature_enabled", true);
 	_initial_set("text_editor/script_list/script_temperature_history_size", 15);
+	_initial_set("text_editor/script_list/last_opened_script_threshold", 8);
 	_initial_set("text_editor/script_list/group_help_pages", true);
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/script_list/sort_scripts_by", 0, "Name,Path,None");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/script_list/sort_scripts_by", 0, "Name,Path,None,Last Opened");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/script_list/list_script_names_as", 0, "Name,Parent Directory And Name,Full Path");
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "text_editor/external/exec_path", "", "");
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "text_editor/external/exec_flags", "{file}", "Call flags with placeholders: {project}, {file}, {col}, {line}.");

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -705,6 +705,17 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 
 	tab_container->set_current_tab(p_idx);
 
+	ScriptSortBy sort_by = (ScriptSortBy)(int)EDITOR_GET("text_editor/script_list/sort_scripts_by");
+	if (sort_by == ScriptSortBy::SORT_BY_LAST_OPENED) {
+		int ignore_threshold = EDITOR_GET("text_editor/script_list/last_opened_script_threshold");
+		if (p_idx >= ignore_threshold) {
+			tab_container->move_child(c, 0);
+			// Needed, to rebuild the script list
+			_update_script_names();
+			p_idx = 0;
+		}
+	}
+
 	c = tab_container->get_current_tab_control();
 
 	if (Object::cast_to<ScriptEditorBase>(c)) {
@@ -954,7 +965,7 @@ void ScriptEditor::_close_other_tabs() {
 	int current_idx = tab_container->get_current_tab();
 	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
 		if (i != current_idx) {
-			script_close_queue.push_back(i);
+			script_close_queue.push_back(tab_container->get_tab_control(i));
 		}
 	}
 	_queue_close_tabs();
@@ -962,18 +973,18 @@ void ScriptEditor::_close_other_tabs() {
 
 void ScriptEditor::_close_all_tabs() {
 	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
-		script_close_queue.push_back(i);
+		script_close_queue.push_back(tab_container->get_tab_control(i));
 	}
 	_queue_close_tabs();
 }
 
 void ScriptEditor::_queue_close_tabs() {
 	while (!script_close_queue.is_empty()) {
-		int idx = script_close_queue.front()->get();
+		Control *c = script_close_queue.front()->get();
 		script_close_queue.pop_front();
 
-		tab_container->set_current_tab(idx);
-		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(idx));
+		tab_container->set_current_tab(tab_container->get_tab_idx_from_control(c));
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(c);
 		if (se) {
 			// Maybe there are unsaved changes.
 			if (se->is_unsaved()) {
@@ -2213,6 +2224,9 @@ void ScriptEditor::_update_script_names() {
 				case SORT_BY_NONE: {
 					sd.sort_key = "";
 				} break;
+				case SORT_BY_LAST_OPENED: {
+					sd.sort_key = "";
+				} break;
 			}
 
 			switch (display_as) {
@@ -2287,7 +2301,7 @@ void ScriptEditor::_update_script_names() {
 		}
 	}
 
-	if (_sort_list_on_update && !sedata.is_empty()) {
+	if (_sort_list_on_update && !sedata.is_empty() && sort_by != SORT_BY_NONE && sort_by != SORT_BY_LAST_OPENED) {
 		sedata.sort();
 
 		// change actual order of tab_container so that the order can be rearranged by user
@@ -2315,6 +2329,7 @@ void ScriptEditor::_update_script_names() {
 		lock_history = false;
 		_sort_list_on_update = false;
 	}
+	lock_history = false;
 
 	Vector<_ScriptEditorItemData> sedata_filtered;
 	for (int i = 0; i < sedata.size(); i++) {
@@ -3570,13 +3585,15 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 		return;
 	}
 
-	for (int i = 0; i < tab_container->get_tab_count(); i++) {
-		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
+	if (!restoring_layout) {
+		for (int i = 0; i < tab_container->get_tab_count(); i++) {
+			EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
 
-		if (eh && eh->get_class() == p_class) {
-			_go_to_tab(i);
-			_update_script_names();
-			return;
+			if (eh && eh->get_class() == p_class) {
+				_go_to_tab(i);
+				_update_script_names();
+				return;
+			}
 		}
 	}
 
@@ -3584,11 +3601,13 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 
 	eh->set_name(p_class);
 	tab_container->add_child(eh);
-	_go_to_tab(tab_container->get_tab_count() - 1);
+	if (!restoring_layout) {
+		_go_to_tab(tab_container->get_tab_count() - 1);
+		_add_recent_script(p_class);
+	}
 	eh->go_to_class(p_class);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 	eh->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history));
-	_add_recent_script(p_class);
 	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -261,7 +261,8 @@ class ScriptEditor : public PanelContainer {
 	enum ScriptSortBy {
 		SORT_BY_NAME,
 		SORT_BY_PATH,
-		SORT_BY_NONE
+		SORT_BY_NONE,
+		SORT_BY_LAST_OPENED,
 	};
 
 	enum ScriptListName {
@@ -344,7 +345,7 @@ class ScriptEditor : public PanelContainer {
 	int history_pos;
 
 	List<String> previous_scripts;
-	List<int> script_close_queue;
+	List<Control *> script_close_queue;
 
 	void _tab_changed(int p_which);
 	void _menu_option(int p_option);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8125
Added "Last Opened" option to text_editor/script_list/sort_scripts_by. I put it after "None", which looks strange, so that it's backwards compatible.
Added an EditorSetting called `last_opened_script_threshold`. A selected script won't be moved to the top if it's already within the first N scripts on the list.
Also added documentation for both.

I had to change `script_close_queue` to reference the Control nodes directly instead of the index, because scripts are selected during the closing process, which shuffled them around and invalidated the previous indices in some cases.

This also changes help classes to not add themselves to the history when loading a project. This was necessary to make them not end up at the top with the new option.
To be clear, the behaviour used to be that when you loaded a project, the script history would be entirely populated by all the opened doc classes, in order. So I reckon it wasn't intended anyway :p

I also avoid sorting the script list in _update_script_names if not on an effective sorting type. So, I set lock_history to false after the loop because otherwise it'd stay true after being set in _update_history_pos. I'm not sure how _update_history_pos works or why it sets it to true, so I figured this was the safest place to set it to false.
