### PR TITLE
Clarify behavior of RayCast when `get_collision_point()` is used inside a collision shape

### DIFF
--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -74,7 +74,7 @@
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the collision point at which the ray intersects the closest object.
+				Returns the collision point at which the ray intersects the closest object. If [member hit_from_inside] is [code]true[/code] and the ray starts inside of a collision shape, this function will return the origin point of the ray.
 				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -81,7 +81,7 @@
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the collision point at which the ray intersects the closest object.
+				Returns the collision point at which the ray intersects the closest object. If [member hit_from_inside] is [code]true[/code] and the ray starts inside of a collision shape, this function will return the origin point of the ray.
 				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>


### PR DESCRIPTION
Clarified documentation on a behavior of get_collision_point() in both RayCast2D and RayCast3D objects when it is used while the ray is inside a collision shape
