### PR TITLE
SCons: Use CXXFLAGS to disable exceptions, it's only for C++

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -722,9 +722,9 @@ if selected_platform in platform_list:
         if env.msvc:
             env.Append(CPPDEFINES=[("_HAS_EXCEPTIONS", 0)])
         else:
-            env.Append(CCFLAGS=["-fno-exceptions"])
+            env.Append(CXXFLAGS=["-fno-exceptions"])
     elif env.msvc:
-        env.Append(CCFLAGS=["/EHsc"])
+        env.Append(CXXFLAGS=["/EHsc"])
 
     # Configure compiler warnings
     if env.msvc:  # MSVC


### PR DESCRIPTION
Following discussion in https://github.com/godotengine/godot-cpp/pull/1216.

Note for `4.1` and `3.x` cherry-picks: there's similar code to change in the `denoise` module.