### PR TITLE
Preserve inspector focus when opening script from scene tree

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1535,7 +1535,9 @@ void SceneTreeDock::_load_request(const String &p_path) {
 }
 
 void SceneTreeDock::_script_open_request(const Ref<Script> &p_script) {
-	EditorNode::get_singleton()->edit_resource(p_script);
+	if (ScriptEditor::get_singleton()->edit(p_script, true)) {
+		EditorNode::get_singleton()->editor_select(EditorNode::EDITOR_SCRIPT);
+	}
 }
 
 void SceneTreeDock::_push_item(Object *p_object) {


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/247#issuecomment-561429796 (and also resolves https://github.com/godotengine/godot/issues/77791)

Opening a script by clicking on a script icon in the scene tree dock currently causes the script resource to grab the inspector's focus. This PR prevents this and leaves the inspector unchanged.

Inpector after opening script from scene tree dock:
| Before PR  |
| ------------- |
| ![image](https://github.com/godotengine/godot/assets/14885846/b779809f-290e-46fa-9e85-97df60f3c0a9) |

| After PR  |
| ------------- |
| ![image](https://github.com/godotengine/godot/assets/14885846/37bd1bc9-c05c-44f1-92d4-e0f2fddccdf5)|