### PR TITLE
Fix `activate_item_by_event` infinite recursion crash

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1487,6 +1487,7 @@ void PopupMenu::add_icon_radio_check_shortcut(const Ref<Texture2D> &p_icon, cons
 }
 
 void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu, int p_id) {
+	ERR_FAIL_COND_MSG(p_submenu.validate_node_name() != p_submenu, "Invalid node name for submenu, the following characters are not allowed:\n" + String::get_invalid_node_name_characters());
 	Item item;
 	item.text = p_label;
 	item.xl_text = atr(p_label);


### PR DESCRIPTION
Fixes #84176

The crash cames from `activate_item_by_event` will call itself on it's submenu item found by name, but if the submenu's name is `.`, it will enter infinite resursion.

I chose to prevent it happen from `add_submenu_item`, but there might be other ways I wasn't aware of. Feel free to correct me.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
