### PR TITLE
Fix disabled tabs being selected when removing the current one

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -317,7 +317,7 @@
 		<signal name="tab_selected">
 			<param index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is selected via click or script, even if it is the current tab.
+				Emitted when a tab is selected via click, directional input, or script, even if it is the current tab.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -243,7 +243,7 @@
 		<signal name="tab_selected">
 			<param index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is selected via click or script, even if it is the current tab.
+				Emitted when a tab is selected via click, directional input, or script, even if it is the current tab.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -669,7 +669,7 @@ bool TabBar::select_previous_available() {
 		if (target_tab < 0) {
 			target_tab += get_tab_count();
 		}
-		if (!is_tab_disabled(target_tab)) {
+		if (!is_tab_disabled(target_tab) && !is_tab_hidden(target_tab)) {
 			set_current_tab(target_tab);
 			return true;
 		}
@@ -681,7 +681,7 @@ bool TabBar::select_next_available() {
 	const int offset_end = (get_tab_count() - get_current_tab());
 	for (int i = 1; i < offset_end; i++) {
 		int target_tab = (get_current_tab() + i) % get_tab_count();
-		if (!is_tab_disabled(target_tab)) {
+		if (!is_tab_disabled(target_tab) && !is_tab_hidden(target_tab)) {
 			set_current_tab(target_tab);
 			return true;
 		}
@@ -1094,6 +1094,23 @@ void TabBar::remove_tab(int p_idx) {
 		max_drawn_tab = 0;
 		previous = 0;
 	} else {
+		// Try to change to a valid tab if possible (without firing the `tab_selected` signal).
+		for (int i = current; i < tabs.size(); i++) {
+			if (!is_tab_disabled(i) && !is_tab_hidden(i)) {
+				current = i;
+				break;
+			}
+		}
+		// If nothing, try backwards.
+		if (is_tab_disabled(current) || is_tab_hidden(current)) {
+			for (int i = current - 1; i >= 0; i--) {
+				if (!is_tab_disabled(i) && !is_tab_hidden(i)) {
+					current = i;
+					break;
+				}
+			}
+		}
+
 		offset = MIN(offset, tabs.size() - 1);
 		max_drawn_tab = MIN(max_drawn_tab, tabs.size() - 1);
 


### PR DESCRIPTION
Currently, if a tab is removed from `TabBar/Container`, it will change to the tab that has replaced the previous index, even if the tab is disabled/hidden. This PR now makes it try to pick an active tab first, and only falling back to them if no valid one was found.

This PR also fixes a bug with the `select_*_available()` methods selecting hidden tabs.