### PR TITLE
Add tile spacing property to tileMap

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -491,6 +491,9 @@
 		<member name="tile_set" type="TileSet" setter="set_tileset" getter="get_tileset">
 			The assigned [TileSet].
 		</member>
+		<member name="tile_spacing" type="Vector2i" setter="set_tile_spacing" getter="get_tile_spacing" default="Vector2i(0, 0)">
+			Defines the size of the grid tiles are placed into. If both x and y are both 0, defaults to the attached TileSet's tile_size.
+		</member>
 	</members>
 	<signals>
 		<signal name="changed">

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -799,7 +799,7 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * tile_map->get_global_transform_with_canvas();
 	Vector2 mpos = tile_map->get_local_mouse_position();
-	Vector2i tile_shape_size = tile_set->get_tile_size();
+	Vector2i tile_shape_size = tile_map->get_tile_spacing();
 
 	// Draw the selection.
 	if ((tiles_bottom_panel->is_visible_in_tree() || patterns_bottom_panel->is_visible_in_tree()) && tool_buttons_group->get_pressed_button() == select_tool_button) {
@@ -868,7 +868,7 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 			}
 		} else if (drag_type == DRAG_TYPE_CLIPBOARD_PASTE) {
 			// Preview when pasting.
-			Vector2 mouse_offset = (Vector2(tile_map_clipboard->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_set->get_tile_size();
+			Vector2 mouse_offset = (Vector2(tile_map_clipboard->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_map->get_tile_spacing();
 			TypedArray<Vector2i> clipboard_used_cells = tile_map_clipboard->get_used_cells();
 			for (int i = 0; i < clipboard_used_cells.size(); i++) {
 				Vector2i coords = tile_map->map_pattern(tile_map->local_to_map(mpos - mouse_offset), clipboard_used_cells[i], tile_map_clipboard);
@@ -1103,7 +1103,7 @@ HashMap<Vector2i, TileMapCell> TileMapEditorTilesPlugin::_draw_line(Vector2 p_st
 		} else {
 			// Paint the pattern.
 			// If we paint several tiles, we virtually move the mouse as if it was in the center of the "brush"
-			Vector2 mouse_offset = (Vector2(pattern->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_set->get_tile_size();
+			Vector2 mouse_offset = (Vector2(pattern->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_map->get_tile_spacing();
 			Vector2i last_hovered_cell = tile_map->local_to_map(p_from_mouse_pos - mouse_offset);
 			Vector2i new_hovered_cell = tile_map->local_to_map(p_to_mouse_pos - mouse_offset);
 			Vector2i drag_start_cell = tile_map->local_to_map(p_start_drag_mouse_pos - mouse_offset);
@@ -1501,7 +1501,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 			undo_redo->commit_action(false);
 		} break;
 		case DRAG_TYPE_CLIPBOARD_PASTE: {
-			Vector2 mouse_offset = (Vector2(tile_map_clipboard->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_set->get_tile_size();
+			Vector2 mouse_offset = (Vector2(tile_map_clipboard->get_size()) / 2.0 - Vector2(0.5, 0.5)) * tile_map->get_tile_spacing();
 			undo_redo->create_action(TTR("Paste tiles"));
 			TypedArray<Vector2i> used_cells = tile_map_clipboard->get_used_cells();
 			for (int i = 0; i < used_cells.size(); i++) {
@@ -3185,7 +3185,7 @@ void TileMapEditorTerrainsPlugin::forward_canvas_draw_over_viewport(Control *p_o
 
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * tile_map->get_global_transform_with_canvas();
 	Vector2 mpos = tile_map->get_local_mouse_position();
-	Vector2i tile_shape_size = tile_set->get_tile_size();
+	Vector2i tile_shape_size = tile_map->get_tile_spacing();
 
 	// Handle the preview of the tiles to be placed.
 	if (main_vbox_container->is_visible_in_tree() && has_mouse) { // Only if the tilemap editor is opened and the viewport is hovered.
@@ -4032,7 +4032,7 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 
 	Transform2D xform = CanvasItemEditor::get_singleton()->get_canvas_transform() * tile_map->get_global_transform_with_canvas();
 	Transform2D xform_inv = xform.affine_inverse();
-	Vector2i tile_shape_size = tile_set->get_tile_size();
+	Vector2i tile_shape_size = tile_map->get_tile_spacing();
 
 	// Draw tiles with invalid IDs in the grid.
 	if (tile_map_layer >= 0) {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -455,6 +455,8 @@ private:
 	// Properties.
 	Ref<TileSet> tile_set;
 	int rendering_quadrant_size = 16;
+	// When set to 0,0 this is ignored in favor of the tile_size value defined in the tileSet.
+	Size2i tile_spacing = Size2i(0, 0);
 	bool collision_animatable = false;
 	VisibilityMode collision_visibility_mode = VISIBILITY_MODE_DEFAULT;
 	VisibilityMode navigation_visibility_mode = VISIBILITY_MODE_DEFAULT;
@@ -508,6 +510,8 @@ public:
 
 	void set_tileset(const Ref<TileSet> &p_tileset);
 	Ref<TileSet> get_tileset() const;
+	void set_tile_spacing(Size2i p_size);
+	Size2i get_tile_spacing() const;
 
 	void set_rendering_quadrant_size(int p_size);
 	int get_rendering_quadrant_size() const;


### PR DESCRIPTION
Adds a tile_spacing option to tileMaps, which defaults to matching the tile_size in the attached tileSet, but can be used to override it.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8187.*