### PR TITLE
Add serialization of foreign external resources.

### DIFF
--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -104,7 +104,7 @@ public:
 	virtual void set_path(const String &p_path, bool p_take_over = false);
 	String get_path() const;
 	void set_path_cache(const String &p_path); // Set raw path without involving resource cache.
-	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.contains("::") || path_cache.begins_with("local://"); }
+	_FORCE_INLINE_ bool is_built_in(String p_local_path = "") const { return path_cache.is_empty() || (path_cache.contains("::") && (path_cache.begins_with(p_local_path) || p_local_path == "")) || path_cache.begins_with("local://"); }
 
 	static String generate_scene_unique_id();
 	void set_scene_unique_id(const String &p_id);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -38,6 +38,7 @@
 #include "core/io/missing_resource.h"
 #include "core/object/script_language.h"
 #include "core/version.h"
+#include "scene/resources/packed_scene.h"
 
 //#define print_bl(m_what) print_line(m_what)
 #define print_bl(m_what) (void)(m_what)
@@ -924,10 +925,21 @@ void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p
 	for (int i = 0; i < external_resources.size(); i++) {
 		String dep;
 		String fallback_path;
+		String base_path = external_resources[i].path;
 
+		String foreign_resource_id;
 		if (external_resources[i].uid != ResourceUID::INVALID_ID) {
+			// Check if the path contains a splitter indicating it points to a foreign resource.
+			if (external_resources[i].path.contains("::")) {
+				PackedStringArray split_path = external_resources[i].path.split("::", false);
+				if (split_path.size() == 2) {
+					base_path = split_path[0];
+					foreign_resource_id = split_path[1];
+				}
+			}
+
 			dep = ResourceUID::get_singleton()->id_to_text(external_resources[i].uid);
-			fallback_path = external_resources[i].path; // Used by Dependency Editor, in case uid path fails.
+			fallback_path = base_path; // Used by Dependency Editor, in case uid path fails.
 		} else {
 			dep = external_resources[i].path;
 		}
@@ -940,6 +952,10 @@ void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p
 				dep += "::"; // Ensure that path comes third, even if there is no type.
 			}
 			dep += "::" + fallback_path;
+			// If we found a sub-resource ID, append it to the path now.
+			if (!foreign_resource_id.is_empty()) {
+				dep += "::" + foreign_resource_id;
+			}
 		}
 
 		p_dependencies->push_back(dep);
@@ -1043,9 +1059,19 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 		ExtResource er;
 		er.type = get_unicode_string();
 		er.path = get_unicode_string();
+		String foreign_resource_id;
+
 		if (using_uids) {
 			er.uid = f->get_64();
 			if (!p_keep_uuid_paths && er.uid != ResourceUID::INVALID_ID) {
+				// Check if the path contains a splitter indicating it points to a foreign resource.
+				if (er.path.contains("::")) {
+					PackedStringArray split_path = er.path.split("::", false);
+					if (split_path.size() == 2) {
+						er.path = split_path[0];
+						foreign_resource_id = split_path[1];
+					}
+				}
 				if (ResourceUID::get_singleton()->has_id(er.uid)) {
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
 					er.path = ResourceUID::get_singleton()->get_id_path(er.uid);
@@ -1062,6 +1088,10 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 			}
 		}
 
+		// If we found a sub-resource ID, append it to the path now.
+		if (!foreign_resource_id.is_empty()) {
+			er.path += "::" + foreign_resource_id;
+		}
 		external_resources.push_back(er);
 	}
 
@@ -1384,6 +1414,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		String type = get_ustring(f);
 		String path = get_ustring(f);
 
+		String original_path = path;
+
 		if (using_uids) {
 			ResourceUID::ID uid = f->get_64();
 			if (uid != ResourceUID::INVALID_ID) {
@@ -1400,23 +1432,37 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 			relative = true;
 		}
 
-		if (p_map.has(path)) {
-			String np = p_map[path];
+		if (p_map.has(original_path)) {
+			String np = p_map[original_path];
 			path = np;
 		}
 
-		String full_path = path;
+		String base_path = path;
+		String foreign_resource_id;
+
+		// Check if the path contains a splitter indicating it points to a foreign resource.
+		if (path.contains("::")) {
+			PackedStringArray split_path = path.split("::", false);
+			if (split_path.size() == 2) {
+				base_path = split_path[0];
+				foreign_resource_id = split_path[1];
+			}
+		}
 
 		if (relative) {
 			//restore relative
-			path = local_path.path_to_file(path);
+			base_path = local_path.path_to_file(base_path);
+		}
+
+		if (!foreign_resource_id.is_empty()) {
+			path = base_path + "::" + foreign_resource_id;
 		}
 
 		save_ustring(fw, type);
 		save_ustring(fw, path);
 
 		if (using_uids) {
-			ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(full_path);
+			ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(base_path);
 			fw->store_64(uid);
 		}
 	}
@@ -1528,7 +1574,7 @@ void ResourceFormatSaverBinaryInstance::_pad_buffer(Ref<FileAccess> f, int p_byt
 	}
 }
 
-void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint) {
+void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint, const String &p_base_path) {
 	switch (p_property.get_type()) {
 		case Variant::NIL: {
 			f->store_32(VARIANT_NIL);
@@ -1783,7 +1829,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 				return; // Don't save it.
 			}
 
-			if (!res->is_built_in()) {
+			if (!res->is_built_in(p_base_path)) {
 				f->store_32(OBJECT_EXTERNAL_RESOURCE_INDEX);
 				f->store_32(external_resources[res]);
 			} else {
@@ -1816,8 +1862,8 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 			d.get_key_list(&keys);
 
 			for (const Variant &E : keys) {
-				write_variant(f, E, resource_map, external_resources, string_map);
-				write_variant(f, d[E], resource_map, external_resources, string_map);
+				write_variant(f, E, resource_map, external_resources, string_map, PropertyInfo(), p_base_path);
+				write_variant(f, d[E], resource_map, external_resources, string_map, PropertyInfo(), p_base_path);
 			}
 
 		} break;
@@ -1826,7 +1872,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 			Array a = p_property;
 			f->store_32(uint32_t(a.size()));
 			for (int i = 0; i < a.size(); i++) {
-				write_variant(f, a[i], resource_map, external_resources, string_map);
+				write_variant(f, a[i], resource_map, external_resources, string_map, PropertyInfo(), p_base_path);
 			}
 
 		} break;
@@ -1940,7 +1986,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 	}
 }
 
-void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant, bool p_main) {
+void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant, const String &p_base_path, bool p_main) {
 	switch (p_variant.get_type()) {
 		case Variant::OBJECT: {
 			Ref<Resource> res = p_variant;
@@ -1949,7 +1995,7 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 				return;
 			}
 
-			if (!p_main && (!bundle_resources) && !res->is_built_in()) {
+			if (!p_main && (!bundle_resources) && !res->is_built_in(p_base_path)) {
 				if (res->get_path() == path) {
 					ERR_PRINT("Circular reference to resource being saved found: '" + local_path + "' will be null next time it's loaded.");
 					return;
@@ -1983,10 +2029,10 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 							resource_set.insert(sres);
 							saved_resources.push_back(sres);
 						} else {
-							_find_resources(value);
+							_find_resources(value, p_base_path);
 						}
 					} else {
-						_find_resources(value);
+						_find_resources(value, p_base_path);
 					}
 				}
 			}
@@ -2000,7 +2046,7 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 			int len = varray.size();
 			for (int i = 0; i < len; i++) {
 				const Variant &v = varray.get(i);
-				_find_resources(v);
+				_find_resources(v, p_base_path);
 			}
 
 		} break;
@@ -2010,9 +2056,9 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 			List<Variant> keys;
 			d.get_key_list(&keys);
 			for (const Variant &E : keys) {
-				_find_resources(E);
+				_find_resources(E, p_base_path);
 				Variant v = d[E];
-				_find_resources(v);
+				_find_resources(v, p_base_path);
 			}
 		} break;
 		case Variant::NODE_PATH: {
@@ -2074,6 +2120,15 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		f = FileAccess::open(p_path, FileAccess::WRITE, &err);
 	}
 
+	String base_path = p_resource->get_path();
+	if (p_path.ends_with(".scn")) {
+		Ref<PackedScene> packed_scene = p_resource;
+		// If we're saving a scene and we don't have a resource path, attempt to derive it by the path in the SceneState.
+		if (base_path.is_empty() && packed_scene.is_valid()) {
+			base_path = packed_scene->get_state()->get_path();
+		}
+	}
+
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot create file '" + p_path + "'.");
 
 	relative_paths = p_flags & ResourceSaver::FLAG_RELATIVE_PATHS;
@@ -2089,7 +2144,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	local_path = p_path.get_base_dir();
 	path = ProjectSettings::get_singleton()->localize_path(p_path);
 
-	_find_resources(p_resource, true);
+	_find_resources(p_resource, base_path, true);
 
 	if (!(p_flags & ResourceSaver::FLAG_COMPRESS)) {
 		//save header compressed
@@ -2220,7 +2275,18 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		String res_path = save_order[i]->get_path();
 		res_path = relative_paths ? local_path.path_to_file(res_path) : res_path;
 		save_unicode_string(f, res_path);
-		ResourceUID::ID ruid = ResourceSaver::get_resource_id_for_path(save_order[i]->get_path(), false);
+
+		// Check if the path contains a splitter indicating it points to a foreign resource.
+		String base_res_path = save_order[i]->get_path();
+		if (base_res_path.contains("::")) {
+			PackedStringArray split_path = base_res_path.split("::", false);
+			if (split_path.size() == 2) {
+				// We found a single split, so just use the base path.
+				base_res_path = split_path[0];
+			}
+		}
+
+		ResourceUID::ID ruid = ResourceSaver::get_resource_id_for_path(base_res_path, false);
 		f->store_64(ruid);
 	}
 	// save internal resource table
@@ -2283,7 +2349,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 		for (const Property &p : rd.properties) {
 			f->store_32(p.name_idx);
-			write_variant(f, p.value, resource_map, external_resources, string_map, p.pi);
+			write_variant(f, p.value, resource_map, external_resources, string_map, p.pi, p_path);
 		}
 	}
 

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -158,7 +158,7 @@ class ResourceFormatSaverBinaryInstance {
 	};
 
 	static void _pad_buffer(Ref<FileAccess> f, int p_bytes);
-	void _find_resources(const Variant &p_variant, bool p_main = false);
+	void _find_resources(const Variant &p_variant, const String &p_base_path, bool p_main = false);
 	static void save_unicode_string(Ref<FileAccess> f, const String &p_string, bool p_bit_on_len = false);
 	int get_string_index(const String &p_string);
 
@@ -174,7 +174,7 @@ public:
 	};
 	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
 	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
-	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
+	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo(), const String &p_base_path = "");
 };
 
 class ResourceFormatSaverBinary : public ResourceFormatSaver {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1802,9 +1802,11 @@ void EditorNode::_save_scene(String p_file, int idx) {
 			sdata->recreate_state();
 		} else {
 			sdata.instantiate();
+			sdata->get_state()->set_path(scene->get_scene_file_path());
 		}
 	} else {
 		sdata.instantiate();
+		sdata->get_state()->set_path(scene->get_scene_file_path());
 	}
 	Error err = sdata->pack(scene);
 
@@ -1820,6 +1822,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	flg |= ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
 
 	err = ResourceSaver::save(sdata, p_file, flg);
+	sdata->set_path(p_file, true);
 
 	// This needs to be emitted before saving external resources.
 	emit_signal(SNAME("scene_saved"), p_file);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6438,6 +6438,10 @@ void GLTFDocument::_import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_
 		library = p_animation_player->get_animation_library("");
 	}
 	library->add_animation(anim_name, animation);
+
+	// Give a unique scene ID to ensure that external resource references
+	// remain consistent.
+	library->set_scene_unique_id("AnimationLibrary_GlobalImport");
 }
 
 void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> p_state) {

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -186,7 +186,7 @@ class ResourceFormatSaverTextInstance {
 		}
 	};
 
-	void _find_resources(const Variant &p_variant, bool p_main = false);
+	void _find_resources(const Variant &p_variant, const String &p_base_path, bool p_main = false);
 
 	static String _write_resources(void *ud, const Ref<Resource> &p_resource);
 	String _write_resource(const Ref<Resource> &res);


### PR DESCRIPTION
Supercedes https://github.com/godotengine/godot/pull/82750
Closes https://github.com/godotengine/godot/issues/74766

So, this is a second attempt at fixing issues with AnimationMixer's libraries parameter after a discussion with @lyuma. The basic problem as I understand this now is that this bug is unfixable without adding the ability for external resources to point to resources inside of other resources. 

The problem is as such: if you import a 3D model with animations included, the default settings, the imported scene will have all its animations stored in an AnimationLibrary resource which is a subresource of imported scene. As such, it can't be edited and it is referenced in the animation library as being 'foreign', which is an external resource which is a subresource of another resource, in this case, a PackedScene.
![godot windows editor dev x86_64_Hnd9ck3mHy](https://github.com/godotengine/godot/assets/12756047/85852c41-35df-4023-a18e-bf386495d8f7)
It can't be directly edited, but this is communicated correctly in the interface, but if you make ANY modifications the layout of the libraries property, renaming them or adding new ones, the library in the imported scene will have its reference broken, and instead be copied into the other scene, along with copies of all its embedded animations too, breaking the ability to update it and bloating the file size, and we also don't communicate that this is a limitation (VERY bad UX).

I believe strongly that the only solution to fixing this is to allow foreign resource references to be saved rather than having them automatically converted into local resources. Fortunately, the engine is mostly already capable of doing this, but none of it is exposed. What this PR does is make it foreign resources be saved with the following convention: it will use the UID for the resource it belongs to and the fact that it's a foreign resource is determined by the fact that the path uses a '::' notation, with the second half being the scene ID of the resource. The engine could already load file paths using this convention, but this PR allows the additional usage of the base resource's UID to provide consistent access even if the file is moved or renamed.

Since this PR is meant to fix the specific bug with references to the AnimationLibrary rather than a general purpose user-facing feature, we also give the AnimationLibrary generated upon scene import a unique consistent name which means that the path should remain consistent, even if its reimported, moved, or modified in any way. The name given is 'AnimationLibrary_GlobalImport', but I welcome alternative suggestions if this is bad for whatever reason.

It also includes some partial preliminary support for the dependency editor, though its not comprehensive. It will display the foreign resource scene IDs correctly, and the 'fix broken' button will actually attempt to fix the path with the scene id intact. There is however currently no way to intentionally select a foreign resource; I think to do this, we would have to build this up into a more comprehensive user-facing feature which would allow specifically named subresources to be accessible via the file browser (Unity has a comparable feature).

It might too difficult to get such a core feature fully battle-tested for 4.2, but I welcome anyone who wants to throughly test this under a variety of conditions. I've already tested it a bunch and it seems pretty robust, though I would recommend testing to make sure it works with localized paths (since I don't fully understand how they work in the context of UIDs). I will delegate this to discussion, though I will say that I feel the bug this intends to fix IS particularly nasty. If we absolutely can't do it, a compromise for 4.2 might be at least popping up a warning when attempting to modify the libraries parameter.

On the whole, I think this solution is relatively elegant and I'm happy introducing this doesn't require any changes to the resource format at all, everything is determined implicitly from data which was already accessible. The only thing I thought was a *little* hacky was using the SceneState object to store the original path of the scene before saving it in order to distinguish between a subresource and a foreign resource. It seems to get the job done though.