### PR TITLE
Add a volumetric fog toggle to the editor environment preview

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -7663,6 +7663,7 @@ Dictionary Node3DEditor::get_state() const {
 		pd["environ_tonemap_enabled"] = environ_tonemap_button->is_pressed();
 		pd["environ_ao_enabled"] = environ_ao_button->is_pressed();
 		pd["environ_gi_enabled"] = environ_gi_button->is_pressed();
+		pd["environ_volumetric_fog_enabled"] = environ_volumetric_fog_button->is_pressed();
 		pd["sun_shadow_max_distance"] = sun_shadow_max_distance->get_value();
 
 		pd["sun_color"] = sun_color->get_pick_color();
@@ -7822,6 +7823,7 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 		environ_tonemap_button->set_pressed_no_signal(pd["environ_tonemap_enabled"]);
 		environ_ao_button->set_pressed_no_signal(pd["environ_ao_enabled"]);
 		environ_gi_button->set_pressed_no_signal(pd["environ_gi_enabled"]);
+		environ_volumetric_fog_button->set_pressed(pd["environ_volumetric_fog_enabled"]);
 		sun_shadow_max_distance->set_value_no_signal(pd["sun_shadow_max_distance"]);
 
 		sun_color->set_pick_color(pd["sun_color"]);
@@ -10213,6 +10215,11 @@ void Node3DEditor::_preview_settings_changed() {
 		environment->set_ssao_enabled(environ_ao_button->is_pressed());
 		environment->set_glow_enabled(environ_glow_button->is_pressed());
 		environment->set_sdfgi_enabled(environ_gi_button->is_pressed());
+		environment->set_volumetric_fog_enabled(environ_volumetric_fog_button->is_pressed());
+		if (environment->is_volumetric_fog_enabled()) {
+			// Decrease volumetric fog density to make scene editing easier. We mainly want to be able to see FogVolume nodes in action.
+			environment->set_volumetric_fog_density(0.01);
+		}
 		environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_FILMIC : Environment::TONE_MAPPER_LINEAR);
 	}
 }
@@ -10240,6 +10247,7 @@ void Node3DEditor::_load_default_preview_settings() {
 	environ_tonemap_button->set_pressed_no_signal(false);
 	environ_ao_button->set_pressed_no_signal(false);
 	environ_gi_button->set_pressed_no_signal(false);
+	environ_volumetric_fog_button->set_pressed(false);
 	sun_shadow_max_distance->set_value_no_signal(100);
 
 	sun_color->set_pick_color(Color(1, 1, 1));
@@ -11117,6 +11125,11 @@ void fragment() {
 		environ_gi_button->set_toggle_mode(true);
 		environ_gi_button->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_environ_set_gi), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_gi_button);
+		environ_volumetric_fog_button = memnew(Button);
+		environ_volumetric_fog_button->set_text(TTR("Vol. Fog"));
+		environ_volumetric_fog_button->set_toggle_mode(true);
+		environ_volumetric_fog_button->connect("pressed", callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
+		fx_vb->add_child(environ_volumetric_fog_button);
 		environ_vb->add_margin_child(TTRC("Post Process"), fx_vb);
 
 		environ_add_to_scene = memnew(Button);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -887,6 +887,7 @@ private:
 	Button *environ_glow_button = nullptr;
 	Button *environ_tonemap_button = nullptr;
 	Button *environ_gi_button = nullptr;
+	Button *environ_volumetric_fog_button = nullptr;
 	Button *environ_add_to_scene = nullptr;
 
 	Button *sun_environ_settings = nullptr;

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -130,7 +130,7 @@ PackedStringArray FogVolume::get_configuration_warnings() const {
 	}
 
 	if (environment.is_valid() && !environment->is_volumetric_fog_enabled()) {
-		warnings.push_back(RTR("Fog Volumes need volumetric fog to be enabled in the scene's Environment in order to be visible."));
+		warnings.push_back(RTR("Fog Volumes need volumetric fog to be enabled in the scene's Environment or preview environment to be visible."));
 	}
 
 	return warnings;


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/49736.

This can be used to preview FogVolume nodes without having to create a WorldEnvironment node.

The volumetric fog density with this preview mode is also lowered from 0.05 to 0.01 to make scene editing easier. We could expose a dedicated slider for it but at the same time, we should keep the preview environment editor as simple as possible.

- This closes https://github.com/godotengine/godot/issues/84534
and closes https://github.com/godotengine/godot-proposals/issues/4014.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/149a6df0-40e4-4eea-a6c9-e3fb7f9bf5c3)

## TODO

- [ ] Fix lingering node configuration warning after enabling volumetric fog in the preview environment. The node configuration warning doesn't update when you toggle it; not sure how to trigger this from within the FogVolume code.
  - Reloading the scene updates the warning.