### PR TITLE
Fix `TabBar` and `TabContainer` dragging issues

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -243,7 +243,7 @@
 		<signal name="tab_selected">
 			<param index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is selected, even if it is the current tab.
+				Emitted when a tab is selected via click or script, even if it is the current tab.
 			</description>
 		</signal>
 	</signals>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4770,21 +4770,15 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 		Ref<InputEventMouseButton> mb = me;
 
 		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed() && dock_popup_selected_idx != nrect) {
-			Control *dock = dock_slot[dock_popup_selected_idx]->get_current_tab_control();
-			if (dock) {
-				dock_slot[dock_popup_selected_idx]->remove_child(dock);
-			}
+			dock_slot[nrect]->move_tab_from_tab_container(dock_slot[dock_popup_selected_idx], dock_slot[dock_popup_selected_idx]->get_current_tab(), dock_slot[nrect]->get_tab_count());
+
 			if (dock_slot[dock_popup_selected_idx]->get_tab_count() == 0) {
 				dock_slot[dock_popup_selected_idx]->hide();
-
 			} else {
 				dock_slot[dock_popup_selected_idx]->set_current_tab(0);
 			}
 
-			dock_slot[nrect]->add_child(dock);
 			dock_popup_selected_idx = nrect;
-			dock_slot[nrect]->set_current_tab(dock_slot[nrect]->get_tab_count() - 1);
-			dock_slot[nrect]->set_tab_title(dock_slot[nrect]->get_tab_count() - 1, TTRGET(dock->get_name()));
 			dock_slot[nrect]->show();
 			dock_select->queue_redraw();
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -55,7 +55,6 @@ public:
 private:
 	struct Tab {
 		String text;
-		String xl_text;
 
 		String language;
 		Control::TextDirection text_direction = Control::TEXT_DIRECTION_INHERITED;
@@ -167,8 +166,13 @@ protected:
 	Variant get_drag_data(const Point2 &p_point) override;
 	bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	void drop_data(const Point2 &p_point, const Variant &p_data) override;
+	void _move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
 
 public:
+	Variant _handle_get_drag_data(const String &p_type, const Point2 &p_point);
+	bool _handle_can_drop_data(const String &p_type, const Point2 &p_point, const Variant &p_data) const;
+	void _handle_drop_data(const String &p_type, const Point2 &p_point, const Variant &p_data, const Callable &p_move_tab_callback, const Callable &p_move_tab_from_other_callback);
+
 	void add_tab(const String &p_str = "", const Ref<Texture2D> &p_icon = Ref<Texture2D>());
 
 	void set_tab_title(int p_tab, const String &p_title);

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -330,143 +330,59 @@ Vector<Control *> TabContainer::_get_tab_controls() const {
 }
 
 Variant TabContainer::_get_drag_data_fw(const Point2 &p_point, Control *p_from_control) {
-	if (!drag_to_rearrange_enabled) {
-		return Variant();
-	}
-
-	int tab_over = get_tab_idx_at_point(p_point);
-	if (tab_over < 0) {
-		return Variant();
-	}
-
-	HBoxContainer *drag_preview = memnew(HBoxContainer);
-
-	Ref<Texture2D> icon = get_tab_icon(tab_over);
-	if (!icon.is_null()) {
-		TextureRect *tf = memnew(TextureRect);
-		tf->set_texture(icon);
-		drag_preview->add_child(tf);
-	}
-
-	Label *label = memnew(Label(get_tab_title(tab_over)));
-	set_drag_preview(drag_preview);
-	drag_preview->add_child(label);
-
-	Dictionary drag_data;
-	drag_data["type"] = "tabc_element";
-	drag_data["tabc_element"] = tab_over;
-	drag_data["from_path"] = get_path();
-
-	return drag_data;
+	return tab_bar->_handle_get_drag_data("tab_container_tab", p_point);
 }
 
 bool TabContainer::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control) const {
-	if (!drag_to_rearrange_enabled) {
-		return false;
-	}
-
-	Dictionary d = p_data;
-	if (!d.has("type")) {
-		return false;
-	}
-
-	if (String(d["type"]) == "tabc_element") {
-		NodePath from_path = d["from_path"];
-		NodePath to_path = get_path();
-		if (from_path == to_path) {
-			return true;
-		} else if (get_tabs_rearrange_group() != -1) {
-			// Drag and drop between other TabContainers.
-			Node *from_node = get_node(from_path);
-			TabContainer *from_tabc = Object::cast_to<TabContainer>(from_node);
-			if (from_tabc && from_tabc->get_tabs_rearrange_group() == get_tabs_rearrange_group()) {
-				return true;
-			}
-		}
-	}
-
-	return false;
+	return tab_bar->_handle_can_drop_data("tab_container_tab", p_point, p_data);
 }
 
 void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control) {
-	if (!drag_to_rearrange_enabled) {
+	return tab_bar->_handle_drop_data("tab_container_tab", p_point, p_data, callable_mp(this, &TabContainer::_drag_move_tab), callable_mp(this, &TabContainer::_drag_move_tab_from));
+}
+
+void TabContainer::_drag_move_tab(int p_from_index, int p_to_index) {
+	move_child(get_tab_control(p_from_index), get_tab_control(p_to_index)->get_index(false));
+}
+
+void TabContainer::_drag_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index) {
+	Node *parent = p_from_tabbar->get_parent();
+	if (!parent) {
 		return;
 	}
-
-	Dictionary d = p_data;
-	if (!d.has("type")) {
+	TabContainer *from_tab_container = Object::cast_to<TabContainer>(parent);
+	if (!from_tab_container) {
 		return;
 	}
+	move_tab_from_tab_container(from_tab_container, p_from_index, p_to_index);
+}
 
-	if (String(d["type"]) == "tabc_element") {
-		int tab_from_id = d["tabc_element"];
-		int hover_now = get_tab_idx_at_point(p_point);
-		NodePath from_path = d["from_path"];
-		NodePath to_path = get_path();
+void TabContainer::move_tab_from_tab_container(TabContainer *p_from, int p_from_index, int p_to_index) {
+	ERR_FAIL_NULL(p_from);
+	ERR_FAIL_INDEX(p_from_index, p_from->get_tab_count());
+	ERR_FAIL_INDEX(p_to_index, get_tab_count() + 1);
 
-		if (from_path == to_path) {
-			if (tab_from_id == hover_now) {
-				return;
-			}
+	// Get the tab properties before they get erased by the child removal.
+	String tab_title = p_from->get_tab_title(p_from_index);
+	Ref<Texture2D> tab_icon = p_from->get_tab_icon(p_from_index);
+	bool tab_disabled = p_from->is_tab_disabled(p_from_index);
+	Variant tab_metadata = p_from->get_tab_metadata(p_from_index);
 
-			// Drop the new tab to the left or right depending on where the target tab is being hovered.
-			if (hover_now != -1) {
-				Rect2 tab_rect = tab_bar->get_tab_rect(hover_now);
-				if (is_layout_rtl() ^ (p_point.x <= tab_rect.position.x + tab_rect.size.width / 2)) {
-					if (hover_now > tab_from_id) {
-						hover_now -= 1;
-					}
-				} else if (tab_from_id > hover_now) {
-					hover_now += 1;
-				}
-			} else {
-				hover_now = is_layout_rtl() ^ (p_point.x < tab_bar->get_tab_rect(0).position.x) ? 0 : get_tab_count() - 1;
-			}
+	Control *moving_tabc = p_from->get_tab_control(p_from_index);
+	p_from->remove_child(moving_tabc);
+	add_child(moving_tabc, true);
 
-			move_child(get_tab_control(tab_from_id), get_tab_control(hover_now)->get_index(false));
-			if (!is_tab_disabled(hover_now)) {
-				emit_signal(SNAME("active_tab_rearranged"), hover_now);
-				set_current_tab(hover_now);
-			}
+	set_tab_title(get_tab_count() - 1, tab_title);
+	set_tab_icon(get_tab_count() - 1, tab_icon);
+	set_tab_disabled(get_tab_count() - 1, tab_disabled);
+	set_tab_metadata(get_tab_count() - 1, tab_metadata);
 
-		} else if (get_tabs_rearrange_group() != -1) {
-			// Drag and drop between TabContainers.
-
-			Node *from_node = get_node(from_path);
-			TabContainer *from_tabc = Object::cast_to<TabContainer>(from_node);
-
-			if (from_tabc && from_tabc->get_tabs_rearrange_group() == get_tabs_rearrange_group()) {
-				// Get the tab properties before they get erased by the child removal.
-				String tab_title = from_tabc->get_tab_title(tab_from_id);
-				Ref<Texture2D> tab_icon = from_tabc->get_tab_icon(tab_from_id);
-				bool tab_disabled = from_tabc->is_tab_disabled(tab_from_id);
-				Variant tab_metadata = from_tabc->get_tab_metadata(tab_from_id);
-
-				// Drop the new tab to the left or right depending on where the target tab is being hovered.
-				if (hover_now != -1) {
-					Rect2 tab_rect = tab_bar->get_tab_rect(hover_now);
-					if (is_layout_rtl() ^ (p_point.x > tab_rect.position.x + tab_rect.size.width / 2)) {
-						hover_now += 1;
-					}
-				} else {
-					hover_now = is_layout_rtl() ^ (p_point.x < tab_bar->get_tab_rect(0).position.x) ? 0 : get_tab_count();
-				}
-
-				Control *moving_tabc = from_tabc->get_tab_control(tab_from_id);
-				from_tabc->remove_child(moving_tabc);
-				add_child(moving_tabc, true);
-
-				set_tab_title(get_tab_count() - 1, tab_title);
-				set_tab_icon(get_tab_count() - 1, tab_icon);
-				set_tab_disabled(get_tab_count() - 1, tab_disabled);
-				set_tab_metadata(get_tab_count() - 1, tab_metadata);
-
-				move_child(moving_tabc, get_tab_control(hover_now)->get_index(false));
-				if (!is_tab_disabled(hover_now)) {
-					set_current_tab(hover_now);
-				}
-			}
-		}
+	if (p_to_index < 0 || p_to_index > get_tab_count() - 1) {
+		p_to_index = get_tab_count() - 1;
+	}
+	move_child(moving_tabc, get_tab_control(p_to_index)->get_index(false));
+	if (!is_tab_disabled(p_to_index)) {
+		set_current_tab(p_to_index);
 	}
 }
 
@@ -494,6 +410,10 @@ void TabContainer::_on_tab_selected(int p_tab) {
 
 void TabContainer::_on_tab_button_pressed(int p_tab) {
 	emit_signal(SNAME("tab_button_pressed"), p_tab);
+}
+
+void TabContainer::_on_active_tab_rearranged(int p_tab) {
+	emit_signal(SNAME("active_tab_rearranged"), p_tab);
 }
 
 void TabContainer::_refresh_tab_names() {
@@ -895,11 +815,11 @@ Popup *TabContainer::get_popup() const {
 }
 
 void TabContainer::set_drag_to_rearrange_enabled(bool p_enabled) {
-	drag_to_rearrange_enabled = p_enabled;
+	tab_bar->set_drag_to_rearrange_enabled(p_enabled);
 }
 
 bool TabContainer::get_drag_to_rearrange_enabled() const {
-	return drag_to_rearrange_enabled;
+	return tab_bar->get_drag_to_rearrange_enabled();
 }
 
 void TabContainer::set_tabs_rearrange_group(int p_group_id) {
@@ -1038,6 +958,7 @@ TabContainer::TabContainer() {
 	tab_bar->connect("tab_hovered", callable_mp(this, &TabContainer::_on_tab_hovered));
 	tab_bar->connect("tab_selected", callable_mp(this, &TabContainer::_on_tab_selected));
 	tab_bar->connect("tab_button_pressed", callable_mp(this, &TabContainer::_on_tab_button_pressed));
+	tab_bar->connect("active_tab_rearranged", callable_mp(this, &TabContainer::_on_active_tab_rearranged));
 
 	connect("mouse_exited", callable_mp(this, &TabContainer::_on_mouse_exited));
 }

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -43,7 +43,6 @@ class TabContainer : public Container {
 	bool all_tabs_in_front = false;
 	bool menu_hovered = false;
 	mutable ObjectID popup_obj_id;
-	bool drag_to_rearrange_enabled = false;
 	bool use_hidden_tabs_for_min_size = false;
 	bool theme_changing = false;
 	Vector<Control *> children_removing;
@@ -97,10 +96,13 @@ class TabContainer : public Container {
 	void _on_tab_hovered(int p_tab);
 	void _on_tab_selected(int p_tab);
 	void _on_tab_button_pressed(int p_tab);
+	void _on_active_tab_rearranged(int p_tab);
 
 	Variant _get_drag_data_fw(const Point2 &p_point, Control *p_from_control);
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control) const;
 	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control);
+	void _drag_move_tab(int p_from_index, int p_to_index);
+	void _drag_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
@@ -165,6 +167,8 @@ public:
 
 	void set_popup(Node *p_popup);
 	Popup *get_popup() const;
+
+	void move_tab_from_tab_container(TabContainer *p_from, int p_from_index, int p_to_index = -1);
 
 	void set_drag_to_rearrange_enabled(bool p_enabled);
 	bool get_drag_to_rearrange_enabled() const;


### PR DESCRIPTION
Removed code duplication between `TabBar` and `TabContainer` for dragging logic.
`TabContainer` now uses its `TabBar` for dragging functionality.

- Fixed `TabContainer` drag preview not using icon minimum size (set through its `TabBar`).
- Fixed `TabBar` drag preview not changing translation after dragging.
- Fixed when dragging a tab to an empty `TabBar`, the tab cache is not updated, causing the tab to be drawn in the wrong area until updated.
- Fixed when dragging a disabled tab to an empty `TabBar`, the `tab_selected` and `tab_changed` signals are emitted.
- Fixed when dragging a tab to an empty `TabBar`, the `tab_selected` signal is emitted twice.
- Fixed `TabContainer` not properly checking if its empty on dropping tabs (It's currently not really possible since it gets hidden without tabs, but still).
- Changing docks with dock select now lets `TabContainer` handle the tab moving logic to reduce duplicate logic and make the code cleaner. It now also properly handles tab icons and metadata.
- Removed `xl_text` from tab struct since it doesn't need to be stored there anymore.
- `TabContainer` now just uses its `TabBar`'s `drag_to_rearrange_enabled`.

