### PR TITLE
Improve threading in ClassDB and EditorHelp

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -309,8 +309,10 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 		r_item->set_custom_color(0, search_options->get_theme_color(SNAME("disabled_font_color"), EditorStringName(Editor)));
 	}
 
-	bool is_deprecated = EditorHelp::get_doc_data()->class_list[p_type].is_deprecated;
-	bool is_experimental = EditorHelp::get_doc_data()->class_list[p_type].is_experimental;
+	HashMap<String, DocData::ClassDoc>::Iterator class_doc = EditorHelp::get_doc_data()->class_list.find(p_type);
+
+	bool is_deprecated = (class_doc && class_doc->value.is_deprecated);
+	bool is_experimental = (class_doc && class_doc->value.is_experimental);
 
 	if (is_deprecated) {
 		r_item->add_button(0, get_editor_theme_icon("StatusError"), 0, false, TTR("This class is marked as deprecated."));
@@ -330,7 +332,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 		r_item->set_collapsed(should_collapse);
 	}
 
-	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
+	const String &description = DTR(class_doc ? class_doc->value.brief_description : "");
 	r_item->set_tooltip_text(0, description);
 
 	if (p_type_category == TypeCategory::OTHER_TYPE && !script_type) {

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -187,12 +187,15 @@ class EditorHelp : public VBoxContainer {
 	String _fix_constant(const String &p_constant) const;
 	void _toggle_scripts_pressed();
 
-	static Thread thread;
+	static String doc_version_hash;
+	static bool doc_gen_first_attempt;
+	static bool doc_gen_use_threads;
+	static Thread gen_thread;
 
 	static void _wait_for_thread();
 	static void _load_doc_thread(void *p_udata);
 	static void _gen_doc_thread(void *p_udata);
-	static void _generate_doc_first_step();
+	static void _compute_doc_version_hash();
 
 protected:
 	virtual void _update_theme_item_cache() override;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -575,6 +575,10 @@ void EditorNode::update_preview_themes(int p_mode) {
 
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			EditorHelp::generate_doc();
+		} break;
+
 		case NOTIFICATION_PROCESS: {
 			if (opening_prev && !confirmation->is_visible()) {
 				opening_prev = false;
@@ -6761,7 +6765,6 @@ EditorNode::EditorNode() {
 		DisplayServer::get_singleton()->cursor_set_custom_image(Ref<Resource>());
 	}
 
-	EditorHelp::generate_doc();
 	SceneState::set_disable_placeholders(true);
 	ResourceLoader::clear_translation_remaps(); // Using no remaps if in editor.
 	ResourceLoader::clear_path_remaps();

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -47,13 +47,16 @@
 
 void SceneCreateDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			select_node_button->set_icon(get_editor_theme_icon(SNAME("ClassList")));
 			node_type_2d->set_icon(get_editor_theme_icon(SNAME("Node2D")));
 			node_type_3d->set_icon(get_editor_theme_icon(SNAME("Node3D")));
 			node_type_gui->set_icon(get_editor_theme_icon(SNAME("Control")));
 			node_type_other->add_theme_icon_override(SNAME("icon"), get_editor_theme_icon(SNAME("Node")));
+		} break;
+
+		case NOTIFICATION_READY: {
+			select_node_dialog->select_base();
 		} break;
 	}
 }
@@ -180,7 +183,6 @@ SceneCreateDialog::SceneCreateDialog() {
 	select_node_dialog = memnew(CreateDialog);
 	add_child(select_node_dialog);
 	select_node_dialog->set_base_type("Node");
-	select_node_dialog->select_base();
 	select_node_dialog->connect("create", callable_mp(this, &SceneCreateDialog::on_type_picked));
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);


### PR DESCRIPTION
Maybe. Related to https://github.com/godotengine/godot/issues/83677.

After talking with @RandomShaper and staring at the code for a few hours I'm not at all confident about what's going on. There is clearly an issue with `ClassDB` locking up, but why exactly that happens is hard to deduce because the issue is not easily reproduceable (I've never had this kind of deadlock myself).

Analyzing code doesn't yield an obvious problem, but Pedro suggested that one of the issues may be in `ClassDB::get_api_hash`. This method has a read lock, but also calls `ClassDB::get_class_list` which attempts to set a read lock as well. This [may be an undefined behavior](https://en.cppreference.com/w/cpp/thread/shared_timed_mutex/lock_shared). There is also another problem with this method. It actually writes the data sometimes, not just reads is. So a read lock is not sufficient, we need an exclusive one.

At first I tried to juggle read and write locks by selectively locking and unlocking the mutex within `ClassDB::get_api_hash`. But that created new deadlocks under some circumstances. So I approached it in another way and extracted relevant bits of `ClassDB::get_class_list` back into `ClassDB::get_api_hash` (the method is trivial, it's just one loop), and added a write lock for the entire duration of it.

I also noticed a couple of methods that didn't have (correct) locks, but I think should have. `ClassDB::_bind_method_custom` is used by GDExtension and doesn't have a write lock. `ClassDB::set_method_error_return_values` mutates the state, but has a read lock, and its getter counterpart has no lock at all. I addressed those issues as well.

-----

At the same time I was looking at the docs generator for a potential issue. I tried to move the generation to be a bit later so, hopefully, `EditorNode` initialized classes would not get in the way. This isn't a proper solution, because more classes can be initialized at any moment afterwards (and indeed they do), but it doesn't seem to hurt either. I only had to adjust `CreateDialog` to not rely on the documentation always being available (which is a good thing to do anyway).

I also changed `EditorHelp::_compute_doc_version_hash()` to only be called once, before we attempt to generate anything. This means it no longer runs in a thread, but it also means it only runs once, which should be great, since it's expensive. In fact, based on the internal benchmark I could notice a 0.5-1.0 second reduction in startup times, though YMMV. I also organized related variables and methods a bit in `EditorHelp`.

-----

Now, whether this helps with https://github.com/godotengine/godot/issues/83677 or not, I cannot claim. I think this is better, since locks in `ClassDB` appear to be a pretty clear inconsistency/logical issue. But I can't measure how much better (or indeed worse) this is in actuality. If this is deemed safe, it should be okay for 4.2, but this is far from my comfort zone to recommend it. 