### PR TITLE
Polish & fix editor help cache generation

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -98,8 +98,23 @@ void ClassDB::get_class_list(List<StringName> *p_classes) {
 		p_classes->push_back(E.key);
 	}
 
-	p_classes->sort();
+	p_classes->sort_custom<StringName::AlphCompare>();
 }
+
+#ifdef TOOLS_ENABLED
+void ClassDB::get_extensions_class_list(List<StringName> *p_classes) {
+	OBJTYPE_RLOCK;
+
+	for (const KeyValue<StringName, ClassInfo> &E : classes) {
+		if (E.value.api != API_EXTENSION && E.value.api != API_EDITOR_EXTENSION) {
+			continue;
+		}
+		p_classes->push_back(E.key);
+	}
+
+	p_classes->sort_custom<StringName::AlphCompare>();
+}
+#endif
 
 void ClassDB::get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes) {
 	OBJTYPE_RLOCK;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -251,6 +251,9 @@ public:
 	}
 
 	static void get_class_list(List<StringName> *p_classes);
+#ifdef TOOLS_ENABLED
+	static void get_extensions_class_list(List<StringName> *p_classes);
+#endif
 	static void get_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static void get_direct_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static StringName get_parent_class_nocheck(const StringName &p_class);

--- a/editor/doc_tools.h
+++ b/editor/doc_tools.h
@@ -45,7 +45,11 @@ public:
 	void add_doc(const DocData::ClassDoc &p_class_doc);
 	void remove_doc(const String &p_class_name);
 	bool has_doc(const String &p_class_name);
-	void generate(bool p_basic_types = false);
+	enum GenerateFlags {
+		GENERATE_FLAG_SKIP_BASIC_TYPES = (1 << 0),
+		GENERATE_FLAG_EXTENSION_CLASSES_ONLY = (1 << 1),
+	};
+	void generate(BitField<GenerateFlags> p_flags = {});
 	Error load_classes(const String &p_dir);
 	Error save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_include_xml_schema = true);
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -188,13 +188,12 @@ class EditorHelp : public VBoxContainer {
 	void _toggle_scripts_pressed();
 
 	static String doc_version_hash;
-	static bool doc_gen_first_attempt;
-	static bool doc_gen_use_threads;
-	static Thread gen_thread;
+	static Thread worker_thread;
 
 	static void _wait_for_thread();
 	static void _load_doc_thread(void *p_udata);
 	static void _gen_doc_thread(void *p_udata);
+	static void _gen_extensions_docs();
 	static void _compute_doc_version_hash();
 
 protected:

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2767,7 +2767,7 @@ bool Main::start() {
 
 #ifdef TOOLS_ENABLED
 	String doc_tool_path;
-	bool doc_base = true;
+	BitField<DocTools::GenerateFlags> gen_flags;
 	String _export_preset;
 	bool export_debug = false;
 	bool export_pack_only = false;
@@ -2792,7 +2792,7 @@ bool Main::start() {
 			check_only = true;
 #ifdef TOOLS_ENABLED
 		} else if (args[i] == "--no-docbase") {
-			doc_base = false;
+			gen_flags.set_flag(DocTools::GENERATE_FLAG_SKIP_BASIC_TYPES);
 #ifndef DISABLE_DEPRECATED
 		} else if (args[i] == "--convert-3to4") {
 			converting_project = true;
@@ -2903,7 +2903,7 @@ bool Main::start() {
 
 		Error err;
 		DocTools doc;
-		doc.generate(doc_base);
+		doc.generate(gen_flags);
 
 		DocTools docsrc;
 		HashMap<String, String> doc_data_classes;


### PR DESCRIPTION
- Isolated the generation of extensions's docs. They're now not cached and refreshed as needed.
- Removed superfluous sorting of the class list.
- Removed some superfluous/unused elements.
- Renamed some items for clarity.

Fixes #82817.