### PR TITLE
Fix 2D bone weight editor not accounting for offset

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1170,7 +1170,7 @@ void Polygon2DEditor::_uv_draw() {
 
 						found_child = true;
 
-						Transform2D bone_xform = node->get_global_transform().affine_inverse() * (skeleton->get_global_transform() * bone->get_skeleton_rest());
+						Transform2D bone_xform = node->get_global_transform().affine_inverse().translated(-node->get_offset()) * (skeleton->get_global_transform() * bone->get_skeleton_rest());
 						Transform2D endpoint_xform = bone_xform * n->get_transform();
 
 						Color color = current ? Color(1, 1, 1) : Color(0.5, 0.5, 0.5);
@@ -1180,7 +1180,7 @@ void Polygon2DEditor::_uv_draw() {
 
 					if (!found_child) {
 						//draw normally
-						Transform2D bone_xform = node->get_global_transform().affine_inverse() * (skeleton->get_global_transform() * bone->get_skeleton_rest());
+						Transform2D bone_xform = node->get_global_transform().affine_inverse().translated(-node->get_offset()) * (skeleton->get_global_transform() * bone->get_skeleton_rest());
 						Transform2D endpoint_xform = bone_xform * Transform2D(0, Vector2(bone->get_length(), 0));
 
 						Color color = current ? Color(1, 1, 1) : Color(0.5, 0.5, 0.5);


### PR DESCRIPTION
Skeleton was shown in wrong place in Polygon2D UV editor's bone painting mode, if Polygon2D's `offset` is set.
Node placement:
![kuva](https://github.com/godotengine/godot/assets/1621768/c8b085c1-6fea-4bf9-a531-95802a7a4029)

Bug inside UV editor, bone edit tab:
![kuva](https://github.com/godotengine/godot/assets/1621768/5afecb89-ca40-42da-9d17-64217ad712cf)

Fixed:
![kuva](https://github.com/godotengine/godot/assets/1621768/58b63ae1-4039-4bef-a1dc-57a15e29d2f2)

MRP: [BonePaintMRP.zip](https://github.com/godotengine/godot/files/13191974/BonePaintMRP.zip)
Didn't find existing report about this, likely because using offset together with skeleton isn't really often done, but I encountered it when I wanted to upgrade cutout animation with skinning.