### PR TITLE
Add method check for `_notify_skeleton_bones_renamed`.

### DIFF
--- a/editor/import/post_import_plugin_skeleton_renamer.cpp
+++ b/editor/import/post_import_plugin_skeleton_renamer.cpp
@@ -31,6 +31,7 @@
 #include "post_import_plugin_skeleton_renamer.h"
 
 #include "editor/import/scene_import_settings.h"
+#include "scene/3d/bone_attachment_3d.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/animation/animation_player.h"
@@ -119,19 +120,17 @@ void PostImportPluginSkeletonRenamer::_internal_process(InternalImportCategory p
 
 	// Rename bones in all Nodes by calling method.
 	{
-		Array vargs;
-		vargs.push_back(p_base_scene);
-		vargs.push_back(skeleton);
 		Dictionary rename_map_dict;
 		for (HashMap<String, String>::Iterator E = p_rename_map.begin(); E; ++E) {
 			rename_map_dict[E->key] = E->value;
 		}
-		vargs.push_back(rename_map_dict);
 
-		TypedArray<Node> nodes = p_base_scene->find_children("*");
+		TypedArray<Node> nodes = p_base_scene->find_children("*", "BoneAttachment3D");
 		while (nodes.size()) {
-			Node *nd = Object::cast_to<Node>(nodes.pop_back());
-			nd->callv("_notify_skeleton_bones_renamed", vargs);
+			BoneAttachment3D *attachment = Object::cast_to<BoneAttachment3D>(nodes.pop_back());
+			if (attachment) {
+				attachment->notify_skeleton_bones_renamed(p_base_scene, skeleton, rename_map_dict);
+			}
 		}
 	}
 }

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -333,7 +333,7 @@ void BoneAttachment3D::on_bone_pose_update(int p_bone_index) {
 	}
 }
 #ifdef TOOLS_ENABLED
-void BoneAttachment3D::_notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map) {
+void BoneAttachment3D::notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map) {
 	const Skeleton3D *parent = nullptr;
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_valid()) {
@@ -370,9 +370,6 @@ void BoneAttachment3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_use_external_skeleton"), &BoneAttachment3D::get_use_external_skeleton);
 	ClassDB::bind_method(D_METHOD("set_external_skeleton", "external_skeleton"), &BoneAttachment3D::set_external_skeleton);
 	ClassDB::bind_method(D_METHOD("get_external_skeleton"), &BoneAttachment3D::get_external_skeleton);
-#ifdef TOOLS_ENABLED
-	ClassDB::bind_method(D_METHOD("_notify_skeleton_bones_renamed"), &BoneAttachment3D::_notify_skeleton_bones_renamed);
-#endif // TOOLS_ENABLED
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -65,11 +65,12 @@ protected:
 	void _notification(int p_what);
 
 	static void _bind_methods();
-#ifdef TOOLS_ENABLED
-	virtual void _notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map);
-#endif // TOOLS_ENABLED
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual void notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map);
+#endif // TOOLS_ENABLED
+
 	virtual PackedStringArray get_configuration_warnings() const override;
 
 	void set_bone_name(const String &p_name);


### PR DESCRIPTION
Adds check for existence of _notify_skeleton_bones_renamed method when walking nodes in PostImportPluginSkeletonRenamer. Silences errors and closes https://github.com/godotengine/godot/issues/83148