### PR TITLE
VideoPlayer: Fix reloading translation remapped stream

### DIFF
--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -6,7 +6,6 @@
 	<description>
 		A control used for playback of [VideoStream] resources.
 		Supported video formats are [url=https://www.theora.org/]Ogg Theora[/url] ([code].ogv[/code], [VideoStreamTheora]) and any format exposed via a GDExtension plugin.
-		[b]Note:[/b] Due to a bug, VideoStreamPlayer does not support localization remapping yet.
 		[b]Warning:[/b] On Web, video playback [i]will[/i] perform poorly due to missing architecture-specific assembly optimizations.
 	</description>
 	<tutorials>

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -237,6 +237,12 @@ bool VideoStreamPlayer::has_loop() const {
 void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 	stop();
 
+	// Make sure to handle stream changes seamlessly, e.g. when done via
+	// translation remapping.
+	if (stream.is_valid()) {
+		stream->disconnect_changed(callable_mp(this, &VideoStreamPlayer::set_stream));
+	}
+
 	AudioServer::get_singleton()->lock();
 	mix_buffer.resize(AudioServer::get_singleton()->thread_get_mix_buffer_size());
 	stream = p_stream;
@@ -247,6 +253,10 @@ void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 		playback = Ref<VideoStreamPlayback>();
 	}
 	AudioServer::get_singleton()->unlock();
+
+	if (stream.is_valid()) {
+		stream->connect_changed(callable_mp(this, &VideoStreamPlayer::set_stream).bind(stream));
+	}
 
 	if (!playback.is_null()) {
 		playback->set_paused(paused);

--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -172,6 +172,7 @@ Ref<VideoStreamPlayback> VideoStream::instantiate_playback() {
 
 void VideoStream::set_file(const String &p_file) {
 	file = p_file;
+	emit_changed();
 }
 
 String VideoStream::get_file() {


### PR DESCRIPTION
- Fixes #43917.
- Reverts #43920.

MRP ported from Godot 3 (might need opening a couple of times, there's some weirdness with the font):
[VideoRemaps.zip](https://github.com/godotengine/godot/files/13328297/VideoRemaps.zip)

### Notes

- For some reason, `.ogv` extension doesn't show up in the list of resources that can be picked from translation remaps. So one needs to select "All Files" to select `.ogv` files.
- A good UX improvement would be to parse the end of the file to see if it's a locale name, and automatically pre-select the matching locale (and country if relevant), so `video_de.ogv` should automatically select "German", and `video_de_AT` should automatically select "German (Austria)".
- This changes means that if the VideoStream resource changes while it's being played, the playback will stop. It's still possible for users to handle automatically restarting the playback when that happens, with something like this (modified from MRP):

```gdscript
extends Control

var is_playing := false

func _ready() -> void:
	$Video.stream.changed.connect(_on_stream_changed, CONNECT_DEFERRED)
	_on_EN_pressed()

func _on_stream_changed() -> void:
	if is_playing:
		_on_Play_pressed()

func _on_video_finished():
	is_playing = false

func _on_EN_pressed() -> void:
	TranslationServer.set_locale("en")

func _on_DE_pressed() -> void:
	TranslationServer.set_locale("de")

func _on_RU_pressed() -> void:
	TranslationServer.set_locale("ru")

func _on_Play_pressed() -> void:
	print("pressed")
	$Video.stop()
	$Video.play()
	is_playing = true
```

But it may not be easy to seek to the previous position. To do so, we would need to only emit `changed`, but not handle in the VideoStreamPlayer, leaving it to the user to implement.

Alternatively the VideoStreamPlayer could have more signals like `stream_changed` that could include relevant information about the previous state (was playing, position, etc.). But the current player is fairly barebones and that's way outside the scope of this bugfix.