### PR TITLE
[3.x] Automatically pick the Android sdk path using environment variables

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -32,9 +32,11 @@
 
 #include "export_plugin.h"
 
+#include "core/os/os.h"
+
 void register_android_exporter() {
 #ifndef ANDROID_ENABLED
-	EDITOR_DEF("export/android/android_sdk_path", "");
+	EDITOR_DEF("export/android/android_sdk_path", OS::get_singleton()->get_environment("ANDROID_SDK_ROOT"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/debug_keystore", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore", PROPERTY_HINT_GLOBAL_FILE, "*.keystore,*.jks"));


### PR DESCRIPTION
[main version](https://github.com/godotengine/godot/pull/84285)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
