### PR TITLE
Fix animation track paths updated by scene dock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1729,6 +1729,11 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 				break;
 			}
 
+			if (Object::cast_to<Animation>(resource)) {
+				// Animation resources are handled by animation editor.
+				break;
+			}
+
 			List<PropertyInfo> properties;
 			resource->get_property_list(&properties);
 


### PR DESCRIPTION
Fixes #83908
There is still some error when moving AnimationPlayer, but looks harmless and unrelated.