### PR TITLE
GDExtension: Use `ObjectID` when creating custom callable

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -159,9 +159,7 @@ public:
 		userdata = p_info->callable_userdata;
 		token = p_info->token;
 
-		if (p_info->object != nullptr) {
-			object = ((Object *)p_info->object)->get_instance_id();
-		}
+		object = p_info->object_id;
 
 		call_func = p_info->call_func;
 		is_valid_func = p_info->is_valid_func;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -392,7 +392,7 @@ typedef GDExtensionBool (*GDExtensionCallableCustomLessThan)(void *callable_user
 typedef void (*GDExtensionCallableCustomToString)(void *callable_userdata, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out);
 
 typedef struct {
-	/* Only `call_func` and `token` are strictly required, however, `object` should be passed if its not a static method.
+	/* Only `call_func` and `token` are strictly required, however, `object_id` should be passed if its not a static method.
 	 *
 	 * `token` should point to an address that uniquely identifies the GDExtension (for example, the
 	 * `GDExtensionClassLibraryPtr` passed to the entry symbol function.
@@ -409,7 +409,7 @@ typedef struct {
 	void *callable_userdata;
 	void *token;
 
-	GDExtensionObjectPtr object;
+	GDObjectInstanceID object_id;
 
 	GDExtensionCallableCustomCall call_func;
 	GDExtensionCallableCustomIsValid is_valid_func;


### PR DESCRIPTION
I have very mixed feelings about this change, but I thought I'd propose it and get some feedback.

As described [in this comment](https://github.com/godotengine/godot-cpp/pull/1280#issuecomment-1774212750), we could make the godot-cpp API mimick the Godot API a little better (without an extra unnecessary hash map lookup) if `GDExtensionCallableCustomInfo` took an `ObjectID` rather than an `Object *`.

However, I do think the current API taking an `Object *` makes the most sense when just looking at the `gdextension_interface.h` API in isolation. In order to pass in an `ObjectID` we need to make an extra call into the engine, whereas we're about to call into the engine anyway to pass in the `GDExtensionCallableCustomInfo`, so why not let the engine lookup the `ObjectID` on its side?

~~So, I'm just really not sure. Please let me know what you think!~~

**UPDATE:** I think I've come around to support the change in this PR. First of all, I think the most common case is just to not have an object on a custom callable. But in the case where there is an object, the GDExtension will probably want to hold on to the `ObjectID` (rather than `Object *`) anyway, in order to check it for validity. So, since it will probably have that data already, it's really not any extra work to provide it when creating the custom callable. Also, it doesn't seem like anyone opposes the change, and in the comments there has been feedback from maintainers of Rust, Lua and Python bindings.