### PR TITLE
Properly rename `INSTANCE_ID` and `VERTEX_ID` in canvas item shaders in the compatibility backend

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1157,8 +1157,8 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["SCREEN_PIXEL_SIZE"] = "screen_pixel_size";
 		actions.renames["FRAGCOORD"] = "gl_FragCoord";
 		actions.renames["POINT_COORD"] = "gl_PointCoord";
-		actions.renames["INSTANCE_ID"] = "gl_InstanceIndex";
-		actions.renames["VERTEX_ID"] = "gl_VertexIndex";
+		actions.renames["INSTANCE_ID"] = "gl_InstanceID";
+		actions.renames["VERTEX_ID"] = "gl_VertexID";
 
 		actions.renames["LIGHT_POSITION"] = "light_position";
 		actions.renames["LIGHT_DIRECTION"] = "light_direction";


### PR DESCRIPTION
This seems to be unreported. 

If a user tried to use ``INSTANCE_ID`` or ``VERTEX_ID`` from a CanvasItem shader the shader would fail to compile without an error in the shader editor. They would get the huge OpenGL error printed out to console though.