### PR TITLE
Scan the filesystem in the first frame when using headless mode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4633,6 +4633,14 @@ void EditorNode::_editor_file_dialog_unregister(EditorFileDialog *p_dialog) {
 Vector<EditorNodeInitCallback> EditorNode::_init_callbacks;
 
 void EditorNode::_begin_first_scan() {
+	// In headless mode, scan right away.
+	// This allows users to continue using `godot --headless --editor --quit` to prepare a project.
+	if (!DisplayServer::get_singleton()->window_can_draw()) {
+		OS::get_singleton()->benchmark_begin_measure("editor_scan_and_import");
+		EditorFileSystem::get_singleton()->scan();
+		return;
+	}
+
 	if (!waiting_for_first_scan) {
 		return;
 	}


### PR DESCRIPTION
Tentative fix for https://github.com/godotengine/godot/issues/84460

I tested with a larger project that uses GDExtension. My testing procedure was as follows:
1. delete `extension_list.cfg`
2. Run `godot --path test/project --headless --editor --quit` using master (`extension_list.cfg` was not generated and I got a warning: `WARNING: Scan thread aborted...`)
3. Run `godot --path test/project --headless --editor --quit-after 100` using master (Same results as before. Since this is a larger project, I imagine the delay would need to be larger as well)
4. `godot --path test/project --headless --editor --quit` using this PR (the `extension_list.cfg` file is generated right away)
