### PR TITLE
Fix nodes being deselected upon reparenting

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3000,6 +3000,9 @@ void SceneTreeDock::_nodes_dragged(Array p_nodes, NodePath p_to, int p_type) {
 
 	_normalize_drop(to_node, to_pos, p_type);
 	_do_reparent(to_node, to_pos, nodes, !Input::get_singleton()->is_key_pressed(Key::SHIFT));
+	for (Node *E : nodes) {
+		editor_selection->add_node(E);
+	}
 }
 
 void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {


### PR DESCRIPTION
Fixes inconsistency when moving nodes in hierarchy, as reparenting caused nodes to be deselected (vs reordering children of same node).
This especially improves flow when building a skeleton by duplicating and reparenting bones:
![reparent](https://github.com/godotengine/godot/assets/1621768/e733bf61-98e2-4221-8437-124e0be2b2d1)

There isn't existing issue about this, just a short conversation at [rocket chat](https://chat.godotengine.org/channel/editor?msg=dB76hqvgdhjrpPLis).