### PR TITLE
Add parameter to allow generation of the Godot native shared libraries from gradle

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -173,10 +173,21 @@ task zipGradleBuild(type: Zip) {
     destinationDirectory = file(binDir)
 }
 
+/**
+ * Returns true if the scons build tasks responsible for generating the Godot native shared
+ * libraries should be excluded.
+ */
+def excludeSconsBuildTasks() {
+    return !isAndroidStudio() && !project.hasProperty("generateNativeLibs")
+}
+
+/**
+ * Generates the list of build tasks that should be excluded from the build process.\
+ */
 def templateExcludedBuildTask() {
     // We exclude these gradle tasks so we can run the scons command manually.
     def excludedTasks = []
-    if (!isAndroidStudio()) {
+    if (excludeSconsBuildTasks()) {
         logger.lifecycle("Excluding Android studio build tasks")
         for (String flavor : supportedFlavors) {
             String[] supportedBuildTypes = supportedFlavorsBuildTypes[flavor]
@@ -190,23 +201,42 @@ def templateExcludedBuildTask() {
     return excludedTasks
 }
 
-def templateBuildTasks() {
+/**
+ * Generates the build tasks for the given flavor
+ * @param flavor Must be one of the supported flavors ('template' / 'editor')
+ */
+def generateBuildTasks(String flavor = "template") {
+    if (!supportedFlavors.contains(flavor)) {
+        throw new GradleException("Invalid build flavor: $flavor")
+    }
+
     def tasks = []
 
-    // Only build the apks and aar files for which we have native shared libraries.
-    for (String target : supportedFlavorsBuildTypes["template"]) {
-        File targetLibs = new File("lib/libs/" + target)
-        if (targetLibs != null
+    // Only build the apks and aar files for which we have native shared libraries unless we intend
+    // to run the scons build tasks.
+    boolean excludeSconsBuildTasks = excludeSconsBuildTasks()
+    boolean isTemplate = flavor == "template"
+    String libsDir = isTemplate ? "lib/libs/" : "lib/libs/tools/"
+    for (String target : supportedFlavorsBuildTypes[flavor]) {
+        File targetLibs = new File(libsDir + target)
+        if (!excludeSconsBuildTasks || (targetLibs != null
             && targetLibs.isDirectory()
             && targetLibs.listFiles() != null
-            && targetLibs.listFiles().length > 0) {
+            && targetLibs.listFiles().length > 0)) {
             String capitalizedTarget = target.capitalize()
-            // Copy the generated aar library files to the build directory.
-            tasks += "copy" + capitalizedTarget + "AARToAppModule"
-            // Copy the generated aar library files to the bin directory.
-            tasks += "copy" + capitalizedTarget + "AARToBin"
-            // Copy the prebuilt binary templates to the bin directory.
-            tasks += "copy" + capitalizedTarget + "BinaryToBin"
+            if (isTemplate) {
+                // Copy the generated aar library files to the build directory.
+                tasks += "copy${capitalizedTarget}AARToAppModule"
+                // Copy the generated aar library files to the bin directory.
+                tasks += "copy${capitalizedTarget}AARToBin"
+                // Copy the prebuilt binary templates to the bin directory.
+                tasks += "copy${capitalizedTarget}BinaryToBin"
+            } else {
+                // Copy the generated editor apk to the bin directory.
+                tasks += "copyEditor${capitalizedTarget}ApkToBin"
+                // Copy the generated editor aab to the bin directory.
+                tasks += "copyEditor${capitalizedTarget}AabToBin"
+            }
         } else {
             logger.lifecycle("No native shared libs for target $target. Skipping build.")
         }
@@ -265,27 +295,13 @@ task copyEditorDevAabToBin(type: Copy) {
 /**
  * Generate the Godot Editor Android apk.
  *
- * Note: The Godot 'tools' shared libraries must have been generated (via scons) prior to running
- * this gradle task. The task will only build the apk(s) for which the shared libraries is
- * available.
+ * Note: Unless the 'generateNativeLibs` argument is specified, the Godot 'tools' shared libraries
+ * must have been generated (via scons) prior to running this gradle task.
+ * The task will only build the apk(s) for which the shared libraries is available.
  */
 task generateGodotEditor {
     gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
-
-    def tasks = []
-
-    for (String target : supportedFlavorsBuildTypes["editor"]) {
-        File targetLibs = new File("lib/libs/tools/" + target)
-        if (targetLibs != null
-            && targetLibs.isDirectory()
-            && targetLibs.listFiles() != null
-            && targetLibs.listFiles().length > 0) {
-            tasks += "copyEditor${target.capitalize()}ApkToBin"
-            tasks += "copyEditor${target.capitalize()}AabToBin"
-        }
-    }
-
-    dependsOn = tasks
+    dependsOn = generateBuildTasks("editor")
 }
 
 /**
@@ -293,7 +309,7 @@ task generateGodotEditor {
  */
 task generateGodotTemplates {
     gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
-    dependsOn = templateBuildTasks()
+    dependsOn = generateBuildTasks("template")
 
     finalizedBy 'zipGradleBuild'
 }
@@ -306,7 +322,7 @@ task generateDevTemplate {
     gradle.startParameter.projectProperties += [doNotStrip: true]
 
     gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
-    dependsOn = templateBuildTasks()
+    dependsOn = generateBuildTasks("template")
 
     finalizedBy 'zipGradleBuild'
 }


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot/pull/84440, this does the reverse by adding a `-PgenerateNativeLibs=true` argument that can be passed to `gradle` to generate the native shared libraries using `scons`.

E.g:
- Generate the Godot templates: `./gradlew generateGodotTemplates -PgenerateNativeLibs=true`
- Generate the Godot editor: `./gradlew generateGodotEditor -PgenerateNativeLibs=true`

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
