### PR TITLE
Fix `noise_direction` variable used before initialized in particle shader when using turbulence with collisions

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -962,10 +962,6 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "			VELOCITY = mix(VELOCITY,vec3(0.0),clamp(collision_friction, 0.0, 1.0));\n";
 		code += "		} else {\n";
 		code += "			VELOCITY = vec3(0.0);\n";
-		// If turbulence is enabled, set the noise direction to up so the turbulence color is "neutral"
-		if (turbulence_enabled) {
-			code += "			noise_direction = vec3(1.0, 0.0, 0.0);\n";
-		}
 		code += "		}\n";
 		code += "	}\n";
 	} else if (collision_mode == COLLISION_HIDE_ON_CONTACT) {
@@ -984,14 +980,16 @@ void ParticleProcessMaterial::_update_shader() {
 		}
 		code += "		\n";
 		code += "		vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
-		// The following snippet causes massive performance hit. We don't need it as long as collision is disabled.
-		// Refer to GH-83744 for more info.
-		if (collision_mode != COLLISION_DISABLED) {
+
+		// Godot detects when the COLLIDED keyword is used. If it's used anywhere in the shader then Godot will generate the screen space SDF for collisions.
+		// We don't need it as long as collision is disabled. Refer to GH-83744 for more info.
+		if (collision_mode == COLLISION_RIGID) {
 			code += "		if (!COLLIDED) {\n";
-			code += "			\n";
-			code += "			float vel_mag = length(final_velocity);\n";
-			code += "			float vel_infl = clamp(dynamic_params.turb_influence * turbulence_influence, 0.0,1.0);\n";
-			code += "			final_velocity = mix(final_velocity, normalize(noise_direction) * vel_mag * (1.0 + (1.0 - vel_infl) * 0.2), vel_infl);\n";
+		}
+		code += "			float vel_mag = length(final_velocity);\n";
+		code += "			float vel_infl = clamp(dynamic_params.turb_influence * turbulence_influence, 0.0,1.0);\n";
+		code += "			final_velocity = mix(final_velocity, normalize(noise_direction) * vel_mag * (1.0 + (1.0 - vel_infl) * 0.2), vel_infl);\n";
+		if (collision_mode == COLLISION_RIGID) {
 			code += "		}\n";
 		}
 	}


### PR DESCRIPTION
Fixes #83858

And why do we not use R""(Raw String Literal) to replace continuous `string +=` in `particle_process_material` ? Much cleaner and potentially faster.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
