### PR TITLE
Fix wrong shader rename in 3-to-4 project converter

### DIFF
--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -1450,7 +1450,7 @@ const char *RenamesMap3To4::shaders_renames[][2] = {
 	{ "NORMALMAP_DEPTH", "NORMAL_MAP_DEPTH" },
 	{ "TRANSMISSION", "BACKLIGHT" },
 	{ "WORLD_MATRIX", "MODEL_MATRIX" },
-	{ "depth_draw_alpha_prepass", "depth_draw_opaque" },
+	{ "depth_draw_alpha_prepass", "depth_prepass_alpha" },
 	{ "hint_albedo", "source_color" },
 	{ "hint_aniso", "hint_anisotropy" },
 	{ "hint_black", "hint_default_black" },


### PR DESCRIPTION
Fixes `depth_draw_alpha_prepass` wrong conversion.

Fixes part of #63673 (?)