### PR TITLE
Ignore path error for built-in scripts/shaders

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -633,7 +633,7 @@ void ScriptCreateDialog::_update_dialog() {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTR("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
 	}
 
-	if (!path_error.is_empty()) {
+	if (!is_built_in && !path_error.is_empty()) {
 		validation_panel->set_message(MSG_ID_PATH, path_error, EditorValidationPanel::MSG_ERROR);
 	}
 

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -494,7 +494,7 @@ void ShaderCreateDialog::_update_dialog() {
 	if (!is_built_in && !is_path_valid) {
 		validation_panel->set_message(MSG_ID_SHADER, TTR("Invalid path."), EditorValidationPanel::MSG_ERROR);
 	}
-	if (!path_error.is_empty()) {
+	if (!is_built_in && !path_error.is_empty()) {
 		validation_panel->set_message(MSG_ID_PATH, path_error, EditorValidationPanel::MSG_ERROR);
 	} else if (validation_panel->is_valid() && !is_new_shader_created) {
 		validation_panel->set_message(MSG_ID_SHADER, TTR("File exists, it will be reused."), EditorValidationPanel::MSG_OK);


### PR DESCRIPTION
Fixes #84071
Regression from #78744

ShaderCreateDialog does not validate path when using built-in shader. While it's correct, if the path was invalid before enabling the checkbox, it will be considered invalid for built-in scripts and fail. This PR makes the error ignored if shader is built-in (I could clear the error instead, but ignoring it is safer).

ScriptCreateDialog has the same problem, but it assigns a path based on node name, so it wasn't visible. Meantime shader uses scene name, which can be empty.