### PR TITLE
Don't check resource type assigned in property

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3448,7 +3448,7 @@ void EditorPropertyResource::update_property() {
 		}
 	}
 
-	resource_picker->set_edited_resource(res);
+	resource_picker->set_edited_resource_no_check(res);
 }
 
 void EditorPropertyResource::collapse_all_folding() {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -903,7 +903,10 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 			ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorResourcePicker only accepts '%s' and its derivatives.", class_str, base_type));
 		}
 	}
+	set_edited_resource_no_check(p_resource);
+}
 
+void EditorResourcePicker::set_edited_resource_no_check(Ref<Resource> p_resource) {
 	edited_resource = p_resource;
 	_update_resource();
 }

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -126,6 +126,7 @@ public:
 	Vector<String> get_allowed_types() const;
 
 	void set_edited_resource(Ref<Resource> p_resource);
+	void set_edited_resource_no_check(Ref<Resource> p_resource);
 	Ref<Resource> get_edited_resource();
 
 	void set_toggle_mode(bool p_enable);


### PR DESCRIPTION
The resource type is validated when assigning to object, so the check in EditorResourcePicker was redundant. This change makes EditorResourcePickers initialize faster, as the valid types are not checked until you actually try to assign something.