### PR TITLE
[4.1] SCons: Re-disable exceptions for Android, iOS, and Web

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -68,6 +68,7 @@ def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
         ("target", "template_debug"),
+        ("disable_exceptions", True),  # Reduces size.
     ]
 
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -49,6 +49,7 @@ def get_flags():
         ("arch", "arm64"),  # Default for convenience.
         ("target", "template_debug"),
         ("use_volk", False),
+        ("disable_exceptions", True),  # Reduces size.
     ]
 
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -69,6 +69,7 @@ def get_flags():
         # 100 KiB over -Os, which does not justify the negative impact on
         # run-time performance.
         ("optimize", "size"),
+        ("disable_exceptions", True),  # Reduces size.
     ]
 
 


### PR DESCRIPTION
We made a mistake when cherry-picking #80612 with 269b115d9cff1ad1bf1cd8675cd26c8a24065c89, where the global flag was defaulted to false to preserve the 4.1-stable behavior for desktop platforms, but we forgot that the refactoring removed the force disabling of exceptions for Android, iOS, and Web.

This reintroduces this behavior so it should be back to the same as in 4.1/4.1.1, and the export templates should get back to their original size.

Only difference, the old code used to keep exceptions for the Web editor, but I see no reason for it, so I disable them like with the templates.