### PR TITLE
Correctly Implements Printing for Unloading ALC

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
+using Godot;
+using FileAccess = System.IO.FileAccess;
 
 namespace GodotPlugins
 {
@@ -37,8 +39,7 @@ namespace GodotPlugins
                 }
                 else
                 {
-                    // TODO: How to log from GodotPlugins? (delegate pointer?)
-                    Console.Error.WriteLine("Failed to set AppContext.BaseDirectory. Dynamic loading of libraries may fail.");
+                    GD.PrintErr("Failed to set AppContext.BaseDirectory. Dynamic loading of libraries may fail.");
                 }
             }
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 #nullable enable
 
+[assembly: InternalsVisibleTo(assemblyName: "GodotPlugins")]
 namespace Godot.NativeInterop
 {
     internal static class ExceptionUtils


### PR DESCRIPTION
Currently GodotPlugins.Main print everything through System.Console (mentioned in TODOs), which is not visible on the Editor side.

This PR addresses this issue by utilizing existing functions in NativeFuncs.cs.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
