### PR TITLE
Fix Camera2D frame delay (port from 3.x)

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -229,7 +229,7 @@ void Camera2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			if (!is_processing_internal() && !is_physics_processing_internal()) {
+			if (!position_smoothing_enabled || _is_editing_in_editor()) {
 				_update_scroll();
 			}
 		} break;


### PR DESCRIPTION
This is a port of https://github.com/godotengine/godot/pull/46697 to the 4.x branch.

Complements https://github.com/godotengine/godot/pull/84380 by further improving the 2D pixel perfect experience.

Test project (to be used in conjunction with PR 84380): [PixelPerfectTestIdle.zip](https://github.com/godotengine/godot/files/13258040/PixelPerfectTestIdle.zip)

Fixes https://github.com/godotengine/godot/issues/74203 and fixes https://github.com/godotengine/godot/issues/77813.