### PR TITLE
Reduced output spam from rapid property changes

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -301,6 +301,8 @@ void UndoRedo::commit_action(bool p_execute) {
 		return; //still nested
 	}
 
+	bool add_message = !merging;
+
 	if (merging) {
 		version--;
 		merging = false;
@@ -314,7 +316,7 @@ void UndoRedo::commit_action(bool p_execute) {
 	_redo(p_execute); // perform action
 	committing--;
 
-	if (callback && actions.size() > 0) {
+	if (add_message && callback && actions.size() > 0) {
 		callback(callback_ud, actions[actions.size() - 1].name);
 	}
 }


### PR DESCRIPTION
Fixes #84499 

Previously rapid changes in properties (dragging on colour picker, spinning through the spinner, etc.) would generate a huge amount of Output Log messages in a very short period of time. This would not only flood console, but eat up a lot of RAM.

This change means that the Property change messages use the same system that UndoRedo and History log uses: Identical changes made less than 800 milliseconds apart only give a single output message. Previously, messing around with the colour picker could give hundreds of messages, now it will only give a handful. Since it reuses the same system that , there's both minimal code change and it's consistent.