### PR TITLE
Add initial dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,44 @@
+FROM mcr.microsoft.com/devcontainers/base:bullseye
+
+# Prepare apt
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive
+
+# Install the dev dependencies
+# Taken straight from https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_linuxbsd.html#doc-compiling-for-linuxbsd
+RUN apt-get install -y \
+  build-essential \
+  scons \
+  pkg-config \
+  libx11-dev \
+  libxcursor-dev \
+  libxinerama-dev \
+  libgl1-mesa-dev \
+  libglu-dev \
+  libasound2-dev \
+  libpulse-dev \
+  libudev-dev \
+  libxi-dev \
+  libxrandr-dev
+
+# Install dependencies for Windows build
+# Translated from https://github.com/godotengine/build-containers/blob/main/Dockerfile.windows (fedora) to debian via command-not-found.com
+RUN apt-get install -y \ 
+    # mingw32-gcc
+    gcc-mingw-w64-i686 \
+    # mingw32-gcc-c++
+    g++-mingw-w64-i686 \
+    # mingw32-winpthreads-static - Is this needed?
+    # mingw64-gcc
+    gcc-mingw-w64-x86-64 \
+    # mingw64-gcc-c++
+    g++-mingw-w64-x86-64
+    # mingw64-winpthreads-static - Is this needed?
+
+# Set to posix
+RUN \
+  # 64-bit
+  update-alternatives --set x86_64-w64-mingw32-gcc $(update-alternatives --list x86_64-w64-mingw32-gcc | grep posix) && \
+  update-alternatives --set x86_64-w64-mingw32-g++ $(update-alternatives --list x86_64-w64-mingw32-g++ | grep posix) && \
+  # 32-bit
+  update-alternatives --set i686-w64-mingw32-gcc $(update-alternatives --list i686-w64-mingw32-gcc | grep posix) && \
+  update-alternatives --set i686-w64-mingw32-g++ $(update-alternatives --list i686-w64-mingw32-g++ | grep posix)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "Godot Dev Container",
+	"build":{
+		"dockerfile": "Dockerfile"
+	},
+	
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"extensions.ignoreRecommendations": true
+			},
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"ms-vscode.cpptools"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This PR adds initial support for [dev-containers](https://containers.dev/).

With this, users that have a supported software (VSCode/IntelliJ backed with WSL2 or a remote Linux box with Docker, Github Codespaces) can startup a complete dev-environment for Godot in a container. For the others, these files make no difference at all.

This is an initial version where building for Linux and Windows already works.

Things to further improve if this is desired:
- Add coding guidelines so they are enforced
- Add support for other platforms?
- Maybe more plugins for VSCode that make sense
- Hardcode dependency versions (gcc and such) so that they can differ between branches/releases

Let me know if that is something more people desire, I know I do so that I can keep my Windows or Linux workbox free of dev-dependencies.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/12747.*