### PR TITLE
Add `Node.get_orphan_node_ids`, edit `Node.print_orphan_nodes`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -495,6 +495,13 @@
 				Fetches a node by [NodePath]. Similar to [method get_node], but does not generate an error if [param path] does not point to a valid node.
 			</description>
 		</method>
+		<method name="get_orphan_node_ids" qualifiers="static">
+			<return type="int[]" />
+			<description>
+				Returns object IDs of all orphan nodes (nodes outside the [SceneTree]). Used for debugging.
+				[b]Note:[/b] [method get_orphan_node_ids] only works in debug builds. When called in a project exported in release mode, [method get_orphan_node_ids] will return an empty array.
+			</description>
+		</method>
 		<method name="get_parent" qualifiers="const">
 			<return type="Node" />
 			<description>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3482,9 +3482,17 @@ static void _print_orphan_nodes_routine(Object *p_obj) {
 		path = String(p->get_name()) + "/" + p->get_path_to(n);
 	}
 
+	String source;
+	Variant script = n->get_script();
+	if (!script.is_null()) {
+		Resource *obj = Object::cast_to<Resource>(script);
+		source = obj->get_path();
+	}
+
 	List<String> info_strings;
 	info_strings.push_back(path);
 	info_strings.push_back(n->get_class());
+	info_strings.push_back(source);
 
 	_print_orphan_nodes_map[p_obj->get_instance_id()] = info_strings;
 }
@@ -3499,12 +3507,30 @@ void Node::print_orphan_nodes() {
 	ObjectDB::debug_objects(_print_orphan_nodes_routine);
 
 	for (const KeyValue<ObjectID, List<String>> &E : _print_orphan_nodes_map) {
-		print_line(itos(E.key) + " - Stray Node: " + E.value.get(0) + " (Type: " + E.value.get(1) + ")");
+		print_line(itos(E.key) + " - Stray Node: " + E.value.get(0) + " (Type: " + E.value.get(1) + ") (Source:" + E.value.get(2) + ")");
 	}
 
 	// Flush it after use.
 	_print_orphan_nodes_map.clear();
 #endif
+}
+TypedArray<int> Node::get_orphan_node_ids() {
+	TypedArray<int> ret;
+#ifdef DEBUG_ENABLED
+	// Make sure it's empty.
+	_print_orphan_nodes_map.clear();
+
+	// Collect and return information about orphan nodes.
+	ObjectDB::debug_objects(_print_orphan_nodes_routine);
+
+	for (const KeyValue<ObjectID, List<String>> &E : _print_orphan_nodes_map) {
+		ret.push_back(E.key);
+	}
+
+	// Flush it after use.
+	_print_orphan_nodes_map.clear();
+#endif
+	return ret;
 }
 
 void Node::queue_free() {
@@ -3815,6 +3841,7 @@ void Node::_bind_methods() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/node_name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case,kebab-case"), NAME_CASING_PASCAL_CASE);
 
 	ClassDB::bind_static_method("Node", D_METHOD("print_orphan_nodes"), &Node::print_orphan_nodes);
+	ClassDB::bind_static_method("Node", D_METHOD("get_orphan_node_ids"), &Node::get_orphan_node_ids);
 	ClassDB::bind_method(D_METHOD("add_sibling", "sibling", "force_readable_name"), &Node::add_sibling, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -742,6 +742,7 @@ public:
 	ProcessThreadGroup get_process_thread_group() const;
 
 	static void print_orphan_nodes();
+	static TypedArray<int> get_orphan_node_ids();
 
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);


### PR DESCRIPTION
### Change Description

`print_orphan_nodes` now prints the script file attached to the node, if any. `list_orphan_nodes` was created to return the same data as `print_orphan_nodes` in a dictionary format for users who wish to process this data via code instead of in the Output window.

### Justification

After discovering the Orphan Nodes Monitor I identified that I had some leaky orphans being left behind after switching between menus. Going from Scene A to Scene B and back to A again should've left me with the same number of Orphan Nodes, but the number kept slowly going up. I found the `print_orphan_nodes` method, but its output mostly looked like this:

```
175808450055 - Stray Node:  (Type: Node)
175909113357 - Stray Node:  (Type: Node)
176009776659 - Stray Node:  (Type: Node)
176110439961 - Stray Node:  (Type: Node)
178828349111 - Stray Node:  (Type: Node)
```

Some had more info, like `154149062747 - Stray Node: SelectionCursor (Type: Node3D)`, but the majority just had no name and a type of `Node`. After updating the `print_orphan_nodes` method, those same nodes looked like this:

```
176026553876 - Stray Node:  (Type: Node) (Source:res://Combat/Data/ActiveWeapon.gd)
176127217178 - Stray Node:  (Type: Node) (Source:res://Combat/Data/ActiveWeapon.gd)
178845126328 - Stray Node:  (Type: Node) (Source:res://Combat/Menu/Player/Actions/CombatActionItem.gd)
179365220055 - Stray Node:  (Type: Node) (Source:res://Combat/Menu/Player/Actions/CombatActionAttack.gd)
179885313782 - Stray Node:  (Type: Node) (Source:res://Combat/Menu/Player/Actions/CombatActionHeal.gd)
```

By seeing which scripts were tied to the `Node`s, I was easily able to identify where they were instantiated and handle their clenup properly.

Then I created `list_orphan_nodes` so that I could filter out orphan nodes I expected to be there to avoid cluttering the Output window, and to only print the new Source values, as the names, types, and instance IDs weren't needed, like so:

```
const SAFE_NODES := ["beehave/blackboard.gd", "/cursor.gd"]
func print_important_orphaned_nodes() -> void:
	var orphans := list_orphan_nodes()
	for o in orphans:
		var script: String = o["script"]
		var skip := false
		for s: String in SAFE_NODES:
			if script.ends_with(s):
				skip = true
				break
		if skip:
			continue
		print(o["script"])
```