### PR TITLE
Clamp the height of description text for property selectors

### DIFF
--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -569,5 +569,7 @@ PropertySelector::PropertySelector() {
 
 	help_bit = memnew(EditorHelpBit);
 	vbc->add_margin_child(TTR("Description:"), help_bit);
+	help_bit->get_rich_text()->set_fit_content(false);
+	help_bit->get_rich_text()->set_custom_minimum_size(Size2(help_bit->get_rich_text()->get_minimum_size().x, 135 * EDSCALE));
 	help_bit->connect("request_hide", callable_mp(this, &PropertySelector::_hide_requested));
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #83495 
### New
![Screenshot from 2023-10-21 13-33-58](https://github.com/godotengine/godot/assets/43453305/d35f8398-48b2-4d28-ae23-9d4681c27f23)
### Old 
![Screenshot from 2023-10-21 13-37-08](https://github.com/godotengine/godot/assets/43453305/ba0a2b2a-2a91-45cc-be7d-4b39b8d23fbc)
