### PR TITLE
Fix invalid return from some more `_get/_set`

### DIFF
--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -48,12 +48,14 @@ bool Bone2D::_set(const StringName &p_path, const Variant &p_value) {
 	} else if (path.begins_with("default_length")) {
 		set_length(p_value);
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor_settings/show_bone_gizmo")) {
+	else if (path.begins_with("editor_settings/show_bone_gizmo")) {
 		_editor_set_show_bone_gizmo(p_value);
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }
@@ -70,12 +72,14 @@ bool Bone2D::_get(const StringName &p_path, Variant &r_ret) const {
 	} else if (path.begins_with("default_length")) {
 		r_ret = get_length();
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor_settings/show_bone_gizmo")) {
+	else if (path.begins_with("editor_settings/show_bone_gizmo")) {
 		r_ret = _editor_get_show_bone_gizmo();
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }

--- a/scene/resources/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_2d_ccdik.cpp
@@ -60,21 +60,23 @@ bool SkeletonModification2DCCDIK::_set(const StringName &p_path, const Variant &
 		} else if (what == "constraint_in_localspace") {
 			set_ccdik_joint_constraint_in_localspace(which, p_value);
 		}
-
 #ifdef TOOLS_ENABLED
-		if (what.begins_with("editor_draw_gizmo")) {
+		else if (what.begins_with("editor_draw_gizmo")) {
 			set_ccdik_joint_editor_draw_gizmo(which, p_value);
 		}
 #endif // TOOLS_ENABLED
-
-		return true;
+		else {
+			return false;
+		}
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor/draw_gizmo")) {
+	else if (path.begins_with("editor/draw_gizmo")) {
 		set_editor_draw_gizmo(p_value);
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }
@@ -104,21 +106,23 @@ bool SkeletonModification2DCCDIK::_get(const StringName &p_path, Variant &r_ret)
 		} else if (what == "constraint_in_localspace") {
 			r_ret = get_ccdik_joint_constraint_in_localspace(which);
 		}
-
 #ifdef TOOLS_ENABLED
-		if (what.begins_with("editor_draw_gizmo")) {
+		else if (what.begins_with("editor_draw_gizmo")) {
 			r_ret = get_ccdik_joint_editor_draw_gizmo(which);
 		}
 #endif // TOOLS_ENABLED
-
-		return true;
+		else {
+			return false;
+		}
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor/draw_gizmo")) {
+	else if (path.begins_with("editor/draw_gizmo")) {
 		r_ret = get_editor_draw_gizmo();
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }

--- a/scene/resources/skeleton_modification_2d_fabrik.cpp
+++ b/scene/resources/skeleton_modification_2d_fabrik.cpp
@@ -51,7 +51,11 @@ bool SkeletonModification2DFABRIK::_set(const StringName &p_path, const Variant 
 			set_fabrik_joint_magnet_position(which, p_value);
 		} else if (what == "use_target_rotation") {
 			set_fabrik_joint_use_target_rotation(which, p_value);
+		} else {
+			return false;
 		}
+	} else {
+		return false;
 	}
 
 	return true;
@@ -73,8 +77,11 @@ bool SkeletonModification2DFABRIK::_get(const StringName &p_path, Variant &r_ret
 			r_ret = get_fabrik_joint_magnet_position(which);
 		} else if (what == "use_target_rotation") {
 			r_ret = get_fabrik_joint_use_target_rotation(which);
+		} else {
+			return false;
 		}
-		return true;
+	} else {
+		return false;
 	}
 	return true;
 }

--- a/scene/resources/skeleton_modification_2d_jiggle.cpp
+++ b/scene/resources/skeleton_modification_2d_jiggle.cpp
@@ -57,14 +57,15 @@ bool SkeletonModification2DJiggle::_set(const StringName &p_path, const Variant 
 			set_jiggle_joint_use_gravity(which, p_value);
 		} else if (what == "gravity") {
 			set_jiggle_joint_gravity(which, p_value);
+		} else {
+			return false;
 		}
-		return true;
+	} else if (path == "use_colliders") {
+		set_use_colliders(p_value);
+	} else if (path == "collision_mask") {
+		set_collision_mask(p_value);
 	} else {
-		if (path == "use_colliders") {
-			set_use_colliders(p_value);
-		} else if (path == "collision_mask") {
-			set_collision_mask(p_value);
-		}
+		return false;
 	}
 	return true;
 }
@@ -93,14 +94,15 @@ bool SkeletonModification2DJiggle::_get(const StringName &p_path, Variant &r_ret
 			r_ret = get_jiggle_joint_use_gravity(which);
 		} else if (what == "gravity") {
 			r_ret = get_jiggle_joint_gravity(which);
+		} else {
+			return false;
 		}
-		return true;
+	} else if (path == "use_colliders") {
+		r_ret = get_use_colliders();
+	} else if (path == "collision_mask") {
+		r_ret = get_collision_mask();
 	} else {
-		if (path == "use_colliders") {
-			r_ret = get_use_colliders();
-		} else if (path == "collision_mask") {
-			r_ret = get_collision_mask();
-		}
+		return false;
 	}
 	return true;
 }

--- a/scene/resources/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/skeleton_modification_2d_lookat.cpp
@@ -51,12 +51,14 @@ bool SkeletonModification2DLookAt::_set(const StringName &p_path, const Variant 
 	} else if (path.begins_with("additional_rotation")) {
 		set_additional_rotation(Math::deg_to_rad(float(p_value)));
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor/draw_gizmo")) {
+	else if (path.begins_with("editor/draw_gizmo")) {
 		set_editor_draw_gizmo(p_value);
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }
@@ -77,12 +79,14 @@ bool SkeletonModification2DLookAt::_get(const StringName &p_path, Variant &r_ret
 	} else if (path.begins_with("additional_rotation")) {
 		r_ret = Math::rad_to_deg(get_additional_rotation());
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor/draw_gizmo")) {
+	else if (path.begins_with("editor/draw_gizmo")) {
 		r_ret = get_editor_draw_gizmo();
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }

--- a/scene/resources/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/skeleton_modification_2d_physicalbones.cpp
@@ -55,10 +55,10 @@ bool SkeletonModification2DPhysicalBones::_set(const StringName &p_path, const V
 
 		if (what == "nodepath") {
 			set_physical_bone_node(which, p_value);
+			return true;
 		}
-		return true;
 	}
-	return true;
+	return false;
 }
 
 bool SkeletonModification2DPhysicalBones::_get(const StringName &p_path, Variant &r_ret) const {
@@ -79,10 +79,10 @@ bool SkeletonModification2DPhysicalBones::_get(const StringName &p_path, Variant
 
 		if (what == "nodepath") {
 			r_ret = get_physical_bone_node(which);
+			return true;
 		}
-		return true;
 	}
-	return true;
+	return false;
 }
 
 void SkeletonModification2DPhysicalBones::_get_property_list(List<PropertyInfo> *p_list) const {

--- a/scene/resources/skeleton_modification_2d_stackholder.cpp
+++ b/scene/resources/skeleton_modification_2d_stackholder.cpp
@@ -37,12 +37,14 @@ bool SkeletonModification2DStackHolder::_set(const StringName &p_path, const Var
 	if (path == "held_modification_stack") {
 		set_held_modification_stack(p_value);
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path == "editor/draw_gizmo") {
+	else if (path == "editor/draw_gizmo") {
 		set_editor_draw_gizmo(p_value);
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }
@@ -53,12 +55,14 @@ bool SkeletonModification2DStackHolder::_get(const StringName &p_path, Variant &
 	if (path == "held_modification_stack") {
 		r_ret = get_held_modification_stack();
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path == "editor/draw_gizmo") {
+	else if (path == "editor/draw_gizmo") {
 		r_ret = get_editor_draw_gizmo();
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }

--- a/scene/resources/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_2d_twoboneik.cpp
@@ -47,14 +47,16 @@ bool SkeletonModification2DTwoBoneIK::_set(const StringName &p_path, const Varia
 	} else if (path == "joint_two_bone2d_node") {
 		set_joint_two_bone2d_node(p_value);
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor/draw_gizmo")) {
+	else if (path.begins_with("editor/draw_gizmo")) {
 		set_editor_draw_gizmo(p_value);
 	} else if (path.begins_with("editor/draw_min_max")) {
 		set_editor_draw_min_max(p_value);
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }
@@ -71,14 +73,16 @@ bool SkeletonModification2DTwoBoneIK::_get(const StringName &p_path, Variant &r_
 	} else if (path == "joint_two_bone2d_node") {
 		r_ret = get_joint_two_bone2d_node();
 	}
-
 #ifdef TOOLS_ENABLED
-	if (path.begins_with("editor/draw_gizmo")) {
+	else if (path.begins_with("editor/draw_gizmo")) {
 		r_ret = get_editor_draw_gizmo();
 	} else if (path.begins_with("editor/draw_min_max")) {
 		r_ret = get_editor_draw_min_max();
 	}
 #endif // TOOLS_ENABLED
+	else {
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Invalidly returned `true` on the non-matched path

Follow-up to:
* https://github.com/godotengine/godot/pull/84054

Reviewers: If these cases are invalid (i.e. all paths should return true) then please explain why and I'll add a note for it instead

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
