### PR TITLE
Fix for stopping the Undo History being desynchronized from actual Undo queue

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -463,6 +463,10 @@ bool UndoRedo::has_redo() const {
 	return (current_action + 1) < actions.size();
 }
 
+bool UndoRedo::is_merging() const {
+	return merging;
+}
+
 uint64_t UndoRedo::get_version() const {
 	return version;
 }

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -131,6 +131,8 @@ public:
 	bool has_undo() const;
 	bool has_redo() const;
 
+	bool is_merging() const;
+
 	uint64_t get_version() const;
 
 	void set_commit_notify_callback(CommitNotifyCallback p_callback, void *p_ud);

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -239,6 +239,7 @@ void EditorUndoRedoManager::commit_action(bool p_execute) {
 	is_committing = true;
 
 	History &history = get_or_create_history(pending_action.history_id);
+	bool merging = history.undo_redo->is_merging();
 	history.undo_redo->commit_action(p_execute);
 	history.redo_stack.clear();
 
@@ -248,39 +249,10 @@ void EditorUndoRedoManager::commit_action(bool p_execute) {
 		return;
 	}
 
-	if (!history.undo_stack.is_empty()) {
-		// Discard action if it should be merged (UndoRedo handles merging internally).
-		switch (pending_action.merge_mode) {
-			case UndoRedo::MERGE_DISABLE:
-				break; // Nothing to do here.
-			case UndoRedo::MERGE_ENDS: {
-				if (history.undo_stack.size() < 2) {
-					break;
-				}
-
-				const Action &prev_action = history.undo_stack.back()->get();
-				const Action &pre_prev_action = history.undo_stack.back()->prev()->get();
-				if (pending_action.merge_mode == prev_action.merge_mode && pending_action.merge_mode == pre_prev_action.merge_mode &&
-						pending_action.action_name == prev_action.action_name && pending_action.action_name == pre_prev_action.action_name) {
-					pending_action = Action();
-					is_committing = false;
-					emit_signal(SNAME("history_changed"));
-					return;
-				}
-			} break;
-			case UndoRedo::MERGE_ALL: {
-				const Action &prev_action = history.undo_stack.back()->get();
-				if (pending_action.merge_mode == prev_action.merge_mode && pending_action.action_name == prev_action.action_name) {
-					pending_action = Action();
-					is_committing = false;
-					emit_signal(SNAME("history_changed"));
-					return;
-				}
-			} break;
-		}
+	if (!merging) {
+		history.undo_stack.push_back(pending_action);
 	}
 
-	history.undo_stack.push_back(pending_action);
 	pending_action = Action();
 	is_committing = false;
 	emit_signal(SNAME("history_changed"));


### PR DESCRIPTION
Fix for Issue #83945 

The Undo History was getting desynched from the actual Undo queue. The reason is that the editor_undo_redo_manager.cpp (which handles History) and undo_redo.cpp (which handles actual Undo functionality) did their own parallel checks for whether the latest action should be merged with the previous one.

My fix eliminates the checks in editor_undo_redo_manager.cpp and simply queries undo_redo as to whether it merged the latest action. If so, it doesn't create a new action in the History list.

This ensures the two don't get desynched from different ideas about merging, and also future proofs it. Since all the rules for merging are in undo_redo.cpp, they can be changed there without having to also change the rules in editor_undo_redo_manager.cpp (DRY principal)

_Production edit: Fixes https://github.com/godotengine/godot/issues/83945_
