### PR TITLE
Ensure SoftBody3D does not use compressed mesh format.

### DIFF
--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -471,6 +471,7 @@ void SoftBody3D::_become_mesh_owner() {
 	uint32_t surface_format = mesh->surface_get_format(0);
 
 	surface_format |= Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE;
+	surface_format &= ~Mesh::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
 
 	Ref<ArrayMesh> soft_mesh;
 	soft_mesh.instantiate();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84094

When using the compressed mesh format (default for imported meshes when possible) the SoftBody3D ended up still updating its vertex attributes as if the attributes were uncompressed leading to the mesh containing bogus data. 

The solution is to force it to use an uncompressed format since we are creating a new ArrayMesh internally anyway. There is no need to copy the compression flag. 
