### PR TITLE
Clarify that `@GlobalScope.clamp` does not do component-wise clamping

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -234,20 +234,9 @@
 
 				var b = clamp(8.1, 0.9, 5.5)
 				# b is 5.5
-
-				var c = clamp(Vector2(-3.5, -4), Vector2(-3.2, -2), Vector2(2, 6.5))
-				# c is (-3.2, -2)
-
-				var d = clamp(Vector2i(7, 8), Vector2i(-3, -2), Vector2i(2, 6))
-				# d is (2, 6)
-
-				var e = clamp(Vector3(-7, 8.5, -3.8), Vector3(-3, -2, 5.4), Vector3(-2, 6, -4.1))
-				# e is (-3, -2, 5.4)
-
-				var f = clamp(Vector3i(-7, -8, -9), Vector3i(-1, 2, 3), Vector3i(-4, -5, -6))
-				# f is (-4, -5, -6)
 				[/codeblock]
-				[b]Note:[/b] For better type safety, use [method clampf], [method clampi], [method Vector2.clamp], [method Vector2i.clamp], [method Vector3.clamp], [method Vector3i.clamp], [method Vector4.clamp], [method Vector4i.clamp], or [method Color.clamp].
+				[b]Note:[/b] For better type safety, use [method clampf], [method clampi], [method Vector2.clamp], [method Vector2i.clamp], [method Vector3.clamp], [method Vector3i.clamp], [method Vector4.clamp], [method Vector4i.clamp], or [method Color.clamp] (not currently supported by this method).
+				[b]Note:[/b] When using this on vectors it will [i]not[/i] perform component-wise clamping, and will pick [param min] if [code]value &lt; min[/code] or [param max] if [code]value &gt; max[/code]. To perform component-wise clamping use the methods listed above.
 			</description>
 		</method>
 		<method name="clampf">


### PR DESCRIPTION
Unsure about the exact wording, but as this confusion has come up on a number of occasions it would be good to clarify as it might not be obvious from the example though it does show this aspect

* Closes: #84655

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
