### PR TITLE
[Label] Add get_character_bounds method to get bounding rectangles of the characters.

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -10,6 +10,13 @@
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
 	</tutorials>
 	<methods>
+		<method name="get_character_bounds" qualifiers="const">
+			<return type="Rect2" />
+			<param index="0" name="pos" type="int" />
+			<description>
+				Returns the bounding rectangle of the character at position [param pos]. If the character is a non-visual character or [param pos] is outside the valid range, an empty [Rect2] is returned. If the character is a part of a composite grapheme, the bounding rectangle of the whole grapheme is returned.
+			</description>
+		</method>
 		<method name="get_line_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -161,6 +161,8 @@ public:
 	int get_line_count() const;
 	int get_visible_line_count() const;
 
+	Rect2 get_character_bounds(int p_pos) const;
+
 	Label(const String &p_text = String());
 	~Label();
 };


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8299

Adds `Label.get_character_bounds(character pos)` method, which return bounding rectangle of the character. If the character is a non-visual character or `pos` is invalid, empty `Rect2` is returned. If the character is a part of a composite grapheme, the bounding rectangle of the whole grapheme is returned.