### PR TITLE
Fix infinite loop when importing 3D object named "-colonly"

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -669,7 +669,11 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			fixed_name = _fixstr(name, "convcolonly");
 		}
 
-		ERR_FAIL_COND_V(fixed_name.is_empty(), nullptr);
+		if (fixed_name.is_empty()) {
+			p_node->set_owner(nullptr);
+			memdelete(p_node);
+			ERR_FAIL_V_MSG(nullptr, vformat("Skipped node `%s` because its name is empty after removing the suffix.", name));
+		}
 
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 		if (mi) {


### PR DESCRIPTION
Fixes #83763

The `set_owner()` seems unnecessary to me. But it's called in other branches where `p_node` needs to be deleted and return null.