### PR TITLE
Doc: Mention C++ uses `Basis::get_column`

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -269,6 +269,7 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Access basis components using their index. [code]b[0][/code] is equivalent to [code]b.x[/code], [code]b[1][/code] is equivalent to [code]b.y[/code], and [code]b[2][/code] is equivalent to [code]b.z[/code].
+				[b]Note:[/b] In C++ use methods [code]set_column[/code]/[code]get_column[/code]. Array indexes are rows!
 			</description>
 		</operator>
 	</operators>


### PR DESCRIPTION
I have face-planted now a couple of times to this.

For GDScript users `Basis` has an `x`, `y`, and  `z` for accessing the columns of the basis matrix. These can also be accessed in GDScript by array index.

When using C++ GDExtension, `Basis` does not have `x`, `y`, or `z`, so I have used array indexing twice to access the columns. Except, this does not work! Array index in C++ gives the rows of the basis matrix!

To access columns undocumented `get_column`/`set_column` methods have to be used.

As such, I would like to suggest that documentation would have a note for C++ developers. This is one of the rare instances where a C++ developer has to have arcane knowledge to follow a GDScrip tutorial.
