### PR TITLE
Fix uninitialized variable in `Image::fix_alpha_edges()`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3773,7 +3773,7 @@ void Image::fix_alpha_edges() {
 			}
 
 			int closest_dist = max_dist;
-			uint8_t closest_color[3];
+			uint8_t closest_color[3] = { 0 };
 
 			int from_x = MAX(0, j - max_radius);
 			int to_x = MIN(width - 1, j + max_radius);


### PR DESCRIPTION
`core\io\image.cpp:3776:33: error: 'closest_color[0]' may be used uninitialized [-Werror=maybe-uninitialized]`

https://github.com/V-Sekai/godot/actions/runs/6687763423/job/18168929852

![image](https://github.com/godotengine/godot/assets/32321/49667396-7680-481e-bb13-3c95249af802)


