### PR TITLE
Take care of Plane => vec4 type conversion when converting materials

### DIFF
--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -391,6 +391,12 @@ Ref<Resource> StandardMaterial3DConversionPlugin::convert(const Ref<Resource> &p
 			smat->set_shader_parameter(E.name, texture);
 		} else {
 			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+
+			// "_texture_channel" params need to be converted to vec4.
+			if (value.get_type() == Variant::PLANE && E.name.contains("_texture_channel")) {
+				Plane p = value;
+				value = Vector4(p.normal.x, p.normal.y, p.normal.z, p.d);
+			}
 			smat->set_shader_parameter(E.name, value);
 		}
 	}


### PR DESCRIPTION
Fixes #84633

Also, I'm a little curious why we use `Plane` as the parameter type at the first place.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
