### PR TITLE
Allow auto-generated node names in `PopupMenu::add_submenu_item`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4699,11 +4699,16 @@ String String::property_name_encode() const {
 
 static const char32_t invalid_node_name_characters[] = { '.', ':', '@', '/', '\"', UNIQUE_NODE_PREFIX[0], 0 };
 
-String String::get_invalid_node_name_characters() {
+String String::get_invalid_node_name_characters(bool p_allow_internal) {
 	// Do not use this function for critical validation.
 	String r;
 	const char32_t *c = invalid_node_name_characters;
 	while (*c) {
+		if (p_allow_internal && *c == '@') {
+			c++;
+			continue;
+		}
+
 		if (c != invalid_node_name_characters) {
 			r += " ";
 		}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -437,7 +437,7 @@ public:
 	String property_name_encode() const;
 
 	// node functions
-	static String get_invalid_node_name_characters();
+	static String get_invalid_node_name_characters(bool p_allow_internal = false);
 	String validate_node_name() const;
 	String validate_identifier() const;
 	String validate_filename() const;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1487,7 +1487,11 @@ void PopupMenu::add_icon_radio_check_shortcut(const Ref<Texture2D> &p_icon, cons
 }
 
 void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu, int p_id) {
-	ERR_FAIL_COND_MSG(p_submenu.validate_node_name() != p_submenu, "Invalid node name for submenu, the following characters are not allowed:\n" + String::get_invalid_node_name_characters());
+	String submenu_name_safe = p_submenu.replace("@", "_"); // Allow special characters for auto-generated names.
+	if (submenu_name_safe.validate_node_name() != submenu_name_safe) {
+		ERR_FAIL_MSG(vformat("Invalid node name '%s' for a submenu, the following characters are not allowed:\n%s", p_submenu, String::get_invalid_node_name_characters(true)));
+	}
+
 	Item item;
 	item.text = p_label;
 	item.xl_text = atr(p_label);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/84617. After a bit of consideration, @akien-mga and I decided that it's best to allow the forbidden character. This is an ad-hoc way to address it, though exposing it on `String` would've been useful as well. But it's an exposed method there and I don't want to mess up things.
