### PR TITLE
Fix invalid return from some `_get/_set`

### DIFF
--- a/scene/resources/bone_map.cpp
+++ b/scene/resources/bone_map.cpp
@@ -37,7 +37,7 @@ bool BoneMap::_set(const StringName &p_path, const Variant &p_value) {
 		set_skeleton_bone_name(which, p_value);
 		return true;
 	}
-	return true;
+	return false;
 }
 
 bool BoneMap::_get(const StringName &p_path, Variant &r_ret) const {
@@ -47,7 +47,7 @@ bool BoneMap::_get(const StringName &p_path, Variant &r_ret) const {
 		r_ret = get_skeleton_bone_name(which);
 		return true;
 	}
-	return true;
+	return false;
 }
 
 void BoneMap::_get_property_list(List<PropertyInfo> *p_list) const {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1712,7 +1712,7 @@ bool ArrayMesh::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 
-	return true;
+	return false;
 }
 
 void ArrayMesh::reset_state() {

--- a/scene/resources/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/skeleton_modification_stack_2d.cpp
@@ -49,7 +49,7 @@ bool SkeletonModificationStack2D::_set(const StringName &p_path, const Variant &
 		set_modification(mod_idx, p_value);
 		return true;
 	}
-	return true;
+	return false;
 }
 
 bool SkeletonModificationStack2D::_get(const StringName &p_path, Variant &r_ret) const {
@@ -60,7 +60,7 @@ bool SkeletonModificationStack2D::_get(const StringName &p_path, Variant &r_ret)
 		r_ret = get_modification(mod_idx);
 		return true;
 	}
-	return true;
+	return false;
 }
 
 void SkeletonModificationStack2D::setup() {


### PR DESCRIPTION
Invalidly returned `true` on the non-matched path, these do not break anything by blocking inherited properties, at least not right now

There are some remaining cases for `Skeleton` and `SkeletonModification*`, but they are a bit more complicated so not touching them right now, these were the trivial cases

* Fixes: #84041
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
