### PR TITLE
Fix missing NavigationAgent property updates in constructor

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -294,6 +294,13 @@ NavigationAgent2D::NavigationAgent2D() {
 	NavigationServer2D::get_singleton()->agent_set_time_horizon_obstacles(agent, time_horizon_obstacles);
 	NavigationServer2D::get_singleton()->agent_set_radius(agent, radius);
 	NavigationServer2D::get_singleton()->agent_set_max_speed(agent, max_speed);
+	NavigationServer2D::get_singleton()->agent_set_avoidance_layers(agent, avoidance_layers);
+	NavigationServer2D::get_singleton()->agent_set_avoidance_mask(agent, avoidance_mask);
+	NavigationServer2D::get_singleton()->agent_set_avoidance_priority(agent, avoidance_priority);
+	NavigationServer2D::get_singleton()->agent_set_avoidance_enabled(agent, avoidance_enabled);
+	if (avoidance_enabled) {
+		NavigationServer2D::get_singleton()->agent_set_avoidance_callback(agent, callable_mp(this, &NavigationAgent2D::_avoidance_done));
+	}
 
 	// Preallocate query and result objects to improve performance.
 	navigation_query = Ref<NavigationPathQueryParameters2D>();
@@ -301,11 +308,6 @@ NavigationAgent2D::NavigationAgent2D() {
 
 	navigation_result = Ref<NavigationPathQueryResult2D>();
 	navigation_result.instantiate();
-
-	set_avoidance_layers(avoidance_layers);
-	set_avoidance_mask(avoidance_mask);
-	set_avoidance_priority(avoidance_priority);
-	set_avoidance_enabled(avoidance_enabled);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer2D::get_singleton()->connect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationAgent2D::_navigation_debug_changed));

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -329,6 +329,14 @@ NavigationAgent3D::NavigationAgent3D() {
 	NavigationServer3D::get_singleton()->agent_set_radius(agent, radius);
 	NavigationServer3D::get_singleton()->agent_set_height(agent, height);
 	NavigationServer3D::get_singleton()->agent_set_max_speed(agent, max_speed);
+	NavigationServer3D::get_singleton()->agent_set_avoidance_layers(agent, avoidance_layers);
+	NavigationServer3D::get_singleton()->agent_set_avoidance_mask(agent, avoidance_mask);
+	NavigationServer3D::get_singleton()->agent_set_avoidance_priority(agent, avoidance_priority);
+	NavigationServer3D::get_singleton()->agent_set_use_3d_avoidance(agent, use_3d_avoidance);
+	NavigationServer3D::get_singleton()->agent_set_avoidance_enabled(agent, avoidance_enabled);
+	if (avoidance_enabled) {
+		NavigationServer3D::get_singleton()->agent_set_avoidance_callback(agent, callable_mp(this, &NavigationAgent3D::_avoidance_done));
+	}
 
 	// Preallocate query and result objects to improve performance.
 	navigation_query = Ref<NavigationPathQueryParameters3D>();
@@ -336,12 +344,6 @@ NavigationAgent3D::NavigationAgent3D() {
 
 	navigation_result = Ref<NavigationPathQueryResult3D>();
 	navigation_result.instantiate();
-
-	set_avoidance_layers(avoidance_layers);
-	set_avoidance_mask(avoidance_mask);
-	set_avoidance_priority(avoidance_priority);
-	set_use_3d_avoidance(use_3d_avoidance);
-	set_avoidance_enabled(avoidance_enabled);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton()->connect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationAgent3D::_navigation_debug_changed));


### PR DESCRIPTION
Fixes missing NavigationAgent property updates in constructor.

Agent version of https://github.com/godotengine/godot/pull/83802 and https://github.com/godotengine/godot/pull/83812

In this case it wasn't to bad because avoidance properties were set with their functions below and most of them had no setter guards that would prevent the update, or they had a duplicate update later when joining the SceneTree so that blocking went mostly unnoticed.

Still, better change it now to stay consistent and have no rude awakening should someone change the defaults or add guards without double checking ... wouldn't happen to be future me obviously of course why would it, that never happens :smile:.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
