### PR TITLE
Fix disabled color not being customizable for LinkButton

### DIFF
--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -62,7 +62,7 @@
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
-		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.5)">
 			Text [Color] used when the [LinkButton] is disabled.
 		</theme_item>
 		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -217,6 +217,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_pressed_color", "LinkButton", control_font_pressed_color);
 	theme->set_color("font_hover_color", "LinkButton", control_font_hover_color);
 	theme->set_color("font_focus_color", "LinkButton", control_font_focus_color);
+	theme->set_color("font_disabled_color", "LinkButton", control_font_disabled_color);
 	theme->set_color("font_outline_color", "LinkButton", Color(1, 1, 1));
 
 	theme->set_constant("outline_size", "LinkButton", 0);


### PR DESCRIPTION
Fixes #83748
The property for changing the `LinkButton`'s disabled color was there, but it was not being shown in the editor. It should be visible now.