### PR TITLE
Rename `Vector2/3/4I.Min/Max` to `MinValue/MaxValue`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -182,8 +182,8 @@ namespace Godot
         }
 
         // Constants
-        private static readonly Vector2I _min = new Vector2I(int.MinValue, int.MinValue);
-        private static readonly Vector2I _max = new Vector2I(int.MaxValue, int.MaxValue);
+        private static readonly Vector2I _minValue = new Vector2I(int.MinValue, int.MinValue);
+        private static readonly Vector2I _maxValue = new Vector2I(int.MaxValue, int.MaxValue);
 
         private static readonly Vector2I _zero = new Vector2I(0, 0);
         private static readonly Vector2I _one = new Vector2I(1, 1);
@@ -197,12 +197,12 @@ namespace Godot
         /// Min vector, a vector with all components equal to <see cref="int.MinValue"/>. Can be used as a negative integer equivalent of <see cref="Vector2.Inf"/>.
         /// </summary>
         /// <value>Equivalent to <c>new Vector2I(int.MinValue, int.MinValue)</c>.</value>
-        public static Vector2I Min { get { return _min; } }
+        public static Vector2I MinValue { get { return _minValue; } }
         /// <summary>
         /// Max vector, a vector with all components equal to <see cref="int.MaxValue"/>. Can be used as an integer equivalent of <see cref="Vector2.Inf"/>.
         /// </summary>
         /// <value>Equivalent to <c>new Vector2I(int.MaxValue, int.MaxValue)</c>.</value>
-        public static Vector2I Max { get { return _max; } }
+        public static Vector2I MaxValue { get { return _maxValue; } }
 
         /// <summary>
         /// Zero vector, a vector with all components set to <c>0</c>.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -193,8 +193,8 @@ namespace Godot
         }
 
         // Constants
-        private static readonly Vector3I _min = new Vector3I(int.MinValue, int.MinValue, int.MinValue);
-        private static readonly Vector3I _max = new Vector3I(int.MaxValue, int.MaxValue, int.MaxValue);
+        private static readonly Vector3I _minValue = new Vector3I(int.MinValue, int.MinValue, int.MinValue);
+        private static readonly Vector3I _maxValue = new Vector3I(int.MaxValue, int.MaxValue, int.MaxValue);
 
         private static readonly Vector3I _zero = new Vector3I(0, 0, 0);
         private static readonly Vector3I _one = new Vector3I(1, 1, 1);
@@ -210,12 +210,12 @@ namespace Godot
         /// Min vector, a vector with all components equal to <see cref="int.MinValue"/>. Can be used as a negative integer equivalent of <see cref="Vector3.Inf"/>.
         /// </summary>
         /// <value>Equivalent to <c>new Vector3I(int.MinValue, int.MinValue, int.MinValue)</c>.</value>
-        public static Vector3I Min { get { return _min; } }
+        public static Vector3I MinValue { get { return _minValue; } }
         /// <summary>
         /// Max vector, a vector with all components equal to <see cref="int.MaxValue"/>. Can be used as an integer equivalent of <see cref="Vector3.Inf"/>.
         /// </summary>
         /// <value>Equivalent to <c>new Vector3I(int.MaxValue, int.MaxValue, int.MaxValue)</c>.</value>
-        public static Vector3I Max { get { return _max; } }
+        public static Vector3I MaxValue { get { return _maxValue; } }
 
         /// <summary>
         /// Zero vector, a vector with all components set to <c>0</c>.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -228,8 +228,8 @@ namespace Godot
         }
 
         // Constants
-        private static readonly Vector4I _min = new Vector4I(int.MinValue, int.MinValue, int.MinValue, int.MinValue);
-        private static readonly Vector4I _max = new Vector4I(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+        private static readonly Vector4I _minValue = new Vector4I(int.MinValue, int.MinValue, int.MinValue, int.MinValue);
+        private static readonly Vector4I _maxValue = new Vector4I(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
 
         private static readonly Vector4I _zero = new Vector4I(0, 0, 0, 0);
         private static readonly Vector4I _one = new Vector4I(1, 1, 1, 1);
@@ -238,12 +238,12 @@ namespace Godot
         /// Min vector, a vector with all components equal to <see cref="int.MinValue"/>. Can be used as a negative integer equivalent of <see cref="Vector4.Inf"/>.
         /// </summary>
         /// <value>Equivalent to <c>new Vector4I(int.MinValue, int.MinValue, int.MinValue, int.MinValue)</c>.</value>
-        public static Vector4I Min { get { return _min; } }
+        public static Vector4I MinValue { get { return _minValue; } }
         /// <summary>
         /// Max vector, a vector with all components equal to <see cref="int.MaxValue"/>. Can be used as an integer equivalent of <see cref="Vector4.Inf"/>.
         /// </summary>
         /// <value>Equivalent to <c>new Vector4I(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue)</c>.</value>
-        public static Vector4I Max { get { return _max; } }
+        public static Vector4I MaxValue { get { return _maxValue; } }
 
         /// <summary>
         /// Zero vector, a vector with all components set to <c>0</c>.


### PR DESCRIPTION
More consistent with the `Mathf` constants they reference

As discussed in https://github.com/godotengine/godot/pull/80223#issuecomment-1803800803

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
