### PR TITLE
Fix some `Node3DEditor` snapping issues

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4882,8 +4882,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 			if (_edit.snap || spatial_editor->is_snap_enabled()) {
 				snap = spatial_editor->get_rotate_snap();
 			}
-			angle = Math::rad_to_deg(angle) + snap * 0.5; //else it won't reach +180
-			angle -= Math::fmod(angle, snap);
+			angle = Math::snapped(Math::rad_to_deg(angle), snap);
 			set_message(vformat(TTR("Rotating %s degrees."), String::num(angle, snap_step_decimals)));
 			angle = Math::deg_to_rad(angle);
 
@@ -5857,9 +5856,9 @@ Dictionary Node3DEditor::get_state() const {
 	Dictionary d;
 
 	d["snap_enabled"] = snap_enabled;
-	d["translate_snap"] = get_translate_snap();
-	d["rotate_snap"] = get_rotate_snap();
-	d["scale_snap"] = get_scale_snap();
+	d["translate_snap"] = snap_translate_value;
+	d["rotate_snap"] = snap_rotate_value;
+	d["scale_snap"] = snap_scale_value;
 
 	d["local_coords"] = tool_option_button[TOOL_OPT_LOCAL_COORDS]->is_pressed();
 
@@ -8872,9 +8871,8 @@ void Node3DEditorPlugin::set_state(const Dictionary &p_state) {
 
 Vector3 Node3DEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
 	if (is_snap_enabled()) {
-		p_target.x = Math::snap_scalar(0.0, get_translate_snap(), p_target.x);
-		p_target.y = Math::snap_scalar(0.0, get_translate_snap(), p_target.y);
-		p_target.z = Math::snap_scalar(0.0, get_translate_snap(), p_target.z);
+		real_t snap = get_translate_snap();
+		p_target.snap(Vector3(snap, snap, snap));
 	}
 	return p_target;
 }
@@ -8886,36 +8884,27 @@ bool Node3DEditor::is_gizmo_visible() const {
 	return gizmo.visible;
 }
 
-double Node3DEditor::get_translate_snap() const {
-	double snap_value;
+real_t Node3DEditor::get_translate_snap() const {
+	real_t snap_value = snap_translate_value;
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
-		snap_value = snap_translate->get_text().to_float() / 10.0;
-	} else {
-		snap_value = snap_translate->get_text().to_float();
+		snap_value /= 10.0f;
 	}
-
 	return snap_value;
 }
 
-double Node3DEditor::get_rotate_snap() const {
-	double snap_value;
+real_t Node3DEditor::get_rotate_snap() const {
+	real_t snap_value = snap_rotate_value;
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
-		snap_value = snap_rotate->get_text().to_float() / 3.0;
-	} else {
-		snap_value = snap_rotate->get_text().to_float();
+		snap_value /= 3.0f;
 	}
-
 	return snap_value;
 }
 
-double Node3DEditor::get_scale_snap() const {
-	double snap_value;
+real_t Node3DEditor::get_scale_snap() const {
+	real_t snap_value = snap_scale_value;
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
-		snap_value = snap_scale->get_text().to_float() / 2.0;
-	} else {
-		snap_value = snap_scale->get_text().to_float();
+		snap_value /= 2.0f;
 	}
-
 	return snap_value;
 }
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -850,9 +850,9 @@ public:
 	bool are_local_coords_enabled() const { return tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->is_pressed(); }
 	void set_local_coords_enabled(bool on) const { tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->set_pressed(on); }
 	bool is_snap_enabled() const { return snap_enabled ^ snap_key_enabled; }
-	double get_translate_snap() const;
-	double get_rotate_snap() const;
-	double get_scale_snap() const;
+	real_t get_translate_snap() const;
+	real_t get_rotate_snap() const;
+	real_t get_scale_snap() const;
 
 	Ref<ArrayMesh> get_move_gizmo(int idx) const { return move_gizmo[idx]; }
 	Ref<ArrayMesh> get_axis_gizmo(int idx) const { return axis_gizmo[idx]; }


### PR DESCRIPTION
Fixes #79862.

There was a discrepancy between what's saved in the plugin's state and where it gets loaded to:
https://github.com/godotengine/godot/blob/dd74ffde95110ccb828424964d137aa8f2465806/editor/plugins/node_3d_editor_plugin.cpp#L5860-L5862
https://github.com/godotengine/godot/blob/dd74ffde95110ccb828424964d137aa8f2465806/editor/plugins/node_3d_editor_plugin.cpp#L5940-L5950
All `get_translate_snap`/`get_rotate_snap`/`get_scale_snap` were reading the values from the snap dialog's LineEdits instead of using plugin's `snap_translate_value`/`snap_rotate_value`/`snap_scale_value` (which are being updated according to these LineEdits on pressing OK / confirming in the snap dialog). Also what's worse (given these were the values being saved), these methods return smaller snap values when <kbd>Shift</kbd> is being pressed. 

https://github.com/godotengine/godot/blob/dd74ffde95110ccb828424964d137aa8f2465806/editor/plugins/node_3d_editor_plugin.cpp#L8889-L8920

Meaning if <kbd>Shift</kbd> was pressed when plugin's state was being saved then values smaller than the actual snap values were being saved into a file. Then when loading they'd be loaded as the actual snap values. Everytime this happened the snap values were becoming smaller and smaller.

For reproducing #79862 it was enough for me to create two 3D scenes and keep switching between them (by pressing their tabs) while keeping <kbd>Shift</kbd> pressed.

This PR makes `get_translate_snap`/`get_rotate_snap`/`get_scale_snap` properly use `snap_translate_value`/`snap_rotate_value`/`snap_scale_value`, and makes `snap_translate_value`/`snap_rotate_value`/`snap_scale_value` be what's saved in the plugin's state.

Since `get_translate_snap`/`get_rotate_snap`/`get_scale_snap` no longer read values from LineEdits they were changed to return `real_t` instead of `double`, as that's the type of `snap_translate_value`/`snap_rotate_value`/`snap_scale_value`. See https://github.com/godotengine/godot/pull/49783#discussion_r657902668 for why they were returning doubles before.
If we'd want snapping to always operate on doubles then what would need to be changed are `snap_translate_value`/`snap_rotate_value`/`snap_scale_value`. I could make such changes if that's desired.

---

Fixes #39507.

https://github.com/godotengine/godot/blob/dd74ffde95110ccb828424964d137aa8f2465806/editor/plugins/node_3d_editor_plugin.cpp#L4885-L4886

`Math::fmod` would return NaN for `snap == 0.0`. Besides, this calculation doesn't correctly snap for negative angles anyway.
Fixed it to use `Math::snapped` which handles these cases properly.