### PR TITLE
Ensure optional CopyEffects variants are loaded last.

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -104,9 +104,9 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		copy_modes.push_back("\n"); // COPY_TO_FB_COPY
 		copy_modes.push_back("\n#define MODE_PANORAMA_TO_DP\n"); // COPY_TO_FB_COPY_PANORAMA_TO_DP
 		copy_modes.push_back("\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_COPY2
+		copy_modes.push_back("\n#define MODE_SET_COLOR\n"); // COPY_TO_FB_SET_COLOR
 		copy_modes.push_back("\n#define MULTIVIEW\n"); // COPY_TO_FB_MULTIVIEW
 		copy_modes.push_back("\n#define MULTIVIEW\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_MULTIVIEW_WITH_DEPTH
-		copy_modes.push_back("\n#define MODE_SET_COLOR\n"); // COPY_TO_FB_SET_COLOR
 
 		copy_to_fb.shader.initialize(copy_modes);
 

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -172,11 +172,13 @@ private:
 		COPY_TO_FB_COPY,
 		COPY_TO_FB_COPY_PANORAMA_TO_DP,
 		COPY_TO_FB_COPY2,
+		COPY_TO_FB_SET_COLOR,
 
+		// These variants are disabled unless XR shaders are enabled.
+		// They should be listed last.
 		COPY_TO_FB_MULTIVIEW,
 		COPY_TO_FB_MULTIVIEW_WITH_DEPTH,
 
-		COPY_TO_FB_SET_COLOR,
 		COPY_TO_FB_MAX,
 	};
 


### PR DESCRIPTION
This is a quick fix for #84841

There is an issue with our shader cache when there are disabled variants, it does not seem to deal with these properly (though this seems to be a recently introduced issue, possibly due to shader groups being added in 4.2).
For the most part this isn't a problem as the missing variants end up being recompiled and the cache fixes itself. The exception are our copy effects where a new copy type was added after the optional variants.
There is a more serious bug in the shader cache that causes all variants to be deleted (even the ones loaded properly) but in such a way that the Godot can no longer compile new versions.

This PR works around the problem by moving this new variant before the optional variants. This fixes the immediate problem.

We will need to fix the cache logic at some point but that will be a 4.3 fix. 

*Bugsquad edit:*
- Fixes #84841 