### PR TITLE
Prevent crash on conversion of invalid data in `Image`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -509,6 +509,7 @@ static void _convert(int p_width, int p_height, const uint8_t *p_src, uint8_t *p
 }
 
 void Image::convert(Format p_new_format) {
+	ERR_FAIL_INDEX_MSG(p_new_format, FORMAT_MAX, "The Image format specified (" + itos(p_new_format) + ") is out of range. See Image's Format enum.");
 	if (data.size() == 0) {
 		return;
 	}

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -403,6 +403,29 @@ TEST_CASE("[Image] Custom mipmaps") {
 	}
 }
 
+TEST_CASE("[Image] Convert image") {
+	for (int format = Image::FORMAT_RF; format < Image::FORMAT_RGBE9995; format++) {
+		for (int new_format = Image::FORMAT_RF; new_format < Image::FORMAT_RGBE9995; new_format++) {
+			Ref<Image> image = memnew(Image(4, 4, false, (Image::Format)format));
+			image->convert((Image::Format)new_format);
+			String format_string = Image::format_names[(Image::Format)format];
+			String new_format_string = Image::format_names[(Image::Format)new_format];
+			format_string = "Error converting from " + format_string + " to " + new_format_string + ".";
+			CHECK_MESSAGE(image->get_format() == new_format, format_string);
+		}
+	}
+
+	Ref<Image> image = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
+	PackedByteArray image_data = image->get_data();
+	image->convert((Image::Format)-1);
+	CHECK_MESSAGE(image->get_data() == image_data, "Image conversion to invalid type (-1) should not alter image.");
+
+	Ref<Image> image2 = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
+	image_data = image2->get_data();
+	image2->convert((Image::Format)(Image::FORMAT_MAX + 1));
+	CHECK_MESSAGE(image2->get_data() == image_data, "Image conversion to invalid type (Image::FORMAT_MAX + 1) should not alter image.");
+}
+
 } // namespace TestImage
 
 #endif // TEST_IMAGE_H


### PR DESCRIPTION
Added error to address https://github.com/godotengine/godot/issues/84750 

<i>Bugsquad edit:</i> 
- Fix #84750 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
