### PR TITLE
Prevent encoding/decoding objects that cannot be instantiated

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -638,6 +638,8 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 				if (str.is_empty()) {
 					r_variant = (Object *)nullptr;
 				} else {
+					ERR_FAIL_COND_V(!ClassDB::can_instantiate(str), ERR_INVALID_DATA);
+
 					Object *obj = ClassDB::instantiate(str);
 
 					ERR_FAIL_NULL_V(obj, ERR_UNAVAILABLE);
@@ -1492,6 +1494,8 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 					r_len += 4;
 
 				} else {
+					ERR_FAIL_COND_V(!ClassDB::can_instantiate(obj->get_class()), ERR_INVALID_PARAMETER);
+
 					_encode_string(obj->get_class(), buf, r_len);
 
 					List<PropertyInfo> props;


### PR DESCRIPTION
Ensures that encoding classes that cannot be instantiated errors, both when encoding and decoding

Could make the error message more descriptive but starting out simple

The decoding side isn't necessarily needed but it reduces the error count and could add a clearer message as well there (though I think the error return is better, `ERR_INVALID_DATA` over `ERR_UNAVAILABLE`)

* Closes: #84552

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
