### PR TITLE
Fix shadow map debug visualization camera frustum index buffer size

### DIFF
--- a/servers/rendering/renderer_rd/effects/debug_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/debug_effects.cpp
@@ -108,7 +108,7 @@ void DebugEffects::_create_frustum_arrays() {
 
 		// Create our index_array
 		PackedByteArray data;
-		data.resize(6 * 2 * 3 * 4);
+		data.resize(6 * 2 * 3 * 2);
 		{
 			uint8_t *w = data.ptrw();
 			uint16_t *p16 = (uint16_t *)w;
@@ -142,7 +142,7 @@ void DebugEffects::_create_frustum_arrays() {
 
 		// Create our lines_array
 		PackedByteArray data;
-		data.resize(12 * 2 * 4);
+		data.resize(12 * 2 * 2);
 		{
 			uint8_t *w = data.ptrw();
 			uint16_t *p16 = (uint16_t *)w;


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/81288 changed to 16-bit indices but missed a spot updating buffer sizes, so using **Display Advanced... -> Directional Shadow Map** doesn't show the camera frustum and fills Output with the following error in 4.2.beta2:

```
  Default index buffer initializer array size (144) does not match format required size (72).
  drivers/vulkan/rendering_device_vulkan.cpp:4584 - Condition "!index_buffer_owner.owns(p_index_buffer)" is true. Returning: RID()
  Default index buffer initializer array size (96) does not match format required size (48).
  drivers/vulkan/rendering_device_vulkan.cpp:4584 - Condition "!index_buffer_owner.owns(p_index_buffer)" is true. Returning: RID()
  drivers/vulkan/rendering_device_vulkan.cpp:7408 - Parameter "index_array" is null.
  Draw command requested indices, but no index buffer was set.
  drivers/vulkan/rendering_device_vulkan.cpp:7408 - Parameter "index_array" is null.
  Draw command requested indices, but no index buffer was set.