### PR TITLE
[3.x] Add Android project settings for gesture support

### DIFF
--- a/doc/classes/InputEventMagnifyGesture.xml
+++ b/doc/classes/InputEventMagnifyGesture.xml
@@ -3,6 +3,7 @@
 	<brief_description>
 	</brief_description>
 	<description>
+		[b]Note:[/b] On Android, this requires the [member ProjectSettings.input_devices/pointing/android/enable_pan_and_scale_gestures] project setting to be enabled.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventPanGesture.xml
+++ b/doc/classes/InputEventPanGesture.xml
@@ -3,6 +3,7 @@
 	<brief_description>
 	</brief_description>
 	<description>
+		[b]Note:[/b] On Android, this requires the [member ProjectSettings.input_devices/pointing/android/enable_pan_and_scale_gestures] project setting to be enabled.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -669,6 +669,12 @@
 			If [code]false[/code], no input will be lost.
 			[b]Note:[/b] You should in nearly all cases prefer the [code]false[/code] setting. The legacy behavior is to enable supporting old projects that rely on the old logic, without changes to script.
 		</member>
+		<member name="input_devices/pointing/android/enable_long_press_as_right_click" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], long press events on an Android touchscreen are transformed into right click events.
+		</member>
+		<member name="input_devices/pointing/android/enable_pan_and_scale_gestures" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], multi-touch pan and scale gestures are enabled on Android devices.
+		</member>
 		<member name="input_devices/pointing/emulate_mouse_from_touch" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], sends mouse input events when tapping or swiping on the touchscreen.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1579,6 +1579,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF("input_devices/pointing/emulate_mouse_from_touch", true)));
 	}
 
+	GLOBAL_DEF("input_devices/pointing/android/enable_long_press_as_right_click", false);
+	GLOBAL_DEF("input_devices/pointing/android/enable_pan_and_scale_gestures", false);
+
 	MAIN_PRINT("Main: Load Translations and Remaps");
 
 	translation_server->setup(); //register translations, load them, etc.

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -34,6 +34,7 @@ import static android.content.Context.MODE_PRIVATE;
 import static android.content.Context.WINDOW_SERVICE;
 
 import org.godotengine.godot.input.GodotEditText;
+import org.godotengine.godot.input.GodotInputHandler;
 import org.godotengine.godot.io.directory.DirectoryAccessHandler;
 import org.godotengine.godot.io.file.FileAccessHandler;
 import org.godotengine.godot.plugin.GodotPlugin;
@@ -334,6 +335,21 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	 */
 	@CallSuper
 	protected void onGodotSetupCompleted() {
+		Log.d(TAG, "OnGodotSetupCompleted");
+
+		// These properties are defined after Godot setup completion, so we retrieve them here.
+		boolean longPressEnabled = Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"));
+		boolean panScaleEnabled = Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"));
+
+		runOnUiThread(() -> {
+			GodotView renderView = getRenderView();
+			GodotInputHandler inputHandler = renderView != null ? renderView.getInputHandler() : null;
+			if (inputHandler != null) {
+				inputHandler.enableLongPress(longPressEnabled);
+				inputHandler.enablePanningAndScalingGestures(panScaleEnabled);
+			}
+		});
+
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onGodotSetupCompleted();
 		}
@@ -348,6 +364,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	 */
 	@CallSuper
 	protected void onGodotMainLoopStarted() {
+		Log.d(TAG, "OnGodotMainLoopStarted");
+
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onGodotMainLoopStarted();
 		}


### PR DESCRIPTION
- Include project setting to enable long press for Android devices
- Include project setting to enable pan and scale gestures on Android devices

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
