### PR TITLE
Allow Vulkan local devices to enjoy the full feature set

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -250,7 +250,7 @@ private:
 
 	Error _initialize_queues(VkSurfaceKHR p_surface);
 
-	Error _create_device();
+	Error _create_device(VkDevice &r_vk_device);
 
 	Error _clean_up_swap_chain(Window *window);
 


### PR DESCRIPTION
This avoids some duplicate code as a side effect of its goal, which is let the creation of local devices be as complete as that of the main device. This enables local devices to use features such as VRS that require additional setup that formerly was done only for the main device.