### PR TITLE
SCons: Fix build with GDScript LSP disabled

### DIFF
--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -19,6 +19,8 @@ if env.editor_build:
         # Using a define in the disabled case, to avoid having an extra define
         # in regular builds where all modules are enabled.
         env_gdscript.Append(CPPDEFINES=["GDSCRIPT_NO_LSP"])
+        # Also needed in main env to unexpose --lsp-port option.
+        env.Append(CPPDEFINES=["GDSCRIPT_NO_LSP"])
 
 
 if env["tests"]:


### PR DESCRIPTION
- Follow-up to #81844.
- Fixes #83947.