### PR TITLE
Improve error message when trying to call non-`@tool` function from `@tool` script

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1776,7 +1776,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							}
 						}
 					}
-					err_text = _get_call_error(err, "function '" + methodstr + (is_callable ? "" : "' in base '" + basestr) + "'", (const Variant **)argptrs);
+
+					String tool_suffix;
+					if (base->has_method(methodstr)) {
+						// If the method isn't found but `has_method()` returns `true`,
+						// this is because it's a non-tool script called from a tool script.
+						tool_suffix = " ('" + methodstr + "' is from a non-@tool script, but is called from @tool script; make the script containing '" + methodstr + "' @tool)";
+					}
+					err_text = _get_call_error(err, "function '" + methodstr + (is_callable ? "" : "' in base '" + basestr) + "'" + tool_suffix, (const Variant **)argptrs);
 					OPCODE_BREAK;
 				}
 #endif
@@ -1860,7 +1867,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							}
 						}
 					}
-					err_text = _get_call_error(err, "function '" + methodstr + "' in base '" + basestr + "'", (const Variant **)argptrs);
+
+					String tool_suffix;
+					if (base->has_method(methodstr)) {
+						// If the method isn't found but `has_method()` returns `true`,
+						// this is because it's a non-tool script called from a tool script.
+						tool_suffix = " ('" + methodstr + "' is from a non-@tool script, but is called from @tool script; make the script containing '" + methodstr + "' @tool)";
+					}
+					err_text = _get_call_error(err, "function '" + methodstr + "' in base '" + basestr + "'" + tool_suffix, (const Variant **)argptrs);
 					OPCODE_BREAK;
 				}
 #endif


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/36592.

**Testing project:** [test_tool_script_function_error.zip](https://github.com/godotengine/godot/files/13187382/test_tool_script_function_error.zip)

## Preview

### Before

```
  res://Node2D.gd:6 - Invalid call. Nonexistent function 'say_hello' in base 'Node (ChildNode.gd)'.
```

### After

```
 res://Node2D.gd:6 - Invalid call. Nonexistent function 'say_hello' in base 'Node (ChildNode.gd)' ('say_hello' is from a non-@tool script, but is called from @tool script; make the script containing 'say_hello' @tool).
```