### PR TITLE
Fix for opening non-script text files when using an external editor

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -96,6 +96,10 @@ public:
 	_FORCE_INLINE_ bool operator!=(const Ref<T> &p_r) const {
 		return reference != p_r.reference;
 	}
+	template <class D>
+	_FORCE_INLINE_ bool operator!=(const Ref<D> &p_r) const {
+		return reference != p_r.ptr();
+	}
 
 	_FORCE_INLINE_ T *operator*() const {
 		return reference;


### PR DESCRIPTION
I have a couple of markdown files in my project and I use an external editor. When I try to open the markdown files from the filesystem dock, Godot does not open them in my external editor. 

I tracked the issue to `editor/plugins/script_editor_plugin.cpp:2299`, specifically this part of the code: 
```
EditorDebuggerNode::get_singleton()->get_dump_stack_script() != p_resource
```
`p_resource` is of type `Ref<Resource>` and `get_dump_stack_script() `is of type `Ref<Script>`. So when the two get compared, `p_resource` is converted to `Ref<Script>`, but this makes it null. So the check fails because the dump stack is also null.  

To fix the issue, I added a not equal operator overload for Refs of different types. It fixes this issue and I think should prevent any unexpected behavior in the future? Alternately, I could also fix the issue by updating `script_editor_plugin.cpp` to: 
```
EditorDebuggerNode::get_singleton().get_dump_stack_script().ptr()->!= p_resource.ptr()
```
But that felt like a workaround and might lead to similar issues in the future. 

Let me know your thoughts. I hope this of some use. 

Fixes https://github.com/godotengine/godot/issues/73078
