### PR TITLE
Fix stuck cursor in Advanced Scene Importer

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1046,6 +1046,9 @@ void SceneImportSettings::_viewport_input(const Ref<InputEvent> &p_input) {
 		(*rot_x) = CLAMP((*rot_x), -Math_PI / 2, Math_PI / 2);
 		_update_camera();
 	}
+	if (mm.is_valid() && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+		DisplayServer::get_singleton()->cursor_set_shape(DisplayServer::CursorShape::CURSOR_ARROW);
+	}
 	Ref<InputEventMouseButton> mb = p_input;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 		(*zoom) *= 1.1;


### PR DESCRIPTION
Display an Arrow mouse cursor, while the mouse is moved within the `SubViewportContainer` of the Advanced Scene Importer.

resolve #84002
alternative to #84003

Related to the comment https://github.com/godotengine/godot/pull/79805#issuecomment-1652129321
This is a quick solution. Implementing the methodology of this comment would take more time.