### PR TITLE
Fix macOS and Windows build with statically linked ANGLE/EGL.

### DIFF
--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -34,6 +34,7 @@
 
 #if defined(EGL_STATIC)
 #define KHRONOS_STATIC 1
+#define GLAD_EGL_VERSION_1_5 true
 extern "C" EGLAPI void EGLAPIENTRY eglSetBlobCacheFuncsANDROID(EGLDisplay dpy, EGLSetBlobFuncANDROID set, EGLGetBlobFuncANDROID get);
 #undef KHRONOS_STATIC
 #endif


### PR DESCRIPTION
Fixes macOS and Windows build after https://github.com/godotengine/godot/pull/83930, static ANGLE always include EGL 1.5 and does not use GLAD to load it therefore `GLAD_EGL_VERSION_1_5` is undefined.
