### PR TITLE
Improve display for lightmap probes in the editor

### DIFF
--- a/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
@@ -44,7 +44,10 @@ LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
 
 	Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
 	mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	mat->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
+	// Fade out probes when camera gets too close to them.
+	mat->set_distance_fade(StandardMaterial3D::DISTANCE_FADE_PIXEL_DITHER);
+	mat->set_distance_fade_min_distance(0.5);
+	mat->set_distance_fade_max_distance(1.5);
 	mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	mat->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, false);
 	mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);


### PR DESCRIPTION
- Use the default Back cull mode to improve performance slightly and prevent obstructing the camera.
- Fade probes when the camera gets close as to be less intrusive.

Unfortunately, I didn't manage to make direct light display on probes. Removing unshaded draw mode doesn't make them receive any light, likely because of the general light mask used by 3D editor gizmos.

- See https://github.com/godotengine/godot-proposals/issues/7938#issuecomment-1750812242.

**Testing project:** [test_lightmap_preview_bake_4.x.zip](https://github.com/godotengine/godot/files/13079358/test_lightmap_preview_bake_4.x.zip)

## Preview

https://github.com/godotengine/godot/assets/180032/64624aaf-2564-4086-8a59-308a1a050793

