### PR TITLE
Add const references detected by clang-tidy

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -162,7 +162,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 	singleton_script_debugger->set_skip_breakpoints(p_skip_breakpoints);
 
 	for (int i = 0; i < p_breakpoints.size(); i++) {
-		String bp = p_breakpoints[i];
+		const String &bp = p_breakpoints[i];
 		int sp = bp.rfind(":");
 		ERR_CONTINUE_MSG(sp == -1, "Invalid breakpoint: '" + bp + "', expected file:line format.");
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1518,7 +1518,7 @@ void Input::add_joy_mapping(String p_mapping, bool p_update_existing) {
 	parse_mapping(p_mapping);
 	if (p_update_existing) {
 		Vector<String> entry = p_mapping.split(",");
-		String uid = entry[0];
+		const String &uid = entry[0];
 		for (KeyValue<int, Joypad> &E : joy_names) {
 			Joypad &joy = E.value;
 			if (joy.uid == uid) {

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -754,7 +754,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 		String fullname = E.key;
 
 		Vector<String> split = fullname.split(".");
-		String name = split[0];
+		const String &name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
 		if (!override_for.is_empty() && OS::get_singleton()->has_feature(override_for)) {
@@ -766,7 +766,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 		String fullname = E.key;
 
 		Vector<String> split = fullname.split(".");
-		String name = split[0];
+		const String &name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
 		if (builtins_with_overrides.has(name) && override_for.is_empty()) {

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -491,7 +491,7 @@ PackedData::PackedDir *DirAccessPack::_find_dir(String p_dir) {
 	}
 
 	for (int i = 0; i < paths.size(); i++) {
-		String p = paths[i];
+		const String &p = paths[i];
 		if (p == ".") {
 			continue;
 		} else if (p == "..") {

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -73,7 +73,7 @@ String HTTPClient::query_string_from_dict(const Dictionary &p_dict) {
 	Array keys = p_dict.keys();
 	for (int i = 0; i < keys.size(); ++i) {
 		String encoded_key = String(keys[i]).uri_encode();
-		Variant value = p_dict[keys[i]];
+		const Variant &value = p_dict[keys[i]];
 		switch (value.get_type()) {
 			case Variant::ARRAY: {
 				// Repeat the key with every values

--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -410,7 +410,7 @@ Key find_keycode(const String &p_codestr) {
 		return keycode;
 	}
 
-	String last_part = code_parts[code_parts.size() - 1];
+	const String &last_part = code_parts[code_parts.size() - 1];
 	const _KeyCodeText *kct = &_keycodes[0];
 
 	while (kct->text) {
@@ -422,7 +422,7 @@ Key find_keycode(const String &p_codestr) {
 	}
 
 	for (int part = 0; part < code_parts.size() - 1; part++) {
-		String code_part = code_parts[part];
+		const String &code_part = code_parts[part];
 		if (code_part.nocasecmp_to(find_keycode_name(Key::SHIFT)) == 0) {
 			keycode |= KeyModifierMask::SHIFT;
 		} else if (code_part.nocasecmp_to(find_keycode_name(Key::CTRL)) == 0) {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4569,7 +4569,7 @@ bool String::is_valid_ip_address() const {
 	if (find(":") >= 0) {
 		Vector<String> ip = split(":");
 		for (int i = 0; i < ip.size(); i++) {
-			String n = ip[i];
+			const String &n = ip[i];
 			if (n.is_empty()) {
 				continue;
 			}
@@ -4591,7 +4591,7 @@ bool String::is_valid_ip_address() const {
 			return false;
 		}
 		for (int i = 0; i < ip.size(); i++) {
-			String n = ip[i];
+			const String &n = ip[i];
 			if (!n.is_valid_int()) {
 				return false;
 			}

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -49,7 +49,7 @@ void ShaderGLES3::_add_stage(const char *p_code, StageType p_stage_type) {
 	String text;
 
 	for (int i = 0; i < lines.size(); i++) {
-		String l = lines[i];
+		const String &l = lines[i];
 		bool push_chunk = false;
 
 		StageTemplate::Chunk chunk;

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -766,7 +766,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	ERR_FAIL_COND(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP && p_layers.size() != 6);
 	ERR_FAIL_COND_MSG(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP_ARRAY, "Cubemap Arrays are not supported in the GL Compatibility backend.");
 
-	Ref<Image> image = p_layers[0];
+	const Ref<Image> &image = p_layers[0];
 	{
 		int valid_width = 0;
 		int valid_height = 0;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1277,7 +1277,7 @@ void CodeTextEditor::move_lines_up() {
 
 		for (int j = 0; j < caret_groups[i].size(); j++) {
 			int c = caret_groups[i][j];
-			Vector<int> caret_parameters = caret_group_parameters[j];
+			const Vector<int> &caret_parameters = caret_group_parameters[j];
 			text_editor->set_caret_line(caret_parameters[4] - 1, c == 0, true, 0, c);
 			text_editor->set_caret_column(caret_parameters[5], c == 0, c);
 
@@ -1374,7 +1374,7 @@ void CodeTextEditor::move_lines_down() {
 
 		for (int j = 0; j < caret_groups[i].size(); j++) {
 			int c = caret_groups[i][j];
-			Vector<int> caret_parameters = caret_group_parameters[j];
+			const Vector<int> &caret_parameters = caret_group_parameters[j];
 			text_editor->set_caret_line(caret_parameters[4] + 1, c == 0, true, 0, c);
 			text_editor->set_caret_column(caret_parameters[5], c == 0, c);
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1683,7 +1683,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 			// Parse back the `file:line @ method()` string.
 			const Vector<String> file_line_number = ci->get_text(1).split("@")[0].strip_edges().split(":");
 			ERR_FAIL_COND_MSG(file_line_number.size() < 2, "Incorrect C++ source stack trace file:line format (please report).");
-			const String file = file_line_number[0];
+			const String &file = file_line_number[0];
 			const int line_number = file_line_number[1].to_int();
 
 			// Construct a GitHub repository URL and open it in the user's default web browser.

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -382,7 +382,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				continue;
 			}
 
-			String cname = name;
+			const String &cname = name;
 			// Property setters and getters do not get exposed as individual methods.
 			HashSet<StringName> setters_getters;
 

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -481,7 +481,7 @@ void EditorBuildProfileManager::_detect_classes() {
 			String l = f->get_line();
 			Vector<String> fields = l.split("::");
 			if (fields.size() == 4) {
-				String path = fields[0];
+				const String &path = fields[0];
 				DetectedFile df;
 				df.timestamp = fields[1].to_int();
 				df.md5 = fields[2];
@@ -597,7 +597,7 @@ void EditorBuildProfileManager::_fill_classes_from(TreeItem *p_parent, const Str
 	TreeItem *class_item = class_list->create_item(p_parent);
 	class_item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 	class_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_class));
-	String text = p_class;
+	const String &text = p_class;
 
 	bool disabled = edited->is_class_disabled(p_class);
 	if (disabled) {

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -256,7 +256,7 @@ void EditorFileSystem::_scan_filesystem() {
 				if (l.begins_with("::")) {
 					Vector<String> split = l.split("::");
 					ERR_CONTINUE(split.size() != 3);
-					String name = split[1];
+					const String &name = split[1];
 
 					cpath = name;
 
@@ -289,7 +289,7 @@ void EditorFileSystem::_scan_filesystem() {
 					if (deps.length()) {
 						Vector<String> dp = deps.split("<>");
 						for (int i = 0; i < dp.size(); i++) {
-							String path = dp[i];
+							const String &path = dp[i];
 							fc.deps.push_back(path);
 						}
 					}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2867,10 +2867,10 @@ void EditorHelpTooltip::parse_tooltip(const String &p_text) {
 	PackedStringArray slices = p_text.split("|", true, 3);
 	ERR_FAIL_COND_MSG(slices.size() < 4, "Invalid tooltip formatting. The expect string should be formatted as 'type|class|property|args'.");
 
-	String type = slices[0];
-	String class_name = slices[1];
-	String property_name = slices[2];
-	String property_args = slices[3];
+	const String &type = slices[0];
+	const String &class_name = slices[1];
+	const String &property_name = slices[2];
+	const String &property_args = slices[3];
 
 	String title;
 	String description;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3018,7 +3018,7 @@ void EditorInspector::update_tree() {
 
 		Vector<String> components = path.split("/");
 		for (int i = 0; i < components.size(); i++) {
-			String component = components[i];
+			const String &component = components[i];
 			acc_path += (i > 0) ? "/" + component : component;
 
 			if (!vbox_per_path[root_vbox].has(acc_path)) {

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -127,7 +127,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 	Vector<Ref<Texture2D>> textures;
 
 	for (int i = 0; i < p_meshes.size(); i++) {
-		Ref<Mesh> mesh = p_meshes[i];
+		const Ref<Mesh> &mesh = p_meshes[i];
 		if (!mesh.is_valid()) {
 			textures.push_back(Ref<Texture2D>());
 			continue;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -176,7 +176,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 	Vector<RBSet<int>> index_sets;
 	HashMap<String, int> scene_name_to_set_index;
 	for (int i = 0; i < r_filenames.size(); i++) {
-		String scene_name = r_filenames[i];
+		const String &scene_name = r_filenames[i];
 		if (!scene_name_to_set_index.has(scene_name)) {
 			index_sets.append(RBSet<int>());
 			scene_name_to_set_index.insert(r_filenames[i], index_sets.size() - 1);
@@ -232,7 +232,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 					if (E->get() == F) {
 						continue;
 					}
-					String other_scene_name = r_filenames[F];
+					const String &other_scene_name = r_filenames[F];
 					if (other_scene_name == scene_name) {
 						duplicate_found = true;
 						break;
@@ -4197,7 +4197,7 @@ void EditorNode::_quick_opened() {
 
 	bool open_scene_dialog = quick_open->get_base_type() == "PackedScene";
 	for (int i = 0; i < files.size(); i++) {
-		String res_path = files[i];
+		const String &res_path = files[i];
 		if (open_scene_dialog || ClassDB::is_parent_class(ResourceLoader::get_resource_type(res_path), "PackedScene")) {
 			open_request(res_path);
 		} else {
@@ -4595,8 +4595,8 @@ String EditorNode::_get_system_info() const {
 	}
 	graphics += rendering_device_name;
 	if (video_adapter_driver_info.size() == 2) { // This vector is always either of length 0 or 2.
-		String vad_name = video_adapter_driver_info[0];
-		String vad_version = video_adapter_driver_info[1]; // Version could be potentially empty on Linux/BSD.
+		const String &vad_name = video_adapter_driver_info[0];
+		const String &vad_version = video_adapter_driver_info[1]; // Version could be potentially empty on Linux/BSD.
 		if (!vad_version.is_empty()) {
 			graphics += vformat(" (%s; %s)", vad_name, vad_version);
 		} else {
@@ -5187,7 +5187,7 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 		Vector<String> names = String(p_layout->get_value(p_section, "dock_" + itos(i + 1))).split(",");
 
 		for (int j = names.size() - 1; j >= 0; j--) {
-			String name = names[j];
+			const String &name = names[j];
 
 			// FIXME: Find it, in a horribly inefficient way.
 			int atidx = -1;
@@ -6003,7 +6003,7 @@ void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, Str
 	ERR_FAIL_COND(dir.is_null());
 
 	for (int i = 0; i < p_files.size(); i++) {
-		String from = p_files[i];
+		const String &from = p_files[i];
 		String to = to_path.path_join(from.get_file());
 
 		if (dir->dir_exists(from)) {

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -64,7 +64,7 @@ void EditorPluginSettings::update_plugins() {
 	for (int i = 0; i < plugins.size(); i++) {
 		Ref<ConfigFile> cf;
 		cf.instantiate();
-		const String path = plugins[i];
+		const String &path = plugins[i];
 
 		Error err2 = cf->load(path);
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -468,7 +468,7 @@ bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
 		Vector<String> files = drag_data["files"];
 
 		for (int i = 0; i < files.size(); i++) {
-			String file = files[i];
+			const String &file = files[i];
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
 
 			for (int j = 0; j < allowed_type.get_slice_count(","); j++) {
@@ -510,7 +510,7 @@ void EditorPropertyArray::drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 		// Loop the file array and add to existing array.
 		for (int i = 0; i < files.size(); i++) {
-			String file = files[i];
+			const String &file = files[i];
 
 			Ref<Resource> res = ResourceLoader::load(file);
 			if (res.is_valid()) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -456,7 +456,7 @@ void EditorExportPlatform::_edit_files_with_filter(Ref<DirAccess> &da, const Vec
 	da->list_dir_end();
 
 	for (int i = 0; i < dirs.size(); ++i) {
-		String dir = dirs[i];
+		const String &dir = dirs[i];
 		if (dir.begins_with(".")) {
 			continue;
 		}
@@ -1096,7 +1096,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				Vector<String> fields = l.split("::");
 				if (fields.size() == 4) {
 					FileExportCache fec;
-					String path = fields[0];
+					const String &path = fields[0];
 					fec.source_md5 = fields[1].strip_edges();
 					fec.source_modified_time = fields[2].strip_edges().to_int();
 					fec.saved_path = fields[3];
@@ -1364,8 +1364,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	if (path_remaps.size()) {
 		if (true) { //new remap mode, use always as it's friendlier with multiple .pck exports
 			for (int i = 0; i < path_remaps.size(); i += 2) {
-				String from = path_remaps[i];
-				String to = path_remaps[i + 1];
+				const String &from = path_remaps[i];
+				const String &to = path_remaps[i + 1];
 				String remap_file = "[remap]\n\npath=\"" + to.c_escape() + "\"\n";
 				CharString utf8 = remap_file.utf8();
 				Vector<uint8_t> new_file;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -388,7 +388,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 	const Color default_folder_color = get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog"));
 
 	for (int i = 0; i < favorite_paths.size(); i++) {
-		String favorite = favorite_paths[i];
+		const String &favorite = favorite_paths[i];
 		if (!favorite.begins_with("res://")) {
 			continue;
 		}
@@ -2172,7 +2172,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			// Instantiate all selected scenes.
 			Vector<String> paths;
 			for (int i = 0; i < p_selected.size(); i++) {
-				String fpath = p_selected[i];
+				const String &fpath = p_selected[i];
 				if (EditorFileSystem::get_singleton()->get_file_type(fpath) == "PackedScene") {
 					paths.push_back(fpath);
 				}
@@ -2210,7 +2210,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_DEPENDENCIES: {
 			// Checkout the file dependencies.
 			if (!p_selected.is_empty()) {
-				String fpath = p_selected[0];
+				const String &fpath = p_selected[0];
 				deps_editor->edit(fpath);
 			}
 		} break;
@@ -2218,7 +2218,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_OWNERS: {
 			// Checkout the file owners.
 			if (!p_selected.is_empty()) {
-				String fpath = p_selected[0];
+				const String &fpath = p_selected[0];
 				owners_editor->show(fpath);
 			}
 		} break;
@@ -2228,7 +2228,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			to_move.clear();
 			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
 			for (int i = collapsed_paths.size() - 1; i >= 0; i--) {
-				String fpath = collapsed_paths[i];
+				const String &fpath = collapsed_paths[i];
 				if (fpath != "res://") {
 					to_move.push_back(FileOrFolder(fpath, !fpath.ends_with("/")));
 				}
@@ -2275,7 +2275,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
 
 			for (int i = 0; i < collapsed_paths.size(); i++) {
-				String fpath = collapsed_paths[i];
+				const String &fpath = collapsed_paths[i];
 				if (fpath != "res://") {
 					if (fpath.ends_with("/")) {
 						remove_folders.push_back(fpath);
@@ -2347,7 +2347,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 		case FILE_COPY_PATH: {
 			if (!p_selected.is_empty()) {
-				String fpath = p_selected[0];
+				const String &fpath = p_selected[0];
 				DisplayServer::get_singleton()->clipboard_set(fpath);
 			}
 		} break;
@@ -2859,7 +2859,7 @@ void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu)
 
 	// Update project settings with new folder colors.
 	for (int i = 0; i < selected.size(); i++) {
-		String fpath = selected[i];
+		const String &fpath = selected[i];
 
 		if (chosen_color_name) {
 			assigned_folder_colors[fpath] = chosen_color_name;
@@ -2890,7 +2890,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 	bool all_not_favorites = true;
 
 	for (int i = 0; i < p_paths.size(); i++) {
-		String fpath = p_paths[i];
+		const String &fpath = p_paths[i];
 		if (fpath.ends_with("/")) {
 			foldernames.push_back(fpath);
 			all_files = false;
@@ -3048,7 +3048,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 	}
 
 	if (p_paths.size() == 1) {
-		const String fpath = p_paths[0];
+		const String &fpath = p_paths[0];
 
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 		p_popup->add_separator();
@@ -3424,7 +3424,7 @@ void FileSystemDock::_update_import_dock() {
 	Vector<String> imports;
 	String import_type;
 	for (int i = 0; i < efiles.size(); i++) {
-		String fpath = efiles[i];
+		const String &fpath = efiles[i];
 		Ref<ConfigFile> cf;
 		cf.instantiate();
 		Error err = cf->load(fpath + ".import");

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -728,7 +728,7 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, PackedStringArra
 	}
 
 	for (int i = 0; i < p_terms.size(); i++) {
-		String term = p_terms[i];
+		const String &term = p_terms[i];
 
 		// Recognize special filter.
 		if (term.contains(":") && !term.get_slicec(':', 0).is_empty()) {

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -1718,7 +1718,7 @@ void Collada::_parse_animation(XMLParser &p_parser) {
 
 	for (int i = 0; i < channel_sources.size(); i++) {
 		String source = _uri_to_id(channel_sources[i]);
-		String target = channel_targets[i];
+		const String &target = channel_targets[i];
 		ERR_CONTINUE(!samplers.has(source));
 		HashMap<String, String> &sampler = samplers[source];
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1151,7 +1151,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 
 					ERR_FAIL_COND_V(skeletons.is_empty(), ERR_INVALID_DATA);
 
-					String skname = skeletons[0];
+					const String &skname = skeletons[0];
 					ERR_FAIL_COND_V(!node_map.has(skname), ERR_INVALID_DATA);
 					NodeMap nmsk = node_map[skname];
 					Skeleton3D *sk = Object::cast_to<Skeleton3D>(nmsk.node);
@@ -1205,7 +1205,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 							valid = true;
 							Vector<String> names = morph->sources[target].sarray;
 							for (int i = 0; i < names.size(); i++) {
-								String meshid2 = names[i];
+								const String &meshid2 = names[i];
 								if (collada.state.mesh_data_map.has(meshid2)) {
 									Ref<ImporterMesh> mesh = Ref<ImporterMesh>(memnew(ImporterMesh));
 									const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid2];

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -545,7 +545,7 @@ void LocalizationEditor::update_translations() {
 
 				PackedStringArray selected = remaps[keys[i]];
 				for (int j = 0; j < selected.size(); j++) {
-					String s2 = selected[j];
+					const String &s2 = selected[j];
 					int qp = s2.rfind(":");
 					String path = s2.substr(0, qp);
 					String locale = s2.substr(qp + 1, s2.length());

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -189,7 +189,7 @@ void EditorPropertyAnchorsPreset::setup(const Vector<String> &p_options) {
 		Vector<String> text_split = p_options[i].split(":");
 		int64_t current_val = text_split[1].to_int();
 
-		String option_name = text_split[0];
+		const String &option_name = text_split[0];
 		if (option_name.begins_with("Preset")) {
 			String preset_name = option_name.trim_prefix("Preset");
 			String humanized_name = preset_name.capitalize();

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -50,7 +50,7 @@ void ResourcePreloaderEditor::_notification(int p_what) {
 
 void ResourcePreloaderEditor::_files_load_request(const Vector<String> &p_paths) {
 	for (int i = 0; i < p_paths.size(); i++) {
-		String path = p_paths[i];
+		const String &path = p_paths[i];
 
 		Ref<Resource> resource;
 		resource = ResourceLoader::load(path);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2963,7 +2963,7 @@ bool ScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 		}
 
 		for (int i = 0; i < files.size(); i++) {
-			String file = files[i];
+			const String &file = files[i];
 			if (file.is_empty() || !FileAccess::exists(file)) {
 				continue;
 			}
@@ -3043,7 +3043,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		}
 		int num_tabs_before = tab_container->get_tab_count();
 		for (int i = 0; i < files.size(); i++) {
-			String file = files[i];
+			const String &file = files[i];
 			if (file.is_empty() || !FileAccess::exists(file)) {
 				continue;
 			}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1409,7 +1409,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				PackedStringArray results;
 
 				for (int i = 0; i < lines.size(); i++) {
-					String line = lines[i];
+					const String &line = lines[i];
 					String whitespace = line.substr(0, line.size() - line.strip_edges(true, false).size()); // Extract the whitespace at the beginning.
 					if (expression.parse(line) == OK) {
 						Variant result = expression.execute(Array(), Variant(), false, true);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -517,7 +517,7 @@ bool ShaderEditorPlugin::can_drop_data_fw(const Point2 &p_point, const Variant &
 		}
 
 		for (int i = 0; i < files.size(); i++) {
-			String file = files[i];
+			const String &file = files[i];
 			if (ResourceLoader::exists(file, "Shader")) {
 				Ref<Shader> shader = ResourceLoader::load(file);
 				if (shader.is_valid()) {
@@ -558,7 +558,7 @@ void ShaderEditorPlugin::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		Vector<String> files = d["files"];
 
 		for (int i = 0; i < files.size(); i++) {
-			String file = files[i];
+			const String &file = files[i];
 			Ref<Resource> res;
 			if (ResourceLoader::exists(file, "Shader") || ResourceLoader::exists(file, "ShaderInclude")) {
 				res = ResourceLoader::load(file);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1425,7 +1425,7 @@ bool SpriteFramesEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 		}
 
 		for (int i = 0; i < files.size(); i++) {
-			String f = files[i];
+			const String &f = files[i];
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(f);
 
 			if (!ClassDB::is_parent_class(ftype, "Texture2D")) {

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -52,7 +52,7 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 		// Compute the new texture region size.
 		Vector2i new_texture_region_size;
 		for (int source_index = 0; source_index < p_atlas_sources.size(); source_index++) {
-			Ref<TileSetAtlasSource> atlas_source = p_atlas_sources[source_index];
+			const Ref<TileSetAtlasSource> &atlas_source = p_atlas_sources[source_index];
 			new_texture_region_size = new_texture_region_size.max(atlas_source->get_texture_region_size());
 		}
 
@@ -60,7 +60,7 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 		Vector2i atlas_offset;
 		int line_height = 0;
 		for (int source_index = 0; source_index < p_atlas_sources.size(); source_index++) {
-			Ref<TileSetAtlasSource> atlas_source = p_atlas_sources[source_index];
+			const Ref<TileSetAtlasSource> &atlas_source = p_atlas_sources[source_index];
 			Ref<Image> input_image = atlas_source->get_texture()->get_image();
 			if (input_image->get_format() != Image::FORMAT_RGBA8) {
 				input_image->convert(Image::FORMAT_RGBA8);
@@ -111,7 +111,7 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 
 		// Copy the tiles to the merged TileSetAtlasSource.
 		for (int source_index = 0; source_index < p_atlas_sources.size(); source_index++) {
-			Ref<TileSetAtlasSource> atlas_source = p_atlas_sources[source_index];
+			const Ref<TileSetAtlasSource> &atlas_source = p_atlas_sources[source_index];
 			for (KeyValue<Vector2i, Vector2i> tile_mapping : merged_mapping[source_index]) {
 				// Create tiles and alternatives, then copy their properties.
 				for (int alternative_index = 0; alternative_index < atlas_source->get_alternative_tiles_count(tile_mapping.key); alternative_index++) {

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -69,7 +69,7 @@ void POTGenerator::generate_pot(const String &p_file) {
 	for (int i = 0; i < files.size(); i++) {
 		Vector<String> msgids;
 		Vector<Vector<String>> msgids_context_plural;
-		String file_path = files[i];
+		const String &file_path = files[i];
 		String file_extension = file_path.get_extension();
 
 		if (EditorTranslationParser::get_singleton()->can_parse(file_extension)) {
@@ -80,7 +80,7 @@ void POTGenerator::generate_pot(const String &p_file) {
 		}
 
 		for (int j = 0; j < msgids_context_plural.size(); j++) {
-			Vector<String> entry = msgids_context_plural[j];
+			const Vector<String> &entry = msgids_context_plural[j];
 			_add_new_msgid(entry[0], entry[1], entry[2], file_path);
 		}
 		for (int j = 0; j < msgids.size(); j++) {

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -561,7 +561,7 @@ bool ProjectConverter3To4::validate_conversion() {
 
 	// Check file by file.
 	for (int i = 0; i < collected_files.size(); i++) {
-		String file_name = collected_files[i];
+		const String &file_name = collected_files[i];
 		Vector<String> lines;
 		uint32_t ignored_lines = 0;
 		uint64_t file_size = 0;
@@ -2732,7 +2732,7 @@ void ProjectConverter3To4::rename_joypad_buttons_and_axes(Vector<SourceLine> &so
 			for (int i = 0; i < reg_match.size(); ++i) {
 				Ref<RegExMatch> match = reg_match[i];
 				PackedStringArray strings = match->get_strings();
-				String button_index_entry = strings[0];
+				const String &button_index_entry = strings[0];
 				int button_index_value = strings[1].to_int();
 				if (button_index_value == 6) { // L2 and R2 are mapped to joypad axes in Godot 4.
 					line = line.replace("InputEventJoypadButton", "InputEventJoypadMotion");
@@ -2741,7 +2741,7 @@ void ProjectConverter3To4::rename_joypad_buttons_and_axes(Vector<SourceLine> &so
 					line = line.replace("InputEventJoypadButton", "InputEventJoypadMotion");
 					line = line.replace(button_index_entry, ",\"axis\":5,\"axis_value\":1.0");
 				} else if (button_index_value < 22) { // There are no mappings for indexes greater than 22 in both Godot 3 & 4.
-					String pressure_and_pressed_properties = strings[2];
+					const String &pressure_and_pressed_properties = strings[2];
 					line = line.replace(button_index_entry, ",\"button_index\":" + String::num_int64(reg_container.joypad_button_mappings[button_index_value]) + "," + pressure_and_pressed_properties);
 				}
 			}
@@ -2750,7 +2750,7 @@ void ProjectConverter3To4::rename_joypad_buttons_and_axes(Vector<SourceLine> &so
 			for (int i = 0; i < reg_match.size(); ++i) {
 				Ref<RegExMatch> match = reg_match[i];
 				PackedStringArray strings = match->get_strings();
-				String axis_entry = strings[0];
+				const String &axis_entry = strings[0];
 				int axis_value = strings[1].to_int();
 				if (axis_value == 6) {
 					line = line.replace(axis_entry, ",\"axis\":4");
@@ -2772,7 +2772,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_joypad_buttons_and_axes(Ve
 			for (int i = 0; i < reg_match.size(); ++i) {
 				Ref<RegExMatch> match = reg_match[i];
 				PackedStringArray strings = match->get_strings();
-				String button_index_entry = strings[0];
+				const String &button_index_entry = strings[0];
 				int button_index_value = strings[1].to_int();
 				if (button_index_value == 6) { // L2 and R2 are mapped to joypad axes in Godot 4.
 					found_renames.append(line_formatter(current_line, "InputEventJoypadButton", "InputEventJoypadMotion", line));
@@ -2789,7 +2789,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_joypad_buttons_and_axes(Ve
 			for (int i = 0; i < reg_match.size(); ++i) {
 				Ref<RegExMatch> match = reg_match[i];
 				PackedStringArray strings = match->get_strings();
-				String axis_entry = strings[0];
+				const String &axis_entry = strings[0];
 				int axis_value = strings[1].to_int();
 				if (axis_value == 6) {
 					found_renames.append(line_formatter(current_line, axis_entry, ",\"axis\":4", line));

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2660,7 +2660,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 	HashSet<String> folders_set;
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	for (int i = 0; i < p_files.size(); i++) {
-		String file = p_files[i];
+		const String &file = p_files[i];
 		folders_set.insert(da->dir_exists(file) ? file : file.get_base_dir());
 	}
 	if (folders_set.size() > 0) {
@@ -3058,7 +3058,7 @@ ProjectManager::ProjectManager() {
 		language_btn->set_text(current_lang);
 
 		for (int i = 0; i < editor_languages.size(); i++) {
-			String lang = editor_languages[i];
+			const String &lang = editor_languages[i];
 			String lang_name = TranslationServer::get_singleton()->get_locale_name(lang);
 			language_btn->add_item(vformat("[%s] %s", lang, lang_name), i);
 			language_btn->set_item_metadata(i, lang);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -171,7 +171,7 @@ void ProjectSettingsEditor::_feature_selected(int p_index) {
 void ProjectSettingsEditor::_update_property_box() {
 	const String setting = _get_setting_name();
 	const Vector<String> t = setting.split(".", true, 1);
-	const String name = t[0];
+	const String &name = t[0];
 	const String feature = (t.size() == 2) ? t[1] : "";
 	bool feature_invalid = (t.size() == 2) && (t[1].is_empty());
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2932,7 +2932,7 @@ void SceneTreeDock::_files_dropped(Vector<String> p_files, NodePath p_to, int p_
 		_normalize_drop(node, to_pos, p_type);
 		_perform_instantiate_scenes(p_files, node, to_pos);
 	} else {
-		String res_path = p_files[0];
+		const String &res_path = p_files[0];
 		StringName res_type = EditorFileSystem::get_singleton()->get_file_type(res_path);
 		List<String> valid_properties;
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -620,9 +620,9 @@ static String _trim_parent_class(const String &p_class, const String &p_base_cla
 	}
 	Vector<String> names = p_class.split(".", false, 1);
 	if (names.size() == 2) {
-		String first = names[0];
-		String rest = names[1];
+		const String &first = names[0];
 		if (ClassDB::class_exists(p_base_class) && ClassDB::class_exists(first) && ClassDB::is_parent_class(p_base_class, first)) {
+			const String &rest = names[1];
 			return rest;
 		}
 	}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -625,7 +625,7 @@ GDScriptParser::ClassNode *GDScriptParser::find_class(const String &p_qualified_
 
 	// Starts at index 1 because index 0 was handled above.
 	for (int i = 1; result != nullptr && i < class_names.size(); i++) {
-		String current_name = class_names[i];
+		const String &current_name = class_names[i];
 		GDScriptParser::ClassNode *next = nullptr;
 		if (result->has_member(current_name)) {
 			GDScriptParser::ClassNode::Member member = result->get_member(current_name);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6151,9 +6151,9 @@ T GLTFDocument::_interpolate_track(const Vector<real_t> &p_times, const Vector<T
 
 			const float c = (p_time - p_times[idx]) / (p_times[idx + 1] - p_times[idx]);
 
-			const T from = p_values[idx * 3 + 1];
+			const T &from = p_values[idx * 3 + 1];
 			const T c1 = from + p_values[idx * 3 + 2];
-			const T to = p_values[idx * 3 + 4];
+			const T &to = p_values[idx * 3 + 4];
 			const T c2 = to + p_values[idx * 3 + 3];
 
 			return interp.bezier(from, c1, c2, to, c);
@@ -7052,9 +7052,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p
 		} else if (String(final_track_path).contains(":")) {
 			//Process skeleton
 			const Vector<String> node_suffix = String(final_track_path).split(":");
-			const String node = node_suffix[0];
+			const String &node = node_suffix[0];
 			const NodePath node_path = node;
-			const String suffix = node_suffix[1];
+			const String &suffix = node_suffix[1];
 			Node *godot_node = animation_base_node->get_node_or_null(node_path);
 			if (!godot_node) {
 				continue;

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -77,7 +77,7 @@ void OpenXRSelectInteractionProfileDialog::open(PackedStringArray p_do_not_inclu
 	// in with the new
 	PackedStringArray interaction_profiles = OpenXRInteractionProfileMetadata::get_singleton()->get_interaction_profile_paths();
 	for (int i = 0; i < interaction_profiles.size(); i++) {
-		String path = interaction_profiles[i];
+		const String &path = interaction_profiles[i];
 		if (!p_do_not_include.has(path)) {
 			Button *ip_button = memnew(Button);
 			ip_button->set_flat(true);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1111,7 +1111,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 						}
 
 						for (int i = 0; i < feature_names.size(); i++) {
-							String feature_name = feature_names[i];
+							const String &feature_name = feature_names[i];
 							bool feature_required = feature_required_list[i];
 							int feature_version = feature_versions[i];
 							bool has_version_attribute = feature_version != -1;

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1226,7 +1226,7 @@ Error EditorExportPlatformIOS::_copy_asset(const String &p_out_dir, const String
 
 Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir, const Vector<String> &p_assets, bool p_is_framework, bool p_should_embed, Vector<IOSExportAsset> &r_exported_assets) {
 	for (int f_idx = 0; f_idx < p_assets.size(); ++f_idx) {
-		String asset = p_assets[f_idx];
+		const String &asset = p_assets[f_idx];
 		if (asset.begins_with("res://")) {
 			Error err = _copy_asset(p_out_dir, asset, nullptr, p_is_framework, p_should_embed, r_exported_assets);
 			ERR_FAIL_COND_V(err != OK, err);

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -162,7 +162,7 @@ void FreeDesktopPortalDesktop::append_dbus_dict_filters(DBusMessageIter *p_iter,
 		append_dbus_string(&struct_iter, p_filter_names[i]);
 
 		dbus_message_iter_open_container(&struct_iter, DBUS_TYPE_ARRAY, "(us)", &array_iter);
-		String flt = p_filter_exts[i];
+		const String &flt = p_filter_exts[i];
 		int filter_slice_count = flt.get_slice_count(",");
 		for (int j = 0; j < filter_slice_count; j++) {
 			dbus_message_iter_open_container(&array_iter, DBUS_TYPE_STRUCT, nullptr, &array_struct_iter);

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -316,7 +316,7 @@ Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
 			continue;
 		}
 		String device_class = columns[1].trim_suffix(":");
-		String vendor_device_id_mapping = columns[2];
+		const String &vendor_device_id_mapping = columns[2];
 
 #ifdef MODULE_REGEX_ENABLED
 		if (regex_id_format.search(vendor_device_id_mapping).is_null()) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -89,7 +89,7 @@ void FileDialog::set_visible(bool p_visible) {
 void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files, int p_filter) {
 	if (p_ok) {
 		if (p_files.size() > 0) {
-			String f = p_files[0];
+			const String &f = p_files[0];
 			if (mode == FILE_MODE_OPEN_FILES) {
 				emit_signal(SNAME("files_selected"), p_files);
 			} else {

--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -287,13 +287,13 @@ Vector<StringName> GraphEditArranger::_split(const Vector<StringName> &r_layer, 
 		return Vector<StringName>();
 	}
 
-	StringName p = r_layer[Math::random(0, r_layer.size() - 1)];
+	const StringName &p = r_layer[Math::random(0, r_layer.size() - 1)];
 	Vector<StringName> left;
 	Vector<StringName> right;
 
 	for (int i = 0; i < r_layer.size(); i++) {
 		if (p != r_layer[i]) {
-			StringName q = r_layer[i];
+			const StringName &q = r_layer[i];
 			int cross_pq = r_crossings[p][q];
 			int cross_qp = r_crossings[q][p];
 			if (cross_pq > cross_qp) {
@@ -326,9 +326,9 @@ void GraphEditArranger::_horizontal_alignment(Dictionary &r_root, Dictionary &r_
 
 		for (int j = 0; j < lower_layer.size(); j++) {
 			Vector<Pair<int, StringName>> up;
-			StringName current_node = lower_layer[j];
+			const StringName &current_node = lower_layer[j];
 			for (int k = 0; k < upper_layer.size(); k++) {
-				StringName adjacent_neighbour = upper_layer[k];
+				const StringName &adjacent_neighbour = upper_layer[k];
 				if (r_upper_neighbours[current_node].has(adjacent_neighbour)) {
 					up.push_back(Pair<int, StringName>(k, adjacent_neighbour));
 				}
@@ -360,12 +360,12 @@ void GraphEditArranger::_crossing_minimisation(HashMap<int, Vector<StringName>> 
 		HashMap<StringName, Dictionary> c;
 
 		for (int j = 0; j < lower_layer.size(); j++) {
-			StringName p = lower_layer[j];
+			const StringName &p = lower_layer[j];
 			Dictionary d;
 
 			for (int k = 0; k < lower_layer.size(); k++) {
 				unsigned int crossings = 0;
-				StringName q = lower_layer[k];
+				const StringName &q = lower_layer[k];
 
 				if (j != k) {
 					for (int h = 1; h < upper_layer.size(); h++) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -159,7 +159,7 @@ void OptionButton::_notification(int p_what) {
 bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0] == "popup") {
-		String property = components[2];
+		const String &property = components[2];
 		if (property != "text" && property != "icon" && property != "id" && property != "disabled" && property != "separator") {
 			return false;
 		}
@@ -186,7 +186,7 @@ bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 bool OptionButton::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0] == "popup") {
-		String property = components[2];
+		const String &property = components[2];
 		if (property != "text" && property != "icon" && property != "id" && property != "disabled" && property != "separator") {
 			return false;
 		}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2483,7 +2483,7 @@ bool PopupMenu::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("item_") && components[0].trim_prefix("item_").is_valid_int()) {
 		int item_index = components[0].trim_prefix("item_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "text") {
 			set_item_text(item_index, p_value);
 			return true;
@@ -2562,7 +2562,7 @@ bool PopupMenu::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("item_") && components[0].trim_prefix("item_").is_valid_int()) {
 		int item_index = components[0].trim_prefix("item_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "text") {
 			r_ret = get_item_text(item_index);
 			return true;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4532,7 +4532,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 				if (subtag_a.size() == 2) {
 					if (subtag_a[0] == "font" || subtag_a[0] == "f") {
-						String fnt = subtag_a[1];
+						const String &fnt = subtag_a[1];
 						Ref<Font> font = ResourceLoader::load(fnt, "Font");
 						if (font.is_valid()) {
 							f = font;
@@ -4776,7 +4776,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 				if (subtag_a.size() == 2) {
 					if (subtag_a[0] == "name" || subtag_a[0] == "n") {
-						String fnt = subtag_a[1];
+						const String &fnt = subtag_a[1];
 						Ref<Font> font_data = ResourceLoader::load(fnt, "Font");
 						if (font_data.is_valid()) {
 							font = font_data;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1657,7 +1657,7 @@ bool TabBar::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("tab_") && components[0].trim_prefix("tab_").is_valid_int()) {
 		int tab_index = components[0].trim_prefix("tab_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "title") {
 			set_tab_title(tab_index, p_value);
 			return true;
@@ -1676,7 +1676,7 @@ bool TabBar::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("tab_") && components[0].trim_prefix("tab_").is_valid_int()) {
 		int tab_index = components[0].trim_prefix("tab_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "title") {
 			r_ret = get_tab_title(tab_index);
 			return true;

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -527,7 +527,7 @@ bool Curve::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("point_") && components[0].trim_prefix("point_").is_valid_int()) {
 		int point_index = components[0].trim_prefix("point_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "position") {
 			Vector2 position = p_value.operator Vector2();
 			set_point_offset(point_index, position.x);
@@ -556,7 +556,7 @@ bool Curve::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("point_") && components[0].trim_prefix("point_").is_valid_int()) {
 		int point_index = components[0].trim_prefix("point_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "position") {
 			r_ret = get_point_position(point_index);
 			return true;
@@ -1255,7 +1255,7 @@ bool Curve2D::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("point_") && components[0].trim_prefix("point_").is_valid_int()) {
 		int point_index = components[0].trim_prefix("point_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "position") {
 			set_point_position(point_index, p_value);
 			return true;
@@ -1274,7 +1274,7 @@ bool Curve2D::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("point_") && components[0].trim_prefix("point_").is_valid_int()) {
 		int point_index = components[0].trim_prefix("point_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "position") {
 			r_ret = get_point_position(point_index);
 			return true;
@@ -2220,7 +2220,7 @@ bool Curve3D::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("point_") && components[0].trim_prefix("point_").is_valid_int()) {
 		int point_index = components[0].trim_prefix("point_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "position") {
 			set_point_position(point_index, p_value);
 			return true;
@@ -2242,7 +2242,7 @@ bool Curve3D::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0].begins_with("point_") && components[0].trim_prefix("point_").is_valid_int()) {
 		int point_index = components[0].trim_prefix("point_").to_int();
-		String property = components[1];
+		const String &property = components[1];
 		if (property == "position") {
 			r_ret = get_point_position(point_index);
 			return true;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1118,11 +1118,11 @@ bool FontFile::_set(const StringName &p_name, const Variant &p_value) {
 #endif // DISABLE_DEPRECATED
 
 	if (tokens.size() == 2 && tokens[0] == "language_support_override") {
-		String lang_code = tokens[1];
+		const String &lang_code = tokens[1];
 		set_language_support_override(lang_code, p_value);
 		return true;
 	} else if (tokens.size() == 2 && tokens[0] == "script_support_override") {
-		String script_code = tokens[1];
+		const String &script_code = tokens[1];
 		set_script_support_override(script_code, p_value);
 		return true;
 	} else if (tokens.size() >= 3 && tokens[0] == "cache") {
@@ -1209,11 +1209,11 @@ bool FontFile::_set(const StringName &p_name, const Variant &p_value) {
 bool FontFile::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> tokens = p_name.operator String().split("/");
 	if (tokens.size() == 2 && tokens[0] == "language_support_override") {
-		String lang_code = tokens[1];
+		const String &lang_code = tokens[1];
 		r_ret = get_language_support_override(lang_code);
 		return true;
 	} else if (tokens.size() == 2 && tokens[0] == "script_support_override") {
-		String script_code = tokens[1];
+		const String &script_code = tokens[1];
 		r_ret = get_script_support_override(script_code);
 		return true;
 	} else if (tokens.size() >= 3 && tokens[0] == "cache") {

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -45,7 +45,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 	String text;
 
 	for (int i = 0; i < lines.size(); i++) {
-		String l = lines[i];
+		const String &l = lines[i];
 		bool push_chunk = false;
 
 		StageTemplate::Chunk chunk;

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -543,7 +543,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			uniform_names.sort_custom<StringName::AlphCompare>(); //ensure order is deterministic so the same shader is always produced
 
 			for (int k = 0; k < uniform_names.size(); k++) {
-				StringName uniform_name = uniform_names[k];
+				const StringName &uniform_name = uniform_names[k];
 				const SL::ShaderNode::Uniform &uniform = pnode->uniforms[uniform_name];
 
 				String ucode;
@@ -670,7 +670,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			varying_names.sort_custom<StringName::AlphCompare>(); //ensure order is deterministic so the same shader is always produced
 
 			for (int k = 0; k < varying_names.size(); k++) {
-				StringName varying_name = varying_names[k];
+				const StringName &varying_name = varying_names[k];
 				const SL::ShaderNode::Varying &varying = pnode->varyings[varying_name];
 
 				if (varying.stage == SL::ShaderNode::Varying::STAGE_FRAGMENT_TO_LIGHT || varying.stage == SL::ShaderNode::Varying::STAGE_FRAGMENT) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -103,7 +103,7 @@ PackedInt64Array RenderingServer::_instances_cull_convex_bind(const TypedArray<P
 	}
 	Vector<Plane> planes;
 	for (int i = 0; i < p_convex.size(); ++i) {
-		Variant v = p_convex[i];
+		const Variant &v = p_convex[i];
 		ERR_FAIL_COND_V(v.get_type() != Variant::PLANE, PackedInt64Array());
 		planes.push_back(v);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

I stumbled upon a couple of lines where data is unnecessarily copied data during variable initialization (for which I opened #84379) and decided to scan the codebase with `clang-tidy` to see what it could find.

If this pull request conflicts with another one, priority should be given to the other pull request since this particular patch can be automatically generated with:

```
find . -name 'thirdparty' -prune -o -iname '*.cpp' -print -exec clang-tidy --checks=performance-unnecessary-copy-initialization -p $(pwd) --fix --fix-errors {} \;
git diff -U0  | grepdiff -E 'const.*&' --output-matching=hunk | sed -e 's/const \(.*\)& /const \1 \&/g' | git apply --cached --unidiff-zero
git reset platform/macos/export/export_plugin.cpp
```

And selectively choosing what to commit