### PR TITLE
Prevent crash and error spam related to Sprite2D with a region

### DIFF
--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -127,59 +127,57 @@ void Sprite2DEditor::_menu_option(int p_option) {
 			debug_uv_dialog->set_ok_button_text(TTR("Create MeshInstance2D"));
 			debug_uv_dialog->set_title(TTR("MeshInstance2D Preview"));
 
-			_update_mesh_data();
-			debug_uv_dialog->popup_centered();
-			debug_uv->queue_redraw();
-
+			_popup_debug_uv_dialog();
 		} break;
 		case MENU_OPTION_CONVERT_TO_POLYGON_2D: {
 			debug_uv_dialog->set_ok_button_text(TTR("Create Polygon2D"));
 			debug_uv_dialog->set_title(TTR("Polygon2D Preview"));
 
-			_update_mesh_data();
-			debug_uv_dialog->popup_centered();
-			debug_uv->queue_redraw();
+			_popup_debug_uv_dialog();
 		} break;
 		case MENU_OPTION_CREATE_COLLISION_POLY_2D: {
 			debug_uv_dialog->set_ok_button_text(TTR("Create CollisionPolygon2D"));
 			debug_uv_dialog->set_title(TTR("CollisionPolygon2D Preview"));
 
-			_update_mesh_data();
-			debug_uv_dialog->popup_centered();
-			debug_uv->queue_redraw();
-
+			_popup_debug_uv_dialog();
 		} break;
 		case MENU_OPTION_CREATE_LIGHT_OCCLUDER_2D: {
 			debug_uv_dialog->set_ok_button_text(TTR("Create LightOccluder2D"));
 			debug_uv_dialog->set_title(TTR("LightOccluder2D Preview"));
 
-			_update_mesh_data();
-			debug_uv_dialog->popup_centered();
-			debug_uv->queue_redraw();
-
+			_popup_debug_uv_dialog();
 		} break;
 	}
 }
 
-void Sprite2DEditor::_update_mesh_data() {
+void Sprite2DEditor::_popup_debug_uv_dialog() {
+	String error_message;
 	if (node->get_owner() != get_tree()->get_edited_scene_root()) {
-		err_dialog->set_text(TTR("Can't convert a Sprite2D from a foreign scene."));
-		err_dialog->popup_centered();
+		error_message = TTR("Can't convert a sprite from a foreign scene.");
 	}
-
 	Ref<Texture2D> texture = node->get_texture();
 	if (texture.is_null()) {
-		err_dialog->set_text(TTR("Sprite2D is empty!"));
-		err_dialog->popup_centered();
-		return;
+		error_message = TTR("Can't convert an empty sprite to mesh.");
 	}
-
 	if (node->get_hframes() > 1 || node->get_vframes() > 1) {
-		err_dialog->set_text(TTR("Can't convert a sprite using animation frames to mesh."));
+		error_message = TTR("Can't convert a sprite using animation frames to mesh.");
+	}
+
+	if (!error_message.is_empty()) {
+		err_dialog->set_text(error_message);
 		err_dialog->popup_centered();
 		return;
 	}
 
+	_update_mesh_data();
+	debug_uv_dialog->popup_centered();
+	debug_uv->queue_redraw();
+}
+
+void Sprite2DEditor::_update_mesh_data() {
+	ERR_FAIL_NULL(node);
+	Ref<Texture2D> texture = node->get_texture();
+	ERR_FAIL_COND(texture.is_null());
 	Ref<Image> image = texture->get_image();
 	ERR_FAIL_COND(image.is_null());
 
@@ -187,12 +185,9 @@ void Sprite2DEditor::_update_mesh_data() {
 		image->decompress();
 	}
 
+	// TODO: Add support for Sprite2D's region.
 	Rect2 rect;
-	if (node->is_region_enabled()) {
-		rect = node->get_region_rect();
-	} else {
-		rect.size = image->get_size();
-	}
+	rect.size = image->get_size();
 
 	Ref<BitMap> bm;
 	bm.instantiate();

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -79,6 +79,7 @@ class Sprite2DEditor : public Control {
 	friend class Sprite2DEditorPlugin;
 
 	void _debug_uv_draw();
+	void _popup_debug_uv_dialog();
 	void _update_mesh_data();
 
 	void _create_node();

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -54,7 +54,7 @@ Transform2D TextureRegionEditor::_get_offset_transform() const {
 }
 
 void TextureRegionEditor::_texture_preview_draw() {
-	Ref<Texture2D> object_texture = _get_edited_object_texture();
+	const Ref<Texture2D> object_texture = _get_edited_object_texture();
 	if (object_texture.is_null()) {
 		return;
 	}
@@ -68,7 +68,7 @@ void TextureRegionEditor::_texture_preview_draw() {
 }
 
 void TextureRegionEditor::_texture_overlay_draw() {
-	Ref<Texture2D> object_texture = _get_edited_object_texture();
+	const Ref<Texture2D> object_texture = _get_edited_object_texture();
 	if (object_texture.is_null()) {
 		return;
 	}
@@ -746,7 +746,7 @@ void TextureRegionEditor::_update_autoslice() {
 	autoslice_is_dirty = false;
 	autoslice_cache.clear();
 
-	Ref<Texture2D> object_texture = _get_edited_object_texture();
+	const Ref<Texture2D> object_texture = _get_edited_object_texture();
 	if (object_texture.is_null()) {
 		return;
 	}
@@ -860,14 +860,6 @@ void TextureRegionEditor::_node_removed(Node *p_node) {
 }
 
 void TextureRegionEditor::_clear_edited_object() {
-	node_sprite_2d = nullptr;
-	node_sprite_3d = nullptr;
-	node_ninepatch = nullptr;
-	res_stylebox = Ref<StyleBoxTexture>();
-	res_atlas_texture = Ref<AtlasTexture>();
-}
-
-void TextureRegionEditor::edit(Object *p_obj) {
 	if (node_sprite_2d) {
 		node_sprite_2d->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
@@ -884,6 +876,14 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		res_atlas_texture->disconnect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 
+	node_sprite_2d = nullptr;
+	node_sprite_3d = nullptr;
+	node_ninepatch = nullptr;
+	res_stylebox = Ref<StyleBoxTexture>();
+	res_atlas_texture = Ref<AtlasTexture>();
+}
+
+void TextureRegionEditor::edit(Object *p_obj) {
 	_clear_edited_object();
 
 	if (p_obj) {
@@ -950,8 +950,9 @@ Rect2 TextureRegionEditor::_get_edited_object_region() const {
 		region = res_atlas_texture->get_region();
 	}
 
-	if (region == Rect2()) {
-		region = Rect2(Vector2(), _get_edited_object_texture()->get_size());
+	const Ref<Texture2D> object_texture = _get_edited_object_texture();
+	if (region == Rect2() && object_texture.is_valid()) {
+		region = Rect2(Vector2(), object_texture->get_size());
 	}
 
 	return region;
@@ -965,7 +966,7 @@ void TextureRegionEditor::_texture_changed() {
 }
 
 void TextureRegionEditor::_edit_region() {
-	Ref<Texture2D> object_texture = _get_edited_object_texture();
+	const Ref<Texture2D> object_texture = _get_edited_object_texture();
 	if (object_texture.is_null()) {
 		_zoom_reset();
 		hscroll->hide();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/84349 and a couple other problems.

1. The reported issue is related to deleting the node that was previously edited by the region editor, and then undoing this. Normally, UndoRedo actions should be attached to the edited objects themselves, but in this case the action is a part of the region editor, which no longer has a valid reference to work with. I made sure we don't handle invalid values, which leads to crashes, but there may be a further improvement possible in there. We could make sure that the historical reference to the edited object is preserved and used by the editor method. But for now fixing the crash should be good enough, and there should be no visible issues to the user.
2. Related to UndoRedo there was also an error message due to poor handling on the signal handlers. I adjusted the code to correctly disconnect them when the node disappears.
3. While testing the linked issue I noticed that regions don't work with the Sprite 2D editor, namely when converting sprites to 2D meshes. If the region is smaller than the texture, [the crop is misaligned](https://github.com/godotengine/godot/assets/11782833/f492b1db-46a7-4891-b7c8-b16201af1cfb). If the region is bigger than the texture, [there is error spam](https://github.com/godotengine/godot/assets/11782833/90c4d1d0-3d2d-4da4-a270-dde0969f5532) related to trying to access a bad pixel coordinate. I could probably fix it properly, but this close to the release I don't want to cause any further regressions. So I simply removed the region handling code, and it is for now simply ignored. It was introduced like that in the original PR in 9e3a1e5401f9f807085547de0ecc3f527610daa4, so it probably never worked.

While working on the third point I also cleaned up error handling logic, so error popups should now appear correctly, won't be obscured by the useless Sprite 2D editor, and excessive checks won't run on each update (since they don't validate anything that the user can change from the dialog anyway).