### PR TITLE
HTTPRequest C# Example Fix

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -46,14 +46,14 @@
 		    var httpRequest = new HttpRequest();
 		    AddChild(httpRequest);
 		    httpRequest.RequestCompleted += HttpRequestCompleted;
-		
+
 		    // Perform a GET request. The URL below returns JSON as of writing.
 		    Error error = httpRequest.Request("https://httpbin.org/get");
 		    if (error != Error.Ok)
 		    {
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
-		
+
 		    // Perform a POST request. The URL below returns JSON as of writing.
 		    // Note: Don't make simultaneous requests using a single HTTPRequest node.
 		    // The snippet below is provided for reference only.
@@ -67,14 +67,14 @@
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
 		}
-		
+
 		// Called when the HTTP request is completed.
 		private void HttpRequestCompleted(long result, long responseCode, string[] headers, byte[] body)
 		{
 		    var json = new Json();
 		    json.Parse(body.GetStringFromUtf8());
 		    var response = json.Data.AsGodotDictionary();
-		
+
 		    // Will print the user agent string used by the HTTPRequest node (as recognized by httpbin.org).
 		    GD.Print((response["headers"].AsGodotDictionary())["User-Agent"]);
 		}
@@ -118,7 +118,7 @@
 		    var httpRequest = new HttpRequest();
 		    AddChild(httpRequest);
 		    httpRequest.RequestCompleted += HttpRequestCompleted;
-		
+
 		    // Perform the HTTP request. The URL below returns a PNG image as of writing.
 		    Error error = httpRequest.Request("https://via.placeholder.com/512");
 		    if (error != Error.Ok)
@@ -126,7 +126,7 @@
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
 		}
-		
+
 		// Called when the HTTP request is completed.
 		private void HttpRequestCompleted(long result, long responseCode, string[] headers, byte[] body)
 		{
@@ -140,9 +140,9 @@
 		    {
 		        GD.PushError("Couldn't load the image.");
 		    }
-		
+
 		    var texture = ImageTexture.CreateFromImage(image);
-		
+
 		    // Display the image in a TextureRect node.
 		    var textureRect = new TextureRect();
 		    AddChild(textureRect);

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -46,18 +46,18 @@
 		    var httpRequest = new HttpRequest();
 		    AddChild(httpRequest);
 		    httpRequest.RequestCompleted += HttpRequestCompleted;
-
+		
 		    // Perform a GET request. The URL below returns JSON as of writing.
 		    Error error = httpRequest.Request("https://httpbin.org/get");
 		    if (error != Error.Ok)
 		    {
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
-
+		
 		    // Perform a POST request. The URL below returns JSON as of writing.
 		    // Note: Don't make simultaneous requests using a single HTTPRequest node.
 		    // The snippet below is provided for reference only.
-		    string body = new Json().Stringify(new Godot.Collections.Dictionary
+		    string body = Json.Stringify(new Godot.Collections.Dictionary
 		    {
 		        { "name", "Godette" }
 		    });
@@ -67,14 +67,14 @@
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
 		}
-
+		
 		// Called when the HTTP request is completed.
 		private void HttpRequestCompleted(long result, long responseCode, string[] headers, byte[] body)
 		{
 		    var json = new Json();
 		    json.Parse(body.GetStringFromUtf8());
-		    var response = json.GetData().AsGodotDictionary();
-
+		    var response = json.Data.AsGodotDictionary();
+		
 		    // Will print the user agent string used by the HTTPRequest node (as recognized by httpbin.org).
 		    GD.Print((response["headers"].AsGodotDictionary())["User-Agent"]);
 		}
@@ -118,7 +118,7 @@
 		    var httpRequest = new HttpRequest();
 		    AddChild(httpRequest);
 		    httpRequest.RequestCompleted += HttpRequestCompleted;
-
+		
 		    // Perform the HTTP request. The URL below returns a PNG image as of writing.
 		    Error error = httpRequest.Request("https://via.placeholder.com/512");
 		    if (error != Error.Ok)
@@ -126,7 +126,7 @@
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
 		}
-
+		
 		// Called when the HTTP request is completed.
 		private void HttpRequestCompleted(long result, long responseCode, string[] headers, byte[] body)
 		{
@@ -140,9 +140,9 @@
 		    {
 		        GD.PushError("Couldn't load the image.");
 		    }
-
+		
 		    var texture = ImageTexture.CreateFromImage(image);
-
+		
 		    // Display the image in a TextureRect node.
 		    var textureRect = new TextureRect();
 		    AddChild(textureRect);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

**Issue description:**
The C# code examples for the use of HTTPRequests are currently invalid, and do not compile. This PR makes a small correction to class names and JSON usage within HTTPRequest C# code examples.