### PR TITLE
Limit custom icons size in various editor widgets

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -37,18 +37,6 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 
-void EditorHelpSearch::_update_icons() {
-	search_box->set_right_icon(results_tree->get_editor_theme_icon(SNAME("Search")));
-	search_box->set_clear_button_enabled(true);
-	search_box->add_theme_icon_override("right_icon", results_tree->get_editor_theme_icon(SNAME("Search")));
-	case_sensitive_button->set_icon(results_tree->get_editor_theme_icon(SNAME("MatchCase")));
-	hierarchy_button->set_icon(results_tree->get_editor_theme_icon(SNAME("ClassList")));
-
-	if (is_visible()) {
-		_update_results();
-	}
-}
-
 void EditorHelpSearch::_update_results() {
 	String term = search_box->get_text();
 
@@ -114,16 +102,24 @@ void EditorHelpSearch::_notification(int p_what) {
 			}
 		} break;
 
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			_update_icons();
-		} break;
-
 		case NOTIFICATION_READY: {
 			connect("confirmed", callable_mp(this, &EditorHelpSearch::_confirmed));
 		} break;
 
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			_update_icons();
+			const int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+			results_tree->add_theme_constant_override("icon_max_width", icon_width);
+
+			search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
+			search_box->add_theme_icon_override("right_icon", get_editor_theme_icon(SNAME("Search")));
+
+			case_sensitive_button->set_icon(get_editor_theme_icon(SNAME("MatchCase")));
+			hierarchy_button->set_icon(get_editor_theme_icon(SNAME("ClassList")));
+
+			if (is_visible()) {
+				_update_results();
+			}
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -204,6 +200,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	search_box = memnew(LineEdit);
 	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_clear_button_enabled(true);
 	search_box->connect("gui_input", callable_mp(this, &EditorHelpSearch::_search_box_gui_input));
 	search_box->connect("text_changed", callable_mp(this, &EditorHelpSearch::_search_box_text_changed));
 	register_text_enter(search_box);

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -67,7 +67,6 @@ class EditorHelpSearch : public ConfirmationDialog {
 	class Runner;
 	Ref<Runner> search;
 
-	void _update_icons();
 	void _update_results();
 
 	void _search_box_gui_input(const Ref<InputEvent> &p_event);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -443,6 +443,9 @@ void InspectorDock::_notification(int p_what) {
 				forward_button->set_icon(get_editor_theme_icon(SNAME("Forward")));
 			}
 
+			const int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+			history_menu->get_popup()->add_theme_constant_override("icon_max_width", icon_width);
+
 			history_menu->set_icon(get_editor_theme_icon(SNAME("History")));
 			object_menu->set_icon(get_editor_theme_icon(SNAME("Tools")));
 			search->set_right_icon(get_editor_theme_icon(SNAME("Search")));


### PR DESCRIPTION
Fixed cases reported in https://github.com/godotengine/godot/issues/83801#issuecomment-1781157294 by @chybby.
