### PR TITLE
Correct image parameter type for set_custom_mouse_cursor()

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -312,7 +312,7 @@
 		</method>
 		<method name="set_custom_mouse_cursor">
 			<return type="void" />
-			<param index="0" name="image" type="Resource" />
+			<param index="0" name="image" type="ImageTexture" />
 			<param index="1" name="shape" type="int" enum="Input.CursorShape" default="0" />
 			<param index="2" name="hotspot" type="Vector2" default="Vector2(0, 0)" />
 			<description>


### PR DESCRIPTION
Hi there, 

the current image parameter type of `Input.set_custom_mouse_cursor()` suggests that objects of type `Image` (part of inherited  object list of `Resource`) can be passed, but this leads to an error. Instead, an `ImageTexture` object seems to be expected.

The following worked for me in Godot 4.1.2, while following a tutorial on how to set a custom mouse cursor in Godot 4:
```
extends CanvasLayer

@export var default_cursor: Texture2D = null
[...]


func _ready():
    [...]
    update_cursor()
    [...]


func update_cursor(_cursor = default_cursor):
    [...]
    var _cursor_img = _cursor.get_image()
    var _cursor_texture = ImageTexture.create_from_image(_cursor_img)
    Input.set_custom_mouse_cursor(_cursor_texture, Input.CURSOR_ARROW)
    [...]

```

Simply passing `_cursor_img` of type `Image` failed with the following error message:

>  e 0:00:00:0900 cursor_manager.gd:75 @ update_cursor(): condition "!texture.is_valid()" is true. <c++ source> platform/macos/display_server_macos.mm:3327 @ cursor_set_custom_image() <stack trace> cursor_manager.gd:75 @ update_cursor() cursor_manager.gd:42 @ _ready()

See also https://ask.godotengine.org/65265/problem-getting-a-portion-of-an-image, which pointed me into the right direction to solve the error. 

PS: I'm totally new to Godot, but thought I'd help to improve the docs, based on my experiences while learning Godot... :)
