### PR TITLE
Fix StateMachine transition Sync not working on looped animations

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -157,7 +157,7 @@ double AnimationNodeAnimation::_process(const AnimationMixer::PlaybackInfo p_pla
 				process_state->tree->call_deferred(SNAME("emit_signal"), "animation_started", animation);
 			}
 			// Finished.
-			if (prev_time < anim_size && cur_time >= anim_size) {
+			if (prev_time < anim_size && cur_time >= anim_size && !is_looping) {
 				process_state->tree->call_deferred(SNAME("emit_signal"), "animation_finished", animation);
 			}
 		}

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -178,7 +178,7 @@ double AnimationNodeAnimation::_process(const AnimationMixer::PlaybackInfo p_pla
 	}
 	set_parameter(time, cur_time);
 
-	return is_looping ? HUGE_LENGTH : anim_size - cur_time;
+	return anim_size - cur_time;
 }
 
 String AnimationNodeAnimation::get_caption() const {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1040,13 +1040,13 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p
 		return false;
 	}
 
-    // Prevent automatic transitioning looped animations
-    bool is_looping = false;
-    Ref<AnimationNodeAnimation> node = p_state_machine->states[current].node;
-    if (node.is_valid()) {
-        Ref<Animation> anim = p_tree->get_animation(node->get_animation());
-        is_looping = anim.is_valid() && anim->get_loop_mode() != Animation::LOOP_NONE;
-    }
+	// Prevent automatic transitioning looped animations
+	bool is_looping = false;
+	Ref<AnimationNodeAnimation> node = p_state_machine->states[current].node;
+	if (node.is_valid()) {
+		Ref<Animation> anim = p_tree->get_animation(node->get_animation());
+		is_looping = anim.is_valid() && anim->get_loop_mode() != Animation::LOOP_NONE;
+	}
 
 	if (current != p_state_machine->start_node && p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END && !is_looping) {
 		return pos_current >= len_current - p_next.xfade;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1038,6 +1038,16 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p
 		return false;
 	}
 
+    // Prevent automatic transitioning looped animations
+    AnimationNode::State* state = p_state_machine->states[current].node->state;
+    if (state) {
+        AnimationPlayer *player = state->player;
+        Ref<Animation> anim = player->get_animation(player->get_current_animation());
+        if (anim.is_valid() && anim->get_loop_mode() != Animation::LOOP_NONE) {
+            return false;
+        }
+    }
+
 	if (current != p_state_machine->start_node && p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
 		return pos_current >= len_current - p_next.xfade;
 	}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -31,6 +31,8 @@
 #include "animation_node_state_machine.h"
 #include "scene/main/window.h"
 
+#include "scene/animation/animation_blend_tree.h"
+
 /////////////////////////////////////////////////
 
 void AnimationNodeStateMachineTransition::set_switch_mode(SwitchMode p_mode) {
@@ -1039,16 +1041,14 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p
 	}
 
     // Prevent automatic transitioning looped animations
-    AnimationNode::State* state = p_state_machine->states[current].node->state;
-    if (state) {
-        AnimationPlayer *player = state->player;
-        Ref<Animation> anim = player->get_animation(player->get_current_animation());
-        if (anim.is_valid() && anim->get_loop_mode() != Animation::LOOP_NONE) {
-            return false;
-        }
+    bool is_looping = false;
+    Ref<AnimationNodeAnimation> node = p_state_machine->states[current].node;
+    if (node.is_valid()) {
+        Ref<Animation> anim = p_tree->get_animation(node->get_animation());
+        is_looping = anim.is_valid() && anim->get_loop_mode() != Animation::LOOP_NONE;
     }
 
-	if (current != p_state_machine->start_node && p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
+	if (current != p_state_machine->start_node && p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END && !is_looping) {
 		return pos_current >= len_current - p_next.xfade;
 	}
 	return true;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/79505

Also properly shows the statemachine node progress on looped animations (originally static and constantly maxed out)
