### PR TITLE
Add support for EGL 1.4

### DIFF
--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -52,9 +52,13 @@ int EGLManager::_get_gldisplay_id(void *p_display) {
 	GLDisplay new_gldisplay;
 	new_gldisplay.display = p_display;
 
-	Vector<EGLAttrib> attribs = _get_platform_display_attributes();
-
-	new_gldisplay.egl_display = eglGetPlatformDisplay(_get_platform_extension_enum(), new_gldisplay.display, (attribs.size() > 0) ? attribs.ptr() : nullptr);
+	if (GLAD_EGL_VERSION_1_5) {
+		Vector<EGLAttrib> attribs = _get_platform_display_attributes();
+		new_gldisplay.egl_display = eglGetPlatformDisplay(_get_platform_extension_enum(), new_gldisplay.display, (attribs.size() > 0) ? attribs.ptr() : nullptr);
+	} else {
+		NativeDisplayType *native_display_type = (NativeDisplayType *)new_gldisplay.display;
+		new_gldisplay.egl_display = eglGetDisplay(*native_display_type);
+	}
 	ERR_FAIL_COND_V(eglGetError() != EGL_SUCCESS, -1);
 
 	ERR_FAIL_COND_V_MSG(new_gldisplay.egl_display == EGL_NO_DISPLAY, -1, "Can't create an EGL display.");
@@ -198,7 +202,12 @@ Error EGLManager::window_create(DisplayServer::WindowID p_window_id, void *p_dis
 	GLWindow &glwindow = windows[p_window_id];
 	glwindow.gldisplay_id = gldisplay_id;
 
-	glwindow.egl_surface = eglCreatePlatformWindowSurface(gldisplay.egl_display, gldisplay.egl_config, p_native_window, nullptr);
+	if (GLAD_EGL_VERSION_1_5) {
+		glwindow.egl_surface = eglCreatePlatformWindowSurface(gldisplay.egl_display, gldisplay.egl_config, p_native_window, nullptr);
+	} else {
+		EGLNativeWindowType *native_window_type = (EGLNativeWindowType *)p_native_window;
+		glwindow.egl_surface = eglCreateWindowSurface(gldisplay.egl_display, gldisplay.egl_config, *native_window_type, nullptr);
+	}
 
 	if (glwindow.egl_surface == EGL_NO_SURFACE) {
 		return ERR_CANT_CREATE;
@@ -345,7 +354,7 @@ Error EGLManager::initialize() {
 	ERR_FAIL_COND_V_MSG(!version, ERR_UNAVAILABLE, "Can't load EGL.");
 	print_verbose(vformat("Loaded EGL %d.%d", GLAD_VERSION_MAJOR(version), GLAD_VERSION_MINOR(version)));
 
-	ERR_FAIL_COND_V_MSG(!GLAD_EGL_VERSION_1_5, ERR_UNAVAILABLE, "EGL version is too old!");
+	ERR_FAIL_COND_V_MSG(!GLAD_EGL_VERSION_1_4, ERR_UNAVAILABLE, "EGL version is too old!");
 
 	eglTerminate(tmp_display);
 #endif


### PR DESCRIPTION
Debian 10 and (I think) 11 only have libEGL Version 1.4. Those OS are still widely used in integrated hardware like Rock PI and similar ARM devices. 
This patch checks for the EGL version and calls older methods if necessary.