### PR TITLE
Fix VisualShader Texture2DParameter node filter bug

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -6346,6 +6346,7 @@ String get_sampler_hint(VisualShaderNodeTextureParameter::TextureType p_texture_
 		if (!repeat_code.is_empty()) {
 			if (!has_colon) {
 				code += " : ";
+				has_colon = true;
 			} else {
 				code += ", ";
 			}
@@ -6353,6 +6354,7 @@ String get_sampler_hint(VisualShaderNodeTextureParameter::TextureType p_texture_
 		}
 	}
 
+	// source
 	{
 		String source_code;
 


### PR DESCRIPTION
This bug was appending 2 colons in the generated code.  Fixed it by updating the `has_colon` variable in the filter section.

Also added the source section comment.

*Bugsquad edit:*
- Fixes #84769 
