### PR TITLE
Add instructions to get shape of `RayCast2D/3D`

### DIFF
--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -56,6 +56,21 @@
 			<return type="int" />
 			<description>
 				Returns the shape ID of the first object that the ray intersects, or [code]0[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				To get the intersected shape node, for a [CollisionObject2D] target, use:
+				[codeblocks]
+				[gdscript]
+				var target = get_collider() # A CollisionObject2D.
+				var shape_id = get_collider_shape() # The shape index in the collider.
+				var owner_id = target.shape_find_owner(shape_id) # The owner ID in the collider.
+				var shape = target.shape_owner_get_owner(owner_id)
+				[/gdscript]
+				[csharp]
+				var target = (CollisionObject2D)GetCollider(); // A CollisionObject2D.
+				var shapeId = GetColliderShape(); // The shape index in the collider.
+				var ownerId = target.ShapeFindOwner(shapeId); // The owner ID in the collider.
+				var shape = target.ShapeOwnerGetOwner(ownerId);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_collision_mask_value" qualifiers="const">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -57,6 +57,21 @@
 			<return type="int" />
 			<description>
 				Returns the shape ID of the first object that the ray intersects, or [code]0[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				To get the intersected shape node, for a [CollisionObject3D] target, use:
+				[codeblocks]
+				[gdscript]
+				var target = get_collider() # A CollisionObject3D.
+				var shape_id = get_collider_shape() # The shape index in the collider.
+				var owner_id = target.shape_find_owner(shape_id) # The owner ID in the collider.
+				var shape = target.shape_owner_get_owner(owner_id)
+				[/gdscript]
+				[csharp]
+				var target = (CollisionObject3D)GetCollider(); // A CollisionObject3D.
+				var shapeId = GetColliderShape(); // The shape index in the collider.
+				var ownerId = target.ShapeFindOwner(shapeId); // The owner ID in the collider.
+				var shape = target.ShapeOwnerGetOwner(ownerId);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_collision_face_index" qualifiers="const">


### PR DESCRIPTION
Adds details on how to get the intersected shape

* Closes: #83732

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
