### PR TITLE
Fix OGG Vorbis infinite error spam with corrupt file.

### DIFF
--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -144,7 +144,7 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 }
 
 int AudioStreamPlaybackOggVorbis::_mix_frames_vorbis(AudioFrame *p_buffer, int p_frames) {
-	ERR_FAIL_COND_V(!ready, 0);
+	ERR_FAIL_COND_V(!ready, p_frames);
 	if (!have_samples_left) {
 		ogg_packet *packet = nullptr;
 		int err;
@@ -156,10 +156,10 @@ int AudioStreamPlaybackOggVorbis::_mix_frames_vorbis(AudioFrame *p_buffer, int p
 		}
 
 		err = vorbis_synthesis(&block, packet);
-		ERR_FAIL_COND_V_MSG(err != 0, 0, "Error during vorbis synthesis " + itos(err));
+		ERR_FAIL_COND_V_MSG(err != 0, p_frames, "Error during vorbis synthesis " + itos(err));
 
 		err = vorbis_synthesis_blockin(&dsp_state, &block);
-		ERR_FAIL_COND_V_MSG(err != 0, 0, "Error during vorbis block processing " + itos(err));
+		ERR_FAIL_COND_V_MSG(err != 0, p_frames, "Error during vorbis block processing " + itos(err));
 
 		have_packets_left = !packet->e_o_s;
 	}


### PR DESCRIPTION
When OGG Vorbis encountered unreadable file, it emitted infinite error spam.
This PR returns the full number of frames in the case of error, to prevent infinite loop.

Fixes #84712

## Notes
* Bug occurs because if you return 0 with error, the calling function enters an infinite loop as it keeps trying to read.
* Have fixed all 3 error conditions, even though 1 was active in the issue.
* This same bug may be present on other audio readers.

## Discussion
Alternatively we could set an error flag. This PR could potentially spam quite a few errors for each audio tile, but it won't enter an infinite loop. If we used an error flag this could prevent more than one error message.

I'm erring on the side of spamming here for now, unless it causes a problem in the wild, or others prefer the flag approach.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
