### PR TITLE
GDScript: Rework `GDScriptUtilityFunctions` macros

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -61,7 +61,7 @@
 		<method name="convert" deprecated="Use [method @GlobalScope.type_convert] instead.">
 			<return type="Variant" />
 			<param index="0" name="what" type="Variant" />
-			<param index="1" name="type" type="int" />
+			<param index="1" name="type" type="int" enum="Variant.Type" />
 			<description>
 				Converts [param what] to [param type] in the best way possible. The [param type] uses the [enum Variant.Type] values.
 				[codeblock]

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -34,7 +34,6 @@
 
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
-#include "core/object/method_bind.h"
 #include "core/object/object.h"
 #include "core/templates/oa_hash_map.h"
 #include "core/templates/vector.h"
@@ -42,101 +41,105 @@
 
 #ifdef DEBUG_ENABLED
 
-#define VALIDATE_ARG_COUNT(m_count)                                         \
-	if (p_arg_count < m_count) {                                            \
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;  \
-		r_error.expected = m_count;                                         \
+#define DEBUG_VALIDATE_ARG_COUNT(m_min_count, m_max_count)                  \
+	if (unlikely(p_arg_count < m_min_count)) {                              \
 		*r_ret = Variant();                                                 \
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;  \
+		r_error.expected = m_min_count;                                     \
 		return;                                                             \
 	}                                                                       \
-	if (p_arg_count > m_count) {                                            \
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS; \
-		r_error.expected = m_count;                                         \
+	if (unlikely(p_arg_count > m_max_count)) {                              \
 		*r_ret = Variant();                                                 \
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS; \
+		r_error.expected = m_max_count;                                     \
 		return;                                                             \
 	}
 
-#define VALIDATE_ARG_INT(m_arg)                                           \
-	if (p_args[m_arg]->get_type() != Variant::INT) {                      \
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT; \
-		r_error.argument = m_arg;                                         \
-		r_error.expected = Variant::INT;                                  \
-		*r_ret = Variant();                                               \
-		return;                                                           \
+#define DEBUG_VALIDATE_ARG_TYPE(m_arg, m_type)                                       \
+	if (unlikely(!Variant::can_convert_strict(p_args[m_arg]->get_type(), m_type))) { \
+		*r_ret = Variant();                                                          \
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;            \
+		r_error.argument = m_arg;                                                    \
+		r_error.expected = m_type;                                                   \
+		return;                                                                      \
 	}
 
-#define VALIDATE_ARG_NUM(m_arg)                                           \
-	if (!p_args[m_arg]->is_num()) {                                       \
+#define DEBUG_VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg)           \
+	if (unlikely(m_cond)) {                                               \
+		*r_ret = m_msg;                                                   \
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT; \
 		r_error.argument = m_arg;                                         \
-		r_error.expected = Variant::FLOAT;                                \
-		*r_ret = Variant();                                               \
+		r_error.expected = m_type;                                        \
 		return;                                                           \
 	}
 
 #else // !DEBUG_ENABLED
 
-#define VALIDATE_ARG_COUNT(m_count)
-#define VALIDATE_ARG_INT(m_arg)
-#define VALIDATE_ARG_NUM(m_arg)
+#define DEBUG_VALIDATE_ARG_COUNT(m_min_count, m_max_count)
+#define DEBUG_VALIDATE_ARG_TYPE(m_arg, m_type)
+#define DEBUG_VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg)
 
 #endif // DEBUG_ENABLED
+
+#define VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg)                 \
+	if (unlikely(m_cond)) {                                               \
+		*r_ret = m_msg;                                                   \
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT; \
+		r_error.argument = m_arg;                                         \
+		r_error.expected = m_type;                                        \
+		return;                                                           \
+	}
+
+#define GDFUNC_FAIL_COND_MSG(m_cond, m_msg)                             \
+	if (unlikely(m_cond)) {                                             \
+		*r_ret = m_msg;                                                 \
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD; \
+		return;                                                         \
+	}
 
 struct GDScriptUtilityFunctionsDefinitions {
 #ifndef DISABLE_DEPRECATED
 	static inline void convert(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(2);
-		VALIDATE_ARG_INT(1);
-		int type = *p_args[1];
-		if (type < 0 || type >= Variant::VARIANT_MAX) {
-			*r_ret = RTR("Invalid type argument to convert(), use TYPE_* constants.");
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::INT;
-			return;
+		DEBUG_VALIDATE_ARG_COUNT(2, 2);
+		DEBUG_VALIDATE_ARG_TYPE(1, Variant::INT);
 
-		} else {
-			Variant::construct(Variant::Type(type), *r_ret, p_args, 1, r_error);
-			if (r_error.error != Callable::CallError::CALL_OK) {
-				*r_ret = vformat(RTR(R"(Cannot convert "%s" to "%s".)"), Variant::get_type_name(p_args[0]->get_type()), Variant::get_type_name(Variant::Type(type)));
-			}
-		}
+		int type = *p_args[1];
+		DEBUG_VALIDATE_ARG_CUSTOM(1, Variant::INT, type < 0 || type >= Variant::VARIANT_MAX,
+				RTR("Invalid type argument to convert(), use TYPE_* constants."));
+
+		Variant::construct(Variant::Type(type), *r_ret, p_args, 1, r_error);
 	}
 #endif // DISABLE_DEPRECATED
 
 	static inline void type_exists(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(1);
+		DEBUG_VALIDATE_ARG_COUNT(1, 1);
+		DEBUG_VALIDATE_ARG_TYPE(0, Variant::STRING_NAME);
 		*r_ret = ClassDB::class_exists(*p_args[0]);
 	}
 
 	static inline void _char(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(1);
-		VALIDATE_ARG_INT(0);
+		DEBUG_VALIDATE_ARG_COUNT(1, 1);
+		DEBUG_VALIDATE_ARG_TYPE(0, Variant::INT);
 		char32_t result[2] = { *p_args[0], 0 };
 		*r_ret = String(result);
 	}
 
 	static inline void range(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+		DEBUG_VALIDATE_ARG_COUNT(1, 3);
 		switch (p_arg_count) {
-			case 0: {
-				r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-				r_error.expected = 1;
-				*r_ret = Variant();
-			} break;
 			case 1: {
-				VALIDATE_ARG_NUM(0);
+				DEBUG_VALIDATE_ARG_TYPE(0, Variant::INT);
+
 				int count = *p_args[0];
+
 				Array arr;
 				if (count <= 0) {
 					*r_ret = arr;
 					return;
 				}
+
 				Error err = arr.resize(count);
-				if (err != OK) {
-					*r_ret = RTR("Cannot resize array.");
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					return;
-				}
+				GDFUNC_FAIL_COND_MSG(err != OK, RTR("Cannot resize array."));
 
 				for (int i = 0; i < count; i++) {
 					arr[i] = i;
@@ -145,8 +148,8 @@ struct GDScriptUtilityFunctionsDefinitions {
 				*r_ret = arr;
 			} break;
 			case 2: {
-				VALIDATE_ARG_NUM(0);
-				VALIDATE_ARG_NUM(1);
+				DEBUG_VALIDATE_ARG_TYPE(0, Variant::INT);
+				DEBUG_VALIDATE_ARG_TYPE(1, Variant::INT);
 
 				int from = *p_args[0];
 				int to = *p_args[1];
@@ -156,30 +159,26 @@ struct GDScriptUtilityFunctionsDefinitions {
 					*r_ret = arr;
 					return;
 				}
+
 				Error err = arr.resize(to - from);
-				if (err != OK) {
-					*r_ret = RTR("Cannot resize array.");
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					return;
-				}
+				GDFUNC_FAIL_COND_MSG(err != OK, RTR("Cannot resize array."));
+
 				for (int i = from; i < to; i++) {
 					arr[i - from] = i;
 				}
+
 				*r_ret = arr;
 			} break;
 			case 3: {
-				VALIDATE_ARG_NUM(0);
-				VALIDATE_ARG_NUM(1);
-				VALIDATE_ARG_NUM(2);
+				DEBUG_VALIDATE_ARG_TYPE(0, Variant::INT);
+				DEBUG_VALIDATE_ARG_TYPE(1, Variant::INT);
+				DEBUG_VALIDATE_ARG_TYPE(2, Variant::INT);
 
 				int from = *p_args[0];
 				int to = *p_args[1];
 				int incr = *p_args[2];
-				if (incr == 0) {
-					*r_ret = RTR("Step argument is zero!");
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					return;
-				}
+
+				VALIDATE_ARG_CUSTOM(2, Variant::INT, incr == 0, RTR("Step argument is zero!"));
 
 				Array arr;
 				if (from >= to && incr > 0) {
@@ -200,12 +199,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 				}
 
 				Error err = arr.resize(count);
-
-				if (err != OK) {
-					*r_ret = RTR("Cannot resize array.");
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					return;
-				}
+				GDFUNC_FAIL_COND_MSG(err != OK, RTR("Cannot resize array."));
 
 				if (incr > 0) {
 					int idx = 0;
@@ -221,138 +215,79 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 				*r_ret = arr;
 			} break;
-			default: {
-				r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-				r_error.expected = 3;
-				*r_ret = Variant();
-
-			} break;
 		}
 	}
 
 	static inline void load(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(1);
-		if (!p_args[0]->is_string()) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::STRING;
-			*r_ret = Variant();
-		} else {
-			*r_ret = ResourceLoader::load(*p_args[0]);
-		}
+		DEBUG_VALIDATE_ARG_COUNT(1, 1);
+		DEBUG_VALIDATE_ARG_TYPE(0, Variant::STRING);
+		*r_ret = ResourceLoader::load(*p_args[0]);
 	}
 
 	static inline void inst_to_dict(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(1);
+		DEBUG_VALIDATE_ARG_COUNT(1, 1);
+		DEBUG_VALIDATE_ARG_TYPE(0, Variant::OBJECT);
 
 		if (p_args[0]->get_type() == Variant::NIL) {
 			*r_ret = Variant();
-		} else if (p_args[0]->get_type() != Variant::OBJECT) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::OBJECT;
+			return;
+		}
+
+		Object *obj = *p_args[0];
+		if (!obj) {
 			*r_ret = Variant();
-		} else {
-			Object *obj = *p_args[0];
-			if (!obj) {
-				*r_ret = Variant();
+			return;
+		}
 
-			} else if (!obj->get_script_instance() || obj->get_script_instance()->get_language() != GDScriptLanguage::get_singleton()) {
-				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-				r_error.argument = 0;
-				r_error.expected = Variant::DICTIONARY;
-				*r_ret = RTR("Not a script with an instance");
-				return;
-			} else {
-				GDScriptInstance *ins = static_cast<GDScriptInstance *>(obj->get_script_instance());
-				Ref<GDScript> base = ins->get_script();
-				if (base.is_null()) {
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-					r_error.argument = 0;
-					r_error.expected = Variant::DICTIONARY;
-					*r_ret = RTR("Not based on a script");
-					return;
-				}
+		VALIDATE_ARG_CUSTOM(0, Variant::OBJECT,
+				!obj->get_script_instance() || obj->get_script_instance()->get_language() != GDScriptLanguage::get_singleton(),
+				RTR("Not a script with an instance."));
 
-				GDScript *p = base.ptr();
-				String path = p->get_script_path();
-				Vector<StringName> sname;
+		GDScriptInstance *inst = static_cast<GDScriptInstance *>(obj->get_script_instance());
 
-				while (p->_owner) {
-					sname.push_back(p->local_name);
-					p = p->_owner;
-				}
-				sname.reverse();
+		Ref<GDScript> base = inst->get_script();
+		VALIDATE_ARG_CUSTOM(0, Variant::OBJECT, base.is_null(), RTR("Not based on a script."));
 
-				if (!path.is_resource_file()) {
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-					r_error.argument = 0;
-					r_error.expected = Variant::DICTIONARY;
-					*r_ret = Variant();
+		GDScript *p = base.ptr();
+		String path = p->get_script_path();
+		Vector<StringName> sname;
 
-					*r_ret = RTR("Not based on a resource file");
+		while (p->_owner) {
+			sname.push_back(p->local_name);
+			p = p->_owner;
+		}
+		sname.reverse();
 
-					return;
-				}
+		VALIDATE_ARG_CUSTOM(0, Variant::OBJECT, !path.is_resource_file(), RTR("Not based on a resource file."));
 
-				NodePath cp(sname, Vector<StringName>(), false);
+		NodePath cp(sname, Vector<StringName>(), false);
 
-				Dictionary d;
-				d["@subpath"] = cp;
-				d["@path"] = path;
+		Dictionary d;
+		d["@subpath"] = cp;
+		d["@path"] = path;
 
-				for (const KeyValue<StringName, GDScript::MemberInfo> &E : base->member_indices) {
-					if (!d.has(E.key)) {
-						d[E.key] = ins->members[E.value.index];
-					}
-				}
-				*r_ret = d;
+		for (const KeyValue<StringName, GDScript::MemberInfo> &E : base->member_indices) {
+			if (!d.has(E.key)) {
+				d[E.key] = inst->members[E.value.index];
 			}
 		}
+
+		*r_ret = d;
 	}
 
 	static inline void dict_to_inst(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(1);
-
-		if (p_args[0]->get_type() != Variant::DICTIONARY) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::DICTIONARY;
-			*r_ret = Variant();
-
-			return;
-		}
+		DEBUG_VALIDATE_ARG_COUNT(1, 1);
+		DEBUG_VALIDATE_ARG_TYPE(0, Variant::DICTIONARY);
 
 		Dictionary d = *p_args[0];
 
-		if (!d.has("@path")) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::OBJECT;
-			*r_ret = RTR("Invalid instance dictionary format (missing @path)");
-
-			return;
-		}
+		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !d.has("@path"), RTR("Invalid instance dictionary format (missing @path)."));
 
 		Ref<Script> scr = ResourceLoader::load(d["@path"]);
-		if (!scr.is_valid()) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::OBJECT;
-			*r_ret = RTR("Invalid instance dictionary format (can't load script at @path)");
-			return;
-		}
+		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !scr.is_valid(), RTR("Invalid instance dictionary format (can't load script at @path)."));
 
 		Ref<GDScript> gdscr = scr;
-
-		if (!gdscr.is_valid()) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::OBJECT;
-			*r_ret = Variant();
-			*r_ret = RTR("Invalid instance dictionary format (invalid script at @path)");
-			return;
-		}
+		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !gdscr.is_valid(), RTR("Invalid instance dictionary format (invalid script at @path)."));
 
 		NodePath sub;
 		if (d.has("@subpath")) {
@@ -361,54 +296,35 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		for (int i = 0; i < sub.get_name_count(); i++) {
 			gdscr = gdscr->subclasses[sub.get_name(i)];
-			if (!gdscr.is_valid()) {
-				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-				r_error.argument = 0;
-				r_error.expected = Variant::OBJECT;
-				*r_ret = Variant();
-				*r_ret = RTR("Invalid instance dictionary (invalid subclasses)");
-				return;
-			}
+			VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !gdscr.is_valid(), RTR("Invalid instance dictionary (invalid subclasses)."));
 		}
-		*r_ret = gdscr->_new(nullptr, -1 /*skip initializer*/, r_error);
 
+		*r_ret = gdscr->_new(nullptr, -1 /* skip initializer */, r_error);
 		if (r_error.error != Callable::CallError::CALL_OK) {
 			*r_ret = RTR("Cannot instantiate GDScript class.");
 			return;
 		}
 
-		GDScriptInstance *ins = static_cast<GDScriptInstance *>(static_cast<Object *>(*r_ret)->get_script_instance());
-		Ref<GDScript> gd_ref = ins->get_script();
+		GDScriptInstance *inst = static_cast<GDScriptInstance *>(static_cast<Object *>(*r_ret)->get_script_instance());
+		Ref<GDScript> gd_ref = inst->get_script();
 
 		for (KeyValue<StringName, GDScript::MemberInfo> &E : gd_ref->member_indices) {
 			if (d.has(E.key)) {
-				ins->members.write[E.value.index] = d[E.key];
+				inst->members.write[E.value.index] = d[E.key];
 			}
 		}
 	}
 
 	static inline void Color8(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		if (p_arg_count < 3) {
-			r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-			r_error.expected = 3;
-			*r_ret = Variant();
-			return;
-		}
-		if (p_arg_count > 4) {
-			r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-			r_error.expected = 4;
-			*r_ret = Variant();
-			return;
-		}
-
-		VALIDATE_ARG_INT(0);
-		VALIDATE_ARG_INT(1);
-		VALIDATE_ARG_INT(2);
+		DEBUG_VALIDATE_ARG_COUNT(3, 4);
+		DEBUG_VALIDATE_ARG_TYPE(0, Variant::INT);
+		DEBUG_VALIDATE_ARG_TYPE(1, Variant::INT);
+		DEBUG_VALIDATE_ARG_TYPE(2, Variant::INT);
 
 		Color color((int64_t)*p_args[0] / 255.0f, (int64_t)*p_args[1] / 255.0f, (int64_t)*p_args[2] / 255.0f);
 
 		if (p_arg_count == 4) {
-			VALIDATE_ARG_INT(3);
+			DEBUG_VALIDATE_ARG_TYPE(3, Variant::INT);
 			color.a = (int64_t)*p_args[3] / 255.0f;
 		}
 
@@ -435,7 +351,8 @@ struct GDScriptUtilityFunctionsDefinitions {
 	}
 
 	static inline void print_stack(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(0);
+		DEBUG_VALIDATE_ARG_COUNT(0, 0);
+
 		if (Thread::get_caller_id() != Thread::get_main_id()) {
 			print_line("Cannot retrieve debug info outside the main thread. Thread ID: " + itos(Thread::get_caller_id()));
 			return;
@@ -449,7 +366,8 @@ struct GDScriptUtilityFunctionsDefinitions {
 	}
 
 	static inline void get_stack(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(0);
+		DEBUG_VALIDATE_ARG_COUNT(0, 0);
+
 		if (Thread::get_caller_id() != Thread::get_main_id()) {
 			*r_ret = TypedArray<Dictionary>();
 			return;
@@ -468,7 +386,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 	}
 
 	static inline void len(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(1);
+		DEBUG_VALIDATE_ARG_COUNT(1, 1);
 		switch (p_args[0]->get_type()) {
 			case Variant::STRING:
 			case Variant::STRING_NAME: {
@@ -524,56 +442,34 @@ struct GDScriptUtilityFunctionsDefinitions {
 				*r_ret = d.size();
 			} break;
 			default: {
+				*r_ret = vformat(RTR("Value of type '%s' can't provide a length."), Variant::get_type_name(p_args[0]->get_type()));
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument = 0;
 				r_error.expected = Variant::NIL;
-				*r_ret = vformat(RTR("Value of type '%s' can't provide a length."), Variant::get_type_name(p_args[0]->get_type()));
-			}
+			} break;
 		}
 	}
 
 	static inline void is_instance_of(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(2);
+		DEBUG_VALIDATE_ARG_COUNT(2, 2);
 
 		if (p_args[1]->get_type() == Variant::INT) {
 			int builtin_type = *p_args[1];
-			if (builtin_type < 0 || builtin_type >= Variant::VARIANT_MAX) {
-				*r_ret = RTR("Invalid type argument for is_instance_of(), use TYPE_* constants for built-in types.");
-				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-				r_error.argument = 1;
-				r_error.expected = Variant::NIL;
-				return;
-			}
+			DEBUG_VALIDATE_ARG_CUSTOM(1, Variant::NIL, builtin_type < 0 || builtin_type >= Variant::VARIANT_MAX,
+					RTR("Invalid type argument for is_instance_of(), use TYPE_* constants for built-in types."));
 			*r_ret = p_args[0]->get_type() == builtin_type;
 			return;
 		}
 
 		bool was_type_freed = false;
 		Object *type_object = p_args[1]->get_validated_object_with_check(was_type_freed);
-		if (was_type_freed) {
-			*r_ret = RTR("Type argument is a previously freed instance.");
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 1;
-			r_error.expected = Variant::NIL;
-			return;
-		}
-		if (!type_object) {
-			*r_ret = RTR("Invalid type argument for is_instance_of(), should be a TYPE_* constant, a class or a script.");
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 1;
-			r_error.expected = Variant::NIL;
-			return;
-		}
+		VALIDATE_ARG_CUSTOM(1, Variant::NIL, was_type_freed, RTR("Type argument is a previously freed instance."));
+		VALIDATE_ARG_CUSTOM(1, Variant::NIL, !type_object,
+				RTR("Invalid type argument for is_instance_of(), should be a TYPE_* constant, a class or a script."));
 
 		bool was_value_freed = false;
 		Object *value_object = p_args[0]->get_validated_object_with_check(was_value_freed);
-		if (was_value_freed) {
-			*r_ret = RTR("Value argument is a previously freed instance.");
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::NIL;
-			return;
-		}
+		VALIDATE_ARG_CUSTOM(0, Variant::NIL, was_value_freed, RTR("Value argument is a previously freed instance."));
 		if (!value_object) {
 			*r_ret = false;
 			return;
@@ -618,113 +514,77 @@ struct GDScriptUtilityFunctionInfo {
 static OAHashMap<StringName, GDScriptUtilityFunctionInfo> utility_function_table;
 static List<StringName> utility_function_name_table;
 
-static void _register_function(const String &p_name, const MethodInfo &p_method_info, GDScriptUtilityFunctions::FunctionPtr p_function, bool p_is_const) {
-	StringName sname(p_name);
-
-	ERR_FAIL_COND(utility_function_table.has(sname));
+static void _register_function(const StringName &p_name, const MethodInfo &p_method_info, GDScriptUtilityFunctions::FunctionPtr p_function, bool p_is_const) {
+	ERR_FAIL_COND(utility_function_table.has(p_name));
 
 	GDScriptUtilityFunctionInfo function;
 	function.function = p_function;
 	function.info = p_method_info;
 	function.is_constant = p_is_const;
 
-	utility_function_table.insert(sname, function);
-	utility_function_name_table.push_back(sname);
+	utility_function_table.insert(p_name, function);
+	utility_function_name_table.push_back(p_name);
 }
 
-#define REGISTER_FUNC(m_func, m_is_const, m_return_type, ...)                                    \
+#define REGISTER_FUNC(m_func, m_is_const, m_return, m_args, m_is_vararg, m_default_args)         \
 	{                                                                                            \
 		String name(#m_func);                                                                    \
 		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
+			name = name.substr(1);                                                               \
 		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = m_return_type;                                                    \
+		MethodInfo info = m_args;                                                                \
+		info.name = name;                                                                        \
+		info.return_val = m_return;                                                              \
+		info.default_arguments = m_default_args;                                                 \
+		if (m_is_vararg) {                                                                       \
+			info.flags |= METHOD_FLAG_VARARG;                                                    \
+		}                                                                                        \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
 
-#define REGISTER_FUNC_NO_ARGS(m_func, m_is_const, m_return_type)                                 \
-	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name);                                                      \
-		info.return_val.type = m_return_type;                                                    \
-		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
-	}
+#define RET(m_type) \
+	PropertyInfo(Variant::m_type, "")
 
-#define REGISTER_VARARG_FUNC(m_func, m_is_const, m_return_type)                                  \
-	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name);                                                      \
-		info.return_val.type = m_return_type;                                                    \
-		info.flags |= METHOD_FLAG_VARARG;                                                        \
-		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
-	}
+#define RETVAR \
+	PropertyInfo(Variant::NIL, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)
 
-#define REGISTER_VARIANT_FUNC(m_func, m_is_const, ...)                                           \
-	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = Variant::NIL;                                                     \
-		info.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;                                  \
-		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
-	}
+#define RETCLS(m_class) \
+	PropertyInfo(Variant::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, m_class)
 
-#define REGISTER_CLASS_FUNC(m_func, m_is_const, m_return_type, ...)                              \
-	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = Variant::OBJECT;                                                  \
-		info.return_val.hint = PROPERTY_HINT_RESOURCE_TYPE;                                      \
-		info.return_val.class_name = m_return_type;                                              \
-		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
-	}
+#define NOARGS \
+	MethodInfo()
 
-#define REGISTER_FUNC_DEF(m_func, m_is_const, m_default, m_return_type, ...)                     \
-	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = m_return_type;                                                    \
-		info.default_arguments.push_back(m_default);                                             \
-		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
-	}
+#define ARGS(...) \
+	MethodInfo("", __VA_ARGS__)
 
 #define ARG(m_name, m_type) \
-	PropertyInfo(m_type, m_name)
+	PropertyInfo(Variant::m_type, m_name)
 
-#define VARARG(m_name) \
-	PropertyInfo(Variant::NIL, m_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT)
+#define ARGVAR(m_name) \
+	PropertyInfo(Variant::NIL, m_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)
+
+#define ARGTYPE(m_name) \
+	PropertyInfo(Variant::INT, m_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_ENUM, "Variant.Type")
 
 void GDScriptUtilityFunctions::register_functions() {
+	/* clang-format off */
 #ifndef DISABLE_DEPRECATED
-	REGISTER_VARIANT_FUNC(convert, true, VARARG("what"), ARG("type", Variant::INT));
+	REGISTER_FUNC( convert,        true,  RETVAR,             ARGS( ARGVAR("what"), ARGTYPE("type") ), false, varray(     ));
 #endif // DISABLE_DEPRECATED
-	REGISTER_FUNC(type_exists, true, Variant::BOOL, ARG("type", Variant::STRING_NAME));
-	REGISTER_FUNC(_char, true, Variant::STRING, ARG("char", Variant::INT));
-	REGISTER_VARARG_FUNC(range, false, Variant::ARRAY);
-	REGISTER_CLASS_FUNC(load, false, "Resource", ARG("path", Variant::STRING));
-	REGISTER_FUNC(inst_to_dict, false, Variant::DICTIONARY, ARG("instance", Variant::OBJECT));
-	REGISTER_FUNC(dict_to_inst, false, Variant::OBJECT, ARG("dictionary", Variant::DICTIONARY));
-	REGISTER_FUNC_DEF(Color8, true, 255, Variant::COLOR, ARG("r8", Variant::INT), ARG("g8", Variant::INT), ARG("b8", Variant::INT), ARG("a8", Variant::INT));
-	REGISTER_VARARG_FUNC(print_debug, false, Variant::NIL);
-	REGISTER_FUNC_NO_ARGS(print_stack, false, Variant::NIL);
-	REGISTER_FUNC_NO_ARGS(get_stack, false, Variant::ARRAY);
-	REGISTER_FUNC(len, true, Variant::INT, VARARG("var"));
-	REGISTER_FUNC(is_instance_of, true, Variant::BOOL, VARARG("value"), VARARG("type"));
+	REGISTER_FUNC( type_exists,    true,  RET(BOOL),          ARGS( ARG("type", STRING_NAME)        ), false, varray(     ));
+	REGISTER_FUNC( _char,          true,  RET(STRING),        ARGS( ARG("char", INT)                ), false, varray(     ));
+	REGISTER_FUNC( range,          false, RET(ARRAY),         NOARGS,                                  true,  varray(     ));
+	REGISTER_FUNC( load,           false, RETCLS("Resource"), ARGS( ARG("path", STRING)             ), false, varray(     ));
+	REGISTER_FUNC( inst_to_dict,   false, RET(DICTIONARY),    ARGS( ARG("instance", OBJECT)         ), false, varray(     ));
+	REGISTER_FUNC( dict_to_inst,   false, RET(OBJECT),        ARGS( ARG("dictionary", DICTIONARY)   ), false, varray(     ));
+	REGISTER_FUNC( Color8,         true,  RET(COLOR),         ARGS( ARG("r8", INT), ARG("g8", INT),
+																	ARG("b8", INT), ARG("a8", INT)  ), false, varray( 255 ));
+	REGISTER_FUNC( print_debug,    false, RET(NIL),           NOARGS,                                  true,  varray(     ));
+	REGISTER_FUNC( print_stack,    false, RET(NIL),           NOARGS,                                  false, varray(     ));
+	REGISTER_FUNC( get_stack,      false, RET(ARRAY),         NOARGS,                                  false, varray(     ));
+	REGISTER_FUNC( len,            true,  RET(INT),           ARGS( ARGVAR("var")                   ), false, varray(     ));
+	REGISTER_FUNC( is_instance_of, true,  RET(BOOL),          ARGS( ARGVAR("value"), ARGVAR("type") ), false, varray(     ));
+	/* clang-format on */
 }
 
 void GDScriptUtilityFunctions::unregister_functions() {

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.gd
@@ -1,0 +1,12 @@
+func test():
+	const COLOR = Color8(255, 0.0, false)
+	var false_value := false
+	@warning_ignore("narrowing_conversion")
+	var color = Color8(255, 0.0, false_value)
+	print(var_to_str(COLOR))
+	print(var_to_str(color))
+
+	var string := "Node"
+	var string_name := &"Node"
+	print(type_exists(string))
+	print(type_exists(string_name))

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.out
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+Color(1, 0, 0, 1)
+Color(1, 0, 0, 1)
+true
+true


### PR DESCRIPTION
1. Rework macros for validating count and types of arguments. This makes the code easier to read and reduces the likelihood of accidental bugs. This also fixes a [bug](https://github.com/godotengine/godot/pull/68747#issuecomment-1554211108) with implicit conversions don't work for some utility functions.
2. Rework function registration macros. Instead of several `REGISTER_FUNC_*` macros for different signature variations, there is now one `REGISTER_FUNC` macro and several shorthands for `PropertyInfo`/`MethodInfo`.