### PR TITLE
Remove EditorFileDialog warning when skipping project directories

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2369,7 +2369,9 @@ bool EditorFileSystem::_should_skip_directory(const String &p_path) {
 
 	if (FileAccess::exists(p_path.path_join("project.godot"))) {
 		// Skip if another project inside this.
-		WARN_PRINT_ONCE(vformat("Detected another project.godot at %s. The folder will be ignored.", p_path));
+		if (EditorFileSystem::get_singleton()->first_scan) {
+			WARN_PRINT_ONCE(vformat("Detected another project.godot at %s. The folder will be ignored.", p_path));
+		}
 		return true;
 	}
 


### PR DESCRIPTION
We might need better UX to handle this in EditorFileDialog, showing the directories as greyed out with a tooltip, but for now this silences a warning that users have no control over.

Removes this kind of warning that happens frequently when exporting projects and browsing to find where to export them:
```
WARNING: Detected another project.godot at /home/akien/tmp/godot/bug/Translation Example. The folder will be ignored.
     at: _should_skip_directory (editor/editor_file_system.cpp:2371)
```