### PR TITLE
Minor improvements to editor's UndoRedo

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -119,10 +119,6 @@ void EditorSettingsDialog::_filter_shortcuts_by_event(const Ref<InputEvent> &p_e
 	}
 }
 
-void EditorSettingsDialog::_undo_redo_callback(void *p_self, const String &p_name) {
-	EditorNode::get_log()->add_message(p_name, EditorLog::MSG_TYPE_EDITOR);
-}
-
 void EditorSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -130,13 +126,6 @@ void EditorSettingsDialog::_notification(int p_what) {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "editor_settings", Rect2(get_position(), get_size()));
 				set_process_shortcut_input(false);
 			}
-		} break;
-
-		case NOTIFICATION_READY: {
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->get_or_create_history(EditorUndoRedoManager::GLOBAL_HISTORY).undo_redo->set_method_notify_callback(EditorDebuggerNode::_method_changeds, nullptr);
-			undo_redo->get_or_create_history(EditorUndoRedoManager::GLOBAL_HISTORY).undo_redo->set_property_notify_callback(EditorDebuggerNode::_property_changeds, nullptr);
-			undo_redo->get_or_create_history(EditorUndoRedoManager::GLOBAL_HISTORY).undo_redo->set_commit_notify_callback(_undo_redo_callback, this);
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -106,8 +106,6 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);
 	void _shortcut_cell_double_clicked();
 
-	static void _undo_redo_callback(void *p_self, const String &p_name);
-
 	Label *restart_label = nullptr;
 	TextureRect *restart_icon = nullptr;
 	PanelContainer *restart_container = nullptr;

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -42,16 +42,17 @@
 EditorUndoRedoManager *EditorUndoRedoManager::singleton = nullptr;
 
 EditorUndoRedoManager::History &EditorUndoRedoManager::get_or_create_history(int p_idx) {
-	if (!history_map.has(p_idx)) {
+	HashMap<int, EditorUndoRedoManager::History>::Iterator I = history_map.find(p_idx);
+	if (!I) {
 		History history;
 		history.undo_redo = memnew(UndoRedo);
 		history.id = p_idx;
-		history_map[p_idx] = history;
+		I = history_map.insert(p_idx, history);
 
 		EditorNode::get_singleton()->get_log()->register_undo_redo(history.undo_redo);
 		EditorDebuggerNode::get_singleton()->register_undo_redo(history.undo_redo);
 	}
-	return history_map[p_idx];
+	return I->value;
 }
 
 UndoRedo *EditorUndoRedoManager::get_history_undo_redo(int p_idx) const {
@@ -417,8 +418,9 @@ int EditorUndoRedoManager::get_current_action_history_id() {
 }
 
 void EditorUndoRedoManager::discard_history(int p_idx, bool p_erase_from_map) {
-	ERR_FAIL_COND(!history_map.has(p_idx));
-	History &history = history_map[p_idx];
+	HashMap<int, EditorUndoRedoManager::History>::Iterator I = history_map.find(p_idx);
+	ERR_FAIL_COND_MSG(!I, vformat("Invalid history ID: %d.", p_idx));
+	History &history = I->value;
 
 	if (history.undo_redo) {
 		memdelete(history.undo_redo);
@@ -426,7 +428,7 @@ void EditorUndoRedoManager::discard_history(int p_idx, bool p_erase_from_map) {
 	}
 
 	if (p_erase_from_map) {
-		history_map.erase(p_idx);
+		history_map.remove(I);
 	}
 }
 


### PR DESCRIPTION
- remove redundant `_undo_redo_callback` from EditorSettingsDialog
- optimize some HashMap usage in EditorUndoRedoManager