### PR TITLE
Fix `GPUParticles3D` on the Meta Quest 2 with OpenGL renderer

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -818,6 +818,7 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 	}
 
 	glEnable(GL_RASTERIZER_DISCARD);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	_particles_update_instance_buffer(particles, axis, p_up_axis);
 	glDisable(GL_RASTERIZER_DISCARD);
 }
@@ -1001,6 +1002,7 @@ void ParticlesStorage::_particles_update_instance_buffer(Particles *particles, c
 
 void ParticlesStorage::update_particles() {
 	glEnable(GL_RASTERIZER_DISCARD);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
 	GLuint global_buffer = GLES3::MaterialStorage::get_singleton()->global_shader_parameters_get_uniform_buffer();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/83275

It's the same problem that PR https://github.com/godotengine/godot/pull/79772 fixed for skeleton animations: the multiview framebuffer was still bound when trying to run a non-rendering, non-multiview shader.

This uses the same solution: unbind the framebuffer before running the particles shader.