### PR TITLE
Save scene together with script/shader when Ctrl+S is pressed.

### DIFF
--- a/core/input/shortcut.cpp
+++ b/core/input/shortcut.cpp
@@ -86,6 +86,30 @@ String Shortcut::get_as_text() const {
 	return "None";
 }
 
+bool Shortcut::is_match(const Ref<Shortcut> &p_shortcut) const {
+	if (p_shortcut.is_null()) {
+		return false;
+	}
+
+	for (int i = 0; i < events.size(); i++) {
+		Ref<InputEvent> ie = events[i];
+		if (!ie.is_valid()) {
+			continue;
+		}
+		for (int j = 0; j < p_shortcut->events.size(); j++) {
+			Ref<InputEvent> ie_overlap = p_shortcut->events[i];
+			if (!ie_overlap.is_valid()) {
+				continue;
+			}
+
+			if (ie->is_match(ie_overlap)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 bool Shortcut::has_valid_event() const {
 	// Tests if there is ANY input event which is valid.
 	for (int i = 0; i < events.size(); i++) {

--- a/core/input/shortcut.h
+++ b/core/input/shortcut.h
@@ -51,6 +51,8 @@ public:
 	bool matches_event(const Ref<InputEvent> &p_event) const;
 	bool has_valid_event() const;
 
+	bool is_match(const Ref<Shortcut> &p_shortcut) const;
+
 	String get_as_text() const;
 
 	static bool is_event_array_equal(const Array &p_event_array1, const Array &p_event_array2);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -581,7 +581,7 @@ private:
 	void _set_current_scene(int p_idx);
 	void _set_current_scene_nocheck(int p_idx);
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);
-	void _save_scene(String p_file, int idx = -1);
+	void _save_scene(String p_file, int idx = -1, bool p_show_error_dialogs = true);
 	void _save_all_scenes();
 	int _next_unsaved_scene(bool p_valid_filename, int p_start = 0);
 	void _discard_changes(const String &p_str = String());
@@ -622,7 +622,7 @@ private:
 	void _mark_unsaved_scenes();
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
-	void _save_scene_with_preview(String p_file, int p_idx = -1);
+	void _save_scene_with_preview(String p_file, int p_idx = -1, bool p_show_error_dialogs = true);
 
 	bool _find_scene_in_use(Node *p_node, const String &p_path) const;
 
@@ -877,6 +877,8 @@ public:
 	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only);
 
 	Control *get_gui_base() { return gui_base; }
+
+	void save_scene_if_valid();
 
 	void save_scene_to_path(String p_file, bool p_with_preview = true) {
 		if (p_with_preview) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1311,6 +1311,18 @@ void ScriptEditor::_menu_option(int p_option) {
 		switch (p_option) {
 			case FILE_SAVE: {
 				save_current_script();
+				{
+					// If both scene and script use same shortcut to save (most likely ctrl-s),
+					// save the current scene silently (omitting error dialogs if any).
+					Ref<Shortcut> save_shortcut = ED_GET_SHORTCUT("script_editor/save");
+					Ref<Shortcut> scene_save_shortcut = ED_GET_SHORTCUT("editor/save_scene");
+					if (save_shortcut.is_valid()) {
+						if (save_shortcut->is_match(scene_save_shortcut)) {
+							EditorNode::get_singleton()->save_scene_if_valid();
+						}
+					}
+				}
+
 			} break;
 			case FILE_SAVE_AS: {
 				if (trim_trailing_whitespace_on_save) {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -413,11 +413,29 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 			if (editor && editor->get_trim_trailing_whitespace_on_save()) {
 				editor->trim_trailing_whitespace();
 			}
+
+			Ref<Resource> resource;
 			if (edited_shaders[index].shader.is_valid()) {
-				EditorNode::get_singleton()->save_resource(edited_shaders[index].shader);
+				resource = edited_shaders[index].shader;
 			} else {
-				EditorNode::get_singleton()->save_resource(edited_shaders[index].shader_inc);
+				resource = edited_shaders[index].shader_inc;
 			}
+
+			EditorNode::get_singleton()->save_resource(resource);
+
+			if (resource->get_path().is_resource_file()) {
+				// If resource file exists, this means that the shader will not trigger a save-as popup-up.
+				// If both scene and script use same shortcut to save (most likely ctrl-s),
+				// save the current scene silently (omitting error dialogs if any).
+				Ref<Shortcut> save_shortcut = ED_GET_SHORTCUT("shader_editor/save");
+				Ref<Shortcut> scene_save_shortcut = ED_GET_SHORTCUT("editor/save_scene");
+				if (save_shortcut.is_valid()) {
+					if (save_shortcut->is_match(scene_save_shortcut)) {
+						EditorNode::get_singleton()->save_scene_if_valid();
+					}
+				}
+			}
+
 			if (editor) {
 				editor->tag_saved_version();
 			}


### PR DESCRIPTION
Fixes #84601.

If both *"Script -> Save Script"* and *"Scene -> Save Scene"* use the same shortcut, the scene will also silently be saved (just like before), since many users are not necessarily aware that the script or shader editor editors are focused at the time of saving. Now, however, if something causes the save to fail it will not be notified to the user, to avoid the annoyance caused by #84039.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
