### PR TITLE
Add dotted grid to GraphEdit

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -237,6 +237,9 @@
 			The thickness of the lines between the nodes.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="grid_pattern" type="int" setter="set_grid_pattern" getter="get_grid_pattern" enum="GraphEdit.GridPattern" default="0">
+			The pattern used for drawing the grid.
+		</member>
 		<member name="minimap_enabled" type="bool" setter="set_minimap_enabled" getter="is_minimap_enabled" default="true">
 			If [code]true[/code], the minimap is visible.
 		</member>
@@ -405,16 +408,22 @@
 		<constant name="SCROLL_PANS" value="1" enum="PanningScheme">
 			[kbd]Mouse Wheel[/kbd] will move the view, [kbd]Ctrl + Mouse Wheel[/kbd] will zoom.
 		</constant>
+		<constant name="GRID_PATTERN_LINES" value="0" enum="GridPattern">
+			Draw the grid using solid lines.
+		</constant>
+		<constant name="GRID_PATTERN_DOTS" value="1" enum="GridPattern">
+			Draw the grid using dots.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Color of the connection's activity (see [method set_connection_activity]).
 		</theme_item>
 		<theme_item name="grid_major" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">
-			Color of major grid lines.
+			Color of major grid lines/dots.
 		</theme_item>
 		<theme_item name="grid_minor" data_type="color" type="Color" default="Color(1, 1, 1, 0.05)">
-			Color of minor grid lines.
+			Color of minor grid lines/dots.
 		</theme_item>
 		<theme_item name="selection_fill" data_type="color" type="Color" default="Color(1, 1, 1, 0.3)">
 			The fill color of the selection rectangle.

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -126,6 +126,11 @@ public:
 		SCROLL_PANS,
 	};
 
+	enum GridPattern {
+		GRID_PATTERN_LINES,
+		GRID_PATTERN_DOTS
+	};
+
 private:
 	struct ConnectionType {
 		union {
@@ -176,6 +181,7 @@ private:
 	bool snapping_enabled = true;
 	int snapping_distance = 20;
 	bool show_grid = true;
+	GridPattern grid_pattern = GRID_PATTERN_LINES;
 
 	bool connecting = false;
 	String connecting_from;
@@ -288,6 +294,8 @@ private:
 	void _top_layer_draw();
 	void _connections_layer_draw();
 	void _minimap_draw();
+
+	void _draw_grid();
 
 	TypedArray<Dictionary> _get_connection_list() const;
 
@@ -412,6 +420,9 @@ public:
 	void set_show_grid(bool p_enable);
 	bool is_showing_grid() const;
 
+	void set_grid_pattern(GridPattern p_pattern);
+	GridPattern get_grid_pattern() const;
+
 	void set_connection_lines_curvature(float p_curvature);
 	float get_connection_lines_curvature() const;
 
@@ -431,5 +442,6 @@ public:
 };
 
 VARIANT_ENUM_CAST(GraphEdit::PanningScheme);
+VARIANT_ENUM_CAST(GraphEdit::GridPattern);
 
 #endif // GRAPH_EDIT_H


### PR DESCRIPTION
Introduces a `grid_pattern` property for `GraphEdit`.
The new dotted pattern adapts to the zoom level (fading) and should be a bit more pleasant to the eye.

This PR only contains the additon to `GraphEdit`, but to demonstrate how it could look I tested it on the VisualShader editor:
![GE_dots_zoom](https://github.com/godotengine/godot/assets/50084500/79804cbf-d145-4726-96c6-bd39991f0b20)
