### PR TITLE
Fix FogMaterial memory leak

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1220,6 +1220,7 @@ void unregister_scene_types() {
 	PhysicalSkyMaterial::cleanup_shader();
 	PanoramaSkyMaterial::cleanup_shader();
 	ProceduralSkyMaterial::cleanup_shader();
+	FogMaterial::cleanup_shader();
 #endif // _3D_DISABLED
 
 	ParticleProcessMaterial::finish_shaders();


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/84691

Fixes the FogMaterial resource/memory leak. `FogMaterial::cleanup_shader()` was implemented and it releases the shared fog shader resource and memory correctly but the method was just never called from anywhere. This PR adds the missing call.