### PR TITLE
r128: Update to include latest fix for intrinsics being incorrect included

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -610,7 +610,7 @@ Collection of single-file libraries used in Godot components.
   * License: MIT
 - `r128.{c,h}`
   * Upstream: https://github.com/fahickman/r128
-  * Version: 1.4.4 (cf2e88fc3e7d7dfe99189686f914874cd0bda15e, 2020)
+  * Version: git (6fc177671c47640d5bb69af10cf4ee91050015a1, 2023)
   * License: Public Domain or Unlicense
 - `smaz.{c,h}`
   * Upstream: https://github.com/antirez/smaz

--- a/thirdparty/misc/r128.h
+++ b/thirdparty/misc/r128.h
@@ -1,5 +1,5 @@
 /*
-r128.h: 128-bit (64.64) signed fixed-point arithmetic. Version 1.4.4
+r128.h: 128-bit (64.64) signed fixed-point arithmetic. Version 1.6.0
 
 COMPILATION
 -----------
@@ -127,8 +127,10 @@ extern double r128ToFloat(const R128 *v);
 // Copy
 extern void r128Copy(R128 *dst, const R128 *src);
 
-// Negate
-extern void r128Neg(R128 *dst, const R128 *src);
+// Sign manipulation
+extern void r128Neg(R128 *dst, const R128 *v);   // -v
+extern void r128Abs(R128* dst, const R128* v);   // abs(v)
+extern void r128Nabs(R128* dst, const R128* v);  // -abs(v)
 
 // Bitwise operations
 extern void r128Not(R128 *dst, const R128 *src);               // ~a
@@ -155,6 +157,7 @@ extern void r128Min(R128 *dst, const R128 *a, const R128 *b);
 extern void r128Max(R128 *dst, const R128 *a, const R128 *b);
 extern void r128Floor(R128 *dst, const R128 *v);
 extern void r128Ceil(R128 *dst, const R128 *v);
+extern void r128Round(R128 *dst, const R128 *v);    // round to nearest, rounding halfway values away from zero
 extern int  r128IsNeg(const R128 *v); // quick check for < 0
 
 // String conversion
@@ -1413,15 +1416,15 @@ void r128FromString(R128 *dst, const char *s, char **endptr)
          }
       }
 
-      for (--s; s >= exp; --s) {
+      for (const char *c = s - 1; c >= exp; --c) {
          R128_U64 digit, unused;
 
-         if ('0' <= *s && *s <= '9') {
-            digit = *s - '0';
-         } else if ('a' <= *s && *s <= 'f') {
-            digit = *s - 'a' + 10;
+         if ('0' <= *c && *c <= '9') {
+            digit = *c - '0';
+         } else if ('a' <= *c && *c <= 'f') {
+            digit = *c - 'a' + 10;
          } else {
-            digit = *s - 'A' + 10;
+            digit = *c - 'A' + 10;
          }
 
          lo = r128__udiv128(lo, digit, base, &unused);
@@ -1441,7 +1444,11 @@ void r128FromString(R128 *dst, const char *s, char **endptr)
 R128_S64 r128ToInt(const R128 *v)
 {
    R128_ASSERT(v != NULL);
-   return (R128_S64)v->hi;
+   if ((R128_S64)v->hi < 0) {
+      return (R128_S64)v->hi + (v->lo != 0);
+   } else {
+      return (R128_S64)v->hi;
+   }
 }
 
 double r128ToFloat(const R128 *v)
@@ -1546,10 +1553,38 @@ void r128Copy(R128 *dst, const R128 *src)
    R128_DEBUG_SET(dst);
 }
 
-void r128Neg(R128 *dst, const R128 *src)
+void r128Neg(R128 *dst, const R128 *v)
 {
-   r128__neg(dst, src);
+   r128__neg(dst, v);
    R128_DEBUG_SET(dst);
+}
+
+void r128Abs(R128* dst, const R128* v)
+{
+    R128 sign, inv;
+
+    R128_ASSERT(dst != NULL);
+    R128_ASSERT(v != NULL);
+
+    sign.lo = sign.hi = (R128_U64)(((R128_S64)v->hi) >> 63);
+    inv.lo = v->lo ^ sign.lo;
+    inv.hi = v->hi ^ sign.hi;
+
+    r128Sub(dst, &inv, &sign);
+}
+
+void r128Nabs(R128* dst, const R128* v)
+{
+    R128 sign, inv;
+
+    R128_ASSERT(dst != NULL);
+    R128_ASSERT(v != NULL);
+
+    sign.lo = sign.hi = (R128_U64)(((R128_S64)v->hi) >> 63);
+    inv.lo = v->lo ^ sign.lo;
+    inv.hi = v->hi ^ sign.hi;
+
+    r128Sub(dst, &sign, &inv);
 }
 
 void r128Not(R128 *dst, const R128 *src)
@@ -1643,7 +1678,7 @@ void r128Shl(R128 *dst, const R128 *src, int amount)
       r[1] = r[0] << (amount - 64);
       r[0] = 0;
    } else if (amount) {
-#  ifdef _M_X64
+#  if defined(_M_X64) && !defined(R128_STDC_ONLY)
       r[1] = __shiftleft128(r[0], r[1], (char) amount);
 #  else
       r[1] = (r[1] << amount) | (r[0] >> (64 - amount));
@@ -1705,7 +1740,7 @@ void r128Shr(R128 *dst, const R128 *src, int amount)
       r[2] = r[3] >> (amount - 64);
       r[3] = 0;
    } else if (amount) {
-#ifdef _M_X64
+#if defined(_M_X64) && !defined(R128_STDC_ONLY)
       r[2] = __shiftright128(r[2], r[3], (char) amount);
 #else
       r[2] = (r[2] >> amount) | (r[3] << (64 - amount));
@@ -2097,11 +2132,7 @@ void r128Floor(R128 *dst, const R128 *v)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(v != NULL);
 
-   if ((R128_S64)v->hi < 0) {
-      dst->hi = v->hi - (v->lo != 0);
-   } else {
-      dst->hi = v->hi;
-   }
+   dst->hi = v->hi;
    dst->lo = 0;
    R128_DEBUG_SET(dst);
 }
@@ -2111,11 +2142,17 @@ void r128Ceil(R128 *dst, const R128 *v)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(v != NULL);
 
-   if ((R128_S64)v->hi > 0) {
-      dst->hi = v->hi + (v->lo != 0);
-   } else {
-      dst->hi = v->hi;
-   }
+   dst->hi = v->hi + (v->lo != 0);
+   dst->lo = 0;
+   R128_DEBUG_SET(dst);
+}
+
+void r128Round(R128* dst, const R128* v)
+{
+   R128_ASSERT(dst != NULL);
+   R128_ASSERT(v != NULL);
+
+   dst->hi = v->hi + (v->lo >= R128_LIT_U64(0x8000000000000000) + (R128_U64)((R128_S64)v->hi < 0));
    dst->lo = 0;
    R128_DEBUG_SET(dst);
 }


### PR DESCRIPTION
r128 upstream has a fix that is needed in order to compile on certain console platforms (https://github.com/fahickman/r128/pull/15). 

I'm not sure there's a great reason to diverge from upstream by only picking up the R128_STDC_ONLY patch and none of the other fixes that upstream has - there aren't that many, and it's probably good to have them. Therefore, this PR updates r128.h to the latest version on upstream master, with all the fixes it has since the last time we updated r128 🙂 

*Contributed by W4 Games*