### PR TITLE
Fallback to `to` in `get_path_to` to preserve path.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2003,8 +2003,7 @@ NodePath Node::get_path_to(const Node *p_node, bool p_use_unique_path) const {
 		common_parent = common_parent->data.parent;
 	}
 
-	ERR_FAIL_NULL_V(common_parent, NodePath()); //nodes not in the same tree
-
+	ERR_FAIL_NULL_V(common_parent, NodePath(p_node->get_name())); //nodes not in the same tree
 	visited.clear();
 
 	Vector<StringName> path;


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/84016

Most of the code that deals with this is @ `SceneTreeDock::_new_scene_from`
Noticed the error when saving and replaced the empty NodePath with `to` in `get_path_to`
Works but not update everything right away, need to save and close and reopen scene to see that it really works.
Ya prob wrong fix... but it is a start.

```
ERROR: Parameter "common_parent" is null.
   at: get_path_to (scene/main/node.cpp:2006)
ERROR: Parameter "common_parent" is null.
   at: get_path_to (scene/main/node.cpp:2006)
```
