### PR TITLE
Add vertical scrolling to bézier track editor.

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -42,7 +42,7 @@
 
 float AnimationBezierTrackEdit::_bezier_h_to_pixel(float p_h) {
 	float h = p_h;
-	h = (h - v_scroll) / v_zoom;
+	h = (h - timeline_v_scroll) / timeline_v_zoom;
 	h = (get_size().height / 2.0) - h;
 	return h;
 }
@@ -251,7 +251,9 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 			int right_limit = get_size().width;
 
-			int vofs = vsep;
+			track_v_scroll_max = vsep;
+
+			int vofs = vsep + track_v_scroll;
 			int margin = 0;
 
 			RBMap<int, Color> subtrack_colors;
@@ -328,6 +330,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 						text_buf.draw(get_canvas_item(), string_pos, color);
 
 						vofs += h + vsep;
+						track_v_scroll_max += h + vsep;
 					}
 				}
 
@@ -439,6 +442,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 					subtrack_icons[current_track] = track_icons;
 
 					vofs += text_buf.get_size().y + vsep;
+					track_v_scroll_max += text_buf.get_size().y + vsep;
 				}
 			}
 
@@ -447,11 +451,11 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			{ //guides
 				float min_left_scale = font->get_height(font_size) + vsep;
 
-				float scale = (min_left_scale * 2) * v_zoom;
+				float scale = (min_left_scale * 2) * timeline_v_zoom;
 				float step = Math::pow(10.0, Math::round(Math::log(scale / 5.0) / Math::log(10.0))) * 5.0;
 				scale = Math::snapped(scale, step);
 
-				while (scale / v_zoom < min_left_scale * 2) {
+				while (scale / timeline_v_zoom < min_left_scale * 2) {
 					scale += step;
 				}
 
@@ -459,8 +463,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 				int prev_iv = 0;
 				for (int i = font->get_height(font_size); i < get_size().height; i++) {
 					float ofs = get_size().height / 2.0 - i;
-					ofs *= v_zoom;
-					ofs += v_scroll;
+					ofs *= timeline_v_zoom;
+					ofs += timeline_v_scroll;
 
 					int iv = int(ofs / scale);
 					if (ofs < 0) {
@@ -908,9 +912,9 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (Math::is_finite(minimum_value) && Math::is_finite(maximum_value)) {
-				v_scroll = (maximum_value + minimum_value) / 2.0;
+				timeline_v_scroll = (maximum_value + minimum_value) / 2.0;
 				if (maximum_value - minimum_value > CMP_EPSILON) {
-					v_zoom = (maximum_value - minimum_value) / ((get_size().height - timeline->get_size().height) * 0.9);
+					timeline_v_zoom = (maximum_value - minimum_value) / ((get_size().height - timeline->get_size().height) * 0.9);
 				}
 			}
 
@@ -1160,7 +1164,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			Array new_point;
 			new_point.resize(5);
 
-			float h = (get_size().height / 2.0 - mb->get_position().y) * v_zoom + v_scroll;
+			float h = (get_size().height / 2.0 - mb->get_position().y) * timeline_v_zoom + timeline_v_scroll;
 
 			new_point[0] = h;
 			new_point[1] = -0.25;
@@ -1393,7 +1397,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			select_single_attempt = IntPair(-1, -1);
 		}
 
-		float y = (get_size().height / 2.0 - mm->get_position().y) * v_zoom + v_scroll;
+		float y = (get_size().height / 2.0 - mm->get_position().y) * timeline_v_zoom + timeline_v_scroll;
 		float x = editor->snap_time(((mm->get_position().x - limit) / timeline->get_zoom_scale()) + timeline->get_value());
 
 		if (!read_only) {
@@ -1422,7 +1426,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if ((moving_handle == 1 || moving_handle == -1) && mm.is_valid()) {
-		float y = (get_size().height / 2.0 - mm->get_position().y) * v_zoom + v_scroll;
+		float y = (get_size().height / 2.0 - mm->get_position().y) * timeline_v_zoom + timeline_v_scroll;
 		float x = editor->snap_time((mm->get_position().x - timeline->get_name_limit()) / timeline->get_zoom_scale()) + timeline->get_value();
 
 		Vector2 key_pos = Vector2(animation->track_get_key_time(selected_track, moving_handle_key), animation->bezier_track_get_key_value(selected_track, moving_handle_key));
@@ -1438,7 +1442,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			Animation::HandleMode handle_mode = animation->bezier_track_get_key_handle_mode(moving_handle_track, moving_handle_key);
 
 			if (handle_mode == Animation::HANDLE_MODE_BALANCED) {
-				real_t ratio = timeline->get_zoom_scale() * v_zoom;
+				real_t ratio = timeline->get_zoom_scale() * timeline_v_zoom;
 				Transform2D xform;
 				xform.set_scale(Vector2(1.0, 1.0 / ratio));
 
@@ -1455,7 +1459,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			Animation::HandleMode handle_mode = animation->bezier_track_get_key_handle_mode(moving_handle_track, moving_handle_key);
 
 			if (handle_mode == Animation::HANDLE_MODE_BALANCED) {
-				real_t ratio = timeline->get_zoom_scale() * v_zoom;
+				real_t ratio = timeline->get_zoom_scale() * timeline_v_zoom;
 				Transform2D xform;
 				xform.set_scale(Vector2(1.0, 1.0 / ratio));
 
@@ -1475,11 +1479,11 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Move Bezier Points"));
 			if (moving_handle == -1) {
-				real_t ratio = timeline->get_zoom_scale() * v_zoom;
+				real_t ratio = timeline->get_zoom_scale() * timeline_v_zoom;
 				undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_in_handle", moving_handle_track, moving_handle_key, moving_handle_left, ratio);
 				undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_in_handle", moving_handle_track, moving_handle_key, animation->bezier_track_get_key_in_handle(moving_handle_track, moving_handle_key), ratio);
 			} else if (moving_handle == 1) {
-				real_t ratio = timeline->get_zoom_scale() * v_zoom;
+				real_t ratio = timeline->get_zoom_scale() * timeline_v_zoom;
 				undo_redo->add_do_method(animation.ptr(), "bezier_track_set_key_out_handle", moving_handle_track, moving_handle_key, moving_handle_right, ratio);
 				undo_redo->add_undo_method(animation.ptr(), "bezier_track_set_key_out_handle", moving_handle_track, moving_handle_key, animation->bezier_track_get_key_out_handle(moving_handle_track, moving_handle_key), ratio);
 			}
@@ -1491,22 +1495,34 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void AnimationBezierTrackEdit::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
-	v_scroll += p_scroll_vec.y * v_zoom;
-	v_scroll = CLAMP(v_scroll, -100000, 100000);
-	timeline->set_value(timeline->get_value() - p_scroll_vec.x / timeline->get_zoom_scale());
-	queue_redraw();
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		if (mm->get_position().x > timeline->get_name_limit()) {
+			timeline_v_scroll += p_scroll_vec.y * timeline_v_zoom;
+			timeline_v_scroll = CLAMP(timeline_v_scroll, -100000, 100000);
+			timeline->set_value(timeline->get_value() - p_scroll_vec.x / timeline->get_zoom_scale());
+		} else {
+			track_v_scroll += p_scroll_vec.y;
+			if (track_v_scroll < -track_v_scroll_max) {
+				track_v_scroll = -track_v_scroll_max;
+			} else if (track_v_scroll > 0) {
+				track_v_scroll = 0;
+			}
+		}
+		queue_redraw();
+	}
 }
 
 void AnimationBezierTrackEdit::_zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event) {
-	const float v_zoom_orig = v_zoom;
+	const float v_zoom_orig = timeline_v_zoom;
 	Ref<InputEventWithModifiers> iewm = p_event;
 	if (iewm.is_valid() && iewm->is_alt_pressed()) {
 		// Alternate zoom (doesn't affect timeline).
-		v_zoom = CLAMP(v_zoom * p_zoom_factor, 0.000001, 100000);
+		timeline_v_zoom = CLAMP(timeline_v_zoom * p_zoom_factor, 0.000001, 100000);
 	} else {
 		timeline->get_zoom()->set_value(timeline->get_zoom()->get_value() / p_zoom_factor);
 	}
-	v_scroll = v_scroll + (p_origin.y - get_size().y / 2.0) * (v_zoom - v_zoom_orig);
+	timeline_v_scroll = timeline_v_scroll + (p_origin.y - get_size().y / 2.0) * (timeline_v_zoom - v_zoom_orig);
 	queue_redraw();
 }
 
@@ -1517,7 +1533,7 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 				Array new_point;
 				new_point.resize(5);
 
-				float h = (get_size().height / 2.0 - menu_insert_key.y) * v_zoom + v_scroll;
+				float h = (get_size().height / 2.0 - menu_insert_key.y) * timeline_v_zoom + timeline_v_scroll;
 
 				new_point[0] = h;
 				new_point[1] = -0.25;

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -81,8 +81,11 @@ class AnimationBezierTrackEdit : public Control {
 	int solo_track = -1;
 	bool is_filtered = false;
 
-	float v_scroll = 0;
-	float v_zoom = 1;
+	float track_v_scroll = 0;
+	float track_v_scroll_max = 0;
+
+	float timeline_v_scroll = 0;
+	float timeline_v_zoom = 1;
 
 	PopupMenu *menu = nullptr;
 


### PR DESCRIPTION
While the bézier editor likely needs a much broader UX pass, this at least adds means to scroll the track list, the absence of which makes the bézier editor basically unusable with large numbers of tracks.

![godot windows editor dev x86_64_xpMQOQe8x8](https://github.com/godotengine/godot/assets/12756047/9d6f9d80-4374-452b-8b66-d686d7016dbf)

Closes https://github.com/godotengine/godot/issues/74577