### PR TITLE
[3.x] Fix image links to `godot-docs` repository

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -52,7 +52,7 @@
 			<argument index="0" name="to" type="Vector2" />
 			<description>
 				Returns the angle between the line connecting the two points and the X axis, in radians.
-				[url=https://raw.githubusercontent.com/godotengine/godot-docs/stable/img/vector2_angle_to_point.png]Illustration of the returned angle.[/url]
+				[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.6/img/vector2_angle_to_point.png]Illustration of the returned angle.[/url]
 			</description>
 		</method>
 		<method name="aspect">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -276,7 +276,7 @@
 				- 1.0: Linear
 				- Greater than 1.0 (exclusive): Ease in
 				[/codeblock]
-				[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.5/img/ease_cheatsheet.png]ease() curve values cheatsheet[/url]
+				[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.6/img/ease_cheatsheet.png]ease() curve values cheatsheet[/url]
 				See also [method smoothstep]. If you need to perform more advanced transitions, use [Tween] or [AnimationPlayer].
 			</description>
 		</method>
@@ -974,7 +974,7 @@
 				smoothstep(0, 2, 2.0) # Returns 1.0
 				[/codeblock]
 				Compared to [method ease] with a curve value of [code]-1.6521[/code], [method smoothstep] returns the smoothest possible curve with no sudden changes in the derivative. If you need to perform more advanced transitions, use [Tween] or [AnimationPlayer].
-				[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.5/img/smoothstep_ease_comparison.png]Comparison between smoothstep() and ease(x, -1.6521) return values[/url]
+				[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.6/img/smoothstep_ease_comparison.png]Comparison between smoothstep() and ease(x, -1.6521) return values[/url]
 			</description>
 		</method>
 		<method name="sqrt">


### PR DESCRIPTION
These images should point to `3.6` instead of `3.5` or `stable`.