### PR TITLE
Sync changes between ShapeCast and RayCast class references

### DIFF
--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -34,7 +34,7 @@
 		<method name="force_shapecast_update">
 			<return type="void" />
 			<description>
-				Updates the collision information for the shape. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the shape or its parent has changed state.
+				Updates the collision information for the shape immediately, without waiting for the next [code]_physics_process[/code] call. Use this method, for example, when the shape or its parent has changed state.
 				[b]Note:[/b] [code]enabled == true[/code] is not required for this to work.
 			</description>
 		</method>
@@ -130,10 +130,10 @@
 	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
-			If [code]true[/code], collision with [Area2D]s will be reported.
+			If [code]true[/code], collisions with [Area2D]s will be reported.
 		</member>
 		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
-			If [code]true[/code], collision with [PhysicsBody2D]s will be reported.
+			If [code]true[/code], collisions with [PhysicsBody2D]s will be reported.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
 			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected.

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -34,7 +34,7 @@
 		<method name="force_shapecast_update">
 			<return type="void" />
 			<description>
-				Updates the collision information for the shape. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the shape or its parent has changed state.
+				Updates the collision information for the shape immediately, without waiting for the next [code]_physics_process[/code] call. Use this method, for example, when the shape or its parent has changed state.
 				[b]Note:[/b] [code]enabled == true[/code] is not required for this to work.
 			</description>
 		</method>
@@ -137,10 +137,10 @@
 	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
-			If [code]true[/code], collision with [Area3D]s will be reported.
+			If [code]true[/code], collisions with [Area3D]s will be reported.
 		</member>
 		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
-			If [code]true[/code], collision with [PhysicsBody3D]s will be reported.
+			If [code]true[/code], collisions with [PhysicsBody3D]s will be reported.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
 			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.


### PR DESCRIPTION
ShapeCast version of #81132

The main problem is that the description of `collide_with_{areas,bodies}()` was the same before that PR. So that PR resulted in two entries on Weblate that differs only at `collision` vs `collisions`. This situation easily makes Weblate complain about reused translation.