### PR TITLE
Initialize `Quaternion` variant with identity

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -54,6 +54,9 @@ public:
 			case Variant::TRANSFORM2D:
 				init_transform2d(v);
 				break;
+			case Variant::QUATERNION:
+				init_quaternion(v);
+				break;
 			case Variant::AABB:
 				init_aabb(v);
 				break;
@@ -219,7 +222,7 @@ public:
 
 	// Should be in the same order as Variant::Type for consistency.
 	// Those primitive and vector types don't need an `init_` method:
-	// Nil, bool, float, Vector2/i, Rect2/i, Vector3/i, Plane, Quat, RID.
+	// Nil, bool, float, Vector2/i, Rect2/i, Vector3/i, Plane, RID.
 	// Object is a special case, handled via `object_reset_data`.
 	_FORCE_INLINE_ static void init_string(Variant *v) {
 		memnew_placement(v->_data._mem, String);
@@ -229,6 +232,10 @@ public:
 		v->_data._transform2d = (Transform2D *)Variant::Pools::_bucket_small.alloc();
 		memnew_placement(v->_data._transform2d, Transform2D);
 		v->type = Variant::TRANSFORM2D;
+	}
+	_FORCE_INLINE_ static void init_quaternion(Variant *v) {
+		memnew_placement(v->_data._mem, Quaternion);
+		v->type = Variant::QUATERNION;
 	}
 	_FORCE_INLINE_ static void init_aabb(Variant *v) {
 		v->_data._aabb = (AABB *)Variant::Pools::_bucket_small.alloc();


### PR DESCRIPTION
Initializes the `Quaternion` variant with its identity value.

There are some cases where quaternions are initialized with zeroed values, which is not valid. For example, when resizing an array of type `Array[Quaternion]`:

```gdscript
var array: Array[Quaternion] = []

array.resize(3)

# Prints `[(0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)]`.
print(array)
```

This also applies to exported variables of type `Array[Quaternion]` and to some extend to `Quaternion` (when resetting in inspector):

```gdscript
@tool
class_name TestResource
extends Resource

# Without specified value, defaults to `Quaternion(0, 0, 0, 0)` in editor when resetting.
@export var quaternion: Quaternion

# New elements added in editor default to `Quaternion(0, 0, 0, 0)`.
# Also prints `The quaternion must be normalized.` in the console.
@export var quaternion_array: Array[Quaternion] = []
```

As `VariantInternal::initialize` is also used in the script engine, I'm not sure if this has some implications for the core functionality.

Test project: [quaternion.zip](https://github.com/godotengine/godot/files/13307513/quaternion.zip)
