### PR TITLE
C#: Free dialogs when exiting the editor

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -626,6 +626,12 @@ namespace GodotTools
             _editorSettings.SettingsChanged -= OnSettingsChanged;
         }
 
+        public override void _ExitTree()
+        {
+            _errorDialog?.QueueFree();
+            _confirmCreateSlnDialog?.QueueFree();
+        }
+
         private void OnSettingsChanged()
         {
             // We want to force NoConsoleLogging to true when the VerbosityLevel is at Detailed or above.


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/82683.
- Fixes https://github.com/godotengine/godot/issues/83717.

In the previously linked PR I unparented the dialogs to fix the `Transient parent has another exclusive child` error. This means the dialogs aren't freed when exiting the editor. This PR now frees those dialogs on `_exit_tree` which should prevent the leaks reported in the issue linked above.