### PR TITLE
Only build glslang if Vulkan or Direct3D 12 rendering is enabled

### DIFF
--- a/modules/glslang/config.py
+++ b/modules/glslang/config.py
@@ -1,5 +1,7 @@
 def can_build(env, platform):
-    return True
+    # glslang is only needed when Vulkan or Direct3D 12-based renderers are available,
+    # as OpenGL doesn't use glslang.
+    return env["vulkan"] or env["d3d12"]
 
 
 def configure(env):


### PR DESCRIPTION
glslang isn't needed for OpenGL rendering, which includes the web export. This reduces the web release export template's `.wasm` size by about 20 KB, since web builds use `vulkan=no`.

This check may need to be revisited once https://github.com/godotengine/godot/pull/70315 is merged, as I assume the Direct3D 12 renderer also needs the glslang module to be enabled.

I found this while working on https://github.com/godotengine/godot-docs/pull/8424 :slightly_smiling_face: 