### PR TITLE
Hide private enums from documentation

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1379,7 +1379,17 @@ void EditorHelp::_update_doc() {
 		}
 
 		// Enums
-		if (enums.size()) {
+		bool has_enums = enums.size() && !cd.is_script_doc;
+		if (enums.size() && !has_enums) {
+			for (KeyValue<String, DocData::EnumDoc> &E : cd.enums) {
+				if (E.key.begins_with("_") && E.value.description.strip_edges().is_empty()) {
+					continue;
+				}
+				has_enums = true;
+				break;
+			}
+		}
+		if (has_enums) {
 			section_line.push_back(Pair<String, int>(TTR("Enumerations"), class_desc->get_paragraph_count() - 2));
 			_push_title_font();
 			class_desc->add_text(TTR("Enumerations"));
@@ -1389,8 +1399,17 @@ void EditorHelp::_update_doc() {
 			class_desc->add_newline();
 
 			for (KeyValue<String, Vector<DocData::ConstantDoc>> &E : enums) {
-				enum_line[E.key] = class_desc->get_paragraph_count() - 2;
+				String key = E.key;
+				if ((key.get_slice_count(".") > 1) && (key.get_slice(".", 0) == edited_class)) {
+					key = key.get_slice(".", 1);
+				}
+				if (cd.enums.has(key)) {
+					if (cd.is_script_doc && cd.enums[key].description.strip_edges().is_empty() && E.key.begins_with("_")) {
+						continue;
+					}
+				}
 
+				enum_line[E.key] = class_desc->get_paragraph_count() - 2;
 				_push_code_font();
 
 				class_desc->push_color(theme_cache.title_color);
@@ -1401,27 +1420,19 @@ void EditorHelp::_update_doc() {
 				}
 				class_desc->pop();
 
-				String e = E.key;
-				if ((e.get_slice_count(".") > 1) && (e.get_slice(".", 0) == edited_class)) {
-					e = e.get_slice(".", 1);
-				}
-
 				class_desc->push_color(theme_cache.headline_color);
-				class_desc->add_text(e);
+				class_desc->add_text(key);
 				class_desc->pop();
 
 				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(":");
 				class_desc->pop();
 
-				if (cd.enums.has(e)) {
-					if (cd.enums[e].is_deprecated) {
-						DEPRECATED_DOC_TAG;
-					}
-
-					if (cd.enums[e].is_experimental) {
-						EXPERIMENTAL_DOC_TAG;
-					}
+				if (cd.enums[key].is_deprecated) {
+					DEPRECATED_DOC_TAG;
+				}
+				if (cd.enums[key].is_experimental) {
+					EXPERIMENTAL_DOC_TAG;
 				}
 
 				_pop_code_font();
@@ -1430,11 +1441,11 @@ void EditorHelp::_update_doc() {
 				class_desc->add_newline();
 
 				// Enum description.
-				if (e != "@unnamed_enums" && cd.enums.has(e) && !cd.enums[e].description.strip_edges().is_empty()) {
+				if (key != "@unnamed_enums" && cd.enums.has(key) && !cd.enums[key].description.strip_edges().is_empty()) {
 					class_desc->push_color(theme_cache.text_color);
 					_push_normal_font();
 					class_desc->push_indent(1);
-					_add_text(cd.enums[e].description);
+					_add_text(cd.enums[key].description);
 					class_desc->pop();
 					_pop_normal_font();
 					class_desc->pop();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This loops through all the enums and checks if it has a description (doc comment) or if it is public. it also renames the variable `e` to a more descriptive name 
fixes #84119 