### PR TITLE
Restore losed focus for some pop-up dialogs in visual shader editor

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4081,6 +4081,7 @@ void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos, VisualShaderNod
 		members_dialog->set_position(graph->get_screen_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	}
 	members_dialog->popup();
+	members_dialog->grab_focus();
 
 	// Keep dialog within window bounds.
 	Rect2 window_rect = Rect2(get_window()->get_position(), get_window()->get_size());
@@ -4110,6 +4111,7 @@ void VisualShaderEditor::_show_add_varying_dialog() {
 
 	add_varying_dialog->set_position(graph->get_screen_position() + varying_button->get_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	add_varying_dialog->popup();
+	add_varying_dialog->grab_focus();
 
 	// Keep dialog within window bounds.
 	Rect2 window_rect = Rect2(DisplayServer::get_singleton()->window_get_position(), DisplayServer::get_singleton()->window_get_size());
@@ -4121,6 +4123,7 @@ void VisualShaderEditor::_show_add_varying_dialog() {
 void VisualShaderEditor::_show_remove_varying_dialog() {
 	remove_varying_dialog->set_position(graph->get_screen_position() + varying_button->get_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
 	remove_varying_dialog->popup();
+	remove_varying_dialog->grab_focus();
 
 	// Keep dialog within window bounds.
 	Rect2 window_rect = Rect2(DisplayServer::get_singleton()->window_get_position(), DisplayServer::get_singleton()->window_get_size());


### PR DESCRIPTION
Fix dialog behavior which may loses the required focus (for example, when the user right-click on graph if members dialog is opened).

Before:
![focus](https://github.com/godotengine/godot/assets/3036176/37c0585d-f6b5-4162-904d-a2c4a8335467)

After:
![focus2](https://github.com/godotengine/godot/assets/3036176/e87d80f6-2424-454a-b9a5-4f497cd29a81)
