### PR TITLE
Use colored output on CI for Doctest

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --test --headless
+          ${{ matrix.bin }} --headless --test --force-colors
 
       # Check class reference
       - name: Check for class reference updates

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -72,4 +72,4 @@ jobs:
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --test
+          ${{ matrix.bin }} --test --force-colors

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -75,4 +75,4 @@ jobs:
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --test
+          ${{ matrix.bin }} --test --force-colors


### PR DESCRIPTION
GitHub Actions output is not considered a TTY, so colored output must be forced.

I noticed this while working on https://github.com/godotengine/godot/pull/84045.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/592039b2-e55d-414b-8d28-a281fb93886b)