### PR TITLE
Don't modify source `TileMap` `TileSetAtlasSource` when copying between scenes

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -68,7 +68,6 @@
 			<description>
 				Adds a [TileSetSource] to the TileSet. If [param atlas_source_id_override] is not -1, also set its source ID. Otherwise, a unique identifier is automatically generated.
 				The function returns the added source ID or -1 if the source could not be added.
-				[b]Warning:[/b] A source cannot belong to two TileSets at the same time. If the added source was attached to another [TileSet], it will be removed from that one.
 			</description>
 		</method>
 		<method name="add_terrain">

--- a/doc/classes/TileSetSource.xml
+++ b/doc/classes/TileSetSource.xml
@@ -8,7 +8,6 @@
 		Tiles in a source are indexed with two IDs, coordinates ID (of type Vector2i) and an alternative ID (of type int), named according to their use in the [TileSetAtlasSource] class.
 		Depending on the TileSet source type, those IDs might have restrictions on their values, this is why the base [TileSetSource] class only exposes getters for them.
 		You can iterate over all tiles exposed by a TileSetSource by first iterating over coordinates IDs using [method get_tiles_count] and [method get_tile_id], then over alternative IDs using [method get_alternative_tiles_count] and [method get_alternative_tile_id].
-		[b]Warning:[/b] [TileSetSource] can only be added to one TileSet at the same time. Calling [method TileSet.add_source] on a second [TileSet] will remove the source from the first one.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -2130,7 +2130,9 @@ TileData *TileMapLayer::get_cell_tile_data(const Vector2i &p_coords, bool p_use_
 	const Ref<TileSet> &tile_set = tile_map_node->get_tileset();
 	Ref<TileSetAtlasSource> source = tile_set->get_source(source_id);
 	if (source.is_valid()) {
-		return source->get_tile_data(get_cell_atlas_coords(p_coords, p_use_proxies), get_cell_alternative_tile(p_coords, p_use_proxies));
+		TileData *tile_data = source->get_tile_data(get_cell_atlas_coords(p_coords, p_use_proxies), get_cell_alternative_tile(p_coords, p_use_proxies));
+		tile_data->set_tile_set(*tile_set);
+		return tile_data;
 	}
 
 	return nullptr;

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -420,7 +420,6 @@ public:
 	int add_source(Ref<TileSetSource> p_tile_set_source, int p_source_id_override = -1);
 	void set_source_id(int p_source_id, int p_new_id);
 	void remove_source(int p_source_id);
-	void remove_source_ptr(TileSetSource *p_tile_set_source); // Not exposed
 	bool has_source(int p_source_id) const;
 	Ref<TileSetSource> get_source(int p_source_id) const;
 
@@ -556,7 +555,6 @@ public:
 
 	// Not exposed.
 	virtual void set_tile_set(const TileSet *p_tile_set);
-	TileSet *get_tile_set() const;
 	virtual void notify_tile_data_properties_should_change(){};
 	virtual void add_occlusion_layer(int p_index){};
 	virtual void move_occlusion_layer(int p_from_index, int p_to_pos){};


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/83218

This fixes the issue by effectively reversing some changes from https://github.com/godotengine/godot/pull/78477 ~~for internal tilesets.~~ and fixing it another way.

I am unsure exactly when it is the right time to delete the source from the old tilemap so maybe these conditions are wrong but seems to work.

~~EDIT: TODO: need to ensure this issue is not "unfixed". which it seems to be now? https://github.com/godotengine/godot/issues/77045 (ya condition must be wrong as that example uses internal tileset too.)~~

Thanks.