### PR TITLE
Clean up some Editor, OpenXR, VideoStream code

### DIFF
--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -45,7 +45,6 @@
 void OpenXRInteractionProfileEditorBase::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_add_binding", "action", "path"), &OpenXRInteractionProfileEditorBase::_add_binding);
 	ClassDB::bind_method(D_METHOD("_remove_binding", "action", "path"), &OpenXRInteractionProfileEditorBase::_remove_binding);
-	ClassDB::bind_method(D_METHOD("_update_interaction_profile"), &OpenXRInteractionProfileEditorBase::_update_interaction_profile);
 }
 
 void OpenXRInteractionProfileEditorBase::_notification(int p_what) {
@@ -63,7 +62,7 @@ void OpenXRInteractionProfileEditorBase::_notification(int p_what) {
 void OpenXRInteractionProfileEditorBase::_do_update_interaction_profile() {
 	if (!is_dirty) {
 		is_dirty = true;
-		call_deferred("_update_interaction_profile");
+		callable_mp(this, &OpenXRInteractionProfileEditorBase::_update_interaction_profile).call_deferred();
 	}
 }
 

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -94,8 +94,7 @@ class VideoStream : public Resource {
 	OBJ_SAVE_TYPE(VideoStream);
 
 protected:
-	static void
-	_bind_methods();
+	static void _bind_methods();
 
 	GDVIRTUAL0R(Ref<VideoStreamPlayback>, _instantiate_playback);
 


### PR DESCRIPTION
While investigating some issues I noticed a few things that could be cleaned up, but don't fit any particular PR I can make right now. So I made this.

- EditorNode has excessive and pointless checks for Input singleton (we already access it without a check prior to this, and then we also check for it twice for some reason).
- EditorNode initialization order is a bit awkward (grouped server configuration a bit better, moved some instructions in a more sensible order).
- OpenXR binds a method that doesn't need that (used only for `call_deferred`, which doesn't need it with Callable).
- VideoStream has a formatting error (surprised it's not caught by clang format).
