### PR TITLE
Fix engine configuration icons using old convention

### DIFF
--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -596,7 +596,7 @@ void EditorBuildProfileManager::_action_confirm() {
 void EditorBuildProfileManager::_fill_classes_from(TreeItem *p_parent, const String &p_class, const String &p_selected) {
 	TreeItem *class_item = class_list->create_item(p_parent);
 	class_item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-	class_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_class, "Node"));
+	class_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_class));
 	String text = p_class;
 
 	bool disabled = edited->is_class_disabled(p_class);


### PR DESCRIPTION
![image](https://github.com/godotengine/godot/assets/85438892/3d773b4e-48fe-47d7-b49b-28bb781b8e0e)

We now use object icons, white or gray, for anything that doesn't inherit Node.