### PR TITLE
Correctly set up shortcut context in the shader editor

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -609,6 +609,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	vb->add_child(menu_hb);
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("File"));
+	file_menu->set_shortcut_context(main_split);
 	file_menu->get_popup()->add_item(TTR("New Shader"), FILE_NEW);
 	file_menu->get_popup()->add_item(TTR("New Shader Include"), FILE_NEW_INCLUDE);
 	file_menu->get_popup()->add_separator();


### PR DESCRIPTION
Fixes the main bug in https://github.com/godotengine/godot/issues/84601 (the discussion should still continue about the usability, but this resolves the bug that gets in the way of saving scenes).
