### PR TITLE
Disable multi-window buttons instead of hiding them when support is unavailable

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -195,6 +195,15 @@
 				Shows the given property on the given [param object] in the editor's Inspector dock. If [param inspector_only] is [code]true[/code], plugins will not attempt to edit [param object].
 			</description>
 		</method>
+		<method name="is_multi_window_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if multiple window support is enabled in the editor. Multiple window support is enabled if [i]all[/i] of these statements are true:
+				- [member EditorSettings.interface/multi_window/enable] is [code]true[/code].
+				- [member EditorSettings.interface/editor/single_window_mode] is [code]false[/code].
+				- [member Viewport.gui_embed_subwindows] is [code]false[/code]. This is forced to [code]true[/code] on platforms that don't support multiple windows such as Web, or when the [code]--single-window[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url] is used.
+			</description>
+		</method>
 		<method name="is_playing_scene" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -616,6 +616,7 @@
 		</member>
 		<member name="interface/editor/single_window_mode" type="bool" setter="" getter="">
 			If [code]true[/code], embed modal windows such as docks inside the main editor window. When single-window mode is enabled, tooltips will also be embedded inside the main editor window, which means they can't be displayed outside of the editor window.
+			[b]Note:[/b] To query whether the editor can use multiple windows in an editor plugin, use [method EditorInterface.is_multi_window_enabled] instead of querying the value of this editor setting.
 		</member>
 		<member name="interface/editor/ui_layout_direction" type="int" setter="" getter="">
 			Editor UI default layout direction.
@@ -637,8 +638,9 @@
 			If [code]true[/code], display OpenType features marked as [code]hidden[/code] by the font file in the [Font] editor.
 		</member>
 		<member name="interface/multi_window/enable" type="bool" setter="" getter="">
-			If [code]true[/code], the multi window support in editor is enabled. The following panels can become dedicated windows (made floating): Docks, Script editor, and Shader editor.
+			If [code]true[/code], multiple window support in editor is enabled. The following panels can become dedicated windows (i.e. made floating): Docks, Script editor, and Shader editor.
 			[b]Note:[/b] When [member interface/editor/single_window_mode] is [code]true[/code], the multi window support is always disabled.
+			[b]Note:[/b] To query whether the editor can use multiple windows in an editor plugin, use [method EditorInterface.is_multi_window_enabled] instead of querying the value of this editor setting.
 		</member>
 		<member name="interface/multi_window/maximize_window" type="bool" setter="" getter="">
 			If [code]true[/code], when panels are made floating they will be maximized.

--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -702,15 +702,18 @@ EditorDockManager::EditorDockManager() {
 	dock_select->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	dock_vb->add_child(dock_select);
 
-	if (!SceneTree::get_singleton()->get_root()->is_embedding_subwindows() && !EDITOR_GET("interface/editor/single_window_mode") && EDITOR_GET("interface/multi_window/enable")) {
-		dock_float = memnew(Button);
-		dock_float->set_text(TTR("Make Floating"));
-		dock_float->set_focus_mode(Control::FOCUS_NONE);
-		dock_float->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-		dock_float->connect("pressed", callable_mp(this, &EditorDockManager::_dock_make_selected_float));
-
-		dock_vb->add_child(dock_float);
+	dock_float = memnew(Button);
+	dock_float->set_text(TTR("Make Floating"));
+	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
+		dock_float->set_disabled(true);
+		dock_float->set_tooltip_text(EditorNode::get_singleton()->get_multiwindow_support_tooltip_text());
+	} else {
+		dock_float->set_tooltip_text(TTR("Make this dock floating."));
 	}
+	dock_float->set_focus_mode(Control::FOCUS_NONE);
+	dock_float->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
+	dock_float->connect("pressed", callable_mp(this, &EditorDockManager::_dock_make_selected_float));
+	dock_vb->add_child(dock_float);
 
 	dock_select_popup->reset_size();
 }

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -235,6 +235,10 @@ bool EditorInterface::is_distraction_free_mode_enabled() const {
 	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
 }
 
+bool EditorInterface::is_multi_window_enabled() const {
+	return EditorNode::get_singleton()->is_multi_window_enabled();
+}
+
 float EditorInterface::get_editor_scale() const {
 	return EDSCALE;
 }
@@ -445,6 +449,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
 	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
+	ClassDB::bind_method(D_METHOD("is_multi_window_enabled"), &EditorInterface::is_multi_window_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -99,6 +99,7 @@ public:
 	void set_main_screen_editor(const String &p_name);
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
+	bool is_multi_window_enabled() const;
 
 	float get_editor_scale() const;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3711,6 +3711,10 @@ bool EditorNode::is_scene_open(const String &p_path) {
 	return false;
 }
 
+bool EditorNode::is_multi_window_enabled() const {
+	return !SceneTree::get_singleton()->get_root()->is_embedding_subwindows() && !EDITOR_GET("interface/editor/single_window_mode") && EDITOR_GET("interface/multi_window/enable");
+}
+
 void EditorNode::fix_dependencies(const String &p_for_file) {
 	dependency_fixer->edit(p_for_file);
 }
@@ -4120,6 +4124,20 @@ void EditorNode::request_instantiate_scene(const String &p_path) {
 
 void EditorNode::request_instantiate_scenes(const Vector<String> &p_files) {
 	SceneTreeDock::get_singleton()->instantiate_scenes(p_files);
+}
+
+String EditorNode::get_multiwindow_support_tooltip_text() const {
+	if (SceneTree::get_singleton()->get_root()->is_embedding_subwindows()) {
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SUBWINDOWS)) {
+			return TTR("Multi-window support is not available because the `--single-window` command line argument was used to start the editor.");
+		} else {
+			return TTR("Multi-window support is not available because the current platform doesn't support multiple windows.");
+		}
+	} else if (EDITOR_GET("interface/editor/single_window_mode")) {
+		return TTR("Multi-window support is not available because Interface > Editor > Single Window Mode is enabled in the editor settings.");
+	}
+
+	return TTR("Multi-window support is not available because Interface > Multi Window > Enable is disabled in the editor settings.");
 }
 
 void EditorNode::_inherit_request(String p_file) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -758,6 +758,8 @@ public:
 
 	bool is_resource_read_only(Ref<Resource> p_resource, bool p_foreign_resources_are_writable = false);
 
+	String get_multiwindow_support_tooltip_text() const;
+
 	bool is_changing_scene() const;
 
 	VBoxContainer *get_main_screen_control();
@@ -807,6 +809,7 @@ public:
 			List<AdditiveNodeEntry> &p_addition_list);
 
 	bool is_scene_open(const String &p_path);
+	bool is_multi_window_enabled() const;
 
 	void setup_color_picker(ColorPicker *p_picker);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4074,17 +4074,18 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_forward->set_disabled(true);
 	script_forward->set_tooltip_text(TTR("Go to next edited document."));
 
-	if (p_wrapper->is_window_available()) {
-		menu_hb->add_child(memnew(VSeparator));
+	menu_hb->add_child(memnew(VSeparator));
 
-		make_floating = memnew(ScreenSelect);
-		make_floating->set_flat(true);
+	make_floating = memnew(ScreenSelect);
+	make_floating->set_flat(true);
+	make_floating->connect("request_open_in_screen", callable_mp(window_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
+	if (!make_floating->is_disabled()) {
+		// Override default ScreenSelect tooltip if multi-window support is available.
 		make_floating->set_tooltip_text(TTR("Make the script editor floating."));
-		make_floating->connect("request_open_in_screen", callable_mp(window_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
-
-		menu_hb->add_child(make_floating);
-		p_wrapper->connect("window_visibility_changed", callable_mp(this, &ScriptEditor::_window_changed));
 	}
+
+	menu_hb->add_child(make_floating);
+	p_wrapper->connect("window_visibility_changed", callable_mp(this, &ScriptEditor::_window_changed));
 
 	tab_container->connect("tab_changed", callable_mp(this, &ScriptEditor::_tab_changed));
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -643,19 +643,20 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 		file_menu->get_popup()->set_item_disabled(file_menu->get_popup()->get_item_index(i), true);
 	}
 
-	if (window_wrapper->is_window_available()) {
-		Control *padding = memnew(Control);
-		padding->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		menu_hb->add_child(padding);
+	Control *padding = memnew(Control);
+	padding->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	menu_hb->add_child(padding);
 
-		make_floating = memnew(ScreenSelect);
-		make_floating->set_flat(true);
+	make_floating = memnew(ScreenSelect);
+	make_floating->set_flat(true);
+	make_floating->connect("request_open_in_screen", callable_mp(window_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
+	if (!make_floating->is_disabled()) {
+		// Override default ScreenSelect tooltip if multi-window support is available.
 		make_floating->set_tooltip_text(TTR("Make the shader editor floating."));
-		make_floating->connect("request_open_in_screen", callable_mp(window_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
-
-		menu_hb->add_child(make_floating);
-		window_wrapper->connect("window_visibility_changed", callable_mp(this, &ShaderEditorPlugin::_window_changed));
 	}
+
+	menu_hb->add_child(make_floating);
+	window_wrapper->connect("window_visibility_changed", callable_mp(this, &ShaderEditorPlugin::_window_changed));
 
 	shader_list = memnew(ItemList);
 	shader_list->set_auto_translate(false);

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -315,7 +315,7 @@ void WindowWrapper::set_margins_enabled(bool p_enabled) {
 }
 
 WindowWrapper::WindowWrapper() {
-	if (SceneTree::get_singleton()->get_root()->is_embedding_subwindows() || EDITOR_GET("interface/editor/single_window_mode") || !EDITOR_GET("interface/multi_window/enable")) {
+	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
 		return;
 	}
 
@@ -375,7 +375,9 @@ void ScreenSelect::_build_advanced_menu() {
 }
 
 void ScreenSelect::_emit_screen_signal(int p_screen_idx) {
-	emit_signal("request_open_in_screen", p_screen_idx);
+	if (!is_disabled()) {
+		emit_signal("request_open_in_screen", p_screen_idx);
+	}
 }
 
 void ScreenSelect::_bind_methods() {
@@ -436,12 +438,18 @@ void ScreenSelect::pressed() {
 }
 
 ScreenSelect::ScreenSelect() {
-	set_tooltip_text(TTR("Make this panel floating.\nRight click to open the screen selector."));
 	set_button_mask(MouseButtonMask::RIGHT);
 	set_flat(true);
 	set_toggle_mode(true);
 	set_focus_mode(FOCUS_NONE);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
+
+	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
+		set_disabled(true);
+		set_tooltip_text(EditorNode::get_singleton()->get_multiwindow_support_tooltip_text());
+	} else {
+		set_tooltip_text(TTR("Make this panel floating.\nRight-click to open the screen selector."));
+	}
 
 	// Create the popup.
 	const Size2 borders = Size2(4, 4) * EDSCALE;


### PR DESCRIPTION
This is more explicit as for why this functionality isn't available depending on editor settings and current platform.

This also exposes a `EditorInterface.is_multi_window_enabled()` method so that editor plugins can easily query whether the editor is able and expected to create multiple windows.

- This closes https://github.com/godotengine/godot/issues/84435.

## Preview

![Screenshot_20231106_123931](https://github.com/godotengine/godot/assets/180032/c8472080-b112-492b-a435-6ed49b83e4c6)

![Screenshot_20231106_124049](https://github.com/godotengine/godot/assets/180032/90b0f643-eb2a-470f-9e98-07e0098990c0)
