### PR TITLE
Replace confusing code in `GodotCapsuleShape2D::get_supports`

### DIFF
--- a/servers/physics_2d/godot_shape_2d.cpp
+++ b/servers/physics_2d/godot_shape_2d.cpp
@@ -373,8 +373,7 @@ void GodotCapsuleShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_suppo
 	if (h > 0 && Math::abs(n.x) > segment_is_valid_support_threshold) {
 		// make it flat
 		n.y = 0.0;
-		n.normalize();
-		n *= radius;
+		n.x = SIGN(n.x) * radius;
 
 		r_amount = 2;
 		r_supports[0] = n;


### PR DESCRIPTION
I am doing some bug hunting and found a place where the code is unnecessarily complicated. Its not a big change, but it helps with understanding what this function is doing when reading it.