### PR TITLE
Add extra warning messages to `VisualShaderNodeTextureParameter`

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -6346,6 +6346,7 @@ String get_sampler_hint(VisualShaderNodeTextureParameter::TextureType p_texture_
 		if (!repeat_code.is_empty()) {
 			if (!has_colon) {
 				code += " : ";
+				has_colon = true;
 			} else {
 				code += ", ";
 			}
@@ -6493,6 +6494,58 @@ Vector<StringName> VisualShaderNodeTextureParameter::get_editable_properties() c
 
 bool VisualShaderNodeTextureParameter::is_show_prop_names() const {
 	return true;
+}
+
+String VisualShaderNodeTextureParameter::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
+	if (texture_source != SOURCE_NONE) {
+		String texture_source_str;
+
+		switch (texture_source) {
+			case SOURCE_SCREEN: {
+				texture_source_str = "Screen";
+			} break;
+			case SOURCE_DEPTH: {
+				texture_source_str = "Depth";
+			} break;
+			case SOURCE_NORMAL_ROUGHNESS: {
+				texture_source_str = "NormalRoughness";
+			} break;
+			default:
+				break;
+		}
+
+		if (texture_type == TYPE_NORMAL_MAP || texture_type == TYPE_ANISOTROPY) {
+			String texture_type_str;
+
+			switch (texture_type) {
+				case TYPE_NORMAL_MAP: {
+					texture_type_str = "Normal Map";
+				} break;
+				case TYPE_ANISOTROPY: {
+					texture_type_str = "Anisotropic";
+				} break;
+				default:
+					break;
+			}
+			return vformat(RTR("'%s' type is incompatible with '%s' source."), texture_type_str, texture_source_str);
+		} else if (color_default != COLOR_DEFAULT_WHITE) {
+			String color_default_str;
+
+			switch (color_default) {
+				case COLOR_DEFAULT_BLACK: {
+					color_default_str = "Black";
+				} break;
+				case COLOR_DEFAULT_TRANSPARENT: {
+					color_default_str = "Transparent";
+				} break;
+				default:
+					break;
+			}
+			return vformat(RTR("'%s' default color is incompatible with '%s' source."), color_default_str, texture_source_str);
+		}
+	}
+
+	return "";
 }
 
 HashMap<StringName, String> VisualShaderNodeTextureParameter::get_editable_properties_names() const {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -2452,6 +2452,7 @@ public:
 
 	virtual HashMap<StringName, String> get_editable_properties_names() const override;
 	virtual bool is_show_prop_names() const override;
+	virtual String get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const override;
 
 	Vector<StringName> get_editable_properties() const override;
 


### PR DESCRIPTION
Currently, some modes in that node excludes each other:

![изображение](https://github.com/godotengine/godot/assets/3036176/096f9384-17c6-4285-80ce-884674ef5be3)

So I've added the warnings for them:

![изображение](https://github.com/godotengine/godot/assets/3036176/b3bfcb9e-2e2a-4cf1-b086-d84e59363f96)

Also fixes a bug where the repeat flag incorrectly combined with non-default texture source using `:` symbol :

![изображение](https://github.com/godotengine/godot/assets/3036176/935550a7-d0dd-493f-8c26-7fcff4d5b116)
