### PR TITLE
[DRAFT] Fix WebXR with `proxy_to_pthread=yes`

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -287,8 +287,9 @@ const GodotWebXR = {
 			// Store onsimpleevent so we can use it later.
 			GodotWebXR.onsimpleevent = onsimpleevent;
 
-			const gl_context_handle = _emscripten_webgl_get_current_context(); // eslint-disable-line no-undef
-			const gl = GL.getContext(gl_context_handle).GLctx;
+			//const gl_context_handle = _emscripten_webgl_get_current_context(); // eslint-disable-line no-undef
+			//const gl = GL.getContext(gl_context_handle).GLctx;
+			const gl = GL.currentContext.GLctx;
 			GodotWebXR.gl = gl;
 
 			gl.makeXRCompatible().then(function () {
@@ -312,7 +313,7 @@ const GodotWebXR = {
 					// Now that both GodotWebXR.session and GodotWebXR.space are
 					// set, we need to pause and resume the main loop for the XR
 					// main loop to kick in.
-					GodotWebXR.pauseResumeMainLoop();
+					//GodotWebXR.pauseResumeMainLoop();
 
 					// Call in setTimeout() so that errors in the onstarted()
 					// callback don't bubble up here and cause Godot to try the
@@ -377,7 +378,7 @@ const GodotWebXR = {
 		// Disable the monkey-patched window.requestAnimationFrame() and
 		// pause/restart the main loop to activate it on all platforms.
 		GodotWebXR.monkeyPatchRequestAnimationFrame(false);
-		GodotWebXR.pauseResumeMainLoop();
+		//GodotWebXR.pauseResumeMainLoop();
 	},
 
 	godot_webxr_get_view_count__proxy: 'sync',

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -127,6 +127,10 @@ public:
 
 	virtual void process() override;
 
+	// These have to be public, but don't call them.
+	void _emit_session_supported(const String &p_session_mode, bool p_supported);
+	void _emit_session_failed(const String &p_message);
+	void _emit_simple_signal(const StringName &p_signal);
 	void _on_input_event(int p_event_type, int p_input_source_id);
 
 	WebXRInterfaceJS();


### PR DESCRIPTION
Attempts to fix https://github.com/godotengine/godot/issues/83733

There's a number of problems here. I think this PR satisfactorily solves the `"Caller thread can't call this function"` error. However, WebXR still isn't actually working...
