### PR TITLE
Fix `Node3D` children using `top_level` in different position in-editor versus runtime

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -149,7 +149,11 @@ void Node3D::_notification(int p_what) {
 
 			if (data.top_level && !Engine::get_singleton()->is_editor_hint()) {
 				if (data.parent) {
-					data.local_transform = data.parent->get_global_transform() * get_transform();
+					if (!data.top_level) {
+						data.local_transform = data.parent->get_global_transform() * get_transform();
+					} else {
+						data.local_transform = get_transform();
+					}
 					_replace_dirty_mask(DIRTY_EULER_ROTATION_AND_SCALE); // As local transform was updated, rot/scale should be dirty.
 				}
 			}
@@ -738,7 +742,7 @@ void Node3D::set_as_top_level(bool p_enabled) {
 	if (data.top_level == p_enabled) {
 		return;
 	}
-	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+	if (is_inside_tree()) {
 		if (p_enabled) {
 			set_transform(get_global_transform());
 		} else if (data.parent) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/84290

Factored in top_level when setting position the first time a tree is entered. I had to get rid of the !Engine::get_singleton()->is_editor_hint() to make position information update immediately upon setting top_level, otherwise the position would remain incorrect until the object is moved again. If the object isn't wasn't moved prior to running the game, the problem would persist as the position information would be incorrect.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
