### PR TITLE
Add `draw_texture_rotated()` to CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -393,6 +393,18 @@
 				Draws a textured rectangle from a texture's region (specified by [param src_rect]) at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped. See also [method draw_texture_rect].
 			</description>
 		</method>
+		<method name="draw_texture_rotated">
+			<return type="void" />
+			<param index="0" name="texture" type="Texture2D" />
+			<param index="1" name="position" type="Vector2" />
+			<param index="2" name="rotation" type="float" />
+			<param index="3" name="origin" type="Vector2" default="Vector2(0.5, 0.5)" />
+			<param index="4" name="region" type="Rect2" default="Rect2(0, 0, 0, 0)" />
+			<param index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
+			<description>
+				Draws a texture at a given [param position] with a given [param rotation]. [param origin] is a relative pivot point, with [code]Vector2(0.5, 0.5)[/code] (default) being the texture center. [param region] can be used to draw a sub-region of the texture; if its size is [code]0[/code], whole texture will be used.
+			</description>
+		</method>
 		<method name="force_update_transform">
 			<return type="void" />
 			<description>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -454,6 +454,18 @@
 				[b]Note:[/b] Styleboxes, textures, and meshes stored only inside local variables should [b]not[/b] be used with this method in GDScript, because the drawing operation doesn't begin immediately once this method is called. In GDScript, when the function with the local variables ends, the local variables get destroyed before the rendering takes place.
 			</description>
 		</method>
+		<method name="draw_texture_rotated">
+			<return type="void" />
+			<param index="0" name="texture" type="Texture2D" />
+			<param index="1" name="position" type="Vector2" />
+			<param index="2" name="rotation" type="float" />
+			<param index="3" name="origin" type="Vector2" default="Vector2(0.5, 0.5)" />
+			<param index="4" name="region" type="Rect2" default="Rect2(0, 0, 0, 0)" />
+			<param index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
+			<description>
+				Draws a texture at a given [param position] with a given [param rotation]. [param origin] is a relative pivot point, with [code]Vector2(0.5, 0.5)[/code] (default) being the texture center. [param region] can be used to draw a sub-region of the texture; if its size is [code]0[/code], the whole texture will be used, and if the size is negative, the texture will be flipped.
+			</description>
+		</method>
 		<method name="force_update_transform">
 			<return type="void" />
 			<description>

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -276,6 +276,9 @@ void CanvasItem::_exit_canvas() {
 
 void CanvasItem::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			draw_transform = Transform2D();
+		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			ERR_MAIN_THREAD_GUARD;
 			ERR_FAIL_COND(!is_inside_tree());
@@ -757,6 +760,24 @@ void CanvasItem::draw_texture_rect_region(const Ref<Texture2D> &p_texture, const
 	p_texture->draw_rect_region(canvas_item, p_rect, p_src_rect, p_modulate, p_transpose, p_clip_uv);
 }
 
+void CanvasItem::draw_texture_rotated(const Ref<Texture2D> &p_texture, const Point2 &p_pos, real_t p_rotation, const Vector2 &p_origin, const Rect2 &p_texture_region, const Color &p_modulate) {
+	ERR_THREAD_GUARD;
+	ERR_DRAW_GUARD;
+	ERR_FAIL_COND(p_texture.is_null());
+
+	Transform2D prev_transform = draw_transform;
+	draw_set_transform_matrix(draw_transform * Transform2D(p_rotation, p_pos));
+
+	if (p_texture_region.has_area()) {
+		const Rect2 draw_rect(-p_texture_region.get_size() * p_origin, p_texture_region.get_size());
+		p_texture->draw_rect_region(canvas_item, draw_rect, p_texture_region, p_modulate, false);
+	} else {
+		p_texture->draw(canvas_item, -p_texture->get_size() * p_origin, p_modulate, false);
+	}
+
+	draw_set_transform_matrix(prev_transform);
+}
+
 void CanvasItem::draw_msdf_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, double p_outline, double p_pixel_range, double p_scale) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
@@ -794,6 +815,7 @@ void CanvasItem::draw_set_transform(const Point2 &p_offset, real_t p_rot, const 
 
 	Transform2D xform(p_rot, p_offset);
 	xform.scale_basis(p_scale);
+	draw_transform = xform;
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(canvas_item, xform);
 }
 
@@ -801,6 +823,7 @@ void CanvasItem::draw_set_transform_matrix(const Transform2D &p_matrix) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
+	draw_transform = p_matrix;
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(canvas_item, p_matrix);
 }
 void CanvasItem::draw_animation_slice(double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) {
@@ -1167,6 +1190,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_texture", "texture", "position", "modulate"), &CanvasItem::draw_texture, DEFVAL(Color(1, 1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_texture_rect", "texture", "rect", "tile", "modulate", "transpose"), &CanvasItem::draw_texture_rect, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_texture_rect_region", "texture", "rect", "src_rect", "modulate", "transpose", "clip_uv"), &CanvasItem::draw_texture_rect_region, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(false), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("draw_texture_rotated", "texture", "position", "rotation", "origin", "region", "modulate"), &CanvasItem::draw_texture_rotated, DEFVAL(Vector2(0.5, 0.5)), DEFVAL(Rect2()), DEFVAL(Color(1, 1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_msdf_texture_rect_region", "texture", "rect", "src_rect", "modulate", "outline", "pixel_range", "scale"), &CanvasItem::draw_msdf_texture_rect_region, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(0.0), DEFVAL(4.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("draw_lcd_texture_rect_region", "texture", "rect", "src_rect", "modulate"), &CanvasItem::draw_lcd_texture_rect_region, DEFVAL(Color(1, 1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_style_box", "style_box", "rect"), &CanvasItem::draw_style_box);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -999,6 +999,46 @@ void CanvasItem::draw_texture_rect_region(RequiredParam<Texture2D> p_texture, co
 	texture->draw_rect_region(canvas_item, p_rect, p_src_rect, p_modulate, p_transpose, p_clip_uv);
 }
 
+void CanvasItem::draw_texture_rotated(const Ref<Texture2D> &p_texture, const Point2 &p_pos, real_t p_rotation, const Vector2 &p_origin, const Rect2 &p_texture_region, const Color &p_modulate) {
+	ERR_THREAD_GUARD;
+	ERR_DRAW_GUARD;
+	ERR_FAIL_COND(p_texture.is_null());
+
+	const Vector2 texture_size = p_texture->get_size() * Vector2(p_texture_region.size.x < 0 ? -1 : 1, p_texture_region.size.y < 0 ? -1 : 1);
+	Rect2 region = p_texture_region.abs();
+	if (!region.has_area()) {
+		region = Rect2(Vector2(), texture_size);
+	}
+	const Vector2 draw_offset = Vector2::from_angle(p_rotation - Math::PI / 2);
+
+	const Vector2 dist_to_left(
+			draw_offset.y * region.size.x * p_origin.x,
+			-draw_offset.x * region.size.x * p_origin.x);
+	const Vector2 dist_to_right(
+			-draw_offset.y * region.size.x * (1 - p_origin.x),
+			draw_offset.x * region.size.x * (1 - p_origin.x));
+	const Vector2 dist_to_top(
+			draw_offset.x * region.size.y * p_origin.y,
+			draw_offset.y * region.size.y * p_origin.y);
+	const Vector2 dist_to_bottom(
+			-draw_offset.x * region.size.y * (1 - p_origin.y),
+			-draw_offset.y * region.size.y * (1 - p_origin.y));
+
+	PackedVector2Array points{
+		Vector2(p_pos.x + dist_to_left.x + dist_to_top.x, p_pos.y + dist_to_left.y + dist_to_top.y),
+		Vector2(p_pos.x + dist_to_right.x + dist_to_top.x, p_pos.y + dist_to_right.y + dist_to_top.y),
+		Vector2(p_pos.x + dist_to_right.x + dist_to_bottom.x, p_pos.y + dist_to_right.y + dist_to_bottom.y),
+		Vector2(p_pos.x + dist_to_left.x + dist_to_bottom.x, p_pos.y + dist_to_left.y + dist_to_bottom.y),
+	};
+	PackedVector2Array uvs{
+		region.position / texture_size,
+		Vector2(region.get_end().x, region.position.y) / texture_size,
+		region.get_end() / texture_size,
+		Vector2(region.position.x, region.get_end().y) / texture_size,
+	};
+	draw_colored_polygon(points, p_modulate, uvs, p_texture);
+}
+
 void CanvasItem::draw_msdf_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, double p_outline, double p_pixel_range, double p_scale) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
@@ -1497,6 +1537,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_texture", "texture", "position", "modulate"), &CanvasItem::draw_texture, DEFVAL(Color(1, 1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_texture_rect", "texture", "rect", "tile", "modulate", "transpose"), &CanvasItem::draw_texture_rect, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_texture_rect_region", "texture", "rect", "src_rect", "modulate", "transpose", "clip_uv"), &CanvasItem::draw_texture_rect_region, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(false), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("draw_texture_rotated", "texture", "position", "rotation", "origin", "region", "modulate"), &CanvasItem::draw_texture_rotated, DEFVAL(Vector2(0.5, 0.5)), DEFVAL(Rect2()), DEFVAL(Color(1, 1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_msdf_texture_rect_region", "texture", "rect", "src_rect", "modulate", "outline", "pixel_range", "scale"), &CanvasItem::draw_msdf_texture_rect_region, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(0.0), DEFVAL(4.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("draw_lcd_texture_rect_region", "texture", "rect", "src_rect", "modulate"), &CanvasItem::draw_lcd_texture_rect_region, DEFVAL(Color(1, 1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_style_box", "style_box", "rect"), &CanvasItem::draw_style_box);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -119,6 +119,7 @@ private:
 
 	mutable Transform2D global_transform;
 	mutable MTFlag global_invalid;
+	Transform2D draw_transform;
 
 	_FORCE_INLINE_ bool _is_global_invalid() const { return is_group_processing() ? global_invalid.mt.is_set() : global_invalid.st; }
 	void _set_global_invalid(bool p_invalid) const;
@@ -274,6 +275,7 @@ public:
 	void draw_texture(const Ref<Texture2D> &p_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
 	void draw_texture_rect(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
 	void draw_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	void draw_texture_rotated(const Ref<Texture2D> &p_texture, const Point2 &p_pos, real_t p_rotation, const Vector2 &p_origin = Vector2(0.5, 0.5), const Rect2 &p_texture_region = Rect2(), const Color &p_modulate = Color(1, 1, 1, 1));
 	void draw_msdf_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), double p_outline = 0.0, double p_pixel_range = 4.0, double p_scale = 1.0);
 	void draw_lcd_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
 	void draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p_rect);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -344,6 +344,7 @@ public:
 	void draw_texture(RequiredParam<Texture2D> p_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
 	void draw_texture_rect(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
 	void draw_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	void draw_texture_rotated(const Ref<Texture2D> &p_texture, const Point2 &p_pos, real_t p_rotation, const Vector2 &p_origin = Vector2(0.5, 0.5), const Rect2 &p_texture_region = Rect2(), const Color &p_modulate = Color(1, 1, 1, 1));
 	void draw_msdf_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), double p_outline = 0.0, double p_pixel_range = 4.0, double p_scale = 1.0);
 	void draw_lcd_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
 	void draw_style_box(RequiredParam<StyleBox> p_style_box, const Rect2 &p_rect);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2624

This PR adds a new method: `draw_texture_rotated(texture, position, rotation, origin, region, modulate)`. From my experience, when drawing a rotated texture, you want to draw the whole texture or its sub-region (spritesheet, animation etc.), so this covers the most common use-cases and there is no real need for other versions (i.e. draw rect/region).
```GDScript
func _draw() -> void:
	draw_texture_rotated(preload("res://icon.svg"), draw_offset, draw_rotation, draw_origin)
```

https://github.com/godotengine/godot/assets/2223172/d5e06f89-ccc1-4a93-9f67-c5b1040d5ce3

```GDScript
func _draw() -> void:
	draw_texture_rotated(preload("res://icon.svg"), draw_offset, draw_rotation, draw_origin, Rect2(16, 8, 48, 32), Color.RED)
```

https://github.com/godotengine/godot/assets/2223172/f75ef92e-8041-4d20-b8cb-bc14a73492c9

The method I used modifies the draw transform, so I had to add a cached transform in case the user wants to use a custom transform. Maybe it's not worth it though and we should just document that this resets the drawing transform. Or maybe there is a way to achieve it without changing drawing transform, idk.

EDIT:
Draw transform is no longer modified.