### PR TITLE
Importer version system for files imported in older Godot versions

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -483,6 +483,14 @@ ResourceFormatImporter::ResourceFormatImporter() {
 
 //////////////
 
+int ResourceImporter::get_importer_version() const {
+	return _importer_version;
+}
+
+void ResourceImporter::set_importer_version(int p_version) {
+	_importer_version = p_version;
+}
+
 void ResourceImporter::_bind_methods() {
 	BIND_ENUM_CONSTANT(IMPORT_ORDER_DEFAULT);
 	BIND_ENUM_CONSTANT(IMPORT_ORDER_SCENE);

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -99,6 +99,8 @@ public:
 class ResourceImporter : public RefCounted {
 	GDCLASS(ResourceImporter, RefCounted);
 
+	int _importer_version = get_latest_importer_version();
+
 protected:
 	static void _bind_methods();
 
@@ -110,7 +112,10 @@ public:
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }
 	virtual int get_import_order() const { return IMPORT_ORDER_DEFAULT; }
-	virtual int get_format_version() const { return 0; }
+	virtual int get_latest_importer_version(const String &p_file_extension = "") const { return 0; }
+
+	int get_importer_version() const;
+	void set_importer_version(int p_version);
 
 	struct ImportOption {
 		PropertyInfo option;

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -532,7 +532,7 @@ String ResourceImporterOBJ::get_resource_type() const {
 	return "Mesh";
 }
 
-int ResourceImporterOBJ::get_format_version() const {
+int ResourceImporterOBJ::get_latest_importer_version(const String &p_file_extension) const {
 	return 1;
 }
 

--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -53,7 +53,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
-	virtual int get_format_version() const override;
+	virtual int get_latest_importer_version(const String &p_file_extension = "") const override;
 
 	virtual int get_preset_count() const override;
 	virtual String get_preset_name(int p_idx) const override;

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -51,6 +51,8 @@ class ImporterMesh;
 class EditorSceneFormatImporter : public RefCounted {
 	GDCLASS(EditorSceneFormatImporter, RefCounted);
 
+	int _importer_version = 1;
+
 protected:
 	static void _bind_methods();
 
@@ -79,6 +81,9 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option, const HashMap<StringName, Variant> &p_options);
+
+	int get_importer_version() const;
+	void set_importer_version(int p_version);
 
 	EditorSceneFormatImporter() {}
 };
@@ -246,6 +251,7 @@ public:
 
 	static void add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority = false);
 	static void remove_importer(Ref<EditorSceneFormatImporter> p_importer);
+	static Ref<EditorSceneFormatImporter> get_scene_importer_for_file_extension(const String &p_file_extension);
 
 	static void clean_up_importer_plugins();
 
@@ -254,7 +260,7 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
-	virtual int get_format_version() const override;
+	virtual int get_latest_importer_version(const String &p_file_extension = "") const override;
 
 	virtual int get_preset_count() const override;
 	virtual String get_preset_name(int p_idx) const override;

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -51,6 +51,7 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	gltf.instantiate();
 	Ref<GLTFState> state;
 	state.instantiate();
+	gltf->set_importer_version(get_importer_version());
 	if (p_options.has("gltf/embedded_image_handling")) {
 		int32_t enum_option = p_options["gltf/embedded_image_handling"];
 		state->set_handle_binary_image(enum_option);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -576,6 +576,9 @@ Error GLTFDocument::_parse_scenes(Ref<GLTFState> p_state) {
 		} else {
 			p_state->scene_name = p_state->filename;
 		}
+		if (_importer_version < 2) {
+			p_state->scene_name = _gen_unique_name(p_state, p_state->scene_name);
+		}
 	}
 
 	return OK;
@@ -3006,6 +3009,14 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 	return OK;
 }
 
+int GLTFDocument::get_importer_version() const {
+	return _importer_version;
+}
+
+void GLTFDocument::set_importer_version(int p_version) {
+	_importer_version = p_version;
+}
+
 void GLTFDocument::set_image_format(const String &p_image_format) {
 	_image_format = p_image_format;
 }
@@ -5341,12 +5352,22 @@ void GLTFDocument::_assign_node_names(Ref<GLTFState> p_state) {
 		}
 		String gltf_node_name = gltf_node->get_name();
 		if (gltf_node_name.is_empty()) {
-			if (gltf_node->mesh >= 0) {
-				gltf_node_name = "Mesh";
-			} else if (gltf_node->camera >= 0) {
-				gltf_node_name = "Camera";
+			if (_importer_version < 2) {
+				if (gltf_node->mesh >= 0) {
+					gltf_node_name = _gen_unique_name(p_state, "Mesh");
+				} else if (gltf_node->camera >= 0) {
+					gltf_node_name = _gen_unique_name(p_state, "Camera3D");
+				} else {
+					gltf_node_name = _gen_unique_name(p_state, "Node");
+				}
 			} else {
-				gltf_node_name = "Node";
+				if (gltf_node->mesh >= 0) {
+					gltf_node_name = "Mesh";
+				} else if (gltf_node->camera >= 0) {
+					gltf_node_name = "Camera";
+				} else {
+					gltf_node_name = "Node";
+				}
 			}
 		}
 		gltf_node->set_name(_gen_unique_name(p_state, gltf_node_name));
@@ -7388,7 +7409,11 @@ Node *GLTFDocument::_generate_scene_node_tree(Ref<GLTFState> p_state) {
 	if (unlikely(p_state->scene_name.is_empty())) {
 		p_state->scene_name = single_root->get_name();
 	} else if (single_root->get_name() == StringName()) {
-		single_root->set_name(_gen_unique_name(p_state, p_state->scene_name));
+		if (_importer_version < 2) {
+			single_root->set_name(p_state->scene_name);
+		} else {
+			single_root->set_name(_gen_unique_name(p_state, p_state->scene_name));
+		}
 	}
 	return single_root;
 }

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -73,6 +73,7 @@ public:
 
 private:
 	const float BAKE_FPS = 30.0f;
+	int _importer_version = 2;
 	String _image_format = "PNG";
 	float _lossy_quality = 0.75f;
 	Ref<GLTFDocumentExtension> _image_save_extension;
@@ -86,6 +87,8 @@ public:
 	static void unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension);
 	static void unregister_all_gltf_document_extensions();
 
+	int get_importer_version() const;
+	void set_importer_version(int p_version);
 	void set_image_format(const String &p_image_format);
 	String get_image_format() const;
 	void set_lossy_quality(float p_lossy_quality);


### PR DESCRIPTION
Fixes #83429, caused by a behavior change from #80270 (the old behavior is wrong, but we must keep it for compat), and also fixes the behavior change from #81264.

I think the easiest way to explain how this works is by giving examples. Comprehensive test project: [Block.zip](https://github.com/godotengine/godot/files/13184346/Block.zip) All `.glb` files in this project are the exact same, just with different file names and `.import` files.

The "4.2" folder has `.import` files generated with this PR.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/17d04dc4-da3c-4697-a9a0-946a73016ffc">

The "4.1" folder has `.import` files generated in Godot 4.1. The expected behavior is that they import the same way as they did in 4.1, when the scene name (usually file name) took priority over the node name.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/fbc21eb5-b12e-4445-806a-e72095b78b74">

The "NoVersion" folder has `.import` files without a `importer_version=` field. The expected behavior is that they import with the old 4.1 behavior.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/6c604af7-54e1-4f73-9e0d-4d43d9951a38">

The `NoImportFile` folder does not have `.import` files for the `.glb` files. This is the case when a user brings in a new model, or wants to reset the settings by deleting the `.import` files. This should generate new files with the importer version set to 2, and then import the same as the files in the 4.2 folder.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/a1bfbdc0-3c34-47bd-9b8d-0d35feccc739">

The importer version is read by `EditorFileSystem`, then passed to `ResourceImporter`, then for scenes this is passed to `EditorSceneFormatImporter`, then for GLTF this is passed to `GLTFDocument`.

If desired, we could expose the methods to set the importer version to allow users to manually import files with an older importer version (ex: when using GLTFDocument at runtime), but the use case here is not entirely clear (modifying a file after import, when we care about preserving the exact same data, is mostly relevant in the editor).

The default value of the importer version is `RESOURCE_IMPORTER_VERSION` which is set to 2 in this PR (it can be incremented later), and this value is also used when generating a new `.import` file.