### PR TITLE
Implement glTF compatibility system for files imported in older Godot versions

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -136,6 +136,7 @@ public:
 
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const = 0;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const = 0;
+	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {}
 	virtual String get_option_group_file() const { return String(); }
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) = 0;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2012,6 +2012,11 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 	}
 
+	if (FileAccess::exists(p_file + ".import")) {
+		// We only want to handle compat for existing files, not new ones.
+		importer->handle_compatibility_options(params);
+	}
+
 	//mix with default params, in case a parameter is missing
 
 	List<ResourceImporter::ImportOption> opts;

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1954,6 +1954,12 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	}
 }
 
+void ResourceImporterScene::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
+	for (Ref<EditorSceneFormatImporter> importer_elem : importers) {
+		importer_elem->handle_compatibility_options(p_import_params);
+	}
+}
+
 void ResourceImporterScene::_replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner) {
 	if (p_node != p_new_owner && p_node->get_owner() == p_scene) {
 		p_node->set_owner(p_new_owner);
@@ -2658,10 +2664,10 @@ ResourceImporterScene *ResourceImporterScene::animation_singleton = nullptr;
 Vector<Ref<EditorSceneFormatImporter>> ResourceImporterScene::importers;
 Vector<Ref<EditorScenePostImportPlugin>> ResourceImporterScene::post_importer_plugins;
 
-bool ResourceImporterScene::ResourceImporterScene::has_advanced_options() const {
+bool ResourceImporterScene::has_advanced_options() const {
 	return true;
 }
-void ResourceImporterScene::ResourceImporterScene::show_advanced_options(const String &p_path) {
+void ResourceImporterScene::show_advanced_options(const String &p_path) {
 	SceneImportSettings::get_singleton()->open_settings(p_path, animation_importer);
 }
 

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -79,6 +79,7 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option, const HashMap<StringName, Variant> &p_options);
+	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {}
 
 	EditorSceneFormatImporter() {}
 };
@@ -276,6 +277,7 @@ public:
 
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
+	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 	// Import scenes *after* everything else (such as textures).
 	virtual int get_import_order() const override { return ResourceImporter::IMPORT_ORDER_SCENE; }
 

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -51,6 +51,10 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	gltf.instantiate();
 	Ref<GLTFState> state;
 	state.instantiate();
+	if (p_options.has("gltf/naming_version")) {
+		int naming_version = p_options["gltf/naming_version"];
+		gltf->set_naming_version(naming_version);
+	}
 	if (p_options.has("gltf/embedded_image_handling")) {
 		int32_t enum_option = p_options["gltf/embedded_image_handling"];
 		state->set_handle_binary_image(enum_option);
@@ -77,7 +81,16 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 
 void EditorSceneFormatImporterGLTF::get_import_options(const String &p_path,
 		List<ResourceImporter::ImportOption> *r_options) {
+	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/naming_version", PROPERTY_HINT_ENUM, "Godot 4.1 or 4.0,Godot 4.2 or later"), 1));
 	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/embedded_image_handling", PROPERTY_HINT_ENUM, "Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), GLTFState::HANDLE_BINARY_EXTRACT_TEXTURES));
+}
+
+void EditorSceneFormatImporterGLTF::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
+	if (!p_import_params.has("gltf/naming_version")) {
+		// If an existing import file is missing the glTF
+		// compatibility version, we need to use version 0.
+		p_import_params["gltf/naming_version"] = 0;
+	}
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -49,6 +49,7 @@ public:
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
+	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 };
 
 #endif // TOOLS_ENABLED

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -73,6 +73,7 @@ public:
 
 private:
 	const float BAKE_FPS = 30.0f;
+	int _naming_version = 1;
 	String _image_format = "PNG";
 	float _lossy_quality = 0.75f;
 	Ref<GLTFDocumentExtension> _image_save_extension;
@@ -86,6 +87,8 @@ public:
 	static void unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension);
 	static void unregister_all_gltf_document_extensions();
 
+	void set_naming_version(int p_version);
+	int get_naming_version() const;
 	void set_image_format(const String &p_image_format);
 	String get_image_format() const;
 	void set_lossy_quality(float p_lossy_quality);


### PR DESCRIPTION
This PR is an alternative to #84034. The code is completely different, so I'm opening a new PR.

Fixes #83429, caused by a behavior change from #80270 (the old behavior is wrong, but we must keep it for compat), and also fixes the behavior change from #81264.

I think the easiest way to explain how this works is by giving examples. Comprehensive test project: [Block.zip](https://github.com/godotengine/godot/files/13221994/Block.zip) All `.glb` files in this project are the exact same, just with different file names and `.import` files.

The "4.2" folder has `.import` files generated with this PR, with the glTF compatibility version set to 1.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/17d04dc4-da3c-4697-a9a0-946a73016ffc">

The "4.1" folder has `.import` files generated in Godot 4.1. The expected behavior is that they import the same way as they did in 4.1, when the scene name (usually file name) took priority over the node name. The files in this folder do not have a `gltf/compatibility_version=` field, and are assigned version 0 when opened with this PR.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/fbc21eb5-b12e-4445-806a-e72095b78b74">

The `NoImportFile` folder does not have `.import` files for the `.glb` files. This is the case when a user brings in a new model, or wants to reset the settings by deleting the `.import` files. This should generate new files with the glTF compatibility version set to 1, and then import the same as the files in the 4.2 folder.
<img width="282" alt="expected" src="https://github.com/godotengine/godot/assets/1646875/a1bfbdc0-3c34-47bd-9b8d-0d35feccc739">

If desired, we could expose the methods to set the importer version to allow users to manually import files with an older importer version (ex: when using GLTFDocument at runtime), but the use case here is not entirely clear (modifying a file after import, when we care about preserving the exact same data, is mostly relevant in the editor).

The default value of the compatibility version is 1 in this PR (it can be incremented later), and this value is also used when generating a new `.import` file. However, existing files are assigned version 0.

A new method `handle_compatibility_options` has been added to allow importers to control what happens when loading existing files. We need to call something from EditorFileSystem to disambiguate the case of a file without a version (that should use the oldest version) from a missing file (that should use the default version). 