### PR TITLE
Fix PlaneMesh tangents for 'Face X' orientation

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1300,7 +1300,11 @@ void PlaneMesh::_create_mesh_array(Array &p_arr) const {
 				points.push_back(Vector3(-x, z, 0.0) + center_offset);
 			}
 			normals.push_back(normal);
-			ADD_TANGENT(1.0, 0.0, 0.0, 1.0);
+			if (orientation == FACE_X) {
+				ADD_TANGENT(0.0, 0.0, -1.0, 1.0);
+			} else {
+				ADD_TANGENT(1.0, 0.0, 0.0, 1.0);
+			}
 			uvs.push_back(Vector2(1.0 - u, 1.0 - v)); /* 1.0 - uv to match orientation with Quad */
 			point++;
 


### PR DESCRIPTION
PlaneMesh currently uses tangent (1, 0, 0) for all orientations.  But the normal for the FACE_X orientation is also (1, 0, 0) so normal maps don't currently work.  This pull request would change it in the FACE_X case to (0, 0, -1) which makes it match the others AFAICT.

Before, with Z, Y, X orientations, and a second set all rotated to face Z:
![plane-mesh-tangent-bug](https://github.com/godotengine/godot/assets/44447892/5633620c-b91c-4985-a00e-03b0e7ea6c8d)

After:
![plane-mesh-tangent-bug-fixed](https://github.com/godotengine/godot/assets/44447892/79b8cbc1-644e-4cb4-9ca3-330875c9aab3)
