### PR TITLE
TTS_Linux: Fix size_t template issue on OpenBSD by using int consistently

### DIFF
--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -82,11 +82,11 @@ void TTS_Linux::speech_init_thread_func(void *p_userdata) {
 void TTS_Linux::speech_event_index_mark(size_t p_msg_id, size_t p_client_id, SPDNotificationType p_type, char *p_index_mark) {
 	TTS_Linux *tts = TTS_Linux::get_singleton();
 	if (tts) {
-		callable_mp(tts, &TTS_Linux::_speech_index_mark).call_deferred(p_msg_id, p_client_id, (int)p_type, String::utf8(p_index_mark));
+		callable_mp(tts, &TTS_Linux::_speech_index_mark).call_deferred((int)p_msg_id, (int)p_type, String::utf8(p_index_mark));
 	}
 }
 
-void TTS_Linux::_speech_index_mark(size_t p_msg_id, size_t p_client_id, int p_type, const String &p_index_mark) {
+void TTS_Linux::_speech_index_mark(int p_msg_id, int p_type, const String &p_index_mark) {
 	_THREAD_SAFE_METHOD_
 
 	if (ids.has(p_msg_id)) {
@@ -97,7 +97,7 @@ void TTS_Linux::_speech_index_mark(size_t p_msg_id, size_t p_client_id, int p_ty
 void TTS_Linux::speech_event_callback(size_t p_msg_id, size_t p_client_id, SPDNotificationType p_type) {
 	TTS_Linux *tts = TTS_Linux::get_singleton();
 	if (tts) {
-		callable_mp(tts, &TTS_Linux::_speech_event).call_deferred(p_msg_id, p_client_id, (int)p_type);
+		callable_mp(tts, &TTS_Linux::_speech_event).call_deferred((int)p_msg_id, (int)p_type);
 	}
 }
 
@@ -119,7 +119,7 @@ void TTS_Linux::_load_voices() {
 	}
 }
 
-void TTS_Linux::_speech_event(size_t p_msg_id, size_t p_client_id, int p_type) {
+void TTS_Linux::_speech_event(int p_msg_id, int p_type) {
 	_THREAD_SAFE_METHOD_
 
 	if (!paused && ids.has(p_msg_id)) {
@@ -226,7 +226,7 @@ void TTS_Linux::speak(const String &p_text, const String &p_voice, int p_volume,
 	if (is_paused()) {
 		resume();
 	} else {
-		_speech_event(0, 0, (int)SPD_EVENT_BEGIN);
+		_speech_event(0, (int)SPD_EVENT_BEGIN);
 	}
 }
 

--- a/platform/linuxbsd/tts_linux.h
+++ b/platform/linuxbsd/tts_linux.h
@@ -72,8 +72,8 @@ class TTS_Linux : public Object {
 
 protected:
 	void _load_voices();
-	void _speech_event(size_t p_msg_id, size_t p_client_id, int p_type);
-	void _speech_index_mark(size_t p_msg_id, size_t p_client_id, int p_type, const String &p_index_mark);
+	void _speech_event(int p_msg_id, int p_type);
+	void _speech_index_mark(int p_msg_id, int p_type, const String &p_index_mark);
 
 public:
 	static TTS_Linux *get_singleton();


### PR DESCRIPTION
This is a follow-up of https://github.com/godotengine/godot/pull/83804. The issue was observed on OpenBSD where compilation failed because of a missing `GetTypeInfo<unsigned long>` template. Using uint64_t for `TTS_Linux::_speech_index_mark()` and `TTS_Linux::_speech_event()` arguments fixes this.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/74669