### PR TITLE
Warn about autowrapped labels in containers

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1653,6 +1653,7 @@ void Control::set_custom_minimum_size(const Size2 &p_custom) {
 
 	data.custom_minimum_size = p_custom;
 	update_minimum_size();
+	update_configuration_warnings();
 }
 
 Size2 Control::get_custom_minimum_size() const {


### PR DESCRIPTION
Adds a warning for cases like https://github.com/godotengine/godot/issues/83546, until we fix the sizing model for autowrapped nodes.