### PR TITLE
Fix errors and warnings when loading Skeleton2D Modifications

### DIFF
--- a/scene/resources/2d/skeleton/skeleton_modification_2d.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d.cpp
@@ -233,6 +233,11 @@ void SkeletonModification2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "execution_mode", PROPERTY_HINT_ENUM, "process,physics_process"), "set_execution_mode", "get_execution_mode");
 }
 
+void SkeletonModification2D::reset_state() {
+	stack = nullptr;
+	is_setup = false;
+}
+
 SkeletonModification2D::SkeletonModification2D() {
 	stack = nullptr;
 	is_setup = false;

--- a/scene/resources/2d/skeleton/skeleton_modification_2d.h
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d.h
@@ -57,6 +57,8 @@ protected:
 
 	bool _print_execution_error(bool p_condition, String p_message);
 
+	virtual void reset_state() override;
+
 	GDVIRTUAL1(_execute, double)
 	GDVIRTUAL1(_setup_modification, Ref<SkeletonModificationStack2D>)
 	GDVIRTUAL0(_draw_editor_gizmo)

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
@@ -266,7 +266,9 @@ void SkeletonModification2DCCDIK::_draw_editor_gizmo() {
 
 void SkeletonModification2DCCDIK::update_target_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -287,7 +289,9 @@ void SkeletonModification2DCCDIK::update_target_cache() {
 
 void SkeletonModification2DCCDIK::update_tip_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update tip cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update tip cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -309,7 +313,9 @@ void SkeletonModification2DCCDIK::update_tip_cache() {
 void SkeletonModification2DCCDIK::ccdik_joint_update_bone2d_cache(int p_joint_idx) {
 	ERR_FAIL_INDEX_MSG(p_joint_idx, ccdik_data_chain.size(), "Cannot update bone2d cache: joint index out of range!");
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update CCDIK Bone2D cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update CCDIK Bone2D cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -390,7 +396,6 @@ void SkeletonModification2DCCDIK::set_ccdik_joint_bone_index(int p_joint_idx, in
 			ccdik_data_chain.write[p_joint_idx].bone_idx = p_bone_idx;
 		}
 	} else {
-		WARN_PRINT("Cannot verify the CCDIK joint " + itos(p_joint_idx) + " bone index for this modification...");
 		ccdik_data_chain.write[p_joint_idx].bone_idx = p_bone_idx;
 	}
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.cpp
@@ -289,13 +289,21 @@ void SkeletonModification2DFABRIK::_setup_modification(SkeletonModificationStack
 
 	if (stack != nullptr) {
 		is_setup = true;
+
+		if (stack->skeleton) {
+			for (int i = 0; i < fabrik_data_chain.size(); i++) {
+				fabrik_joint_update_bone2d_cache(i);
+			}
+		}
 		update_target_cache();
 	}
 }
 
 void SkeletonModification2DFABRIK::update_target_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -317,7 +325,9 @@ void SkeletonModification2DFABRIK::update_target_cache() {
 void SkeletonModification2DFABRIK::fabrik_joint_update_bone2d_cache(int p_joint_idx) {
 	ERR_FAIL_INDEX_MSG(p_joint_idx, fabrik_data_chain.size(), "Cannot update bone2d cache: joint index out of range!");
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update FABRIK Bone2D cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update FABRIK Bone2D cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -389,7 +399,6 @@ void SkeletonModification2DFABRIK::set_fabrik_joint_bone_index(int p_joint_idx, 
 			fabrik_data_chain.write[p_joint_idx].bone_idx = p_bone_idx;
 		}
 	} else {
-		WARN_PRINT("Cannot verify the FABRIK joint " + itos(p_joint_idx) + " bone index for this modification...");
 		fabrik_data_chain.write[p_joint_idx].bone_idx = p_bone_idx;
 	}
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
@@ -254,6 +254,8 @@ void SkeletonModification2DJiggle::_setup_modification(SkeletonModificationStack
 					Bone2D *bone2d_node = stack->skeleton->get_bone(bone_idx);
 					jiggle_data_chain.write[i].dynamic_position = bone2d_node->get_global_position();
 				}
+
+				jiggle_joint_update_bone2d_cache(i);
 			}
 		}
 
@@ -263,7 +265,9 @@ void SkeletonModification2DJiggle::_setup_modification(SkeletonModificationStack
 
 void SkeletonModification2DJiggle::update_target_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -285,7 +289,9 @@ void SkeletonModification2DJiggle::update_target_cache() {
 void SkeletonModification2DJiggle::jiggle_joint_update_bone2d_cache(int p_joint_idx) {
 	ERR_FAIL_INDEX_MSG(p_joint_idx, jiggle_data_chain.size(), "Cannot update bone2d cache: joint index out of range!");
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update Jiggle " + itos(p_joint_idx) + " Bone2D cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update Jiggle " + itos(p_joint_idx) + " Bone2D cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -425,7 +431,6 @@ void SkeletonModification2DJiggle::set_jiggle_joint_bone_index(int p_joint_idx, 
 			jiggle_data_chain.write[p_joint_idx].bone_idx = p_bone_idx;
 		}
 	} else {
-		WARN_PRINT("Cannot verify the Jiggle joint " + itos(p_joint_idx) + " bone index for this modification...");
 		jiggle_data_chain.write[p_joint_idx].bone_idx = p_bone_idx;
 	}
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
@@ -200,7 +200,9 @@ void SkeletonModification2DLookAt::_draw_editor_gizmo() {
 
 void SkeletonModification2DLookAt::update_bone2d_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update Bone2D cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update Bone2D cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -256,7 +258,6 @@ void SkeletonModification2DLookAt::set_bone_index(int p_bone_idx) {
 			bone_idx = p_bone_idx;
 		}
 	} else {
-		WARN_PRINT("Cannot verify the bone index for this modification...");
 		bone_idx = p_bone_idx;
 	}
 
@@ -265,7 +266,9 @@ void SkeletonModification2DLookAt::set_bone_index(int p_bone_idx) {
 
 void SkeletonModification2DLookAt::update_target_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		}
 		return;
 	}
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -153,7 +153,7 @@ void SkeletonModification2DPhysicalBones::_setup_modification(SkeletonModificati
 void SkeletonModification2DPhysicalBones::_physical_bone_update_cache(int p_joint_idx) {
 	ERR_FAIL_INDEX_MSG(p_joint_idx, physical_bone_chain.size(), "Cannot update PhysicalBone2D cache: joint index out of range!");
 	if (!is_setup || !stack) {
-		if (!stack) {
+		if (is_setup) {
 			ERR_PRINT_ONCE("Cannot update PhysicalBone2D cache: modification is not properly setup!");
 		}
 		return;

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -250,7 +250,9 @@ void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
 
 void SkeletonModification2DTwoBoneIK::update_target_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update target cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -271,7 +273,9 @@ void SkeletonModification2DTwoBoneIK::update_target_cache() {
 
 void SkeletonModification2DTwoBoneIK::update_joint_one_bone2d_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update joint one Bone2D cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update joint one Bone2D cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -299,7 +303,9 @@ void SkeletonModification2DTwoBoneIK::update_joint_one_bone2d_cache() {
 
 void SkeletonModification2DTwoBoneIK::update_joint_two_bone2d_cache() {
 	if (!is_setup || !stack) {
-		ERR_PRINT_ONCE("Cannot update joint two Bone2D cache: modification is not properly setup!");
+		if (is_setup) {
+			ERR_PRINT_ONCE("Cannot update joint two Bone2D cache: modification is not properly setup!");
+		}
 		return;
 	}
 
@@ -400,7 +406,6 @@ void SkeletonModification2DTwoBoneIK::set_joint_one_bone_idx(int p_bone_idx) {
 			joint_one_bone_idx = p_bone_idx;
 		}
 	} else {
-		WARN_PRINT("TwoBoneIK: Cannot verify the joint bone index for joint one...");
 		joint_one_bone_idx = p_bone_idx;
 	}
 
@@ -425,7 +430,6 @@ void SkeletonModification2DTwoBoneIK::set_joint_two_bone_idx(int p_bone_idx) {
 			joint_two_bone_idx = p_bone_idx;
 		}
 	} else {
-		WARN_PRINT("TwoBoneIK: Cannot verify the joint bone index for joint two...");
 		joint_two_bone_idx = p_bone_idx;
 	}
 


### PR DESCRIPTION
Fixes #73247

- Don't print cache errors about not being "properly" setup when not setup, because that is normal
- Don't print warnings about verification when not setup
- Avoid cache warnings and other tree-reference-related errors calling setup_modifications on NOTIFICATION_POST_ENTER_TREE