### PR TITLE
Provide context info for why an animation may not be editable.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3341,6 +3341,8 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 		}
 
 		_check_bezier_exist();
+
+		show_readonly_anim_info(read_only);
 	} else {
 		hscroll->hide();
 		edit->set_disabled(true);
@@ -3351,6 +3353,8 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 		snap->set_disabled(true);
 		snap_mode->set_disabled(true);
 		bezier_edit_icon->set_disabled(true);
+
+		show_readonly_anim_info(false);
 	}
 }
 
@@ -4310,6 +4314,10 @@ void AnimationTrackEditor::show_inactive_player_warning(bool p_show) {
 	inactive_player_warning->set_visible(p_show);
 }
 
+void AnimationTrackEditor::show_readonly_anim_info(bool p_show) {
+	readonly_anim_info->set_visible(p_show);
+}
+
 bool AnimationTrackEditor::is_key_selected(int p_track, int p_key) const {
 	SelectedKey sk;
 	sk.key = p_key;
@@ -4645,6 +4653,7 @@ void AnimationTrackEditor::_notification(int p_what) {
 			imported_anim_warning->set_icon(get_editor_theme_icon(SNAME("NodeWarning")));
 			dummy_player_warning->set_icon(get_editor_theme_icon(SNAME("NodeWarning")));
 			inactive_player_warning->set_icon(get_editor_theme_icon(SNAME("NodeWarning")));
+			readonly_anim_info->set_icon(get_editor_theme_icon(SNAME("NodeInfo")));
 			main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_editor_theme_icon(SNAME("Reload")));
 		} break;
@@ -6335,6 +6344,13 @@ void AnimationTrackEditor::_show_inactive_player_warning() {
 			TTR("AnimationPlayer is inactive. The playback will not be processed."));
 }
 
+void AnimationTrackEditor::_show_readonly_anim_info() {
+	if (animation.is_valid()) {
+		EditorNode::get_singleton()->show_warning(
+				TTR("This animation is a sub-resource of another resource or scene, so it cannot be edited directly from here."));
+	}
+}
+
 void AnimationTrackEditor::_select_all_tracks_for_copy() {
 	TreeItem *track = track_copy_select->get_root()->get_first_child();
 	if (!track) {
@@ -6530,6 +6546,13 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	inactive_player_warning->set_tooltip_text(TTR("Warning: AnimationPlayer is inactive"));
 	inactive_player_warning->connect("pressed", callable_mp(this, &AnimationTrackEditor::_show_inactive_player_warning));
 	bottom_hb->add_child(inactive_player_warning);
+
+	readonly_anim_info = memnew(Button);
+	readonly_anim_info->hide();
+	readonly_anim_info->set_text(TTR("Read-only Animation"));
+	readonly_anim_info->set_tooltip_text(TTR("Info: This animation cannot be edited"));
+	readonly_anim_info->connect("pressed", callable_mp(this, &AnimationTrackEditor::_show_readonly_anim_info));
+	bottom_hb->add_child(readonly_anim_info);
 
 	bottom_hb->add_spacer();
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -395,6 +395,9 @@ class AnimationTrackEditor : public VBoxContainer {
 	Button *inactive_player_warning = nullptr;
 	void _show_inactive_player_warning();
 
+	Button *readonly_anim_info = nullptr;
+	void _show_readonly_anim_info();
+
 	void _snap_mode_changed(int p_mode);
 	Vector<AnimationTrackEdit *> track_edits;
 	Vector<AnimationTrackEditGroup *> groups;
@@ -655,6 +658,7 @@ public:
 	void show_select_node_warning(bool p_show);
 	void show_dummy_player_warning(bool p_show);
 	void show_inactive_player_warning(bool p_show);
+	void show_readonly_anim_info(bool p_show);
 
 	bool is_key_selected(int p_track, int p_key) const;
 	bool is_selection_active() const;


### PR DESCRIPTION
WIP PR to introduce improved contextual information in the AnimationPlayer to explain why an animation may not be editable. Still want to improve it further to identify imported animations and explanations on how to save animations from imported scenes externally.
![godot windows editor dev x86_64_6aUWQMDPYX](https://github.com/godotengine/godot/assets/12756047/bc03ae9f-3d55-4c2a-8bc0-d2cfa890a923)
