### PR TITLE
Add OpenGL MSAA support to 2d rendering pipeline

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2142,12 +2142,18 @@ void RasterizerCanvasGLES3::canvas_begin(RID p_to_render_target, bool p_to_backb
 	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
 	if (p_to_backbuffer) {
+		// TODO is backbuffer copy after MSAA resolve and is this thus safe? Or do we have a problem here?
+
 		glBindFramebuffer(GL_FRAMEBUFFER, render_target->backbuffer_fbo);
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
 		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 	} else {
-		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
+		if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.fbo != 0) {
+			glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
+		} else {
+			glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
+		}
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 		glBindTexture(GL_TEXTURE_2D, render_target->backbuffer);
 	}

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -39,6 +39,7 @@
 
 #ifdef ANDROID_ENABLED
 #define glFramebufferTextureMultiviewOVR GLES3::Config::get_singleton()->eglFramebufferTextureMultiviewOVR
+#define glFramebufferTexture2DMultisampleEXT GLES3::Config::get_singleton()->eglFramebufferTexture2DMultisampleEXT
 #endif
 
 using namespace GLES3;
@@ -1813,10 +1814,78 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 			texture->alloc_height = rt->size.y;
 			texture->active = true;
 		}
+
+		glClearColor(0, 0, 0, 0);
+		glClear(GL_COLOR_BUFFER_BIT);
 	}
 
-	glClearColor(0, 0, 0, 0);
-	glClear(GL_COLOR_BUFFER_BIT);
+	if (rt->view_count == 1 && rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && (config->msaa_supported || config->rt_msaa_supported)) {
+		/* MSAA 2D FBO */
+		const GLsizei samples[] = { 1, 2, 4, 8 };
+		rt->msaa_2d.samples = samples[rt->msaa_2d.mode];
+
+		glGenFramebuffers(1, &rt->msaa_2d.fbo);
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->msaa_2d.fbo);
+
+#ifdef ANDROID_ENABLED // Only supported on OpenGLES!
+		if (config->rt_msaa_supported) {
+			// If this extension is supported we use this,
+			// MSAA will remain in tile memory and we write out directly into our final buffers
+			rt->msaa_2d.needs_resolve = false;
+
+			glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0, rt->msaa_2d.samples);
+		} else {
+#else
+		{
+#endif
+			// We create separate MSAA buffers and require a resolve when we're done.
+			rt->msaa_2d.needs_resolve = true;
+
+			// Create our color buffer.
+			glGenRenderbuffers(1, &rt->msaa_2d.color);
+			glBindRenderbuffer(GL_RENDERBUFFER, rt->msaa_2d.color);
+
+			glRenderbufferStorageMultisample(GL_RENDERBUFFER, rt->msaa_2d.samples, rt->color_internal_format, rt->size.x, rt->size.y);
+			GLES3::Utilities::get_singleton()->render_buffer_allocated_data(rt->msaa_2d.color, rt->size.x * rt->size.y * 4 * rt->msaa_2d.samples, "MSAA 2D color render buffer");
+
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->msaa_2d.color);
+		}
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			// If we couldn't create our frame buffer, just fail and disable MSAA.
+			WARN_PRINT("Could not create 2D MSAA render target, status: " + get_framebuffer_error(status));
+
+			glDeleteFramebuffers(1, &rt->msaa_2d.fbo);
+			rt->msaa_2d.fbo = 0;
+
+			if (rt->msaa_2d.color != 0) {
+				GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.color);
+				rt->msaa_2d.color = 0;
+			}
+
+			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+			rt->msaa_2d.samples = 1;
+			rt->msaa_2d.needs_resolve = false;
+		} else {
+			glClearColor(0, 0, 0, 0);
+			glClear(GL_COLOR_BUFFER_BIT);
+		}
+	} else {
+		if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+			if (rt->view_count > 1) {
+				// We don't support 2D in multiview,
+				WARN_PRINT_ONCE("MSAA 2D not supported in multiview.");
+			} else if (!config->msaa_supported && !config->rt_msaa_supported) {
+				WARN_PRINT_ONCE("MSAA 2D not supported on this device.");
+			}
+			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+		}
+
+		rt->msaa_2d.samples = 1;
+		rt->msaa_2d.needs_resolve = false;
+	}
+
 	glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
 }
 
@@ -1953,6 +2022,16 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 	if (rt->fbo) {
 		glDeleteFramebuffers(1, &rt->fbo);
 		rt->fbo = 0;
+	}
+
+	if (rt->msaa_2d.fbo) {
+		glDeleteFramebuffers(1, &rt->msaa_2d.fbo);
+		rt->msaa_2d.fbo = 0;
+	}
+
+	if (rt->msaa_2d.color != 0) {
+		GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.color);
+		rt->msaa_2d.color = 0;
 	}
 
 	if (rt->overridden.color.is_null()) {
@@ -2198,6 +2277,7 @@ void TextureStorage::render_target_set_direct_to_screen(RID p_render_target, boo
 	_clear_render_target(rt);
 	rt->direct_to_screen = p_direct_to_screen;
 	if (rt->direct_to_screen) {
+		rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
 		rt->overridden.color = RID();
 		rt->overridden.depth = RID();
 		rt->overridden.velocity = RID();
@@ -2230,14 +2310,12 @@ void TextureStorage::render_target_set_msaa(RID p_render_target, RS::ViewportMSA
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);
 	ERR_FAIL_COND(rt->direct_to_screen);
-	if (p_msaa == rt->msaa) {
+	if (p_msaa == rt->msaa_2d.mode) {
 		return;
 	}
 
-	WARN_PRINT("2D MSAA is not yet supported for GLES3.");
-
 	_clear_render_target(rt);
-	rt->msaa = p_msaa;
+	rt->msaa_2d.mode = p_msaa;
 	_update_render_target(rt);
 }
 
@@ -2245,7 +2323,7 @@ RS::ViewportMSAA TextureStorage::render_target_get_msaa(RID p_render_target) con
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RS::VIEWPORT_MSAA_DISABLED);
 
-	return rt->msaa;
+	return rt->msaa_2d.mode;
 }
 
 void TextureStorage::render_target_request_clear(RID p_render_target, const Color &p_clear_color) {

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -364,8 +364,15 @@ struct RenderTarget {
 	bool direct_to_screen = false;
 
 	bool used_in_frame = false;
-	RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
 	bool reattach_textures = false;
+
+	struct RTmsaa2d {
+		RS::ViewportMSAA mode = RS::VIEWPORT_MSAA_DISABLED;
+		bool needs_resolve = false;
+		GLsizei samples = 1;
+		GLuint color = 0;
+		GLuint fbo = 0;
+	} msaa_2d;
 
 	struct RTOverridden {
 		bool is_overridden = false;


### PR DESCRIPTION
This PR adds MSAA support to the 2D rendering pipeline. This is a work in progress and not yet functional.

Todos:
- [ ] Blit 3D result into 2D MSAA buffers is required,
- [ ] Resolve 2D MSAA if required,
- [ ] Look into MSAA support on the backbuffer.

If available (OpenGLES only atm) this PR will use the [GL_EXT_multisampled_render_to_texture](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_multisampled_render_to_texture.txt) extension resulting in automatic resolve and MSAA data remaining purely in tile memory. This should provide a marked performance improvement.

Due to the design of the renderer, if MSAA is both used for 2D and 3D, there isn't an ability to share buffers and we incur an overhead if blitting of MSAA buffers is required. If scaling is used this is also unavoidable.
Note that if the aforementioned extension is used, this is not an issue.

This is a follow up from #83976