### PR TITLE
Inspector: Fix clearing array/dictionary element with `<Object#null>`

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -198,6 +198,10 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 		return;
 	}
 
+	if (p_value.get_type() == Variant::OBJECT && p_value.is_null()) {
+		p_value = Variant(); // `EditorResourcePicker` resets to `Ref<Resource>()`. See GH-82716.
+	}
+
 	int index;
 	if (p_property.begins_with("metadata/")) {
 		index = p_property.get_slice("/", 2).to_int();
@@ -726,6 +730,10 @@ EditorPropertyArray::EditorPropertyArray() {
 ///////////////////// DICTIONARY ///////////////////////////
 
 void EditorPropertyDictionary::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+	if (p_value.get_type() == Variant::OBJECT && p_value.is_null()) {
+		p_value = Variant(); // `EditorResourcePicker` resets to `Ref<Resource>()`. See GH-82716.
+	}
+
 	if (p_property == "new_item_key") {
 		object->set_new_item_key(p_value);
 	} else if (p_property == "new_item_value") {


### PR DESCRIPTION
* Fixes #82716.

`EditorPropertyArray` and `EditorPropertyDictionary` use `EditorPropertyResource` and `EditorResourcePicker`, but array elements and dictionary keys/values can be `Variant()` (`null`), unlike `Ref<Resource>`.

https://github.com/godotengine/godot/blob/93cdacbb0a30f12b2f3f5e8e06b90149deeb554b/editor/editor_resource_picker.cpp#L346-L350