### PR TITLE
[3.x] Server: Return exit code 0 when running `--version` or `--help`

### DIFF
--- a/platform/server/godot_server.cpp
+++ b/platform/server/godot_server.cpp
@@ -35,8 +35,12 @@ int main(int argc, char *argv[]) {
 	OS_Server os;
 
 	Error err = Main::setup(argv[0], argc - 1, &argv[1]);
-	if (err != OK)
+	if (err != OK) {
+		if (err == ERR_HELP) { // Returned by --help and --version, so success.
+			return 0;
+		}
 		return 255;
+	}
 
 	if (Main::start())
 		os.run(); // it is actually the OS that decides how to run


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/83661