### PR TITLE
Try to guess method return type even if subscript base has no value

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1925,7 +1925,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 						}
 					}
 
-					if (!found && base.value.get_type() != Variant::NIL) {
+					if (!found) {
 						found = _guess_method_return_type_from_base(c, base, call->function_name, r_type);
 					}
 				}

--- a/modules/gdscript/tests/scripts/completion/common/infer_return_type_without_value.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/infer_return_type_without_value.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    ; String
+    {"display": "begins_with(…)"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/infer_return_type_without_value.gd
+++ b/modules/gdscript/tests/scripts/completion/common/infer_return_type_without_value.gd
@@ -1,0 +1,9 @@
+class B:
+	func to_str(b: int):
+		return str(b)
+
+var a: B
+
+func _ready():
+	a.to_str(10).➡
+    pass


### PR DESCRIPTION
Fixes #78003.

We want to guess the method return type not only if the base has a reduced value but also if the base has a resolved type.

The following example shows the problem:
```gdscript
class B:
	func to_str(b: int):
		return str(b)

var a: B

func _ready():
	a.to_str(10) # Godot does not suggest string methods in autocompletion
```
Since a has no value in the example, the autocompletion does not try to guess the type of `to_str(10)`.

Note that we need to use internal classes to observe that this PR solves the problem. There are other problems preventing it to work in the context of #78003.