### PR TITLE
Make `varray()` variadic

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3495,50 +3495,6 @@ bool Variant::is_ref_counted() const {
 	return type == OBJECT && _get_obj().id.is_ref_counted();
 }
 
-Vector<Variant> varray() {
-	return Vector<Variant>();
-}
-
-Vector<Variant> varray(const Variant &p_arg1) {
-	Vector<Variant> v;
-	v.push_back(p_arg1);
-	return v;
-}
-
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2) {
-	Vector<Variant> v;
-	v.push_back(p_arg1);
-	v.push_back(p_arg2);
-	return v;
-}
-
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3) {
-	Vector<Variant> v;
-	v.push_back(p_arg1);
-	v.push_back(p_arg2);
-	v.push_back(p_arg3);
-	return v;
-}
-
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4) {
-	Vector<Variant> v;
-	v.push_back(p_arg1);
-	v.push_back(p_arg2);
-	v.push_back(p_arg3);
-	v.push_back(p_arg4);
-	return v;
-}
-
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4, const Variant &p_arg5) {
-	Vector<Variant> v;
-	v.push_back(p_arg1);
-	v.push_back(p_arg2);
-	v.push_back(p_arg3);
-	v.push_back(p_arg4);
-	v.push_back(p_arg5);
-	return v;
-}
-
 void Variant::static_assign(const Variant &p_variant) {
 }
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -798,12 +798,23 @@ public:
 //typedef Dictionary Dictionary; no
 //typedef Array Array;
 
-Vector<Variant> varray();
-Vector<Variant> varray(const Variant &p_arg1);
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2);
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3);
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4);
-Vector<Variant> varray(const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4, const Variant &p_arg5);
+template <typename... VarArgs>
+Vector<Variant> varray(VarArgs... p_args) {
+	Vector<Variant> v;
+
+	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+	uint32_t argc = sizeof...(p_args);
+
+	if (argc > 0) {
+		v.resize(argc);
+		Variant *vw = v.ptrw();
+
+		for (uint32_t i = 0; i < argc; i++) {
+			vw[i] = args[i];
+		}
+	}
+	return v;
+}
 
 struct VariantHasher {
 	static _FORCE_INLINE_ uint32_t hash(const Variant &p_variant) { return p_variant.hash(); }


### PR DESCRIPTION
Allows to make an array of any size and is probably faster thanks to loop assign instead of appending.