### PR TITLE
CI: Pin Emscripten to 3.1.39

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 3.1.45
+  EM_VERSION: 3.1.39
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:


### PR DESCRIPTION
Due to #82865, newer versions can't be used for dlink-enabled Web builds. This isn't a problem for CI which doesn't use dlink, but it's clearer for users if our CI version matches the one we use for official builds.

See #84008 for an example of a user confused by our CI version.