### PR TITLE
[TextServer] Fix glyph comparator ambiguous output.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -681,11 +681,7 @@ class TextServerAdvanced : public TextServerExtension {
 		_FORCE_INLINE_ bool operator()(const Glyph &l, const Glyph &r) const {
 			if (l.start == r.start) {
 				if (l.count == r.count) {
-					if ((l.flags & TextServer::GRAPHEME_IS_VIRTUAL) == TextServer::GRAPHEME_IS_VIRTUAL) {
-						return false;
-					} else {
-						return true;
-					}
+					return (l.flags & TextServer::GRAPHEME_IS_VIRTUAL) < (r.flags & TextServer::GRAPHEME_IS_VIRTUAL);
 				}
 				return l.count > r.count; // Sort first glyph with count & flags, order of the rest are irrelevant.
 			} else {


### PR DESCRIPTION
Fixes glyph comparator ambiguous output, causing `bad comparison function` error spam when processing text with excessive use of combining diacritics.