### PR TITLE
Always wait for effective resizing?

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2278,7 +2278,8 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 
 	XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
 
-	if (p_enabled && window_is_maximize_allowed(p_window)) {
+	static bool first = true; // Skip first (create_window) 50 failed attempts, works the second (show_window) time.
+	if (p_enabled && !first) {
 		// Wait for effective resizing (so the GLX context is too).
 		// Give up after 0.5s, it's not going to happen on this WM.
 		// https://github.com/godotengine/godot/issues/19978
@@ -2286,6 +2287,7 @@ void DisplayServerX11::_set_wm_maximized(WindowID p_window, bool p_enabled) {
 			usleep(10000);
 		}
 	}
+	first = false;
 	wd.maximized = p_enabled;
 }
 


### PR DESCRIPTION
https://github.com/godotengine/godot/issues/83693

This fix is probably wrong but it seems to work... called twice first time waits 50 attempts second times waits ~3 attempts
