### PR TITLE
Fix wrong `get_import_options` glue signature in some cases

### DIFF
--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -17,7 +17,7 @@
 			</description>
 		</method>
 		<method name="_get_import_options" qualifiers="virtual">
-			<return type="void" />
+			<return type="Dictionary[]" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Override to add general import options. These will appear in the main import dock on the editor. Add options via [method add_import_option] and [method add_import_option_advanced].

--- a/doc/classes/EditorScenePostImportPlugin.xml
+++ b/doc/classes/EditorScenePostImportPlugin.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<methods>
 		<method name="_get_import_options" qualifiers="virtual">
-			<return type="void" />
+			<return type="Dictionary[]" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Override to add general import options. These will appear in the main import dock on the editor. Add options via [method add_import_option] and [method add_import_option_advanced].

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -93,9 +93,27 @@ void EditorSceneFormatImporter::add_import_option_advanced(Variant::Type p_type,
 }
 
 void EditorSceneFormatImporter::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options) {
-	current_option_list = r_options;
-	GDVIRTUAL_CALL(_get_import_options, p_path);
-	current_option_list = nullptr;
+	Array needed;
+	needed.push_back("name");
+	needed.push_back("default_value");
+
+	TypedArray<Dictionary> options;
+
+	if (GDVIRTUAL_CALL(_get_import_options, p_path, options)) {
+		for (int i = 0; i < options.size(); i++) {
+			Dictionary d = options[i];
+			ERR_FAIL_COND(!d.has_all(needed));
+
+			Variant default_value = d["default_value"];
+			PropertyInfo property_info = PropertyInfo::from_dict(d);
+
+			ResourceImporter::ImportOption option(property_info, default_value);
+			r_options->push_back(option);
+		}
+		return;
+	}
+
+	ERR_FAIL_MSG("Unimplemented _get_import_options in add-on.");
 }
 
 Variant EditorSceneFormatImporter::get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options) {
@@ -199,9 +217,24 @@ void EditorScenePostImportPlugin::internal_process(InternalImportCategory p_cate
 }
 
 void EditorScenePostImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options) {
-	current_option_list = r_options;
-	GDVIRTUAL_CALL(_get_import_options, p_path);
-	current_option_list = nullptr;
+	Array needed = { "name", "default_value" };
+	TypedArray<Dictionary> options;
+
+	if (GDVIRTUAL_CALL(_get_import_options, p_path, options)) {
+		for (int i = 0; i < options.size(); i++) {
+			Dictionary d = options[i];
+			ERR_FAIL_COND(!d.has_all(needed));
+
+			Variant default_value = d["default_value"];
+			PropertyInfo property_info = PropertyInfo::from_dict(d);
+
+			ResourceImporter::ImportOption option(property_info, default_value);
+			r_options->push_back(option);
+		}
+		return;
+	}
+
+	ERR_FAIL_MSG("Unimplemented _get_import_options in add-on.");
 }
 Variant EditorScenePostImportPlugin::get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
 	current_options = &p_options;

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -33,6 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/io/resource_importer.h"
 #include "core/variant/dictionary.h"
+#include "core/variant/typed_array.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"
@@ -59,7 +60,7 @@ protected:
 
 	GDVIRTUAL0RC(Vector<String>, _get_extensions)
 	GDVIRTUAL3R(Object *, _import_scene, String, uint32_t, Dictionary)
-	GDVIRTUAL1(_get_import_options, String)
+	GDVIRTUAL1R(TypedArray<Dictionary>, _get_import_options, String)
 	GDVIRTUAL3RC(Variant, _get_option_visibility, String, bool, String)
 
 public:
@@ -124,7 +125,7 @@ protected:
 	GDVIRTUAL3RC(Variant, _get_internal_option_visibility, int, bool, String)
 	GDVIRTUAL2RC(Variant, _get_internal_option_update_view_required, int, String)
 	GDVIRTUAL4(_internal_process, int, Node *, Node *, Ref<Resource>)
-	GDVIRTUAL1(_get_import_options, String)
+	GDVIRTUAL1R(TypedArray<Dictionary>, _get_import_options, String)
 	GDVIRTUAL3RC(Variant, _get_option_visibility, String, bool, String)
 	GDVIRTUAL1(_pre_process, Node *)
 	GDVIRTUAL1(_post_process, Node *)

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -329,3 +329,11 @@ Validate extension JSON: API was removed: classes/VisualShader/methods/set_graph
 Validate extension JSON: API was removed: classes/VisualShader/methods/get_graph_offset
 
 The graph_offset property was removed from the resource. This information is now stored in `vs_editor_cache.cfg`.
+
+GH-84516
+--------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/EditorSceneFormatImporter/methods/_get_import_options': return_value
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/EditorScenePostImportPlugin/methods/_get_import_options': return_value
+Validate extension JSON: Error: Hash changed for 'classes/EditorScenePostImportPlugin/methods/_get_import_options', from 04FD3184 to 5DFD10C4. This means that the function has changed and no compatibility function was provided.
+
+C# glue for get_import_options of EditorSceneFormatImporter and EditorScenePostImportPlugin overload is missing return value for options which makes it completely useless because there is no way to return the option list to the engine.


### PR DESCRIPTION
 - fixed for EditorSceneFormatImporter
 - fixed for EditorScenePostImportPlugin

fixes #84516

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
