### PR TITLE
Fix crash when saving compressed image as JPG & WebP

### DIFF
--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -156,7 +156,11 @@ public:
 
 static Error _jpgd_save_to_output_stream(jpge::output_stream *p_output_stream, const Ref<Image> &p_img, float p_quality) {
 	ERR_FAIL_COND_V(p_img.is_null() || p_img->is_empty(), ERR_INVALID_PARAMETER);
-	Ref<Image> image = p_img;
+	Ref<Image> image = p_img->duplicate();
+	if (image->is_compressed()) {
+		Error error = image->decompress();
+		ERR_FAIL_COND_V_MSG(error != OK, error, "Couldn't decompress image.");
+	}
 	if (image->get_format() != Image::FORMAT_RGB8) {
 		image->convert(Image::FORMAT_RGB8);
 	}

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -59,6 +59,10 @@ Vector<uint8_t> _webp_packer(const Ref<Image> &p_image, float p_quality, bool p_
 	compression_method = CLAMP(compression_method, 0, 6);
 
 	Ref<Image> img = p_image->duplicate();
+	if (img->is_compressed()) {
+		Error error = img->decompress();
+		ERR_FAIL_COND_V_MSG(error != OK, Vector<uint8_t>(), "Couldn't decompress image.");
+	}
 	if (img->detect_alpha()) {
 		img->convert(Image::FORMAT_RGBA8);
 	} else {


### PR DESCRIPTION
Fixes #84707
Fixes #84743

Unlike saving as PNG & EXR, saving as JPG & WebP did not take compressed images into account. This PR tries to decompress the image before trying to convert it (converting a compressed image always fails).

This PR also makes saving as JPG no longer affect the format of the image (it always converted the image into RGB8 in place). Consistent with saving as other formats.