### PR TITLE
Revert "Add a Disable 2D property to Viewport"

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -258,11 +258,8 @@
 		<member name="debug_draw" type="int" setter="set_debug_draw" getter="get_debug_draw" enum="Viewport.DebugDraw" default="0">
 			The overlay mode for test rendered geometry in debug purposes.
 		</member>
-		<member name="disable_2d" type="bool" setter="set_disable_2d" getter="is_2d_disabled" default="false">
-			If [code]true[/code], disables 2D rendering while keeping 3D rendering. See also [member disable_3d].
-		</member>
 		<member name="disable_3d" type="bool" setter="set_disable_3d" getter="is_3d_disabled" default="false">
-			If [code]true[/code], disables 3D rendering while keeping 2D rendering. See also [member disable_2d].
+			Disable 3D rendering (but keep 2D rendering).
 		</member>
 		<member name="fsr_sharpness" type="float" setter="set_fsr_sharpness" getter="get_fsr_sharpness" default="0.2">
 			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4019,17 +4019,6 @@ void Viewport::set_camera_3d_override_orthogonal(real_t p_size, real_t p_z_near,
 	}
 }
 
-void Viewport::set_disable_2d(bool p_disable) {
-	ERR_MAIN_THREAD_GUARD;
-	disable_2d = p_disable;
-	RenderingServer::get_singleton()->viewport_set_disable_2d(viewport, disable_2d);
-}
-
-bool Viewport::is_2d_disabled() const {
-	ERR_READ_THREAD_GUARD_V(false);
-	return disable_2d;
-}
-
 void Viewport::set_disable_3d(bool p_disable) {
 	ERR_MAIN_THREAD_GUARD;
 	disable_3d = p_disable;
@@ -4472,9 +4461,6 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_as_audio_listener_3d", "enable"), &Viewport::set_as_audio_listener_3d);
 	ClassDB::bind_method(D_METHOD("is_audio_listener_3d"), &Viewport::is_audio_listener_3d);
 
-	ClassDB::bind_method(D_METHOD("set_disable_2d", "disable"), &Viewport::set_disable_2d);
-	ClassDB::bind_method(D_METHOD("is_2d_disabled"), &Viewport::is_2d_disabled);
-
 	ClassDB::bind_method(D_METHOD("set_disable_3d", "disable"), &Viewport::set_disable_3d);
 	ClassDB::bind_method(D_METHOD("is_3d_disabled"), &Viewport::is_3d_disabled);
 
@@ -4499,7 +4485,6 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vrs_texture", "texture"), &Viewport::set_vrs_texture);
 	ClassDB::bind_method(D_METHOD("get_vrs_texture"), &Viewport::get_vrs_texture);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_2d"), "set_disable_2d", "is_2d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_xr"), "set_use_xr", "is_using_xr");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "own_world_3d"), "set_use_own_world_3d", "is_using_own_world_3d");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -283,7 +283,6 @@ private:
 
 	void _update_audio_listener_2d();
 
-	bool disable_2d = false;
 	bool disable_3d = false;
 
 	void _propagate_viewport_notification(Node *p_node, int p_what);
@@ -738,9 +737,6 @@ public:
 
 	void set_camera_3d_override_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
 	void set_camera_3d_override_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
-
-	void set_disable_2d(bool p_disable);
-	bool is_2d_disabled() const;
 
 	void set_disable_3d(bool p_disable);
 	bool is_3d_disabled() const;


### PR DESCRIPTION
This reverts commit f6cc2603a17a64f37c1273cdc4c2a058a0c8afc1 (https://github.com/godotengine/godot/pull/82969).

Adding ``disable_2D`` conflicts with our plans to add a setting that controls which buffers to use for the Viewport. 

By way of background. Currently when rendering to a viewport we always do the following:
```
If !disable_3d:
    - render to 3D buffer
    - copy 3D buffer to 2D buffer
If !disable_2d:
    - render to 2D buffer
If root_viewport:
    - copy to screen
```

``disable_2d`` is exposed through the rendering server so the editor can use it for the 3D viewport. But (as can be seen) it only partially disables 2D, The 2D buffer is still used which is a drain on performance, and reduces the effective precision of the Viewport.

We have firm plans to expose a mode that allows users to choose what buffers are used:
```
XR_ONLY
3D_ONLY
2D_ONLY
2D_AND_3D
```
This will disable rendering and avoid touching the 2D buffer if it can be avoided (3D buffer can be exposed directly to users with the ViewportTexture, or copied directly to screen. This will be a big win for performance on mobile devices, as well as usability for users who like to do advanced effects using the Viewport. 

If we expose ``disable_2d`` now, it is only a half measure that will quickly become out of date and will end up being a nuisance very shortly. We prefer to keep the API clean and functional until we implement a proper solution. Unfortunately, this means we need to revert this PR right after merging it. While regrettable, it will be better in the long run. 


