### PR TITLE
Remove Android specific abis from the export preset feature list

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1717,7 +1717,6 @@ void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPres
 	Vector<ABI> abis = get_enabled_abis(p_preset);
 	for (int i = 0; i < abis.size(); ++i) {
 		r_features->push_back(abis[i].arch);
-		r_features->push_back(abis[i].abi);
 	}
 }
 


### PR DESCRIPTION
The presence of those abis cause them to be included in the set of `p_features` passed to the `gdextension_export_plugin#_export_file(...)` method, which caused them to be lumped in the `features_wo_arch` set.
When trying to find the gdextension library path, we use a predicate with the following logic:
```
[features_wo_arch, arch_tag](String p_feature) { return features_wo_arch.has(p_feature) || (p_feature == arch_tag); }
```

For a `gdextension` config file like the one below, this causes the first android entry (`android.armeabi-v7a = ...`) to always be returned regardless of archs since it always satisfies the predicate.

```
[configuration]

entry_symbol = "example_library_init"
compatibility_minimum = 4.1

[libraries]
linux.x86_64 = "res://libgdexample.so"

android.armeabi-v7a = "res://libgdexample.android.template_release.armeabi-v7a.so"
android.arm32 = "res://libgdexample.android.template_release.armeabi-v7a.so"
android.x86 = "res://x86/libgdexample.android.template_release.x86.so"
android.x86_32 = "res://x86/libgdexample.android.template_release.x86.so"
android.x86_64 = "res://libgdexample.android.template_release.x86_64.so"
android.arm64-v8a = "res://libgdexample.android.template_release.arm64-v8a.so"
android.arm64 = "res://libgdexample.android.template_release.arm64-v8a.so"
```

Fixes https://github.com/godotengine/godot/issues/82727

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
