### PR TITLE
Simplify `Control` internal transform calculation

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -682,12 +682,10 @@ Size2 Control::get_parent_area_size() const {
 // Positioning and sizing.
 
 Transform2D Control::_get_internal_transform() const {
-	Transform2D rot_scale;
-	rot_scale.set_rotation_and_scale(data.rotation, data.scale);
-	Transform2D offset;
-	offset.set_origin(-data.pivot_offset);
-
-	return offset.affine_inverse() * (rot_scale * offset);
+	// T(pivot_offset) * R(rotation) * S(scale) * T(-pivot_offset)
+	Transform2D xform(data.rotation, data.scale, 0.0f, data.pivot_offset);
+	xform.translate_local(-data.pivot_offset);
+	return xform;
 }
 
 void Control::_update_canvas_item_transform() {


### PR DESCRIPTION
```
T // translation
R // rotation
S // scaling

Control._get_internal_transform() = T(pivot_offset) * R(rotation) * S(scale) * T(-pivot_offset)
```

Previously `T(pivot_offset) * R(rotation) * S(scale) * T(-pivot_offset)` was calculated by unnecessarily doing 1 affine inverse ($`T(pivot\_offset) = T^{-1}(-pivot\_offset)`$) and 2 full Transform2D multiplications.

Now `T(pivot_offset) * R(rotation) * S(scale)` is constructed directly, and `T(-pivot_offset)` is applied locally with a dedicated method (not performing full Transform2D multiplication).

Precision of the result is not improved / the same as before because even though before a full inverse were calculated and more multiplications / additions were done, it was just some superfluous multiplications by `1.0` / additions of `0.0 * something`, hence not introducing precision errors.