### PR TITLE
Inform the user when running the project that a rigidbody won't work with the provided concave collision

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -604,6 +604,9 @@
 		<member name="debug/settings/stdout/print_gpu_profile" type="bool" setter="" getter="" default="false">
 			Print GPU profile information to standard output every second. This includes how long each frame takes the GPU to render on average, broken down into different steps of the render pipeline, such as CanvasItems, shadows, glow, etc.
 		</member>
+		<member name="debug/settings/stdout/print_node_configuration_warnings" type="bool" setter="" getter="" default="true">
+			Print Node Configuration Warnings to the debug output when starting the project. This includes the warnings that show up next to nodes in the scene tree.
+		</member>
 		<member name="debug/settings/stdout/verbose_stdout" type="bool" setter="" getter="" default="false">
 			Print more information to standard output when running. It displays information such as memory leaks, which scenes and resources are being loaded, etc. This can also be enabled using the [code]--verbose[/code] or [code]-v[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url], even on an exported project. See also [method OS.is_stdout_verbose] and [method @GlobalScope.print_verbose].
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2090,6 +2090,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
 	GLOBAL_DEF("debug/settings/stdout/print_gpu_profile", false);
+	GLOBAL_DEF("debug/settings/stdout/print_node_configuration_warnings", true);
 	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);
 
 	if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -185,6 +185,15 @@ void Node::_notification(int p_notification) {
 			}
 
 			GDVIRTUAL_CALL(_ready);
+
+#if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
+			if (!Engine::get_singleton()->is_editor_hint() && GLOBAL_GET("debug/settings/stdout/print_node_configuration_warnings")) {
+				PackedStringArray warnings = get_configuration_warnings();
+				for (const String &warning : warnings) {
+					WARN_PRINT(warning);
+				}
+			}
+#endif
 		} break;
 
 		case NOTIFICATION_POSTINITIALIZE: {


### PR DESCRIPTION
Related to #4159. This does not close the issue, it's only related to error reporting for the concave collision warning.

When the node enters the tree, which happens on startup and on play, the configuration warnings are printed to debug window. This is restricted to debug builds.