### PR TITLE
GDExtension: Save and compare modification times separately for reload

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -915,9 +915,9 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 #ifdef TOOLS_ENABLED
 	p_extension->set_reloadable(config->get_value("configuration", "reloadable", false) && Engine::get_singleton()->is_extension_reloading_enabled());
 
-	p_extension->update_last_modified_time(MAX(
-			FileAccess::get_modified_time(library_path),
-			FileAccess::get_modified_time(p_path)));
+	p_extension->update_last_modified_time(
+			FileAccess::get_modified_time(p_path),
+			FileAccess::get_modified_time(library_path));
 #endif
 
 	err = p_extension->open_library(library_path, entry_symbol);
@@ -990,10 +990,13 @@ String GDExtensionResourceLoader::get_resource_type(const String &p_path) const 
 
 #ifdef TOOLS_ENABLED
 bool GDExtension::has_library_changed() const {
-	if (FileAccess::get_modified_time(get_path()) > last_modified_time) {
+	// Check only that the last modified time is different (rather than checking
+	// that it's newer) since some OS's (namely Windows) will preserve the modified
+	// time by default when copying files.
+	if (FileAccess::get_modified_time(get_path()) != resource_last_modified_time) {
 		return true;
 	}
-	if (FileAccess::get_modified_time(library_path) > last_modified_time) {
+	if (FileAccess::get_modified_time(library_path) != library_last_modified_time) {
 		return true;
 	}
 	return false;

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -90,7 +90,8 @@ class GDExtension : public Resource {
 	int32_t level_initialized = -1;
 
 #ifdef TOOLS_ENABLED
-	uint64_t last_modified_time = 0;
+	uint64_t resource_last_modified_time = 0;
+	uint64_t library_last_modified_time = 0;
 	bool is_reloading = false;
 	Vector<GDExtensionMethodBind *> invalid_methods;
 	Vector<ObjectID> instance_bindings;
@@ -140,8 +141,9 @@ public:
 	void set_reloadable(bool p_reloadable) { reloadable = p_reloadable; }
 
 	bool has_library_changed() const;
-	void update_last_modified_time(uint64_t p_last_modified_time) {
-		last_modified_time = MAX(last_modified_time, p_last_modified_time);
+	void update_last_modified_time(uint64_t p_resource_last_modified_time, uint64_t p_library_last_modified_time) {
+		resource_last_modified_time = p_resource_last_modified_time;
+		library_last_modified_time = p_library_last_modified_time;
 	}
 
 	void track_instance_binding(Object *p_object);


### PR DESCRIPTION
In the current GDExtension reload code, we're combining the last modification time of the .gdextension file and the library file by storing only the highest one, and then checking if it's changed by checking if either files' new modification time is greater than that value. This works great on Linux, where modification times move forward in time by default, even when copying existing files (unless you go out of your way to preserve the modification time).

However, this can have [some issues on Windows](https://github.com/godotengine/godot/issues/82738) because copied files will have the same modification time of the original file by default.

So, this PR switches to storing each last modification time individually, and simply checks if the modification time has changed (not that it's greater, just that it's different). As far as I can tell, this matches how the editor decides to reload normal resources, which also have "the two file problem" where you have the actual content file (ex file.png) and the import settings file (ex file.png.import).

Fixes https://github.com/godotengine/godot/issues/82738
