### PR TITLE
Fix Code region remains highlighted when using command `Unfold All Lines`

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1734,7 +1734,9 @@ void CodeEdit::fold_all_lines() {
 }
 
 void CodeEdit::unfold_all_lines() {
-	_unhide_all_lines();
+	for (int i = 0; i < get_line_count(); i++) {
+		unfold_line(i);
+	}
 }
 
 void CodeEdit::toggle_foldable_line(int p_line) {


### PR DESCRIPTION
Previously the handler for `Unfold All Lines` command only executed `_unhide_all_lines` which does not remove the highlighting associated with a code region. This has been replaced with a call to `unfold_line` for every line, which also removes highlighting along with unhiding the lines.

Fixes #83979
