### PR TITLE
Clamp the height of editor language selector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -342,6 +342,18 @@ void EditorPropertyTextEnum::setup(const Vector<String> &p_options, bool p_strin
 	}
 }
 
+void EditorPropertyTextEnum::set_max_size(Size2i size) {
+	option_button->get_popup()->set_max_size(size);
+}
+
+Size2i EditorPropertyTextEnum::get_max_size() {
+	return option_button->get_popup()->get_max_size();
+}
+
+Size2i EditorPropertyTextEnum::get_size() {
+	return option_button->get_popup()->get_size();
+}
+
 void EditorPropertyTextEnum::_bind_methods() {
 }
 
@@ -3698,6 +3710,9 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 			if (p_hint == PROPERTY_HINT_ENUM || p_hint == PROPERTY_HINT_ENUM_SUGGESTION) {
 				EditorPropertyTextEnum *editor = memnew(EditorPropertyTextEnum);
 				Vector<String> options = p_hint_text.split(",", false);
+				// 360 is a arbitrary number.
+				// Also this effects every string enum setting.
+				editor->set_max_size(Size2i(editor->get_max_size().x, 360 * EDSCALE));
 				editor->setup(options, false, (p_hint == PROPERTY_HINT_ENUM_SUGGESTION));
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_MULTILINE_TEXT) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -131,6 +131,11 @@ protected:
 
 public:
 	void setup(const Vector<String> &p_options, bool p_string_name = false, bool p_loose_mode = false);
+	// These functions actually use the option_button's popup
+	void set_max_size(Size2i size);
+	Size2i get_max_size();
+	Size2i get_size();
+
 	virtual void update_property() override;
 	EditorPropertyTextEnum();
 };

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -3038,6 +3038,8 @@ ProjectManager::ProjectManager() {
 		language_btn->set_focus_mode(Control::FOCUS_NONE);
 		language_btn->set_fit_to_longest_item(false);
 		language_btn->set_flat(true);
+		// 360 is a arbitrary number.
+		language_btn->get_popup()->set_max_size(Size2i(language_btn->get_popup()->get_max_size().x, 360 * EDSCALE));
 		language_btn->connect("item_selected", callable_mp(this, &ProjectManager::_language_selected));
 #ifdef ANDROID_ENABLED
 		// The language selection dropdown doesn't work on Android (as the setting isn't saved), see GH-60353.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
The list of editor languages was pretty annoying so this clamps the height of the OptionButton
2 questions
1. What is a good height to clamp it to? the current number I chose is completely arbitrary 
2. Currently this clamps the height of every string enum should this only effect the language list?