### PR TITLE
GDExtension expose `add_move_array_element_function`

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -503,7 +503,7 @@
 			<param index="0" name="class" type="String" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Allows setting a callback to handle adding, removing and changing the order of elements of an array of the given class in the Godot editor's inspector.
+				Allows setting a callback to handle adding, removing, and changing the order of elements of an array of the given class in the Godot editor's inspector.
 				The values of [param from_index] and [param to_position] in the callback function determine if the array element is being added, removed or moved.
 				If [param from_index] is [code]-1[/code] then a new element is being added.
 				If [param to_position] is [code]-1[/code] then an element is being removed.

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -504,7 +504,7 @@
 			<param index="1" name="callable" type="Callable" />
 			<description>
 				Allows setting a callback to handle adding, removing, and changing the order of elements of an array of the given class in the Godot editor's inspector.
-				The values of [param from_index] and [param to_position] in the callback function determine if the array element is being added, removed or moved.
+				The values of [param from_index] and [param to_position] in the callback function determine if the array element is being added, removed, or moved.
 				If [param from_index] is [code]-1[/code] then a new element is being added.
 				If [param to_position] is [code]-1[/code] then an element is being removed.
 				If [param from_index] and [param to_position] are greater or equal to [code]0[/code] then they indicate respectively the current and previous positions in the array for a specific element.

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -498,6 +498,18 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="add_move_array_element_function">
+			<return type="void" />
+			<param index="0" name="class" type="String" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Allows setting a callback to handle adding, removing and changing the order of elements of an array of the given class in the Godot editor's inspector.
+				The values of from_index and to_position in callback function determine if the array element is being added, removed or moved.
+				If from_index is [code]-1[/code] then a new element is being added.
+				If to_position is [code]-1[/code] then an element is being removed.
+				If from_index and to_position are >= 0 then they indicate the current and previous position in the array for a specific element.
+			</description>
+		</method>
 		<method name="add_node_3d_gizmo_plugin">
 			<return type="void" />
 			<param index="0" name="plugin" type="EditorNode3DGizmoPlugin" />
@@ -676,6 +688,13 @@
 			<param index="0" name="plugin" type="EditorInspectorPlugin" />
 			<description>
 				Removes an inspector plugin registered by [method add_import_plugin]
+			</description>
+		</method>
+		<method name="remove_move_array_element_function">
+			<return type="void" />
+			<param index="0" name="class" type="String" />
+			<description>
+				Removes a move array element function registered by [method add_move_array_element_function].
 			</description>
 		</method>
 		<method name="remove_node_3d_gizmo_plugin">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -504,10 +504,10 @@
 			<param index="1" name="callable" type="Callable" />
 			<description>
 				Allows setting a callback to handle adding, removing and changing the order of elements of an array of the given class in the Godot editor's inspector.
-				The values of from_index and to_position in callback function determine if the array element is being added, removed or moved.
-				If from_index is [code]-1[/code] then a new element is being added.
-				If to_position is [code]-1[/code] then an element is being removed.
-				If from_index and to_position are >= 0 then they indicate the current and previous position in the array for a specific element.
+				The values of [param from_index] and [param to_position] in the callback function determine if the array element is being added, removed or moved.
+				If [param from_index] is [code]-1[/code] then a new element is being added.
+				If [param to_position] is [code]-1[/code] then an element is being removed.
+				If [param from_index] and [param to_position] are greater or equal to [code]0[/code] then they indicate respectively the current and previous positions in the array for a specific element.
 			</description>
 		</method>
 		<method name="add_node_3d_gizmo_plugin">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -396,6 +396,14 @@ void EditorPlugin::remove_undo_redo_inspector_hook_callback(Callable p_callable)
 	EditorNode::get_editor_data().remove_undo_redo_inspector_hook_callback(p_callable);
 }
 
+void EditorPlugin::add_move_array_element_function(const String &p_class, Callable p_callable) {
+	EditorNode::get_editor_data().add_move_array_element_function(p_class, p_callable);
+}
+
+void EditorPlugin::remove_move_array_element_function(const String &p_class) {
+	EditorNode::get_editor_data().remove_move_array_element_function(p_class);
+}
+
 void EditorPlugin::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
 	ERR_FAIL_COND(!p_parser.is_valid());
 	EditorTranslationParser::get_singleton()->add_parser(p_parser, EditorTranslationParser::CUSTOM);
@@ -583,6 +591,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::get_undo_redo);
 	ClassDB::bind_method(D_METHOD("add_undo_redo_inspector_hook_callback", "callable"), &EditorPlugin::add_undo_redo_inspector_hook_callback);
 	ClassDB::bind_method(D_METHOD("remove_undo_redo_inspector_hook_callback", "callable"), &EditorPlugin::remove_undo_redo_inspector_hook_callback);
+	ClassDB::bind_method(D_METHOD("add_move_array_element_function", "class", "callable"), &EditorPlugin::add_move_array_element_function);
+	ClassDB::bind_method(D_METHOD("remove_move_array_element_function", "class"), &EditorPlugin::remove_move_array_element_function);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
 	ClassDB::bind_method(D_METHOD("add_translation_parser_plugin", "parser"), &EditorPlugin::add_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -206,6 +206,9 @@ public:
 	void add_undo_redo_inspector_hook_callback(Callable p_callable);
 	void remove_undo_redo_inspector_hook_callback(Callable p_callable);
 
+	void add_move_array_element_function(const String &p_class, Callable p_callable);
+	void remove_move_array_element_function(const String &p_class);
+
 	int update_overlays() const;
 
 	void queue_save_layout();


### PR DESCRIPTION
Add function to editor plugin to allow use in GDExtension

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8293*