### PR TITLE
[Web] Fix closure compiler builds using BIGINT

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -162,7 +162,7 @@ def configure(env: "Environment"):
     env.AddMethod(create_template_zip, "CreateTemplateZip")
 
     # Closure compiler extern and support for ecmascript specs (const, let, etc).
-    env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT6"
+    env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT_2020"
 
     env["CC"] = "emcc"
     env["CXX"] = "em++"


### PR DESCRIPTION
When using proxy_to_pthread we add BIGINT support (to support exchanging 64 bits integers between wasm and JS).

Bigint though, is part of ECMAScript 2020, and the closure compiler was using ECMAScript 6 instead.

This commit update the CC configuration to use ECMAScript 2020 instead.

Follow up on #79711

*Bugsquad edit:*
- Fixes #83584 