### PR TITLE
Fix behavior of ResourceFormatLoader `CACHE_MODE_REPLACE` (reverted)

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -340,7 +340,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 
 	if (load_task.resource.is_valid()) {
 		if (load_task.cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
-			load_task.resource->set_path(load_task.local_path);
+			load_task.resource->set_path(load_task.local_path, load_task.cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
 		} else if (!load_task.local_path.is_resource_file()) {
 			load_task.resource->set_path_cache(load_task.local_path);
 		}
@@ -360,6 +360,17 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 
 		if (_loaded_callback) {
 			_loaded_callback(load_task.resource, load_task.local_path);
+		}
+	} else if (load_task.cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+		Ref<Resource> existing = ResourceCache::get_ref(load_task.local_path);
+		if (existing.is_valid()) {
+			load_task.resource = existing;
+			load_task.status = THREAD_LOAD_LOADED;
+			load_task.progress = 1.0;
+
+			if (_loaded_callback) {
+				_loaded_callback(load_task.resource, load_task.local_path);
+			}
 		}
 	}
 
@@ -463,7 +474,7 @@ Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path,
 			load_task.type_hint = p_type_hint;
 			load_task.cache_mode = p_cache_mode;
 			load_task.use_sub_threads = p_thread_mode == LOAD_THREAD_DISTRIBUTE;
-			if (p_cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+			if (p_cache_mode == ResourceFormatLoader::CACHE_MODE_REUSE) {
 				Ref<Resource> existing = ResourceCache::get_ref(local_path);
 				if (existing.is_valid()) {
 					//referencing is fine

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6216,8 +6216,7 @@ void EditorNode::reload_instances_with_path_in_edited_scenes(const String &p_ins
 	if (edited_scene_map.size() > 0) {
 		// Reload the new instance.
 		Error err;
-		Ref<PackedScene> instance_scene_packed_scene = ResourceLoader::load(p_instance_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE, &err);
-		instance_scene_packed_scene->set_path(p_instance_path, true);
+		Ref<PackedScene> instance_scene_packed_scene = ResourceLoader::load(p_instance_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE, &err);
 
 		ERR_FAIL_COND(err != OK);
 		ERR_FAIL_COND(instance_scene_packed_scene.is_null());
@@ -6324,8 +6323,7 @@ void EditorNode::reload_instances_with_path_in_edited_scenes(const String &p_ins
 					// be properly updated.
 					for (String path : required_load_paths) {
 						if (!local_scene_cache.find(path)) {
-							current_packed_scene = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_IGNORE, &err);
-							current_packed_scene->set_path(path, true);
+							current_packed_scene = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REPLACE, &err);
 							local_scene_cache[path] = current_packed_scene;
 						} else {
 							current_packed_scene = local_scene_cache[path];


### PR DESCRIPTION
I've noticed that CACHE_MODE_REPLACE doesn't seem to be behaving the way I expect it to when using it load resources which have already been cached, specifically that it doesn't seem to be updating, just fetching from the cache. With this change, I've also modified the scene reimport system to use it since the CACHE_MODE_IGNORE enum it was using before appears to break external resource paths.

Would appreciate any feedback and testing for this PR since this part of the resource loader is an area of engine I'm less familiar with.