### PR TITLE
Remove AnimatedSprite pointer when clearing editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1322,8 +1322,9 @@ void SpriteFramesEditor::_edit() {
 void SpriteFramesEditor::edit(Ref<SpriteFrames> p_frames) {
 	_update_stop_icon();
 
-	if (!p_frames.is_valid()) {
+	if (p_frames.is_null()) {
 		frames.unref();
+		_remove_sprite_node();
 		hide();
 		return;
 	}


### PR DESCRIPTION
When SpriteFramesEditor was unedited, the SpriteFrames were removed, but the node was not, resulting in some wrong conditions.

Fixes #84343