### PR TITLE
Fix `FastNoiseLite.get_image` crashes with bad param

### DIFF
--- a/modules/noise/noise.cpp
+++ b/modules/noise/noise.cpp
@@ -166,6 +166,9 @@ Vector<Ref<Image>> Noise::_get_image(int p_width, int p_height, int p_depth, boo
 
 Ref<Image> Noise::get_image(int p_width, int p_height, bool p_invert, bool p_in_3d_space, bool p_normalize) const {
 	Vector<Ref<Image>> images = _get_image(p_width, p_height, 1, p_invert, p_in_3d_space, p_normalize);
+	if (images.is_empty()) {
+		return Ref<Image>();
+	}
 	return images[0];
 }
 


### PR DESCRIPTION
Fixes #84177

I did some quick search about the similar pattern, looks like there is no other places needs fix like this.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
