### PR TITLE
Add details about `AudioEffectCapture.clear_buffer()` and `get_buffer()`

### DIFF
--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
-		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating point PCM.
+		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating-point PCM.
 		Unlike [AudioEffectRecord], this effect only returns the raw audio samples instead of encoding them into an [AudioStream].
 	</description>
 	<tutorials>
@@ -23,6 +23,7 @@
 			<return type="void" />
 			<description>
 				Clears the internal ring buffer.
+				[b]Note:[/b] Calling this during a capture can cause the loss of samples which causes popping in the playback.
 			</description>
 		</method>
 		<method name="get_buffer">
@@ -31,6 +32,7 @@
 			<description>
 				Gets the next [param frames] audio samples from the internal ring buffer.
 				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
+				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
 			</description>
 		</method>
 		<method name="get_buffer_length_frames" qualifiers="const">


### PR DESCRIPTION
This adds a few sentences to the AudioEffectCapture.xml documentation with helpful notes about the clear_buffer() and get_buffer() functions.

It does not fully address issue https://github.com/godotengine/godot-docs/issues/8326 , but should be useful to new users.
