### PR TITLE
Cache allowed types in EditorResourcePicker

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -485,8 +485,8 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 	if (!base_type.is_empty()) {
 		int idx = 0;
 
-		HashSet<StringName> allowed_types;
-		_get_allowed_types(false, &allowed_types);
+		_ensure_allowed_types();
+		HashSet<StringName> allowed_types = allowed_types_without_convert;
 
 		Vector<EditorData::CustomType> custom_resources;
 		if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
@@ -612,23 +612,29 @@ static void _add_allowed_type(const StringName &p_type, HashSet<StringName> *p_v
 	}
 }
 
-void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<StringName> *p_vector) const {
+void EditorResourcePicker::_ensure_allowed_types() const {
+	if (!allowed_types_without_convert.is_empty()) {
+		return;
+	}
+
 	Vector<String> allowed_types = base_type.split(",");
 	int size = allowed_types.size();
 
 	for (int i = 0; i < size; i++) {
-		String base = allowed_types[i].strip_edges();
+		const String base = allowed_types[i].strip_edges();
+		_add_allowed_type(base, &allowed_types_without_convert);
+	}
 
-		_add_allowed_type(base, p_vector);
+	allowed_types_with_convert = HashSet<StringName>(allowed_types_without_convert);
 
-		if (p_with_convert) {
-			if (base == "BaseMaterial3D") {
-				p_vector->insert("Texture2D");
-			} else if (base == "ShaderMaterial") {
-				p_vector->insert("Shader");
-			} else if (base == "Texture2D") {
-				p_vector->insert("Image");
-			}
+	for (int i = 0; i < size; i++) {
+		const String base = allowed_types[i].strip_edges();
+		if (base == "BaseMaterial3D") {
+			allowed_types_with_convert.insert("Texture2D");
+		} else if (base == "ShaderMaterial") {
+			allowed_types_with_convert.insert("Shader");
+		} else if (base == "Texture2D") {
+			allowed_types_with_convert.insert("Image");
 		}
 	}
 }
@@ -658,8 +664,8 @@ bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
 		}
 	}
 
-	HashSet<StringName> allowed_types;
-	_get_allowed_types(true, &allowed_types);
+	_ensure_allowed_types();
+	HashSet<StringName> allowed_types = allowed_types_with_convert;
 
 	if (res.is_valid()) {
 		String res_type = _get_resource_type(res);
@@ -725,8 +731,8 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 	}
 
 	if (dropped_resource.is_valid()) {
-		HashSet<StringName> allowed_types;
-		_get_allowed_types(false, &allowed_types);
+		_ensure_allowed_types();
+		HashSet<StringName> allowed_types = allowed_types_without_convert;
 
 		String res_type = _get_resource_type(dropped_resource);
 
@@ -842,8 +848,8 @@ void EditorResourcePicker::set_base_type(const String &p_base_type) {
 	// There is a possibility that the new base type is conflicting with the existing value.
 	// Keep the value, but warn the user that there is a potential mistake.
 	if (!base_type.is_empty() && edited_resource.is_valid()) {
-		HashSet<StringName> allowed_types;
-		_get_allowed_types(true, &allowed_types);
+		_ensure_allowed_types();
+		HashSet<StringName> allowed_types = allowed_types_with_convert;
 
 		StringName custom_class;
 		bool is_custom = false;
@@ -864,8 +870,8 @@ String EditorResourcePicker::get_base_type() const {
 }
 
 Vector<String> EditorResourcePicker::get_allowed_types() const {
-	HashSet<StringName> allowed_types;
-	_get_allowed_types(false, &allowed_types);
+	_ensure_allowed_types();
+	HashSet<StringName> allowed_types = allowed_types_without_convert;
 
 	Vector<String> types;
 	types.resize(allowed_types.size());
@@ -888,8 +894,8 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 	}
 
 	if (!base_type.is_empty()) {
-		HashSet<StringName> allowed_types;
-		_get_allowed_types(true, &allowed_types);
+		_ensure_allowed_types();
+		HashSet<StringName> allowed_types = allowed_types_with_convert;
 
 		StringName custom_class;
 		bool is_custom = false;

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -52,6 +52,8 @@ class EditorResourcePicker : public HBoxContainer {
 	bool dropping = false;
 
 	Vector<String> inheritors_array;
+	mutable HashSet<StringName> allowed_types_without_convert;
+	mutable HashSet<StringName> allowed_types_with_convert;
 
 	Button *assign_button = nullptr;
 	TextureRect *preview_rect = nullptr;
@@ -96,7 +98,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _button_input(const Ref<InputEvent> &p_event);
 
 	String _get_resource_type(const Ref<Resource> &p_resource) const;
-	void _get_allowed_types(bool p_with_convert, HashSet<StringName> *p_vector) const;
+	void _ensure_allowed_types() const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
 	bool _is_type_valid(const String p_type_name, HashSet<StringName> p_allowed_types) const;
 


### PR DESCRIPTION
EditorResourcePicker would gather allowed types every time they were needed. Worst case scenario is when the base type is Resource (so everything is allowed) and you are dragging a resource over the picker:

https://github.com/godotengine/godot/assets/2223172/339b8f89-d005-4b69-9c49-2c60a195e155

This PR ensures that the types are gathered only once per picker.