### PR TITLE
[GLES3] Use temporary `frag_color`

### DIFF
--- a/drivers/gles3/shaders/effect_blur.glsl
+++ b/drivers/gles3/shaders/effect_blur.glsl
@@ -106,7 +106,8 @@ uniform float glow_hdr_scale;
 uniform float camera_z_far;
 uniform float camera_z_near;
 
-layout(location = 0) out vec4 frag_color;
+layout(location = 0) out vec4 frag_color_final;
+vec4 frag_color;
 
 void main() {
 #ifdef GLOW_GAUSSIAN_HORIZONTAL
@@ -288,4 +289,11 @@ void main() {
 	frag_color = min(frag_color * feedback, vec4(luminance_cap));
 
 #endif
+
+	// Instead of writing directly to final frag_color,
+	// we use an intermediate, and only write
+	// to the final output ONCE at the end of the shader.
+	// This is because some hardware can have huge
+	// slowdown if you modify frag_color_final multiple times.
+	frag_color_final = frag_color;
 }

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -840,7 +840,8 @@ vec2 multiview_uv(vec2 uv) {
 uniform highp mat4 world_transform;
 uniform mediump float opaque_prepass_threshold;
 
-layout(location = 0) out vec4 frag_color;
+layout(location = 0) out vec4 frag_color_final;
+vec4 frag_color;
 
 vec3 F0(float metallic, float specular, vec3 albedo) {
 	float dielectric = 0.16 * specular * specular;
@@ -1801,4 +1802,11 @@ void main() {
 #endif // USE_ADDITIVE_LIGHTING
 
 #endif //!MODE_RENDER_DEPTH
+
+	// Instead of writing directly to final frag_color,
+	// we use an intermediate, and only write
+	// to the final output ONCE at the end of the shader.
+	// This is because some hardware can have huge
+	// slowdown if you modify frag_color_final multiple times.
+	frag_color_final = frag_color;
 }

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -122,7 +122,8 @@ layout(std140) uniform MultiviewData { // ubo:5
 multiview_data;
 #endif
 
-layout(location = 0) out vec4 frag_color;
+layout(location = 0) out vec4 frag_color_final;
+vec4 frag_color;
 
 #ifdef USE_DEBANDING
 // https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
@@ -217,4 +218,11 @@ void main() {
 #ifdef USE_DEBANDING
 	frag_color.rgb += interleaved_gradient_noise(gl_FragCoord.xy) * luminance_multiplier;
 #endif
+
+	// Instead of writing directly to final frag_color,
+	// we use an intermediate, and only write
+	// to the final output ONCE at the end of the shader.
+	// This is because some hardware can have huge
+	// slowdown if you modify frag_color_final multiple times.
+	frag_color_final = frag_color;
 }


### PR DESCRIPTION
Some hardware exhibits a slowdown when shaders modify the frag_color output multiple times. In order to prevent this, we modify a temporary variable instead of the output, then write to the final output once at the end of the shader.

Partially addresses #84526.
Forward port of #84529.

## Notes
* Can lead to 2-4x increase in frame rate on affected hardware.
* The problem shows most in fill rate limited circumstances, e.g. with MSAA, and where `frag_color` is read / modified more than once.
* Should work with custom shaders as they write to e.g. `ALBEDO` rather than `frag_color` directly.
* No changes needed for 2D as far as I can see.
* See https://github.com/godotengine/godot/issues/84526#issuecomment-1798237472 for tests on different hardware.
* Although I've only measured increases in performance through `scene.glsl`, I've included the fix for other potentially affected shaders, as there is no evidence of a drop in performance and potential for gain, especially if these shaders are later modified.
* I've only included changes for GLES, as I'm not familiar with Vulkan.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
