### PR TITLE
[3.x] Add missing include header to FBXCommon.h

### DIFF
--- a/modules/fbx/fbx_parser/FBXCommon.h
+++ b/modules/fbx/fbx_parser/FBXCommon.h
@@ -76,6 +76,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef FBXCOMMON_H
 #define FBXCOMMON_H
 
+#include <cstdint>
 #include <string>
 
 namespace FBXDocParser {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/83865