### PR TITLE
GDScript LSP: Notify client about unsafe lines in document

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -130,6 +130,23 @@ void GDScriptTextDocument::notify_client_show_symbol(const lsp::DocumentSymbol *
 	GDScriptLanguageProtocol::get_singleton()->notify_client("gdscript/show_native_symbol", symbol->to_json(true));
 }
 
+void GDScriptTextDocument::notify_client_unsafe_lines(const String &p_path) {
+	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(p_path);
+	// Notify client about unsafe lines
+	lsp::UnsafeLinesList unsafe_lines;
+	ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts.find(path)->value;
+	HashSet<int> parser_unsafe_lines = parser->get_unsafe_lines();
+	for (int i = 1; i <= parser->get_last_line_number(); i++) {
+		if (parser_unsafe_lines.has(i)) {
+			unsafe_lines.lines.push_back(i);
+		}
+	}
+	unsafe_lines.uri = p_path;
+	if (unsafe_lines.lines.size() > 0) {
+		GDScriptLanguageProtocol::get_singleton()->notify_client("gdscript/unsafe_lines", unsafe_lines.to_json());
+	}
+}
+
 void GDScriptTextDocument::initialize() {
 	if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
 		for (const KeyValue<StringName, ClassMembers> &E : GDScriptLanguageProtocol::get_singleton()->get_workspace()->native_members) {
@@ -488,6 +505,7 @@ void GDScriptTextDocument::sync_script_content(const String &p_path, const Strin
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
 
 	EditorFileSystem::get_singleton()->update_file(path);
+	notify_client_unsafe_lines(p_path);
 }
 
 void GDScriptTextDocument::show_native_symbol_in_editor(const String &p_symbol_id) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -58,6 +58,7 @@ private:
 	Array find_symbols(const lsp::TextDocumentPositionParams &p_location, List<const lsp::DocumentSymbol *> &r_list);
 	lsp::TextDocumentItem load_document_item(const Variant &p_param);
 	void notify_client_show_symbol(const lsp::DocumentSymbol *symbol);
+	void notify_client_unsafe_lines(const String &p_path);
 
 public:
 	Variant nativeSymbol(const Dictionary &p_params);

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1109,6 +1109,22 @@ struct CompletionList {
 	Vector<CompletionItem> items;
 };
 
+/**
+ * Custom godot structure that represents a list of unsafe lines to be presented
+ * in the editor.
+ */
+struct UnsafeLinesList {
+	String uri;
+	Vector<int> lines;
+
+	_FORCE_INLINE_ Dictionary to_json() {
+		Dictionary result;
+		result["uri"] = uri;
+		result["lines"] = lines;
+		return result;
+	}
+};
+
 // Use namespace instead of enumeration to follow the LSP specifications
 // `lsp::EnumName::EnumValue` is OK but `lsp::EnumValue` is not
 // And here C++ compilers are unhappy with our enumeration name like `String`, `Array`, `Object` etc


### PR DESCRIPTION
Adds a new method to the GDScript Language Server Protocol, `gdscript/unsafe_lines` which notifies the client of every unsafe line in a document. Currently, it is called every time a document is updated, saved, or opened.

The structure of this new notification looks like this:

```json
{
    "uri": "file:///file_uri.gd", // Used for example
    "lines": [13, 24, 37, 38]
}
```

This can be used by lsp clients to highlight or mark unsafe lines.