### PR TITLE
Use platform-specific methods for FileAccess reading and writing

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -232,6 +232,10 @@ constexpr T get_num_bits(T x) {
 #define BSWAP16(x) __builtin_bswap16(x)
 #define BSWAP32(x) __builtin_bswap32(x)
 #define BSWAP64(x) __builtin_bswap64(x)
+#elif defined(_MSC_VER)
+#define BSWAP16(x) _byteswap_ushort(x)
+#define BSWAP32(x) _byteswap_ulong(x)
+#define BSWAP64(x) _byteswap_uint64(x)
 #else
 static inline uint16_t BSWAP16(uint16_t x) {
 	return (x >> 8) | (x << 8);

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -228,6 +228,51 @@ uint8_t FileAccessUnix::get_8() const {
 	return b;
 }
 
+uint16_t FileAccessUnix::get_16() const {
+	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
+
+	uint16_t b = 0;
+	if (fread(&b, 1, 2, f) != 2) {
+		check_errors();
+	}
+
+	if (big_endian) {
+		b = BSWAP16(b);
+	}
+
+	return b;
+}
+
+uint32_t FileAccessUnix::get_32() const {
+	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
+
+	uint32_t b = 0;
+	if (fread(&b, 1, 4, f) != 4) {
+		check_errors();
+	}
+
+	if (big_endian) {
+		b = BSWAP32(b);
+	}
+
+	return b;
+}
+
+uint64_t FileAccessUnix::get_64() const {
+	ERR_FAIL_NULL_V_MSG(f, 0, "File must be opened before use.");
+
+	uint64_t b = 0;
+	if (fread(&b, 1, 8, f) != 8) {
+		check_errors();
+	}
+
+	if (big_endian) {
+		b = BSWAP64(b);
+	}
+
+	return b;
+}
+
 uint64_t FileAccessUnix::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_NULL_V_MSG(f, -1, "File must be opened before use.");
@@ -249,6 +294,36 @@ void FileAccessUnix::flush() {
 void FileAccessUnix::store_8(uint8_t p_dest) {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
 	ERR_FAIL_COND(fwrite(&p_dest, 1, 1, f) != 1);
+}
+
+void FileAccessUnix::store_16(uint16_t p_dest) {
+	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
+
+	if (big_endian) {
+		p_dest = BSWAP16(p_dest);
+	}
+
+	ERR_FAIL_COND(fwrite(&p_dest, 1, 2, f) != 2);
+}
+
+void FileAccessUnix::store_32(uint32_t p_dest) {
+	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
+
+	if (big_endian) {
+		p_dest = BSWAP32(p_dest);
+	}
+
+	ERR_FAIL_COND(fwrite(&p_dest, 1, 4, f) != 4);
+}
+
+void FileAccessUnix::store_64(uint64_t p_dest) {
+	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
+
+	if (big_endian) {
+		p_dest = BSWAP64(p_dest);
+	}
+
+	ERR_FAIL_COND(fwrite(&p_dest, 1, 8, f) != 8);
 }
 
 void FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -68,12 +68,18 @@ public:
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
 	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint16_t get_16() const override;
+	virtual uint32_t get_32() const override;
+	virtual uint64_t get_64() const override;
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual void flush() override;
 	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_16(uint16_t p_dest) override;
+	virtual void store_32(uint32_t p_dest) override;
+	virtual void store_64(uint64_t p_dest) override;
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -284,6 +284,72 @@ uint8_t FileAccessWindows::get_8() const {
 	return b;
 }
 
+uint16_t FileAccessWindows::get_16() const {
+	ERR_FAIL_NULL_V(f, 0);
+
+	if (flags == READ_WRITE || flags == WRITE_READ) {
+		if (prev_op == WRITE) {
+			fflush(f);
+		}
+		prev_op = READ;
+	}
+
+	uint16_t b = 0;
+	if (fread(&b, 1, 2, f) != 2) {
+		check_errors();
+	}
+
+	if (big_endian) {
+		b = BSWAP16(b);
+	}
+
+	return b;
+}
+
+uint32_t FileAccessWindows::get_32() const {
+	ERR_FAIL_NULL_V(f, 0);
+
+	if (flags == READ_WRITE || flags == WRITE_READ) {
+		if (prev_op == WRITE) {
+			fflush(f);
+		}
+		prev_op = READ;
+	}
+
+	uint32_t b = 0;
+	if (fread(&b, 1, 4, f) != 4) {
+		check_errors();
+	}
+
+	if (big_endian) {
+		b = BSWAP32(b);
+	}
+
+	return b;
+}
+
+uint64_t FileAccessWindows::get_64() const {
+	ERR_FAIL_NULL_V(f, 0);
+
+	if (flags == READ_WRITE || flags == WRITE_READ) {
+		if (prev_op == WRITE) {
+			fflush(f);
+		}
+		prev_op = READ;
+	}
+
+	uint64_t b = 0;
+	if (fread(&b, 1, 8, f) != 8) {
+		check_errors();
+	}
+
+	if (big_endian) {
+		b = BSWAP64(b);
+	}
+
+	return b;
+}
+
 uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_NULL_V(f, -1);
@@ -324,6 +390,63 @@ void FileAccessWindows::store_8(uint8_t p_dest) {
 		prev_op = WRITE;
 	}
 	fwrite(&p_dest, 1, 1, f);
+}
+
+void FileAccessWindows::store_16(uint16_t p_dest) {
+	ERR_FAIL_NULL(f);
+
+	if (flags == READ_WRITE || flags == WRITE_READ) {
+		if (prev_op == READ) {
+			if (last_error != ERR_FILE_EOF) {
+				fseek(f, 0, SEEK_CUR);
+			}
+		}
+		prev_op = WRITE;
+	}
+
+	if (big_endian) {
+		p_dest = BSWAP16(p_dest);
+	}
+
+	fwrite(&p_dest, 1, 2, f);
+}
+
+void FileAccessWindows::store_32(uint32_t p_dest) {
+	ERR_FAIL_NULL(f);
+
+	if (flags == READ_WRITE || flags == WRITE_READ) {
+		if (prev_op == READ) {
+			if (last_error != ERR_FILE_EOF) {
+				fseek(f, 0, SEEK_CUR);
+			}
+		}
+		prev_op = WRITE;
+	}
+
+	if (big_endian) {
+		p_dest = BSWAP32(p_dest);
+	}
+
+	fwrite(&p_dest, 1, 4, f);
+}
+
+void FileAccessWindows::store_64(uint64_t p_dest) {
+	ERR_FAIL_NULL(f);
+
+	if (flags == READ_WRITE || flags == WRITE_READ) {
+		if (prev_op == READ) {
+			if (last_error != ERR_FILE_EOF) {
+				fseek(f, 0, SEEK_CUR);
+			}
+		}
+		prev_op = WRITE;
+	}
+
+	if (big_endian) {
+		p_dest = BSWAP64(p_dest);
+	}
+
+	fwrite(&p_dest, 1, 8, f);
 }
 
 void FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -69,12 +69,18 @@ public:
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
 	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint16_t get_16() const override;
+	virtual uint32_t get_32() const override;
+	virtual uint64_t get_64() const override;
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error
 
 	virtual void flush() override;
 	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_16(uint16_t p_dest) override;
+	virtual void store_32(uint32_t p_dest) override;
+	virtual void store_64(uint64_t p_dest) override;
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -121,6 +121,75 @@ uint8_t FileAccessAndroid::get_8() const {
 	return byte;
 }
 
+uint16_t FileAccessAndroid::get_16() const {
+	if (pos >= len) {
+		eof = true;
+		return 0;
+	}
+
+	uint16_t bytes = 0;
+	int r = AAsset_read(asset, &bytes, 2);
+
+	if (r >= 0) {
+		pos += r;
+		if (pos >= len) {
+			eof = true;
+		}
+	}
+
+	if (big_endian) {
+		bytes = BSWAP16(bytes);
+	}
+
+	return bytes;
+}
+
+uint32_t FileAccessAndroid::get_32() const {
+	if (pos >= len) {
+		eof = true;
+		return 0;
+	}
+
+	uint32_t bytes = 0;
+	int r = AAsset_read(asset, &bytes, 4);
+
+	if (r >= 0) {
+		pos += r;
+		if (pos >= len) {
+			eof = true;
+		}
+	}
+
+	if (big_endian) {
+		bytes = BSWAP32(bytes);
+	}
+
+	return bytes;
+}
+
+uint64_t FileAccessAndroid::get_64() const {
+	if (pos >= len) {
+		eof = true;
+		return 0;
+	}
+
+	uint64_t bytes = 0;
+	int r = AAsset_read(asset, &bytes, 8);
+
+	if (r >= 0) {
+		pos += r;
+		if (pos >= len) {
+			eof = true;
+		}
+	}
+
+	if (big_endian) {
+		bytes = BSWAP64(bytes);
+	}
+
+	return bytes;
+}
+
 uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
@@ -148,6 +217,18 @@ void FileAccessAndroid::flush() {
 }
 
 void FileAccessAndroid::store_8(uint8_t p_dest) {
+	ERR_FAIL();
+}
+
+void FileAccessAndroid::store_16(uint16_t p_dest) {
+	ERR_FAIL();
+}
+
+void FileAccessAndroid::store_32(uint32_t p_dest) {
+	ERR_FAIL();
+}
+
+void FileAccessAndroid::store_64(uint64_t p_dest) {
 	ERR_FAIL();
 }
 

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -66,12 +66,18 @@ public:
 	virtual bool eof_reached() const override; // reading passed EOF
 
 	virtual uint8_t get_8() const override; // get a byte
+	virtual uint16_t get_16() const override;
+	virtual uint32_t get_32() const override;
+	virtual uint64_t get_64() const override;
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; // get last error
 
 	virtual void flush() override;
 	virtual void store_8(uint8_t p_dest) override; // store a byte
+	virtual void store_16(uint16_t p_dest) override;
+	virtual void store_32(uint32_t p_dest) override;
+	virtual void store_64(uint64_t p_dest) override;
 
 	virtual bool file_exists(const String &p_path) override; // return true if a file exists
 

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -181,6 +181,36 @@ uint8_t FileAccessFilesystemJAndroid::get_8() const {
 	return byte;
 }
 
+uint16_t FileAccessFilesystemJAndroid::get_16() const {
+	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
+	uint16_t bytes = 0;
+	get_buffer(reinterpret_cast<uint8_t *>(&bytes), 2);
+	if (big_endian) {
+		bytes = BSWAP16(bytes);
+	}
+	return bytes;
+}
+
+uint32_t FileAccessFilesystemJAndroid::get_32() const {
+	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
+	uint32_t bytes = 0;
+	get_buffer(reinterpret_cast<uint8_t *>(&bytes), 4);
+	if (big_endian) {
+		bytes = BSWAP32(bytes);
+	}
+	return bytes;
+}
+
+uint64_t FileAccessFilesystemJAndroid::get_64() const {
+	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
+	uint64_t bytes = 0;
+	get_buffer(reinterpret_cast<uint8_t *>(&bytes), 8);
+	if (big_endian) {
+		bytes = BSWAP64(bytes);
+	}
+	return bytes;
+}
+
 String FileAccessFilesystemJAndroid::get_line() const {
 	ERR_FAIL_COND_V_MSG(!is_open(), String(), "File must be opened before use.");
 
@@ -248,6 +278,27 @@ uint64_t FileAccessFilesystemJAndroid::get_buffer(uint8_t *p_dst, uint64_t p_len
 
 void FileAccessFilesystemJAndroid::store_8(uint8_t p_dest) {
 	store_buffer(&p_dest, 1);
+}
+
+void FileAccessFilesystemJAndroid::store_16(uint16_t p_dest) {
+	if (big_endian) {
+		p_dest = BSWAP16(p_dest);
+	}
+	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), 2);
+}
+
+void FileAccessFilesystemJAndroid::store_32(uint32_t p_dest) {
+	if (big_endian) {
+		p_dest = BSWAP32(p_dest);
+	}
+	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), 4);
+}
+
+void FileAccessFilesystemJAndroid::store_64(uint64_t p_dest) {
+	if (big_endian) {
+		p_dest = BSWAP64(p_dest);
+	}
+	store_buffer(reinterpret_cast<uint8_t *>(&p_dest), 8);
 }
 
 void FileAccessFilesystemJAndroid::store_buffer(const uint8_t *p_src, uint64_t p_length) {

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -77,6 +77,9 @@ public:
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
 	virtual uint8_t get_8() const override; ///< get a byte
+	virtual uint16_t get_16() const override;
+	virtual uint32_t get_32() const override;
+	virtual uint64_t get_64() const override;
 	virtual String get_line() const override; ///< get a line
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
@@ -84,6 +87,9 @@ public:
 
 	virtual void flush() override;
 	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_16(uint16_t p_dest) override;
+	virtual void store_32(uint32_t p_dest) override;
+	virtual void store_64(uint64_t p_dest) override;
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
 	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists


### PR DESCRIPTION
Implements platform-specific variants of FileAccess's `get_16`, `get_32`, `get_64`, `store_16`, `store_32`, and `store_64`. Also adds MSVC-specific versions of `BSWAPxx` functions.

This results in a significant performance gain when reading or writing large amounts of binary data: ~5x faster writing and ~6x faster reading.

Benchmark results for writing data to a file: 

Windows x64, build - production
| data | master | PR |
| ------------- | ------------- | ------------- |
| 10000000 x uint64_t (78 mb) | 1.70s | 0.30s  |
| 50000000 x uint64_t (390 mb)  | 8.70s  | 1.80s |
| 10000 x uint64_t (79 kb)  | 0.0020s  | 0.0007s |
| 500000 x uint64_t big endian (4 mb)  | 0.085s  | 0.015s |
| 500000 x uint64_t little endian (4 mb)  | 0.086s  | 0.015s |

A small project for testing whether the changes work correctly: [file_access_test.zip](https://github.com/godotengine/godot/files/13219041/file_access_test.zip)

Progress:
- [x] FileAccessWindows
- [x] FileAccessUnix
- [x] FileAccessAndroid
- [x] Minimal testing project