### PR TITLE
[macOS] Add support for ANGLE over native OpenGL (as a fallback for ANGLE over Metal).

### DIFF
--- a/platform/macos/gl_manager_macos_angle.h
+++ b/platform/macos/gl_manager_macos_angle.h
@@ -45,6 +45,8 @@
 
 class GLManagerANGLE_MacOS : public EGLManager {
 private:
+	bool use_metal = true;
+
 	virtual const char *_get_platform_extension_name() const override;
 	virtual EGLenum _get_platform_extension_enum() const override;
 	virtual EGLenum _get_platform_api_enum() const override;
@@ -54,7 +56,7 @@ private:
 public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {}
 
-	GLManagerANGLE_MacOS() {}
+	GLManagerANGLE_MacOS(bool p_metal);
 	~GLManagerANGLE_MacOS() {}
 };
 

--- a/platform/macos/gl_manager_macos_angle.mm
+++ b/platform/macos/gl_manager_macos_angle.mm
@@ -48,7 +48,11 @@ EGLenum GLManagerANGLE_MacOS::_get_platform_extension_enum() const {
 Vector<EGLAttrib> GLManagerANGLE_MacOS::_get_platform_display_attributes() const {
 	Vector<EGLAttrib> ret;
 	ret.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
-	ret.push_back(EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE);
+	if (use_metal) {
+		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE);
+	} else {
+		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
+	}
 	ret.push_back(EGL_NONE);
 
 	return ret;
@@ -65,6 +69,10 @@ Vector<EGLint> GLManagerANGLE_MacOS::_get_platform_context_attribs() const {
 	ret.push_back(EGL_NONE);
 
 	return ret;
+}
+
+GLManagerANGLE_MacOS::GLManagerANGLE_MacOS(bool p_metal) {
+	use_metal = p_metal;
 }
 
 #endif // MACOS_ENABLED && GLES3_ENABLED


### PR DESCRIPTION
- Adds support for ANGLE over native GL for macOS.
- ANGLE over Metal is used on macOS 10.15+ with Metal 2 level of hardware, older Macs default to ANGLE over native GL.
- ANGLE over GL is also used if ANGLE over Metal fails.

Depends on https://github.com/godotengine/godot-angle-static/pull/2