### PR TITLE
Fix rotated tile collision not working at runtime

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3072,8 +3072,12 @@ void TileMap::_internal_update() {
 		return;
 	}
 
+	// FIXME: This should only clear polygons that are no longer going to be used, but since it's difficult to determine,
+	// the cache is never cleared at runtime to prevent invalidating used polygons.
+	if (Engine::get_singleton()->is_editor_hint()) {
+		polygon_cache.clear();
+	}
 	// Update dirty quadrants on layers.
-	polygon_cache.clear();
 	for (Ref<TileMapLayer> &layer : layers) {
 		layer->internal_update();
 	}


### PR DESCRIPTION
Quick fix for #83825
It does not resolve the issue properly, but at least it makes rotated tile collision working correctly at runtime.