### PR TITLE
[GLES3] Protect against bogus `glGetShaderInfoLog` return values.

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -328,7 +328,7 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 				}
 
 				char *ilogmem = (char *)Memory::alloc_static(iloglen + 1);
-				ilogmem[iloglen] = '\0';
+				memset(ilogmem, 0, iloglen + 1);
 				glGetShaderInfoLog(spec.vert_id, iloglen, &iloglen, ilogmem);
 
 				String err_string = name + ": Vertex shader compilation failed:\n";
@@ -376,7 +376,7 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 				}
 
 				char *ilogmem = (char *)Memory::alloc_static(iloglen + 1);
-				ilogmem[iloglen] = '\0';
+				memset(ilogmem, 0, iloglen + 1);
 				glGetShaderInfoLog(spec.frag_id, iloglen, &iloglen, ilogmem);
 
 				String err_string = name + ": Fragment shader compilation failed:\n";


### PR DESCRIPTION
On some buggy drivers `GL_INFO_LOG_LENGTH` returns incorrect values, which may lead to incorrectly filling in the log string. This could lead to uninitialized data being attempted to be printed and a crash. This PR zeros the array to ensure uninitialized data is not used.

## Notes
* Reported by mori on rocket chat.
* This may or may not fix the crash, but seems good practice.

> mori
> 6:30 AM
> any openGL folks on? maybe lawnjelly ? i was debugging a web crash and it brought me to https://github.com/godotengine/godot/blob/e38686f85b768a451dc06324fe2471adc8665448/drivers/gles3/shader_gles3.cpp#L317-L328. regarding GL_INFO_LOG_LENGTH, the spec says For implementations that support a shader compiler, params returns the number of characters in the information log for shader including the null termination character (i.e., the size of the character buffer required to store the information log). If shader has no information log, a value of 0 is returned. so i would think any code written against that spec would not have a <0 case, nor would it assume ==0 implies there are logs to be had
the issue is thickened by the fact emscripten, at least once, had a bug in this area https://github.com/emscripten-core/emscripten/issues/11673

> lawnjelly
> This is probably for clayjohn but what was the crash call stack? Where was it crashing?
> Maybe ilogmem should be memsetted to zero rather than just the last element.
> If emscripten is returning 1 for length (bug), then not filling in ilogmem at all (because it should have returned zero), then it will try to print uninitialized memory.
> So from the description memsetting may be the fix. But would have to see call stack of the crash.
> If you create an issue that would be a good place to start.
> I suspect that memsetting would be safer regardless.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
