### PR TITLE
Fix several Material texture parameter updates

### DIFF
--- a/scene/resources/fog_material.cpp
+++ b/scene/resources/fog_material.cpp
@@ -82,7 +82,7 @@ float FogMaterial::get_edge_fade() const {
 
 void FogMaterial::set_density_texture(const Ref<Texture3D> &p_texture) {
 	density_texture = p_texture;
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RS::get_singleton()->material_set_param(_get_material(), "density_texture", tex_rid);
 }
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1930,7 +1930,7 @@ void BaseMaterial3D::set_texture(TextureParam p_param, const Ref<Texture2D> &p_t
 	ERR_FAIL_INDEX(p_param, TEXTURE_MAX);
 
 	textures[p_param] = p_texture;
-	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RS::get_singleton()->material_set_param(_get_material(), shader_names->texture_names[p_param], rid);
 
 	if (p_texture.is_valid() && p_param == TEXTURE_ALBEDO) {

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1380,7 +1380,7 @@ void ParticleProcessMaterial::set_param_texture(Parameter p_param, const Ref<Tex
 
 	tex_parameters[p_param] = p_texture;
 
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 
 	switch (p_param) {
 		case PARAM_INITIAL_LINEAR_VELOCITY: {
@@ -1476,7 +1476,7 @@ Color ParticleProcessMaterial::get_color() const {
 
 void ParticleProcessMaterial::set_color_ramp(const Ref<Texture2D> &p_texture) {
 	color_ramp = p_texture;
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->color_ramp, tex_rid);
 	_queue_shader_change();
 	notify_property_list_changed();
@@ -1488,7 +1488,7 @@ Ref<Texture2D> ParticleProcessMaterial::get_color_ramp() const {
 
 void ParticleProcessMaterial::set_color_initial_ramp(const Ref<Texture2D> &p_texture) {
 	color_initial_ramp = p_texture;
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->color_initial_ramp, tex_rid);
 	_queue_shader_change();
 	notify_property_list_changed();
@@ -1509,7 +1509,7 @@ void ParticleProcessMaterial::set_particle_flag(ParticleFlags p_particle_flag, b
 
 void ParticleProcessMaterial::set_alpha_curve(const Ref<Texture2D> &p_texture) {
 	alpha_curve = p_texture;
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->alpha_ramp, tex_rid);
 	_queue_shader_change();
 	notify_property_list_changed();
@@ -1521,7 +1521,7 @@ Ref<Texture2D> ParticleProcessMaterial::get_alpha_curve() const {
 
 void ParticleProcessMaterial::set_emission_curve(const Ref<Texture2D> &p_texture) {
 	emission_curve = p_texture;
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_ramp, tex_rid);
 	_queue_shader_change();
 	notify_property_list_changed();
@@ -1533,7 +1533,7 @@ Ref<Texture2D> ParticleProcessMaterial::get_emission_curve() const {
 
 void ParticleProcessMaterial::set_velocity_limit_curve(const Ref<Texture2D> &p_texture) {
 	velocity_limit_curve = p_texture;
-	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	Variant tex_rid = p_texture.is_valid() ? Variant(p_texture->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->velocity_limit_curve, tex_rid);
 	_queue_shader_change();
 	notify_property_list_changed();
@@ -1567,19 +1567,19 @@ void ParticleProcessMaterial::set_emission_box_extents(Vector3 p_extents) {
 
 void ParticleProcessMaterial::set_emission_point_texture(const Ref<Texture2D> &p_points) {
 	emission_point_texture = p_points;
-	RID tex_rid = p_points.is_valid() ? p_points->get_rid() : RID();
+	Variant tex_rid = p_points.is_valid() ? Variant(p_points->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_texture_points, tex_rid);
 }
 
 void ParticleProcessMaterial::set_emission_normal_texture(const Ref<Texture2D> &p_normals) {
 	emission_normal_texture = p_normals;
-	RID tex_rid = p_normals.is_valid() ? p_normals->get_rid() : RID();
+	Variant tex_rid = p_normals.is_valid() ? Variant(p_normals->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_texture_normal, tex_rid);
 }
 
 void ParticleProcessMaterial::set_emission_color_texture(const Ref<Texture2D> &p_colors) {
 	emission_color_texture = p_colors;
-	RID tex_rid = p_colors.is_valid() ? p_colors->get_rid() : RID();
+	Variant tex_rid = p_colors.is_valid() ? Variant(p_colors->get_rid()) : Variant();
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_texture_color, tex_rid);
 	_queue_shader_change();
 }


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/60849
* Fixes https://github.com/godotengine/godot/issues/83190
* Fixes https://github.com/godotengine/godot/issues/84139

Fixes the issues when assigning or initializing a null/default texture to certain material properties doesn't properly update the material state. This can happen in normal use when updating textures in code, but usually this is more noticeable when duplicating a material either explicitly by calling duplicate() or indirectly during instantiation if the material has `Local To Scene` enabled. This bug causes certain empty textures in a material to be initialized incorrectly. Seems like at least emission, back light and height mapping textures are most affected as they use `hint_default_black` fallback.

I also noticed possible issues in particle process material, so this fix may also affect particle system behavior in certain situations. In normal materials this bug is usually obvious and can be worked around as discussed in the issue reports, but with particle systems the change in behavior might not be immediately clear.

The basic problem is that calling `RenderingServer::material_set_param()` with a `Variant::Type::NIL` parameter value will result in different behavior compared to using a zero/null RID. Only a NIL Variant will clear the internal material parameter inside the MaterialStorage:

https://github.com/godotengine/godot/blob/6afd320984cf14198368cc6c53752813a02169e3/servers/rendering/renderer_rd/storage_rd/material_storage.cpp#L2142-L2147

Many places already correctly use the NIL Variant, so I changed all obvious places I could find in this PR. Another alternative is to change `MaterialStorage::material_set_param()` to clear the material (texture) property also when using an empty RID. However, as that API is exposed to scripting it would change existing behavior, although I doubt many people are relying on that behavior and if they are their code is probably buggy in a similar way.