### PR TITLE
Fix documentation in MultiplayerAPIExtension

### DIFF
--- a/doc/classes/MultiplayerAPIExtension.xml
+++ b/doc/classes/MultiplayerAPIExtension.xml
@@ -15,7 +15,7 @@
 		var base_multiplayer = SceneMultiplayer.new()
 
 		func _init():
-		    # Just passthourgh base signals (copied to var to avoid cyclic reference)
+		    # Just passthrough base signals (copied to var to avoid cyclic reference)
 		    var cts = connected_to_server
 		    var cf = connection_failed
 		    var pc = peer_connected
@@ -25,13 +25,16 @@
 		    base_multiplayer.peer_connected.connect(func(id): pc.emit(id))
 		    base_multiplayer.peer_disconnected.connect(func(id): pd.emit(id))
 
+		func _poll():
+		    return base_multiplayer.poll()
+
 		# Log RPC being made and forward it to the default multiplayer.
-		func _rpc(peer: int, object: Object, method: StringName, args: Array) -&gt; int: # Error
+		func _rpc(peer: int, object: Object, method: StringName, args: Array) -&gt; Error:
 		    print("Got RPC for %d: %s::%s(%s)" % [peer, object, method, args])
 		    return base_multiplayer.rpc(peer, object, method, args)
 
 		# Log configuration add. E.g. root path (nullptr, NodePath), replication (Node, Spawner|Synchronizer), custom.
-		func _object_configuration_add(object, config: Variant) -&gt; int: # Error
+		func _object_configuration_add(object, config: Variant) -&gt; Error:
 		    if config is MultiplayerSynchronizer:
 		        print("Adding synchronization configuration for %s. Synchronizer: %s" % [object, config])
 		    elif config is MultiplayerSpawner:
@@ -39,7 +42,7 @@
 		    return base_multiplayer.object_configuration_add(object, config)
 
 		# Log configuration remove. E.g. root path (nullptr, NodePath), replication (Node, Spawner|Synchronizer), custom.
-		func _object_configuration_remove(object, config: Variant) -&gt; int: # Error
+		func _object_configuration_remove(object, config: Variant) -&gt; Error:
 		    if config is MultiplayerSynchronizer:
 		        print("Removing synchronization configuration for %s. Synchronizer: %s" % [object, config])
 		    elif config is MultiplayerSpawner:


### PR DESCRIPTION
In implementing a MultiplayerAPIExtension, I found that the example from documentation did not function even in the Multiplayer tutorial example.

Eventually, I found that the issue was that base_multiplayer will not poll unless told to by the LogMultiplayer implementation. With my changes, the example code compiles and functions in that project in 4.1.

I also corrected a spelling issue and a few out-of-date return types.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
