### PR TITLE
Adding `clip_uv` parameter description

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -390,7 +390,7 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. When you don't specify [param clip_uv], the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure they do not extend beyond the texture's dimensions. This is useful to prevent texture bleeding or artifacts when rendering a part of a texture. Otherwise, the UV values specified in [param src_rect] are used as-is without modification, even if they extend beyond the texture's dimensions. This can be useful in situations where you want to manually control UV coordinates and are certain that they won't cause texture artifacts. See also [method draw_texture_rect].
+				Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. When [param clip_uv] is true, the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure you don't read outside of the [param src_rect] (e.g. due to precision issues). See also [method draw_texture_rect].
 			</description>
 		</method>
 		<method name="force_update_transform">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -390,7 +390,7 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. See also [method draw_texture_rect].
+				Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. When you don't specify [param clip_uv], the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure they do not extend beyond the texture's dimensions. This is useful to prevent texture bleeding or artifacts when rendering a part of a texture. Otherwise, the UV values specified in [param src_rect] are used as-is without modification, even if they extend beyond the texture's dimensions. This can be useful in situations where you want to manually control UV coordinates and are certain that they won't cause texture artifacts. See also [method draw_texture_rect].
 			</description>
 		</method>
 		<method name="force_update_transform">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -382,7 +382,7 @@
 			<param index="5" name="transpose" type="bool" default="false" />
 			<param index="6" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws the specified region of a 2D textured rectangle on the [CanvasItem] pointed to by the [param item] [RID]. When you don't specify [param clip_uv], the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure they do not extend beyond the texture's dimensions. This is useful to prevent texture bleeding or artifacts when rendering a part of a texture. Otherwise, the UV values specified in [param src_rect] are used as-is without modification, even if they extend beyond the texture's dimensions. This can be useful in situations where you want to manually control UV coordinates and are certain that they won't cause texture artifacts. See also [method CanvasItem.draw_texture_rect_region] and [method Texture2D.draw_rect_region].
+				Draws the specified region of a 2D textured rectangle on the [CanvasItem] pointed to by the [param item] [RID]. When [param clip_uv] is true, the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure you don't read outside of the [param src_rect] (e.g. due to precision issues). See also [method CanvasItem.draw_texture_rect_region] and [method Texture2D.draw_rect_region].
 			</description>
 		</method>
 		<method name="canvas_item_add_triangle_array">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -382,7 +382,7 @@
 			<param index="5" name="transpose" type="bool" default="false" />
 			<param index="6" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws the specified region of a 2D textured rectangle on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_texture_rect_region] and [method Texture2D.draw_rect_region].
+				Draws the specified region of a 2D textured rectangle on the [CanvasItem] pointed to by the [param item] [RID]. When you don't specify [param clip_uv], the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure they do not extend beyond the texture's dimensions. This is useful to prevent texture bleeding or artifacts when rendering a part of a texture. Otherwise, the UV values specified in [param src_rect] are used as-is without modification, even if they extend beyond the texture's dimensions. This can be useful in situations where you want to manually control UV coordinates and are certain that they won't cause texture artifacts. See also [method CanvasItem.draw_texture_rect_region] and [method Texture2D.draw_rect_region].
 			</description>
 		</method>
 		<method name="canvas_item_add_triangle_array">

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -110,7 +110,7 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API. When you don't specify [param clip_uv], the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure they do not extend beyond the texture's dimensions. This is useful to prevent texture bleeding or artifacts when rendering a part of a texture. Otherwise, the UV values specified in [param src_rect] are used as-is without modification, even if they extend beyond the texture's dimensions. This can be useful in situations where you want to manually control UV coordinates and are certain that they won't cause texture artifacts.
+				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API. When [param clip_uv] is ture, the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure you don't read outside of the [param src_rect] (e.g. due to precision issues).
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -110,7 +110,7 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API. When [param clip_uv] is ture, the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure you don't read outside of the [param src_rect] (e.g. due to precision issues).
+				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API. When [param clip_uv] is true, the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure you don't read outside of the [param src_rect] (e.g. due to precision issues).
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -110,7 +110,7 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API.
+				Draws a part of the texture using a [CanvasItem] with the [RenderingServer] API. When you don't specify [param clip_uv], the UV (texture coordinate) values passed in [param src_rect] will be clipped to ensure they do not extend beyond the texture's dimensions. This is useful to prevent texture bleeding or artifacts when rendering a part of a texture. Otherwise, the UV values specified in [param src_rect] are used as-is without modification, even if they extend beyond the texture's dimensions. This can be useful in situations where you want to manually control UV coordinates and are certain that they won't cause texture artifacts.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes godotengine/godot-docs/issues/8292

If I understand the clipping behavior correctly, this is to prevent overflow of pixels and this explains the `true` default. Please, if I am wrong, explain more about it.
