### PR TITLE
Fixed rigidbody2D and 3D floating when supporting body changes

### DIFF
--- a/servers/physics_2d/godot_area_pair_2d.cpp
+++ b/servers/physics_2d/godot_area_pair_2d.cpp
@@ -111,6 +111,7 @@ GodotAreaPair2D::~GodotAreaPair2D() {
 		}
 	}
 	body->remove_constraint(this, 0);
+	body->wakeup();
 	area->remove_constraint(this);
 }
 

--- a/servers/physics_2d/godot_body_2d.h
+++ b/servers/physics_2d/godot_body_2d.h
@@ -288,6 +288,7 @@ public:
 		if ((!get_space()) || mode == PhysicsServer2D::BODY_MODE_STATIC || mode == PhysicsServer2D::BODY_MODE_KINEMATIC) {
 			return;
 		}
+		still_time = 0;
 		set_active(true);
 	}
 

--- a/servers/physics_2d/godot_body_pair_2d.cpp
+++ b/servers/physics_2d/godot_body_pair_2d.cpp
@@ -604,5 +604,7 @@ GodotBodyPair2D::GodotBodyPair2D(GodotBody2D *p_A, int p_shape_A, GodotBody2D *p
 
 GodotBodyPair2D::~GodotBodyPair2D() {
 	A->remove_constraint(this, 0);
+	A->wakeup();
 	B->remove_constraint(this, 1);
+	B->wakeup();
 }

--- a/servers/physics_3d/godot_area_pair_3d.cpp
+++ b/servers/physics_3d/godot_area_pair_3d.cpp
@@ -112,6 +112,7 @@ GodotAreaPair3D::~GodotAreaPair3D() {
 		}
 	}
 	body->remove_constraint(this);
+	body->wakeup();
 	area->remove_constraint(this);
 }
 

--- a/servers/physics_3d/godot_body_3d.h
+++ b/servers/physics_3d/godot_body_3d.h
@@ -287,6 +287,7 @@ public:
 		if ((!get_space()) || mode == PhysicsServer3D::BODY_MODE_STATIC || mode == PhysicsServer3D::BODY_MODE_KINEMATIC) {
 			return;
 		}
+		still_time = 0;
 		set_active(true);
 	}
 

--- a/servers/physics_3d/godot_body_pair_3d.cpp
+++ b/servers/physics_3d/godot_body_pair_3d.cpp
@@ -608,7 +608,9 @@ GodotBodyPair3D::GodotBodyPair3D(GodotBody3D *p_A, int p_shape_A, GodotBody3D *p
 
 GodotBodyPair3D::~GodotBodyPair3D() {
 	A->remove_constraint(this);
+	A->wakeup();
 	B->remove_constraint(this);
+	B->wakeup();
 }
 
 void GodotBodySoftBodyPair3D::_contact_added_callback(const Vector3 &p_point_A, int p_index_A, const Vector3 &p_point_B, int p_index_B, const Vector3 &normal, void *p_userdata) {
@@ -984,5 +986,6 @@ GodotBodySoftBodyPair3D::GodotBodySoftBodyPair3D(GodotBody3D *p_A, int p_shape_A
 
 GodotBodySoftBodyPair3D::~GodotBodySoftBodyPair3D() {
 	body->remove_constraint(this);
+	body->wakeup();
 	soft_body->remove_constraint(this);
 }


### PR DESCRIPTION
This PR aims to fix the case where a `Rigidbody3D` (or `Rigidbody3D`, we'll call them `RigidBodyXD` here) is supported by another body that leaves without using physics friendly methods (e.g. is deleted or moved with its transform)
To fix that, i've modified the method `RigidbodyXD::wakeup()` to reset the field `still_time` to 0 and really wake it up. Then in the destructors of pairs that implies a rigidbody, i added a call to the `RigidbodyXD::wakeup()` method.

In the github issues that are focused on that issue, there are discussions about that being a "feature" (or rather not a bug), that can be solved by waking up the body with a script for optimization purpose. I think that solution does not decrease performance drastically so I think it is optimal.

Closes #77543
Closes (maybe, these issues are for 3.x and not for 4.x) #64890 and #56304