### PR TITLE
Keep Variant type after `zero()`

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1291,7 +1291,13 @@ void Variant::zero() {
 			break;
 
 		default:
+			Type prev_type = type;
 			this->clear();
+			if (type != prev_type) {
+				// clear() changes type to NIL, so it needs to be restored.
+				Callable::CallError ce;
+				Variant::construct(prev_type, *this, nullptr, 0, ce);
+			}
 			break;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-demo-projects/issues/979
Regression from https://github.com/godotengine/godot/pull/80813

`Variant.zero()` (apparently used by animation) is supposed to revert the value to default. However in case of some types, it clears internals and changes the type to NIL. This PR ensures that the type is retained and initializes the value anew. (tested only with Transform3D)