### PR TITLE
Fix Android editor crash issue when pressing Back

### DIFF
--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         <activity
             android:name=".GodotProjectManager"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
             android:exported="true"
             android:process=":GodotProjectManager">
@@ -54,7 +54,7 @@
             android:name=".GodotEditor"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:process=":GodotEditor"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
             android:exported="false">
             <layout android:defaultHeight="@dimen/editor_default_window_height"
@@ -66,7 +66,7 @@
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:label="@string/godot_project_name_string"
             android:process=":GodotGame"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:exported="false"
             android:screenOrientation="userLandscape">
             <layout android:defaultHeight="@dimen/editor_default_window_height"


### PR DESCRIPTION
Fix issue causing the Android editor to crash when pressing back from a running project

Fixes https://github.com/godotengine/godot/issues/79291

[3.x version](https://github.com/godotengine/godot/pull/84415)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
