### PR TITLE
Fix hole in heightmap navigation mesh baking

### DIFF
--- a/modules/navigation/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/nav_mesh_generator_3d.cpp
@@ -384,33 +384,23 @@ void NavMeshGenerator3D::generator_parse_staticbody3d_node(const Ref<NavigationM
 							const Vector<real_t> &map_data = heightmap_shape->get_map_data();
 
 							Vector2 heightmap_gridsize(heightmap_width - 1, heightmap_depth - 1);
-							Vector2 start = heightmap_gridsize * -0.5;
+							Vector3 start = Vector3(heightmap_gridsize.x, 0, heightmap_gridsize.y) * -0.5;
 
 							Vector<Vector3> vertex_array;
 							vertex_array.resize((heightmap_depth - 1) * (heightmap_width - 1) * 6);
-							int map_data_current_index = 0;
+							Vector3 *vertex_array_ptrw = vertex_array.ptrw();
+							const real_t *map_data_ptr = map_data.ptr();
+							int vertex_index = 0;
 
-							for (int d = 0; d < heightmap_depth; d++) {
-								for (int w = 0; w < heightmap_width; w++) {
-									if (map_data_current_index + 1 + heightmap_depth < map_data.size()) {
-										float top_left_height = map_data[map_data_current_index];
-										float top_right_height = map_data[map_data_current_index + 1];
-										float bottom_left_height = map_data[map_data_current_index + heightmap_depth];
-										float bottom_right_height = map_data[map_data_current_index + 1 + heightmap_depth];
-
-										Vector3 top_left = Vector3(start.x + w, top_left_height, start.y + d);
-										Vector3 top_right = Vector3(start.x + w + 1.0, top_right_height, start.y + d);
-										Vector3 bottom_left = Vector3(start.x + w, bottom_left_height, start.y + d + 1.0);
-										Vector3 bottom_right = Vector3(start.x + w + 1.0, bottom_right_height, start.y + d + 1.0);
-
-										vertex_array.push_back(top_right);
-										vertex_array.push_back(bottom_left);
-										vertex_array.push_back(top_left);
-										vertex_array.push_back(top_right);
-										vertex_array.push_back(bottom_right);
-										vertex_array.push_back(bottom_left);
-									}
-									map_data_current_index += 1;
+							for (int d = 0; d < heightmap_depth - 1; d++) {
+								for (int w = 0; w < heightmap_width - 1; w++) {
+									vertex_array_ptrw[vertex_index] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + w], d);
+									vertex_array_ptrw[vertex_index + 1] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
+									vertex_array_ptrw[vertex_index + 2] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
+									vertex_array_ptrw[vertex_index + 3] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
+									vertex_array_ptrw[vertex_index + 4] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + heightmap_width + w + 1], d + 1);
+									vertex_array_ptrw[vertex_index + 5] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
+									vertex_index += 6;
 								}
 							}
 							if (vertex_array.size() > 0) {
@@ -540,33 +530,23 @@ void NavMeshGenerator3D::generator_parse_gridmap_node(const Ref<NavigationMesh> 
 							const Vector<real_t> &map_data = dict["heights"];
 
 							Vector2 heightmap_gridsize(heightmap_width - 1, heightmap_depth - 1);
-							Vector2 start = heightmap_gridsize * -0.5;
+							Vector3 start = Vector3(heightmap_gridsize.x, 0, heightmap_gridsize.y) * -0.5;
 
 							Vector<Vector3> vertex_array;
 							vertex_array.resize((heightmap_depth - 1) * (heightmap_width - 1) * 6);
-							int map_data_current_index = 0;
+							Vector3 *vertex_array_ptrw = vertex_array.ptrw();
+							const real_t *map_data_ptr = map_data.ptr();
+							int vertex_index = 0;
 
-							for (int d = 0; d < heightmap_depth; d++) {
-								for (int w = 0; w < heightmap_width; w++) {
-									if (map_data_current_index + 1 + heightmap_depth < map_data.size()) {
-										float top_left_height = map_data[map_data_current_index];
-										float top_right_height = map_data[map_data_current_index + 1];
-										float bottom_left_height = map_data[map_data_current_index + heightmap_depth];
-										float bottom_right_height = map_data[map_data_current_index + 1 + heightmap_depth];
-
-										Vector3 top_left = Vector3(start.x + w, top_left_height, start.y + d);
-										Vector3 top_right = Vector3(start.x + w + 1.0, top_right_height, start.y + d);
-										Vector3 bottom_left = Vector3(start.x + w, bottom_left_height, start.y + d + 1.0);
-										Vector3 bottom_right = Vector3(start.x + w + 1.0, bottom_right_height, start.y + d + 1.0);
-
-										vertex_array.push_back(top_right);
-										vertex_array.push_back(bottom_left);
-										vertex_array.push_back(top_left);
-										vertex_array.push_back(top_right);
-										vertex_array.push_back(bottom_right);
-										vertex_array.push_back(bottom_left);
-									}
-									map_data_current_index += 1;
+							for (int d = 0; d < heightmap_depth - 1; d++) {
+								for (int w = 0; w < heightmap_width - 1; w++) {
+									vertex_array_ptrw[vertex_index] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + w], d);
+									vertex_array_ptrw[vertex_index + 1] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
+									vertex_array_ptrw[vertex_index + 2] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
+									vertex_array_ptrw[vertex_index + 3] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
+									vertex_array_ptrw[vertex_index + 4] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + heightmap_width + w + 1], d + 1);
+									vertex_array_ptrw[vertex_index + 5] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
+									vertex_index += 6;
 								}
 							}
 							if (vertex_array.size() > 0) {


### PR DESCRIPTION
Fixes hole in heightmap navigation mesh baking.

Fixes https://github.com/godotengine/godot/issues/80509.

Apparently the pr https://github.com/godotengine/godot/pull/76212 that was made to fix https://github.com/godotengine/godot/issues/76195 was wrong. I now tried with both MRPs with this pr and it fixes both for me. No "inexplicable holes" show up and the heightmap-from-texture also bakes its half-sphere correctly but more testers are welcome to finally close this heightmap bug-juggle-chapter.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
