### PR TITLE
Increase precision of RAW mode in ColorPicker

### DIFF
--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -43,6 +43,7 @@ public:
 
 	virtual int get_slider_count() const { return 3; };
 	virtual float get_slider_step() const = 0;
+	virtual float get_spinbox_arrow_step() const { return get_slider_step(); };
 	virtual String get_slider_label(int idx) const = 0;
 	virtual float get_slider_max(int idx) const = 0;
 	virtual float get_slider_value(int idx) const = 0;
@@ -109,7 +110,8 @@ public:
 
 	virtual String get_name() const override { return "RAW"; }
 
-	virtual float get_slider_step() const override { return 0.01; }
+	virtual float get_slider_step() const override { return 0.001; }
+	virtual float get_spinbox_arrow_step() const override { return 0.01; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
 	virtual float get_slider_value(int idx) const override;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -575,9 +575,11 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 
 	if (p_update_sliders) {
 		float step = modes[current_mode]->get_slider_step();
+		float spinbox_arrow_step = modes[current_mode]->get_spinbox_arrow_step();
 		for (int i = 0; i < current_slider_count; i++) {
 			sliders[i]->set_max(modes[current_mode]->get_slider_max(i));
 			sliders[i]->set_step(step);
+			values[i]->set_custom_arrow_step(spinbox_arrow_step);
 			sliders[i]->set_value(modes[current_mode]->get_slider_value(i));
 		}
 		alpha_slider->set_max(modes[current_mode]->get_slider_max(current_slider_count));


### PR DESCRIPTION
This sets the slider step to `0.001` but keeps SpinBox arrow increments at `0.01`.

Thanks @axu-ap for the suggested fix :slightly_smiling_face: 

- This closes https://github.com/godotengine/godot/issues/82514.

## Preview

https://github.com/godotengine/godot/assets/180032/e7d9c875-b929-4e0c-a6e3-493b19800ef5

