### PR TITLE
Fix translation remapping check for imported resources

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -918,7 +918,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 		}
 
 		// Fallback to p_path if new_path does not exist.
-		if (!FileAccess::exists(new_path)) {
+		if (!FileAccess::exists(new_path + ".import") && !FileAccess::exists(new_path)) {
 			WARN_PRINT(vformat("Translation remap '%s' does not exist. Falling back to '%s'.", new_path, p_path));
 			new_path = p_path;
 		}


### PR DESCRIPTION
The logic didn't take `.import` files into account, so it would fail when exporting projects, as the remapping couldn't be done.

The exported MRP looks like this:
```
.
./icon.svg
./project.binary
./cassette_player_text_en.png.import
./cassette_player_text_ja_JP.png.import
./icon.svg.import
./test.tscn.remap
./test.gd
./.godot
./.godot/imported
./.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex
./.godot/imported/cassette_player_text_en.png-5d88eeeff54919eb8d8309119eae0520.ctex
./.godot/imported/cassette_player_text_ja_JP.png-c206992b4242e4e4b53fb44b3b4a5a95.ctex
./.godot/uid_cache.bin
./.godot/exported
./.godot/exported/133200997
./.godot/exported/133200997/export-f0a4ea32b72b64218d23e48a955cbc61-test.scn
./.godot/global_script_class_cache.cfg
```

I'm not sure if the check for the path without `.import` should be kept, I assumed this code might be used for both imported and non imported remapped files.

Fixes #81660.