### PR TITLE
GDExtension: Fix `variant_iter_get()` actually calling `iter_next()`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -400,7 +400,7 @@ static void gdextension_variant_iter_get(GDExtensionConstVariantPtr p_self, GDEx
 	Variant *iter = (Variant *)r_iter;
 
 	bool valid;
-	memnew_placement(r_ret, Variant(self->iter_next(*iter, valid)));
+	memnew_placement(r_ret, Variant(self->iter_get(*iter, valid)));
 	*r_valid = valid;
 }
 


### PR DESCRIPTION
While attempting to test PR https://github.com/godotengine/godot-cpp/pull/1253, I discovered that GDExtension's `variant_iter_get()` was actually calling `Variant::iter_next()`! Probably a copy-paste mistake.