### PR TITLE
Replace the use of the `ANDROID_SDK_ROOT` env variable with `ANDROID_HOME`

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -21,7 +21,7 @@ def get_opts():
     from SCons.Variables import BoolVariable
 
     return [
-        ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
+        ("ANDROID_HOME", "Path to the Android SDK", get_env_android_sdk_root()),
         (
             "ndk_platform",
             'Target platform (android-<api>, e.g. "android-' + str(get_min_target_api()) + '")',
@@ -41,9 +41,9 @@ def get_doc_path():
     return "doc_classes"
 
 
-# Return the ANDROID_SDK_ROOT environment variable.
+# Return the ANDROID_HOME environment variable.
 def get_env_android_sdk_root():
-    return os.environ.get("ANDROID_SDK_ROOT", -1)
+    return os.environ.get("ANDROID_HOME", os.environ.get("ANDROID_SDK_ROOT", ""))
 
 
 def get_min_sdk_version(platform):
@@ -51,7 +51,7 @@ def get_min_sdk_version(platform):
 
 
 def get_android_ndk_root(env):
-    return env["ANDROID_SDK_ROOT"] + "/ndk/" + get_ndk_version()
+    return env["ANDROID_HOME"] + "/ndk/" + get_ndk_version()
 
 
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.
@@ -75,7 +75,7 @@ def get_flags():
 # If not, install it.
 def install_ndk_if_needed(env):
     print("Checking for Android NDK...")
-    sdk_root = env["ANDROID_SDK_ROOT"]
+    sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
         sdkmanager = sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension
@@ -87,7 +87,7 @@ def install_ndk_if_needed(env):
         else:
             print("Cannot find " + sdkmanager)
             print(
-                "Please ensure ANDROID_SDK_ROOT is correct and cmdline-tools are installed, or install NDK version "
+                "Please ensure ANDROID_HOME is correct and cmdline-tools are installed, or install NDK version "
                 + get_ndk_version()
                 + " manually."
             )

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -42,7 +42,7 @@ void register_android_exporter_types() {
 
 void register_android_exporter() {
 #ifndef ANDROID_ENABLED
-	EDITOR_DEF("export/android/android_sdk_path", OS::get_singleton()->get_environment("ANDROID_SDK_ROOT"));
+	EDITOR_DEF("export/android/android_sdk_path", OS::get_singleton()->get_environment("ANDROID_HOME"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/debug_keystore", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore", PROPERTY_HINT_GLOBAL_FILE, "*.keystore,*.jks"));


### PR DESCRIPTION
Replace the use of the `ANDROID_SDK_ROOT` env variable with `ANDROID_HOME` as the former is deprecated.

See https://developer.android.com/tools/variables#android_home for more details.

Fixes https://github.com/godotengine/godot/issues/80910

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
