### PR TITLE
Avoid popping up dialogs excessively in the Animation editor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -653,26 +653,23 @@ void AnimationPlayerEditor::_blend_editor_next_changed(const int p_idx) {
 	undo_redo->commit_action();
 }
 
-void AnimationPlayerEditor::_animation_blend() {
-	if (updating_blends) {
+void AnimationPlayerEditor::_edit_animation_blend() {
+	if (updating_blends || !animation->has_selectable_items()) {
+		return;
+	}
+
+	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
+	_update_animation_blend();
+}
+
+void AnimationPlayerEditor::_update_animation_blend() {
+	if (updating_blends || !animation->has_selectable_items()) {
 		return;
 	}
 
 	blend_editor.tree->clear();
 
-	if (!animation->has_selectable_items()) {
-		return;
-	}
-
 	String current = animation->get_item_text(animation->get_selected());
-
-	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
-
-	blend_editor.tree->set_hide_root(true);
-	blend_editor.tree->set_column_expand_ratio(0, 10);
-	blend_editor.tree->set_column_clip_content(0, true);
-	blend_editor.tree->set_column_expand_ratio(1, 3);
-	blend_editor.tree->set_column_clip_content(1, true);
 
 	List<StringName> anims;
 	player->get_animation_list(&anims);
@@ -711,20 +708,16 @@ void AnimationPlayerEditor::_animation_blend() {
 }
 
 void AnimationPlayerEditor::_blend_edited() {
-	if (updating_blends) {
+	if (updating_blends || !animation->has_selectable_items()) {
 		return;
 	}
-
-	if (!animation->has_selectable_items()) {
-		return;
-	}
-
-	String current = animation->get_item_text(animation->get_selected());
 
 	TreeItem *selected = blend_editor.tree->get_edited();
 	if (!selected) {
 		return;
 	}
+
+	String current = animation->get_item_text(animation->get_selected());
 
 	updating_blends = true;
 	String to = selected->get_text(0);
@@ -1277,9 +1270,11 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool 
 
 void AnimationPlayerEditor::_animation_player_changed(Object *p_pl) {
 	_update_player();
+
 	if (blend_editor.dialog->is_visible()) {
-		_animation_blend(); // Update.
+		_update_animation_blend(); // Update.
 	}
+
 	if (library_editor->is_visible()) {
 		library_editor->update_tree();
 	}
@@ -1366,7 +1361,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 			_animation_rename();
 		} break;
 		case TOOL_EDIT_TRANSITIONS: {
-			_animation_blend();
+			_edit_animation_blend();
 		} break;
 		case TOOL_REMOVE_ANIM: {
 			_animation_remove();
@@ -1802,17 +1797,8 @@ bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {
 }
 
 void AnimationPlayerEditor::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_animation_new"), &AnimationPlayerEditor::_animation_new);
-	ClassDB::bind_method(D_METHOD("_animation_rename"), &AnimationPlayerEditor::_animation_rename);
-	ClassDB::bind_method(D_METHOD("_animation_remove"), &AnimationPlayerEditor::_animation_remove);
-	ClassDB::bind_method(D_METHOD("_animation_blend"), &AnimationPlayerEditor::_animation_blend);
-	ClassDB::bind_method(D_METHOD("_animation_edit"), &AnimationPlayerEditor::_animation_edit);
-	ClassDB::bind_method(D_METHOD("_animation_resource_edit"), &AnimationPlayerEditor::_animation_resource_edit);
+	// Needed for UndoRedo.
 	ClassDB::bind_method(D_METHOD("_animation_player_changed"), &AnimationPlayerEditor::_animation_player_changed);
-	ClassDB::bind_method(D_METHOD("_animation_libraries_updated"), &AnimationPlayerEditor::_animation_libraries_updated);
-	ClassDB::bind_method(D_METHOD("_list_changed"), &AnimationPlayerEditor::_list_changed);
-	ClassDB::bind_method(D_METHOD("_animation_duplicate"), &AnimationPlayerEditor::_animation_duplicate);
-
 	ClassDB::bind_method(D_METHOD("_start_onion_skinning"), &AnimationPlayerEditor::_start_onion_skinning);
 	ClassDB::bind_method(D_METHOD("_stop_onion_skinning"), &AnimationPlayerEditor::_stop_onion_skinning);
 
@@ -1833,11 +1819,8 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	plugin = p_plugin;
 	singleton = this;
 
-	updating = false;
-
 	set_focus_mode(FOCUS_ALL);
-
-	player = nullptr;
+	set_process_shortcut_input(true);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -1921,7 +1904,6 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	hb->add_child(memnew(VSeparator));
 
 	track_editor = memnew(AnimationTrackEditor);
-
 	hb->add_child(track_editor->get_edit_menu());
 
 	hb->add_child(memnew(VSeparator));
@@ -1992,21 +1974,27 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	name_dialog->connect(SNAME("confirmed"), callable_mp(this, &AnimationPlayerEditor::_animation_name_edited));
 
 	blend_editor.dialog = memnew(AcceptDialog);
-	add_child(blend_editor.dialog);
+	blend_editor.dialog->set_title(TTR("Cross-Animation Blend Times"));
 	blend_editor.dialog->set_ok_button_text(TTR("Close"));
 	blend_editor.dialog->set_hide_on_ok(true);
+	add_child(blend_editor.dialog);
+
 	VBoxContainer *blend_vb = memnew(VBoxContainer);
 	blend_editor.dialog->add_child(blend_vb);
+
 	blend_editor.tree = memnew(Tree);
+	blend_editor.tree->set_hide_root(true);
 	blend_editor.tree->set_columns(2);
+	blend_editor.tree->set_column_expand_ratio(0, 10);
+	blend_editor.tree->set_column_clip_content(0, true);
+	blend_editor.tree->set_column_expand_ratio(1, 3);
+	blend_editor.tree->set_column_clip_content(1, true);
 	blend_vb->add_margin_child(TTR("Blend Times:"), blend_editor.tree, true);
+	blend_editor.tree->connect(SNAME("item_edited"), callable_mp(this, &AnimationPlayerEditor::_blend_edited));
+
 	blend_editor.next = memnew(OptionButton);
 	blend_editor.next->set_auto_translate(false);
 	blend_vb->add_margin_child(TTR("Next (Auto Queue):"), blend_editor.next);
-	blend_editor.dialog->set_title(TTR("Cross-Animation Blend Times"));
-	updating_blends = false;
-
-	blend_editor.tree->connect(SNAME("item_edited"), callable_mp(this, &AnimationPlayerEditor::_blend_edited));
 
 	autoplay->connect(SNAME("pressed"), callable_mp(this, &AnimationPlayerEditor::_autoplay_pressed));
 	autoplay->set_toggle_mode(true);
@@ -2020,11 +2008,6 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 
 	frame->connect(SNAME("value_changed"), callable_mp(this, &AnimationPlayerEditor::_seek_value_changed).bind(true, false));
 	scale->connect(SNAME("text_submitted"), callable_mp(this, &AnimationPlayerEditor::_scale_changed));
-
-	last_active = false;
-	timeline_position = 0;
-
-	set_process_shortcut_input(true);
 
 	add_child(track_editor);
 	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -111,8 +111,9 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Ref<Texture2D> autoplay_icon;
 	Ref<Texture2D> reset_icon;
 	Ref<ImageTexture> autoplay_reset_icon;
-	bool last_active;
-	float timeline_position;
+
+	bool last_active = false;
+	float timeline_position = 0;
 
 	EditorFileDialog *file = nullptr;
 	ConfirmationDialog *delete_dialog = nullptr;
@@ -130,8 +131,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	ConfirmationDialog *error_dialog = nullptr;
 	int name_dialog_op = TOOL_NEW_ANIM;
 
-	bool updating;
-	bool updating_blends;
+	bool updating = false;
+	bool updating_blends = false;
 
 	AnimationTrackEditor *track_editor = nullptr;
 	static AnimationPlayerEditor *singleton;
@@ -190,7 +191,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	void _animation_remove();
 	void _animation_remove_confirmed();
-	void _animation_blend();
 	void _animation_edit();
 	void _animation_duplicate();
 	Ref<Animation> _animation_clone(const Ref<Animation> p_anim);
@@ -198,6 +198,9 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _scale_changed(const String &p_scale);
 	void _seek_value_changed(float p_value, bool p_set = false, bool p_timeline_only = false);
 	void _blend_editor_next_changed(const int p_idx);
+
+	void _edit_animation_blend();
+	void _update_animation_blend();
 
 	void _list_changed();
 	void _current_animation_changed(const String &p_name);


### PR DESCRIPTION
Quick refactoring to fix https://github.com/godotengine/godot/issues/83167. Some other codestyle changes as well, such as initializing primitive types in the header, removing unneeded ClassDB binds, and moving some commands around.

Whether we should at all allow to pop windows which are already visible I don't know. It was also possible in Godot 3. It should not lead to issues anyway, I don't think. I, for one, cannot reproduce the particular issue from the clip in the linked report. But there may be some timing issues, I can imagine.