### PR TITLE
Fix heap-use-after-free when resource loaded with `load_threaded_request` is never fetched

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1053,8 +1053,9 @@ void ResourceLoader::clear_thread_load_tasks() {
 		thread_load_mutex.lock();
 	}
 
-	for (KeyValue<String, LoadToken *> &E : user_load_tokens) {
-		memdelete(E.value);
+	while (user_load_tokens.begin()) {
+		// User load tokens remove themselves from the map on destruction.
+		memdelete(user_load_tokens.begin()->value);
 	}
 	user_load_tokens.clear();
 


### PR DESCRIPTION
Fixes #83778

`LoadToken`'s destructor erases itself from `user_load_tokens`, invalidating the iterator.