### PR TITLE
Revert to `proxy_to_pthread=no` as default

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -44,7 +44,7 @@ def get_opts():
         BoolVariable(
             "proxy_to_pthread",
             "Use Emscripten PROXY_TO_PTHREAD option to run the main application code to a separate thread",
-            True,
+            False,
         ),
     ]
 


### PR DESCRIPTION
Currently, `proxy_to_pthread=yes` option as default breaks WebXR support.

Relates to #83733.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
