### PR TITLE
Comment the shader template light function by default

### DIFF
--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -175,9 +175,10 @@ void fragment() {
 	// Called for every pixel the material is visible on.
 }
 
-void light() {
+//void light() {
 	// Called for every pixel for every light affecting the material.
-}
+	// Uncomment to replace the default light processing function with this one.
+//}
 )";
 						break;
 					case Shader::MODE_CANVAS_ITEM:
@@ -190,9 +191,10 @@ void fragment() {
 	// Called for every pixel the material is visible on.
 }
 
-void light() {
+//void light() {
 	// Called for every pixel for every light affecting the CanvasItem.
-}
+	// Uncomment to replace the default light processing function with this one.
+//}
 )";
 						break;
 					case Shader::MODE_PARTICLES:


### PR DESCRIPTION
This is a minor usability tweak.

The light functions replace the default ones, so even if empty they will avoid the current shader to have proper lighting and users will have no idea why.

Code was changed to have the shader function commented by default, indicating that uncommenting replaces the default function.

_Bugsquad edit: fixes: https://github.com/godotengine/godot/issues/84639_

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
