### PR TITLE
Fix CollisionObject3D Gizmo not updated after calling `shape_owner_*` functions

### DIFF
--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -624,6 +624,7 @@ void CollisionObject3D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3
 	total_subshapes++;
 
 	_update_shape_data(p_owner);
+	update_gizmos();
 }
 
 int CollisionObject3D::shape_owner_get_shape_count(uint32_t p_owner) const {
@@ -687,6 +688,8 @@ void CollisionObject3D::shape_owner_clear_shapes(uint32_t p_owner) {
 	while (shape_owner_get_shape_count(p_owner) > 0) {
 		shape_owner_remove_shape(p_owner, 0);
 	}
+
+	update_gizmos();
 }
 
 uint32_t CollisionObject3D::shape_find_owner(int p_shape_index) const {


### PR DESCRIPTION
Fixes #84540

Two things to disscuss:
1. potential performance problem because of additional calls to `update_gizmo`
2. Is there any other defered gizmo update call be immediate
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
