### PR TITLE
Improve compatibility with different Linux environments.

### DIFF
--- a/drivers/alsa/asound-so_wrap.c
+++ b/drivers/alsa/asound-so_wrap.c
@@ -3826,6 +3826,9 @@ int initialize_asound(int verbose) {
   char *error;
   handle = dlopen("libasound.so.2", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libasound.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/drivers/pulseaudio/pulse-so_wrap.c
+++ b/drivers/pulseaudio/pulse-so_wrap.c
@@ -1066,6 +1066,9 @@ int initialize_pulse(int verbose) {
   char *error;
   handle = dlopen("libpulse.so.0", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libpulse.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/dbus-so_wrap.c
+++ b/platform/linuxbsd/dbus-so_wrap.c
@@ -727,6 +727,9 @@ int initialize_dbus(int verbose) {
   char *error;
   handle = dlopen("libdbus-1.so.3", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libdbus-1.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/fontconfig-so_wrap.c
+++ b/platform/linuxbsd/fontconfig-so_wrap.c
@@ -628,6 +628,9 @@ int initialize_fontconfig(int verbose) {
   char *error;
   handle = dlopen("libfontconfig.so.1", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libfontconfig.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/libudev-so_wrap.c
+++ b/platform/linuxbsd/libudev-so_wrap.c
@@ -283,6 +283,9 @@ int initialize_libudev(int verbose) {
   char *error;
   handle = dlopen("libudev.so.1", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libudev.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/speechd-so_wrap.c
+++ b/platform/linuxbsd/speechd-so_wrap.c
@@ -238,6 +238,9 @@ int initialize_speechd(int verbose) {
   char *error;
   handle = dlopen("libspeechd.so.2", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libspeechd.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -403,11 +403,13 @@ void DisplayServerX11::mouse_set_mode(MouseMode p_mode) {
 		}
 	}
 
-	for (const KeyValue<WindowID, WindowData> &E : windows) {
-		if (show_cursor) {
-			XDefineCursor(x11_display, E.value.x11_window, cursors[current_cursor]); // show cursor
-		} else {
-			XDefineCursor(x11_display, E.value.x11_window, null_cursor); // hide cursor
+	if (xcursor_loaded) {
+		for (const KeyValue<WindowID, WindowData> &E : windows) {
+			if (show_cursor) {
+				XDefineCursor(x11_display, E.value.x11_window, cursors[current_cursor]); // show cursor
+			} else {
+				XDefineCursor(x11_display, E.value.x11_window, null_cursor); // hide cursor
+			}
 		}
 	}
 	mouse_mode = p_mode;
@@ -3000,14 +3002,16 @@ void DisplayServerX11::cursor_set_shape(CursorShape p_shape) {
 		return;
 	}
 
-	if (mouse_mode == MOUSE_MODE_VISIBLE || mouse_mode == MOUSE_MODE_CONFINED) {
-		if (cursors[p_shape] != None) {
-			for (const KeyValue<WindowID, WindowData> &E : windows) {
-				XDefineCursor(x11_display, E.value.x11_window, cursors[p_shape]);
-			}
-		} else if (cursors[CURSOR_ARROW] != None) {
-			for (const KeyValue<WindowID, WindowData> &E : windows) {
-				XDefineCursor(x11_display, E.value.x11_window, cursors[CURSOR_ARROW]);
+	if (xcursor_loaded) {
+		if (mouse_mode == MOUSE_MODE_VISIBLE || mouse_mode == MOUSE_MODE_CONFINED) {
+			if (cursors[p_shape] != None) {
+				for (const KeyValue<WindowID, WindowData> &E : windows) {
+					XDefineCursor(x11_display, E.value.x11_window, cursors[p_shape]);
+				}
+			} else if (cursors[CURSOR_ARROW] != None) {
+				for (const KeyValue<WindowID, WindowData> &E : windows) {
+					XDefineCursor(x11_display, E.value.x11_window, cursors[CURSOR_ARROW]);
+				}
 			}
 		}
 	}
@@ -3023,6 +3027,10 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
+
+	if (!xcursor_loaded) {
+		return;
+	}
 
 	if (p_cursor.is_valid()) {
 		HashMap<CursorShape, Vector<Variant>>::Iterator cursor_c = cursors_cache.find(p_shape);
@@ -5647,7 +5655,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 	}
 
 	//set cursor
-	if (cursors[current_cursor] != None) {
+	if (xcursor_loaded && (cursors[current_cursor] != None)) {
 		XDefineCursor(x11_display, wd.x11_window, cursors[current_cursor]);
 	}
 
@@ -5725,10 +5733,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		ERR_FAIL_MSG("Can't load Xlib dynamically.");
 	}
 
-	if (initialize_xcursor(dylibloader_verbose) != 0) {
-		r_error = ERR_UNAVAILABLE;
-		ERR_FAIL_MSG("Can't load XCursor dynamically.");
-	}
+	xcursor_loaded = (initialize_xcursor(dylibloader_verbose) != 0);
+
 #ifdef XKB_ENABLED
 	bool xkb_loaded = (initialize_xkbcommon(dylibloader_verbose) == 0);
 	xkb_loaded_v05p = xkb_loaded;
@@ -5765,6 +5771,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		ERR_FAIL_MSG("Can't load Xinput2 dynamically.");
 	}
 #else
+	xcursor_loaded = true;
 #ifdef XKB_ENABLED
 	bool xkb_loaded = true;
 	xkb_loaded_v05p = true;
@@ -5796,12 +5803,11 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	r_error = OK;
 
 #ifdef SOWRAP_ENABLED
-	{
+	if (xcursor_loaded) {
 		if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
 			// There's no API to check version, check if functions are available instead.
-			ERR_PRINT("Unsupported Xcursor library version.");
-			r_error = ERR_UNAVAILABLE;
-			return;
+			xcursor_loaded = false;
+			print_verbose("Unsupported Xcursor library version.");
 		}
 	}
 #endif
@@ -6142,94 +6148,96 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		XISelectEvents(x11_display, DefaultRootWindow(x11_display), &all_master_event_mask, 1);
 	}
 
-	cursor_size = XcursorGetDefaultSize(x11_display);
-	cursor_theme = XcursorGetTheme(x11_display);
+	if (xcursor_loaded) {
+		cursor_size = XcursorGetDefaultSize(x11_display);
+		cursor_theme = XcursorGetTheme(x11_display);
 
-	if (!cursor_theme) {
-		print_verbose("XcursorGetTheme could not get cursor theme");
-		cursor_theme = "default";
-	}
-
-	for (int i = 0; i < CURSOR_MAX; i++) {
-		static const char *cursor_file[] = {
-			"left_ptr",
-			"xterm",
-			"hand2",
-			"cross",
-			"watch",
-			"left_ptr_watch",
-			"fleur",
-			"dnd-move",
-			"crossed_circle",
-			"v_double_arrow",
-			"h_double_arrow",
-			"size_bdiag",
-			"size_fdiag",
-			"move",
-			"row_resize",
-			"col_resize",
-			"question_arrow"
-		};
-
-		cursor_img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
-		if (!cursor_img[i]) {
-			const char *fallback = nullptr;
-
-			switch (i) {
-				case CURSOR_POINTING_HAND:
-					fallback = "pointer";
-					break;
-				case CURSOR_CROSS:
-					fallback = "crosshair";
-					break;
-				case CURSOR_WAIT:
-					fallback = "wait";
-					break;
-				case CURSOR_BUSY:
-					fallback = "progress";
-					break;
-				case CURSOR_DRAG:
-					fallback = "grabbing";
-					break;
-				case CURSOR_CAN_DROP:
-					fallback = "hand1";
-					break;
-				case CURSOR_FORBIDDEN:
-					fallback = "forbidden";
-					break;
-				case CURSOR_VSIZE:
-					fallback = "ns-resize";
-					break;
-				case CURSOR_HSIZE:
-					fallback = "ew-resize";
-					break;
-				case CURSOR_BDIAGSIZE:
-					fallback = "fd_double_arrow";
-					break;
-				case CURSOR_FDIAGSIZE:
-					fallback = "bd_double_arrow";
-					break;
-				case CURSOR_MOVE:
-					cursor_img[i] = cursor_img[CURSOR_DRAG];
-					break;
-				case CURSOR_VSPLIT:
-					fallback = "sb_v_double_arrow";
-					break;
-				case CURSOR_HSPLIT:
-					fallback = "sb_h_double_arrow";
-					break;
-				case CURSOR_HELP:
-					fallback = "help";
-					break;
-			}
-			if (fallback != nullptr) {
-				cursor_img[i] = XcursorLibraryLoadImage(fallback, cursor_theme, cursor_size);
-			}
+		if (!cursor_theme) {
+			print_verbose("XcursorGetTheme could not get cursor theme");
+			cursor_theme = "default";
 		}
-		if (cursor_img[i]) {
-			cursors[i] = XcursorImageLoadCursor(x11_display, cursor_img[i]);
-		} else {
-			print_verbose("Failed loading custom cursor: " + String(cursor_file[i]));
+
+		for (int i = 0; i < CURSOR_MAX; i++) {
+			static const char *cursor_file[] = {
+				"left_ptr",
+				"xterm",
+				"hand2",
+				"cross",
+				"watch",
+				"left_ptr_watch",
+				"fleur",
+				"dnd-move",
+				"crossed_circle",
+				"v_double_arrow",
+				"h_double_arrow",
+				"size_bdiag",
+				"size_fdiag",
+				"move",
+				"row_resize",
+				"col_resize",
+				"question_arrow"
+			};
+
+			cursor_img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
+			if (!cursor_img[i]) {
+				const char *fallback = nullptr;
+
+				switch (i) {
+					case CURSOR_POINTING_HAND:
+						fallback = "pointer";
+						break;
+					case CURSOR_CROSS:
+						fallback = "crosshair";
+						break;
+					case CURSOR_WAIT:
+						fallback = "wait";
+						break;
+					case CURSOR_BUSY:
+						fallback = "progress";
+						break;
+					case CURSOR_DRAG:
+						fallback = "grabbing";
+						break;
+					case CURSOR_CAN_DROP:
+						fallback = "hand1";
+						break;
+					case CURSOR_FORBIDDEN:
+						fallback = "forbidden";
+						break;
+					case CURSOR_VSIZE:
+						fallback = "ns-resize";
+						break;
+					case CURSOR_HSIZE:
+						fallback = "ew-resize";
+						break;
+					case CURSOR_BDIAGSIZE:
+						fallback = "fd_double_arrow";
+						break;
+					case CURSOR_FDIAGSIZE:
+						fallback = "bd_double_arrow";
+						break;
+					case CURSOR_MOVE:
+						cursor_img[i] = cursor_img[CURSOR_DRAG];
+						break;
+					case CURSOR_VSPLIT:
+						fallback = "sb_v_double_arrow";
+						break;
+					case CURSOR_HSPLIT:
+						fallback = "sb_h_double_arrow";
+						break;
+					case CURSOR_HELP:
+						fallback = "help";
+						break;
+				}
+				if (fallback != nullptr) {
+					cursor_img[i] = XcursorLibraryLoadImage(fallback, cursor_theme, cursor_size);
+				}
+			}
+			if (cursor_img[i]) {
+				cursors[i] = XcursorImageLoadCursor(x11_display, cursor_img[i]);
+			} else {
+				print_verbose("Failed loading custom cursor: " + String(cursor_file[i]));
+			}
 		}
 	}
 
@@ -6370,12 +6378,14 @@ DisplayServerX11::~DisplayServerX11() {
 		dlclose(xrandr_handle);
 	}
 
-	for (int i = 0; i < CURSOR_MAX; i++) {
-		if (cursors[i] != None) {
-			XFreeCursor(x11_display, cursors[i]);
-		}
-		if (cursor_img[i] != nullptr) {
-			XcursorImageDestroy(cursor_img[i]);
+	if (xcursor_loaded) {
+		for (int i = 0; i < CURSOR_MAX; i++) {
+			if (cursors[i] != None) {
+				XFreeCursor(x11_display, cursors[i]);
+			}
+			if (cursor_img[i] != nullptr) {
+				XcursorImageDestroy(cursor_img[i]);
+			}
 		}
 	}
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -309,6 +309,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	bool do_mouse_warp = false;
 
+	bool xcursor_loaded = false;
 	const char *cursor_theme = nullptr;
 	int cursor_size = 0;
 	XcursorImage *cursor_img[CURSOR_MAX];

--- a/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.c
@@ -194,6 +194,9 @@ int initialize_xcursor(int verbose) {
   char *error;
   handle = dlopen("libXcursor.so.1", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libXcursor.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.c
@@ -56,6 +56,9 @@ int initialize_xext(int verbose) {
   char *error;
   handle = dlopen("libXext.so.6", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libXext.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.c
@@ -29,6 +29,9 @@ int initialize_xinerama(int verbose) {
   char *error;
   handle = dlopen("libXinerama.so.1", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libXinerama.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.c
@@ -119,6 +119,9 @@ int initialize_xinput2(int verbose) {
   char *error;
   handle = dlopen("libXi.so.6", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libXi.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.c
@@ -1830,6 +1830,9 @@ int initialize_xlib(int verbose) {
   char *error;
   handle = dlopen("libX11.so.6", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libX11.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.c
@@ -227,6 +227,9 @@ int initialize_xrandr(int verbose) {
   char *error;
   handle = dlopen("libXrandr.so.2", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libXrandr.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.c
@@ -149,6 +149,9 @@ int initialize_xrender(int verbose) {
   char *error;
   handle = dlopen("libXrender.so.1", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libXrender.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/platform/linuxbsd/xkbcommon-so_wrap.c
+++ b/platform/linuxbsd/xkbcommon-so_wrap.c
@@ -285,6 +285,9 @@ int initialize_xkbcommon(int verbose) {
   char *error;
   handle = dlopen("libxkbcommon.so.0", RTLD_LAZY);
   if (!handle) {
+    handle = dlopen("libxkbcommon.so", RTLD_LAZY);
+  }
+  if (!handle) {
     if (verbose) {
       fprintf(stderr, "%s\n", dlerror());
     }

--- a/thirdparty/embree/common/simd/arm/sse2neon.h
+++ b/thirdparty/embree/common/simd/arm/sse2neon.h
@@ -5954,7 +5954,13 @@ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
 FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
 {
 #if __has_builtin(__builtin_nontemporal_store)
+// -- GODOT start --
+#if defined(__aarch64__)
+    __builtin_nontemporal_store(a, (float64x2_t *) p);
+#else
     __builtin_nontemporal_store(a, (float32x4_t *) p);
+#endif
+// -- GODOT end --
 #elif defined(__aarch64__)
     vst1q_f64(p, vreinterpretq_f64_m128d(a));
 #else


### PR DESCRIPTION
- Tries loading dynamic libs using name w/o version number if loading with version number failed (some environment, like Termux without chroot do not have symlinks with the version number).
- Makes XCursor library optional (it's used for setting custom mouse cursors only, and therefore is not essential).
- Fixes invalid type cast on the ARM64 in raycast/embree module (building Linux VM on Apple Silicon or Termux on Android).