### PR TITLE
Describe usage of one_way_collision of CollisionShape2D in more detail

### DIFF
--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -22,6 +22,7 @@
 		</member>
 		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" default="false">
 			Sets whether this collision shape should only detect collision on one side (top or bottom).
+			If [code]true[/code], only edges that face up, relative to [CollisionShape2D]'s rotation, will collide with other objects. When [code]true[/code], a red vector arrow will appear on the [CollisionShape2D] in the 2D screen.
 			[b]Note:[/b] This property has no effect if this [CollisionShape2D] is a child of an [Area2D] node.
 		</member>
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin" default="1.0">


### PR DESCRIPTION

For me as a new Godot user the docs currently don't describe the usage of `CollisionShape2D.one_way_collision` in enough detail. From the current description, it was not clear for me how to change the direction of the one way collision (bottom vs. top).