### PR TITLE
Avoid punning enum names in documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1393,7 +1393,7 @@
 			<description>
 				Converts the given [param variant] to the given [param type], using the [enum Variant.Type] values. This method is generous with how it handles types, it can automatically convert between array types, convert numeric [String]s to [int], and converting most things to [String].
 				If the type conversion cannot be done, this method will return the default value for that type, for example converting [Rect2] to [Vector2] will always return [constant Vector2.ZERO]. This method will never show error messages as long as [param type] is a valid Variant type.
-				The returned value is a [Variant], but the data inside and the [enum Variant.Type] will be the same as the requested type.
+				The returned value is a [Variant], but the data inside and its type will be the same as the requested type.
 				[codeblock]
 				type_convert("Hi!", TYPE_INT) # Returns 0
 				type_convert("123", TYPE_INT) # Returns 123

--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -48,7 +48,7 @@
 		<method name="get_packet_mode" qualifiers="const">
 			<return type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
-				Returns the [enum MultiplayerPeer.TransferMode] the remote peer used to send the next available packet. See [method PacketPeer.get_available_packet_count].
+				Returns the transfer mode the remote peer used to send the next available packet. See [method PacketPeer.get_available_packet_count].
 			</description>
 		</method>
 		<method name="get_packet_peer" qualifiers="const">

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -58,7 +58,7 @@
 		<method name="_get_packet_mode" qualifiers="virtual const">
 			<return type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
-				Called to get the [enum MultiplayerPeer.TransferMode] the remote peer used to send the next available packet. See [method MultiplayerPeer.get_packet_mode].
+				Called to get the transfer mode the remote peer used to send the next available packet. See [method MultiplayerPeer.get_packet_mode].
 			</description>
 		</method>
 		<method name="_get_packet_peer" qualifiers="virtual const">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3329,7 +3329,7 @@
 			<return type="int" enum="Image.Format" />
 			<param index="0" name="texture" type="RID" />
 			<description>
-				Returns the [enum Image.Format] for the texture.
+				Returns the format for the texture.
 			</description>
 		</method>
 		<method name="texture_get_native_handle" qualifiers="const">

--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -90,7 +90,7 @@
 			<return type="int" enum="TileSetAtlasSource.TileAnimationMode" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns the [enum TileAnimationMode] of the tile at [param atlas_coords]. See also [method set_tile_animation_mode].
+				Returns the tile animation mode of the tile at [param atlas_coords]. See also [method set_tile_animation_mode].
 			</description>
 		</method>
 		<method name="get_tile_animation_separation" qualifiers="const">
@@ -239,7 +239,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="mode" type="int" enum="TileSetAtlasSource.TileAnimationMode" />
 			<description>
-				Sets the [enum TileAnimationMode] of the tile at [param atlas_coords] to [param mode]. See also [method get_tile_animation_mode].
+				Sets the tile animation mode of the tile at [param atlas_coords] to [param mode]. See also [method get_tile_animation_mode].
 			</description>
 		</method>
 		<method name="set_tile_animation_separation">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -75,7 +75,7 @@
 			<return type="int" enum="Viewport.PositionalShadowAtlasQuadrantSubdiv" />
 			<param index="0" name="quadrant" type="int" />
 			<description>
-				Returns the [enum PositionalShadowAtlasQuadrantSubdiv] of the specified quadrant.
+				Returns the positional shadow atlas quadrant subdivision of the specified quadrant.
 			</description>
 		</method>
 		<method name="get_render_info">

--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -119,7 +119,7 @@
 			<param index="0" name="mode" type="int" enum="XRInterface.EnvironmentBlendMode" />
 			<description>
 				Sets the active environment blend mode.
-				[param mode] is the [enum XRInterface.EnvironmentBlendMode] starting with the next frame.
+				[param mode] is the environment blend mode starting with the next frame.
 				[b]Note:[/b] Not all runtimes support all environment blend modes, so it is important to check this at startup. For example:
 				[codeblock]
 				                func _ready():

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -67,7 +67,7 @@
 		<method name="_get_play_area_mode" qualifiers="virtual const">
 			<return type="int" enum="XRInterface.PlayAreaMode" />
 			<description>
-				Returns the [enum XRInterface.PlayAreaMode] that sets up our play area.
+				Returns the play area mode that sets up our play area.
 			</description>
 		</method>
 		<method name="_get_projection_for_view" qualifiers="virtual">

--- a/modules/csg/doc_classes/CSGPolygon3D.xml
+++ b/modules/csg/doc_classes/CSGPolygon3D.xml
@@ -39,7 +39,7 @@
 			When [member mode] is [constant MODE_PATH], the location of the [Path3D] object used to extrude the [member polygon].
 		</member>
 		<member name="path_rotation" type="int" setter="set_path_rotation" getter="get_path_rotation" enum="CSGPolygon3D.PathRotation">
-			When [member mode] is [constant MODE_PATH], the [enum PathRotation] method used to rotate the [member polygon] as it is extruded.
+			When [member mode] is [constant MODE_PATH], the path rotation method used to rotate the [member polygon] as it is extruded.
 		</member>
 		<member name="path_simplify_angle" type="float" setter="set_path_simplify_angle" getter="get_path_simplify_angle">
 			When [member mode] is [constant MODE_PATH], extrusions that are less than this angle, will be merged together to reduce polygon count.

--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -76,7 +76,7 @@
 		<method name="get_signaling_state" qualifiers="const">
 			<return type="int" enum="WebRTCPeerConnection.SignalingState" />
 			<description>
-				Returns the [enum SignalingState] on the local end of the connection while connecting or reconnecting to another peer.
+				Returns the signaling state on the local end of the connection while connecting or reconnecting to another peer.
 			</description>
 		</method>
 		<method name="initialize">


### PR DESCRIPTION
This makes these descriptions easier to read & translate.

Information is not lost because these enum names are available in the function signature.