### PR TITLE
Fix potential crash on failed move

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1554,7 +1554,9 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, String> &p_renames, const HashMap<String, ResourceUID::ID> &p_uids) const {
 	// Update the paths in ResourceUID, so that UIDs remain valid.
 	for (const KeyValue<String, ResourceUID::ID> &pair : p_uids) {
-		ResourceUID::get_singleton()->set_id(pair.value, p_renames[pair.key]);
+		if (p_renames.has(pair.key)) {
+			ResourceUID::get_singleton()->set_id(pair.value, p_renames[pair.key]);
+		}
 	}
 
 	// Rename all resources loaded, be it subresources or actual resources.


### PR DESCRIPTION
My mistake from #81657. In case a move fails in `_try_move_item()` no key for it will exist in `p_renames`, but the UID change function would try to access it anyway, which would cause a crash if the file has a UID.