### PR TITLE
Fix folder color not showing up in file dialogs

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3477,6 +3477,14 @@ void FileSystemDock::_file_sort_popup(int p_id) {
 	set_file_sort((FileSortOption)p_id);
 }
 
+const HashMap<String, Color> &FileSystemDock::get_folder_colors() const {
+	return folder_colors;
+}
+
+Dictionary FileSystemDock::get_assigned_folder_colors() const {
+	return assigned_folder_colors;
+}
+
 MenuButton *FileSystemDock::_create_file_menu_button() {
 	MenuButton *button = memnew(MenuButton);
 	button->set_flat(true);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -369,6 +369,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	const HashMap<String, Color> &get_folder_colors() const;
+	Dictionary get_assigned_folder_colors() const;
+
 	Vector<String> get_selected_paths() const;
 	Vector<String> get_uncollapsed_paths() const;
 

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -40,6 +40,7 @@
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/filesystem_dock.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/margin_container.h"
@@ -766,6 +767,28 @@ void EditorFileDialog::update_file_name() {
 	}
 }
 
+// TODO: Could use a unit test.
+Color EditorFileDialog::get_dir_icon_color(const String &p_dir_path) {
+	const HashMap<String, Color> &folder_colors = FileSystemDock::get_singleton()->get_folder_colors();
+	Dictionary assigned_folder_colors = FileSystemDock::get_singleton()->get_assigned_folder_colors();
+
+	Color folder_icon_color = theme_cache.folder_icon_color;
+
+	// Check for a folder color to inherit (if one is assigned).
+	String parent_dir = p_dir_path;
+	while (parent_dir != "res://" && folder_icon_color == theme_cache.folder_icon_color) {
+		if (!parent_dir.ends_with("/")) {
+			parent_dir += "/";
+		}
+		if (assigned_folder_colors.has(parent_dir)) {
+			folder_icon_color = folder_colors[assigned_folder_colors[parent_dir]];
+		}
+		parent_dir = parent_dir.trim_suffix("/").get_base_dir();
+	}
+
+	return folder_icon_color;
+}
+
 // DO NOT USE THIS FUNCTION UNLESS NEEDED, CALL INVALIDATE() INSTEAD.
 void EditorFileDialog::update_file_list() {
 	int thumbnail_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
@@ -859,7 +882,7 @@ void EditorFileDialog::update_file_list() {
 		d["dir"] = true;
 
 		item_list->set_item_metadata(-1, d);
-		item_list->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
+		item_list->set_item_icon_modulate(-1, get_dir_icon_color(String(d["path"])));
 
 		dirs.pop_front();
 	}
@@ -1435,7 +1458,7 @@ void EditorFileDialog::_update_favorites() {
 	for (int i = 0; i < favorited_paths.size(); i++) {
 		favorites->add_item(favorited_names[i], theme_cache.folder);
 		favorites->set_item_metadata(-1, favorited_paths[i]);
-		favorites->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
+		favorites->set_item_icon_modulate(-1, get_dir_icon_color(favorited_paths[i]));
 
 		if (i == current_favorite) {
 			favorite->set_pressed(true);
@@ -1518,7 +1541,7 @@ void EditorFileDialog::_update_recent() {
 	for (int i = 0; i < recentd_paths.size(); i++) {
 		recent->add_item(recentd_names[i], theme_cache.folder);
 		recent->set_item_metadata(-1, recentd_paths[i]);
-		recent->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
+		recent->set_item_icon_modulate(-1, get_dir_icon_color(recentd_paths[i]));
 	}
 	EditorSettings::get_singleton()->set_recent_dirs(recentd);
 }

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -239,6 +239,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	Color get_dir_icon_color(const String &p_dir_path);
+
 	// Public for use with callable_mp.
 	void _file_submitted(const String &p_file);
 


### PR DESCRIPTION
Fixes #83366.

Here is an example project with a bunch of colored folders to verify that my changes work: [preview_project.zip](https://github.com/godotengine/godot/files/13333793/preview_project.zip).

I can also provide a compiled Windows 10 executable of the editor if someone needs it.

Screenshots:
![image](https://github.com/godotengine/godot/assets/61655860/4c2775b7-9954-4e62-8476-ec5f5cf32eb0)