### PR TITLE
Robustify handling of activation & focus on Windows

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -402,7 +402,6 @@ class DisplayServerWindows : public DisplayServer {
 
 		// Timers.
 		uint32_t move_timer_id = 0U;
-		uint32_t focus_timer_id = 0U;
 
 		HANDLE wtctx;
 		LOGCONTEXTW wtlc;


### PR DESCRIPTION
I found the need for this while assessing #80548. The central ideas are these:
- In Godot we don't really need to tell activation apart from focus. It's the same. The only need, given how the handle child windows, is to explicitly set focus to any window just activated (see the linked PR).
- The handling of application-wide focus is reimplemented here in a more reliable way.
- Certain timer hack is removed (while the issue it intended to fix, #44953, is still gone).