### PR TITLE
Fix transform notification not getting sent out for RigidBody2D (reverted)

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -891,22 +891,18 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 	 * notification anyway).
 	 */
 
-	if (/*p_node->xform_change.in_list() &&*/ p_node->_is_global_invalid()) {
+	if (p_node->block_transform_notify || p_node->_is_global_invalid()) {
 		return; //nothing to do
 	}
 
 	p_node->_set_global_invalid(true);
 
-	if (p_node->notify_transform && !p_node->xform_change.in_list()) {
-		if (!p_node->block_transform_notify) {
-			if (p_node->is_inside_tree()) {
-				if (is_accessible_from_caller_thread()) {
-					get_tree()->xform_change_list.add(&p_node->xform_change);
-				} else {
-					// Should be rare, but still needs to be handled.
-					MessageQueue::get_singleton()->push_callable(callable_mp(p_node, &CanvasItem::_notify_transform_deferred));
-				}
-			}
+	if (p_node->notify_transform && !p_node->xform_change.in_list() && p_node->is_inside_tree()) {
+		if (is_accessible_from_caller_thread()) {
+			get_tree()->xform_change_list.add(&p_node->xform_change);
+		} else {
+			// Should be rare, but still needs to be handled.
+			MessageQueue::get_singleton()->push_callable(callable_mp(p_node, &CanvasItem::_notify_transform_deferred));
 		}
 	}
 


### PR DESCRIPTION
(This is the follow-up PR mentioned here: https://github.com/godotengine/godot/pull/84799#issuecomment-1807222827)

## Problem

As a result of #79977 (partially alleviated by #84799) we now have a problem with `RigidBody2D` that manifests as follows:

```gdscript
extends RigidBody2D

func _integrate_forces(_state):
	# This has no effect
	rotation_degrees = 45
```

```gdscript
extends RigidBody2D

func _integrate_forces(_state):
	# This has no effect
	global_rotation_degrees = 45
```

```gdscript
extends RigidBody2D

func _integrate_forces(state):
	# This has no effect
	rotation_degrees += 45 * state.step
```

```gdscript
extends RigidBody2D

func _integrate_forces(state):
	# This _does_ have an effect
	global_rotation_degrees += 45 * state.step
```

The key difference here is that the last script reads from `global_transform`.

## Context

https://github.com/godotengine/godot/blob/59457685c18e2d729eea50c751c11f049a7186f0/scene/2d/physics_body_2d.cpp#L448-L460

https://github.com/godotengine/godot/blob/59457685c18e2d729eea50c751c11f049a7186f0/scene/2d/physics_body_2d.cpp#L432-L446

https://github.com/godotengine/godot/blob/59457685c18e2d729eea50c751c11f049a7186f0/scene/main/canvas_item.cpp#L887-L919

## Flow of Events

(This applies to the first three of the problem scripts shown at the top.)

- `_body_state_changed` calls `_sync_body_state`.
    - `_sync_body_state` sets the `block_transform_notify` flag while it fetches the transform from the physics server.
    - `_sync_body_state` calls `set_global_transform` and thus `_notify_transform`.
        - `_notify_transform` sets the `global_invalid` flag (🐞) to indicate that this branch has been invalidated.
        - `_notify_transform` does **not** append to `xform_change_list`, because `block_transform_notify` is set.
- `_body_state_changed` calls `_integrate_forces`.
    - `_integrate_forces` writes to the transform in some way, thereby calling `_notify_transform`.
        - `_notify_transform` sees that `global_invalid` is set and does nothing.
- `_body_state_changed` calls `force_update_transform`.
    - `force_update_transform` checks to see whether the node is in `xform_change_list`, which it is not, and does nothing.

... resulting in the `force_update_transform` added by #84799 being rendered pointless.

## Solution

I believe (as indicated by 🐞) that this `global_invalid` flag should not be set when the `block_transform_notify` flag is set, since you end up blocking not only that `xform_change_list` append but also any future `xform_change_list` append, unless you first happen to clear `global_invalid` by reading from the global transform, which is what happens in the last problem script.

By moving the `block_transform_notify` check to before where the `global_invalid` flag is set we solve this problem.