### PR TITLE
Create tangent array if mesh created without tangents

### DIFF
--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -166,7 +166,7 @@ void ImmediateMesh::surface_end() {
 		normal_tangent_stride += sizeof(uint32_t);
 	}
 	uint32_t tangent_offset = 0;
-	if (uses_tangents) {
+	if (uses_tangents || uses_normals) {
 		format |= ARRAY_FORMAT_TANGENT;
 		tangent_offset = vertex_stride * vertices.size() + normal_tangent_stride;
 		normal_tangent_stride += sizeof(uint32_t);
@@ -202,9 +202,16 @@ void ImmediateMesh::surface_end() {
 
 				*normal = value;
 			}
-			if (uses_tangents) {
+			if (uses_tangents || uses_normals) {
 				uint32_t *tangent = (uint32_t *)&surface_vertex_ptr[i * normal_tangent_stride + tangent_offset];
-				Vector2 t = tangents[i].normal.octahedron_tangent_encode(tangents[i].d);
+				Vector2 t;
+				if (uses_tangents) {
+					t = tangents[i].normal.octahedron_tangent_encode(tangents[i].d);
+				} else {
+					Vector3 tan = Vector3(0.0, 1.0, 0.0).cross(normals[i].normalized());
+					t = tan.octahedron_tangent_encode(1.0);
+				}
+
 				uint32_t value = 0;
 				value |= (uint16_t)CLAMP(t.x * 65535, 0, 65535);
 				value |= (uint16_t)CLAMP(t.y * 65535, 0, 65535) << 16;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84277
Fixes: https://github.com/godotengine/godot/issues/83667

In both cases the issue came from a limitation in the Metal API that we were unaware of. We previously relied on overlapping reads from the normal buffer to pretend that we had tangents. Since we can't do that on Apple devices, we just provide tangent arrays always.

MoltenVK "corrected" our mistake which avoided logical errors on Apple devices, but which led to this subtle bug (https://github.com/KhronosGroup/MoltenVK/blob/bb914faa533a3ed923abf9cce3f9702492bfaef0/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm#L1454-L1455)

This greatly simplifies our compression code at the cost of a small amount of bandwidth.

We can now go through our compression code and assume that tangents are always available (and thus remove some now superfluous code). I haven't done so yet as it will be a riskier change. This change is very low risk and is more suitable for a beta fix. I may make a follow up PR to clean the compression code if it makes sense to do so and can be done without compat breakage


