### PR TITLE
Fix crash when extending taken-over named class

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2666,7 +2666,10 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	GDScriptDataType base_type = _gdtype_from_datatype(p_class->base_type, p_script, false);
 
+	ERR_FAIL_COND_V_MSG(base_type.native_type == StringName(), ERR_BUG, vformat(R"(Failed to get base class for "%s")", p_script->path));
+
 	int native_idx = GDScriptLanguage::get_singleton()->get_global_map()[base_type.native_type];
+
 	p_script->native = GDScriptLanguage::get_singleton()->get_global_array()[native_idx];
 	ERR_FAIL_COND_V(p_script->native.is_null(), ERR_BUG);
 


### PR DESCRIPTION
Added error handling in `_prepare_compilation()` to address cases where the `base_type` cannot be found, preventing a crash. 
Added an additional if statement to `find_class()` to check the script path.

I expect this to not be the ideal solution, as I stated in my issue comment.
But this PR might be a better place to discuss code changes, and I'm looking forward to any feedback.

Nonetheless, I ran all the GDScript tests and tried this fix in the MRP and two bigger projects with success and no obvious side effects.

Cheers.

---
> [!NOTE]
> This now only contains the crash prevention. Future debugging is needed. #83542 will stay open.
