### PR TITLE
Fix several ParticleProcessMaterial texture names

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -86,9 +86,9 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->tangent_accel_texture = "tangent_accel_texture";
 	shader_names->damping_texture = "damping_texture";
 	shader_names->scale_texture = "scale_curve";
-	shader_names->hue_variation_texture = "hue_variation_texture";
-	shader_names->anim_speed_texture = "anim_speed_texture";
-	shader_names->anim_offset_texture = "anim_offset_texture";
+	shader_names->hue_variation_texture = "hue_rot_curve";
+	shader_names->anim_speed_texture = "animation_speed_curve";
+	shader_names->anim_offset_texture = "animation_offset_curve";
 	shader_names->directional_velocity_texture = "directional_velocity_curve";
 	shader_names->scale_over_velocity_texture = "scale_over_velocity_curve";
 


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/84819
* Fixes https://github.com/godotengine/godot/issues/84818

Looks like small regressions from https://github.com/godotengine/godot/pull/79527, some texture name strings were not updated to match the new names. The wrong hue variation curve texture name seems not to be reported, but this seems fix it too.

I could also change the C++ `shader_names->xyz` to match their new string content, but currently there are many other similar inconsistensies in those string names between user visible naming convention and internal shader names, so it might be a good idea to update them all in a separate PR if wanted.