### PR TITLE
Fix ColorPicker committing extra action to history

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2712,16 +2712,6 @@ void EditorPropertyColor::_color_changed(const Color &p_color) {
 	emit_changed(get_edited_property(), p_color, "", true);
 }
 
-void EditorPropertyColor::_popup_closed() {
-	if (picker->get_pick_color() != last_color) {
-		emit_changed(get_edited_property(), picker->get_pick_color(), "", false);
-	}
-}
-
-void EditorPropertyColor::_picker_opening() {
-	last_color = picker->get_pick_color();
-}
-
 void EditorPropertyColor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
@@ -2761,9 +2751,7 @@ EditorPropertyColor::EditorPropertyColor() {
 	add_child(picker);
 	picker->set_flat(true);
 	picker->connect("color_changed", callable_mp(this, &EditorPropertyColor::_color_changed));
-	picker->connect("popup_closed", callable_mp(this, &EditorPropertyColor::_popup_closed));
 	picker->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(picker->get_picker()));
-	picker->get_popup()->connect("about_to_popup", callable_mp(this, &EditorPropertyColor::_picker_opening));
 }
 
 ////////////// NODE PATH //////////////////////

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -632,11 +632,6 @@ class EditorPropertyColor : public EditorProperty {
 	GDCLASS(EditorPropertyColor, EditorProperty);
 	ColorPickerButton *picker = nullptr;
 	void _color_changed(const Color &p_color);
-	void _popup_closed();
-	void _picker_created();
-	void _picker_opening();
-
-	Color last_color;
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;


### PR DESCRIPTION
Fixes #83642
You had to Ctrl+Z twice to undo setting color in inspector.

Of note: I don't know where the changes get committed to history, but they obviously do without the help of this function. So tested empirically to be working, but something to keep in mind when reviewing this.
I also removed a method declaration (`EditorPropertyColor::_picker_created()`) without definition (unless there's some magic behind this function that I don't understand 👀).