### PR TITLE
Add descriptive warning for animation track hint fails.

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -31,6 +31,7 @@
 #include "animation_track_editor.h"
 
 #include "animation_track_editor_plugins.h"
+#include "core/error/error_macros.h"
 #include "core/input/input.h"
 #include "editor/animation_bezier_editor.h"
 #include "editor/editor_node.h"
@@ -4105,6 +4106,12 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 	for (int i = 0; i < leftover_path.size() - 1; i++) {
 		bool valid;
 		property_info_base = property_info_base.get_named(leftover_path[i], valid);
+	}
+
+	if (property_info_base.is_null()) {
+		WARN_PRINT(vformat("Could not determine track hint for '%s:%s' because its base property is null.",
+				String(path.get_concatenated_names()), String(path.get_concatenated_subnames())));
+		return PropertyInfo();
 	}
 
 	List<PropertyInfo> pinfo;


### PR DESCRIPTION
While this does not properly fix this bug (https://github.com/godotengine/godot/issues/83421), I feel its somewhat lower priority at the moment, but this PR at least provides a more descriptive warning of what happened rather than just failing with a generic null error. An actual fix for this bug in the case of reported issue probably involves running the track hint AFTER animation has had chance to run one frame, but even if we add that handling, track hint detection can still fail, so the warning is still relevant.