### PR TITLE
Unexpose internal data property of `AnimationLibrary`

### DIFF
--- a/doc/classes/AnimationLibrary.xml
+++ b/doc/classes/AnimationLibrary.xml
@@ -54,10 +54,6 @@
 			</description>
 		</method>
 	</methods>
-	<members>
-		<member name="_data" type="Dictionary" setter="_set_data" getter="_get_data" default="{}">
-		</member>
-	</members>
 	<signals>
 		<signal name="animation_added">
 			<param index="0" name="name" type="StringName" />

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -154,7 +154,8 @@ void AnimationLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &AnimationLibrary::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &AnimationLibrary::_get_data);
 
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
+
 	ADD_SIGNAL(MethodInfo("animation_added", PropertyInfo(Variant::STRING_NAME, "name")));
 	ADD_SIGNAL(MethodInfo("animation_removed", PropertyInfo(Variant::STRING_NAME, "name")));
 	ADD_SIGNAL(MethodInfo("animation_renamed", PropertyInfo(Variant::STRING_NAME, "name"), PropertyInfo(Variant::STRING_NAME, "to_name")));


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/82713, see the discussion there.

Underscored properties should not be exposed in the first place, so this was a mistake in either the name or property flags. In either case fixing this breaks compat, and it's safer to assume this was not supposed to be exposed.