### PR TITLE
Add `single`/`double` as export features automatically

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -481,6 +481,12 @@ HashSet<String> EditorExportPlatform::get_features(const Ref<EditorExportPreset>
 		result.insert("template_release");
 	}
 
+#ifdef REAL_T_IS_DOUBLE
+	result.insert("double");
+#else
+	result.insert("single");
+#endif // REAL_T_IS_DOUBLE
+
 	if (!p_preset->get_custom_features().is_empty()) {
 		Vector<String> tmp_custom_list = p_preset->get_custom_features().split(",");
 

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -409,6 +409,12 @@ void ProjectExportDialog::_update_feature_list() {
 		feature_set.insert(E);
 	}
 
+#ifdef REAL_T_IS_DOUBLE
+	feature_set.insert("double");
+#else
+	feature_set.insert("single");
+#endif // REAL_T_IS_DOUBLE
+
 	custom_feature_display->clear();
 	String text;
 	bool first = true;


### PR DESCRIPTION
Related to #69538.

This adds either `single` or `double` to the list of export feature tags (to signify floating-point precision) based on whether the editor from which you're exporting is built with single or double precision.

This was arguably something that should've been part of #69538 to begin with, as not having this can pose a problem for extensions that use these feature tags as part of their `.gdextension` file, and potentially other things that rely on feature tags.

For example, an extension might add the `single` feature tag to all its `[libraries]` to make sure it doesn't get used/loaded in a double-precision build of Godot, or vice versa. In that scenario you would have to manually add either the `single` or `double` feature tag to the export options in order for the extension to be bundled (and not throw an error) when exporting a project using said extension.

With that said, this change is a little bit crude/simplistic, as it always adds these feature tags regardless of platform with no configurability, so at the risk of further complicating this PR, here are some questions/concerns:

1. Should this instead be done in each respective `EditorExportPlatform::get_platform_features`? Are there (or could there be) platforms that don't support double-precision?
2. ... or should this instead be done in each respective `EditorExportPlatform::get_preset_features`, with "Double Precision" being a configurable preset option? Does it even make sense to export a single-precision build from a double-precision editor and vice versa?