### PR TITLE
Fix freeze when requesting clipboard image from our own window

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -672,7 +672,7 @@ Atom DisplayServerX11::_clipboard_get_image_target(Atom p_source, Window x11_win
 	unsigned long atom_count = 0;
 
 	Window selection_owner = XGetSelectionOwner(x11_display, p_source);
-	if (selection_owner != None) {
+	if (selection_owner != None && selection_owner != x11_window) {
 		// Block events polling while processing selection events.
 		MutexLock mutex_lock(events_mutex);
 
@@ -783,7 +783,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 
 	Window selection_owner = XGetSelectionOwner(x11_display, clipboard);
 
-	if (selection_owner != None) {
+	if (selection_owner != None && selection_owner != x11_window) {
 		// Block events polling while processing selection events.
 		MutexLock mutex_lock(events_mutex);
 


### PR DESCRIPTION
Fixes #83949.
When requesting clipboard contents from the current window, the `SelectionNotify` event is never received, which causes a freeze. I'm not sure if that's expected X11 behavior or a bug in the selection logic. Either way, the text clipboard avoids this problem by handling the request without involving the X11 clipboard system, so here I've done something similar. Since we don't support putting images on the clipboard (yet 🤞), I just early-exit in the selection logic.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
