### PR TITLE
Fix WebXR on desktop emulator by resetting active texture unit

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2497,6 +2497,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	}
 	glDisable(GL_BLEND);
 	texture_storage->render_target_disable_clear_request(rb->render_target);
+
+	glActiveTexture(GL_TEXTURE0);
 }
 
 template <PassMode p_pass_mode>


### PR DESCRIPTION
This is such a dumb change, that I'm astonished that it fixes anything :-)

By selectively commenting out code, I found that it was `RasterizerCanvasGLES3::reset_canvas()` that ran when drawing 2D which fixed WebXR. So, I copied everything from that function into the end of `RasterizerSceneGLES3::render_scene()`, and by selectively commenting out those lines, I was able to narrow it down to this one line.

It seems super weird that changing the active texture unit fixes anything! It must mean that there's code somewhere else that's doing something with textures _without_ remembering to set the active texture unit first? I looked around a little bit but couldn't identify what it could be.

Fixes https://github.com/godotengine/godot/issues/84255