### PR TITLE
Fix NavigationObstacle3D height

### DIFF
--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -162,6 +162,8 @@ void NavigationObstacle3D::_notification(int p_what) {
 NavigationObstacle3D::NavigationObstacle3D() {
 	obstacle = NavigationServer3D::get_singleton()->obstacle_create();
 
+	NavigationServer3D::get_singleton()->obstacle_set_height(obstacle, height);
+
 	set_radius(radius);
 	set_height(height);
 	set_vertices(vertices);


### PR DESCRIPTION
Fixes NavigationObstacle3D height.

Part of https://github.com/godotengine/godot/issues/83625.

Affected all projects that used the default height because the height setter does not send the update when the value has not changed from the default.

The NavigationObstacle3D is one of those special cases where the server object default does not match the node default. The server object is shared with 2D and 2D requires a height of zero while 3D requires a height of 1.0 so it needs that update to go through to work. With the setter not sending the update and at a height of zero the obstacle that used the default height was only working while agents were on the same y-axis as the obstacle.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
