### PR TITLE
Don't store shader edit path in metadata

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -65,9 +65,7 @@ void ShaderEditorPlugin::_update_shader_list() {
 		}
 
 		// When shader is deleted in filesystem dock, need this to correctly close shader editor.
-		if (!path.is_empty()) {
-			shader->set_meta("_edit_res_path", path);
-		}
+		edited_shader.path = path;
 
 		bool unsaved = false;
 		if (edited_shader.shader_editor) {
@@ -578,9 +576,9 @@ void ShaderEditorPlugin::_window_changed(bool p_visible) {
 
 void ShaderEditorPlugin::_file_removed(const String &p_removed_file) {
 	for (uint32_t i = 0; i < edited_shaders.size(); i++) {
-		const Ref<Shader> &shader = edited_shaders[i].shader;
-		if (shader->get_meta("_edit_res_path") == p_removed_file) {
+		if (edited_shaders[i].path == p_removed_file) {
 			_close_shader(i);
+			break;
 		}
 	}
 }

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -50,6 +50,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 		Ref<ShaderInclude> shader_inc;
 		TextShaderEditor *shader_editor = nullptr;
 		VisualShaderEditor *visual_shader_editor = nullptr;
+		String path;
 	};
 
 	LocalVector<EditedShader> edited_shaders;


### PR DESCRIPTION
Fixes regression from #83137

The `_edit_res_path` meta was saved in the file. The code was inspired by script editor, but there the meta is applied to script sub-editors, not script themselves.