### PR TITLE
Fix UV editor not using texture transform

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -989,7 +989,10 @@ void Polygon2DEditor::_uv_draw() {
 	mtx.columns[2] = -uv_draw_ofs;
 	mtx.scale_basis(Vector2(uv_draw_zoom, uv_draw_zoom));
 
-	RS::get_singleton()->canvas_item_add_set_transform(uv_edit_draw->get_canvas_item(), mtx);
+	Transform2D texture_transform = Transform2D(node->get_texture_rotation(), node->get_texture_offset());
+	texture_transform.scale(node->get_texture_scale());
+	texture_transform.affine_invert();
+	RS::get_singleton()->canvas_item_add_set_transform(uv_edit_draw->get_canvas_item(), mtx * texture_transform);
 	uv_edit_draw->draw_texture(base_tex, Point2());
 	RS::get_singleton()->canvas_item_add_set_transform(uv_edit_draw->get_canvas_item(), Transform2D());
 


### PR DESCRIPTION
If you set Polygon2D's texture transform (offset, scale or rotation), texture would still draw with default transform in UV editor.
Properties:
![kuva](https://github.com/godotengine/godot/assets/1621768/cc022bc9-94eb-4265-8f43-08bba5d0d58c)
Bug in UV editor:
![kuva](https://github.com/godotengine/godot/assets/1621768/a6c94a2d-b56d-48c0-b07e-c267415a6422)
Fixed:
![kuva](https://github.com/godotengine/godot/assets/1621768/043d3435-2425-47d7-ae15-83ace203de9b)
MRP: [TextureTransformMRP.zip](https://github.com/godotengine/godot/files/13192695/TextureTransformMRP.zip)

I didn't find any existing issues about this. As a side effect of this fix, if you rotate the texture 90-270 degrees (and no offset), the texture isn't going to be in the initial view (it's rotated around the top-left corner). Well, it's better than texture appearing in the wrong place altogether, but might be a bit confusing. See #83731 for a fix for that problem (altough it should be updated for transformed textures after this pr).