### PR TITLE
Ensure AnimationPlayer evaluate animations when autoplay is enabled and node becomes ready

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -151,6 +151,7 @@ void AnimationPlayer::_notification(int p_what) {
 			if (!Engine::get_singleton()->is_editor_hint() && animation_set.has(autoplay)) {
 				set_active(true);
 				play(autoplay);
+				seek(0, true);
 			}
 		} break;
 	}


### PR DESCRIPTION
Fixes #83326.

The issue was introduced in the refactoring done in 1b95827d3ef244de322b0c16deb49fefe48ed1a1.
