### PR TITLE
Add missing word in `NOTIFICATION_POST_ENTER_TREE` documentation

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1034,7 +1034,7 @@
 			Notification received every frame when the internal physics process flag is set (see [method set_physics_process_internal]).
 		</constant>
 		<constant name="NOTIFICATION_POST_ENTER_TREE" value="27">
-			Notification received when the node is ready, just before [constant NOTIFICATION_READY] is received. Unlike the latter, it's sent every time the node enters tree, instead of only once.
+			Notification received when the node is ready, just before [constant NOTIFICATION_READY] is received. Unlike the latter, it's sent every time the node enters the tree, instead of only once.
 		</constant>
 		<constant name="NOTIFICATION_DISABLED" value="28">
 			Notification received when the node is disabled. See [constant PROCESS_MODE_DISABLED].


### PR DESCRIPTION
Small fix in `NOTIFICATION_POST_ENTER_TREE`'s documentation. A `the` was missing.