### PR TITLE
[Windows] Add some AMD GPUs to the OpenGL blocklist.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2401,7 +2401,7 @@
 			If [code]true[/code], the compatibility renderer will fall back to native OpenGL if ANGLE over Metal is not supported.
 			[b]Note:[/b] This setting is implemented only on macOS.
 		</member>
-		<member name="rendering/gl_compatibility/force_angle_on_devices" type="Array" setter="" getter="" default="[]">
+		<member name="rendering/gl_compatibility/force_angle_on_devices" type="Array" setter="" getter="">
 			An [Array] of devices which should always use the ANGLE renderer.
 			Each entry is a [Dictionary] with the following keys: [code]vendor[/code] and [code]name[/code]. [code]name[/code] can be set to [code]*[/code] to add all devices with the specified [code]vendor[/code].
 			[b]Note:[/b] This setting is implemented only on Windows.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1776,7 +1776,28 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_native", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_gles", true);
 
-		GLOBAL_DEF_RST(PropertyInfo(Variant::ARRAY, "rendering/gl_compatibility/force_angle_on_devices", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::DICTIONARY, PROPERTY_HINT_NONE, String())), Array());
+		Array device_blocklist;
+
+#define BLOCK_DEVICE(m_vendor, m_name)      \
+	{                                       \
+		Dictionary device;                  \
+		device["vendor"] = m_vendor;        \
+		device["name"] = m_name;            \
+		device_blocklist.push_back(device); \
+	}
+
+		// AMD GPUs.
+		BLOCK_DEVICE("ATI", "AMD Radeon(TM) R2 Graphics");
+		BLOCK_DEVICE("ATI", "AMD Radeon(TM) R3 Graphics");
+		BLOCK_DEVICE("ATI", "AMD Radeon HD 8400 / R3 Series");
+		BLOCK_DEVICE("ATI", "AMD Radeon R5 M200 Series");
+		BLOCK_DEVICE("ATI", "AMD Radeon R5 M230 Series");
+		BLOCK_DEVICE("ATI", "AMD Radeon R5 M255");
+		BLOCK_DEVICE("AMD", "AMD Radeon (TM) R5 M330");
+
+#undef BLOCK_DEVICE
+
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::ARRAY, "rendering/gl_compatibility/force_angle_on_devices", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::DICTIONARY, PROPERTY_HINT_NONE, String())), device_blocklist);
 	}
 
 	// Start with RenderingDevice-based backends. Should be included if any RD driver present.

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4658,7 +4658,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		Array device_list = GLOBAL_GET("rendering/gl_compatibility/force_angle_on_devices");
 		for (int i = 0; i < device_list.size(); i++) {
 			const Dictionary &device = device_list[i];
-			if (device.has("vendor") && device.has("name") && device["vendor"].operator String().to_upper() == gl_info["vendor"].operator String().to_upper() && (device["name"] == "*" || device["name"].operator String().to_upper() == gl_info["name"].operator String().to_upper())) {
+			if (device.has("vendor") && device.has("name") && gl_info["vendor"].operator String().to_upper().contains(device["vendor"].operator String().to_upper()) && (device["name"] == "*" || gl_info["name"].operator String().to_upper().contains(device["name"].operator String().to_upper()))) {
 				force_angle = true;
 				break;
 			}


### PR DESCRIPTION
Adds some devices to force use of ANGLE instead of OpenGL.

See https://github.com/godotengine/godot/issues/84517

Unlikely there's a reliable way to auto-detect bad drivers, so having a device blocklist based on user reports is probably the way to handle it.