### PR TITLE
Select newly added nodes on drag and drop in 2D viewport 

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5811,10 +5811,12 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 	instantiated_scene->set_scene_file_path(ProjectSettings::get_singleton()->localize_path(path));
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	undo_redo->add_do_method(parent, "add_child", instantiated_scene, true);
 	undo_redo->add_do_method(instantiated_scene, "set_owner", edited_scene);
 	undo_redo->add_do_reference(instantiated_scene);
 	undo_redo->add_undo_method(parent, "remove_child", instantiated_scene);
+	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 
 	String new_name = parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
@@ -5853,6 +5855,8 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action_for_history(TTR("Create Node"), EditorNode::get_editor_data().get_current_edited_scene_history_id());
+	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
+	undo_redo->add_do_method(editor_selection, "clear");
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];
@@ -5879,6 +5883,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 			if (texture != nullptr && texture.is_valid()) {
 				Node *child = Object::cast_to<Node>(ClassDB::instantiate(default_texture_node_type));
 				_create_nodes(target_node, child, path, drop_pos);
+				undo_redo->add_do_method(editor_selection, "add_node", child);
 			}
 		}
 	}


### PR DESCRIPTION
Implements this proposal: https://github.com/godotengine/godot-proposals/issues/8282 for 2D viewport.

Testing:
Create couple scenes of different types which can be added to a 2D scene and save them as separate. Try to drag and drop these directly in to the viewport (not the scene tree tab that's a different thing and works ok), one by one, multiple files, have some root node selected or not, do the same with images/icons in FileSystem.
What you should see with this change is that the newly added node(s) will be selected immediately so you should be able to work with them in the viewport.
Test with Undo/Redo too please.

Known issues:
When undoing the orange selection borders remain on the screen until you release the undo shortcut or press for example a mouse button. So far it doesn't seem to be a functional issue as far as I can tell. I don't know what to do about it, I'm open to opinions and suggestions.

---
Related 3D PR: https://github.com/godotengine/godot/pull/84347