### PR TITLE
Add MSAA support for WebXR

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -99,8 +99,14 @@ Config::Config() {
 	msaa_supported = extensions.has("GL_EXT_framebuffer_multisample");
 #endif
 #ifndef IOS_ENABLED
+#ifdef WEB_ENABLED
+	msaa_multiview_supported = extensions.has("OCULUS_multiview");
+	rt_msaa_multiview_supported = msaa_multiview_supported;
+#else
 	msaa_multiview_supported = extensions.has("GL_EXT_multiview_texture_multisample");
-	multiview_supported = extensions.has("GL_OVR_multiview2") || extensions.has("GL_OVR_multiview");
+#endif
+
+	multiview_supported = extensions.has("OCULUS_multiview") || extensions.has("GL_OVR_multiview2") || extensions.has("GL_OVR_multiview");
 #endif
 
 #ifdef ANDROID_ENABLED

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -95,6 +95,7 @@ private:
 	void _clear_intermediate_buffers();
 	void _clear_back_buffers();
 
+	void _rt_attach_textures(GLuint p_color, GLuint p_depth, GLsizei p_samples, uint32_t p_view_count);
 	GLuint _rt_get_cached_fbo(GLuint p_color, GLuint p_depth, GLsizei p_samples, uint32_t p_view_count);
 
 public:

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2320,6 +2320,20 @@ GLuint TextureStorage::render_target_get_depth(RID p_render_target) const {
 	}
 }
 
+void TextureStorage::render_target_set_reattach_textures(RID p_render_target, bool p_reattach_textures) const {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(rt);
+
+	rt->reattach_textures = p_reattach_textures;
+}
+
+bool TextureStorage::render_target_is_reattach_textures(RID p_render_target) const {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL_V(rt, false);
+
+	return rt->reattach_textures;
+}
+
 void TextureStorage::render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -365,6 +365,7 @@ struct RenderTarget {
 
 	bool used_in_frame = false;
 	RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
+	bool reattach_textures = false;
 
 	struct RTOverridden {
 		bool is_overridden = false;
@@ -639,6 +640,8 @@ public:
 	GLuint render_target_get_fbo(RID p_render_target) const;
 	GLuint render_target_get_color(RID p_render_target) const;
 	GLuint render_target_get_depth(RID p_render_target) const;
+	void render_target_set_reattach_textures(RID p_render_target, bool p_reattach_textures) const;
+	bool render_target_is_reattach_textures(RID p_render_target) const;
 
 	virtual void render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale) override;
 	virtual Rect2i render_target_get_sdf_rect(RID p_render_target) const override;

--- a/platform/web/godot_webgl2.h
+++ b/platform/web/godot_webgl2.h
@@ -44,9 +44,11 @@ extern "C" {
 #endif
 
 void godot_webgl2_glFramebufferTextureMultiviewOVR(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
+void godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR(GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
 void godot_webgl2_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
 
 #define glFramebufferTextureMultiviewOVR godot_webgl2_glFramebufferTextureMultiviewOVR
+#define glFramebufferTextureMultisampleMultiviewOVR godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR
 
 #ifdef __cplusplus
 }

--- a/platform/web/js/libs/library_godot_webgl2.externs.js
+++ b/platform/web/js/libs/library_godot_webgl2.externs.js
@@ -34,3 +34,19 @@ OVR_multiview2.prototype.FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR;
  * @return {void}
  */
 OVR_multiview2.prototype.framebufferTextureMultiviewOVR = function(target, attachment, texture, level, baseViewIndex, numViews) {};
+
+/**
+ * @constructor OCULUS_multiview
+ */
+function OCULUS_multiview() {}
+
+/**
+ * @param {number} target
+ * @param {number} attachment
+ * @param {WebGLTexture} texture
+ * @param {number} level
+ * @param {number} baseViewIndex
+ * @param {number} numViews
+ * @return {void}
+ */
+OCULUS_multiview.prototype.framebufferTextureMultisampleMultiviewOVR = function(target, attachment, texture, level, samples, baseViewIndex, numViews) {};

--- a/platform/web/js/libs/library_godot_webgl2.js
+++ b/platform/web/js/libs/library_godot_webgl2.js
@@ -61,6 +61,23 @@ const GodotWebGL2 = {
 		const /** OVR_multiview2 */ ext = context.multiviewExt;
 		ext.framebufferTextureMultiviewOVR(target, attachment, GL.textures[texture], level, base_view_index, num_views);
 	},
+
+	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR__deps: ['emscripten_webgl_get_current_context'],
+	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR__proxy: 'sync',
+	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR__sig: 'viiiiiii',
+	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR: function (target, attachment, texture, level, samples, base_view_index, num_views) {
+		const context = GL.currentContext;
+		if (typeof context.oculusMultiviewExt === 'undefined') {
+			const /** OCULUS_multiview */ ext = context.GLctx.getExtension('OCULUS_multiview');
+			if (!ext) {
+				GodotRuntime.error('Trying to call glFramebufferTextureMultisampleMultiviewOVR() without the OCULUS_multiview extension');
+				return;
+			}
+			context.oculusMultiviewExt = ext;
+		}
+		const /** OCULUS_multiview */ ext = context.oculusMultiviewExt;
+		ext.framebufferTextureMultisampleMultiviewOVR(target, attachment, GL.textures[texture], level, samples, base_view_index, num_views);
+	},
 };
 
 autoAddDeps(GodotWebGL2, '$GodotWebGL2');


### PR DESCRIPTION
This builds on top of PR https://github.com/godotengine/godot/pull/83976

It works in my testing on the Meta Quest 2.

Due to one of the weirder parts of WebXR, we need to re-attach the color and depth texture to any FBO using them on every frame. Previously, this was being done via `WebXRInterfaceJS::pre_draw_viewport()` by updating the render target's FBO. However, that won't work with MSAA because it's not using the render target's FBO, but instead one created by `RenderSceneBuffersGLES3`, so I had to add a special flag to render targets telling `RenderSceneBuffersGLES3` to reattach the textures. This is a little hacky, but I can't think of a better way to do it.

~~Keeping this as a draft until PR https://github.com/godotengine/godot/pull/83976 has been merged~~

UPDATE: It has been merged! This is no longer a draft :-)

_Production edit: closes godotengine/godot-roadmap#72_