### PR TITLE
GDScript: Add `unsafe_assignment` warning

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -552,6 +552,9 @@
 		<member name="debug/gdscript/warnings/unreachable_pattern" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an unreachable [code]match[/code] pattern is detected.
 		</member>
+		<member name="debug/gdscript/warnings/unsafe_assignment" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when performing an unsafe implicit cast on assignment.
+		</member>
 		<member name="debug/gdscript/warnings/unsafe_call_argument" type="int" setter="" getter="" default="0">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using an expression whose type may not be compatible with the function parameter expected.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1939,6 +1939,11 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 			if (initializer_type.is_variant() || !initializer_type.is_hard_type()) {
 				mark_node_unsafe(p_assignable->initializer);
 				p_assignable->use_conversion_assign = true;
+#ifdef DEBUG_ENABLED
+				if (initializer_type.is_variant() && !initializer_type.is_hard_type()) {
+					parser->push_warning(p_assignable, GDScriptWarning::UNSAFE_ASSIGNMENT, p_assignable->identifier->name);
+				}
+#endif
 				if (!initializer_type.is_variant() && !is_type_compatible(specified_type, initializer_type, true, p_assignable->initializer)) {
 					downgrade_node_type_source(p_assignable->initializer);
 				}

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -103,6 +103,9 @@ String GDScriptWarning::get_message() const {
 		case UNSAFE_METHOD_ACCESS:
 			CHECK_SYMBOLS(2);
 			return vformat(R"*(The method "%s()" is not present on the inferred type "%s" (but may be present on a subtype).)*", symbols[0], symbols[1]);
+		case UNSAFE_ASSIGNMENT:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(The variable of type "%s" is implicitly cast from a value of unknown type.)*", symbols[0]);
 		case UNSAFE_CAST:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The value is cast to "%s" but has an unknown type.)", symbols[0]);
@@ -213,6 +216,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"INFERRED_DECLARATION",
 		"UNSAFE_PROPERTY_ACCESS",
 		"UNSAFE_METHOD_ACCESS",
+		"UNSAFE_ASSIGNMENT",
 		"UNSAFE_CAST",
 		"UNSAFE_CALL_ARGUMENT",
 		"UNSAFE_VOID_RETURN",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -68,6 +68,7 @@ public:
 		INFERRED_DECLARATION, // Variable/constant/parameter has an implicitly inferred static type.
 		UNSAFE_PROPERTY_ACCESS, // Property not found in the detected type (but can be in subtypes).
 		UNSAFE_METHOD_ACCESS, // Function not found in the detected type (but can be in subtypes).
+		UNSAFE_ASSIGNMENT, // Assignment used in an unknown type.
 		UNSAFE_CAST, // Cast used in an unknown type.
 		UNSAFE_CALL_ARGUMENT, // Function call argument is of a supertype of the required type.
 		UNSAFE_VOID_RETURN, // Function returns void but returned a call to a function that can't be type checked.
@@ -117,6 +118,7 @@ public:
 		IGNORE, // INFERRED_DECLARATION // Static typing is optional, we don't want to spam warnings.
 		IGNORE, // UNSAFE_PROPERTY_ACCESS // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_METHOD_ACCESS // Too common in untyped scenarios.
+		IGNORE, // UNSAFE_ASSIGNMENT // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_CAST // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_CALL_ARGUMENT // Too common in untyped scenarios.
 		WARN, // UNSAFE_VOID_RETURN


### PR DESCRIPTION
This PR adds a new `unsafe_assignment` warning, which optionally can be enabled to warn the user if they are implicitly assigning a value of unknown type to a variable without casting it.

*NOTE:* This warning conflicts with the existing `unsafe_cast` warning, and this PR should include discussion on whether we prefer warning for unsafe casting or for unsafe assignment.

Examples of both warnings:
```gdscript
var dict: Dictionary = {
    "value": "foo"
}

var unsafe_cast: String = dict.value as String # unsafe_cast warning
var unsafe_assignment: String = dict.value # unsafe_assignment warning
```

CC @dalexeev since we were talking about a separate discussion of pattern matching and the topic of unsafe casting was brought up and whether unsafe assignment should be a warning.