### PR TITLE
Use the Blender file name instead of the generated GLTF file name

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -130,8 +130,9 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	// Get global paths for source and sink.
 	// Escape paths to be valid Python strings to embed in the script.
 	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path).c_escape();
+	const String blend_basename = p_path.get_file().get_basename();
 	const String sink = ProjectSettings::get_singleton()->get_imported_files_path().path_join(
-			vformat("%s-%s.gltf", p_path.get_file().get_basename(), p_path.md5_text()));
+			vformat("%s-%s.gltf", blend_basename, p_path.md5_text()));
 	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink).c_escape();
 
 	// Handle configuration options.
@@ -282,6 +283,7 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	if (p_options.has(SNAME("blender/materials/unpack_enabled")) && p_options[SNAME("blender/materials/unpack_enabled")]) {
 		base_dir = sink.get_base_dir();
 	}
+	state->set_scene_name(blend_basename);
 	err = gltf->append_from_file(sink.get_basename() + ".gltf", state, p_flags, base_dir);
 	if (err != OK) {
 		if (r_err) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -573,7 +573,7 @@ Error GLTFDocument::_parse_scenes(Ref<GLTFState> p_state) {
 		// Determine what to use for the scene name.
 		if (scene_dict.has("name") && !String(scene_dict["name"]).is_empty() && !((String)scene_dict["name"]).begins_with("Scene")) {
 			p_state->scene_name = scene_dict["name"];
-		} else {
+		} else if (p_state->scene_name.is_empty()) {
 			p_state->scene_name = p_state->filename;
 		}
 		if (_naming_version == 0) {


### PR DESCRIPTION
Fixes #84025. This was caused by #79774, not #80272. I'll explain what's going on.

In Godot 4.1 and earlier, if a GLTF file had no scene name, the GLTF importer code used the file name as the scene name. This was then overridden by the general scene importer code to be the file name (again). This seemed redundant to me, and I wanted to ensure the GLTF importer has the ability to set the scene name, so any scene names processed by GLTF will be preserved. However, let's look at some scenarios to see what happens:

* Importing `my_scene.glb` (assuming no scene name OR "Scene"): The Godot GLTF importer sees no scene name so it sets the scene name to the file name `"my_scene"`. Then the general-purpose importer code overrides this to the file name again `"my_scene"`. Therefore the scene root is named `"my_scene"`.

* Importing `my_scene.blend`: Blender exports a GLTF with the scene name set to "Scene" and a temporary file name `my_scene-123456etc.glb`. The Godot GLTF importer ignores the scene name when it is empty OR set to `"Scene"`, so it sets it to the file name `"my_scene-123456etc"`. Then the general-purpose importer code overrides this to the Blender file name `"my_scene"`. Therefore the scene root is named `"my_scene"`.

In master before this PR, this means that `"my_scene"` was used in both cases. However #79774 removed the general-purpose importer code overriding the root name, so that importers can set their own root node name. I completely missed that this would change the behavior for Blender file importing.

So, the solution: Update the Blend file import code to set the scene name as the file name before importing the GLTF. The GLTF code will still check for an explicit scene name in the file first, but then if that's not present adjust the GLTF code to prefer any existing scene name if set, instead of using the GLTF file name in that case.

I also checked the FBX importer, and... it's changed in a different way. In Godot 4.1 and earlier it uses "Node3D" as the scene root node name, because the general-purpose importer code overrides this. In master the scene root node name is set to "Root Scene" because that's what the FBX2glTF tool outputs. Both are wrong, we should fall back to the file name just like the Blender and GLTF importers. However in order to fix this I really don't want to add another hack to ignore scene names of "Root Scene", so since we have control over our fork of FBX2glTF I think we should do the proper fix and adjust the FBX2glTF code to allow specifying a scene name.