### PR TITLE
Update Quaternion.cs

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -631,12 +631,6 @@ namespace Godot
         /// <returns>The rotated Vector3.</returns>
         public static Vector3 operator *(Quaternion quaternion, Vector3 vector)
         {
-#if DEBUG
-            if (!quaternion.IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized.");
-            }
-#endif
             var u = new Vector3(quaternion.X, quaternion.Y, quaternion.Z);
             Vector3 uv = u.Cross(vector);
             return vector + (((uv * quaternion.W) + u.Cross(uv)) * 2);
@@ -651,6 +645,12 @@ namespace Godot
         /// <returns>The inversely rotated Vector3.</returns>
         public static Vector3 operator *(Vector3 vector, Quaternion quaternion)
         {
+#if DEBUG
+            if (!quaternion.IsNormalized())
+            {
+                throw new InvalidOperationException("Quaternion is not normalized.");
+            }
+#endif
             return quaternion.Inverse() * vector;
         }
 


### PR DESCRIPTION
Change the quaternion normalize check for the * operation, as the check is incorrectly placed on * (quaternion, vector3) and it should be on *(vector3, quaternion) as it need to be normalized in order to make a quaternion.inverse()

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
