### PR TITLE
Fix ColorPicker committing extra action to history

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2712,16 +2712,6 @@ void EditorPropertyColor::_color_changed(const Color &p_color) {
 	emit_changed(get_edited_property(), p_color, "", true);
 }
 
-void EditorPropertyColor::_popup_closed() {
-	if (picker->get_pick_color() != last_color) {
-		emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
-	}
-}
-
-void EditorPropertyColor::_picker_opening() {
-	last_color = picker->get_pick_color();
-}
-
 void EditorPropertyColor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
@@ -2761,9 +2751,7 @@ EditorPropertyColor::EditorPropertyColor() {
 	add_child(picker);
 	picker->set_flat(true);
 	picker->connect("color_changed", callable_mp(this, &EditorPropertyColor::_color_changed));
-	picker->connect("popup_closed", callable_mp(this, &EditorPropertyColor::_popup_closed));
 	picker->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(picker->get_picker()));
-	picker->get_popup()->connect("about_to_popup", callable_mp(this, &EditorPropertyColor::_picker_opening));
 }
 
 ////////////// NODE PATH //////////////////////

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -632,11 +632,6 @@ class EditorPropertyColor : public EditorProperty {
 	GDCLASS(EditorPropertyColor, EditorProperty);
 	ColorPickerButton *picker = nullptr;
 	void _color_changed(const Color &p_color);
-	void _popup_closed();
-	void _picker_created();
-	void _picker_opening();
-
-	Color last_color;
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -563,7 +563,7 @@ void ColorPicker::_html_submitted(const String &p_html) {
 		color.a = previous_color.a;
 	}
 
-	if (color == previous_color) {
+	if (color.to_abgr32() == previous_color.to_abgr32()) {
 		return;
 	}
 	if (!is_inside_tree()) {


### PR DESCRIPTION
Fixes #83642 Fixes #45186
ColorPicker committed value on both on `color_change` and `popup_closed` signals, so same value got submitted twice to undoredo.

Addionally, ColorPicker changed set value upon exit due to HTML value getting submitted. Since HTML color codes are 32-bit color, but Godot uses higher precision colors internally, this meant that color from HTML value differed from currently selected value, thus it was submitted resulting less precision on colors chosen via picker.
Fixed by checking if color is different with precision offered by 32-bit color.

EDIT: Combined #83787 into this pr since they are both needed to fix the problem.