### PR TITLE
Preserve focus during rescans in FileSystem dock

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -46,6 +46,7 @@ class CreateDialog;
 class EditorDirDialog;
 class ItemList;
 class LineEdit;
+class PanelContainer;
 class ProgressBar;
 class SceneCreateDialog;
 class ShaderCreateDialog;
@@ -144,7 +145,7 @@ private:
 
 	FileSortOption file_sort = FILE_SORT_NAME;
 
-	VBoxContainer *scanning_vb = nullptr;
+	PanelContainer *scanning_panel = nullptr;
 	ProgressBar *scanning_progress = nullptr;
 	SplitContainer *split_box = nullptr;
 	VBoxContainer *file_list_vb = nullptr;


### PR DESCRIPTION
Fixes #33126

Certain operations in the FileSystem dock trigger a rescan. During rescans, a progress bar is being shown in place of FileSystemTree and FileSystemList, and the container that holds them (_split_box_) is hidden, causing them to lose focus:

https://github.com/godotengine/godot/blob/6543495b49613d20f7e32f2b9d38e4a2f1d06db1/editor/filesystem_dock.cpp#L1303-L1307

So, I added some containers to display the progress bar on top of them instead of completely hiding them.