### PR TITLE
Expose `energy_multiplier` to remaining SkyMaterials

### DIFF
--- a/doc/classes/PanoramaSkyMaterial.xml
+++ b/doc/classes/PanoramaSkyMaterial.xml
@@ -11,6 +11,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="energy_multiplier" type="float" setter="set_energy_multiplier" getter="get_energy_multiplier" default="1.0">
+			The sky's overall brightness multiplier. Higher values result in a brighter sky.
+		</member>
 		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
 			A boolean value to determine if the background texture should be filtered or not.
 		</member>

--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -11,6 +11,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="energy_multiplier" type="float" setter="set_energy_multiplier" getter="get_energy_multiplier" default="1.0">
+			The sky's overall brightness multiplier. Higher values result in a brighter sky.
+		</member>
 		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color(0.2, 0.169, 0.133, 1)">
 			Color of the ground at the bottom. Blends with [member ground_horizon_color].
 		</member>

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -53,6 +53,7 @@ private:
 	float sun_angle_max = 0.0f;
 	float sun_curve = 0.0f;
 	bool use_debanding = true;
+	float global_energy_multiplier = 1.0f;
 
 	static Mutex shader_mutex;
 	static RID shader_cache[2];
@@ -103,6 +104,9 @@ public:
 	void set_use_debanding(bool p_use_debanding);
 	bool get_use_debanding() const;
 
+	void set_energy_multiplier(float p_multiplier);
+	float get_energy_multiplier() const;
+
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
 	virtual RID get_rid() const override;
@@ -121,6 +125,7 @@ class PanoramaSkyMaterial : public Material {
 
 private:
 	Ref<Texture2D> panorama;
+	float energy_multiplier = 1.0f;
 
 	static Mutex shader_mutex;
 	static RID shader_cache[2];


### PR DESCRIPTION
Reported on twitter: https://x.com/PLyczkowski/status/1717134276133589340?s=20

These are needed to tweak sky exposure separately from background. We had the ability to modify exposure in 3.x. In 4.x I partially brought it back, but only for PhysicalSkyMaterial. For PanoramaSkyMaterial the function definitions were added, but not implemented. For ProceduralSkyMaterial you have to adjust ground energy and sky energy separately, which really sucks. 
