### PR TITLE
Fix Scene Importer crashing when animation or mesh save paths are invalid

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -31,6 +31,7 @@
 #include "resource_importer_scene.h"
 
 #include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
 #include "core/io/resource_saver.h"
 #include "core/object/script_language.h"
 #include "editor/editor_node.h"
@@ -2390,6 +2391,21 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	return scene;
 }
 
+Error ResourceImporterScene::_check_resource_save_paths(const Dictionary &p_data) {
+	Array keys = p_data.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		const Dictionary &settings = p_data[keys[i]];
+
+		if (bool(settings.get("save_to_file/enabled", false)) && settings.has("save_to_file/path")) {
+			const String &save_path = settings["save_to_file/path"];
+
+			ERR_FAIL_COND_V(!save_path.is_empty() && !DirAccess::exists(save_path.get_base_dir()), ERR_FILE_BAD_PATH);
+		}
+	}
+
+	return OK;
+}
+
 Error ResourceImporterScene::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	const String &src_path = p_source_file;
 
@@ -2442,7 +2458,42 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		import_flags |= EditorSceneFormatImporter::IMPORT_FORCE_DISABLE_MESH_COMPRESSION;
 	}
 
+	Dictionary subresources = p_options["_subresources"];
+
+	Dictionary node_data;
+	if (subresources.has("nodes")) {
+		node_data = subresources["nodes"];
+	}
+
+	Dictionary material_data;
+	if (subresources.has("materials")) {
+		material_data = subresources["materials"];
+	}
+
+	Dictionary animation_data;
+	if (subresources.has("animations")) {
+		animation_data = subresources["animations"];
+	}
+
+	Dictionary mesh_data;
+	if (subresources.has("meshes")) {
+		mesh_data = subresources["meshes"];
+	}
+
 	Error err = OK;
+
+	// Check whether any of the meshes or animations have nonexistent save paths
+	// and if they do, fail the import immediately.
+	err = _check_resource_save_paths(mesh_data);
+	if (err != OK) {
+		return err;
+	}
+
+	err = _check_resource_save_paths(animation_data);
+	if (err != OK) {
+		return err;
+	}
+
 	List<String> missing_deps; // for now, not much will be done with this
 	Node *scene = importer->import_scene(src_path, import_flags, p_options, &missing_deps, &err);
 	if (!scene || err != OK) {
@@ -2465,22 +2516,6 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		} else {
 			scene_3d->scale(scale);
 		}
-	}
-	Dictionary subresources = p_options["_subresources"];
-
-	Dictionary node_data;
-	if (subresources.has("nodes")) {
-		node_data = subresources["nodes"];
-	}
-
-	Dictionary material_data;
-	if (subresources.has("materials")) {
-		material_data = subresources["materials"];
-	}
-
-	Dictionary animation_data;
-	if (subresources.has("animations")) {
-		animation_data = subresources["animations"];
 	}
 
 	HashSet<Ref<ImporterMesh>> scanned_meshes;
@@ -2561,10 +2596,6 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		}
 	}
 
-	Dictionary mesh_data;
-	if (subresources.has("meshes")) {
-		mesh_data = subresources["meshes"];
-	}
 	scene = _generate_meshes(scene, mesh_data, gen_lods, create_shadow_meshes, LightBakeMode(light_bake_mode), lightmap_texel_size, src_lightmap_cache, mesh_lightmap_caches);
 
 	if (mesh_lightmap_caches.size()) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -214,6 +214,7 @@ class ResourceImporterScene : public ResourceImporter {
 		SHAPE_TYPE_CAPSULE,
 	};
 
+	static Error _check_resource_save_paths(const Dictionary &p_data);
 	Array _get_skinned_pose_transforms(ImporterMeshInstance3D *p_src_mesh_node);
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);


### PR DESCRIPTION
Fixes #79145.
Supersedes #80017.

Adds an additional check to the Advanced Scene Import settings to ensure the meshes and animations are to be saved in existing directories. Now, if any of the save paths are invalid, the whole file will fail to import with an error instead.