### PR TITLE
Fix normals in TileSet when using CanvasTextures

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4787,15 +4787,17 @@ Ref<ImageTexture> TileSetAtlasSource::_create_padded_image_texture(const Ref<Tex
 
 			image->blit_rect(*src_image, src_rect, base_pos);
 
+			// Sides
 			image->blit_rect(*src_image, top_src_rect, base_pos + Vector2i(0, -1));
 			image->blit_rect(*src_image, bottom_src_rect, base_pos + Vector2i(0, src_rect.size.y));
 			image->blit_rect(*src_image, left_src_rect, base_pos + Vector2i(-1, 0));
 			image->blit_rect(*src_image, right_src_rect, base_pos + Vector2i(src_rect.size.x, 0));
 
-			image->set_pixelv(base_pos + Vector2i(-1, -1), src_image->get_pixelv(src_rect.position));
-			image->set_pixelv(base_pos + Vector2i(src_rect.size.x, -1), src_image->get_pixelv(src_rect.position + Vector2i(src_rect.size.x - 1, 0)));
-			image->set_pixelv(base_pos + Vector2i(-1, src_rect.size.y), src_image->get_pixelv(src_rect.position + Vector2i(0, src_rect.size.y - 1)));
-			image->set_pixelv(base_pos + Vector2i(src_rect.size.x, src_rect.size.y), src_image->get_pixelv(src_rect.position + Vector2i(src_rect.size.x - 1, src_rect.size.y - 1)));
+			// Corners
+			image->blit_rect(*src_image, Rect2i(src_rect.position, Vector2i(1, 1)), base_pos + Vector2i(-1, -1));
+			image->blit_rect(*src_image, Rect2i(src_rect.position + Vector2i(src_rect.size.x - 1, 0), Vector2i(1, 1)), base_pos + Vector2i(src_rect.size.x, -1));
+			image->blit_rect(*src_image, Rect2i(src_rect.position + Vector2i(0, src_rect.size.y - 1), Vector2i(1, 1)), base_pos + Vector2i(-1, src_rect.size.y));
+			image->blit_rect(*src_image, Rect2i(src_rect.position + Vector2i(src_rect.size.x - 1, src_rect.size.y - 1), Vector2i(1, 1)), base_pos + Vector2i(src_rect.size.x, src_rect.size.y));
 		}
 	}
 
@@ -4831,31 +4833,20 @@ void TileSetAtlasSource::_update_padded_texture() {
 		Ref<Texture2D> src = src_canvas_texture->get_diffuse_texture();
 		Ref<ImageTexture> image_texture;
 		if (src.is_valid()) {
-			image_texture = _create_padded_image_texture(src);
-		} else {
-			image_texture.instantiate();
+			padded_texture->set_diffuse_texture(_create_padded_image_texture(src));
 		}
-		padded_texture->set_diffuse_texture(image_texture);
 
 		// Normal
 		src = src_canvas_texture->get_normal_texture();
-		image_texture.instantiate();
 		if (src.is_valid()) {
-			image_texture = _create_padded_image_texture(src);
-		} else {
-			image_texture.instantiate();
+			padded_texture->set_normal_texture(_create_padded_image_texture(src));
 		}
-		padded_texture->set_normal_texture(image_texture);
 
 		// Specular
 		src = src_canvas_texture->get_specular_texture();
-		image_texture.instantiate();
 		if (src.is_valid()) {
-			image_texture = _create_padded_image_texture(src);
-		} else {
-			image_texture.instantiate();
+			padded_texture->set_specular_texture(_create_padded_image_texture(src));
 		}
-		padded_texture->set_specular_texture(image_texture);
 
 		// Other properties.
 		padded_texture->set_specular_color(src_canvas_texture->get_specular_color());


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/83874

Also solves a bunch of error being printed when the provided normal map is not the same size as the diffuse map.