### PR TITLE
Prevent `encode_variant` doing `memcpy` from `nullptr`

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1621,8 +1621,10 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				encode_uint32(datalen, buf);
 				buf += 4;
 				const uint8_t *r = data.ptr();
-				memcpy(buf, &r[0], datalen * datasize);
-				buf += datalen * datasize;
+				if (r) {
+					memcpy(buf, &r[0], datalen * datasize);
+					buf += datalen * datasize;
+				}
 			}
 
 			r_len += 4 + datalen * datasize;


### PR DESCRIPTION
`memcpy` will crash on some platforms if the second argument is `nullptr` (the cases with `String` doesn't suffer from this as `get_data` doesn't return `nullptr`)

* Fixes (partially): https://github.com/godotengine/godot/issues/84152
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
