### PR TITLE
Fix retrieving command line flags in Android.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -906,7 +906,7 @@ class Godot(private val context: Context) : SensorEventListener {
 				val arg = ByteArray(strlen)
 				r = inputStream.read(arg)
 				if (r == strlen) {
-					cmdline[i] = String(arg, StandardCharsets.UTF_8)
+					cmdline.add(String(arg, StandardCharsets.UTF_8))
 				}
 			}
 			cmdline


### PR DESCRIPTION
Fixes #80574 

This fix stemmed from immersive mode not working in Godot 4.2. It was caused by the command line flags not properly being retrieved.

In this case, the strings retrieved were not properly added to the ArrayList. I do not know Kotlin, so it took time for me to find this fix, but that also means there might be a better fix than this one.
