### PR TITLE
Force alpha to 1 in tonemap pass in RD renderers

### DIFF
--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -128,6 +128,7 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	tonemap.push_constant.pixel_size[1] = 1.0 / p_settings.texture_size.y;
 
 	tonemap.push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
+	tonemap.push_constant.flags |= p_settings.transparent_bg ? TONEMAP_FLAG_TRANSPARENT_BG : 0;
 
 	if (p_settings.view_count > 1) {
 		// Use MULTIVIEW versions
@@ -212,6 +213,7 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
 
 	tonemap.push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
+	tonemap.push_constant.flags |= p_settings.transparent_bg ? TONEMAP_FLAG_TRANSPARENT_BG : 0;
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 	RID default_mipmap_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -67,6 +67,7 @@ private:
 		TONEMAP_FLAG_USE_FXAA = (1 << 4),
 		TONEMAP_FLAG_USE_DEBANDING = (1 << 5),
 		TONEMAP_FLAG_CONVERT_TO_SRGB = (1 << 6),
+		TONEMAP_FLAG_TRANSPARENT_BG = (1 << 7),
 	};
 
 	struct TonemapPushConstant {
@@ -146,6 +147,8 @@ public:
 		bool use_debanding = false;
 		Vector2i texture_size;
 		uint32_t view_count = 1;
+
+		bool transparent_bg = false;
 
 		bool convert_to_srgb = false;
 	};

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2000,7 +2000,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 			Vector<Color> c;
 			{
 				Color cc = clear_color.srgb_to_linear();
-				if (using_separate_specular || rb_data.is_valid()) {
+				if (using_separate_specular || RendererRD::TextureStorage::get_singleton()->render_target_get_transparent(rb->get_render_target())) {
 					// Effects that rely on separate specular, like subsurface scattering, must clear the alpha to zero.
 					cc.a = 0;
 				}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -933,7 +933,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 			Vector<Color> c;
 			{
 				Color cc = clear_color.srgb_to_linear() * inverse_luminance_multiplier;
-				if (rb_data.is_valid()) {
+				if (RendererRD::TextureStorage::get_singleton()->render_target_get_transparent(rb->get_render_target())) {
 					cc.a = 0; // For transparent viewport backgrounds.
 				}
 				c.push_back(cc); // Our render buffer.

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -571,6 +571,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		tonemap.view_count = rb->get_view_count();
 
 		tonemap.convert_to_srgb = !texture_storage->render_target_is_using_hdr(render_target);
+		tonemap.transparent_bg = texture_storage->render_target_get_transparent(render_target);
 
 		RID dest_fb;
 		bool use_intermediate_fb = use_fsr;
@@ -681,6 +682,7 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 	tonemap.view_count = rb->get_view_count();
 
 	tonemap.convert_to_srgb = !texture_storage->render_target_is_using_hdr(rb->get_render_target());
+	tonemap.transparent_bg = texture_storage->render_target_get_transparent(rb->get_render_target());
 
 	tone_mapper->tonemapper(draw_list, p_source_texture, RD::get_singleton()->framebuffer_get_format(p_framebuffer), tonemap);
 

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -64,6 +64,7 @@ layout(set = 3, binding = 0) uniform sampler3D source_color_correction;
 #define FLAG_USE_FXAA (1 << 4)
 #define FLAG_USE_DEBANDING (1 << 5)
 #define FLAG_CONVERT_TO_SRGB (1 << 6)
+#define FLAG_TRANSPARENT_BG (1 << 7)
 
 layout(push_constant, std430) uniform Params {
 	vec3 bcs;
@@ -507,4 +508,8 @@ void main() {
 	}
 
 	frag_color = color;
+
+	if (!bool(params.flags & FLAG_TRANSPARENT_BG)) {
+		frag_color.a = 1.0;
+	}
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/83131 for X11
Fixes: https://github.com/godotengine/godot/issues/61969

Also only clear to alpha 0 when using transparent background

This change isn't needed in the compatibility renderer as it already correctly checks for transparent_bg when setting the clear color and it avoids writing to alpha when not needed.

Setting to draft for now as I have only tested with the MRPs from the two projects. Its possible that other effects rely on this previous erroneous behaviour. So we need to test carefully. 