### PR TITLE
Compile libpng arm neon specific files also if arch aarch64

### DIFF
--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -37,7 +37,7 @@ if env["builtin_libpng"]:
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 
-    if env["arch"].startswith("arm"):
+    if env["arch"].startswith("arm") or env["arch"].startswith("aarch"):
         if env.msvc:  # Can't compile assembly files with MSVC.
             env_thirdparty.Append(CPPDEFINES=[("PNG_ARM_NEON_OPT"), 0])
         else:


### PR DESCRIPTION
This is a trivial fix to support `aarch64` when `libpng_builtin` is enabled.

Fixes : #84827 
