### PR TITLE
Do not mutate source Image in `Image::save_jpg` and use encoder return value

### DIFF
--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -158,6 +158,7 @@ static Error _jpgd_save_to_output_stream(jpge::output_stream *p_output_stream, c
 	ERR_FAIL_COND_V(p_img.is_null() || p_img->is_empty(), ERR_INVALID_PARAMETER);
 	Ref<Image> image = p_img;
 	if (image->get_format() != Image::FORMAT_RGB8) {
+		image = p_img->duplicate();
 		image->convert(Image::FORMAT_RGB8);
 	}
 
@@ -169,12 +170,16 @@ static Error _jpgd_save_to_output_stream(jpge::output_stream *p_output_stream, c
 
 	const uint8_t *src_data = image->get_data().ptr();
 	for (int i = 0; i < image->get_height(); i++) {
-		enc.process_scanline(&src_data[i * image->get_width() * 3]);
+		if (!enc.process_scanline(&src_data[i * image->get_width() * 3])) {
+			return FAILED;
+		}
 	}
 
-	enc.process_scanline(nullptr);
-
-	return OK;
+	if (enc.process_scanline(nullptr)) {
+		return OK;
+	} else {
+		return FAILED;
+	}
 }
 
 static Vector<uint8_t> _jpgd_buffer_save_func(const Ref<Image> &p_img, float p_quality) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

In the patch, `p_img` comes from casting a `this` pointer a few stack frames above:
https://github.com/godotengine/godot/blob/4c96e9676b66d0cc9a25022b019b78f4c20ddc60/core/io/image.cpp#L2529 

Meaning that calling `Image::save_jpg` may eventually call `Image::convert` which mutates the source `Image` data into a different format if needed to overcome an encoder bug. See https://github.com/godotengine/godot/pull/66929#issue-1397725680.

I don't think the source `Image` data should be mutated just to save it. Additionally the encoder return value was not previously used.

This is a follow up to https://github.com/godotengine/godot/pull/84459#discussion_r1383346570.