### PR TITLE
[Audio] Fix pausing stream on entering tree

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -43,7 +43,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
-			set_stream_paused(false);
+			set_stream_paused(!can_process());
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -245,7 +245,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
-			set_stream_paused(false);
+			set_stream_paused(!can_process());
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -40,7 +40,7 @@ void AudioStreamPlayer::_notification(int p_what) {
 			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
-			set_stream_paused(false);
+			set_stream_paused(!can_process());
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {


### PR DESCRIPTION
The paused notifications are only sent when pause status is changed, this ensures that streams that are non-processing do not play when added to the tree. Also ensures that the `process_mode` property applies generally.

* Fixes: https://github.com/godotengine/godot/issues/83775

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
