### PR TITLE
Select newly added nodes on drag and drop in 3D viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4353,6 +4353,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 	undo_redo->add_do_method(instantiated_scene, "set_owner", EditorNode::get_singleton()->get_edited_scene());
 	undo_redo->add_do_reference(instantiated_scene);
 	undo_redo->add_undo_method(parent, "remove_child", instantiated_scene);
+	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 
 	String new_name = parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
@@ -4401,7 +4402,8 @@ void Node3DEditorViewport::_perform_drop_data() {
 
 	Vector<String> error_files;
 
-	undo_redo->create_action(TTR("Create Node"));
+	undo_redo->create_action(TTR("Create Node"), UndoRedo::MERGE_DISABLE, target_node);
+	undo_redo->add_do_method(editor_selection, "clear");
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];


### PR DESCRIPTION
Implements this proposal: https://github.com/godotengine/godot-proposals/issues/8282 for 3D viewport.

Testing:
Create couple scenes of different types which can be added to a 3D scene and save them as separate. Try to drag and drop these directly in to the viewport (not the scene tree tab that's a different thing and works ok), one by one, multiple files, have some root node selected or not.
What you should see with this change is that the newly added node(s) will be selected immediately so you should be able to work with them in the viewport.
Test Undo and Redo too please.

Huge thanks to KoBeWi for advice.

---
Related 2D PR: https://github.com/godotengine/godot/pull/84356