### PR TITLE
Fix the size of index buffers for debug shadow maps.

### DIFF
--- a/servers/rendering/renderer_rd/effects/debug_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/debug_effects.cpp
@@ -108,7 +108,7 @@ void DebugEffects::_create_frustum_arrays() {
 
 		// Create our index_array
 		PackedByteArray data;
-		data.resize(6 * 2 * 3 * 4);
+		data.resize(6 * 2 * 3 * 2);
 		{
 			uint8_t *w = data.ptrw();
 			uint16_t *p16 = (uint16_t *)w;
@@ -142,7 +142,7 @@ void DebugEffects::_create_frustum_arrays() {
 
 		// Create our lines_array
 		PackedByteArray data;
-		data.resize(12 * 2 * 4);
+		data.resize(12 * 2 * 2);
 		{
 			uint8_t *w = data.ptrw();
 			uint16_t *p16 = (uint16_t *)w;


### PR DESCRIPTION
The size for both the lines array and index array use 4 bytes per item but then uses INDEX_BUFFER_FORMAT_UINT16 which checks that the size matches 2 bytes when creating the buffer(in a dev build). This results in error spew for dev builds which do extra checks that the sizes match(see index_buffer_create).

For example:
    ERROR: Default index buffer initializer array size (144) does not match format required size (72).
        at: index_buffer_create (drivers/vulkan/rendering_device_vulkan.cpp:4541)
    ERROR: Condition "!index_buffer_owner.owns(p_index_buffer)" is true. Returning: RID()
        at: index_array_create (drivers/vulkan/rendering_device_vulkan.cpp:4584)
    ERROR: Default index buffer initializer array size (96) does not match format required size (48).
        at: index_buffer_create (drivers/vulkan/rendering_device_vulkan.cpp:4541)
    ERROR: Condition "!index_buffer_owner.owns(p_index_buffer)" is true. Returning: RID()
        at: index_array_create (drivers/vulkan/rendering_device_vulkan.cpp:4584)
    ERROR: Parameter "index_array" is null.
        at: draw_list_bind_index_array (drivers/vulkan/rendering_device_vulkan.cpp:7408)
    ERROR: Draw command requested indices, but no index buffer was set.
        at: draw_list_draw (drivers/vulkan/rendering_device_vulkan.cpp:7512)

This commit fixes the initial size calculation to match the calculation performed with a dev build.