### PR TITLE
Add pin to AnimationTree and various pinning-related fixes.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7093,6 +7093,7 @@ void AnimationTrackEditor::_select_all_tracks_for_copy() {
 }
 
 void AnimationTrackEditor::_bind_methods() {
+	ClassDB::bind_method("set_root", &AnimationTrackEditor::set_root);
 	ClassDB::bind_method("_track_grab_focus", &AnimationTrackEditor::_track_grab_focus);
 	ClassDB::bind_method("_redraw_tracks", &AnimationTrackEditor::_redraw_tracks);
 	ClassDB::bind_method("_clear_selection_for_anim", &AnimationTrackEditor::_clear_selection_for_anim);

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -40,9 +40,11 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/node_dock.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
+#include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
+#include "modules/multiplayer/editor/replication_editor.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
@@ -112,10 +114,14 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_PIN) {
 		if (n->is_class("AnimationMixer")) {
-			AnimationPlayerEditor::get_singleton()->unpin();
-			_update_tree();
+			AnimationPlayerEditor::get_singleton()->unpin(n);
+			if (n->is_class("AnimationTree")) {
+				AnimationTreeEditor::get_singleton()->unpin(n);
+			}
+		} else if (n->is_class("MultiplayerSynchronizer")) {
+			ReplicationEditor::get_singleton()->unpin(n);
 		}
-
+		_update_tree();
 	} else if (p_id == BUTTON_GROUP) {
 		undo_redo->create_action(TTR("Ungroup Children"));
 
@@ -214,6 +220,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	}
 
 	TreeItem *item = tree->create_item(p_parent);
+	ERR_FAIL_NULL(item);
 
 	item->set_text(0, p_node->get_name());
 	if (can_rename && !part_of_subscene) {
@@ -398,9 +405,12 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			item->set_button_color(0, item->get_button_count(0) - 1, button_color);
 		}
 
+		int pin_count = 0;
+
 		if (p_node->has_meta("_edit_lock_")) {
 			item->add_button(0, get_editor_theme_icon(SNAME("Lock")), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
 		}
+
 		if (p_node->has_meta("_edit_group_")) {
 			item->add_button(0, get_editor_theme_icon(SNAME("Group")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make them selectable."));
 		}
@@ -420,10 +430,26 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		}
 
 		if (p_node->is_class("AnimationMixer")) {
-			bool is_pinned = AnimationPlayerEditor::get_singleton()->get_editing_node() == p_node && AnimationPlayerEditor::get_singleton()->is_pinned();
+			if (AnimationPlayerEditor::get_singleton()->get_editing_node() == p_node && AnimationPlayerEditor::get_singleton()->is_pinned()) {
+				pin_count++;
+			}
 
-			if (is_pinned) {
-				item->add_button(0, get_editor_theme_icon(SNAME("Pin")), BUTTON_PIN, false, TTR("AnimationPlayer is pinned.\nClick to unpin."));
+			if (p_node->is_class("AnimationTree")) {
+				if (AnimationTreeEditor::get_singleton()->get_animation_tree() == p_node && AnimationTreeEditor::get_singleton()->is_pinned()) {
+					pin_count++;
+				}
+			}
+		} else if (p_node->is_class("MultiplayerSynchronizer")) {
+			if (ReplicationEditor::get_singleton()->get_current() == p_node && ReplicationEditor::get_singleton()->is_pinned()) {
+				pin_count++;
+			}
+		}
+
+		if (pin_count) {
+			if (pin_count > 1) {
+				item->add_button(0, get_editor_theme_icon(SNAME("MultiplePins")), BUTTON_PIN, false, TTR("Node is pinned.\nClick to unpin."));
+			} else {
+				item->add_button(0, get_editor_theme_icon(SNAME("Pin")), BUTTON_PIN, false, TTR("Node is pinned.\nClick to unpin."));
 			}
 		}
 	}

--- a/editor/icons/MultiplePins.svg
+++ b/editor/icons/MultiplePins.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m2 1v1l1 1v3h4 2 4v-3l1-1v-1h-4-4zm1 6-2 3h4 6 4l-2-3h-4-2zm0 4v2l1 2 1-2v-2zm4 0v2l1 2 1-2v-2zm4 0v2l1 2 1-2v-2z" fill="#e0e0e0"/></svg>

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/inspector_dock.h"
+#include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h" // For onion skinning.
 #include "editor/plugins/node_3d_editor_plugin.h" // For onion skinning.
 #include "editor/scene_tree_dock.h"
@@ -130,14 +131,14 @@ void AnimationPlayerEditor::_notification(int p_what) {
 			get_tree()->connect(SNAME("node_removed"), callable_mp(this, &AnimationPlayerEditor::_node_removed));
 
 			add_theme_style_override(SceneStringName(panel), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SceneStringName(panel), SNAME("Panel")));
-		} break;
-
+			[[fallthrough]];
+		}
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorThemeManager::is_generated_theme_outdated()) {
 				add_theme_style_override(SceneStringName(panel), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SceneStringName(panel), SNAME("Panel")));
 			}
-		} break;
-
+			[[fallthrough]];
+		}
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1114,8 +1115,8 @@ void AnimationPlayerEditor::edit(AnimationMixer *p_node, AnimationPlayer *p_play
 	AnimationTree *tree = Object::cast_to<AnimationTree>(p_node);
 
 	if (tree) {
-		if (tree->is_connected(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin))) {
-			tree->disconnect(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin));
+		if (tree->is_connected(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin).bind(tree))) {
+			tree->disconnect(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin).bind(tree));
 		}
 	}
 
@@ -1124,8 +1125,8 @@ void AnimationPlayerEditor::edit(AnimationMixer *p_node, AnimationPlayer *p_play
 	is_dummy = p_is_dummy;
 
 	if (tree) {
-		if (!tree->is_connected(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin))) {
-			tree->connect(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin));
+		if (!tree->is_connected(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin).bind(tree))) {
+			tree->connect(SNAME("animation_player_changed"), callable_mp(this, &AnimationPlayerEditor::unpin).bind(tree));
 		}
 	}
 
@@ -1806,6 +1807,7 @@ void AnimationPlayerEditor::_stop_onion_skinning() {
 }
 
 void AnimationPlayerEditor::_pin_pressed() {
+	emit_signal("pin_toggled");
 	SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
 }
 
@@ -1873,11 +1875,14 @@ bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {
 
 void AnimationPlayerEditor::_bind_methods() {
 	// Needed for UndoRedo.
+	ClassDB::bind_method(D_METHOD("unpin"), &AnimationPlayerEditor::unpin);
+
 	ClassDB::bind_method(D_METHOD("_animation_player_changed"), &AnimationPlayerEditor::_animation_player_changed);
 	ClassDB::bind_method(D_METHOD("_start_onion_skinning"), &AnimationPlayerEditor::_start_onion_skinning);
 	ClassDB::bind_method(D_METHOD("_stop_onion_skinning"), &AnimationPlayerEditor::_stop_onion_skinning);
 
 	ADD_SIGNAL(MethodInfo("animation_selected", PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("pin_toggled"));
 }
 
 AnimationPlayerEditor *AnimationPlayerEditor::singleton = nullptr;
@@ -2154,7 +2159,17 @@ void AnimationPlayerEditorPlugin::_notification(int p_what) {
 			InspectorDock::get_inspector_singleton()->connect(SNAME("property_keyed"), callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
 			anim_editor->get_track_editor()->connect(SNAME("keying_changed"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_keying));
 			InspectorDock::get_inspector_singleton()->connect(SNAME("edited_object_changed"), callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
+			anim_editor->connect("pin_toggled", callable_mp(this, &AnimationPlayerEditorPlugin::_pin_toggled));
 			set_force_draw_over_forwarding_enabled();
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			Node3DEditor::get_singleton()->disconnect(SNAME("transform_key_request"), callable_mp(this, &AnimationPlayerEditorPlugin::_transform_key_request));
+			InspectorDock::get_inspector_singleton()->disconnect(SNAME("property_keyed"), callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
+			anim_editor->get_track_editor()->disconnect(SNAME("keying_changed"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_keying));
+			InspectorDock::get_inspector_singleton()->disconnect(SNAME("edited_object_changed"), callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
+			anim_editor->disconnect("pin_toggled", callable_mp(this, &AnimationPlayerEditorPlugin::_pin_toggled));
+
+			_clear_dummy_player();
 		} break;
 	}
 }
@@ -2185,9 +2200,38 @@ void AnimationPlayerEditorPlugin::_update_keying() {
 	InspectorDock::get_inspector_singleton()->set_keying(anim_editor->get_track_editor()->has_keying());
 }
 
+void AnimationPlayerEditorPlugin::_pin_toggled() {
+	if (!anim_editor->is_pinned()) {
+		if (anim_editor->get_selected_node()) {
+			AnimationMixer *selected_node = anim_editor->get_selected_node();
+			anim_editor->set_selected_node(nullptr);
+			edit(selected_node);
+		}
+	}
+}
+
 void AnimationPlayerEditorPlugin::edit(Object *p_object) {
-	if (player && anim_editor && anim_editor->is_pinned()) {
-		return; // Ignore, pinned.
+	anim_editor->set_selected_node(Object::cast_to<AnimationMixer>(p_object));
+
+	{
+		AnimationMixer *last_mixer_instance = Object::cast_to<AnimationMixer>(ObjectDB::get_instance(last_mixer));
+		if ((last_mixer_instance && last_mixer_instance->is_inside_tree())) {
+			if (player) {
+				if (Object::cast_to<AnimationMixer>(p_object)) {
+					player->clear_caches();
+				}
+			}
+			if (anim_editor && anim_editor->is_pinned()) {
+				// Only raise the panel if the editor is not currently visible and the node is the one we have pinned.
+				if (!anim_editor->is_visible_in_tree() && p_object == anim_editor->get_editing_node()) {
+					// Check if the AnimationTreeEditor's tree node conflicts with this node.
+					if (AnimationTreeEditor::get_singleton()->get_animation_tree() != p_object) {
+						EditorNode::get_bottom_panel()->make_item_visible(anim_editor, true);
+					}
+				}
+				return; // Ignore, pinned.
+			}
+		}
 	}
 
 	player = nullptr;
@@ -2198,21 +2242,26 @@ void AnimationPlayerEditorPlugin::edit(Object *p_object) {
 
 	AnimationMixer *src_node = Object::cast_to<AnimationMixer>(p_object);
 	bool is_dummy = false;
-	if (!p_object->is_class("AnimationPlayer")) {
-		// If it needs dummy AnimationPlayer, assign original AnimationMixer to LibraryEditor.
-		_update_dummy_player(src_node);
+	if (!player) {
+		if (!p_object->is_class("AnimationPlayer")) {
+			// If it needs dummy AnimationPlayer, assign original AnimationMixer to LibraryEditor.
+			_update_dummy_player(src_node);
 
-		is_dummy = true;
+			is_dummy = true;
 
-		if (!src_node->is_connected(SNAME("mixer_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player))) {
-			src_node->connect(SNAME("mixer_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player).bind(src_node), CONNECT_DEFERRED);
+			if (!src_node->is_connected(SNAME("mixer_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player))) {
+				src_node->connect(SNAME("mixer_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player).bind(src_node), CONNECT_DEFERRED);
+			}
+			if (!src_node->is_connected(SNAME("animation_libraries_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player))) {
+				src_node->connect(SNAME("animation_libraries_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player).bind(src_node), CONNECT_DEFERRED);
+			}
+		} else {
+			_clear_dummy_player();
+			player = Object::cast_to<AnimationPlayer>(p_object);
+
+			// If the class derives from the regular AnimationPlayer, select it in the bottom panel.
+			EditorNode::get_bottom_panel()->make_item_visible(anim_editor, true);
 		}
-		if (!src_node->is_connected(SNAME("animation_libraries_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player))) {
-			src_node->connect(SNAME("animation_libraries_updated"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_dummy_player).bind(src_node), CONNECT_DEFERRED);
-		}
-	} else {
-		_clear_dummy_player();
-		player = Object::cast_to<AnimationPlayer>(p_object);
 	}
 	player->set_dummy(is_dummy);
 
@@ -2272,8 +2321,9 @@ bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
 }
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
+	anim_editor->set_selected_node(nullptr);
+
 	if (p_visible) {
-		EditorNode::get_bottom_panel()->make_item_visible(anim_editor);
 		anim_editor->set_process(true);
 		anim_editor->ensure_visibility();
 	}

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -51,6 +51,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	AnimationPlayerEditorPlugin *plugin = nullptr;
 	AnimationMixer *original_node = nullptr; // For pinned mark in SceneTree.
+	AnimationMixer *selected_node = nullptr; // The last edited node, irrespective of pinning.
 	AnimationPlayer *player = nullptr; // For AnimationPlayerEditor, could be dummy.
 	bool is_dummy = false;
 
@@ -248,16 +249,22 @@ protected:
 	static void _bind_methods();
 
 public:
+	AnimationMixer *get_selected_node() { return selected_node; }
+	void set_selected_node(AnimationMixer *p_selected_node) { selected_node = p_selected_node; }
+
 	AnimationMixer *get_editing_node() const;
 	AnimationPlayer *get_player() const;
 	AnimationMixer *fetch_mixer_for_library() const;
 
 	static AnimationPlayerEditor *get_singleton() { return singleton; }
 
+	Button *get_pin() const { return pin; }
 	bool is_pinned() const { return pin->is_pressed(); }
-	void unpin() {
-		pin->set_pressed(false);
-		_pin_pressed();
+	void unpin(Node *n) {
+		if (n == original_node) {
+			pin->set_pressed(false);
+			_pin_pressed();
+		}
 	}
 	AnimationTrackEditor *get_track_editor() { return track_editor; }
 	Dictionary get_state() const;
@@ -285,11 +292,14 @@ class AnimationPlayerEditorPlugin : public EditorPlugin {
 	void _clear_dummy_player();
 
 protected:
+	bool animation_tree_selected = false;
+
 	void _notification(int p_what);
 
 	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
 	void _transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key);
 	void _update_keying();
+	void _pin_toggled();
 
 public:
 	virtual Dictionary get_state() const override { return anim_editor->get_state(); }

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_command_palette.h"
 #include "editor/editor_node.h"
 #include "editor/gui/editor_bottom_panel.h"
+#include "editor/scene_tree_dock.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
@@ -45,6 +46,10 @@
 #include "scene/gui/separator.h"
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
+	if (is_pinned()) {
+		return;
+	}
+
 	if (p_tree && !p_tree->is_connected("animation_list_changed", callable_mp(this, &AnimationTreeEditor::_animation_list_changed))) {
 		p_tree->connect("animation_list_changed", callable_mp(this, &AnimationTreeEditor::_animation_list_changed), CONNECT_DEFERRED);
 	}
@@ -63,12 +68,20 @@ void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 	if (tree) {
 		edit_path(path);
 	}
+
+	pin->set_disabled(tree == nullptr);
 }
 
 void AnimationTreeEditor::_node_removed(Node *p_node) {
 	if (p_node == tree) {
-		tree = nullptr;
+		pin->set_pressed(false);
 		_clear_editors();
+
+		tree = nullptr;
+		Vector<String> path;
+		edit_path(path);
+
+		emit_signal(SNAME("animation_tree_removed"), p_node);
 	}
 }
 
@@ -84,6 +97,12 @@ void AnimationTreeEditor::_animation_list_changed() {
 	if (bte) {
 		bte->update_graph();
 	}
+}
+
+void AnimationTreeEditor::_pin_pressed() {
+	emit_signal("pin_toggled");
+
+	SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
 }
 
 void AnimationTreeEditor::_update_path() {
@@ -118,7 +137,10 @@ void AnimationTreeEditor::_update_path() {
 void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 	button_path.clear();
 
-	Ref<AnimationNode> node = tree->get_root_animation_node();
+	Ref<AnimationNode> node;
+	if (tree) {
+		node = tree->get_root_animation_node();
+	}
 
 	if (node.is_valid()) {
 		current_root = node->get_instance_id();
@@ -168,6 +190,21 @@ Vector<String> AnimationTreeEditor::get_edited_path() const {
 	return button_path;
 }
 
+Button *AnimationTreeEditor::get_pin() {
+	return pin;
+}
+
+bool AnimationTreeEditor::is_pinned() const {
+	return pin->is_pressed();
+}
+
+void AnimationTreeEditor::unpin(Node *n) {
+	if (n == tree) {
+		pin->set_pressed(false);
+		_pin_pressed();
+	}
+}
+
 void AnimationTreeEditor::enter_editor(const String &p_path) {
 	Vector<String> path = edited_path;
 	path.push_back(p_path);
@@ -176,9 +213,6 @@ void AnimationTreeEditor::enter_editor(const String &p_path) {
 
 void AnimationTreeEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			get_tree()->connect("node_removed", callable_mp(this, &AnimationTreeEditor::_node_removed));
-		} break;
 		case NOTIFICATION_PROCESS: {
 			ObjectID root;
 			if (tree && tree->get_root_animation_node().is_valid()) {
@@ -196,7 +230,20 @@ void AnimationTreeEditor::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			get_tree()->disconnect("node_removed", callable_mp(this, &AnimationTreeEditor::_node_removed));
 		} break;
+		case NOTIFICATION_ENTER_TREE:
+			get_tree()->connect("node_removed", callable_mp(this, &AnimationTreeEditor::_node_removed));
+			[[fallthrough]];
+		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
+			pin->set_icon(get_editor_theme_icon(SNAME("Pin")));
+		} break;
 	}
+}
+
+void AnimationTreeEditor::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("animation_tree_removed", PropertyInfo(Variant::OBJECT, "animation_tree")));
+	ADD_SIGNAL(MethodInfo("pin_toggled"));
 }
 
 AnimationTreeEditor *AnimationTreeEditor::singleton = nullptr;
@@ -256,12 +303,31 @@ Vector<String> AnimationTreeEditor::get_animation_list() {
 
 AnimationTreeEditor::AnimationTreeEditor() {
 	AnimationNodeAnimation::get_editable_animation_list = get_animation_list;
+
+	hb = memnew(HBoxContainer);
+	add_child(hb);
+
 	path_edit = memnew(ScrollContainer);
-	add_child(path_edit);
+	hb->add_child(path_edit);
 	path_edit->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	path_edit->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+
 	path_hb = memnew(HBoxContainer);
 	path_edit->add_child(path_hb);
 	path_hb->add_child(memnew(Label(TTR("Path:"))));
+
+	options_hb = memnew(HBoxContainer);
+	hb->add_child(options_hb);
+
+	VSeparator *vsep = memnew(VSeparator);
+	options_hb->add_child(vsep);
+
+	pin = memnew(Button);
+	pin->set_theme_type_variation("FlatButton");
+	pin->set_toggle_mode(true);
+	pin->set_tooltip_text(TTR("Pin AnimationTree"));
+	options_hb->add_child(pin);
+	pin->connect(SNAME("pressed"), callable_mp(this, &AnimationTreeEditor::_pin_pressed));
 
 	add_child(memnew(HSeparator));
 
@@ -276,8 +342,51 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	add_plugin(memnew(AnimationNodeStateMachineEditor));
 }
 
+void AnimationTreeEditorPlugin::_pin_toggled() {
+	if (!anim_tree_editor->is_pinned()) {
+		if (!anim_tree_editor->get_selected_node()) {
+			// If we don't have another valid selected node, hide everything.
+			if (anim_tree_editor->is_visible_in_tree()) {
+				EditorNode::get_bottom_panel()->hide_bottom_panel();
+			}
+			button->hide();
+		} else {
+			edit(anim_tree_editor->get_selected_node());
+		}
+	}
+}
+
+void AnimationTreeEditorPlugin::_animation_tree_removed(Node *p_node) {
+	if (anim_tree_editor->is_visible_in_tree()) {
+		EditorNode::get_bottom_panel()->hide_bottom_panel();
+	}
+	button->hide();
+}
+
 void AnimationTreeEditorPlugin::edit(Object *p_object) {
-	anim_tree_editor->edit(Object::cast_to<AnimationTree>(p_object));
+	anim_tree_editor->set_selected_node(Object::cast_to<AnimationTree>(p_object));
+
+	if (anim_tree_editor && anim_tree_editor->is_pinned()) {
+		AnimationTree *last_anim_tree_instance = Object::cast_to<AnimationTree>(ObjectDB::get_instance(last_anim_tree));
+
+		// Safety check to make sure the pinned instance is actually still valid.
+		if (last_anim_tree_instance && last_anim_tree_instance->is_inside_tree()) {
+			// Only raise the panel if the editor is not currently visible and the node is the one we have pinned.
+			if (!anim_tree_editor->is_visible_in_tree() && p_object == anim_tree_editor->get_animation_tree()) {
+				EditorNode::get_bottom_panel()->make_item_visible(anim_tree_editor, true);
+			}
+		} else {
+			// The pinned object seems to have gone missing, so force an unpin.
+			anim_tree_editor->get_pin()->set_pressed(false);
+		}
+	}
+
+	last_anim_tree = ObjectID();
+	if (p_object) {
+		last_anim_tree = p_object->get_instance_id();
+	}
+
+	anim_tree_editor->edit(anim_tree_editor->get_selected_node());
 }
 
 bool AnimationTreeEditorPlugin::handles(Object *p_object) const {
@@ -285,18 +394,37 @@ bool AnimationTreeEditorPlugin::handles(Object *p_object) const {
 }
 
 void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
+	anim_tree_editor->set_selected_node(nullptr);
+
 	if (p_visible) {
-		//editor->hide_animation_player_editors();
-		//editor->animation_panel_make_visible(true);
 		button->show();
-		EditorNode::get_bottom_panel()->make_item_visible(anim_tree_editor);
+
+		if (anim_tree_editor && !anim_tree_editor->is_pinned()) {
+			EditorNode::get_bottom_panel()->make_item_visible(anim_tree_editor, true);
+		}
+
 		anim_tree_editor->set_process(true);
 	} else {
-		if (anim_tree_editor->is_visible_in_tree()) {
-			EditorNode::get_bottom_panel()->hide_bottom_panel();
+		if (!anim_tree_editor->is_pinned()) {
+			if (anim_tree_editor->is_visible_in_tree()) {
+				EditorNode::get_bottom_panel()->hide_bottom_panel();
+			}
+			button->hide();
+			anim_tree_editor->set_process(false);
 		}
-		button->hide();
-		anim_tree_editor->set_process(false);
+	}
+}
+
+void AnimationTreeEditorPlugin::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			anim_tree_editor->connect("animation_tree_removed", callable_mp(this, &AnimationTreeEditorPlugin::_animation_tree_removed));
+			anim_tree_editor->connect("pin_toggled", callable_mp(this, &AnimationTreeEditorPlugin::_pin_toggled));
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			anim_tree_editor->disconnect("animation_tree_removed", callable_mp(this, &AnimationTreeEditorPlugin::_animation_tree_removed));
+			anim_tree_editor->disconnect("pin_toggled", callable_mp(this, &AnimationTreeEditorPlugin::_pin_toggled));
+		} break;
 	}
 }
 

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -50,8 +50,16 @@ public:
 class AnimationTreeEditor : public VBoxContainer {
 	GDCLASS(AnimationTreeEditor, VBoxContainer);
 
+	HBoxContainer *hb = nullptr;
+
 	ScrollContainer *path_edit = nullptr;
 	HBoxContainer *path_hb = nullptr;
+
+	HBoxContainer *options_hb = nullptr;
+
+	Button *pin = nullptr;
+
+	AnimationTree *selected_node = nullptr;
 
 	AnimationTree *tree = nullptr;
 	MarginContainer *editor_base = nullptr;
@@ -67,15 +75,22 @@ class AnimationTreeEditor : public VBoxContainer {
 	void _path_button_pressed(int p_path);
 	void _animation_list_changed();
 
+	void _pin_pressed();
+
 	static Vector<String> get_animation_list();
 
 protected:
+	static void _bind_methods();
+
 	void _notification(int p_what);
 	void _node_removed(Node *p_node);
 
 	static AnimationTreeEditor *singleton;
 
 public:
+	AnimationTree *get_selected_node() { return selected_node; }
+	void set_selected_node(AnimationTree *p_selected_node) { selected_node = p_selected_node; }
+
 	AnimationTree *get_animation_tree() { return tree; }
 	void add_plugin(AnimationTreeNodeEditorPlugin *p_editor);
 	void remove_plugin(AnimationTreeNodeEditorPlugin *p_editor);
@@ -86,6 +101,10 @@ public:
 
 	void edit_path(const Vector<String> &p_path);
 	Vector<String> get_edited_path() const;
+
+	Button *get_pin();
+	bool is_pinned() const;
+	void unpin(Node *n);
 
 	void enter_editor(const String &p_path = "");
 	static AnimationTreeEditor *get_singleton() { return singleton; }
@@ -98,6 +117,11 @@ class AnimationTreeEditorPlugin : public EditorPlugin {
 
 	AnimationTreeEditor *anim_tree_editor = nullptr;
 	Button *button = nullptr;
+	ObjectID last_anim_tree;
+
+protected:
+	void _pin_toggled();
+	void _animation_tree_removed(Node *p_node);
 
 public:
 	virtual String get_name() const override { return "AnimationTree"; }
@@ -105,6 +129,8 @@ public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+
+	void _notification(int p_what);
 
 	AnimationTreeEditorPlugin();
 	~AnimationTreeEditorPlugin();

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -116,7 +116,6 @@ MultiplayerEditorPlugin::MultiplayerEditorPlugin() {
 	repl_editor = memnew(ReplicationEditor);
 	button = EditorNode::get_bottom_panel()->add_item(TTR("Replication"), repl_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_replication_bottom_panel", TTR("Toggle Replication Bottom Panel")));
 	button->hide();
-	repl_editor->get_pin()->connect(SceneStringName(pressed), callable_mp(this, &MultiplayerEditorPlugin::_pinned));
 	debugger.instantiate();
 	debugger->connect("open_request", callable_mp(this, &MultiplayerEditorPlugin::_open_request));
 }
@@ -128,16 +127,21 @@ void MultiplayerEditorPlugin::_open_request(const String &p_path) {
 void MultiplayerEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			get_tree()->connect("node_removed", callable_mp(this, &MultiplayerEditorPlugin::_node_removed));
+			repl_editor->connect("multiplayer_synchronizer_removed", callable_mp(this, &MultiplayerEditorPlugin::_multiplayer_synchronizer_removed));
+			repl_editor->connect("pin_toggled", callable_mp(this, &MultiplayerEditorPlugin::_pin_toggled));
+
 			add_debugger_plugin(debugger);
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			repl_editor->disconnect("multiplayer_synchronizer_removed", callable_mp(this, &MultiplayerEditorPlugin::_multiplayer_synchronizer_removed));
+			repl_editor->disconnect("pressed", callable_mp(this, &MultiplayerEditorPlugin::_pin_toggled));
+
 			remove_debugger_plugin(debugger);
 		}
 	}
 }
 
-void MultiplayerEditorPlugin::_node_removed(Node *p_node) {
+void MultiplayerEditorPlugin::_multiplayer_synchronizer_removed(Node *p_node) {
 	if (p_node && p_node == repl_editor->get_current()) {
 		repl_editor->edit(nullptr);
 		if (repl_editor->is_visible_in_tree()) {
@@ -148,17 +152,44 @@ void MultiplayerEditorPlugin::_node_removed(Node *p_node) {
 	}
 }
 
-void MultiplayerEditorPlugin::_pinned() {
-	if (!repl_editor->get_pin()->is_pressed() && repl_editor->get_current() == nullptr) {
-		if (repl_editor->is_visible_in_tree()) {
-			EditorNode::get_bottom_panel()->hide_bottom_panel();
+void MultiplayerEditorPlugin::_pin_toggled() {
+	if (!repl_editor->is_pinned()) {
+		if (!repl_editor->get_selected_node()) {
+			// If we don't have another valid selected node, hide everything.
+			if (repl_editor->is_visible_in_tree()) {
+				EditorNode::get_bottom_panel()->hide_bottom_panel();
+			}
+			button->hide();
+		} else {
+			edit(repl_editor->get_selected_node());
 		}
-		button->hide();
 	}
 }
 
 void MultiplayerEditorPlugin::edit(Object *p_object) {
-	repl_editor->edit(Object::cast_to<MultiplayerSynchronizer>(p_object));
+	repl_editor->set_selected_node(Object::cast_to<MultiplayerSynchronizer>(p_object));
+
+	if (repl_editor && repl_editor->is_pinned()) {
+		MultiplayerSynchronizer *last_multiplayer_sync_instance = Object::cast_to<MultiplayerSynchronizer>(ObjectDB::get_instance(last_multiplayer_sync));
+
+		// Safety check to make sure the pinned instance is actually still valid.
+		if (last_multiplayer_sync_instance && last_multiplayer_sync_instance->is_inside_tree()) {
+			// Only raise the panel if the editor is not currently visible and the node is the one we have pinned.
+			if (!repl_editor->is_visible_in_tree() && p_object == repl_editor->get_current()) {
+				EditorNode::get_bottom_panel()->make_item_visible(repl_editor, true);
+			}
+		} else {
+			// The pinned object seems to have gone missing, so force an unpin.
+			repl_editor->get_pin()->set_pressed(false);
+		}
+	}
+
+	last_multiplayer_sync = ObjectID();
+	if (p_object) {
+		last_multiplayer_sync = p_object->get_instance_id();
+	}
+
+	repl_editor->edit(repl_editor->get_selected_node());
 }
 
 bool MultiplayerEditorPlugin::handles(Object *p_object) const {
@@ -166,13 +197,23 @@ bool MultiplayerEditorPlugin::handles(Object *p_object) const {
 }
 
 void MultiplayerEditorPlugin::make_visible(bool p_visible) {
+	repl_editor->set_selected_node(nullptr);
+
 	if (p_visible) {
 		button->show();
-		EditorNode::get_bottom_panel()->make_item_visible(repl_editor);
-	} else if (!repl_editor->get_pin()->is_pressed()) {
-		if (repl_editor->is_visible_in_tree()) {
-			EditorNode::get_bottom_panel()->hide_bottom_panel();
+
+		if (repl_editor && !repl_editor->is_pinned()) {
+			EditorNode::get_bottom_panel()->make_item_visible(repl_editor, true);
 		}
-		button->hide();
+
+		repl_editor->set_process(true);
+	} else {
+		if (!repl_editor->is_pinned()) {
+			if (repl_editor->is_visible_in_tree()) {
+				EditorNode::get_bottom_panel()->hide_bottom_panel();
+			}
+			button->hide();
+			repl_editor->set_process(false);
+		}
 	}
 }

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.h
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.h
@@ -62,13 +62,15 @@ class MultiplayerEditorPlugin : public EditorPlugin {
 
 private:
 	Button *button = nullptr;
+	ObjectID last_multiplayer_sync;
 	ReplicationEditor *repl_editor = nullptr;
 	Ref<MultiplayerEditorDebugger> debugger;
+	bool is_visible = false;
 
 	void _open_request(const String &p_path);
-	void _node_removed(Node *p_node);
+	void _multiplayer_synchronizer_removed(Node *p_node);
 
-	void _pinned();
+	void _pin_toggled();
 
 protected:
 	void _notification(int p_what);

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -39,11 +39,23 @@
 #include "editor/gui/scene_tree_editor.h"
 #include "editor/inspector_dock.h"
 #include "editor/property_selector.h"
+#include "editor/scene_tree_dock.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
+
+ReplicationEditor *ReplicationEditor::singleton = nullptr;
+
+void ReplicationEditor::_node_removed(Node *p_node) {
+	if (p_node == current) {
+		pin->set_pressed(false);
+		current = nullptr;
+
+		emit_signal(SNAME("multiplayer_synchronizer_removed"), p_node);
+	}
+}
 
 void ReplicationEditor::_pick_node_filter_text_changed(const String &p_newtext) {
 	TreeItem *root_item = pick_node->get_scene_tree()->get_scene_tree()->get_root();
@@ -162,6 +174,12 @@ void ReplicationEditor::_add_sync_property(String p_path) {
 	undo_redo->commit_action();
 }
 
+void ReplicationEditor::_pin_pressed() {
+	emit_signal("pin_toggled");
+
+	SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
+}
+
 void ReplicationEditor::_pick_node_property_selected(String p_name) {
 	String adding_prop_path = String(adding_node_path) + ":" + p_name;
 
@@ -273,6 +291,7 @@ ReplicationEditor::ReplicationEditor() {
 	pin->set_toggle_mode(true);
 	pin->set_tooltip_text(TTR("Pin replication editor"));
 	hb->add_child(pin);
+	pin->connect(SNAME("pressed"), callable_mp(this, &ReplicationEditor::_pin_pressed));
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
@@ -300,12 +319,17 @@ ReplicationEditor::ReplicationEditor() {
 	tree->add_child(drop_label);
 	drop_label->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 
+	singleton = this;
+
 	SET_DRAG_FORWARDING_CDU(tree, ReplicationEditor);
 }
 
 void ReplicationEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_config"), &ReplicationEditor::_update_config);
 	ClassDB::bind_method(D_METHOD("_update_value", "property", "column", "value"), &ReplicationEditor::_update_value);
+
+	ADD_SIGNAL(MethodInfo("multiplayer_synchronizer_removed", PropertyInfo(Variant::OBJECT, "multiplayer_synchronizer")));
+	ADD_SIGNAL(MethodInfo("pin_toggled"));
 }
 
 bool ReplicationEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
@@ -365,17 +389,20 @@ void ReplicationEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_da
 
 void ReplicationEditor::_notification(int p_what) {
 	switch (p_what) {
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+		case NOTIFICATION_TRANSLATION_CHANGED:
 			if (!EditorThemeManager::is_generated_theme_outdated()) {
 				break;
 			}
 			[[fallthrough]];
-		}
 		case NOTIFICATION_ENTER_TREE: {
 			add_theme_style_override(SceneStringName(panel), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SceneStringName(panel), SNAME("Panel")));
-			add_pick_button->set_icon(get_theme_icon(SNAME("Add"), EditorStringName(EditorIcons)));
-			pin->set_icon(get_theme_icon(SNAME("Pin"), EditorStringName(EditorIcons)));
-		} break;
+			[[fallthrough]];
+			case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+			case NOTIFICATION_THEME_CHANGED: {
+				add_pick_button->set_icon(get_theme_icon(SNAME("Add"), EditorStringName(EditorIcons)));
+				pin->set_icon(get_theme_icon(SNAME("Pin"), EditorStringName(EditorIcons)));
+			}
+		}
 	}
 }
 
@@ -525,6 +552,10 @@ void ReplicationEditor::_update_config() {
 }
 
 void ReplicationEditor::edit(MultiplayerSynchronizer *p_sync) {
+	if (is_pinned()) {
+		return;
+	}
+
 	if (current == p_sync) {
 		return;
 	}

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -34,7 +34,9 @@
 #include "../scene_replication_config.h"
 
 #include "editor/plugins/editor_plugin.h"
+#include "modules/multiplayer/multiplayer_synchronizer.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
 
 class ConfirmationDialog;
 class MultiplayerSynchronizer;
@@ -50,6 +52,7 @@ class ReplicationEditor : public VBoxContainer {
 
 private:
 	MultiplayerSynchronizer *current = nullptr;
+	MultiplayerSynchronizer *selected_node = nullptr;
 
 	ConfirmationDialog *delete_dialog = nullptr;
 	Button *add_pick_button = nullptr;
@@ -69,6 +72,8 @@ private:
 	Button *pin = nullptr;
 
 	Ref<Texture2D> _get_class_icon(const Node *p_node);
+
+	void _node_removed(Node *p_node);
 
 	void _add_pressed();
 	void _np_text_submitted(const String &p_newtext);
@@ -92,16 +97,33 @@ private:
 
 	void _add_sync_property(String p_path);
 
+	void _pin_pressed();
+
 protected:
 	static void _bind_methods();
 
 	void _notification(int p_what);
 
+	static ReplicationEditor *singleton;
+
 public:
 	void edit(MultiplayerSynchronizer *p_object);
 	MultiplayerSynchronizer *get_current() const { return current; }
 
+	MultiplayerSynchronizer *get_selected_node() { return selected_node; }
+	void set_selected_node(MultiplayerSynchronizer *p_selected_node) { selected_node = p_selected_node; }
+
 	Button *get_pin() { return pin; }
+	bool is_pinned() { return pin->is_pressed(); }
+	void unpin(Node *n) {
+		if (n == current) {
+			pin->set_pressed(false);
+			_pin_pressed();
+		}
+	}
+
+	static ReplicationEditor *get_singleton() { return singleton; }
+
 	ReplicationEditor();
 	~ReplicationEditor() {}
 };

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -838,11 +838,11 @@ void AnimationTree::_setup_animation_player() {
 	// Using AnimationPlayer here is for compatibility. Changing to AnimationMixer needs extra work like error handling.
 	AnimationPlayer *player = Object::cast_to<AnimationPlayer>(get_node_or_null(animation_player));
 	if (player) {
-		if (!player->is_connected(SNAME("caches_cleared"), callable_mp(this, &AnimationTree::_setup_animation_player))) {
-			player->connect(SNAME("caches_cleared"), callable_mp(this, &AnimationTree::_setup_animation_player), CONNECT_DEFERRED);
+		if (player->is_connected(SNAME("caches_cleared"), callable_mp(this, &AnimationTree::_setup_animation_player))) {
+			player->disconnect(SNAME("caches_cleared"), callable_mp(this, &AnimationTree::_setup_animation_player));
 		}
-		if (!player->is_connected(SNAME("animation_list_changed"), callable_mp(this, &AnimationTree::_setup_animation_player))) {
-			player->connect(SNAME("animation_list_changed"), callable_mp(this, &AnimationTree::_setup_animation_player), CONNECT_DEFERRED);
+		if (player->is_connected(SNAME("animation_list_changed"), callable_mp(this, &AnimationTree::_setup_animation_player))) {
+			player->disconnect(SNAME("animation_list_changed"), callable_mp(this, &AnimationTree::_setup_animation_player));
 		}
 		Node *root = player->get_node_or_null(player->get_root_node());
 		if (root) {
@@ -858,6 +858,13 @@ void AnimationTree::_setup_animation_player() {
 			if (lib.is_valid()) {
 				add_animation_library(E, lib);
 			}
+		}
+
+		if (!player->is_connected(SNAME("caches_cleared"), callable_mp(this, &AnimationTree::_setup_animation_player))) {
+			player->connect(SNAME("caches_cleared"), callable_mp(this, &AnimationTree::_setup_animation_player), CONNECT_DEFERRED);
+		}
+		if (!player->is_connected(SNAME("animation_list_changed"), callable_mp(this, &AnimationTree::_setup_animation_player))) {
+			player->connect(SNAME("animation_list_changed"), callable_mp(this, &AnimationTree::_setup_animation_player), CONNECT_DEFERRED);
 		}
 	}
 


### PR DESCRIPTION
The PR adds pinning to the AnimationTreeEditor to solve an important UX issue where, if you are using a base expression node other than the AnimationTree itself, you cannot modify its properties and observe the interactions with the state machine at the same time, since clicking off the AnimationTree node will hide the editor.

Additionally, this PR provides a broader set of tweaks and to the existing pinning logic which should provide a variety of usability improvements, consistency and bug fixes:
- Deleting a node or switching to another scene will always ensure the pin is correctly removed which fixes this glitch when switching to a new scene while an AnimationPlayer is pinned.
![godot windows editor dev x86_64_vPv7sjU9pD](https://github.com/godotengine/godot/assets/12756047/83330928-3232-464f-a290-5fa4d5aaec7d)
- Switching from an AnimationTree to an AnimationPlayer won't result in the AnimationPlayer being hidden anymore.
- Pinned item will always be what shows up in the respective editor until it is either unpinned or the node is removed. The editor will then immediatley update to show the correct contents for the currently selected node.
- The respective editor won't pop up for a respective node if another node using the same editor is already pinned.
- Both the MultiplayerSynchronizer and the newly added AnimationTreeEditor will now show pinning in the inspector scene tree in the same fashion as the AnimationPlayer. Additionally, since the unification of the AnimationTree and AnimationPlayer into an AnimationMixer, this means that both a tree and player can be pinned to the same node. In this instance, a new 'multiple pin' icon will show up to convey this information.
![godot windows editor dev x86_64_FPlQIsXqfR](https://github.com/godotengine/godot/assets/12756047/ca1ad081-784a-4fca-81f7-6f752e2ab91d)