### PR TITLE
Fix `HingeJoint3D` gizmo to point correct direction

### DIFF
--- a/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/joint_3d_gizmo_plugin.cpp
@@ -208,8 +208,8 @@ void JointGizmosDrawer::draw_circle(Vector3::Axis p_axis, real_t p_radius, const
 					}
 					break;
 				case Vector3::AXIS_Z:
-					from = p_base.xform(Vector3(Math::cos(s), Math::sin(s), 0)) * p_radius;
-					to = p_base.xform(Vector3(Math::cos(n), Math::sin(n), 0)) * p_radius;
+					from = p_base.xform(Vector3(Math::cos(s), -Math::sin(s), 0)) * p_radius;
+					to = p_base.xform(Vector3(Math::cos(n), -Math::sin(n), 0)) * p_radius;
 					break;
 			}
 


### PR DESCRIPTION
A solution to point HingeJoint3D in the correct direction of the objects attached to it.

- Fixes https://github.com/godotengine/godot/issues/84468