### PR TITLE
Fix Open External Editor from Godot Debugger Panel

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -469,7 +469,7 @@ void ScriptEditor::_goto_script_line2(int p_line) {
 void ScriptEditor::_goto_script_line(Ref<RefCounted> p_script, int p_line) {
 	Ref<Script> scr = Object::cast_to<Script>(*p_script);
 	if (scr.is_valid() && (scr->has_source_code() || scr->get_path().is_resource_file())) {
-		if (edit(p_script, p_line, 0)) {
+		if (edit(p_script, p_line, 0, true, true)) {
 			EditorNode::get_singleton()->push_item(p_script.ptr());
 
 			ScriptEditorBase *current = _get_current_editor();
@@ -2265,7 +2265,7 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 	return OK;
 }
 
-bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus) {
+bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus, bool ignore_external_debug_check) {
 	if (p_resource.is_null()) {
 		return false;
 	}
@@ -2291,9 +2291,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		return false;
 	}
 
-	if (use_external_editor &&
-			(EditorDebuggerNode::get_singleton()->get_dump_stack_script() != p_resource || EditorDebuggerNode::get_singleton()->get_debug_with_external_editor()) &&
-			p_resource->get_path().is_resource_file()) {
+	if (use_external_editor && p_resource->get_path().is_resource_file() &&
+			((EditorDebuggerNode::get_singleton()->get_dump_stack_script() != p_resource || EditorDebuggerNode::get_singleton()->get_debug_with_external_editor()) || ignore_external_debug_check)) {
 		String path = EDITOR_GET("text_editor/external/exec_path");
 		String flags = EDITOR_GET("text_editor/external/exec_flags");
 
@@ -3584,7 +3583,7 @@ bool ScriptEditor::script_goto_method(Ref<Script> p_script, const String &p_meth
 		return false;
 	}
 
-	return edit(p_script, line, 0);
+	return edit(p_script, line, 0, true, true);
 }
 
 void ScriptEditor::set_live_auto_reload_running_scripts(bool p_enabled) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -511,7 +511,7 @@ public:
 	bool is_editor_floating();
 
 	_FORCE_INLINE_ bool edit(const Ref<Resource> &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
-	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true);
+	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true, bool ignore_external_debug_check = false);
 
 	void get_breakpoints(List<String> *p_breakpoints);
 


### PR DESCRIPTION
This PR fixes the calls to open the configurated external Editor from the "Stack Trace" and "Errors" panels.

Closes #19838
Closes #36414

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
