### PR TITLE
Improve X11 `screen_get_refresh_rate` performance

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1571,7 +1571,7 @@ float DisplayServerX11::screen_get_refresh_rate(int p_screen) const {
 
 	//Use xrandr to get screen refresh rate.
 	if (xrandr_ext_ok) {
-		XRRScreenResources *screen_info = XRRGetScreenResources(x11_display, windows[MAIN_WINDOW_ID].x11_window);
+		XRRScreenResources *screen_info = XRRGetScreenResourcesCurrent(x11_display, windows[MAIN_WINDOW_ID].x11_window);
 		if (screen_info) {
 			RRMode current_mode = 0;
 			xrr_monitor_info *monitors = nullptr;


### PR DESCRIPTION
Merge request done in response to https://github.com/godotengine/godot/issues/73563

`XRRGetScreenResources` causes significant performance issues if called frequently causing X11 entirely to slow to a crawl. Using `XRRGetScreenResourcesCurrent` significantly reduces the severity of the issue though with a still noticeable mild jitter.

Multiple other projects seem to have done this same fix for the same problem.

- https://github.com/JoseExposito/touchegg/pull/564
- https://github.com/glfw/glfw/issues/347

*Bugsquad edit:*
- Fixes #73563