### PR TITLE
Fix slow raycast editing

### DIFF
--- a/editor/plugins/cast_2d_editor_plugin.cpp
+++ b/editor/plugins/cast_2d_editor_plugin.cpp
@@ -98,7 +98,6 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 
 		node->set("target_position", point);
 		canvas_item_editor->update_viewport();
-		node->notify_property_list_changed();
 
 		return true;
 	}


### PR DESCRIPTION
Moving Raycast2D target position using the editor gizmo will cause unnecessary inspector refresh and severe editor slowdowns. This PR fixes it.