### PR TITLE
Use unfilled panel splitting icons

### DIFF
--- a/editor/icons/Panels1.svg
+++ b/editor/icons/Panels1.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m0 0h16v16h-16z" fill="#e0e0e0"/></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 1h14v14H1z" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/></svg>

--- a/editor/icons/Panels2.svg
+++ b/editor/icons/Panels2.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m0 0v7h16v-7zm0 9v7h16v-7z" fill="#e0e0e0"/></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 1v14h14V1zm0 7h14" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/></svg>

--- a/editor/icons/Panels2Alt.svg
+++ b/editor/icons/Panels2Alt.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m0 0v16h7v-16zm9 0v16h7v-16z" fill="#e0e0e0"/></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 1v14h14V1zm7 0v14" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/></svg>

--- a/editor/icons/Panels3.svg
+++ b/editor/icons/Panels3.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m0 0v7h16v-7zm0 9v7h7v-7zm9 0v7h7v-7z" fill="#e0e0e0"/></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 1v14h14V1zm0 7h14M8 8v7" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/></svg>

--- a/editor/icons/Panels3Alt.svg
+++ b/editor/icons/Panels3Alt.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m0 0v7h7v-7zm9 0v16h7v-16zm-9 9v7h7v-7z" fill="#e0e0e0"/></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 1v14h14V1zm7 0v14M1 8h7" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/></svg>

--- a/editor/icons/Panels4.svg
+++ b/editor/icons/Panels4.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m0 0v7h7v-7zm9 0v7h7v-7zm-9 9v7h7v-7zm9 0v7h7v-7z" fill="#e0e0e0"/></svg>
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 1v14h14V1zm0 7h14M8 1v14" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
![image](https://github.com/godotengine/godot/assets/85438892/7970555e-ed3a-4ce4-b9d9-34351b99f063)

Old one looked like this, much worse in my opinion; the 4-split one also collided with thumbnail mode, and the no-split one famously looked broken:

![image](https://github.com/godotengine/godot/assets/85438892/cd5fdb25-18d3-4f2b-ba23-891f2128712d)

Fixes #84309