### PR TITLE
Fix a property reference in `EditorSpinSlider` documentation

### DIFF
--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This [Control] node is used in the editor's Inspector dock to allow editing of numeric values. Can be used with [EditorInspectorPlugin] to recreate the same behavior.
-		If [member step] is [code]1[/code], the [EditorSpinSlider] will display up/down arrows, similar to [SpinBox]. If the [member step] is not [code]1[/code], a slider will be displayed instead.
+		If the [member Range.step] value is [code]1[/code], the [EditorSpinSlider] will display up/down arrows, similar to [SpinBox]. If the [member Range.step] value is not [code]1[/code], a slider will be displayed instead.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
A regression from one of the recent changes. Basically, we don't seem to validate at any point if a class member referenced in the class documentation is local or inherited but overridden. When it's an overridden reference, the link should be done to the owning class, but all our checks seem to be satisfied with an empty `overrides` record:

```
<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
```

This breaks when building online docs, however, since overridden properties do not generate any sections in the class reference and so don't generate links.

```
/home/yuris/projects/godot-docs/classes/class_editorspinslider.rst:24: WARNING: undefined label: class_editorspinslider_property_step                                                                      
/home/yuris/projects/godot-docs/classes/class_editorspinslider.rst:24: WARNING: undefined label: class_editorspinslider_property_step
```

Surprising that this is a rare issue. Ideally I'd want to fix the validation, but I'll have to do this later. Fixing the docs themselves for now should be enough.