### PR TITLE
SCons: Reduce and cleanup verbose output for SCU builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -565,7 +565,7 @@ if selected_platform in platform_list:
         if read_scu_limit != 0:
             max_includes_per_scu = read_scu_limit
 
-        methods.set_scu_folders(scu_builders.generate_scu_files(env["verbose"], max_includes_per_scu))
+        methods.set_scu_folders(scu_builders.generate_scu_files(max_includes_per_scu))
 
     # Must happen after the flags' definition, as configure is when most flags
     # are actually handled to change compile options, etc.

--- a/methods.py
+++ b/methods.py
@@ -96,9 +96,6 @@ def add_source_files_scu(self, sources, files, allow_gen=False):
         if section_name not in (_scu_folders):
             return False
 
-        if self["verbose"]:
-            print("SCU building " + section_name)
-
         # Add all the gen.cpp files in the SCU directory
         add_source_files_orig(self, sources, subdir + "scu/scu_*.gen.cpp", True)
         return True

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -7,7 +7,7 @@ from os.path import normpath, basename
 
 base_folder_path = str(Path(__file__).parent) + "/"
 base_folder_only = os.path.basename(os.path.normpath(base_folder_path))
-_verbose = False
+_verbose = True  # Set manually for debug prints
 _scu_folders = set()
 _max_includes_per_scu = 1024
 
@@ -35,7 +35,7 @@ def find_files_in_folder(folder, sub_folder, include_list, extension, sought_exc
     abs_folder = base_folder_path + folder + "/" + sub_folder
 
     if not os.path.isdir(abs_folder):
-        print("ERROR " + abs_folder + " not found.")
+        print("SCU: ERROR: %s not found." % abs_folder)
         return include_list, found_exceptions
 
     os.chdir(abs_folder)
@@ -67,9 +67,10 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
         # create
         os.mkdir(output_folder)
         if not os.path.isdir(output_folder):
-            print("ERROR " + output_folder + " could not be created.")
+            print("SCU: ERROR: %s could not be created." % output_folder)
             return
-        print("CREATING folder " + output_folder)
+        if _verbose:
+            print("SCU: Creating folder: %s" % output_folder)
 
     file_text = ""
 
@@ -79,8 +80,6 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
             li = line + "\n"
             file_text += li
 
-    # print(file_text)
-
     num_string = ""
     if file_count > 0:
         num_string = "_" + str(file_count)
@@ -88,7 +87,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
     short_filename = output_filename_prefix + num_string + ".gen." + extension
     output_filename = output_folder + "/" + short_filename
     if _verbose:
-        print("generating: " + short_filename)
+        print("SCU: Generating: %s" % short_filename)
 
     output_path = Path(output_filename)
     output_path.write_text(file_text, encoding="utf8")
@@ -97,7 +96,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
 def write_exception_output_file(file_count, exception_string, output_folder, output_filename_prefix, extension):
     output_folder = os.path.abspath(output_folder)
     if not os.path.isdir(output_folder):
-        print("ERROR " + output_folder + " does not exist.")
+        print("SCU: ERROR: %s does not exist." % output_folder)
         return
 
     file_text = exception_string + "\n"
@@ -110,10 +109,8 @@ def write_exception_output_file(file_count, exception_string, output_folder, out
     output_filename = output_folder + "/" + short_filename
 
     if _verbose:
-        print("generating: " + short_filename)
+        print("SCU: Generating: " + short_filename)
 
-    # print("text: " + file_text)
-    # return
     output_path = Path(output_filename)
     output_path.write_text(file_text, encoding="utf8")
 
@@ -242,15 +239,15 @@ def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension=
         )
 
 
-def generate_scu_files(verbose, max_includes_per_scu):
+def generate_scu_files(max_includes_per_scu):
     print("=============================")
     print("Single Compilation Unit Build")
     print("=============================")
-    global _verbose
-    _verbose = verbose
+
     global _max_includes_per_scu
     _max_includes_per_scu = max_includes_per_scu
-    print("Generating SCU build files... (max includes per scu " + str(_max_includes_per_scu) + ")")
+
+    print("SCU: Generating build files... (max includes per SCU: %d)" % _max_includes_per_scu)
 
     curr_folder = os.path.abspath("./")
 
@@ -333,5 +330,8 @@ def generate_scu_files(verbose, max_includes_per_scu):
 
     # Finally change back the path to the calling folder
     os.chdir(curr_folder)
+
+    if _verbose:
+        print("SCU: Processed folders: %s" % sorted(_scu_folders))
 
     return _scu_folders


### PR DESCRIPTION
Verbose output is meant for debugging the SCU mode itself and can be triggered by changing the `_verbose` bool manually.

Prefix all prints with "SCU:" for context, and print the processed folders all at once instead of when adding the sources.

<details>
<summary>Build outputs before and after the PR</summary>

`scons verbose=yes` null build before the PR:

```
pyston-scons -j7 p=linuxbsd dev_build=yes dev_mode=yes linker=mold scu_build=all 2>&1 | tee -a build.log
scons: Reading SConscript files ...
=============================
Single Compilation Unit Build
=============================
Generating SCU build files... (max includes per scu 1024)
generating: scu_core.gen.cpp
generating: scu_core_crypto.gen.cpp
generating: scu_core_debugger.gen.cpp
generating: scu_core_extension.gen.cpp
generating: scu_core_input.gen.cpp
generating: scu_core_io.gen.cpp
generating: scu_core_math.gen.cpp
generating: scu_core_object.gen.cpp
generating: scu_core_os.gen.cpp
generating: scu_core_string.gen.cpp
generating: scu_core_variant.gen.cpp
generating: scu_core_variant_exception.gen.cpp
generating: scu_drivers_unix.gen.cpp
generating: scu_drivers_png.gen.cpp
generating: scu_editor.gen.cpp
generating: scu_editor_1.gen.cpp
generating: scu_editor_2.gen.cpp
generating: scu_editor_exception.gen.cpp
generating: scu_editor_debugger.gen.cpp
generating: scu_editor_debugger_debug_adapter.gen.cpp
generating: scu_editor_export.gen.cpp
generating: scu_editor_gui.gen.cpp
generating: scu_editor_import.gen.cpp
generating: scu_editor_plugins.gen.cpp
generating: scu_editor_plugins_gizmos.gen.cpp
generating: scu_editor_plugins_tiles.gen.cpp
generating: scu_platform_android_export.gen.cpp
generating: scu_platform_ios_export.gen.cpp
generating: scu_platform_linuxbsd_export.gen.cpp
generating: scu_platform_macos_export.gen.cpp
generating: scu_platform_web_export.gen.cpp
generating: scu_platform_windows_export.gen.cpp
generating: scu_modules_gltf.gen.cpp
generating: scu_modules_gltf_structures.gen.cpp
generating: scu_modules_gltf_editor.gen.cpp
generating: scu_modules_gltf_extensions.gen.cpp
generating: scu_modules_gltf_extensions_physics.gen.cpp
generating: scu_modules_navigation.gen.cpp
generating: scu_modules_webrtc.gen.cpp
generating: scu_modules_websocket.gen.cpp
generating: scu_modules_gridmap.gen.cpp
generating: scu_modules_multiplayer.gen.cpp
generating: scu_modules_multiplayer_editor.gen.cpp
generating: scu_modules_openxr.gen.cpp
generating: scu_modules_openxr_exception.gen.cpp
generating: scu_modules_openxr_action_map.gen.cpp
generating: scu_modules_openxr_editor.gen.cpp
generating: scu_modules_csg.gen.cpp
generating: scu_modules_gdscript.gen.cpp
generating: scu_modules_gdscript_editor.gen.cpp
generating: scu_modules_gdscript_language_server.gen.cpp
generating: scu_scene_2d.gen.cpp
generating: scu_scene_3d.gen.cpp
generating: scu_scene_animation.gen.cpp
generating: scu_scene_gui.gen.cpp
generating: scu_scene_main.gen.cpp
generating: scu_scene_resources.gen.cpp
generating: scu_servers.gen.cpp
generating: scu_servers_rendering.gen.cpp
generating: scu_servers_rendering_storage.gen.cpp
generating: scu_servers_rendering_renderer_rd.gen.cpp
generating: scu_servers_rendering_renderer_rd_effects.gen.cpp
generating: scu_servers_rendering_renderer_rd_environment.gen.cpp
generating: scu_servers_rendering_renderer_rd_storage_rd.gen.cpp
generating: scu_servers_physics_2d.gen.cpp
generating: scu_servers_physics_3d.gen.cpp
generating: scu_servers_physics_3d_joints.gen.cpp
generating: scu_servers_audio.gen.cpp
generating: scu_servers_audio_effects.gen.cpp
Using linker program: mold
Building for platform "linuxbsd", architecture "x86_64", target "editor".
NOTE: Developer build, with debug optimization level and debug symbols (unless overridden).
SCU building core
SCU building core/os
SCU building core/math
SCU building core/crypto
SCU building core/io
SCU building core/debugger
SCU building core/input
SCU building core/variant
SCU building core/extension
SCU building core/object
SCU building core/string
SCU building servers
SCU building servers/physics_3d
SCU building servers/physics_3d/joints
SCU building servers/physics_2d
SCU building servers/rendering
SCU building servers/rendering/renderer_rd
SCU building servers/rendering/renderer_rd/effects
SCU building servers/rendering/renderer_rd/environment
SCU building servers/rendering/renderer_rd/storage_rd
SCU building servers/rendering/storage
SCU building servers/audio
SCU building servers/audio/effects
SCU building scene/main
SCU building scene/gui
SCU building scene/3d
SCU building scene/2d
SCU building scene/animation
SCU building scene/resources
SCU building platform/android/export
SCU building platform/ios/export
SCU building platform/linuxbsd/export
SCU building platform/macos/export
SCU building platform/web/export
SCU building platform/windows/export
SCU building editor
SCU building editor/debugger
SCU building editor/debugger/debug_adapter
SCU building editor/export
SCU building editor/gui
SCU building editor/import
SCU building editor/plugins
SCU building editor/plugins/gizmos
SCU building editor/plugins/tiles
SCU building drivers/unix
SCU building drivers/png
SCU building modules/websocket
SCU building modules/webrtc
SCU building modules/openxr
SCU building modules/openxr/action_map
SCU building modules/openxr/editor
SCU building modules/navigation
SCU building modules/multiplayer
SCU building modules/multiplayer/editor
SCU building modules/gridmap
SCU building modules/gltf
SCU building modules/gltf/structures
SCU building modules/gltf/extensions
SCU building modules/gltf/extensions/physics
SCU building modules/gltf/editor
SCU building modules/gdscript
SCU building modules/gdscript/editor
SCU building modules/gdscript/language_server
SCU building modules/csg
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
progress_finish(["progress_finish"], [])
scons: done building targets.
[Time elapsed: 00:00:03.983]
```

`scons verbose=yes` null build with this PR:

```
$ gobuild_linux
pyston-scons -j7 p=linuxbsd dev_build=yes dev_mode=yes linker=mold scu_build=all 2>&1 | tee -a build.log
scons: Reading SConscript files ...
Single Compilation Unit mode enabled.
SCU: Generating build files... (max includes per SCU: 1024)
Using linker program: mold
Building for platform "linuxbsd", architecture "x86_64", target "editor".
NOTE: Developer build, with debug optimization level and debug symbols (unless overridden).
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
progress_finish(["progress_finish"], [])
scons: done building targets.
[Time elapsed: 00:00:03.933]
```

`scons verbose=yes` null build with the `_verbose` flag enabled manually in `scu_builders.py`, for debugging:

```
$ gobuild_linux
pyston-scons -j7 p=linuxbsd dev_build=yes dev_mode=yes linker=mold scu_build=all 2>&1 | tee -a build.log
scons: Reading SConscript files ...
Single Compilation Unit mode enabled.
SCU: Generating build files... (max includes per SCU: 1024)
SCU: Generating: scu_core.gen.cpp
SCU: Generating: scu_core_crypto.gen.cpp
SCU: Generating: scu_core_debugger.gen.cpp
SCU: Generating: scu_core_extension.gen.cpp
SCU: Generating: scu_core_input.gen.cpp
SCU: Generating: scu_core_io.gen.cpp
SCU: Generating: scu_core_math.gen.cpp
SCU: Generating: scu_core_object.gen.cpp
SCU: Generating: scu_core_os.gen.cpp
SCU: Generating: scu_core_string.gen.cpp
SCU: Generating: scu_core_variant.gen.cpp
SCU: Generating: scu_core_variant_exception.gen.cpp
SCU: Generating: scu_drivers_unix.gen.cpp
SCU: Generating: scu_drivers_png.gen.cpp
SCU: Generating: scu_editor.gen.cpp
SCU: Generating: scu_editor_1.gen.cpp
SCU: Generating: scu_editor_2.gen.cpp
SCU: Generating: scu_editor_exception.gen.cpp
SCU: Generating: scu_editor_debugger.gen.cpp
SCU: Generating: scu_editor_debugger_debug_adapter.gen.cpp
SCU: Generating: scu_editor_export.gen.cpp
SCU: Generating: scu_editor_gui.gen.cpp
SCU: Generating: scu_editor_import.gen.cpp
SCU: Generating: scu_editor_plugins.gen.cpp
SCU: Generating: scu_editor_plugins_gizmos.gen.cpp
SCU: Generating: scu_editor_plugins_tiles.gen.cpp
SCU: Generating: scu_platform_android_export.gen.cpp
SCU: Generating: scu_platform_ios_export.gen.cpp
SCU: Generating: scu_platform_linuxbsd_export.gen.cpp
SCU: Generating: scu_platform_macos_export.gen.cpp
SCU: Generating: scu_platform_web_export.gen.cpp
SCU: Generating: scu_platform_windows_export.gen.cpp
SCU: Generating: scu_modules_gltf.gen.cpp
SCU: Generating: scu_modules_gltf_structures.gen.cpp
SCU: Generating: scu_modules_gltf_editor.gen.cpp
SCU: Generating: scu_modules_gltf_extensions.gen.cpp
SCU: Generating: scu_modules_gltf_extensions_physics.gen.cpp
SCU: Generating: scu_modules_navigation.gen.cpp
SCU: Generating: scu_modules_webrtc.gen.cpp
SCU: Generating: scu_modules_websocket.gen.cpp
SCU: Generating: scu_modules_gridmap.gen.cpp
SCU: Generating: scu_modules_multiplayer.gen.cpp
SCU: Generating: scu_modules_multiplayer_editor.gen.cpp
SCU: Generating: scu_modules_openxr.gen.cpp
SCU: Generating: scu_modules_openxr_exception.gen.cpp
SCU: Generating: scu_modules_openxr_action_map.gen.cpp
SCU: Generating: scu_modules_openxr_editor.gen.cpp
SCU: Generating: scu_modules_csg.gen.cpp
SCU: Generating: scu_modules_gdscript.gen.cpp
SCU: Generating: scu_modules_gdscript_editor.gen.cpp
SCU: Generating: scu_modules_gdscript_language_server.gen.cpp
SCU: Generating: scu_scene_2d.gen.cpp
SCU: Generating: scu_scene_3d.gen.cpp
SCU: Generating: scu_scene_animation.gen.cpp
SCU: Generating: scu_scene_gui.gen.cpp
SCU: Generating: scu_scene_main.gen.cpp
SCU: Generating: scu_scene_resources.gen.cpp
SCU: Generating: scu_servers.gen.cpp
SCU: Generating: scu_servers_rendering.gen.cpp
SCU: Generating: scu_servers_rendering_storage.gen.cpp
SCU: Generating: scu_servers_rendering_renderer_rd.gen.cpp
SCU: Generating: scu_servers_rendering_renderer_rd_effects.gen.cpp
SCU: Generating: scu_servers_rendering_renderer_rd_environment.gen.cpp
SCU: Generating: scu_servers_rendering_renderer_rd_storage_rd.gen.cpp
SCU: Generating: scu_servers_physics_2d.gen.cpp
SCU: Generating: scu_servers_physics_3d.gen.cpp
SCU: Generating: scu_servers_physics_3d_joints.gen.cpp
SCU: Generating: scu_servers_audio.gen.cpp
SCU: Generating: scu_servers_audio_effects.gen.cpp
SCU: Processed folders: ['core', 'core/crypto', 'core/debugger', 'core/extension', 'core/input', 'core/io', 'core/math', 'core/object', 'core/os', 'core/string', 'core/variant', 'drivers/png', 'drivers/unix', 'editor', 'editor/debugger', 'editor/debugger/debug_adapter', 'editor/export', 'editor/gui', 'editor/import', 'editor/plugins', 'editor/plugins/gizmos', 'editor/plugins/tiles', 'modules/csg', 'modules/gdscript', 'modules/gdscript/editor', 'modules/gdscript/language_server', 'modules/gltf', 'modules/gltf/editor', 'modules/gltf/extensions', 'modules/gltf/extensions/physics', 'modules/gltf/structures', 'modules/gridmap', 'modules/multiplayer', 'modules/multiplayer/editor', 'modules/navigation', 'modules/openxr', 'modules/openxr/action_map', 'modules/openxr/editor', 'modules/webrtc', 'modules/websocket', 'platform/android/export', 'platform/ios/export', 'platform/linuxbsd/export', 'platform/macos/export', 'platform/web/export', 'platform/windows/export', 'scene/2d', 'scene/3d', 'scene/animation', 'scene/gui', 'scene/main', 'scene/resources', 'servers', 'servers/audio', 'servers/audio/effects', 'servers/physics_2d', 'servers/physics_3d', 'servers/physics_3d/joints', 'servers/rendering', 'servers/rendering/renderer_rd', 'servers/rendering/renderer_rd/effects', 'servers/rendering/renderer_rd/environment', 'servers/rendering/renderer_rd/storage_rd', 'servers/rendering/storage']
Using linker program: mold
Building for platform "linuxbsd", architecture "x86_64", target "editor".
NOTE: Developer build, with debug optimization level and debug symbols (unless overridden).
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
progress_finish(["progress_finish"], [])
scons: done building targets.
[Time elapsed: 00:00:03.970]
```

</details>