### PR TITLE
Add `generate_apk=yes` to generate an APK after building

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -182,6 +182,7 @@ opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", False))
 opts.Add(BoolVariable("separate_debug_symbols", "Extract debugging symbols to a separate file", False))
 opts.Add(EnumVariable("lto", "Link-time optimization (production builds)", "none", ("none", "auto", "thin", "full")))
 opts.Add(BoolVariable("production", "Set defaults to build Godot for use in production", False))
+opts.Add(BoolVariable("generate_apk", "Generate an APK/AAB after building Android library by calling Gradle", False))
 
 # Components
 opts.Add(BoolVariable("deprecated", "Enable compatibility code for deprecated and removed features", True))

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import subprocess
+
 Import("env")
 
 android_files = [
@@ -77,3 +79,29 @@ if lib_arch_dir != "":
         str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"
     )
     env_android.Command(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
+
+    def generate_apk(target, source, env):
+        if env["target"] != "editor" and env["dev_build"]:
+            subprocess.run(
+                [
+                    "./gradlew",
+                    "generateDevTemplate",
+                    "--quiet",
+                ],
+                cwd="platform/android/java",
+            )
+        else:
+            # Android editor with `dev_build=yes` is handled by the `generateGodotEditor` task.
+            subprocess.run(
+                [
+                    "./gradlew",
+                    "generateGodotEditor" if env["target"] == "editor" else "generateGodotTemplates",
+                    "--quiet",
+                ],
+                cwd="platform/android/java",
+            )
+
+    if env["generate_apk"]:
+        generate_apk_command = env_android.Command("generate_apk", [], generate_apk)
+        command = env_android.AlwaysBuild(generate_apk_command)
+        env_android.Depends(command, [lib])


### PR DESCRIPTION
This is useful to speed up iteration when working on the engine (or editor). If you need multiple architectures in the APK, specify `generate_apk=yes` when building the *last* architecture you're interested in only.

This can be combined with a script that calls `adb` to deploy the APK on a device (coupled with Godot's `--export-*` for projects) to further speed up iteration.

Gradle output is set to `--quiet`, which means it only leaves persistent messages on errors (progress is visible inline while building):

```
scons: Reading SConscript files ...
Checking for Android NDK...
Building for platform "android", architecture "arm64", target "template_release".
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
Linking Shared Library bin/libgodot.android.template_release.arm64.so ...
progress_finish(["progress_finish"], [])
generate_apk(["platform/android/generate_apk"], [])
scons: done building targets.
[Time elapsed: 00:00:08.836]
```
