### PR TITLE
[iOS, GDExtension] Fix loading and exporting static libraries and xcframeworks.

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -904,6 +904,8 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 		return ERR_FILE_NOT_FOUND;
 	}
 
+	bool is_static_library = library_path.ends_with(".a") || library_path.ends_with(".xcframework");
+
 	if (!library_path.is_resource_file() && !library_path.is_absolute_path()) {
 		library_path = p_path.get_base_dir().path_join(library_path);
 	}
@@ -920,7 +922,7 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 			FileAccess::get_modified_time(library_path));
 #endif
 
-	err = p_extension->open_library(library_path, entry_symbol);
+	err = p_extension->open_library(is_static_library ? String() : library_path, entry_symbol);
 	if (err != OK) {
 #if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
 		// If the DLL fails to load, make sure that temporary DLL copies are cleaned up.

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -490,6 +490,12 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #endif
 
+#if defined(IOS_SIMULATOR)
+	if (p_feature == "simulator") {
+		return true;
+	}
+#endif
+
 	if (_check_internal_feature_support(p_feature)) {
 		return true;
 	}

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -500,6 +500,7 @@
 				Returns [code]true[/code] if the feature for the given feature tag is supported in the currently running instance, depending on the platform, build, etc. Can be used to check whether you're currently running a debug build, on a certain platform or arch, etc. Refer to the [url=$DOCS_URL/tutorials/export/feature_tags.html]Feature Tags[/url] documentation for more details.
 				[b]Note:[/b] Tag names are case-sensitive.
 				[b]Note:[/b] On the web platform, one of the following additional tags is defined to indicate host platform: [code]web_android[/code], [code]web_ios[/code], [code]web_linuxbsd[/code], [code]web_macos[/code], or [code]web_windows[/code].
+				[b]Note:[/b] On the iOS simulator, the additional [code]simulator[/code] tag is defined.
 			</description>
 		</method>
 		<method name="is_debug_build" qualifiers="const">

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -88,14 +88,20 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 		archs.insert("unknown_arch"); // Not archs specified, still try to match.
 	}
 
+	HashSet<String> libs_added;
+
 	for (const String &arch_tag : archs) {
 		PackedStringArray tags;
 		String library_path = GDExtension::find_extension_library(
 				p_path, config, [features_wo_arch, arch_tag](String p_feature) { return features_wo_arch.has(p_feature) || (p_feature == arch_tag); }, &tags);
+		if (libs_added.has(library_path)) {
+			continue; // Universal library, already added for another arch, do not duplicate.
+		}
 		if (!library_path.is_empty()) {
+			libs_added.insert(library_path);
 			add_shared_object(library_path, tags);
 
-			if (p_features.has("iOS") && (library_path.ends_with(".a") || library_path.ends_with(".xcframework"))) {
+			if (p_features.has("ios") && (library_path.ends_with(".a") || library_path.ends_with(".xcframework"))) {
 				String additional_code = "extern void register_dynamic_symbol(char *name, void *address);\n"
 										 "extern void add_ios_init_callback(void (*cb)());\n"
 										 "\n"

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -105,6 +105,7 @@ def configure(env: "Environment"):
         detect_darwin_sdk_path("iossimulator", env)
         env.Append(ASFLAGS=["-mios-simulator-version-min=12.0"])
         env.Append(CCFLAGS=["-mios-simulator-version-min=12.0"])
+        env.Append(CPPDEFINES=["IOS_SIMULATOR"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         detect_darwin_sdk_path("ios", env)


### PR DESCRIPTION
- Fixes `.xcframework` and `.a` export and loading.
- Adds `simulator` OS feature.

Depends on https://github.com/godotengine/godot-cpp/pull/1302
