### PR TITLE
Move tile transforms handling cache to TileData

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -70,15 +70,23 @@
 		<method name="get_navigation_polygon" qualifiers="const">
 			<return type="NavigationPolygon" />
 			<param index="0" name="layer_id" type="int" />
+			<param index="1" name="flip_h" type="bool" default="false" />
+			<param index="2" name="flip_v" type="bool" default="false" />
+			<param index="3" name="transpose" type="bool" default="false" />
 			<description>
 				Returns the navigation polygon of the tile for the TileSet navigation layer with index [param layer_id].
+				[param flip_h], [param flip_v], and [param transpose] allow transforming the returned polygon.
 			</description>
 		</method>
 		<method name="get_occluder" qualifiers="const">
 			<return type="OccluderPolygon2D" />
 			<param index="0" name="layer_id" type="int" />
+			<param index="1" name="flip_h" type="bool" default="false" />
+			<param index="2" name="flip_v" type="bool" default="false" />
+			<param index="3" name="transpose" type="bool" default="false" />
 			<description>
 				Returns the occluder polygon of the tile for the TileSet occlusion layer with index [param layer_id].
+				[param flip_h], [param flip_v], and [param transpose] allow transforming the returned polygon.
 			</description>
 		</method>
 		<method name="get_terrain_peering_bit" qualifiers="const">

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1421,8 +1421,8 @@ void TileDataOcclusionShapeEditor::draw_over_tile(CanvasItem *p_canvas_item, Tra
 
 Variant TileDataOcclusionShapeEditor::_get_painted_value() {
 	Ref<OccluderPolygon2D> occluder_polygon;
-	occluder_polygon.instantiate();
 	if (polygon_editor->get_polygon_count() >= 1) {
+		occluder_polygon.instantiate();
 		occluder_polygon->set_polygon(polygon_editor->get_polygon(0));
 	}
 	return occluder_polygon;

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -7,3 +7,10 @@ should instead be used to justify these changes and describe how users should wo
 Add new entries at the end of the file.
 
 ## Changes between 4.2-stable and 4.3-stable
+
+GH-84660
+--------
+Validate extension JSON: Error: Field 'classes/TileData/methods/get_navigation_polygon/arguments': size changed value in new API, from 1 to 4.
+Validate extension JSON: Error: Field 'classes/TileData/methods/get_occluder/arguments': size changed value in new API, from 1 to 4.
+
+Added optional argument to get_navigation_polygon and get_occluder to specify a polygon transform.

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -472,10 +472,6 @@ private:
 
 	void _update_notify_local_transform();
 
-	// Polygons.
-	HashMap<Pair<Ref<Resource>, int>, Ref<Resource>, PairHash<Ref<Resource>, int>> polygon_cache;
-	PackedVector2Array _get_transformed_vertices(const PackedVector2Array &p_vertices, int p_alternative_id);
-
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -619,7 +615,6 @@ public:
 	// Helpers?
 	TypedArray<Vector2i> get_surrounding_cells(const Vector2i &coords);
 	void draw_cells_outline(Control *p_control, const RBSet<Vector2i> &p_cells, Color p_color, Transform2D p_transform = Transform2D());
-	Ref<Resource> get_transformed_polygon(Ref<Resource> p_polygon, int p_alternative_id);
 
 	// Virtual function to modify the TileData at runtime.
 	GDVIRTUAL2R(bool, _use_tile_data_runtime_update, int, Vector2i);

--- a/scene/resources/tile_set.compat.inc
+++ b/scene/resources/tile_set.compat.inc
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  tile_set.compat.inc                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "tile_set.h"
+
+Ref<NavigationPolygon> TileData::_get_navigation_polygon_bind_compat_84660(int p_layer_id) const {
+	return get_navigation_polygon(p_layer_id, false, false, false);
+}
+
+Ref<OccluderPolygon2D> TileData::_get_occluder_bind_compat_84660(int p_layer_id) const {
+	return get_occluder(p_layer_id, false, false, false);
+}
+
+void TileData::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_navigation_polygon"), &TileData::_get_navigation_polygon_bind_compat_84660);
+	ClassDB::bind_compatibility_method(D_METHOD("get_occluder"), &TileData::_get_occluder_bind_compat_84660);
+}
+
+#endif

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -815,13 +815,18 @@ private:
 	Color modulate = Color(1.0, 1.0, 1.0, 1.0);
 	int z_index = 0;
 	int y_sort_origin = 0;
-	Vector<Ref<OccluderPolygon2D>> occluders;
+	struct OcclusionLayerTileData {
+		Ref<OccluderPolygon2D> occluder;
+		mutable HashMap<int, Ref<OccluderPolygon2D>> transformed_occluders;
+	};
+	Vector<OcclusionLayerTileData> occluders;
 
 	// Physics
 	struct PhysicsLayerTileData {
 		struct PolygonShapeTileData {
 			LocalVector<Vector2> polygon;
 			LocalVector<Ref<ConvexPolygonShape2D>> shapes;
+			mutable HashMap<int, LocalVector<Ref<ConvexPolygonShape2D>>> transformed_shapes;
 			bool one_way = false;
 			float one_way_margin = 1.0;
 		};
@@ -839,7 +844,11 @@ private:
 	int terrain_peering_bits[16] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
 	// Navigation
-	Vector<Ref<NavigationPolygon>> navigation;
+	struct NavigationLayerTileData {
+		Ref<NavigationPolygon> navigation_polygon;
+		mutable HashMap<int, Ref<NavigationPolygon>> transformed_navigation_polygon;
+	};
+	Vector<NavigationLayerTileData> navigation;
 
 	// Misc
 	double probability = 1.0;
@@ -852,6 +861,13 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	Ref<NavigationPolygon> _get_navigation_polygon_bind_compat_84660(int p_layer_id) const;
+	Ref<OccluderPolygon2D> _get_occluder_bind_compat_84660(int p_layer_id) const;
+
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	// Not exposed.
@@ -901,7 +917,7 @@ public:
 	int get_y_sort_origin() const;
 
 	void set_occluder(int p_layer_id, Ref<OccluderPolygon2D> p_occluder_polygon);
-	Ref<OccluderPolygon2D> get_occluder(int p_layer_id) const;
+	Ref<OccluderPolygon2D> get_occluder(int p_layer_id, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false) const;
 
 	// Physics
 	void set_constant_linear_velocity(int p_layer_id, const Vector2 &p_velocity);
@@ -919,7 +935,7 @@ public:
 	void set_collision_polygon_one_way_margin(int p_layer_id, int p_polygon_index, float p_one_way_margin);
 	float get_collision_polygon_one_way_margin(int p_layer_id, int p_polygon_index) const;
 	int get_collision_polygon_shapes_count(int p_layer_id, int p_polygon_index) const;
-	Ref<ConvexPolygonShape2D> get_collision_polygon_shape(int p_layer_id, int p_polygon_index, int shape_index) const;
+	Ref<ConvexPolygonShape2D> get_collision_polygon_shape(int p_layer_id, int p_polygon_index, int shape_index, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false) const;
 
 	// Terrain
 	void set_terrain_set(int p_terrain_id);
@@ -934,7 +950,7 @@ public:
 
 	// Navigation
 	void set_navigation_polygon(int p_layer_id, Ref<NavigationPolygon> p_navigation_polygon);
-	Ref<NavigationPolygon> get_navigation_polygon(int p_layer_id) const;
+	Ref<NavigationPolygon> get_navigation_polygon(int p_layer_id, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false) const;
 
 	// Misc
 	void set_probability(float p_probability);
@@ -945,6 +961,9 @@ public:
 	Variant get_custom_data(String p_layer_name) const;
 	void set_custom_data_by_layer_id(int p_layer_id, Variant p_value);
 	Variant get_custom_data_by_layer_id(int p_layer_id) const;
+
+	// Polygons.
+	static PackedVector2Array get_transformed_vertices(const PackedVector2Array &p_vertices, bool p_flip_h, bool p_flip_v, bool p_transpose);
 };
 
 VARIANT_ENUM_CAST(TileSet::CellNeighbor);


### PR DESCRIPTION
This PR does multiple things:
- moves the transformed polygons data cache to the TileData object. Since it's part of the TileSet resource, that should avoid further errors like https://github.com/godotengine/godot/issues/83825. It reverts https://github.com/godotengine/godot/pull/84261 and fix the issue in a cleaner way.
- Fix some errors that would be printed when using occluders. We were storing invalid occlusion polygons in the TileSet which caused errors to be printed.
- Fixed baking NavigationRegions with rotated tiles (an island is collision shapes, the other in navigation polygons, both work):  
![Screenshot_20231109_123615](https://github.com/godotengine/godot/assets/6093119/3ea9b38d-b6a1-4681-8514-a5e4413d84de)

*Bugsquad edit:* Fixes #83825
