### PR TITLE
Add PropertyListHelper

### DIFF
--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -33,6 +33,7 @@
 
 #include "scene/gui/control.h"
 #include "scene/gui/scroll_bar.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/text_paragraph.h"
 
 class ItemList : public Control {
@@ -82,7 +83,12 @@ private:
 		Item() {
 			text_buf.instantiate();
 		}
+
+		Item(bool p_dummy) {}
 	};
+
+	static PropertyListHelper base_property_helper;
+	PropertyListHelper property_helper;
 
 	int current = -1;
 	int hovered = -1;
@@ -157,6 +163,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 	static void _bind_methods();
 
 public:

--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -1,0 +1,138 @@
+/**************************************************************************/
+/*  property_list_helper.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "property_list_helper.h"
+
+const PropertyListHelper::Property *PropertyListHelper::_get_property(const String &p_property, int *r_index) const {
+	const Vector<String> components = p_property.split("/", true, 2);
+	if (components.size() < 2 || !components[0].begins_with(prefix)) {
+		return nullptr;
+	}
+
+	{
+		const String index_string = components[0].trim_prefix(prefix);
+		if (!index_string.is_valid_int()) {
+			return nullptr;
+		}
+		*r_index = index_string.to_int();
+	}
+
+	return property_list.getptr(components[1]);
+}
+
+void PropertyListHelper::_bind_property(const Property &p_property, const Object *p_object) {
+	Property property = p_property;
+	property.info = p_property.info;
+	property.default_value = p_property.default_value;
+	property.setter = Callable(p_object, p_property.setter_name);
+	property.getter = Callable(p_object, p_property.getter_name);
+
+	property_list[property.info.name] = property;
+}
+
+void PropertyListHelper::set_prefix(const String &p_prefix) {
+	prefix = p_prefix;
+}
+
+void PropertyListHelper::register_property(const PropertyInfo &p_info, const Variant &p_default, const StringName &p_setter, const StringName &p_getter) {
+	Property property;
+	property.info = p_info;
+	property.default_value = p_default;
+	property.setter_name = p_setter;
+	property.getter_name = p_getter;
+
+	property_list[p_info.name] = property;
+}
+
+void PropertyListHelper::setup_for_instance(const PropertyListHelper &p_base, const Object *p_object) {
+	prefix = p_base.prefix;
+	for (const KeyValue<String, Property> &E : p_base.property_list) {
+		_bind_property(E.value, p_object);
+	}
+}
+
+void PropertyListHelper::get_property_list(List<PropertyInfo> *p_list, int p_count) const {
+	for (int i = 0; i < p_count; i++) {
+		for (const KeyValue<String, Property> &E : property_list) {
+			const Property &property = E.value;
+
+			PropertyInfo info = property.info;
+			if (property.getter.call(i) == property.default_value) {
+				info.usage &= (~PROPERTY_USAGE_STORAGE);
+			}
+
+			info.name = vformat("%s%d/%s", prefix, i, info.name);
+			p_list->push_back(info);
+		}
+	}
+}
+
+bool PropertyListHelper::property_get_value(const String &p_property, Variant &r_ret) const {
+	int index;
+	const Property *property = _get_property(p_property, &index);
+
+	if (property) {
+		r_ret = property->getter.call(index);
+		return true;
+	}
+	return false;
+}
+
+bool PropertyListHelper::property_set_value(const String &p_property, const Variant &p_value) const {
+	int index;
+	const Property *property = _get_property(p_property, &index);
+
+	if (property) {
+		property->setter.call(index, p_value);
+		return true;
+	}
+	return false;
+}
+
+bool PropertyListHelper::property_can_revert(const String &p_property) const {
+	int index;
+	const Property *property = _get_property(p_property, &index);
+
+	if (property) {
+		return property->getter.call(index) != property->default_value;
+	}
+	return false;
+}
+
+bool PropertyListHelper::property_get_revert(const String &p_property, Variant &r_value) const {
+	int index;
+	const Property *property = _get_property(p_property, &index);
+
+	if (property) {
+		r_value = property->default_value;
+		return true;
+	}
+	return false;
+}

--- a/scene/property_list_helper.h
+++ b/scene/property_list_helper.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  property_list_helper.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PROPERTY_LIST_HELPER_H
+#define PROPERTY_LIST_HELPER_H
+
+#include "core/object/object.h"
+
+class PropertyListHelper {
+	struct Property {
+		PropertyInfo info;
+		Variant default_value;
+		StringName setter_name;
+		StringName getter_name;
+		Callable setter;
+		Callable getter;
+	};
+
+	String prefix;
+	HashMap<String, Property> property_list;
+
+	const Property *_get_property(const String &p_property, int *r_index) const;
+	void _bind_property(const Property &p_property, const Object *p_object);
+
+public:
+	void set_prefix(const String &p_prefix);
+	void register_property(const PropertyInfo &p_info, const Variant &p_default, const StringName &p_setter, const StringName &p_getter);
+	void setup_for_instance(const PropertyListHelper &p_base, const Object *p_object);
+
+	void get_property_list(List<PropertyInfo> *p_list, int p_count) const;
+	bool property_get_value(const String &p_property, Variant &r_ret) const;
+	bool property_set_value(const String &p_property, const Variant &p_value) const;
+	bool property_can_revert(const String &p_property) const;
+	bool property_get_revert(const String &p_property, Variant &r_value) const;
+};
+
+#endif // PROPERTY_LIST_HELPER_H


### PR DESCRIPTION
Follow-up to #83888 (partially)

This PR adds PropertyListHelper. It's a helper class for managing dynamic properties added with `_get_property_list()`. Initialize it with prefix, then register properties with name, default, setter and getter. Afterwards, instead of implementing `_get_property_list()`, `_set()` and `_get()`, just call a method in the helper and it handles everything for you. As a bonus it can also handle reverts.

I added it to ItemList. Property handling is now a bunch of one-liners, while the functionality has improved. Defaults no longer save in the scene and you can revert.

https://github.com/godotengine/godot/assets/2223172/39c4900e-1681-4be4-a292-34e136867eaf

I will do a follow-up to apply it to all relevant classes (TileMap, PopupMenu and probably some others).

UPDATE
In the second commit I changed how properties are registered and the 2 implementations are different. idk which one is better.

_Production edit: closes godotengine/godot-roadmap#14_