### PR TITLE
[RichTextLabel] Fix `remove_paragraph` crash by popping current

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3151,7 +3151,7 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	queue_redraw();
 }
 
-void RichTextLabel::_remove_item(Item *p_item, const int p_line, const int p_subitem_line) {
+void RichTextLabel::_remove_item(Item *p_item, const int p_line) {
 	int size = p_item->subitems.size();
 	if (size == 0) {
 		p_item->parent->subitems.erase(p_item);
@@ -3160,7 +3160,7 @@ void RichTextLabel::_remove_item(Item *p_item, const int p_line, const int p_sub
 			current_frame->lines.remove_at(p_line);
 			if (p_line < (int)current_frame->lines.size() && current_frame->lines[p_line].from) {
 				for (List<Item *>::Element *E = current_frame->lines[p_line].from->E; E; E = E->next()) {
-					if (E->get()->line > p_subitem_line) {
+					if (E->get()->line > p_line) {
 						E->get()->line--;
 					}
 				}
@@ -3169,7 +3169,7 @@ void RichTextLabel::_remove_item(Item *p_item, const int p_line, const int p_sub
 	} else {
 		// First, remove all child items for the provided item.
 		while (p_item->subitems.size()) {
-			_remove_item(p_item->subitems.front()->get(), p_line, p_subitem_line);
+			_remove_item(p_item->subitems.front()->get(), p_line);
 		}
 		// Then remove the provided item itself.
 		p_item->parent->subitems.erase(p_item);
@@ -3377,7 +3377,10 @@ bool RichTextLabel::remove_paragraph(const int p_paragraph) {
 	for (int i = subitem_to_remove.size() - 1; i >= 0; i--) {
 		List<Item *>::Element *subitem = subitem_to_remove[i];
 		had_newline = had_newline || subitem->get()->type == ITEM_NEWLINE;
-		_remove_item(subitem->get(), subitem->get()->line, p_paragraph);
+		if (subitem->get() == current) {
+			pop();
+		}
+		_remove_item(subitem->get(), p_paragraph);
 	}
 
 	if (!had_newline) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -461,7 +461,7 @@ private:
 	_FORCE_INLINE_ float _update_scroll_exceeds(float p_total_height, float p_ctrl_height, float p_width, int p_idx, float p_old_scroll, float p_text_rect_height);
 
 	void _add_item(Item *p_item, bool p_enter = false, bool p_ensure_newline = false);
-	void _remove_item(Item *p_item, const int p_line, const int p_subitem_line);
+	void _remove_item(Item *p_item, const int p_line);
 
 	String language;
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #84202 
In my investigation of the issue, it appears to be caused when `current` is pushed into `subitem_to_remove` in `RichTextLabel::remove_paragraph`. This calls memdelete on the pointer in `RichTextLabel::_remove_item`, and we get a dangling pointer.

My solution was to pop `current` up if it's being added as a sub item to be removed, which should be okay since we're removing them in reverse order.