### PR TITLE
Refactor the parsing of port names in visual shader's expressions

### DIFF
--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -819,6 +819,10 @@ public:
 class VisualShaderNodeExpression : public VisualShaderNodeGroupBase {
 	GDCLASS(VisualShaderNodeExpression, VisualShaderNodeGroupBase);
 
+private:
+	bool _is_valid_identifier_char(char32_t p_c) const;
+	String _replace_port_names(const Vector<Pair<String, String>> &p_pairs, const String &p_expression) const;
+
 protected:
 	String expression = "";
 


### PR DESCRIPTION
I've decided to rewrite that part of the code to prevent further exclusion of control symbols (and easing up the code itself by removing the needing of running multiple loops for each symbol).

Now, only the symbols (before and after the expression) which may be a part of other identifiers (underscore symbol '_', A-Z, a-z, 0-9) will make the string replacing of port names in the expression to be failed.

- Fix https://github.com/godotengine/godot/issues/83944.
