### PR TITLE
C#: Generate strongly-typed method to call Rpc.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -232,6 +232,9 @@ namespace Godot.SourceGenerators
         public static bool IsGodotExportAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportAttr;
 
+        public static bool IsGodotRpcAttribute(this INamedTypeSymbol symbol)
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.RpcAttr;
+
         public static bool IsGodotSignalAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SignalAttr;
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -8,6 +8,7 @@ namespace Godot.SourceGenerators
         public const string ExportCategoryAttr = "Godot.ExportCategoryAttribute";
         public const string ExportGroupAttr = "Godot.ExportGroupAttribute";
         public const string ExportSubgroupAttr = "Godot.ExportSubgroupAttribute";
+        public const string RpcAttr = "Godot.RpcAttribute";
         public const string SignalAttr = "Godot.SignalAttribute";
         public const string MustBeVariantAttr = "Godot.MustBeVariantAttribute";
         public const string GodotClassNameAttr = "Godot.GodotClassNameAttribute";


### PR DESCRIPTION

``` C#
    [Rpc(MultiplayerApi.RpcMode.AnyPeer)]
    public void RegisterPlayer(string newPlayerName)
    {
    }

    //Generate
    /// <inheritdoc cref="RegisterPlayer"/>
    public void RegisterPlayerRpc(string newPlayerName)
    {
        Rpc(MethodName.RegisterPlayer, newPlayerName);
    }
    /// <inheritdoc cref="RegisterPlayer"/>
    public void RegisterPlayerRpc(long peerId, string newPlayerName)
    {
        RpcId(peerId, MethodName.RegisterPlayer, newPlayerName);
    }
```