### PR TITLE
[PopupMenu] Expose missing item properties to the editor inspector.

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -467,6 +467,14 @@
 				Sets language code of item's text used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 			</description>
 		</method>
+		<method name="set_item_max_states">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="max_state" type="int" />
+			<description>
+				Sets maximum number of states of the multistate item at the given [param index].
+			</description>
+		</method>
 		<method name="set_item_metadata">
 			<return type="void" />
 			<param index="0" name="index" type="int" />

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -257,6 +257,7 @@ public:
 	void set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bool p_global = false);
 	void set_item_indent(int p_idx, int p_indent);
 	void set_item_multistate(int p_idx, int p_state);
+	void set_item_max_states(int p_idx, int p_state);
 	void toggle_item_multistate(int p_idx);
 	void set_item_shortcut_disabled(int p_idx, bool p_disabled);
 


### PR DESCRIPTION
Adds missing item properties to the dynamic property list, most notably `submenu` and `shortcut`, absence of which is extremely inconvenient.

<img width="555" alt="Screenshot 2023-11-14 at 12 42 35" src="https://github.com/godotengine/godot/assets/7645683/357eec58-2935-48f3-a9cd-bbf9cbb489c3">
