### PR TITLE
Ignore locked nodes when click selecting in 3d editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1918,12 +1918,17 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					}
 
 					if (after != EditorPlugin::AFTER_GUI_INPUT_CUSTOM) {
-						//clicking is always deferred to either move or release
-						clicked = _select_ray(b->get_position());
+						// Single item selection.
+						Vector<_RayResult> selection;
+						_find_items_at_pos(b->get_position(), selection, false);
+						if (!selection.is_empty()) {
+							clicked = selection[0].item->get_instance_id();
+						}
+
 						selection_in_progress = true;
 
 						if (clicked.is_null()) {
-							//default to regionselect
+							// Default to region select.
 							cursor.region_select = true;
 							cursor.region_begin = b->get_position();
 							cursor.region_end = b->get_position();


### PR DESCRIPTION
This PR changes the 3D node editor click selection to skip locked nodes.
Previously clicking on a locked node blocked the input. Now the next closest unlocked node is selected instead.

Fixes #84764