### PR TITLE
Fix inverted condition when unwrapping lightmap

### DIFF
--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -367,7 +367,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 						}
 
 						uint64_t format = array_mesh->surface_get_format(i);
-						if (format & Mesh::ArrayFormat::ARRAY_FORMAT_NORMAL) {
+						if (!(format & Mesh::ArrayFormat::ARRAY_FORMAT_NORMAL)) {
 							err_dialog->set_text(TTR("Normals are required for lightmap unwrap."));
 							err_dialog->popup_centered();
 							return;


### PR DESCRIPTION
Condition checking for the presence of normals was inverted, it now matches the same check in `lightmap_gi.cpp`

* Fixes: #84373
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
