### PR TITLE
Prevent `_allocate_placeholders` crash if `p_version->variants` is null

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -480,6 +480,7 @@ void ShaderRD::_save_to_cache(Version *p_version, int p_group) {
 }
 
 void ShaderRD::_allocate_placeholders(Version *p_version, int p_group) {
+	ERR_FAIL_NULL(p_version->variants);
 	for (uint32_t i = 0; i < group_to_variant_map[p_group].size(); i++) {
 		int variant_id = group_to_variant_map[p_group][i];
 		RID shader = RD::get_singleton()->shader_create_placeholder();


### PR DESCRIPTION
Fixes the cause of crash of #83742. cc @clayjohn 

However the situation which triggerred that crash is the wrong use of varying, which I suppose it can be prevented by better varying checking or at least better documentation? Not sure whether I should put that in this pr too (Ater I figured out how to fix it tmr).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
