### PR TITLE
Optimize `find` in `Array` and `CowData`

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -341,20 +341,16 @@ Error CowData<T>::resize(int p_size) {
 
 template <class T>
 int CowData<T>::find(const T &p_val, int p_from) const {
-	int ret = -1;
-
 	if (p_from < 0 || size() == 0) {
-		return ret;
+		return -1;
 	}
 
 	for (int i = p_from; i < size(); i++) {
 		if (get(i) == p_val) {
-			ret = i;
-			break;
+			return i;
 		}
 	}
-
-	return ret;
+	return -1;
 }
 
 template <class T>

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -337,20 +337,16 @@ int Array::find(const Variant &p_value, int p_from) const {
 	Variant value = p_value;
 	ERR_FAIL_COND_V(!_p->typed.validate(value, "find"), -1);
 
-	int ret = -1;
-
 	if (p_from < 0 || size() == 0) {
-		return ret;
+		return -1;
 	}
 
 	for (int i = p_from; i < size(); i++) {
 		if (StringLikeVariantComparator::compare(_p->array[i], value)) {
-			ret = i;
-			break;
+			return i;
 		}
 	}
-
-	return ret;
+	return -1;
 }
 
 int Array::rfind(const Variant &p_value, int p_from) const {


### PR DESCRIPTION
The array's find implementation looped through all elements, even after finding a corresponding element. On one hand this results in finding the last element (which is already available by rfind), but is also ineffient and can cause issues, when a partial element is followed by a complete element (finding the partial one can cause runtime errors)

To clarify, I was using a comment indenting algorithm, that indented each comment based on their parent comment's level of indentation. It was known, that the parent comment will be positioned in the array, before any element without the indentation field (that's what I referred to as partial data) but this implementation caused an error

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
