### PR TITLE
Add `_text_changed()` at the end of `insert_text_at_caret(String)`

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1755,6 +1755,8 @@ void LineEdit::insert_text_at_caret(String p_text) {
 	if (!ime_text.is_empty()) {
 		_shape();
 	}
+	
+	_text_changed();
 }
 
 void LineEdit::clear_internal() {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1755,7 +1755,7 @@ void LineEdit::insert_text_at_caret(String p_text) {
 	if (!ime_text.is_empty()) {
 		_shape();
 	}
-	
+
 	_text_changed();
 }
 


### PR DESCRIPTION
Fixes text_changed signal is emitted by delete_char_at_caret but not by insert_text_at_caret #84377

_Production edit: Fixes https://github.com/godotengine/godot/issues/84377_