### PR TITLE
Allow dragging editable children

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -120,7 +120,7 @@ class SceneTreeEditor : public Control {
 	void _set_item_custom_color(TreeItem *p_item, Color p_color);
 
 	void _selection_changed();
-	Node *get_scene_node();
+	Node *get_scene_node() const;
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;


### PR DESCRIPTION
Fixes #84144

Nodes from an instantiated scene was prevented from being dragged. This makes sense since editable children are not supposed to be rearrange. But it also prevents editable children from being dragged into other areas like the script editor and the Inspector.

This PR moves the "any node from an instantiated scene" check from when dragging to when dropping.