### PR TITLE
Fix StringName leaks in VariantParser

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -100,11 +100,9 @@ void StringName::cleanup() {
 				lost_strings++;
 
 				if (OS::get_singleton()->is_stdout_verbose()) {
-					if (d->cname) {
-						print_line("Orphan StringName: " + String(d->cname));
-					} else {
-						print_line("Orphan StringName: " + String(d->name));
-					}
+					String dname = String(d->cname ? d->cname : d->name);
+
+					print_line(vformat("Orphan StringName: %s (static: %d, total: %d)", dname, d->static_count.get(), d->refcount.get()));
 				}
 			}
 
@@ -113,7 +111,7 @@ void StringName::cleanup() {
 		}
 	}
 	if (lost_strings) {
-		print_verbose("StringName: " + itos(lost_strings) + " unclaimed string names at exit.");
+		print_verbose(vformat("StringName: %d unclaimed string names at exit.", lost_strings));
 	}
 	configured = false;
 }

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1075,7 +1075,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return ERR_PARSE_ERROR;
 			}
 
-			static HashMap<StringName, Variant::Type> builtin_types;
+			static HashMap<String, Variant::Type> builtin_types;
 			if (builtin_types.is_empty()) {
 				for (int i = 1; i < Variant::VARIANT_MAX; i++) {
 					builtin_types[Variant::get_type_name((Variant::Type)i)] = (Variant::Type)i;

--- a/modules/webrtc/webrtc_peer_connection.cpp
+++ b/modules/webrtc/webrtc_peer_connection.cpp
@@ -40,14 +40,14 @@ StringName WebRTCPeerConnection::default_extension;
 
 void WebRTCPeerConnection::set_default_extension(const StringName &p_extension) {
 	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_extension, WebRTCPeerConnectionExtension::get_class_static()), vformat("Can't make %s the default WebRTC extension since it does not extend WebRTCPeerConnectionExtension.", p_extension));
-	default_extension = p_extension;
+	default_extension = StringName(p_extension, true);
 }
 
 WebRTCPeerConnection *WebRTCPeerConnection::create() {
 #ifdef WEB_ENABLED
 	return memnew(WebRTCPeerConnectionJS);
 #else
-	if (default_extension == String()) {
+	if (default_extension == StringName()) {
 		WARN_PRINT_ONCE("No default WebRTC extension configured.");
 		return memnew(WebRTCPeerConnectionExtension);
 	}


### PR DESCRIPTION
A follow-up to https://github.com/godotengine/godot/pull/83562.

Out of remaining 38 strings, 37 were variant types, and I was able to pinpoint them to https://github.com/godotengine/godot/pull/69248. It creates a static hashmap in the method's scope, which behaves the same as all other cases addressed in https://github.com/godotengine/godot/pull/83562. I'm not sure if there is any reason to store those identifiers as string names. They are returned as strings, they are compared to strings. It's just a lot conversion all around.

But I may be wrong, so feel free to suggest alternatives!

I also noticed that in one of the WebRTC classes there was a situation similar to https://github.com/godotengine/godot/pull/74031. Seems like Fabio used the same pattern in both places, so it was worth addressing it.

-----

This still leaves one reported orphan string:

```
Orphan StringName: Node (static: 5, total: 6)
StringName: 1 unclaimed string names at exit.
```

Unfortunately, this is a very hard issue to figure out. I can't deduce what could be keeping a reference to something so generic as a string of `"Node"`. There is nothing obvious related to static references, be it of `StringName` or of `HashMaps` or `HashSets`, nor related to `SNAME`. The variant parser issue was created by a cast from a variable, and here it can be the same case. So using a literal to locate the offending code is impossible, and debugging through everything that ever accesses `"Node"` as a string name during a test cycle of opening a project doesn't paint a clear picture.

So I leave it at that. I also tried to improve messages a bit so it may be easier to debug these leaks, if they are even real leaks.