### PR TITLE
Change `debug_symbols` SCons argument from bool to enum

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1592,3 +1592,26 @@ def generate_vs_project(env, original_args, project_name="godot"):
 
     if get_bool(original_args, "vsproj_gen_only", True):
         sys.exit()
+
+
+def get_debug_symbols_enum(default: bool):
+    """debug_symbols is an enum and has multiple options that replace the previous
+    boolean arguments for debug_symbols and separate_debug_symbols.
+
+    This function enables backwards compatibility and handles the boolean arguments
+    of the old system and translates them to the new, proper enums values of the new.
+    """
+    from SCons.Script import ARGUMENTS
+    from SCons.Variables.BoolVariable import TRUE_STRINGS
+
+    arg_value = ARGUMENTS.get("debug_symbols")
+    if arg_value in ["embedded", "separate"]:
+        return arg_value
+
+    return_value = "no"
+    # check if the legacy "yes" value was passed for "debug_symbols"
+    if arg_value in TRUE_STRINGS or default is True:
+        return_value = "embedded"  # if it was, this means we want to embed the symbols in the binary
+        if get_cmdline_bool("separate_debug_symbols", False):
+            return_value = "separate"  # unless the flag to separate them was also passed
+    return return_value

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -40,5 +40,5 @@ if env["dbus"]:
 
 prog = env.add_program("#bin/godot", ["godot_linuxbsd.cpp"] + common_linuxbsd)
 
-if env["debug_symbols"] and env["separate_debug_symbols"]:
+if env["debug_symbols"] == "separate":
     env.AddPostAction(prog, env.Run(platform_linuxbsd_builders.make_debug_linuxbsd))

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -124,7 +124,7 @@ files = [
 
 prog = env.add_program("#bin/godot", files)
 
-if env["debug_symbols"] and env["separate_debug_symbols"]:
+if env["debug_symbols"] == "separate":
     env.AddPostAction(prog, env.Run(platform_macos_builders.make_debug_macos))
 
 if env["generate_bundle"]:

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -133,7 +133,7 @@ if env["d3d12"]:
         )
 
 if not os.getenv("VCINSTALLDIR"):
-    if env["debug_symbols"]:
+    if env["debug_symbols"] in ["embedded", "separate"]:
         env.AddPostAction(prog, env.Run(platform_windows_builders.make_debug_mingw))
         if env["windows_subsystem"] == "gui":
             env.AddPostAction(prog_wrap, env.Run(platform_windows_builders.make_debug_mingw))

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -8,7 +8,7 @@ from detect import try_cmd
 def make_debug_mingw(target, source, env):
     dst = str(target[0])
     # Force separate debug symbols if executable size is larger than 1.9 GB.
-    if env["separate_debug_symbols"] or os.stat(dst).st_size >= 2040109465:
+    if env["debug_symbols"] == "separate" or os.stat(dst).st_size >= 2040109465:
         mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
         if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
             os.system(mingw_bin_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))

--- a/tests/python_build/test_methods.py
+++ b/tests/python_build/test_methods.py
@@ -1,0 +1,35 @@
+import pytest
+import sys
+
+from unittest.mock import MagicMock
+
+from methods import get_debug_symbols_enum
+
+
+@pytest.mark.parametrize(
+    "default,debug_symbols,separate_debug_symbols,expected",
+    [
+        (False, "no", None, "no"),
+        (True, None, None, "embedded"),
+        (False, "embedded", None, "embedded"),
+        (False, "separate", None, "separate"),
+        # backwards compatibility checks
+        (False, "yes", None, "embedded"),
+        (False, "yes", "no", "embedded"),
+        (False, "yes", "yes", "separate"),
+        (False, "true", None, "embedded"),
+        (False, "false", None, "no"),
+    ],
+)
+def test_get_debug_symbols_enum(default, debug_symbols, separate_debug_symbols, expected):
+    # mock SCons via sys.modules so we can run this test even if SCons isn't installed
+    scons_script_mock = MagicMock()
+    scons_script_mock.ARGUMENTS = {"debug_symbols": debug_symbols, "separate_debug_symbols": separate_debug_symbols}
+    sys.modules["SCons.Script"] = scons_script_mock
+    scons_vars_mock = MagicMock()
+    scons_vars_mock.TRUE_STRINGS = ("y", "yes", "true", "t", "1", "on", "all")
+    scons_vars_mock._text2bool = lambda x: x in scons_vars_mock.TRUE_STRINGS
+    sys.modules["SCons.Variables.BoolVariable"] = scons_vars_mock
+    result = get_debug_symbols_enum(default)
+
+    assert expected == result


### PR DESCRIPTION
resolves https://github.com/godotengine/godot/issues/72247

Seems simpler than adding logic to coerce `debug_symbols` to `True` when `debug_symbols=yes` is passed

EDIT: switching to an enum while preserving old behavior