### PR TITLE
Fix external editors opened on errors with single click

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1533,6 +1533,10 @@ void ScriptEditorDebugger::_error_activated() {
 	if (ci) {
 		selected->set_collapsed(!selected->is_collapsed());
 	}
+
+	if (bool(EDITOR_GET("text_editor/external/use_external_editor"))) {
+		_emit_error_selected(selected);
+	}
 }
 
 void ScriptEditorDebugger::_error_selected() {
@@ -1542,7 +1546,15 @@ void ScriptEditorDebugger::_error_selected() {
 		return;
 	}
 
-	Array meta = selected->get_metadata(0);
+	if (bool(EDITOR_GET("text_editor/external/use_external_editor"))) {
+		return;
+	}
+
+	_emit_error_selected(selected);
+}
+
+void ScriptEditorDebugger::_emit_error_selected(TreeItem *p_selected) {
+	Array meta = p_selected->get_metadata(0);
 	if (meta.size() == 0) {
 		return;
 	}

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -208,6 +208,7 @@ private:
 
 	void _error_activated();
 	void _error_selected();
+	void _emit_error_selected(TreeItem *p_selected);
 
 	void _expand_errors_list();
 	void _collapse_errors_list();


### PR DESCRIPTION
Fixes #84306 by changing behavior when external editors are used to only open it with a double-click.
