### PR TITLE
Vulkan: Fix incorrect access to the buffers on Android

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -1365,6 +1365,9 @@ Error RenderingDeviceVulkan::_buffer_allocate(Buffer *p_buffer, uint32_t p_size,
 	allocInfo.memoryTypeBits = 0;
 	allocInfo.pool = nullptr;
 	allocInfo.pUserData = nullptr;
+	if (p_mem_usage == VMA_MEMORY_USAGE_AUTO_PREFER_HOST) {
+		allocInfo.requiredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+	}
 	if (p_size <= SMALL_ALLOCATION_MAX_SIZE) {
 		uint32_t mem_type_index = 0;
 		vmaFindMemoryTypeIndexForBufferInfo(allocator, &bufferInfo, &allocInfo, &mem_type_index);
@@ -1410,7 +1413,7 @@ Error RenderingDeviceVulkan::_insert_staging_block() {
 	VmaAllocationCreateInfo allocInfo;
 	allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
 	allocInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
-	allocInfo.requiredFlags = 0;
+	allocInfo.requiredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
 	allocInfo.preferredFlags = 0;
 	allocInfo.memoryTypeBits = 0;
 	allocInfo.pool = nullptr;

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -43,7 +43,7 @@
 #define _DEBUG
 #endif
 #endif
-#include "vk_mem_alloc.h"
+#include "thirdparty/vulkan/vk_mem_alloc.h"
 
 #ifdef USE_VOLK
 #include <volk.h>


### PR DESCRIPTION
Fixes #78715
Fixes #75599
Fixes #80371
Fixes #84355

**Error description:** https://github.com/godotengine/godot/issues/78715#issuecomment-1793603910 / https://github.com/godotengine/godot/issues/78715#issuecomment-1807297175




- **Test project** [test.buffer.zip](https://github.com/godotengine/godot/files/13349980/test.buffer.zip) for **78715**, **75599** and **84355**
- 41 MB download (drive.google.com) [android_editor-debug.apk](https://drive.google.com/file/d/1nU4DTZTTaukpxyQ_JssT8ynenWMsD359/view) for **80371**

-----------------------

<details><summary>old tests</summary>

**Godot 4.2 beta5** **78715** and **75599**
"Mesh Array_Index" is not read correctly (it sometimes contains 'attrib_data' or 'vertex_data'). The app crashes when "soft_body_3d" is inserted.

https://github.com/godotengine/godot/assets/41921395/36fb7eb8-b281-49d5-826e-802992d1c79a





**this PR** **78715** and **75599**
"Mesh Array_Index" is always read correctly and there are no crashes when soft_body_3d is inserted.

https://github.com/godotengine/godot/assets/41921395/ec864576-d0ea-4afa-a490-726b1b21416b


-----------------------
**80371** Godot 4.1.3

https://github.com/godotengine/godot/assets/41921395/bc266921-336c-406c-b78e-a7567a6e66be

**80371** Godot 4.2 (beta.custom, this PR)

https://github.com/godotengine/godot/assets/41921395/07f70a57-92f6-4183-9277-69519012c8ba


</details>
