### PR TITLE
Analyze GDScript dependencies recursively when doing autocompletion

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -709,7 +709,10 @@ Ref<GDScriptParserRef> GDScriptParser::get_depended_parser_for(const String &p_p
 		ref = depended_parsers[p_path];
 	} else {
 		Error err = OK;
-		ref = GDScriptCache::get_parser(p_path, GDScriptParserRef::EMPTY, err, script_path);
+
+		// If analyzing for autocompletion, analyze dependencies recursively to provide completion for nested subscripts.
+		GDScriptParserRef::Status status = for_completion ? GDScriptParserRef::FULLY_SOLVED : GDScriptParserRef::EMPTY;
+		ref = GDScriptCache::get_parser(p_path, status, err, script_path);
 		if (ref.is_valid()) {
 			depended_parsers[p_path] = ref;
 		}


### PR DESCRIPTION
Second part of fixing #78003
Related to #84264

> Please correct me if my assumptions about how GDScript works are wrong. The code is not exactly simple to read.

To allow for cyclic references Godot does not analyze other scripts when references to them are found in a script, since this recursive approach would lead to problems with cyclic references.

This also means that other `CLASS` types are not necessarily completely resolved when they are encountered since they are basically a "shallow" reference. This is fine for running GDScript, but when doing autocompletion it means that we can't get the type for interfered type chains, since this type would be generated by the analyzer in conjunction with the interfered types from analyzing the dependencies.

My idea to solving this, is to change analyzer behavior when doing autocompletion, to recursively resolve dependencies. In edge cases with cyclic references this might fail, but this would only mean we can't provide autocompletion for it. And those cases wouldn't receive completion at the moment anyway.

That said I'm unsure about this implementation. I suspect it may lead to error spam in certain edge cases. I couldn't find one until now however.
