### PR TITLE
Fix navigating within docs page not saving history

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -251,6 +251,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		if (table->has(link)) {
 			// Found in the current page.
 			if (class_desc->is_ready()) {
+				emit_signal(SNAME("navigated_in_page"));
 				class_desc->scroll_to_paragraph((*table)[link]);
 			} else {
 				scroll_to = (*table)[link];
@@ -2559,6 +2560,7 @@ void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_help_callback", &EditorHelp::_help_callback);
 
 	ADD_SIGNAL(MethodInfo("go_to_help"));
+	ADD_SIGNAL(MethodInfo("navigated_in_page"));
 }
 
 EditorHelp::EditorHelp() {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3375,6 +3375,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_class(p_class);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
+	eh->connect("navigated_in_page", callable_mp(this, &ScriptEditor::_save_history));
 	_add_recent_script(p_class);
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -3395,6 +3396,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_help(p_desc);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
+	eh->connect("navigated_in_page", callable_mp(this, &ScriptEditor::_save_history));
 	_add_recent_script(eh->get_class());
 	_sort_list_on_update = true;
 	_update_script_names();


### PR DESCRIPTION
Fixes #82293
Clicking links withing docs which point to the same page didn't save navigation history.