### PR TITLE
Replace `floor()` with `round()` in pixel snap to transform

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -268,7 +268,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 			}
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-				ofs = ofs.floor();
+				ofs = ofs.round();
 			}
 			Rect2 dst_rect(ofs, s);
 

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -99,7 +99,7 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		dest_offset = dest_offset.floor();
+		dest_offset = dest_offset.round();
 	}
 
 	r_dst_rect = Rect2(dest_offset, frame_size);
@@ -402,7 +402,7 @@ Rect2 Sprite2D::get_rect() const {
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		ofs = ofs.floor();
+		ofs = ofs.round();
 	}
 
 	if (s == Size2(0, 0)) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -249,7 +249,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 
 	Transform2D xform = ci->xform;
 	if (snapping_2d_transforms_to_pixel) {
-		xform.columns[2] = xform.columns[2].floor();
+		xform.columns[2] = xform.columns[2].round();
 	}
 	xform = p_transform * xform;
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -44,7 +44,7 @@ static Transform2D _canvas_get_transform(RendererViewport::Viewport *p_viewport,
 	if (p_viewport->canvas_map.has(p_canvas->parent)) {
 		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
 		if (p_viewport->snap_2d_transforms_to_pixel) {
-			c_xform.columns[2] = c_xform.columns[2].floor();
+			c_xform.columns[2] = c_xform.columns[2].round();
 		}
 		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
@@ -53,7 +53,7 @@ static Transform2D _canvas_get_transform(RendererViewport::Viewport *p_viewport,
 	Transform2D c_xform = p_canvas_data->transform;
 
 	if (p_viewport->snap_2d_transforms_to_pixel) {
-		c_xform.columns[2] = c_xform.columns[2].floor();
+		c_xform.columns[2] = c_xform.columns[2].round();
 	}
 
 	xf = xf * c_xform;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/56793.
Fixes https://github.com/godotengine/godot/issues/84632.

Similar to https://github.com/godotengine/godot/pull/76277 except this PR also makes the necessary changes to `renderer_viewport.cpp` to avoid regressions in camera jitter. In fact, with these changes, the camera is actually *more* stable according to my testing.

Before:

https://github.com/godotengine/godot/assets/34800072/dd708c82-9c80-4f2f-8843-7ba8ef04d0e6

After:

https://github.com/godotengine/godot/assets/34800072/8ea44763-9553-4040-90a3-1f3eb2cbe606

**NOTE:** You will still get camera jitter if you are using a script to make a camera follow an object that is moved in idle process. Camera movement is fine if the object is moved in physics process. This is an existing issue which will be addressed in a separate PR.

Test project download:

[PixelPerfectTest.zip](https://github.com/godotengine/godot/files/13244300/PixelPerfectTest.zip)

_Production edit: added fixes https://github.com/godotengine/godot/issues/84632_