### PR TITLE
Fix missing NavigationObstacle property updates in constructor

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -148,10 +148,10 @@ void NavigationObstacle2D::_notification(int p_what) {
 NavigationObstacle2D::NavigationObstacle2D() {
 	obstacle = NavigationServer2D::get_singleton()->obstacle_create();
 
-	set_radius(radius);
-	set_vertices(vertices);
-	set_avoidance_layers(avoidance_layers);
-	set_avoidance_enabled(avoidance_enabled);
+	NavigationServer2D::get_singleton()->obstacle_set_radius(obstacle, radius);
+	NavigationServer2D::get_singleton()->obstacle_set_vertices(obstacle, vertices);
+	NavigationServer2D::get_singleton()->obstacle_set_avoidance_layers(obstacle, avoidance_layers);
+	NavigationServer2D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
 }
 
 NavigationObstacle2D::~NavigationObstacle2D() {

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -167,13 +167,11 @@ NavigationObstacle3D::NavigationObstacle3D() {
 	obstacle = NavigationServer3D::get_singleton()->obstacle_create();
 
 	NavigationServer3D::get_singleton()->obstacle_set_height(obstacle, height);
-
-	set_radius(radius);
-	set_height(height);
-	set_vertices(vertices);
-	set_avoidance_layers(avoidance_layers);
-	set_avoidance_enabled(avoidance_enabled);
-	set_use_3d_avoidance(use_3d_avoidance);
+	NavigationServer3D::get_singleton()->obstacle_set_radius(obstacle, radius);
+	NavigationServer3D::get_singleton()->obstacle_set_vertices(obstacle, vertices);
+	NavigationServer3D::get_singleton()->obstacle_set_avoidance_layers(obstacle, avoidance_layers);
+	NavigationServer3D::get_singleton()->obstacle_set_use_3d_avoidance(obstacle, use_3d_avoidance);
+	NavigationServer3D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton()->connect("avoidance_debug_changed", callable_mp(this, &NavigationObstacle3D::_update_fake_agent_radius_debug));


### PR DESCRIPTION
Fixes missing NavigationObstacle property updates in constructor.

Same as with Agents from https://github.com/godotengine/godot/pull/83814.

The imminent bug with the height setter was already fixed with https://github.com/godotengine/godot/pull/83701 but the other properties have the same issue. They only do not show up as an issue right now because the server object starts with the same default values which was not the case for the height.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
