### PR TITLE
Fix `NOTIFICATION_WM_SIZE_CHANGED` firing if the size hasn't changed (reverted)

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1142,7 +1142,10 @@ void Window::_update_viewport_size() {
 		}
 	}
 
-	notification(NOTIFICATION_WM_SIZE_CHANGED);
+	if (old_size != size) {
+		old_size = size;
+		notification(NOTIFICATION_WM_SIZE_CHANGED);
+	}
 
 	if (embedder) {
 		embedder->_sub_window_update(this);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -117,6 +117,7 @@ private:
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
 	mutable Size2i min_size;
 	mutable Size2i max_size;
+	mutable Size2i old_size = size;
 	mutable Vector<Vector2> mpath;
 	mutable Mode mode = MODE_WINDOWED;
 	mutable bool flags[FLAG_MAX] = {};


### PR DESCRIPTION
Currently, the `NOTIFICATION_WM_SIZE_CHANGED` notification if fired whenever the `_update_viewport_size()` is called, even if the size itself didn't change at all. This PR makes it compare the new size with the old one before firing it.