### PR TITLE
Fix pressing Enter being ignored in "Create Shader" dialog

### DIFF
--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -647,6 +647,7 @@ ShaderCreateDialog::ShaderCreateDialog() {
 	file_path->connect("text_changed", callable_mp(this, &ShaderCreateDialog::_path_changed));
 	file_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hb->add_child(file_path);
+	register_text_enter(file_path);
 	path_button = memnew(Button);
 	path_button->connect("pressed", callable_mp(this, &ShaderCreateDialog::_browse_path));
 	hb->add_child(path_button);


### PR DESCRIPTION
Closes #84433.
I've compiled the code with this change and it does fix the issue.

However, I don't have a good understanding of the underlying code. I would be very glad is someone would explain it to me.

- What does this `register_text_enter(file_path);` method do?
- Where exactly is Enter button is being handled? What if I want to change this button, for example?