### PR TITLE
Fix missing NavigationLink property updates in constructor

### DIFF
--- a/doc/classes/NavigationLink2D.xml
+++ b/doc/classes/NavigationLink2D.xml
@@ -29,6 +29,12 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this link on the [NavigationServer2D].
+			</description>
+		</method>
 		<method name="set_global_end_position">
 			<return type="void" />
 			<param index="0" name="position" type="Vector2" />

--- a/doc/classes/NavigationLink3D.xml
+++ b/doc/classes/NavigationLink3D.xml
@@ -29,6 +29,12 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this link on the [NavigationServer3D].
+			</description>
+		</method>
 		<method name="set_global_end_position">
 			<return type="void" />
 			<param index="0" name="position" type="Vector3" />

--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -36,6 +36,8 @@
 #include "servers/navigation_server_3d.h"
 
 void NavigationLink2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationLink2D::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationLink2D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationLink2D::is_enabled);
 
@@ -174,6 +176,10 @@ bool NavigationLink2D::_edit_is_selected_on_click(const Point2 &p_point, double 
 	return p_point.distance_to(closest_point) < p_tolerance;
 }
 #endif // TOOLS_ENABLED
+
+RID NavigationLink2D::get_rid() const {
+	return link;
+}
 
 void NavigationLink2D::set_enabled(bool p_enabled) {
 	if (enabled == p_enabled) {
@@ -343,7 +349,13 @@ PackedStringArray NavigationLink2D::get_configuration_warnings() const {
 
 NavigationLink2D::NavigationLink2D() {
 	link = NavigationServer2D::get_singleton()->link_create();
+
 	NavigationServer2D::get_singleton()->link_set_owner_id(link, get_instance_id());
+	NavigationServer2D::get_singleton()->link_set_enter_cost(link, enter_cost);
+	NavigationServer2D::get_singleton()->link_set_travel_cost(link, travel_cost);
+	NavigationServer2D::get_singleton()->link_set_navigation_layers(link, navigation_layers);
+	NavigationServer2D::get_singleton()->link_set_bidirectional(link, bidirectional);
+	NavigationServer2D::get_singleton()->link_set_enabled(link, enabled);
 
 	set_notify_transform(true);
 	set_hide_clip_children(true);

--- a/scene/2d/navigation_link_2d.h
+++ b/scene/2d/navigation_link_2d.h
@@ -61,6 +61,7 @@ public:
 	virtual Rect2 _edit_get_rect() const override;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 #endif
+	RID get_rid() const;
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const { return enabled; }

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -147,6 +147,8 @@ void NavigationLink3D::_update_debug_mesh() {
 #endif // DEBUG_ENABLED
 
 void NavigationLink3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationLink3D::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationLink3D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationLink3D::is_enabled);
 
@@ -263,7 +265,13 @@ void NavigationLink3D::_notification(int p_what) {
 
 NavigationLink3D::NavigationLink3D() {
 	link = NavigationServer3D::get_singleton()->link_create();
+
 	NavigationServer3D::get_singleton()->link_set_owner_id(link, get_instance_id());
+	NavigationServer3D::get_singleton()->link_set_enter_cost(link, enter_cost);
+	NavigationServer3D::get_singleton()->link_set_travel_cost(link, travel_cost);
+	NavigationServer3D::get_singleton()->link_set_navigation_layers(link, navigation_layers);
+	NavigationServer3D::get_singleton()->link_set_bidirectional(link, bidirectional);
+	NavigationServer3D::get_singleton()->link_set_enabled(link, enabled);
 
 	set_notify_transform(true);
 }
@@ -282,6 +290,10 @@ NavigationLink3D::~NavigationLink3D() {
 		RenderingServer::get_singleton()->free(debug_mesh->get_rid());
 	}
 #endif // DEBUG_ENABLED
+}
+
+RID NavigationLink3D::get_rid() const {
+	return link;
 }
 
 void NavigationLink3D::set_enabled(bool p_enabled) {

--- a/scene/3d/navigation_link_3d.h
+++ b/scene/3d/navigation_link_3d.h
@@ -67,6 +67,8 @@ public:
 	NavigationLink3D();
 	~NavigationLink3D();
 
+	RID get_rid() const;
+
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const { return enabled; }
 


### PR DESCRIPTION
Fixes missing NavigationLink property updates in constructor.

Fixes https://github.com/godotengine/godot/issues/83707 (again). Link version of https://github.com/godotengine/godot/pull/83814 and https://github.com/godotengine/godot/pull/83812.

Also adds missing `get_rid()` function that every navigation related node should have exposed.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
