### PR TITLE
GDExtension: Fixed error on loading extensions

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -959,13 +959,15 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 	// object if one has already been loaded (even if caching is disabled at the resource
 	// loader level).
 	GDExtensionManager *manager = GDExtensionManager::get_singleton();
-	Ref<GDExtension> lib = manager->get_extension(p_path);
-	if (lib.is_null()) {
-		Error err = load_gdextension_resource(p_path, lib);
-		if (err != OK && r_error) {
-			// Errors already logged in load_gdextension_resource().
-			*r_error = err;
-		}
+	if (manager->is_extension_loaded(p_path)) {
+		return manager->get_extension(p_path);
+	}
+
+	Ref<GDExtension> lib;
+	Error err = load_gdextension_resource(p_path, lib);
+	if (err != OK && r_error) {
+		// Errors already logged in load_gdextension_resource().
+		*r_error = err;
 	}
 	return lib;
 }


### PR DESCRIPTION
Previously, before loading an extension, the editor just tried to retrieve the extension by path to test if it's been loaded already.

While this is handled gracefully, it ignored an error thrown inside `GDExtensionManager::get_extension()`, that would essentially still report a not yet loaded extension to the engine's log:

```
ERROR: Condition "!E" is true. Returning: Ref<GDExtension>()
   at: GDExtensionManager::get_extension (core\extension\gdextension_manager.cpp:165)
```

This change actively checks whether the extension path is known and only then proceeds to actually return the already loaded extension or loads and returns the new one otherwise.