### PR TITLE
Add missing getters to navigation servers

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -31,6 +31,27 @@
 				Return [code]true[/code] if the specified [param agent] uses avoidance.
 			</description>
 		</method>
+		<method name="agent_get_avoidance_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]avoidance_layers[/code] bitmask of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_avoidance_mask" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]avoidance_mask[/code] bitmask of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_avoidance_priority" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]avoidance_priority[/code] of the specified [param agent].
+			</description>
+		</method>
 		<method name="agent_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />
@@ -38,11 +59,74 @@
 				Returns the navigation map [RID] the requested [param agent] is currently assigned to.
 			</description>
 		</method>
+		<method name="agent_get_max_neighbors" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the maximum number of other agents the specified [param agent] takes into account in the navigation.
+			</description>
+		</method>
+		<method name="agent_get_max_speed" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the maximum speed of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_neighbor_distance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the maximum distance to other agents the specified [param agent] takes into account in the navigation.
+			</description>
+		</method>
 		<method name="agent_get_paused" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="agent" type="RID" />
 			<description>
 				Returns [code]true[/code] if the specified [param agent] is paused.
+			</description>
+		</method>
+		<method name="agent_get_position" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the position of the specified [param agent] in world space.
+			</description>
+		</method>
+		<method name="agent_get_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the radius of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_time_horizon_agents" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the minimal amount of time for which the specified [param agent]'s velocities that are computed by the simulation are safe with respect to other agents.
+			</description>
+		</method>
+		<method name="agent_get_time_horizon_obstacles" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the minimal amount of time for which the specified [param agent]'s velocities that are computed by the simulation are safe with respect to static avoidance obstacles.
+			</description>
+		</method>
+		<method name="agent_get_velocity" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the velocity of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_has_avoidance_callback" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Return [code]true[/code] if the specified [param agent] has an avoidance callback.
 			</description>
 		</method>
 		<method name="agent_is_map_changed" qualifiers="const">
@@ -530,6 +614,13 @@
 				Returns [code]true[/code] if the provided [param obstacle] has avoidance enabled.
 			</description>
 		</method>
+		<method name="obstacle_get_avoidance_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the [code]avoidance_layers[/code] bitmask of the specified [param obstacle].
+			</description>
+		</method>
 		<method name="obstacle_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="obstacle" type="RID" />
@@ -542,6 +633,34 @@
 			<param index="0" name="obstacle" type="RID" />
 			<description>
 				Returns [code]true[/code] if the specified [param obstacle] is paused.
+			</description>
+		</method>
+		<method name="obstacle_get_position" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the position of the specified [param obstacle] in world space.
+			</description>
+		</method>
+		<method name="obstacle_get_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the radius of the specified dynamic [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_get_velocity" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the velocity of the specified dynamic [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_get_vertices" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the outline vertices for the specified [param obstacle].
 			</description>
 		</method>
 		<method name="obstacle_set_avoidance_enabled">
@@ -701,6 +820,13 @@
 				Returns a random position picked from all region polygons with matching [param navigation_layers].
 				If [param uniformly] is [code]true[/code], all region polygons and faces are weighted by their surface area (slower).
 				If [param uniformly] is [code]false[/code], just a random polygon and face is picked (faster).
+			</description>
+		</method>
+		<method name="region_get_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<param index="0" name="region" type="RID" />
+			<description>
+				Returns the global transformation of this [param region].
 			</description>
 		</method>
 		<method name="region_get_travel_cost" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -31,11 +31,60 @@
 				Returns [code]true[/code] if the provided [param agent] has avoidance enabled.
 			</description>
 		</method>
+		<method name="agent_get_avoidance_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]avoidance_layers[/code] bitmask of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_avoidance_mask" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]avoidance_mask[/code] bitmask of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_avoidance_priority" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]avoidance_priority[/code] of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_height" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the [code]height[/code] of the specified [param agent].
+			</description>
+		</method>
 		<method name="agent_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />
 			<description>
 				Returns the navigation map [RID] the requested [param agent] is currently assigned to.
+			</description>
+		</method>
+		<method name="agent_get_max_neighbors" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the maximum number of other agents the specified [param agent] takes into account in the navigation.
+			</description>
+		</method>
+		<method name="agent_get_max_speed" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the maximum speed of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_neighbor_distance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the maximum distance to other agents the specified [param agent] takes into account in the navigation.
 			</description>
 		</method>
 		<method name="agent_get_paused" qualifiers="const">
@@ -45,11 +94,53 @@
 				Returns [code]true[/code] if the specified [param agent] is paused.
 			</description>
 		</method>
+		<method name="agent_get_position" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the position of the specified [param agent] in world space.
+			</description>
+		</method>
+		<method name="agent_get_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the radius of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_get_time_horizon_agents" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the minimal amount of time for which the specified [param agent]'s velocities that are computed by the simulation are safe with respect to other agents.
+			</description>
+		</method>
+		<method name="agent_get_time_horizon_obstacles" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the minimal amount of time for which the specified [param agent]'s velocities that are computed by the simulation are safe with respect to static avoidance obstacles.
+			</description>
+		</method>
 		<method name="agent_get_use_3d_avoidance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="agent" type="RID" />
 			<description>
 				Returns [code]true[/code] if the provided [param agent] uses avoidance in 3D space Vector3(x,y,z) instead of horizontal 2D Vector2(x,y) / Vector3(x,0.0,z).
+			</description>
+		</method>
+		<method name="agent_get_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Returns the velocity of the specified [param agent].
+			</description>
+		</method>
+		<method name="agent_has_avoidance_callback" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="agent" type="RID" />
+			<description>
+				Return [code]true[/code] if the specified [param agent] has an avoidance callback.
 			</description>
 		</method>
 		<method name="agent_is_map_changed" qualifiers="const">
@@ -610,6 +701,20 @@
 				Returns [code]true[/code] if the provided [param obstacle] has avoidance enabled.
 			</description>
 		</method>
+		<method name="obstacle_get_avoidance_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the [code]avoidance_layers[/code] bitmask of the specified [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_get_height" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the [code]height[/code] of the specified [param obstacle].
+			</description>
+		</method>
 		<method name="obstacle_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="obstacle" type="RID" />
@@ -624,11 +729,39 @@
 				Returns [code]true[/code] if the specified [param obstacle] is paused.
 			</description>
 		</method>
+		<method name="obstacle_get_position" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the position of the specified [param obstacle] in world space.
+			</description>
+		</method>
+		<method name="obstacle_get_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the radius of the specified dynamic [param obstacle].
+			</description>
+		</method>
 		<method name="obstacle_get_use_3d_avoidance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="obstacle" type="RID" />
 			<description>
 				Returns [code]true[/code] if the provided [param obstacle] uses avoidance in 3D space Vector3(x,y,z) instead of horizontal 2D Vector2(x,y) / Vector3(x,0.0,z).
+			</description>
+		</method>
+		<method name="obstacle_get_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the velocity of the specified dynamic [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_get_vertices" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns the outline vertices for the specified [param obstacle].
 			</description>
 		</method>
 		<method name="obstacle_set_avoidance_enabled">
@@ -813,6 +946,13 @@
 				Returns a random position picked from all region polygons with matching [param navigation_layers].
 				If [param uniformly] is [code]true[/code], all region polygons and faces are weighted by their surface area (slower).
 				If [param uniformly] is [code]false[/code], just a random polygon and face is picked (faster).
+			</description>
+		</method>
+		<method name="region_get_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<param index="0" name="region" type="RID" />
+			<description>
+				Returns the global transformation of this [param region].
 			</description>
 		</method>
 		<method name="region_get_travel_cost" qualifiers="const">

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -391,6 +391,13 @@ COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform) {
 	region->set_transform(p_transform);
 }
 
+Transform3D GodotNavigationServer::region_get_transform(RID p_region) const {
+	NavRegion *region = region_owner.get_or_null(p_region);
+	ERR_FAIL_NULL_V(region, Transform3D());
+
+	return region->get_transform();
+}
+
 COMMAND_2(region_set_enter_cost, RID, p_region, real_t, p_enter_cost) {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_NULL(region);
@@ -719,6 +726,13 @@ COMMAND_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_distance) {
 	agent->set_neighbor_distance(p_distance);
 }
 
+real_t GodotNavigationServer::agent_get_neighbor_distance(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_neighbor_distance();
+}
+
 COMMAND_2(agent_set_max_neighbors, RID, p_agent, int, p_count) {
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
@@ -726,20 +740,41 @@ COMMAND_2(agent_set_max_neighbors, RID, p_agent, int, p_count) {
 	agent->set_max_neighbors(p_count);
 }
 
+int GodotNavigationServer::agent_get_max_neighbors(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_max_neighbors();
+}
+
 COMMAND_2(agent_set_time_horizon_agents, RID, p_agent, real_t, p_time_horizon) {
-	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizion must be positive.");
+	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizon must be positive.");
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
 
 	agent->set_time_horizon_agents(p_time_horizon);
 }
 
+real_t GodotNavigationServer::agent_get_time_horizon_agents(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_time_horizon_agents();
+}
+
 COMMAND_2(agent_set_time_horizon_obstacles, RID, p_agent, real_t, p_time_horizon) {
-	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizion must be positive.");
+	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizon must be positive.");
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
 
 	agent->set_time_horizon_obstacles(p_time_horizon);
+}
+
+real_t GodotNavigationServer::agent_get_time_horizon_obstacles(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_time_horizon_obstacles();
 }
 
 COMMAND_2(agent_set_radius, RID, p_agent, real_t, p_radius) {
@@ -750,12 +785,26 @@ COMMAND_2(agent_set_radius, RID, p_agent, real_t, p_radius) {
 	agent->set_radius(p_radius);
 }
 
+real_t GodotNavigationServer::agent_get_radius(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_radius();
+}
+
 COMMAND_2(agent_set_height, RID, p_agent, real_t, p_height) {
 	ERR_FAIL_COND_MSG(p_height < 0.0, "Height must be positive.");
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
 
 	agent->set_height(p_height);
+}
+
+real_t GodotNavigationServer::agent_get_height(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_height();
 }
 
 COMMAND_2(agent_set_max_speed, RID, p_agent, real_t, p_max_speed) {
@@ -766,11 +815,25 @@ COMMAND_2(agent_set_max_speed, RID, p_agent, real_t, p_max_speed) {
 	agent->set_max_speed(p_max_speed);
 }
 
+real_t GodotNavigationServer::agent_get_max_speed(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_max_speed();
+}
+
 COMMAND_2(agent_set_velocity, RID, p_agent, Vector3, p_velocity) {
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
 
 	agent->set_velocity(p_velocity);
+}
+
+Vector3 GodotNavigationServer::agent_get_velocity(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, Vector3());
+
+	return agent->get_velocity();
 }
 
 COMMAND_2(agent_set_velocity_forced, RID, p_agent, Vector3, p_velocity) {
@@ -785,6 +848,13 @@ COMMAND_2(agent_set_position, RID, p_agent, Vector3, p_position) {
 	ERR_FAIL_NULL(agent);
 
 	agent->set_position(p_position);
+}
+
+Vector3 GodotNavigationServer::agent_get_position(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, Vector3());
+
+	return agent->get_position();
 }
 
 bool GodotNavigationServer::agent_is_map_changed(RID p_agent) const {
@@ -809,10 +879,24 @@ COMMAND_2(agent_set_avoidance_callback, RID, p_agent, Callable, p_callback) {
 	}
 }
 
+bool GodotNavigationServer::agent_has_avoidance_callback(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, false);
+
+	return agent->has_avoidance_callback();
+}
+
 COMMAND_2(agent_set_avoidance_layers, RID, p_agent, uint32_t, p_layers) {
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
 	agent->set_avoidance_layers(p_layers);
+}
+
+uint32_t GodotNavigationServer::agent_get_avoidance_layers(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_avoidance_layers();
 }
 
 COMMAND_2(agent_set_avoidance_mask, RID, p_agent, uint32_t, p_mask) {
@@ -821,12 +905,26 @@ COMMAND_2(agent_set_avoidance_mask, RID, p_agent, uint32_t, p_mask) {
 	agent->set_avoidance_mask(p_mask);
 }
 
+uint32_t GodotNavigationServer::agent_get_avoidance_mask(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_avoidance_mask();
+}
+
 COMMAND_2(agent_set_avoidance_priority, RID, p_agent, real_t, p_priority) {
 	ERR_FAIL_COND_MSG(p_priority < 0.0, "Avoidance priority must be between 0.0 and 1.0 inclusive.");
 	ERR_FAIL_COND_MSG(p_priority > 1.0, "Avoidance priority must be between 0.0 and 1.0 inclusive.");
 	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_NULL(agent);
 	agent->set_avoidance_priority(p_priority);
+}
+
+real_t GodotNavigationServer::agent_get_avoidance_priority(RID p_agent) const {
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_NULL_V(agent, 0);
+
+	return agent->get_avoidance_priority();
 }
 
 RID GodotNavigationServer::obstacle_create() {
@@ -913,10 +1011,24 @@ COMMAND_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius) {
 	obstacle->set_radius(p_radius);
 }
 
+real_t GodotNavigationServer::obstacle_get_radius(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_NULL_V(obstacle, 0);
+
+	return obstacle->get_radius();
+}
+
 COMMAND_2(obstacle_set_height, RID, p_obstacle, real_t, p_height) {
 	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
 	ERR_FAIL_NULL(obstacle);
 	obstacle->set_height(p_height);
+}
+
+real_t GodotNavigationServer::obstacle_get_height(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_NULL_V(obstacle, 0);
+
+	return obstacle->get_height();
 }
 
 COMMAND_2(obstacle_set_velocity, RID, p_obstacle, Vector3, p_velocity) {
@@ -926,10 +1038,24 @@ COMMAND_2(obstacle_set_velocity, RID, p_obstacle, Vector3, p_velocity) {
 	obstacle->set_velocity(p_velocity);
 }
 
+Vector3 GodotNavigationServer::obstacle_get_velocity(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_NULL_V(obstacle, Vector3());
+
+	return obstacle->get_velocity();
+}
+
 COMMAND_2(obstacle_set_position, RID, p_obstacle, Vector3, p_position) {
 	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
 	ERR_FAIL_NULL(obstacle);
 	obstacle->set_position(p_position);
+}
+
+Vector3 GodotNavigationServer::obstacle_get_position(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_NULL_V(obstacle, Vector3());
+
+	return obstacle->get_position();
 }
 
 void GodotNavigationServer::obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) {
@@ -938,10 +1064,24 @@ void GodotNavigationServer::obstacle_set_vertices(RID p_obstacle, const Vector<V
 	obstacle->set_vertices(p_vertices);
 }
 
+Vector<Vector3> GodotNavigationServer::obstacle_get_vertices(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_NULL_V(obstacle, Vector<Vector3>());
+
+	return obstacle->get_vertices();
+}
+
 COMMAND_2(obstacle_set_avoidance_layers, RID, p_obstacle, uint32_t, p_layers) {
 	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
 	ERR_FAIL_NULL(obstacle);
 	obstacle->set_avoidance_layers(p_layers);
+}
+
+uint32_t GodotNavigationServer::obstacle_get_avoidance_layers(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_NULL_V(obstacle, 0);
+
+	return obstacle->get_avoidance_layers();
 }
 
 void GodotNavigationServer::parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -165,6 +165,7 @@ public:
 	COMMAND_2(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers);
 	virtual uint32_t region_get_navigation_layers(RID p_region) const override;
 	COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform);
+	virtual Transform3D region_get_transform(RID p_region) const override;
 	COMMAND_2(region_set_navigation_mesh, RID, p_region, Ref<NavigationMesh>, p_navigation_mesh);
 #ifndef DISABLE_DEPRECATED
 	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override;
@@ -204,20 +205,33 @@ public:
 	COMMAND_2(agent_set_paused, RID, p_agent, bool, p_paused);
 	virtual bool agent_get_paused(RID p_agent) const override;
 	COMMAND_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_distance);
+	virtual real_t agent_get_neighbor_distance(RID p_agent) const override;
 	COMMAND_2(agent_set_max_neighbors, RID, p_agent, int, p_count);
+	virtual int agent_get_max_neighbors(RID p_agent) const override;
 	COMMAND_2(agent_set_time_horizon_agents, RID, p_agent, real_t, p_time_horizon);
+	virtual real_t agent_get_time_horizon_agents(RID p_agent) const override;
 	COMMAND_2(agent_set_time_horizon_obstacles, RID, p_agent, real_t, p_time_horizon);
+	virtual real_t agent_get_time_horizon_obstacles(RID p_agent) const override;
 	COMMAND_2(agent_set_radius, RID, p_agent, real_t, p_radius);
+	virtual real_t agent_get_radius(RID p_agent) const override;
 	COMMAND_2(agent_set_height, RID, p_agent, real_t, p_height);
+	virtual real_t agent_get_height(RID p_agent) const override;
 	COMMAND_2(agent_set_max_speed, RID, p_agent, real_t, p_max_speed);
+	virtual real_t agent_get_max_speed(RID p_agent) const override;
 	COMMAND_2(agent_set_velocity, RID, p_agent, Vector3, p_velocity);
+	virtual Vector3 agent_get_velocity(RID p_agent) const override;
 	COMMAND_2(agent_set_velocity_forced, RID, p_agent, Vector3, p_velocity);
 	COMMAND_2(agent_set_position, RID, p_agent, Vector3, p_position);
+	virtual Vector3 agent_get_position(RID p_agent) const override;
 	virtual bool agent_is_map_changed(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_callback, RID, p_agent, Callable, p_callback);
+	virtual bool agent_has_avoidance_callback(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_layers, RID, p_agent, uint32_t, p_layers);
+	virtual uint32_t agent_get_avoidance_layers(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_mask, RID, p_agent, uint32_t, p_mask);
+	virtual uint32_t agent_get_avoidance_mask(RID p_agent) const override;
 	COMMAND_2(agent_set_avoidance_priority, RID, p_agent, real_t, p_priority);
+	virtual real_t agent_get_avoidance_priority(RID p_agent) const override;
 
 	virtual RID obstacle_create() override;
 	COMMAND_2(obstacle_set_avoidance_enabled, RID, p_obstacle, bool, p_enabled);
@@ -229,11 +243,17 @@ public:
 	COMMAND_2(obstacle_set_paused, RID, p_obstacle, bool, p_paused);
 	virtual bool obstacle_get_paused(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius);
+	virtual real_t obstacle_get_radius(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_velocity, RID, p_obstacle, Vector3, p_velocity);
+	virtual Vector3 obstacle_get_velocity(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_position, RID, p_obstacle, Vector3, p_position);
+	virtual Vector3 obstacle_get_position(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_height, RID, p_obstacle, real_t, p_height);
+	virtual real_t obstacle_get_height(RID p_obstacle) const override;
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) override;
+	virtual Vector<Vector3> obstacle_get_vertices(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_avoidance_layers, RID, p_obstacle, uint32_t, p_layers);
+	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override;
 
 	virtual void parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) override;
 	virtual void bake_from_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override;

--- a/modules/navigation/godot_navigation_server_2d.cpp
+++ b/modules/navigation/godot_navigation_server_2d.cpp
@@ -141,6 +141,13 @@ static Transform3D trf2_to_trf3(const Transform2D &d) {
 	return Transform3D(b, o);
 }
 
+static Transform2D trf3_to_trf2(const Transform3D &d) {
+	Vector3 o = d.get_origin();
+	Vector3 nx = d.xform(Vector3(1, 0, 0)) - o;
+	Vector3 nz = d.xform(Vector3(0, 0, 1)) - o;
+	return Transform2D(nx.x, nx.z, nz.x, nz.z, o.x, o.z);
+}
+
 static ObjectID id_to_id(const ObjectID &id) {
 	return id;
 }
@@ -283,6 +290,10 @@ void FORWARD_2(region_set_navigation_layers, RID, p_region, uint32_t, p_navigati
 uint32_t FORWARD_1_C(region_get_navigation_layers, RID, p_region, rid_to_rid);
 void FORWARD_2(region_set_transform, RID, p_region, Transform2D, p_transform, rid_to_rid, trf2_to_trf3);
 
+Transform2D GodotNavigationServer2D::region_get_transform(RID p_region) const {
+	return trf3_to_trf2(NavigationServer3D::get_singleton()->region_get_transform(p_region));
+}
+
 void GodotNavigationServer2D::region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) {
 	NavigationServer3D::get_singleton()->region_set_navigation_mesh(p_region, poly_to_mesh(p_navigation_polygon));
 }
@@ -326,25 +337,60 @@ void FORWARD_2(agent_set_avoidance_enabled, RID, p_agent, bool, p_enabled, rid_t
 bool FORWARD_1_C(agent_get_avoidance_enabled, RID, p_agent, rid_to_rid);
 void FORWARD_2(agent_set_map, RID, p_agent, RID, p_map, rid_to_rid, rid_to_rid);
 void FORWARD_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_dist, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::agent_get_neighbor_distance(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_neighbor_distance(p_agent);
+}
 void FORWARD_2(agent_set_max_neighbors, RID, p_agent, int, p_count, rid_to_rid, int_to_int);
+int GodotNavigationServer2D::agent_get_max_neighbors(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_max_neighbors(p_agent);
+}
 void FORWARD_2(agent_set_time_horizon_agents, RID, p_agent, real_t, p_time_horizon, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::agent_get_time_horizon_agents(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_time_horizon_agents(p_agent);
+}
 void FORWARD_2(agent_set_time_horizon_obstacles, RID, p_agent, real_t, p_time_horizon, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::agent_get_time_horizon_obstacles(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_time_horizon_obstacles(p_agent);
+}
 void FORWARD_2(agent_set_radius, RID, p_agent, real_t, p_radius, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::agent_get_radius(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_radius(p_agent);
+}
 void FORWARD_2(agent_set_max_speed, RID, p_agent, real_t, p_max_speed, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::agent_get_max_speed(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_max_speed(p_agent);
+}
 void FORWARD_2(agent_set_velocity_forced, RID, p_agent, Vector2, p_velocity, rid_to_rid, v2_to_v3);
 void FORWARD_2(agent_set_velocity, RID, p_agent, Vector2, p_velocity, rid_to_rid, v2_to_v3);
+Vector2 GodotNavigationServer2D::agent_get_velocity(RID p_agent) const {
+	return v3_to_v2(NavigationServer3D::get_singleton()->agent_get_velocity(p_agent));
+}
 void FORWARD_2(agent_set_position, RID, p_agent, Vector2, p_position, rid_to_rid, v2_to_v3);
-
+Vector2 GodotNavigationServer2D::agent_get_position(RID p_agent) const {
+	return v3_to_v2(NavigationServer3D::get_singleton()->agent_get_position(p_agent));
+}
 bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
 void FORWARD_2(agent_set_paused, RID, p_agent, bool, p_paused, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(agent_get_paused, RID, p_agent, rid_to_rid);
 
 void FORWARD_1(free, RID, p_object, rid_to_rid);
 void FORWARD_2(agent_set_avoidance_callback, RID, p_agent, Callable, p_callback, rid_to_rid, callable_to_callable);
+bool GodotNavigationServer2D::agent_has_avoidance_callback(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_has_avoidance_callback(p_agent);
+}
 
 void FORWARD_2(agent_set_avoidance_layers, RID, p_agent, uint32_t, p_layers, rid_to_rid, uint32_to_uint32);
+uint32_t GodotNavigationServer2D::agent_get_avoidance_layers(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_avoidance_layers(p_agent);
+}
 void FORWARD_2(agent_set_avoidance_mask, RID, p_agent, uint32_t, p_mask, rid_to_rid, uint32_to_uint32);
+uint32_t GodotNavigationServer2D::agent_get_avoidance_mask(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_avoidance_mask(p_agent);
+}
 void FORWARD_2(agent_set_avoidance_priority, RID, p_agent, real_t, p_priority, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::agent_get_avoidance_priority(RID p_agent) const {
+	return NavigationServer3D::get_singleton()->agent_get_avoidance_priority(p_agent);
+}
 
 RID GodotNavigationServer2D::obstacle_create() {
 	RID obstacle = NavigationServer3D::get_singleton()->obstacle_create();
@@ -357,12 +403,27 @@ RID FORWARD_1_C(obstacle_get_map, RID, p_obstacle, rid_to_rid);
 void FORWARD_2(obstacle_set_paused, RID, p_obstacle, bool, p_paused, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(obstacle_get_paused, RID, p_obstacle, rid_to_rid);
 void FORWARD_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius, rid_to_rid, real_to_real);
+real_t GodotNavigationServer2D::obstacle_get_radius(RID p_obstacle) const {
+	return NavigationServer3D::get_singleton()->obstacle_get_radius(p_obstacle);
+}
 void FORWARD_2(obstacle_set_velocity, RID, p_obstacle, Vector2, p_velocity, rid_to_rid, v2_to_v3);
+Vector2 GodotNavigationServer2D::obstacle_get_velocity(RID p_obstacle) const {
+	return v3_to_v2(NavigationServer3D::get_singleton()->obstacle_get_velocity(p_obstacle));
+}
 void FORWARD_2(obstacle_set_position, RID, p_obstacle, Vector2, p_position, rid_to_rid, v2_to_v3);
+Vector2 GodotNavigationServer2D::obstacle_get_position(RID p_obstacle) const {
+	return v3_to_v2(NavigationServer3D::get_singleton()->obstacle_get_position(p_obstacle));
+}
 void FORWARD_2(obstacle_set_avoidance_layers, RID, p_obstacle, uint32_t, p_layers, rid_to_rid, uint32_to_uint32);
+uint32_t GodotNavigationServer2D::obstacle_get_avoidance_layers(RID p_obstacle) const {
+	return NavigationServer3D::get_singleton()->obstacle_get_avoidance_layers(p_obstacle);
+}
 
 void GodotNavigationServer2D::obstacle_set_vertices(RID p_obstacle, const Vector<Vector2> &p_vertices) {
 	NavigationServer3D::get_singleton()->obstacle_set_vertices(p_obstacle, vector_v2_to_v3(p_vertices));
+}
+Vector<Vector2> GodotNavigationServer2D::obstacle_get_vertices(RID p_obstacle) const {
+	return vector_v3_to_v2(NavigationServer3D::get_singleton()->obstacle_get_vertices(p_obstacle));
 }
 
 void GodotNavigationServer2D::query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const {

--- a/modules/navigation/godot_navigation_server_2d.h
+++ b/modules/navigation/godot_navigation_server_2d.h
@@ -95,6 +95,7 @@ public:
 	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) override;
 	virtual uint32_t region_get_navigation_layers(RID p_region) const override;
 	virtual void region_set_transform(RID p_region, Transform2D p_transform) override;
+	virtual Transform2D region_get_transform(RID p_region) const override;
 	virtual void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) override;
 	virtual int region_get_connections_count(RID p_region) const override;
 	virtual Vector2 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override;
@@ -159,6 +160,7 @@ public:
 	/// low, the simulation will not be safe.
 	/// Must be non-negative.
 	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) override;
+	virtual real_t agent_get_neighbor_distance(RID p_agent) const override;
 
 	/// The maximum number of other agents this
 	/// agent takes into account in the navigation.
@@ -167,6 +169,7 @@ public:
 	/// number is too low, the simulation will not
 	/// be safe.
 	virtual void agent_set_max_neighbors(RID p_agent, int p_count) override;
+	virtual int agent_get_max_neighbors(RID p_agent) const override;
 
 	/// The minimal amount of time for which this
 	/// agent's velocities that are computed by the
@@ -176,17 +179,20 @@ public:
 	/// other agents, but the less freedom this
 	/// agent has in choosing its velocities.
 	/// Must be positive.
-
 	virtual void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) override;
+	virtual real_t agent_get_time_horizon_agents(RID p_agent) const override;
 	virtual void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) override;
+	virtual real_t agent_get_time_horizon_obstacles(RID p_agent) const override;
 
 	/// The radius of this agent.
 	/// Must be non-negative.
 	virtual void agent_set_radius(RID p_agent, real_t p_radius) override;
+	virtual real_t agent_get_radius(RID p_agent) const override;
 
 	/// The maximum speed of this agent.
 	/// Must be non-negative.
 	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) override;
+	virtual real_t agent_get_max_speed(RID p_agent) const override;
 
 	/// forces and agent velocity change in the avoidance simulation, adds simulation instability if done recklessly
 	virtual void agent_set_velocity_forced(RID p_agent, Vector2 p_velocity) override;
@@ -194,19 +200,27 @@ public:
 	/// The wanted velocity for the agent as a "suggestion" to the avoidance simulation.
 	/// The simulation will try to fulfill this velocity wish if possible but may change the velocity depending on other agent's and obstacles'.
 	virtual void agent_set_velocity(RID p_agent, Vector2 p_velocity) override;
+	virtual Vector2 agent_get_velocity(RID p_agent) const override;
 
 	/// Position of the agent in world space.
 	virtual void agent_set_position(RID p_agent, Vector2 p_position) override;
+	virtual Vector2 agent_get_position(RID p_agent) const override;
 
 	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const override;
 
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) override;
+	virtual bool agent_has_avoidance_callback(RID p_agent) const override;
 
 	virtual void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) override;
+	virtual uint32_t agent_get_avoidance_layers(RID p_agent) const override;
+
 	virtual void agent_set_avoidance_mask(RID p_agent, uint32_t p_mask) override;
+	virtual uint32_t agent_get_avoidance_mask(RID p_agent) const override;
+
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) override;
+	virtual real_t agent_get_avoidance_priority(RID p_agent) const override;
 
 	virtual RID obstacle_create() override;
 	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) override;
@@ -216,10 +230,15 @@ public:
 	virtual void obstacle_set_paused(RID p_obstacle, bool p_paused) override;
 	virtual bool obstacle_get_paused(RID p_obstacle) const override;
 	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius) override;
+	virtual real_t obstacle_get_radius(RID p_obstacle) const override;
 	virtual void obstacle_set_velocity(RID p_obstacle, Vector2 p_velocity) override;
+	virtual Vector2 obstacle_get_velocity(RID p_obstacle) const override;
 	virtual void obstacle_set_position(RID p_obstacle, Vector2 p_position) override;
+	virtual Vector2 obstacle_get_position(RID p_obstacle) const override;
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector2> &p_vertices) override;
+	virtual Vector<Vector2> obstacle_get_vertices(RID p_obstacle) const override;
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override;
+	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override;
 
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const override;
 

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -503,7 +503,7 @@ void NavigationAgent2D::set_max_neighbors(int p_count) {
 }
 
 void NavigationAgent2D::set_time_horizon_agents(real_t p_time_horizon) {
-	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizion must be positive.");
+	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizon must be positive.");
 	if (Math::is_equal_approx(time_horizon_agents, p_time_horizon)) {
 		return;
 	}
@@ -512,7 +512,7 @@ void NavigationAgent2D::set_time_horizon_agents(real_t p_time_horizon) {
 }
 
 void NavigationAgent2D::set_time_horizon_obstacles(real_t p_time_horizon) {
-	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizion must be positive.");
+	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizon must be positive.");
 	if (Math::is_equal_approx(time_horizon_obstacles, p_time_horizon)) {
 		return;
 	}

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -567,7 +567,7 @@ void NavigationAgent3D::set_max_neighbors(int p_count) {
 }
 
 void NavigationAgent3D::set_time_horizon_agents(real_t p_time_horizon) {
-	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizion must be positive.");
+	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizon must be positive.");
 	if (Math::is_equal_approx(time_horizon_agents, p_time_horizon)) {
 		return;
 	}
@@ -576,7 +576,7 @@ void NavigationAgent3D::set_time_horizon_agents(real_t p_time_horizon) {
 }
 
 void NavigationAgent3D::set_time_horizon_obstacles(real_t p_time_horizon) {
-	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizion must be positive.");
+	ERR_FAIL_COND_MSG(p_time_horizon < 0.0, "Time horizon must be positive.");
 	if (Math::is_equal_approx(time_horizon_obstacles, p_time_horizon)) {
 		return;
 	}

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -80,6 +80,7 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_set_navigation_layers", "region", "navigation_layers"), &NavigationServer2D::region_set_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_get_navigation_layers", "region"), &NavigationServer2D::region_get_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer2D::region_set_transform);
+	ClassDB::bind_method(D_METHOD("region_get_transform", "region"), &NavigationServer2D::region_get_transform);
 	ClassDB::bind_method(D_METHOD("region_set_navigation_polygon", "region", "navigation_polygon"), &NavigationServer2D::region_set_navigation_polygon);
 	ClassDB::bind_method(D_METHOD("region_get_connections_count", "region"), &NavigationServer2D::region_get_connections_count);
 	ClassDB::bind_method(D_METHOD("region_get_connection_pathway_start", "region", "connection"), &NavigationServer2D::region_get_connection_pathway_start);
@@ -114,19 +115,31 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_paused", "agent", "paused"), &NavigationServer2D::agent_set_paused);
 	ClassDB::bind_method(D_METHOD("agent_get_paused", "agent"), &NavigationServer2D::agent_get_paused);
 	ClassDB::bind_method(D_METHOD("agent_set_neighbor_distance", "agent", "distance"), &NavigationServer2D::agent_set_neighbor_distance);
+	ClassDB::bind_method(D_METHOD("agent_get_neighbor_distance", "agent"), &NavigationServer2D::agent_get_neighbor_distance);
 	ClassDB::bind_method(D_METHOD("agent_set_max_neighbors", "agent", "count"), &NavigationServer2D::agent_set_max_neighbors);
+	ClassDB::bind_method(D_METHOD("agent_get_max_neighbors", "agent"), &NavigationServer2D::agent_get_max_neighbors);
 	ClassDB::bind_method(D_METHOD("agent_set_time_horizon_agents", "agent", "time_horizon"), &NavigationServer2D::agent_set_time_horizon_agents);
+	ClassDB::bind_method(D_METHOD("agent_get_time_horizon_agents", "agent"), &NavigationServer2D::agent_get_time_horizon_agents);
 	ClassDB::bind_method(D_METHOD("agent_set_time_horizon_obstacles", "agent", "time_horizon"), &NavigationServer2D::agent_set_time_horizon_obstacles);
+	ClassDB::bind_method(D_METHOD("agent_get_time_horizon_obstacles", "agent"), &NavigationServer2D::agent_get_time_horizon_obstacles);
 	ClassDB::bind_method(D_METHOD("agent_set_radius", "agent", "radius"), &NavigationServer2D::agent_set_radius);
+	ClassDB::bind_method(D_METHOD("agent_get_radius", "agent"), &NavigationServer2D::agent_get_radius);
 	ClassDB::bind_method(D_METHOD("agent_set_max_speed", "agent", "max_speed"), &NavigationServer2D::agent_set_max_speed);
+	ClassDB::bind_method(D_METHOD("agent_get_max_speed", "agent"), &NavigationServer2D::agent_get_max_speed);
 	ClassDB::bind_method(D_METHOD("agent_set_velocity_forced", "agent", "velocity"), &NavigationServer2D::agent_set_velocity_forced);
 	ClassDB::bind_method(D_METHOD("agent_set_velocity", "agent", "velocity"), &NavigationServer2D::agent_set_velocity);
+	ClassDB::bind_method(D_METHOD("agent_get_velocity", "agent"), &NavigationServer2D::agent_get_velocity);
 	ClassDB::bind_method(D_METHOD("agent_set_position", "agent", "position"), &NavigationServer2D::agent_set_position);
+	ClassDB::bind_method(D_METHOD("agent_get_position", "agent"), &NavigationServer2D::agent_get_position);
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer2D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_callback", "agent", "callback"), &NavigationServer2D::agent_set_avoidance_callback);
+	ClassDB::bind_method(D_METHOD("agent_has_avoidance_callback", "agent"), &NavigationServer2D::agent_has_avoidance_callback);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_layers", "agent", "layers"), &NavigationServer2D::agent_set_avoidance_layers);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_layers", "agent"), &NavigationServer2D::agent_get_avoidance_layers);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_mask", "agent", "mask"), &NavigationServer2D::agent_set_avoidance_mask);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_mask", "agent"), &NavigationServer2D::agent_get_avoidance_mask);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_priority", "agent", "priority"), &NavigationServer2D::agent_set_avoidance_priority);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_priority", "agent"), &NavigationServer2D::agent_get_avoidance_priority);
 
 	ClassDB::bind_method(D_METHOD("obstacle_create"), &NavigationServer2D::obstacle_create);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_enabled", "obstacle", "enabled"), &NavigationServer2D::obstacle_set_avoidance_enabled);
@@ -136,10 +149,15 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("obstacle_set_paused", "obstacle", "paused"), &NavigationServer2D::obstacle_set_paused);
 	ClassDB::bind_method(D_METHOD("obstacle_get_paused", "obstacle"), &NavigationServer2D::obstacle_get_paused);
 	ClassDB::bind_method(D_METHOD("obstacle_set_radius", "obstacle", "radius"), &NavigationServer2D::obstacle_set_radius);
+	ClassDB::bind_method(D_METHOD("obstacle_get_radius", "obstacle"), &NavigationServer2D::obstacle_get_radius);
 	ClassDB::bind_method(D_METHOD("obstacle_set_velocity", "obstacle", "velocity"), &NavigationServer2D::obstacle_set_velocity);
+	ClassDB::bind_method(D_METHOD("obstacle_get_velocity", "obstacle"), &NavigationServer2D::obstacle_get_velocity);
 	ClassDB::bind_method(D_METHOD("obstacle_set_position", "obstacle", "position"), &NavigationServer2D::obstacle_set_position);
+	ClassDB::bind_method(D_METHOD("obstacle_get_position", "obstacle"), &NavigationServer2D::obstacle_get_position);
 	ClassDB::bind_method(D_METHOD("obstacle_set_vertices", "obstacle", "vertices"), &NavigationServer2D::obstacle_set_vertices);
+	ClassDB::bind_method(D_METHOD("obstacle_get_vertices", "obstacle"), &NavigationServer2D::obstacle_get_vertices);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_layers", "obstacle", "layers"), &NavigationServer2D::obstacle_set_avoidance_layers);
+	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_layers", "obstacle"), &NavigationServer2D::obstacle_get_avoidance_layers);
 
 	ClassDB::bind_method(D_METHOD("parse_source_geometry_data", "navigation_polygon", "source_geometry_data", "root_node", "callback"), &NavigationServer2D::parse_source_geometry_data, DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("bake_from_source_geometry_data", "navigation_polygon", "source_geometry_data", "callback"), &NavigationServer2D::bake_from_source_geometry_data, DEFVAL(Callable()));

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -138,6 +138,7 @@ public:
 
 	/// Set the global transformation of this region.
 	virtual void region_set_transform(RID p_region, Transform2D p_transform) = 0;
+	virtual Transform2D region_get_transform(RID p_region) const = 0;
 
 	/// Set the navigation poly of this region.
 	virtual void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) = 0;
@@ -208,6 +209,7 @@ public:
 	/// low, the simulation will not be safe.
 	/// Must be non-negative.
 	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) = 0;
+	virtual real_t agent_get_neighbor_distance(RID p_agent) const = 0;
 
 	/// The maximum number of other agents this
 	/// agent takes into account in the navigation.
@@ -216,6 +218,7 @@ public:
 	/// number is too low, the simulation will not
 	/// be safe.
 	virtual void agent_set_max_neighbors(RID p_agent, int p_count) = 0;
+	virtual int agent_get_max_neighbors(RID p_agent) const = 0;
 
 	/// The minimal amount of time for which this
 	/// agent's velocities that are computed by the
@@ -225,17 +228,20 @@ public:
 	/// other agents, but the less freedom this
 	/// agent has in choosing its velocities.
 	/// Must be positive.
-
 	virtual void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) = 0;
+	virtual real_t agent_get_time_horizon_agents(RID p_agent) const = 0;
 	virtual void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) = 0;
+	virtual real_t agent_get_time_horizon_obstacles(RID p_agent) const = 0;
 
 	/// The radius of this agent.
 	/// Must be non-negative.
 	virtual void agent_set_radius(RID p_agent, real_t p_radius) = 0;
+	virtual real_t agent_get_radius(RID p_agent) const = 0;
 
 	/// The maximum speed of this agent.
 	/// Must be non-negative.
 	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) = 0;
+	virtual real_t agent_get_max_speed(RID p_agent) const = 0;
 
 	/// forces and agent velocity change in the avoidance simulation, adds simulation instability if done recklessly
 	virtual void agent_set_velocity_forced(RID p_agent, Vector2 p_velocity) = 0;
@@ -243,19 +249,27 @@ public:
 	/// The wanted velocity for the agent as a "suggestion" to the avoidance simulation.
 	/// The simulation will try to fulfill this velocity wish if possible but may change the velocity depending on other agent's and obstacles'.
 	virtual void agent_set_velocity(RID p_agent, Vector2 p_velocity) = 0;
+	virtual Vector2 agent_get_velocity(RID p_agent) const = 0;
 
 	/// Position of the agent in world space.
 	virtual void agent_set_position(RID p_agent, Vector2 p_position) = 0;
+	virtual Vector2 agent_get_position(RID p_agent) const = 0;
 
 	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const = 0;
 
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) = 0;
+	virtual bool agent_has_avoidance_callback(RID p_agent) const = 0;
 
 	virtual void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) = 0;
+	virtual uint32_t agent_get_avoidance_layers(RID p_agent) const = 0;
+
 	virtual void agent_set_avoidance_mask(RID p_agent, uint32_t p_mask) = 0;
+	virtual uint32_t agent_get_avoidance_mask(RID p_agent) const = 0;
+
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) = 0;
+	virtual real_t agent_get_avoidance_priority(RID p_agent) const = 0;
 
 	/// Creates the obstacle.
 	virtual RID obstacle_create() = 0;
@@ -266,10 +280,15 @@ public:
 	virtual void obstacle_set_paused(RID p_obstacle, bool p_paused) = 0;
 	virtual bool obstacle_get_paused(RID p_obstacle) const = 0;
 	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius) = 0;
+	virtual real_t obstacle_get_radius(RID p_obstacle) const = 0;
 	virtual void obstacle_set_velocity(RID p_obstacle, Vector2 p_velocity) = 0;
+	virtual Vector2 obstacle_get_velocity(RID p_obstacle) const = 0;
 	virtual void obstacle_set_position(RID p_obstacle, Vector2 p_position) = 0;
+	virtual Vector2 obstacle_get_position(RID p_obstacle) const = 0;
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector2> &p_vertices) = 0;
+	virtual Vector<Vector2> obstacle_get_vertices(RID p_obstacle) const = 0;
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;
+	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const = 0;
 
 	/// Returns a customized navigation path using a query parameters object
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const = 0;

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -77,6 +77,7 @@ public:
 	void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) override {}
 	uint32_t region_get_navigation_layers(RID p_region) const override { return 0; }
 	void region_set_transform(RID p_region, Transform2D p_transform) override {}
+	Transform2D region_get_transform(RID p_region) const override { return Transform2D(); }
 	void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) override {}
 	int region_get_connections_count(RID p_region) const override { return 0; }
 	Vector2 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override { return Vector2(); }
@@ -111,19 +112,31 @@ public:
 	void agent_set_avoidance_enabled(RID p_agent, bool p_enabled) override {}
 	bool agent_get_avoidance_enabled(RID p_agent) const override { return false; }
 	void agent_set_neighbor_distance(RID p_agent, real_t p_distance) override {}
+	real_t agent_get_neighbor_distance(RID p_agent) const override { return 0; }
 	void agent_set_max_neighbors(RID p_agent, int p_count) override {}
+	int agent_get_max_neighbors(RID p_agent) const override { return 0; }
 	void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) override {}
+	real_t agent_get_time_horizon_agents(RID p_agent) const override { return 0; }
 	void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) override {}
+	real_t agent_get_time_horizon_obstacles(RID p_agent) const override { return 0; }
 	void agent_set_radius(RID p_agent, real_t p_radius) override {}
+	real_t agent_get_radius(RID p_agent) const override { return 0; }
 	void agent_set_max_speed(RID p_agent, real_t p_max_speed) override {}
+	real_t agent_get_max_speed(RID p_agent) const override { return 0; }
 	void agent_set_velocity_forced(RID p_agent, Vector2 p_velocity) override {}
 	void agent_set_velocity(RID p_agent, Vector2 p_velocity) override {}
+	Vector2 agent_get_velocity(RID p_agent) const override { return Vector2(); }
 	void agent_set_position(RID p_agent, Vector2 p_position) override {}
+	Vector2 agent_get_position(RID p_agent) const override { return Vector2(); }
 	bool agent_is_map_changed(RID p_agent) const override { return false; }
 	void agent_set_avoidance_callback(RID p_agent, Callable p_callback) override {}
+	bool agent_has_avoidance_callback(RID p_agent) const override { return false; }
 	void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) override {}
+	uint32_t agent_get_avoidance_layers(RID p_agent) const override { return 0; }
 	void agent_set_avoidance_mask(RID p_agent, uint32_t p_mask) override {}
+	uint32_t agent_get_avoidance_mask(RID p_agent) const override { return 0; }
 	void agent_set_avoidance_priority(RID p_agent, real_t p_priority) override {}
+	real_t agent_get_avoidance_priority(RID p_agent) const override { return 0; }
 
 	RID obstacle_create() override { return RID(); }
 	void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) override {}
@@ -133,10 +146,15 @@ public:
 	void obstacle_set_paused(RID p_obstacle, bool p_paused) override {}
 	bool obstacle_get_paused(RID p_obstacle) const override { return false; }
 	void obstacle_set_radius(RID p_obstacle, real_t p_radius) override {}
+	real_t obstacle_get_radius(RID p_agent) const override { return 0; }
 	void obstacle_set_velocity(RID p_obstacle, Vector2 p_velocity) override {}
+	Vector2 obstacle_get_velocity(RID p_agent) const override { return Vector2(); }
 	void obstacle_set_position(RID p_obstacle, Vector2 p_position) override {}
+	Vector2 obstacle_get_position(RID p_agent) const override { return Vector2(); }
 	void obstacle_set_vertices(RID p_obstacle, const Vector<Vector2> &p_vertices) override {}
+	Vector<Vector2> obstacle_get_vertices(RID p_agent) const override { return Vector<Vector2>(); }
 	void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override {}
+	uint32_t obstacle_get_avoidance_layers(RID p_agent) const override { return 0; }
 
 	void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const override {}
 

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -85,6 +85,7 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_set_navigation_layers", "region", "navigation_layers"), &NavigationServer3D::region_set_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_get_navigation_layers", "region"), &NavigationServer3D::region_get_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer3D::region_set_transform);
+	ClassDB::bind_method(D_METHOD("region_get_transform", "region"), &NavigationServer3D::region_get_transform);
 	ClassDB::bind_method(D_METHOD("region_set_navigation_mesh", "region", "navigation_mesh"), &NavigationServer3D::region_set_navigation_mesh);
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("region_bake_navigation_mesh", "navigation_mesh", "root_node"), &NavigationServer3D::region_bake_navigation_mesh);
@@ -125,20 +126,33 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_paused", "agent", "paused"), &NavigationServer3D::agent_set_paused);
 	ClassDB::bind_method(D_METHOD("agent_get_paused", "agent"), &NavigationServer3D::agent_get_paused);
 	ClassDB::bind_method(D_METHOD("agent_set_neighbor_distance", "agent", "distance"), &NavigationServer3D::agent_set_neighbor_distance);
+	ClassDB::bind_method(D_METHOD("agent_get_neighbor_distance", "agent"), &NavigationServer3D::agent_get_neighbor_distance);
 	ClassDB::bind_method(D_METHOD("agent_set_max_neighbors", "agent", "count"), &NavigationServer3D::agent_set_max_neighbors);
+	ClassDB::bind_method(D_METHOD("agent_get_max_neighbors", "agent"), &NavigationServer3D::agent_get_max_neighbors);
 	ClassDB::bind_method(D_METHOD("agent_set_time_horizon_agents", "agent", "time_horizon"), &NavigationServer3D::agent_set_time_horizon_agents);
+	ClassDB::bind_method(D_METHOD("agent_get_time_horizon_agents", "agent"), &NavigationServer3D::agent_get_time_horizon_agents);
 	ClassDB::bind_method(D_METHOD("agent_set_time_horizon_obstacles", "agent", "time_horizon"), &NavigationServer3D::agent_set_time_horizon_obstacles);
+	ClassDB::bind_method(D_METHOD("agent_get_time_horizon_obstacles", "agent"), &NavigationServer3D::agent_get_time_horizon_obstacles);
 	ClassDB::bind_method(D_METHOD("agent_set_radius", "agent", "radius"), &NavigationServer3D::agent_set_radius);
+	ClassDB::bind_method(D_METHOD("agent_get_radius", "agent"), &NavigationServer3D::agent_get_radius);
 	ClassDB::bind_method(D_METHOD("agent_set_height", "agent", "height"), &NavigationServer3D::agent_set_height);
+	ClassDB::bind_method(D_METHOD("agent_get_height", "agent"), &NavigationServer3D::agent_get_height);
 	ClassDB::bind_method(D_METHOD("agent_set_max_speed", "agent", "max_speed"), &NavigationServer3D::agent_set_max_speed);
+	ClassDB::bind_method(D_METHOD("agent_get_max_speed", "agent"), &NavigationServer3D::agent_get_max_speed);
 	ClassDB::bind_method(D_METHOD("agent_set_velocity_forced", "agent", "velocity"), &NavigationServer3D::agent_set_velocity_forced);
 	ClassDB::bind_method(D_METHOD("agent_set_velocity", "agent", "velocity"), &NavigationServer3D::agent_set_velocity);
+	ClassDB::bind_method(D_METHOD("agent_get_velocity", "agent"), &NavigationServer3D::agent_get_velocity);
 	ClassDB::bind_method(D_METHOD("agent_set_position", "agent", "position"), &NavigationServer3D::agent_set_position);
+	ClassDB::bind_method(D_METHOD("agent_get_position", "agent"), &NavigationServer3D::agent_get_position);
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer3D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_callback", "agent", "callback"), &NavigationServer3D::agent_set_avoidance_callback);
+	ClassDB::bind_method(D_METHOD("agent_has_avoidance_callback", "agent"), &NavigationServer3D::agent_has_avoidance_callback);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_layers", "agent", "layers"), &NavigationServer3D::agent_set_avoidance_layers);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_layers", "agent"), &NavigationServer3D::agent_get_avoidance_layers);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_mask", "agent", "mask"), &NavigationServer3D::agent_set_avoidance_mask);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_mask", "agent"), &NavigationServer3D::agent_get_avoidance_mask);
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_priority", "agent", "priority"), &NavigationServer3D::agent_set_avoidance_priority);
+	ClassDB::bind_method(D_METHOD("agent_get_avoidance_priority", "agent"), &NavigationServer3D::agent_get_avoidance_priority);
 
 	ClassDB::bind_method(D_METHOD("obstacle_create"), &NavigationServer3D::obstacle_create);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_enabled", "obstacle", "enabled"), &NavigationServer3D::obstacle_set_avoidance_enabled);
@@ -150,11 +164,17 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("obstacle_set_paused", "obstacle", "paused"), &NavigationServer3D::obstacle_set_paused);
 	ClassDB::bind_method(D_METHOD("obstacle_get_paused", "obstacle"), &NavigationServer3D::obstacle_get_paused);
 	ClassDB::bind_method(D_METHOD("obstacle_set_radius", "obstacle", "radius"), &NavigationServer3D::obstacle_set_radius);
+	ClassDB::bind_method(D_METHOD("obstacle_get_radius", "obstacle"), &NavigationServer3D::obstacle_get_radius);
 	ClassDB::bind_method(D_METHOD("obstacle_set_height", "obstacle", "height"), &NavigationServer3D::obstacle_set_height);
+	ClassDB::bind_method(D_METHOD("obstacle_get_height", "obstacle"), &NavigationServer3D::obstacle_get_height);
 	ClassDB::bind_method(D_METHOD("obstacle_set_velocity", "obstacle", "velocity"), &NavigationServer3D::obstacle_set_velocity);
+	ClassDB::bind_method(D_METHOD("obstacle_get_velocity", "obstacle"), &NavigationServer3D::obstacle_get_velocity);
 	ClassDB::bind_method(D_METHOD("obstacle_set_position", "obstacle", "position"), &NavigationServer3D::obstacle_set_position);
+	ClassDB::bind_method(D_METHOD("obstacle_get_position", "obstacle"), &NavigationServer3D::obstacle_get_position);
 	ClassDB::bind_method(D_METHOD("obstacle_set_vertices", "obstacle", "vertices"), &NavigationServer3D::obstacle_set_vertices);
+	ClassDB::bind_method(D_METHOD("obstacle_get_vertices", "obstacle"), &NavigationServer3D::obstacle_get_vertices);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_layers", "obstacle", "layers"), &NavigationServer3D::obstacle_set_avoidance_layers);
+	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_layers", "obstacle"), &NavigationServer3D::obstacle_get_avoidance_layers);
 
 	ClassDB::bind_method(D_METHOD("parse_source_geometry_data", "navigation_mesh", "source_geometry_data", "root_node", "callback"), &NavigationServer3D::parse_source_geometry_data, DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("bake_from_source_geometry_data", "navigation_mesh", "source_geometry_data", "callback"), &NavigationServer3D::bake_from_source_geometry_data, DEFVAL(Callable()));

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -149,6 +149,7 @@ public:
 
 	/// Set the global transformation of this region.
 	virtual void region_set_transform(RID p_region, Transform3D p_transform) = 0;
+	virtual Transform3D region_get_transform(RID p_region) const = 0;
 
 	/// Set the navigation mesh of this region.
 	virtual void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) = 0;
@@ -227,6 +228,7 @@ public:
 	/// low, the simulation will not be safe.
 	/// Must be non-negative.
 	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) = 0;
+	virtual real_t agent_get_neighbor_distance(RID p_agent) const = 0;
 
 	/// The maximum number of other agents this
 	/// agent takes into account in the navigation.
@@ -235,25 +237,32 @@ public:
 	/// number is too low, the simulation will not
 	/// be safe.
 	virtual void agent_set_max_neighbors(RID p_agent, int p_count) = 0;
+	virtual int agent_get_max_neighbors(RID p_agent) const = 0;
 
 	// Sets the minimum amount of time in seconds that an agent's
 	// must be able to stay on the calculated velocity while still avoiding collisions with agent's
 	// if this value is set to high an agent will often fall back to using a very low velocity just to be safe
 	virtual void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) = 0;
+	virtual real_t agent_get_time_horizon_agents(RID p_agent) const = 0;
 
 	/// Sets the minimum amount of time in seconds that an agent's
 	// must be able to stay on the calculated velocity while still avoiding collisions with obstacle's
 	// if this value is set to high an agent will often fall back to using a very low velocity just to be safe
 	virtual void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) = 0;
+	virtual real_t agent_get_time_horizon_obstacles(RID p_agent) const = 0;
 
 	/// The radius of this agent.
 	/// Must be non-negative.
 	virtual void agent_set_radius(RID p_agent, real_t p_radius) = 0;
+	virtual real_t agent_get_radius(RID p_agent) const = 0;
+
 	virtual void agent_set_height(RID p_agent, real_t p_height) = 0;
+	virtual real_t agent_get_height(RID p_agent) const = 0;
 
 	/// The maximum speed of this agent.
 	/// Must be non-negative.
 	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) = 0;
+	virtual real_t agent_get_max_speed(RID p_agent) const = 0;
 
 	/// forces and agent velocity change in the avoidance simulation, adds simulation instability if done recklessly
 	virtual void agent_set_velocity_forced(RID p_agent, Vector3 p_velocity) = 0;
@@ -261,22 +270,31 @@ public:
 	/// The wanted velocity for the agent as a "suggestion" to the avoidance simulation.
 	/// The simulation will try to fulfill this velocity wish if possible but may change the velocity depending on other agent's and obstacles'.
 	virtual void agent_set_velocity(RID p_agent, Vector3 p_velocity) = 0;
+	virtual Vector3 agent_get_velocity(RID p_agent) const = 0;
 
 	/// Position of the agent in world space.
 	virtual void agent_set_position(RID p_agent, Vector3 p_position) = 0;
+	virtual Vector3 agent_get_position(RID p_agent) const = 0;
 
 	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const = 0;
 
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_avoidance_callback(RID p_agent, Callable p_callback) = 0;
+	virtual bool agent_has_avoidance_callback(RID p_agent) const = 0;
 
 	virtual void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) = 0;
+	virtual uint32_t agent_get_avoidance_layers(RID p_agent) const = 0;
+
 	virtual void agent_set_avoidance_mask(RID p_agent, uint32_t p_mask) = 0;
+	virtual uint32_t agent_get_avoidance_mask(RID p_agent) const = 0;
+
 	virtual void agent_set_avoidance_priority(RID p_agent, real_t p_priority) = 0;
+	virtual real_t agent_get_avoidance_priority(RID p_agent) const = 0;
 
 	/// Creates the obstacle.
 	virtual RID obstacle_create() = 0;
+
 	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
 	virtual RID obstacle_get_map(RID p_obstacle) const = 0;
 
@@ -285,14 +303,22 @@ public:
 
 	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) = 0;
 	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const = 0;
+
 	virtual void obstacle_set_use_3d_avoidance(RID p_obstacle, bool p_enabled) = 0;
 	virtual bool obstacle_get_use_3d_avoidance(RID p_obstacle) const = 0;
+
 	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius) = 0;
+	virtual real_t obstacle_get_radius(RID p_obstacle) const = 0;
 	virtual void obstacle_set_height(RID p_obstacle, real_t p_height) = 0;
+	virtual real_t obstacle_get_height(RID p_obstacle) const = 0;
 	virtual void obstacle_set_velocity(RID p_obstacle, Vector3 p_velocity) = 0;
+	virtual Vector3 obstacle_get_velocity(RID p_obstacle) const = 0;
 	virtual void obstacle_set_position(RID p_obstacle, Vector3 p_position) = 0;
+	virtual Vector3 obstacle_get_position(RID p_obstacle) const = 0;
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) = 0;
+	virtual Vector<Vector3> obstacle_get_vertices(RID p_obstacle) const = 0;
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;
+	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const = 0;
 
 	/// Destroy the `RID`
 	virtual void free(RID p_object) = 0;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -81,6 +81,7 @@ public:
 	void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) override {}
 	uint32_t region_get_navigation_layers(RID p_region) const override { return 0; }
 	void region_set_transform(RID p_region, Transform3D p_transform) override {}
+	Transform3D region_get_transform(RID p_region) const override { return Transform3D(); }
 	void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) override {}
 #ifndef DISABLE_DEPRECATED
 	void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override {}
@@ -118,20 +119,33 @@ public:
 	void agent_set_use_3d_avoidance(RID p_agent, bool p_enabled) override {}
 	bool agent_get_use_3d_avoidance(RID p_agent) const override { return false; }
 	void agent_set_neighbor_distance(RID p_agent, real_t p_distance) override {}
+	real_t agent_get_neighbor_distance(RID p_agent) const override { return 0; }
 	void agent_set_max_neighbors(RID p_agent, int p_count) override {}
+	int agent_get_max_neighbors(RID p_agent) const override { return 0; }
 	void agent_set_time_horizon_agents(RID p_agent, real_t p_time_horizon) override {}
+	real_t agent_get_time_horizon_agents(RID p_agent) const override { return 0; }
 	void agent_set_time_horizon_obstacles(RID p_agent, real_t p_time_horizon) override {}
+	real_t agent_get_time_horizon_obstacles(RID p_agent) const override { return 0; }
 	void agent_set_radius(RID p_agent, real_t p_radius) override {}
+	real_t agent_get_radius(RID p_agent) const override { return 0; }
 	void agent_set_height(RID p_agent, real_t p_height) override {}
+	real_t agent_get_height(RID p_agent) const override { return 0; }
 	void agent_set_max_speed(RID p_agent, real_t p_max_speed) override {}
+	real_t agent_get_max_speed(RID p_agent) const override { return 0; }
 	void agent_set_velocity_forced(RID p_agent, Vector3 p_velocity) override {}
 	void agent_set_velocity(RID p_agent, Vector3 p_velocity) override {}
+	Vector3 agent_get_velocity(RID p_agent) const override { return Vector3(); }
 	void agent_set_position(RID p_agent, Vector3 p_position) override {}
+	Vector3 agent_get_position(RID p_agent) const override { return Vector3(); }
 	bool agent_is_map_changed(RID p_agent) const override { return false; }
 	void agent_set_avoidance_callback(RID p_agent, Callable p_callback) override {}
+	bool agent_has_avoidance_callback(RID p_agent) const override { return false; }
 	void agent_set_avoidance_layers(RID p_agent, uint32_t p_layers) override {}
+	uint32_t agent_get_avoidance_layers(RID p_agent) const override { return 0; }
 	void agent_set_avoidance_mask(RID p_agent, uint32_t p_mask) override {}
+	uint32_t agent_get_avoidance_mask(RID p_agent) const override { return 0; }
 	void agent_set_avoidance_priority(RID p_agent, real_t p_priority) override {}
+	real_t agent_get_avoidance_priority(RID p_agent) const override { return 0; }
 	RID obstacle_create() override { return RID(); }
 	void obstacle_set_map(RID p_obstacle, RID p_map) override {}
 	RID obstacle_get_map(RID p_obstacle) const override { return RID(); }
@@ -142,11 +156,17 @@ public:
 	void obstacle_set_use_3d_avoidance(RID p_obstacle, bool p_enabled) override {}
 	bool obstacle_get_use_3d_avoidance(RID p_obstacle) const override { return false; }
 	void obstacle_set_radius(RID p_obstacle, real_t p_radius) override {}
+	real_t obstacle_get_radius(RID p_obstacle) const override { return 0; }
 	void obstacle_set_height(RID p_obstacle, real_t p_height) override {}
+	real_t obstacle_get_height(RID p_obstacle) const override { return 0; }
 	void obstacle_set_velocity(RID p_obstacle, Vector3 p_velocity) override {}
+	Vector3 obstacle_get_velocity(RID p_obstacle) const override { return Vector3(); }
 	void obstacle_set_position(RID p_obstacle, Vector3 p_position) override {}
+	Vector3 obstacle_get_position(RID p_obstacle) const override { return Vector3(); }
 	void obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) override {}
+	Vector<Vector3> obstacle_get_vertices(RID p_obstacle) const override { return Vector<Vector3>(); }
 	void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override {}
+	uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override { return 0; }
 	void parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) override {}
 	void bake_from_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override {}
 	void bake_from_source_geometry_data_async(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override {}


### PR DESCRIPTION
Closes #84495 

Add virtual functions and bind to navigation servers
Implement getters
Add documentation
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
