### PR TITLE
Fix buffer updates going to the wrong cmd buffer if barriers were 0

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -5995,7 +5995,7 @@ Error RenderingDeviceVulkan::buffer_update(RID p_buffer, uint32_t p_offset, uint
 	// No barrier should be needed here.
 	// _buffer_memory_barrier(buffer->buffer, p_offset, p_size, dst_stage_mask, VK_PIPELINE_STAGE_TRANSFER_BIT, dst_access, VK_ACCESS_TRANSFER_WRITE_BIT, true);
 
-	Error err = _buffer_update(buffer, p_offset, (uint8_t *)p_data, p_size, p_post_barrier);
+	Error err = _buffer_update(buffer, p_offset, (uint8_t *)p_data, p_size, true);
 	if (err) {
 		return err;
 	}

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1015,8 +1015,13 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		List<ComputePipeline> compute_pipelines_to_dispose_of;
 
 		VkCommandPool command_pool = VK_NULL_HANDLE;
-		VkCommandBuffer setup_command_buffer = VK_NULL_HANDLE; // Used at the beginning of every frame for set-up.
-		VkCommandBuffer draw_command_buffer = VK_NULL_HANDLE; // Used at the beginning of every frame for set-up.
+		// Used for filling up newly created buffers with data provided on creation.
+		// Primarily intended to be accessed by worker threads.
+		// Ideally this cmd buffer should use an async transfer queue.
+		VkCommandBuffer setup_command_buffer = VK_NULL_HANDLE;
+		// The main cmd buffer for drawing and compute.
+		// Primarily intended to be used by the main thread to do most stuff.
+		VkCommandBuffer draw_command_buffer = VK_NULL_HANDLE;
 
 		struct Timestamp {
 			String description;

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -950,7 +950,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 
 	RD::get_singleton()->draw_command_end_label(); // SSIL
 
-	RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_NO_BARRIER);
+	RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_TRANSFER); // Zeroing importance_map_load_counter depends on us.
 
 	int zero[1] = { 0 };
 	RD::get_singleton()->buffer_update(ssil.importance_map_load_counter, 0, sizeof(uint32_t), &zero, 0); //no barrier
@@ -1332,7 +1332,7 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 		RD::get_singleton()->draw_command_end_label(); // Interleave
 	}
 	RD::get_singleton()->draw_command_end_label(); //SSAO
-	RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_NO_BARRIER); //wait for upcoming transfer
+	RD::get_singleton()->compute_list_end(RD::BARRIER_MASK_TRANSFER); // Zeroing importance_map_load_counter depends on us.
 
 	int zero[1] = { 0 };
 	RD::get_singleton()->buffer_update(ssao.importance_map_load_counter, 0, sizeof(uint32_t), &zero, 0); //no barrier


### PR DESCRIPTION
From what I could see only SSAO & SSIL were affected when they both call:

```cpp
int zero[1] = { 0 };
RD::get_singleton()->buffer_update(ssao.importance_map_load_counter, 0, sizeof(uint32_t), &zero, 0);

int zero[1] = { 0 };
RD::get_singleton()->buffer_update(ssil.importance_map_load_counter, 0, sizeof(uint32_t), &zero, 0);
```

Also documented what setup_command_buffer & draw_command_buffer are for.

I placed breakpoints to see who calls buffer_update() with barriers = 0 and those two were the only calls.

@DarioSamo found this bug while working on Acyclic Render Graphs, but asked me to look deeper into it as he is occupied with the ARG.

Fortunately it doesn't seem like the damage is large:

 - When `buffer_update` calls `_buffer_update` with the wrong queue, buffer_update has the `_THREAD_SAFE_METHOD_` macro
 - All the other functions that call `_buffer_update` directly also use the `_THREAD_SAFE_METHOD_` macro.

So there are no race conditions on the CPU side.

As for the GPU side it's a little more horrible:

## What Godot wanted to do:

1. Execute SSAO (or SSIL).
2. Reset the counter to 0 for the next frame.

## What Godot ends up doing:

1. Execute SSAO (or SSIL).
2. Reset the counter to 0 "whenever you feel like". Before SSAO, during SSAO, after SSAO.

### What _most likely_ ends up happening most of the time:

1. Reset the counter to 0 at the beginning of the frame.
2. Execute SSAO (or SSIL).


With my fix, I had to add `BARRIER_MASK_TRANSFER` to compute_list_end so that the reset is guaranteed to happen after the compute work (though it could probably be moved far elsewhere, e.g. at the end of the frame).