### PR TITLE
Hide private enums when generating documentation

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -976,7 +976,7 @@ void EditorHelp::_update_doc() {
 
 	// Properties overview
 	HashSet<String> skip_methods;
-
+	
 	bool has_properties = false;
 	bool has_property_descriptions = false;
 	for (const DocData::PropertyDoc &prop : cd.properties) {
@@ -1379,7 +1379,20 @@ void EditorHelp::_update_doc() {
 		}
 
 		// Enums
+		bool enable_enum_docs = false;
+		//This checks for public enums before adding the whole section.
 		if (enums.size()) {
+			for (KeyValue<String, Vector<DocData::ConstantDoc>> &Constant : enums) {
+				if (Constant.key.begins_with("_")) {
+					continue;
+				} else {
+					enable_enum_docs = true;
+					break;
+				}
+			}
+		}
+		// This actually generates all of the documentation.
+		if (enable_enum_docs == true) {
 			section_line.push_back(Pair<String, int>(TTR("Enumerations"), class_desc->get_paragraph_count() - 2));
 			_push_title_font();
 			class_desc->add_text(TTR("Enumerations"));
@@ -1389,6 +1402,9 @@ void EditorHelp::_update_doc() {
 			class_desc->add_newline();
 
 			for (KeyValue<String, Vector<DocData::ConstantDoc>> &E : enums) {
+				if (E.key.begins_with("_")) {
+					continue;
+				}
 				enum_line[E.key] = class_desc->get_paragraph_count() - 2;
 
 				_push_code_font();

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1240,6 +1240,11 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 		types.insert(E.key);
 	}
 
+	// Variations
+	for (const KeyValue<StringName, StringName> &E : variation_map) {
+		types.insert(E.key);
+	}
+
 	for (const StringName &E : types) {
 		p_list->push_back(E);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This is mostly done but I can't figure out how to show the enum when it is documented 