### PR TITLE
Make "Show Node in Tree" button more user friendly

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2765,7 +2765,16 @@ void EditorPropertyNodePath::_menu_option(int p_idx) {
 			Node *target_node = edited_node->get_node_or_null(np);
 			ERR_FAIL_NULL(target_node);
 
+			SceneTreeDock *scene_tree_dock = SceneTreeDock::get_singleton();
+			if (scene_tree_dock->get_window() == get_tree()->get_root()) {
+				TabContainer *tab_container = (TabContainer *)scene_tree_dock->get_parent_control();
+				tab_container->set_current_tab(tab_container->get_tab_idx_from_control(scene_tree_dock));
+			} else {
+				scene_tree_dock->get_window()->grab_focus();
+			}
+
 			SceneTreeDock::get_singleton()->set_selected(target_node);
+			SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
 		} break;
 	}
 }
@@ -2798,6 +2807,18 @@ const NodePath EditorPropertyNodePath::_get_node_path() const {
 		}
 	} else {
 		return val;
+	}
+}
+
+void EditorPropertyNodePath::_button_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+		menu->show_popup();
+
+		Vector2 pos = menu->get_popup()->get_position();
+		pos.x += mb->get_position().x - assign->get_size().x;
+		menu->get_popup()->set_position(pos);
 	}
 }
 
@@ -2939,6 +2960,7 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	assign->set_expand_icon(true);
 	assign->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyNodePath::_node_assign));
+	assign->connect("gui_input", callable_mp(this, &EditorPropertyNodePath::_button_input));
 	SET_DRAG_FORWARDING_CD(assign, EditorPropertyNodePath);
 	hbc->add_child(assign);
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -638,6 +638,7 @@ class EditorPropertyNodePath : public EditorProperty {
 	void _accept_text();
 	void _text_submitted(const String &p_text);
 	const NodePath _get_node_path() const;
+	void _button_input(const Ref<InputEvent> &p_event);
 
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);


### PR DESCRIPTION
This PR is just building on the great PR #75274. The goal was to improve useability, mostly for the "Show Node in Tree" button.

The changes fix the following issues:

- Dragging and reparenting can now be done more seamlessly.
    - This was harder before due to multiselecting the referenced node with the edited node
- The scene tree dock is now focused if it was not focused when the button is pressed, consistent with pressing the “Show in Filesystem” button on exported resources.
- Pressing the button on multiple properties no longer creates a big glob of selected nodes in the SceneTreeDock.
- Right clicking the assign button now pulls up the little menu, consistent with exported resources.

Here is how it looks in action:

no big glob of multiselect

https://github.com/godotengine/godot/assets/92269209/76618fb1-bc18-4156-bbea-b634f6b4ba27

right clicking works

https://github.com/godotengine/godot/assets/92269209/374e3287-6eea-407a-b81a-e5d7daac4abe

dragging works instantly because of not using multiselect

https://github.com/godotengine/godot/assets/92269209/442066bf-e022-48fb-b5c4-93c681dd4771

tab switches if you don't already have SceneTreeDock open

https://github.com/godotengine/godot/assets/92269209/00366491-022e-4bf1-b38a-c2b2352a7c90

This change does affect the way the node looks when shown in tree (it's a lot more subtle now), but I thought it was worth it for making dragging easier and not making multiselect globs.