### PR TITLE
Disconnect `EditorNode` from file dialogs on destruction

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8076,6 +8076,17 @@ EditorNode::~EditorNode() {
 	GDExtensionEditorPlugins::editor_node_add_plugin = nullptr;
 	GDExtensionEditorPlugins::editor_node_remove_plugin = nullptr;
 
+	FileDialog::get_icon_func = nullptr;
+	FileDialog::register_func = nullptr;
+	FileDialog::unregister_func = nullptr;
+
+	EditorFileDialog::get_icon_func = nullptr;
+	EditorFileDialog::register_func = nullptr;
+	EditorFileDialog::unregister_func = nullptr;
+
+	file_dialogs.clear();
+	editor_file_dialogs.clear();
+
 	singleton = nullptr;
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/84000.

The fact that `EditorNode` is freed before parts of the editor UI created by plugins is a curiosity that may warrant further investigation. But this fixes a crash and is generally a good thing to do on exit.