### PR TITLE
Fix TreeItem truncating node names too much when using a custom icon

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2050,7 +2050,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			int text_width = item_width - theme_cache.inner_item_margin_left - theme_cache.inner_item_margin_right;
 			if (p_item->cells[i].icon.is_valid()) {
-				text_width -= p_item->cells[i].get_icon_size().x + theme_cache.h_separation;
+				text_width -= _get_cell_icon_size(p_item->cells[i]).x + theme_cache.h_separation;
 			}
 
 			p_item->cells.write[i].text_buf->set_width(text_width);


### PR DESCRIPTION
`get_icon_size` returns the size of the `Texture2D` whereas `_get_cell_icon_size` takes into account the max width.

Fixes #83801.