### PR TITLE
Rework input actions to be reliable

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -44,6 +44,8 @@ class Input : public Object {
 
 	static Input *singleton;
 
+	static constexpr uint64_t MAX_EVENT = 31;
+
 public:
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,
@@ -103,11 +105,22 @@ private:
 		uint64_t pressed_process_frame = UINT64_MAX;
 		uint64_t released_physics_frame = UINT64_MAX;
 		uint64_t released_process_frame = UINT64_MAX;
-		int pressed = 0;
-		bool axis_pressed = false;
+		uint64_t pressed = 0;
 		bool exact = true;
 		float strength = 0.0f;
 		float raw_strength = 0.0f;
+		LocalVector<float> strengths;
+		LocalVector<float> raw_strengths;
+
+		Action() {
+			strengths.resize(MAX_EVENT + 1);
+			raw_strengths.resize(MAX_EVENT + 1);
+
+			for (uint64_t i = 0; i <= MAX_EVENT; i++) {
+				strengths[i] = 0.0;
+				raw_strengths[i] = 0.0;
+			}
+		}
 	};
 
 	HashMap<StringName, Action> action_state;
@@ -227,6 +240,8 @@ private:
 	JoyAxis _get_output_axis(String output);
 	void _button_event(int p_device, JoyButton p_index, bool p_pressed);
 	void _axis_event(int p_device, JoyAxis p_axis, float p_value);
+	void _update_action_strength(Action &p_action, int p_event_index, float p_strength);
+	void _update_action_raw_strength(Action &p_action, int p_event_index, float p_strength);
 
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -61,7 +61,7 @@ private:
 	HashMap<String, List<Ref<InputEvent>>> default_builtin_cache;
 	HashMap<String, List<Ref<InputEvent>>> default_builtin_with_overrides_cache;
 
-	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr) const;
+	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
 
 	TypedArray<InputEvent> _action_get_events(const StringName &p_action);
 	TypedArray<StringName> _get_actions();
@@ -86,7 +86,8 @@ public:
 
 	const List<Ref<InputEvent>> *action_get_events(const StringName &p_action);
 	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false) const;
-	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr) const;
+	int event_get_index(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false) const;
+	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
 
 	const HashMap<StringName, Action> &get_action_map() const;
 	void load_from_project_settings();


### PR DESCRIPTION
#80859 introduced surprisingly many regressions (I mean, who would've thought that press and release count for an action don't necessarily match...). This PR reworks the input actions again. This time `pressed` is a bitmask. When an event is pressed, it sets a bit in the `pressed` integer, release resets it. Pressed state is still determined by `pressed` being greater than 0, but since every event corresponds to a bit being either 0 or 1, there is no way to "overpress" or "overrelease" the event.

Action strengths broke again after the rework, so I reworked that too. Since I am using event index anyway, I decided to just keep a vector of all event strengths. Now the action strength is the max value of all event's strengths. It makes action strength more reliable than ever.

Some considerations:
- since the pressed state is stored using bitwise operations, the event count per action is now effectively limited to 32. We should probably enforce that somehow
- `Input.press_action()` will press the action, but then it can be released by any event. `Input.release_action()` releases all events. This is actually how it was before the previous rework

Fixes all input action regressions, probably.
I tested with some projects on Windows and it appears to be working correctly overall.

*Bugsquad edit:*
- Fixes #82262 (https://github.com/godotengine/godot/pull/84685#issuecomment-1805879525)
- Fixes #82732 (https://github.com/godotengine/godot/pull/84685#issuecomment-1805879525)