### PR TITLE
Linux: Remove hardcoded lib path for x86 cross-compilation

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -85,6 +85,16 @@ def configure(env: "Environment"):
         # gdb works fine without it though, so maybe our crash handler could too.
         env.Append(LINKFLAGS=["-rdynamic"])
 
+    # Cross-compilation
+    # TODO: Support cross-compilation on architectures other than x86.
+    host_is_64_bit = sys.maxsize > 2**32
+    if host_is_64_bit and env["arch"] == "x86_32":
+        env.Append(CCFLAGS=["-m32"])
+        env.Append(LINKFLAGS=["-m32"])
+    elif not host_is_64_bit and env["arch"] == "x86_64":
+        env.Append(CCFLAGS=["-m64"])
+        env.Append(LINKFLAGS=["-m64"])
+
     # CPU architecture flags.
     if env["arch"] == "rv64":
         # G = General-purpose extensions, C = Compression extension (very common).
@@ -469,22 +479,11 @@ def configure(env: "Environment"):
     if platform.system() == "FreeBSD":
         env.Append(LINKFLAGS=["-lkvm"])
 
-    ## Cross-compilation
-    # TODO: Support cross-compilation on architectures other than x86.
-    host_is_64_bit = sys.maxsize > 2**32
-    if host_is_64_bit and env["arch"] == "x86_32":
-        env.Append(CCFLAGS=["-m32"])
-        env.Append(LINKFLAGS=["-m32", "-L/usr/lib/i386-linux-gnu"])
-    elif not host_is_64_bit and env["arch"] == "x86_64":
-        env.Append(CCFLAGS=["-m64"])
-        env.Append(LINKFLAGS=["-m64", "-L/usr/lib/i686-linux-gnu"])
-
     # Link those statically for portability
     if env["use_static_cpp"]:
         env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
         if env["use_llvm"] and platform.system() != "FreeBSD":
             env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
-
     else:
         if env["use_llvm"] and platform.system() != "FreeBSD":
             env.Append(LIBS=["atomic"])


### PR DESCRIPTION
This breaks the build with our updated i686 Linux SDK which doesn't contain this path, and may not be needed at all.

This might need further work to be robust, and there's an open PR (#64366) already adding -march flags for all supported architectures, but for now we're playing it safe for 4.2.

I moved the code up to where #64366 puts it as it's more consistent with the rest of the config indeed.

#64366 is probably "better" but @hpvb and I need to double check what are the implications of adding those flags compared to letting the toolchain wrappers do the right thing, so that stays in scope for 4.3.

---

To be clear the only change here is the removal of `"-L/usr/lib/i386-linux-gnu"` and `"-L/usr/lib/i686-linux-gnu"` linkflags when cross-compiling. Those date back to `GODOT IS OPEN SOURCE`, and I assume they were for cross-compiling to i386 from x86_64 Ubuntu. The one with `i686` seems bogus when cross-compiling from i386 Linux to x86_64.

With these removals, I'm still able to cross-compile from x86_64 to i686 on Mageia 9:
```
$ file bin/godot.linuxbsd.editor.dev.x86_32
bin/godot.linuxbsd.editor.dev.x86_32: ELF 32-bit LSB executable, Intel 80386, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=a0475756f8cba350e35120218132038ea0f480b0, with debug_info, not stripped
```

This _may_ break for some Debian/Ubuntu distros, would need testing. But the old flags can be restored manually by passing `LINKFLAGS="-L/usr/lib/i386-linux-gnu` to `scons`.