### PR TITLE
[macOS] Add default Window and Help menus, allow special menu customization.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -235,6 +235,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -258,6 +261,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -281,6 +287,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -305,6 +314,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -327,6 +339,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -353,6 +368,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -376,6 +394,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -391,6 +412,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -408,6 +432,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -421,6 +448,9 @@
 				[codeblock]
 				"_main" - Main menu (macOS).
 				"_dock" - Dock popup menu (macOS).
+				"_apple" - Apple menu (macOS, custom items added before "Services").
+				"_window" - Window menu (macOS, custom items added after "Bring All to Front").
+				"_help" - Help menu (macOS).
 				[/codeblock]
 			</description>
 		</method>
@@ -546,6 +576,13 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the tooltip associated with the specified index [param idx].
+				[b]Note:[/b] This method is implemented only on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_system_menu_roots" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns Dictionary of supported system menu IDs and names.
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -346,6 +346,12 @@
 				Returns [code]true[/code] if the specified item's shortcut is disabled.
 			</description>
 		</method>
+		<method name="is_system_menu" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the menu is bound to the special system menu.
+			</description>
+		</method>
 		<method name="remove_item">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
@@ -565,6 +571,9 @@
 		</member>
 		<member name="submenu_popup_delay" type="float" setter="set_submenu_popup_delay" getter="get_submenu_popup_delay" default="0.3">
 			Sets the delay time in seconds for the submenu item to popup on mouse hovering. If the popup menu is added as a child of another (acting as a submenu), it will inherit the delay time of the parent menu item.
+		</member>
+		<member name="system_menu_root" type="String" setter="set_system_menu_root" getter="get_system_menu_root" default="&quot;&quot;">
+			If set to one of the values returned by [method DisplayServer.global_menu_get_system_menu_roots], this [PopupMenu] is bound to the special system menu. Only one [PopupMenu] can be bound to each special menu at a time.
 		</member>
 	</members>
 	<signals>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7339,6 +7339,20 @@ EditorNode::EditorNode() {
 		file_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/file_quit", TTR("Quit"), KeyModifierMask::CMD_OR_CTRL + Key::Q), FILE_QUIT, true);
 	}
 
+	ED_SHORTCUT_AND_COMMAND("editor/editor_settings", TTR("Editor Settings..."));
+	ED_SHORTCUT_OVERRIDE("editor/editor_settings", "macos", KeyModifierMask::META + Key::COMMA);
+#ifdef MACOS_ENABLED
+	if (global_menu) {
+		apple_menu = memnew(PopupMenu);
+		apple_menu->set_system_menu_root("_apple");
+		main_menu->add_child(apple_menu);
+
+		apple_menu->add_shortcut(ED_GET_SHORTCUT("editor/editor_settings"), SETTINGS_PREFERENCES);
+		apple_menu->add_separator();
+		apple_menu->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
+	}
+#endif
+
 	project_menu = memnew(PopupMenu);
 	project_menu->set_name(TTR("Project"));
 	main_menu->add_child(project_menu);
@@ -7404,9 +7418,13 @@ EditorNode::EditorNode() {
 	settings_menu->set_name(TTR("Editor"));
 	main_menu->add_child(settings_menu);
 
-	ED_SHORTCUT_AND_COMMAND("editor/editor_settings", TTR("Editor Settings..."));
-	ED_SHORTCUT_OVERRIDE("editor/editor_settings", "macos", KeyModifierMask::META + Key::COMMA);
+#ifdef MACOS_ENABLED
+	if (!global_menu) {
+		settings_menu->add_shortcut(ED_GET_SHORTCUT("editor/editor_settings"), SETTINGS_PREFERENCES);
+	}
+#else
 	settings_menu->add_shortcut(ED_GET_SHORTCUT("editor/editor_settings"), SETTINGS_PREFERENCES);
+#endif
 	settings_menu->add_shortcut(ED_SHORTCUT("editor/command_palette", TTR("Command Palette..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::P), HELP_COMMAND_PALETTE);
 	settings_menu->add_separator();
 
@@ -7453,6 +7471,7 @@ EditorNode::EditorNode() {
 
 	help_menu = memnew(PopupMenu);
 	help_menu->set_name(TTR("Help"));
+	help_menu->set_system_menu_root("_help");
 	main_menu->add_child(help_menu);
 
 	help_menu->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -346,6 +346,7 @@ private:
 	EditorRunBar *project_run_bar = nullptr;
 	VBoxContainer *main_screen_vbox = nullptr;
 	MenuBar *main_menu = nullptr;
+	PopupMenu *apple_menu = nullptr;
 	PopupMenu *file_menu = nullptr;
 	PopupMenu *project_menu = nullptr;
 	PopupMenu *debug_menu = nullptr;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -140,6 +140,8 @@ private:
 	String rendering_driver;
 
 	NSMenu *apple_menu = nullptr;
+	NSMenu *window_menu = nullptr;
+	NSMenu *help_menu = nullptr;
 	NSMenu *dock_menu = nullptr;
 	struct MenuData {
 		Callable open;
@@ -226,7 +228,8 @@ private:
 
 	static NSCursor *_cursor_from_selector(SEL p_selector, SEL p_fallback = nil);
 
-	bool _has_help_menu() const;
+	int _get_system_menu_start(const NSMenu *p_menu) const;
+	int _get_system_menu_count(const NSMenu *p_menu) const;
 	NSMenuItem *_menu_add_item(const String &p_menu_root, const String &p_label, Key p_accel, int p_index, int *r_out);
 
 public:
@@ -320,6 +323,8 @@ public:
 
 	virtual void global_menu_remove_item(const String &p_menu_root, int p_idx) override;
 	virtual void global_menu_clear(const String &p_menu_root) override;
+
+	virtual Dictionary global_menu_get_system_menu_roots() const override;
 
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -249,11 +249,13 @@ String MenuBar::bind_global_menu() {
 	Vector<PopupMenu *> popups = _get_popups();
 	for (int i = 0; i < menu_cache.size(); i++) {
 		String submenu_name = popups[i]->bind_global_menu();
-		int index = ds->global_menu_add_submenu_item("_main", menu_cache[i].name, submenu_name, global_start_idx + i);
-		ds->global_menu_set_item_tag("_main", index, global_menu_name + "#" + itos(i));
-		ds->global_menu_set_item_hidden("_main", index, menu_cache[i].hidden);
-		ds->global_menu_set_item_disabled("_main", index, menu_cache[i].disabled);
-		ds->global_menu_set_item_tooltip("_main", index, menu_cache[i].tooltip);
+		if (!popups[i]->is_system_menu()) {
+			int index = ds->global_menu_add_submenu_item("_main", menu_cache[i].name, submenu_name, global_start_idx + i);
+			ds->global_menu_set_item_tag("_main", index, global_menu_name + "#" + itos(i));
+			ds->global_menu_set_item_hidden("_main", index, menu_cache[i].hidden);
+			ds->global_menu_set_item_disabled("_main", index, menu_cache[i].disabled);
+			ds->global_menu_set_item_tooltip("_main", index, menu_cache[i].tooltip);
+		}
 	}
 
 	return global_menu_name;
@@ -268,8 +270,10 @@ void MenuBar::unbind_global_menu() {
 	int global_start = _find_global_start_index();
 	Vector<PopupMenu *> popups = _get_popups();
 	for (int i = menu_cache.size() - 1; i >= 0; i--) {
-		popups[i]->unbind_global_menu();
-		ds->global_menu_remove_item("_main", global_start + i);
+		if (!popups[i]->is_system_menu()) {
+			popups[i]->unbind_global_menu();
+			ds->global_menu_remove_item("_main", global_start + i);
+		}
 	}
 
 	global_menu_name = String();
@@ -558,8 +562,10 @@ void MenuBar::add_child_notify(Node *p_child) {
 
 	if (!global_menu_name.is_empty()) {
 		String submenu_name = pm->bind_global_menu();
-		int index = DisplayServer::get_singleton()->global_menu_add_submenu_item("_main", atr(menu.name), submenu_name, _find_global_start_index() + menu_cache.size() - 1);
-		DisplayServer::get_singleton()->global_menu_set_item_tag("_main", index, global_menu_name + "#" + itos(menu_cache.size() - 1));
+		if (!pm->is_system_menu()) {
+			int index = DisplayServer::get_singleton()->global_menu_add_submenu_item("_main", atr(menu.name), submenu_name, _find_global_start_index() + menu_cache.size() - 1);
+			DisplayServer::get_singleton()->global_menu_set_item_tag("_main", index, global_menu_name + "#" + itos(menu_cache.size() - 1));
+		}
 	}
 	update_minimum_size();
 }
@@ -587,14 +593,16 @@ void MenuBar::move_child_notify(Node *p_child) {
 	menu_cache.insert(new_idx, menu);
 
 	if (!global_menu_name.is_empty()) {
-		int global_start = _find_global_start_index();
-		if (old_idx != -1) {
-			DisplayServer::get_singleton()->global_menu_remove_item("_main", global_start + old_idx);
-		}
-		if (new_idx != -1) {
-			String submenu_name = pm->bind_global_menu();
-			int index = DisplayServer::get_singleton()->global_menu_add_submenu_item("_main", atr(menu.name), submenu_name, global_start + new_idx);
-			DisplayServer::get_singleton()->global_menu_set_item_tag("_main", index, global_menu_name + "#" + itos(new_idx));
+		if (!pm->is_system_menu()) {
+			int global_start = _find_global_start_index();
+			if (old_idx != -1) {
+				DisplayServer::get_singleton()->global_menu_remove_item("_main", global_start + old_idx);
+			}
+			if (new_idx != -1) {
+				String submenu_name = pm->bind_global_menu();
+				int index = DisplayServer::get_singleton()->global_menu_add_submenu_item("_main", atr(menu.name), submenu_name, global_start + new_idx);
+				DisplayServer::get_singleton()->global_menu_set_item_tag("_main", index, global_menu_name + "#" + itos(new_idx));
+			}
 		}
 	}
 }
@@ -612,8 +620,10 @@ void MenuBar::remove_child_notify(Node *p_child) {
 	menu_cache.remove_at(idx);
 
 	if (!global_menu_name.is_empty()) {
-		pm->unbind_global_menu();
-		DisplayServer::get_singleton()->global_menu_remove_item("_main", _find_global_start_index() + idx);
+		if (!pm->is_system_menu()) {
+			pm->unbind_global_menu();
+			DisplayServer::get_singleton()->global_menu_remove_item("_main", _find_global_start_index() + idx);
+		}
 	}
 
 	p_child->remove_meta("_menu_name");

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -40,6 +40,8 @@
 #include "scene/gui/menu_bar.h"
 #include "scene/theme/theme_db.h"
 
+HashMap<String, PopupMenu *> PopupMenu::system_menus;
+
 String PopupMenu::bind_global_menu() {
 #ifdef TOOLS_ENABLED
 	if (is_part_of_edited_scene()) {
@@ -54,8 +56,20 @@ String PopupMenu::bind_global_menu() {
 		return global_menu_name; // Already bound;
 	}
 
-	DisplayServer *ds = DisplayServer::get_singleton();
 	global_menu_name = "__PopupMenu#" + itos(get_instance_id());
+	if (system_menu_name.length() > 0) {
+		if (system_menus.has(system_menu_name)) {
+			WARN_PRINT(vformat("Attempting to bind PopupMenu to the special menu %s, but another menu is already bound to it. This menu: %s, current menu: %s", system_menu_name, this->get_description(), system_menus[system_menu_name]->get_description()));
+		} else {
+			const Dictionary &supported_special_names = DisplayServer::get_singleton()->global_menu_get_system_menu_roots();
+			if (supported_special_names.has(system_menu_name)) {
+				system_menus[system_menu_name] = this;
+				global_menu_name = system_menu_name;
+			}
+		}
+	}
+
+	DisplayServer *ds = DisplayServer::get_singleton();
 	ds->global_menu_set_popup_callbacks(global_menu_name, callable_mp(this, &PopupMenu::_about_to_popup), callable_mp(this, &PopupMenu::_about_to_close));
 	for (int i = 0; i < items.size(); i++) {
 		Item &item = items.write[i];
@@ -105,6 +119,10 @@ void PopupMenu::unbind_global_menu() {
 		return;
 	}
 
+	if (global_menu_name == system_menu_name && system_menus[system_menu_name] == this) {
+		system_menus.erase(system_menu_name);
+	}
+
 	for (int i = 0; i < items.size(); i++) {
 		Item &item = items.write[i];
 		if (!item.submenu.is_empty()) {
@@ -118,6 +136,24 @@ void PopupMenu::unbind_global_menu() {
 	DisplayServer::get_singleton()->global_menu_clear(global_menu_name);
 
 	global_menu_name = String();
+}
+
+bool PopupMenu::is_system_menu() const {
+	return (global_menu_name == system_menu_name) && (system_menu_name.length() > 0);
+}
+
+void PopupMenu::set_system_menu_root(const String &p_special) {
+	if (is_inside_tree() && system_menu_name.length() > 0) {
+		unbind_global_menu();
+	}
+	system_menu_name = p_special;
+	if (is_inside_tree() && system_menu_name.length() > 0) {
+		bind_global_menu();
+	}
+}
+
+String PopupMenu::get_system_menu_root() const {
+	return system_menu_name;
 }
 
 String PopupMenu::_get_accel_text(const Item &p_item) const {
@@ -946,6 +982,15 @@ void PopupMenu::_notification(int p_what) {
 			}
 			if (!is_embedded()) {
 				set_flag(FLAG_NO_FOCUS, true);
+			}
+			if (system_menu_name.length() > 0) {
+				bind_global_menu();
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (system_menu_name.length() > 0) {
+				unbind_global_menu();
 			}
 		} break;
 
@@ -2716,11 +2761,16 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_search", "allow"), &PopupMenu::set_allow_search);
 	ClassDB::bind_method(D_METHOD("get_allow_search"), &PopupMenu::get_allow_search);
 
+	ClassDB::bind_method(D_METHOD("is_system_menu"), &PopupMenu::is_system_menu);
+	ClassDB::bind_method(D_METHOD("set_system_menu_root", "special"), &PopupMenu::set_system_menu_root);
+	ClassDB::bind_method(D_METHOD("get_system_menu_root"), &PopupMenu::get_system_menu_root);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_item_selection"), "set_hide_on_item_selection", "is_hide_on_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_checkable_item_selection"), "set_hide_on_checkable_item_selection", "is_hide_on_checkable_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_state_item_selection"), "set_hide_on_state_item_selection", "is_hide_on_state_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "submenu_popup_delay", PROPERTY_HINT_NONE, "suffix:s"), "set_submenu_popup_delay", "get_submenu_popup_delay");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_search"), "set_allow_search", "get_allow_search");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "system_menu_root", PROPERTY_HINT_ENUM, "Dock (macOS):_dock,Apple Menu(macOS):_apple,Window Menu(macOS):_window,Help Menu(macOS):_help"), "set_system_menu_root", "get_system_menu_root");
 
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "item_");
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -40,6 +40,8 @@
 class PopupMenu : public Popup {
 	GDCLASS(PopupMenu, Popup);
 
+	static HashMap<String, PopupMenu *> system_menus;
+
 	struct Item {
 		Ref<Texture2D> icon;
 		int icon_max_width = 0;
@@ -90,6 +92,7 @@ class PopupMenu : public Popup {
 	};
 
 	String global_menu_name;
+	String system_menu_name;
 
 	bool close_allowed = false;
 	bool activated_by_keyboard = false;
@@ -218,6 +221,9 @@ public:
 
 	String bind_global_menu();
 	void unbind_global_menu();
+	bool is_system_menu() const;
+	void set_system_menu_root(const String &p_special);
+	String get_system_menu_root() const;
 
 	void add_item(const String &p_label, int p_id = -1, Key p_accel = Key::NONE);
 	void add_icon_item(const Ref<Texture2D> &p_icon, const String &p_label, int p_id = -1, Key p_accel = Key::NONE);

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -267,6 +267,11 @@ void DisplayServer::global_menu_clear(const String &p_menu_root) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
+Dictionary DisplayServer::global_menu_get_system_menu_roots() const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return Dictionary();
+}
+
 bool DisplayServer::tts_is_speaking() const {
 	WARN_PRINT("TTS is not supported by this display server.");
 	return false;
@@ -651,6 +656,8 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("global_menu_remove_item", "menu_root", "idx"), &DisplayServer::global_menu_remove_item);
 	ClassDB::bind_method(D_METHOD("global_menu_clear", "menu_root"), &DisplayServer::global_menu_clear);
+
+	ClassDB::bind_method(D_METHOD("global_menu_get_system_menu_roots"), &DisplayServer::global_menu_get_system_menu_roots);
 
 	ClassDB::bind_method(D_METHOD("tts_is_speaking"), &DisplayServer::tts_is_speaking);
 	ClassDB::bind_method(D_METHOD("tts_is_paused"), &DisplayServer::tts_is_paused);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -185,6 +185,8 @@ public:
 	virtual void global_menu_remove_item(const String &p_menu_root, int p_idx);
 	virtual void global_menu_clear(const String &p_menu_root);
 
+	virtual Dictionary global_menu_get_system_menu_roots() const;
+
 	struct TTSUtterance {
 		String text;
 		String voice;


### PR DESCRIPTION
More customizable version of https://github.com/godotengine/godot/pull/83408

- Adds default `Window` and `Help` (for use in conjunction with https://github.com/godotengine/godot/pull/83819) menu.
- Allow adding custom items to the `Apple`, `Window` and `Help`.
- Move `Editor Settings` to the `Apple` menu (where settings option usually is on macOS).

___

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8500.*