### PR TITLE
[GUI] Adds system font fallback configuration warnings.

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1456,6 +1456,13 @@
 				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking (see [enum GraphemeFlag]).
 			</description>
 		</method>
+		<method name="shaped_text_has_invalid_chars" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+				Returns [code]true[/code] if text buffer contains any invalid characters.
+			</description>
+		</method>
 		<method name="shaped_text_has_visible_chars" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
@@ -1484,6 +1491,13 @@
 			<param index="0" name="shaped" type="RID" />
 			<description>
 				Returns [code]true[/code] if buffer is successfully shaped.
+			</description>
+		</method>
+		<method name="shaped_text_is_using_system_font_fallback" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+				Returns [code]true[/code] if text buffer is using system font fallbacks.
 			</description>
 		</method>
 		<method name="shaped_text_next_character_pos" qualifiers="const">

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1276,6 +1276,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_shaped_text_is_using_system_font_fallback" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_shaped_text_next_character_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -4161,6 +4161,8 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	EDITOR_DEF("interface/editors/show_scene_tree_root_selection", true);
 	EDITOR_DEF("interface/editors/derive_script_globals_by_name", true);
 	EDITOR_DEF("docks/scene_tree/ask_before_deleting_related_animation_tracks", true);
+	EDITOR_DEF("docks/scene_tree/system_font_fallback_warnings", true);
+	EDITOR_DEF("docks/scene_tree/missing_glyphs_warnings", true);
 	EDITOR_DEF("_use_favorites_root_selection", false);
 
 	Resource::_update_configuration_warning = _update_configuration_warning;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -3923,6 +3923,7 @@ void TextServerAdvanced::invalidate(TextServerAdvanced::ShapedTextDataAdvanced *
 	p_shaped->line_breaks_valid = false;
 	p_shaped->justification_ops_valid = false;
 	p_shaped->text_trimmed = false;
+	p_shaped->use_sysfb = false;
 	p_shaped->ascent = 0.0;
 	p_shaped->descent = 0.0;
 	p_shaped->width = 0.0;
@@ -5640,6 +5641,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 					}
 					if (best_match != -1) {
 						f = sysf_cache.var[best_match].rid;
+						p_sd->use_sysfb = true;
 					}
 				}
 				if (!f.is_valid()) {
@@ -5737,6 +5739,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 						sysf_cache.var.push_back(sysf);
 					}
 					f = sysf.rid;
+					p_sd->use_sysfb = true;
 				}
 				break;
 			}
@@ -6198,6 +6201,14 @@ bool TextServerAdvanced::_shaped_text_is_ready(const RID &p_shaped) const {
 
 	MutexLock lock(sd->mutex);
 	return sd->valid;
+}
+
+bool TextServerAdvanced::_shaped_text_is_using_system_font_fallback(const RID &p_shaped) const {
+	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	ERR_FAIL_NULL_V(sd, false);
+
+	MutexLock lock(sd->mutex);
+	return sd->use_sysfb;
 }
 
 const Glyph *TextServerAdvanced::_shaped_text_get_glyphs(const RID &p_shaped) const {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -489,6 +489,7 @@ class TextServerAdvanced : public TextServerExtension {
 		bool justification_ops_valid = false; // Virtual elongation glyphs are added to the string.
 		bool sort_valid = false;
 		bool text_trimmed = false;
+		bool use_sysfb = false;
 
 		bool preserve_invalid = true; // Draw hex code box instead of missing characters.
 		bool preserve_control = false; // Draw control characters.
@@ -937,6 +938,7 @@ public:
 	MODBIND3(shaped_text_overrun_trim_to_width, const RID &, double, BitField<TextServer::TextOverrunFlag>);
 
 	MODBIND1RC(bool, shaped_text_is_ready, const RID &);
+	MODBIND1RC(bool, shaped_text_is_using_system_font_fallback, const RID &);
 
 	MODBIND1RC(const Glyph *, shaped_text_get_glyphs, const RID &);
 	MODBIND1R(const Glyph *, shaped_text_sort_logical, const RID &);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3810,6 +3810,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 	sd->descent = 0.0;
 	sd->width = 0.0;
 	sd->glyphs.clear();
+	sd->use_sysfb = false;
 
 	if (sd->text.length() == 0) {
 		sd->valid = true;
@@ -3928,6 +3929,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 								}
 								if (best_match != -1) {
 									gl.font_rid = sysf_cache.var[best_match].rid;
+									sd->use_sysfb = true;
 								}
 							}
 							if (!gl.font_rid.is_valid()) {
@@ -4025,6 +4027,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 									sysf_cache.var.push_back(sysf);
 								}
 								gl.font_rid = sysf.rid;
+								sd->use_sysfb = true;
 							}
 							break;
 						}
@@ -4105,6 +4108,14 @@ bool TextServerFallback::_shaped_text_is_ready(const RID &p_shaped) const {
 
 	MutexLock lock(sd->mutex);
 	return sd->valid;
+}
+
+bool TextServerFallback::_shaped_text_is_using_system_font_fallback(const RID &p_shaped) const {
+	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
+	ERR_FAIL_NULL_V(sd, false);
+
+	MutexLock lock(sd->mutex);
+	return sd->use_sysfb;
 }
 
 const Glyph *TextServerFallback::_shaped_text_get_glyphs(const RID &p_shaped) const {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -434,6 +434,7 @@ class TextServerFallback : public TextServerExtension {
 		bool justification_ops_valid = false; // Virtual elongation glyphs are added to the string.
 		bool sort_valid = false;
 		bool text_trimmed = false;
+		bool use_sysfb = false;
 
 		bool preserve_invalid = true; // Draw hex code box instead of missing characters.
 		bool preserve_control = false; // Draw control characters.
@@ -804,6 +805,7 @@ public:
 	MODBIND3(shaped_text_overrun_trim_to_width, const RID &, double, BitField<TextServer::TextOverrunFlag>);
 
 	MODBIND1RC(bool, shaped_text_is_ready, const RID &);
+	MODBIND1RC(bool, shaped_text_is_using_system_font_fallback, const RID &);
 
 	MODBIND1RC(const Glyph *, shaped_text_get_glyphs, const RID &);
 	MODBIND1R(const Glyph *, shaped_text_sort_logical, const RID &);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -43,6 +43,10 @@ private:
 	String xl_text;
 	Ref<TextParagraph> text_buf;
 
+	mutable bool cw_dirty = true;
+	mutable bool cw_sysfont = false;
+	mutable bool cw_invchar = false;
+
 	String language;
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;
 	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
@@ -107,6 +111,7 @@ protected:
 
 public:
 	virtual Size2 get_minimum_size() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	Size2 get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon) const;
 

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -49,6 +49,10 @@ private:
 	Size2 minsize;
 	bool uppercase = false;
 
+	mutable bool cw_dirty = true;
+	mutable bool cw_sysfont = false;
+	mutable bool cw_invchar = false;
+
 	bool lines_dirty = true;
 	bool dirty = true;
 	bool font_dirty = true;

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -141,6 +141,10 @@ private:
 	bool drag_action = false;
 	bool drag_caret_force_displayed = false;
 
+	mutable bool cw_dirty = true;
+	mutable bool cw_sysfont = false;
+	mutable bool cw_invchar = false;
+
 	Ref<Texture2D> right_icon;
 	bool flat = false;
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -443,6 +443,10 @@ private:
 	bool underline_hint = true;
 	bool use_selected_font_color = false;
 
+	mutable bool cw_dirty = true;
+	mutable bool cw_sysfont = false;
+	mutable bool cw_invchar = false;
+
 	HorizontalAlignment default_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	BitField<TextServer::JustificationFlag> default_jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE;
 
@@ -797,6 +801,7 @@ public:
 	void install_effect(const Variant effect);
 
 	virtual Size2 get_minimum_size() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	RichTextLabel(const String &p_text = String());
 	~RichTextLabel();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -264,6 +264,10 @@ private:
 	bool alt_start = false;
 	uint32_t alt_code = 0;
 
+	mutable bool cw_dirty = true;
+	mutable bool cw_sysfont = false;
+	mutable bool cw_invchar = false;
+
 	// Text properties.
 	String ime_text = "";
 	Point2 ime_selection;
@@ -685,6 +689,7 @@ public:
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
 	bool alt_input(const Ref<InputEvent> &p_gui_input);
 	virtual Size2 get_minimum_size() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 	virtual bool is_text_field() const override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 	virtual Variant get_drag_data(const Point2 &p_point) override;

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -267,6 +267,7 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shaped_text_update_justification_ops, "shaped");
 
 	GDVIRTUAL_BIND(_shaped_text_is_ready, "shaped");
+	GDVIRTUAL_BIND(_shaped_text_is_using_system_font_fallback, "shaped");
 
 	GDVIRTUAL_BIND(_shaped_text_get_glyphs, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_sort_logical, "shaped");
@@ -1167,6 +1168,12 @@ bool TextServerExtension::shaped_text_update_justification_ops(const RID &p_shap
 bool TextServerExtension::shaped_text_is_ready(const RID &p_shaped) const {
 	bool ret = false;
 	GDVIRTUAL_CALL(_shaped_text_is_ready, p_shaped, ret);
+	return ret;
+}
+
+bool TextServerExtension::shaped_text_is_using_system_font_fallback(const RID &p_shaped) const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_is_using_system_font_fallback, p_shaped, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -444,6 +444,8 @@ public:
 
 	virtual bool shaped_text_is_ready(const RID &p_shaped) const override;
 	GDVIRTUAL1RC(bool, _shaped_text_is_ready, RID);
+	virtual bool shaped_text_is_using_system_font_fallback(const RID &p_shaped) const override;
+	GDVIRTUAL1RC(bool, _shaped_text_is_using_system_font_fallback, RID);
 
 	virtual const Glyph *shaped_text_get_glyphs(const RID &p_shaped) const override;
 	virtual const Glyph *shaped_text_sort_logical(const RID &p_shaped) override;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -418,6 +418,8 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shaped_text_shape", "shaped"), &TextServer::shaped_text_shape);
 	ClassDB::bind_method(D_METHOD("shaped_text_is_ready", "shaped"), &TextServer::shaped_text_is_ready);
 	ClassDB::bind_method(D_METHOD("shaped_text_has_visible_chars", "shaped"), &TextServer::shaped_text_has_visible_chars);
+	ClassDB::bind_method(D_METHOD("shaped_text_has_invalid_chars", "shaped"), &TextServer::shaped_text_has_invalid_chars);
+	ClassDB::bind_method(D_METHOD("shaped_text_is_using_system_font_fallback", "shaped"), &TextServer::shaped_text_is_using_system_font_fallback);
 
 	ClassDB::bind_method(D_METHOD("shaped_text_get_glyphs", "shaped"), &TextServer::_shaped_text_get_glyphs_wrapper);
 	ClassDB::bind_method(D_METHOD("shaped_text_sort_logical", "shaped"), &TextServer::_shaped_text_sort_logical_wrapper);
@@ -716,6 +718,21 @@ bool TextServer::shaped_text_has_visible_chars(const RID &p_shaped) const {
 	const Glyph *glyphs = shaped_text_get_glyphs(p_shaped);
 	for (int i = 0; i < v_size; i++) {
 		if (glyphs[i].index != 0 && (glyphs[i].flags & GRAPHEME_IS_VIRTUAL) != GRAPHEME_IS_VIRTUAL) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool TextServer::shaped_text_has_invalid_chars(const RID &p_shaped) const {
+	int v_size = shaped_text_get_glyph_count(p_shaped);
+	if (v_size == 0) {
+		return false;
+	}
+
+	const Glyph *glyphs = shaped_text_get_glyphs(p_shaped);
+	for (int i = 0; i < v_size; i++) {
+		if (glyphs[i].font_rid.is_null() && (glyphs[i].flags & GRAPHEME_IS_VIRTUAL) != GRAPHEME_IS_VIRTUAL) {
 			return true;
 		}
 	}

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -459,6 +459,8 @@ public:
 
 	virtual bool shaped_text_is_ready(const RID &p_shaped) const = 0;
 	bool shaped_text_has_visible_chars(const RID &p_shaped) const;
+	bool shaped_text_has_invalid_chars(const RID &p_shaped) const;
+	virtual bool shaped_text_is_using_system_font_fallback(const RID &p_shaped) const = 0;
 
 	virtual const Glyph *shaped_text_get_glyphs(const RID &p_shaped) const = 0;
 	TypedArray<Dictionary> _shaped_text_get_glyphs_wrapper(const RID &p_shaped) const;


### PR DESCRIPTION
Intended to prevent issues like https://github.com/godotengine/godot/issues/84590. While automatic fallback is convenient for the development, system font might be different or missing on different systems (and not supported on Web), therefor not a reliable way to design GUI.

- Adds a method to determine when text buffer is using system font fallback.
- Adds a configuration warning to the text nodes using system font fallback (currently added to `Label`, `LineEdit`, `TextEdit` and `RTL`, but probably should be extended to all nodes with text).
- Adds editor option to disable these warnings.

Note: warning is displayed only when automatic fallback is used, but not when setting up specific system font manually.