### PR TITLE
Add read-only info to resource embedded in other scenes.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2342,21 +2342,15 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		int subr_idx = current_res->get_path().find("::");
 		if (subr_idx != -1) {
 			String base_path = current_res->get_path().substr(0, subr_idx);
-			if (!base_path.is_resource_file()) {
-				if (FileAccess::exists(base_path + ".import")) {
+			if (FileAccess::exists(base_path + ".import")) {
+				if (!base_path.is_resource_file()) {
 					if (get_edited_scene() && get_edited_scene()->get_scene_file_path() == base_path) {
 						info_is_warning = true;
 					}
-					editable_info = TTR("This resource belongs to a scene that was imported, so it's not editable.\nPlease read the documentation relevant to importing scenes to better understand this workflow.");
-				} else {
-					if ((!get_edited_scene() || get_edited_scene()->get_scene_file_path() != base_path) && ResourceLoader::get_resource_type(base_path) == "PackedScene") {
-						editable_info = TTR("This resource belongs to a scene that was instantiated or inherited.\nChanges to it must be made inside the original scene.");
-					}
 				}
-			} else {
-				if (FileAccess::exists(base_path + ".import")) {
-					editable_info = TTR("This resource belongs to a scene that was imported, so it's not editable.\nPlease read the documentation relevant to importing scenes to better understand this workflow.");
-				}
+				editable_info = TTR("This resource belongs to a scene that was imported, so it's not editable.\nPlease read the documentation relevant to importing scenes to better understand this workflow.");
+			} else if ((!get_edited_scene() || get_edited_scene()->get_scene_file_path() != base_path) && ResourceLoader::get_resource_type(base_path) == "PackedScene") {
+				editable_info = TTR("This resource belongs to a scene that was instantiated or inherited.\nChanges to it must be made inside the original scene.");
 			}
 		} else if (current_res->get_path().is_resource_file()) {
 			if (FileAccess::exists(current_res->get_path() + ".import")) {


### PR DESCRIPTION
Adds the missing 'read-only' info to the top of the inspector for situations where the inspector is viewing a resource which is part of another scene and therefore cannot be directly edited. This situation is usually not seen since when attempting to edit a resource which is linked to another scene (which wasn't imported), you can click 'edit' and will be taken directly to that scene and resource where you are allowed to perform your edits.

However, there are still some situations where you can be viewing a resource in another scene, such as using AnimationTreeEditor and viewing AnimationNodes from another scene. This PR provides consistent info to help the user understand why they are unable to edit a resource from the inspector in this situation rather than just showing them an unmodifiable inspector.
![godot windows editor dev x86_64_ESojKW6O8i](https://github.com/godotengine/godot/assets/12756047/fcac342c-8517-41a8-87e4-09668f7e3593)
![godot windows editor dev x86_64_337Vsj2qwE](https://github.com/godotengine/godot/assets/12756047/2f3ae2f3-8b7d-405d-847a-a6e23254f48a)