### PR TITLE
Fix NavigationObstacle3DEditor parenting error

### DIFF
--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
@@ -503,7 +503,11 @@ void NavigationObstacle3DEditor::edit(Node *p_node) {
 		wip.clear();
 		wip_active = false;
 		edited_point = -1;
-		p_node->add_child(point_lines_meshinstance);
+		if (point_lines_meshinstance->get_parent()) {
+			point_lines_meshinstance->reparent(p_node, false);
+		} else {
+			p_node->add_child(point_lines_meshinstance);
+		}
 		_polygon_draw();
 
 	} else {


### PR DESCRIPTION
Fixes NavigationObstacle3DEditor parenting error.

Fixes https://github.com/godotengine/godot/issues/84050.

The NavigationObstacle3DEditor is based on the polygon 3d plugin which has received fix https://github.com/godotengine/godot/pull/73726.
So this pr is applying the same fix for the obstacle.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
