### PR TITLE
Fix missing NavigationRegion property updates in constructor

### DIFF
--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -43,7 +43,14 @@
 				Returns the current navigation map [RID] used by this region.
 			</description>
 		</method>
-		<method name="get_region_rid" qualifiers="const">
+		<method name="get_region_rid" qualifiers="const" is_deprecated="true">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this region on the [NavigationServer2D].
+				[i]Deprecated.[/i] Use [method get_rid] instead.
+			</description>
+		</method>
+		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
 				Returns the [RID] of this region on the [NavigationServer2D]. Combined with [method NavigationServer2D.map_get_closest_point_owner] can be used to identify the [NavigationRegion2D] closest to a point on the merged navigation map.

--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -36,7 +36,14 @@
 				Returns the current navigation map [RID] used by this region.
 			</description>
 		</method>
-		<method name="get_region_rid" qualifiers="const">
+		<method name="get_region_rid" qualifiers="const" is_deprecated="true">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this region on the [NavigationServer3D].
+				[i]Deprecated.[/i] Use [method get_rid] instead.
+			</description>
+		</method>
+		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
 				Returns the [RID] of this region on the [NavigationServer3D]. Combined with [method NavigationServer3D.map_get_closest_point_owner] can be used to identify the [NavigationRegion3D] closest to a point on the merged navigation map.

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -35,6 +35,10 @@
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_server_2d.h"
 
+RID NavigationRegion2D::get_rid() const {
+	return region;
+}
+
 void NavigationRegion2D::set_enabled(bool p_enabled) {
 	if (enabled == p_enabled) {
 		return;
@@ -136,7 +140,7 @@ real_t NavigationRegion2D::get_travel_cost() const {
 }
 
 RID NavigationRegion2D::get_region_rid() const {
-	return region;
+	return get_rid();
 }
 
 #ifdef TOOLS_ENABLED
@@ -279,6 +283,8 @@ PackedStringArray NavigationRegion2D::get_configuration_warnings() const {
 }
 
 void NavigationRegion2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationRegion2D::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_navigation_polygon", "navigation_polygon"), &NavigationRegion2D::set_navigation_polygon);
 	ClassDB::bind_method(D_METHOD("get_navigation_polygon"), &NavigationRegion2D::get_navigation_polygon);
 
@@ -356,6 +362,9 @@ NavigationRegion2D::NavigationRegion2D() {
 	NavigationServer2D::get_singleton()->region_set_owner_id(region, get_instance_id());
 	NavigationServer2D::get_singleton()->region_set_enter_cost(region, get_enter_cost());
 	NavigationServer2D::get_singleton()->region_set_travel_cost(region, get_travel_cost());
+	NavigationServer2D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
+	NavigationServer2D::get_singleton()->region_set_use_edge_connections(region, use_edge_connections);
+	NavigationServer2D::get_singleton()->region_set_enabled(region, enabled);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer2D::get_singleton()->connect(SNAME("map_changed"), callable_mp(this, &NavigationRegion2D::_navigation_map_changed));

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -76,6 +76,7 @@ public:
 	virtual Rect2 _edit_get_rect() const override;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 #endif
+	RID get_rid() const;
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -33,6 +33,10 @@
 #include "scene/resources/navigation_mesh_source_geometry_data_3d.h"
 #include "servers/navigation_server_3d.h"
 
+RID NavigationRegion3D::get_rid() const {
+	return region;
+}
+
 void NavigationRegion3D::set_enabled(bool p_enabled) {
 	if (enabled == p_enabled) {
 		return;
@@ -154,7 +158,7 @@ real_t NavigationRegion3D::get_travel_cost() const {
 }
 
 RID NavigationRegion3D::get_region_rid() const {
-	return region;
+	return get_rid();
 }
 
 void NavigationRegion3D::_notification(int p_what) {
@@ -275,6 +279,8 @@ PackedStringArray NavigationRegion3D::get_configuration_warnings() const {
 }
 
 void NavigationRegion3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationRegion3D::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_navigation_mesh", "navigation_mesh"), &NavigationRegion3D::set_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_navigation_mesh"), &NavigationRegion3D::get_navigation_mesh);
 
@@ -410,6 +416,9 @@ NavigationRegion3D::NavigationRegion3D() {
 	NavigationServer3D::get_singleton()->region_set_owner_id(region, get_instance_id());
 	NavigationServer3D::get_singleton()->region_set_enter_cost(region, get_enter_cost());
 	NavigationServer3D::get_singleton()->region_set_travel_cost(region, get_travel_cost());
+	NavigationServer3D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
+	NavigationServer3D::get_singleton()->region_set_use_edge_connections(region, use_edge_connections);
+	NavigationServer3D::get_singleton()->region_set_enabled(region, enabled);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton()->connect(SNAME("map_changed"), callable_mp(this, &NavigationRegion3D::_navigation_map_changed));

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -73,6 +73,8 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
+	RID get_rid() const;
+
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 


### PR DESCRIPTION
Fixes missing NavigationRegion property updates in constructor.

Region version of https://github.com/godotengine/godot/pull/83802 and https://github.com/godotengine/godot/pull/83814.

Also added the missing `get_rid()` function that every navigation related node should have exposed and marked the old `get_region_rid()` function deprecated.

The NavigationRegion was the odd one that had a different name for this compared to every other navigation related node that uses get_rid().

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
