### PR TITLE
Use Python venv if detected when building VS project

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -907,9 +907,16 @@ def generate_vs_project(env, original_args, project_name="godot"):
                 defines=mono_defines,
             )
 
-        env["MSVSBUILDCOM"] = module_configs.build_commandline("scons")
-        env["MSVSREBUILDCOM"] = module_configs.build_commandline("scons vsproj=yes")
-        env["MSVSCLEANCOM"] = module_configs.build_commandline("scons --clean")
+        scons_cmd = "scons"
+
+        path_to_venv = os.getenv("VIRTUAL_ENV")
+        path_to_scons_exe = Path(str(path_to_venv)) / "Scripts" / "scons.exe"
+        if path_to_venv and path_to_scons_exe.exists():
+            scons_cmd = str(path_to_scons_exe)
+
+        env["MSVSBUILDCOM"] = module_configs.build_commandline(scons_cmd)
+        env["MSVSREBUILDCOM"] = module_configs.build_commandline(f"{scons_cmd} vsproj=yes")
+        env["MSVSCLEANCOM"] = module_configs.build_commandline(f"{scons_cmd} --clean")
         if not env.get("MSVS"):
             env["MSVS"]["PROJECTSUFFIX"] = ".vcxproj"
             env["MSVS"]["SOLUTIONSUFFIX"] = ".sln"


### PR DESCRIPTION
resolves https://github.com/godotengine/godot/issues/84555

this works for me and solves my problem. I want to use a `venv` to isolate my scons installation from the rest of my system but using it is incompatible with the generated `godot.sln` since the call to `scons` assumes it's installed globally.

If a virtual environment is activated, the `VIRTUAL_ENV` env var should contain a path to its root, and from there we can build the proper command.

No hard feelings if we don't wanna merge this, but it's useful to me ;)
