### PR TITLE
Only copy the relevant portion of the screen when copying to backbuffer in Compatibility backend

### DIFF
--- a/drivers/gles3/effects/copy_effects.cpp
+++ b/drivers/gles3/effects/copy_effects.cpp
@@ -125,6 +125,18 @@ void CopyEffects::copy_to_rect(const Rect2 &p_rect) {
 	draw_screen_quad();
 }
 
+void CopyEffects::copy_to_and_from_rect(const Rect2 &p_rect) {
+	bool success = copy.shader.version_bind_shader(copy.shader_version, CopyShaderGLES3::MODE_COPY_SECTION_SOURCE);
+	if (!success) {
+		return;
+	}
+
+	copy.shader.version_set_uniform(CopyShaderGLES3::COPY_SECTION, p_rect.position.x, p_rect.position.y, p_rect.size.x, p_rect.size.y, copy.shader_version, CopyShaderGLES3::MODE_COPY_SECTION_SOURCE);
+	copy.shader.version_set_uniform(CopyShaderGLES3::SOURCE_SECTION, p_rect.position.x, p_rect.position.y, p_rect.size.x, p_rect.size.y, copy.shader_version, CopyShaderGLES3::MODE_COPY_SECTION_SOURCE);
+
+	draw_screen_quad();
+}
+
 void CopyEffects::copy_screen() {
 	bool success = copy.shader.version_bind_shader(copy.shader_version, CopyShaderGLES3::MODE_DEFAULT);
 	if (!success) {

--- a/drivers/gles3/effects/copy_effects.h
+++ b/drivers/gles3/effects/copy_effects.h
@@ -62,6 +62,7 @@ public:
 
 	// These functions assume that a framebuffer and texture are bound already. They only manage the shader, uniforms, and vertex array.
 	void copy_to_rect(const Rect2 &p_rect);
+	void copy_to_and_from_rect(const Rect2 &p_rect);
 	void copy_screen();
 	void copy_cube_to_rect(const Rect2 &p_rect);
 	void bilinear_blur(GLuint p_source_texture, int p_mipmap_count, const Rect2i &p_region);

--- a/drivers/gles3/shaders/copy.glsl
+++ b/drivers/gles3/shaders/copy.glsl
@@ -3,6 +3,7 @@
 
 mode_default = #define MODE_SIMPLE_COPY
 mode_copy_section = #define USE_COPY_SECTION \n#define MODE_SIMPLE_COPY
+mode_copy_section_source = #define USE_COPY_SECTION \n#define MODE_SIMPLE_COPY \n#define MODE_COPY_FROM
 mode_gaussian_blur = #define MODE_GAUSSIAN_BLUR
 mode_mipmap = #define MODE_MIPMAP
 mode_simple_color = #define MODE_SIMPLE_COLOR \n#define USE_COPY_SECTION
@@ -21,7 +22,7 @@ out vec2 uv_interp;
 // Defined in 0-1 coords.
 uniform highp vec4 copy_section;
 #endif
-#ifdef MODE_GAUSSIAN_BLUR
+#if defined(MODE_GAUSSIAN_BLUR) || defined(MODE_COPY_FROM)
 uniform highp vec4 source_section;
 #endif
 
@@ -32,7 +33,7 @@ void main() {
 #if defined(USE_COPY_SECTION) || defined(MODE_GAUSSIAN_BLUR)
 	gl_Position.xy = (copy_section.xy + uv_interp.xy * copy_section.zw) * 2.0 - 1.0;
 #endif
-#ifdef MODE_GAUSSIAN_BLUR
+#if defined(MODE_GAUSSIAN_BLUR) || defined(MODE_COPY_FROM)
 	uv_interp = source_section.xy + uv_interp * source_section.zw;
 #endif
 }

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2599,7 +2599,10 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 	glBindFramebuffer(GL_FRAMEBUFFER, rt->backbuffer_fbo);
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, rt->color);
-	GLES3::CopyEffects::get_singleton()->copy_screen();
+	Rect2 normalized_region = region;
+	normalized_region.position = normalized_region.position / Size2(rt->size);
+	normalized_region.size = normalized_region.size / Size2(rt->size);
+	GLES3::CopyEffects::get_singleton()->copy_to_and_from_rect(normalized_region);
 
 	if (p_gen_mipmaps) {
 		GLES3::CopyEffects::get_singleton()->gaussian_blur(rt->backbuffer, rt->mipmap_count, region, rt->size);


### PR DESCRIPTION
Partially addresses: https://github.com/godotengine/godot/issues/79439

Implements the first point from https://github.com/godotengine/godot/issues/79439#issuecomment-1756481658

Previously we copied the entire backbuffer, now we only copy the relevant portion. This matches the behavior on the RD backends. 

Opening as draft as I need to do more testing

On my laptop using intel integrated graphics I get roughly double the performance with this change (~160 FPS to ~320 FPS) using the MRP from #79439. Testing on a pixel 4 and there is no difference (likely because it is not a fill rate bottleneck)