### PR TITLE
Donors: Change tiers to match Dev Fund, sync latest data

### DIFF
--- a/DONORS.md
+++ b/DONORS.md
@@ -10,363 +10,349 @@ used, are described on [Godot's website](https://godotengine.org/donate).
 The following is a list of the current monthly donors, who will have their
 generous deed immortalized in the next stable release of Godot Engine.
 
+## Patrons
+
+    OSS Capital <https://oss.capital>
+    Re-Logic <https://re-logic.com>
+
 ## Platinum sponsors
 
-    Gamblify <https://www.gamblify.com>
     Heroic Labs <https://heroiclabs.com>
-    Spiffcode <http://spiffcode.com>
+    Ramatak <https://ramatak.com>
+    W4 Games <https://w4games.com>
 
 ## Gold sponsors
 
-    None currently, become one! <https://godotengine.org/donate>
+    Mega Crit <https://www.megacrit.com>
+    Prehensile Tales <https://prehensile-tales.com>
+    Robot Gentleman <http://robotgentleman.com>
 
 ## Silver sponsors
 
     Affray Interactive <https://scp.games/pandemic>
+    Broken Rules <https://brokenrul.es>
+    Chasing Carrots <https://www.chasing-carrots.com>
     Delton Ding
+    Gamblify <https://www.gamblify.com>
+    Null <https://null.com>
+    Orbital Knight <https://www.orbitalknight.com>
     Playful Studios <https://playfulstudios.com>
-    Robot Gentleman <http://robotgentleman.com>
 
-## Bronze sponsors
+## Diamond members
+
+    Sylv <https://rankith.itch.io/unnamed-space-idle-prototype>
+    And 4 anonymous donors
+
+## Titanium members
 
     Basically Games
-    Bippinbits <https://bippinbits.com>
-    Brandon Lamb
-    Bri
+    FDG Entertainment <https://www.fdg-entertainment.com/>
+    Game Dev Artisan <https://gamedevartisan.com/>
     Garry Newman
-    Isaiah smith
-    Jb Evain
-    Keepsake Games <https://keepsake.games>
-    Kenney <https://kenney.nl>
-    Kitcat490
-    Kyle Szklenski
+    Isaiah Smith <https://www.isaiahsmith.dev/>
+    katnamag <https://katnamag.com/>
+    Kenney <https://kenney.nl/>
+    Lucid Silence Games
     Matthew Campbell
     Maxim Karsten
-    Nik Rudenko
-    TrampolineTales <https://trampolinetales.com>
+    Midjiwan AB <https://polytopia.io/>
+    PolyMars <https://polymars.dev/>
+    Razenpok <https://www.youtube.com/watch?v=-QxI-RP6-HM>
+    RPG in a Box <https://www.rpginabox.com/>
+    Sterling Long <https://www.sterlinglong.me/>
+    Sunshower <https://github.com/Phanterm>
+    TrampolineTales <https://trampolinetales.com/>
+    Wilfred James <https://twitter.com/0430agi>
+    And 7 anonymous donors
 
-## Mini sponsors
+## Platinum members
 
     AD Ford
-    Albin Lundahl
-    Andres Hernandez
-    Andrew Dunai
-    anti666
-    Christopher Shifflett
+    Andy Touch
+    BlockImperiumGames (BIG)
+    Christian Baune
     Christoph Woinke
-    Daniel Edwards
+    Christopher Shifflett
     Darrin Massena
-    David Mydlarz
     Edward Flick
-    Hein-Pieter van Braam
+    F*ckedByUnity
+    Golden Skull Art
+    HP van Braam
     Jonah Stich
-    Justin Arnold
     Justin McGettigan
     Justo Delgado Baudí
-    Kossi Selom Banybah
-    Lloyd Bond
     Marek Belski
-    Markus Ort
-    Michael
     Mike King
     Nassor Paulino da Silva
-    nate-wilkins
     Neal Gompa (Conan Kudo)
-    Nick Macholl
-    Patrick Horn
-    Rami
     Ronnie Cheng
     Ryan Heath
     Samantha
+    Scott Pezza
     ShikadiGum
-    Slobodan Milnovic
+    Silver Creek Entertainment
+    Stephan Kessler
     Stephan Lanfermann
+    TigerJ
     Tim Yuen
     Violin Iliev
     Vladimír Chvátil
+    iCommitGames
+    nate-wilkins
+    And 16 anonymous donors
 
-## Gold donors
+## Gold members
 
-    Adam Brown
-    albinaask
-    Allen Pestaluky
+    @reilaos
+    Artur Ilkaev
     Asher Glick
-    Barugon
+    Ashtreighlia
+    Atsui
+    Ben Burbank
+    Ben Rog-Wilhelm
     Benito
-    Carlo Cabanilla
+    Benjamin Sarsgard
+    Benjo Kho
+    Bernd Barsuhn
+    Blake Farnsworth
+    Brian Ernst
+    Brut
+    Chen-Pang He (jdh8)
+    Cosmin Munteanu
+    Coy Humphrey
     Daniel James
-    David Fedorchak
-    David Gehrig
+    David Chen Zhen
+    David Coles
     David Hubber
     David Snopek
-    Dima Paloskin
+    Dehyvis Coronel
+    Dustuu
     Ed Morley
-    Guilherme de Oliveira
-    Guy Kay Jay
+    ElektroFox
+    Enclusa Games
+    Eric Phy
+    Faisal Al-Kubaisi (QatariGameDev)
+    FeralBytes
+    Frederick Ayala
+    GlassBrick
+    Grau
+    Guangzhou Lingchan
+    Hammster
+    Iggy Zuk
+    Jacob (HACKhalo2 Studios)
+    Jam
+    James Green
+    Jason Cawood
     Javier Roman
-    Jonathan Wright
+    Joel Martinez
+    John Gabriel
     Jon Woodward
-    Karl Werf
-    Klavdij Voncina
-    Manuele Finocchiaro
-    Markus Wiesner
-    Mateo Navarrete
-    Matthew Hillier
+    José Canepa
+    João Pedro Braz
+    KAR Games
+    Kamran Wali
+    Karasu Studio
+    KekLuck
+    Kenneth Christensen
+    Kristian Kriehl
+    Logan Apple
+    Luca Junge
+    Luca Vazzano
+    LyaaaaaGames
+    MHDante
+    Malcolm Nixon
+    Manuel Requena
+    Martin Agnar Dahl
+    Martin Šenkeřík
+    Matheus Gritz
+    Megabit Interactive
+    Mennskr
+    Metanaut
+    Modus Ponens
+    Niklas Wahrman
+    NotNet
+    Obelisk Island Studios
     Officine Pixel S.n.c.
-    Pedro Silva
-    Sarksus
-    Sean
+    Oleksii Nosov
+    Pav Soor
+    Piotr Siuszko
+    RAWRLAB Games
+    RadenTheFolf
+    Request
+    Robin Ward
+    Saltlight Studio
+    Samuel Judd
+    Silverclad Studios
     Sofox
-    Stephan Kessler
+    Space Kraken Studios
+    Spoony Panda
+    Sympa City
+    ThePolyglotProgrammer
+    Tim Nedvyga
     Tom Langwaldt
+    Vincent Foulon
+    Weasel Games
+    WuotanStudios.com
+    Zi
+    albinaask
+    endaye
+    getIntoGameDev
+    nezticle
+    ohanaya3
+    re:thinc
     tukon
+    杨烈胜(zedrun)
 
-    ␣
-    Acheron
-    AdamRatai
     Alexander Erlemann
     Alexandre VALIN
-    Alexej Kowalew
     Alex Khayrullin
     Algebrute
-    alice gambrell
-    Alo Mis
     Andriy
     Antanas Paskauskas
+    anti666
     Ari
     Arisaka Mayuki
     Arthur S. Muszynski
-    BasicIncomePlz
-    Brandon Hawkinson
-    BrizzleBrip
-    c64cosmin
+    Bread
     Cameron Connolly
-    Carlo del Mundo
     Charlie Whitfield
-    Chris Petrich
-    Chris Serino
     Craig Ostrin
-    Craig Scarborough
-    Craig Smith
+    Craig Swain
     CzechBlueBear
     Daniel Eichler
-    Daniel Grice
     Daniel Reed
-    Daniel Tebbutt
     Dennis Belfrage
-    Donn Eddy
     Emily A. Bellows
     Eric Brand
-    Eugenio Hugo Salgüero Jáñez
     Felix Winterhalter
-    Florencio Olsen
     Fransiska
-    Furroy
-    Gabrielius Vaiškūnas
-    Gary Hulst
-    Geoffroy Warin
     George Venizelos
-    GlassBrick
-    GrayDwarf
-    Guilherme Felipe de C. G. da Silva
-    Guillaume Pham Ngoc
     Harry Tumber
     Harvey Fong
     Horváth-Lázár Péter
     illuxxium
-    Jamal Bencharki
     James Couzens
     Jared White
-    Jason Yundt
     Jesús Chicharro
-    Jihun Moon
     Joel Fivat
     Johnathan Kupferer
     Josef Stumpfegger
+    Josh Nygaard
     Joshua Lesperance
-    Judd
-    Julian Todd
-    JUSTIN CARROLL
-    Kelson Ball
     Kelteseth
     Khora
     kickmaniac
-    kinfox
-    leetNightshade
     Liam Smyth
     LoparPanda
-    Lucaaa
-    Luca Vazzano
-    LyaaaaaGames
     Marcus Dobler
-    Marcus Richter
-    Mark Barrett
-    Martin Eigel
     Martin Gulliksson
-    Martin Kotz
     Martin Soucek
     Matt Greene
     Matthew Dana
-    Matthieu Huvé
     Michael Dürwald
     Michael Policastro
-    MikadoSC
     n00sh
     nate etan
-    Nicola Cocchiaro
     Nicolás Monner Sans
-    Nikita Blizniuk
     Nikita Rotskov
     Nikola Whallon
     Oliver Dick
-    Otis Clark
     Patrick Wuttke
-    Paul Hocker
     Pete Goodwin
-    Petr Malac
-    Petrus Prinsloo
     Philip Woods
-    Rebekah Farr
-    red1939
     Reilt
-    Rene Tailleur
     Rickard Hermanson
     Rob
     Rob McInroy
     RodZilla
-    Ronan Zeegers
     Ronnie Ashlock
-    Ronny Mühle
+    Ruzgud
     Ryan Breaker
     "Sage Automatic Systems, LLC"
-    Samuel Hummerstone
-    Samuel Judd
-    schroedinger's possum
     Shishir Tandale
-    SKison
     Song Junwoo
     spacechase0
-    SpicyCactuar
-    Steven Landow
-    Stoned Xander
     sus
     Talii
-    Teslatech
-    Thomas Bjarnelöf
     Thomas Kurz
-    Tim Nedvyga
     Tobias Bocanegra
     Tobias Raggl
     Torbulous
     toto bibi
-    Troy Kinsella
-    Turntsnaco
-    UltyX
     Valryia
-    VeryProfessionalDodo
     VoidPointer
     whatever
-    Winston
     Yifan Lai
-    Yuancheng Zhang
     zkip lan
 
-## Silver donors
-
-    Aaron Adriano
     Aaron Mayfield
-    Aaron Oldenburg
-    Adam Brunnmeier
     Adam Carr
-    Adam N Webber
     Adam Smeltzer
-    Adinimys
     Adisibio
-    Adriano Orioli
     Adrien de Pierres
     Agustinus Arya
+    Aidan Marwick
     Aidan O'Flannagain
+    aiekick
     Aiguo Wang
-    ajaxcc
+    AJWolbers
     Aki Mimoto
     Alan Beauchamp
-    Alberto Salazar Muñoz
-    Alberto Vilches
     Alder Stefano
     Alejandro Saucedo
     AleMax
     Alex Clavelle
     Alex de la Mare
     alex raeside
-    Allan Davis
     Andre Altmueller
+    Andreas Østergaard Nielsen
     Andrei Pufu
     Andre Stackhouse
     Andrew
     Andrew Groot
     andrew james morris
-    Andy Baird
     Ano Nim
-    Anthony Avina
-    Anton Bouwer
     Arch Toasty
     Arda Erol
     Arthur Brainville
     Arturo Rosales
     Ash K
     Aubrey Falconer
-    aurelien condomines
     Austin Miller
     Azar Gurbanov
     AzulCrescent
     Balázs Batári
     Beau Seymour
     Benedikt
-    Ben Vercammen
     Ben Visness
     Bill Thibault
-    bitbrain
     Bjarne Voigtländer
-    Brady Goldsworthy
-    Bram
-    Brian
+    Bread
     Brian Ford
-    Brigham Keys
-    Burney Waring
     Caleb Makela
     Caliburn
     Cameron Meyer
     Carlos Rios
     Carl van der Geest
-    Cesar Ruiz
-    Chad Steadman
+    Cerno_b
     Checkpoint Charlie
     chendrak
     Chris Cavalluzzi
     Chris Jagusch
-    Chris Langford
-    Chris Ridenour
-    Christer Stenbrenden
-    Christian Alexander Bjørklund Bøhler
-    Christian Kaltenecker
+    Chris Lee
     Christian Mauduit
-    Christian Winter
     Christoph Czurda
     Christophe Gagnier
     Ciyvius
-    Codex404
     Cody Parker
     Conall O
     Corchari
     Corey W
-    Craig Post
-    CrispyPin
     cynwav
     Dakota Watkins
+    Daniele Tolomelli
     Daniel Hoffmann
-    Danielle
     Daniel Ramos
-    Dare Looks
     Daren Scot Wilson
     Dave Jansen
     Davesnothere
@@ -377,63 +363,45 @@ generous deed immortalized in the next stable release of Godot Engine.
     Devin Carraway
     Devin R
     Dimitri Roche
-    Dominik Wetzel
     Donovan Hutcheon
-    Doug Walker
-    Dragontrapper
     dragoon
-    Dr Ewan Murray
     Ducky
-    Duobix
     Duodecimal
-    Eduardo Teixeira
     Edward Swartz
     Egon Elbre
-    Elgenzay
     Elijah Anderson
     Emerson MX
-    Ends
     Ephemeral
+    Eric Persson
     Eric Stokes
     Eric Williams
     Erkki Seppälä
     Ewan Holmes
-    Faisal Alkubaisi
-    fby
     Felix Adam
     Fer DC
-    Filip Lundby
     Frank
-    Frank Kurka
     Frying☆Pan
     Game Endeavor
     Garrett Steffen
     Gary Thomas
     gebba
-    George Marques
     Green Fox
     Greg Burkland
-    Gregory Campbell
     Greyson Richey
-    Grid
     Grominet
     Guldoman
     Guo Hongci
     Hans Jorgensen
     Haplo
     Helge Maus
-    Helianthus Games
     Heribert Hirth
     Ian Richard Kunert
     Ian Williams
-    Interstice
     itsybitesyspider
     iveks
-    Jacob D
-    Jaguar
+    Jacob Wallace
     Jako Danar
     James Gary
-    James Thomas
     Jamie Massey
     JARKKO PARVIAINEN
     Jason Evans
@@ -441,115 +409,78 @@ generous deed immortalized in the next stable release of Godot Engine.
     Jeff Hungerford
     Jeffrey Berube
     Jennifer Graves
-    Jesse Dubay
+    Joakim Askenbäck
     João Pedro Braz
-    John Barlex
     John Bruce
-    John Palgut
     Jonas
     Jonas Arndt
-    Jonas Bernemann
-    Jonas LHOSTE
-    Jonas Rudlang
     Jonas Yamazaki
     Jonathan Bieber
     Jonathan Ellis
-    Jonathan G
     Jon Sully
-    Jordy Goodridge
     Joseph Catrambone
-    Josh Segall
     Josh Taylor
     Joshua Heidrich
-    Jozef Krcho
     Juanfran
     Juan Maggi
     Juan Uys
     Jueast
     Julian le Roux
-    Julien Kaspar
-    Justin Hamilton
+    Justin
     Justin Spedding
-    J Vetulani
     Kalydi Balázs
     Katsuomi Kobayashi
     Keedong Park
     Keegan Scott
     Keith Bradner
-    Ken Minardo
     Kent Jofur
-    killaQueen
     kindzadza
     Kodera Software
-    Kostas Mouratidis
-    Krishna Nadoor
     KsyTek Games
-    kycho
     Kyle Burnett
     Kyle Jacobs
     Lasse le Dous
-    Laurent Dethoor
-    Laxman Pradhan
-    Lech Rozanski
     Leland Vakarian
-    Leonardo Baumle
     Levi Berciu
-    Levi Lindsey
     Linus Lind Lundgren
-    Logan Apple
-    Logan Bratton
-    Lonnie Cox
     Ludovic DELVAL
     Luigi Renna
-    Luis Ernesto Del Toro Peña
-    Luis Gaemperle
     Luis Morao
     Lukas Komischke
     Luke Diasio
-    Luke Kasz
     Major Haul
     Malcolm
+    Manuele Finocchiaro
     Mara Huldra
-    Marcell Simon
     Marcos Heitor Carvalho
     Markie Music
-    Mark Tyler
-    Markus Martin
     Markus Michael Egger
     Markus Strompen
-    Martin Fitzke
     Martin Holas
-    Martin Linklater
     Martin Liška
     Martin Trbola
-    Martin Zabinski
     Matěj Drábek
+    Mateo Navarrete
+    Mathieu
     Matt Edwards
-    Matthew
-    Matthew Booe
     Maverick
     Maxime Blade
     Maxwell
     McStuffings
     Melissa Mears
     Metal Demon 2000
-    Michael
     Michael Morrison
     Michal Skwarek
     Mikael Nordenberg
-    Mikail Freitas
     Mikayla
     Mike Copley
-    Mike McRoberts
     Mitchell J. Wagner
-    MJacred
-    ModularMind
-    Molinghu
     Molly Jameson
     MoltenGears
     Moritz Weissenberger
     MrAZIE
     Mrjemandem
+    naonya3
     Nathaniel
     neguse
     neighty
@@ -557,74 +488,49 @@ generous deed immortalized in the next stable release of Godot Engine.
     Neofytos Chimonas
     Nerdforge
     Nerdyninja
-    Nicholas La Roux
     Nick Eldrenkamp
     Nicolas Rosset
-    Nicolò Brigadoi Calamari
-    Nils Nordmark
+    Nik Rudenko
     Noel Billig
-    Noesis
-    obscuresteel
-    Okatima
-    Oleg Reva
     Olexa Tourko
-    Oliver Ambrose
     oscar1000108
     Oscar Domingo
+    ozrk
     Parth Patel
+    Patrick Horn
     Patrick Indermühle
     Patrickm
     Patrick Nafarrete
     Paul Black
     Paul Gieske
-    Paul Hankins
     Paul Mozet
-    Paweł Kowal
     Paweł Łyczkowski
-    Pedro Henrique Martins Garcia
+    Pete
     Philip Ludington (MrPhil)
     Phoenix Jauregui
     Pierre Caye
     Pixel Archipel
-    pj
     Point08
     Portponky
-    Preethi Vaidyanathan
     PsycHead
-    PsyCrab
     Puntigames
-    pwab
     Quincy Quincy
     Quinn Morrison
-    Rafa Laguna
+    Raghava Kovvali
     RagingRoosevelt
     Ragnar Pettersson
-    Rainer Amler
     Rammeow
     Rebecca H
-    Relintai
-    Remi Rampin
-    Reneator
     Richard Hayes
-    Richard Ivánek
     Riley
-    Robin Ward
     RobotCritter
     Rob Ruana
     Rodrigo Loli
-    Roger Smith
-    Roglozor
     Roka
     Roland Rząsa
-    Roman Papush
-    Roy Scayged
     Russ
-    Russell Matney
     Ryan Groom
-    Sacha Waked (Shaidak)
     Sammy Fischer
-    Sangeeth Pavithran
-    Sasha Schwartz
     Sebastian Michailidis
     Sekuta
     SeongWan Kim
@@ -640,77 +546,52 @@ generous deed immortalized in the next stable release of Godot Engine.
     sirn
     Skalli
     slavfox
-    SleepDepJoel1
     smbe19
     smo1704
-    Solene Waked
-    Sophie Winter
+    SpicyCactuar
     Squidgy
     Squirrel
-    SSebigo
     Stephen Rice
     Stephen Schlie
-    summerblind
     Sung soo Choi
     SxP
     tadashi endo
     Tarch
-    Terry
     TheVoiceInMyHead
     Thibaut DECROMBECQUE
     thomas
     Thomas Bechtold
-    Thomas Detoy
     Thomas Pickett
-    thommy
-    Till1805
     Tim Drumheller
-    Tim Erskine
     Tim Gleason
     Tim Klein
     Timothy B. MacDonald
     Tim Raveling
     Tim Riley
-    Toadile
-    Tom Coxon
     Tom Webster
-    Torsten Crass
-    Trent Skinner
-    tril zerobyte
-    Tryggve Sollid
     Turgut Temucin
-    Tycho
     Tyler Stafos
     Tyler Stepke
     Ukko K.
     Uther
-    v01tech
-    Vaida
     Vaughan Ling
-    Vavin.X
+    vgmoose
     Vincent Barkmann
-    Vincent Cloutier
-    Vincent Foulon
     Vulinux
     Wapiti .
+    wasitworthitdev
     Wiley Thompson
     William Bodin
     William Edwards
-    William F Siqueira
-    Wolfram
-    Woonki Moon
-    Xananax
+    Xatonym
     Yan Shi
-    yin
     Zekim
-    Zher Huei Lee
-    Zoee Silcock
-    Zyphery
     ケルベロス
     貴宏 小松
-    郝晨煜
 
-## Bronze donors
+    And 194 anonymous donors
+
+## Silver and bronze donors
 
 There are even more donors that support the project with a small monthly donation.
 Every bit counts and we thank every one of them for their amazing support!

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -176,14 +176,14 @@ TypedArray<Dictionary> Engine::get_copyright_info() const {
 
 Dictionary Engine::get_donor_info() const {
 	Dictionary donors;
-	donors["platinum_sponsors"] = array_from_info(DONORS_SPONSOR_PLATINUM);
-	donors["gold_sponsors"] = array_from_info(DONORS_SPONSOR_GOLD);
-	donors["silver_sponsors"] = array_from_info(DONORS_SPONSOR_SILVER);
-	donors["bronze_sponsors"] = array_from_info(DONORS_SPONSOR_BRONZE);
-	donors["mini_sponsors"] = array_from_info(DONORS_SPONSOR_MINI);
-	donors["gold_donors"] = array_from_info(DONORS_GOLD);
-	donors["silver_donors"] = array_from_info(DONORS_SILVER);
-	donors["bronze_donors"] = array_from_info(DONORS_BRONZE);
+	donors["patrons"] = array_from_info(DONORS_PATRONS);
+	donors["platinum_sponsors"] = array_from_info(DONORS_SPONSORS_PLATINUM);
+	donors["gold_sponsors"] = array_from_info(DONORS_SPONSORS_GOLD);
+	donors["silver_sponsors"] = array_from_info(DONORS_SPONSORS_SILVER);
+	donors["diamond_members"] = array_from_info(DONORS_MEMBERS_DIAMOND);
+	donors["titanium_members"] = array_from_info(DONORS_MEMBERS_TITANIUM);
+	donors["platinum_members"] = array_from_info(DONORS_MEMBERS_PLATINUM);
+	donors["gold_members"] = array_from_info(DONORS_MEMBERS_GOLD);
 	return donors;
 }
 

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -117,24 +117,24 @@ def make_authors_header(target, source, env):
 
 def make_donors_header(target, source, env):
     sections = [
+        "Patrons",
         "Platinum sponsors",
         "Gold sponsors",
         "Silver sponsors",
-        "Bronze sponsors",
-        "Mini sponsors",
-        "Gold donors",
-        "Silver donors",
-        "Bronze donors",
+        "Diamond members",
+        "Titanium members",
+        "Platinum members",
+        "Gold members",
     ]
     sections_id = [
-        "DONORS_SPONSOR_PLATINUM",
-        "DONORS_SPONSOR_GOLD",
-        "DONORS_SPONSOR_SILVER",
-        "DONORS_SPONSOR_BRONZE",
-        "DONORS_SPONSOR_MINI",
-        "DONORS_GOLD",
-        "DONORS_SILVER",
-        "DONORS_BRONZE",
+        "DONORS_PATRONS",
+        "DONORS_SPONSORS_PLATINUM",
+        "DONORS_SPONSORS_GOLD",
+        "DONORS_SPONSORS_SILVER",
+        "DONORS_MEMBERS_DIAMOND",
+        "DONORS_MEMBERS_TITANIUM",
+        "DONORS_MEMBERS_PLATINUM",
+        "DONORS_MEMBERS_GOLD",
     ]
 
     src = source[0]

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -161,7 +161,8 @@ EditorAbout::EditorAbout() {
 
 	Label *about_text = memnew(Label);
 	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
-	about_text->set_text(String::utf8("\xc2\xa9 2014-present ") + TTR("Godot Engine contributors") + "." +
+	about_text->set_text(
+			String::utf8("\xc2\xa9 2014-present ") + TTR("Godot Engine contributors") + "." +
 			String::utf8("\n\xc2\xa9 2007-2014 Juan Linietsky, Ariel Manzur.\n"));
 	version_info_vbc->add_child(about_text);
 
@@ -182,24 +183,35 @@ EditorAbout::EditorAbout() {
 	// TRANSLATORS: This refers to a job title.
 	dev_sections.push_back(TTR("Project Manager", "Job Title"));
 	dev_sections.push_back(TTR("Developers"));
-	const char *const *dev_src[] = { AUTHORS_FOUNDERS, AUTHORS_LEAD_DEVELOPERS,
-		AUTHORS_PROJECT_MANAGERS, AUTHORS_DEVELOPERS };
+	const char *const *dev_src[] = {
+		AUTHORS_FOUNDERS,
+		AUTHORS_LEAD_DEVELOPERS,
+		AUTHORS_PROJECT_MANAGERS,
+		AUTHORS_DEVELOPERS,
+	};
 	tc->add_child(_populate_list(TTR("Authors"), dev_sections, dev_src, 1));
 
 	// Donors
 
 	List<String> donor_sections;
+	donor_sections.push_back(TTR("Patrons"));
 	donor_sections.push_back(TTR("Platinum Sponsors"));
 	donor_sections.push_back(TTR("Gold Sponsors"));
 	donor_sections.push_back(TTR("Silver Sponsors"));
-	donor_sections.push_back(TTR("Bronze Sponsors"));
-	donor_sections.push_back(TTR("Mini Sponsors"));
-	donor_sections.push_back(TTR("Gold Donors"));
-	donor_sections.push_back(TTR("Silver Donors"));
-	donor_sections.push_back(TTR("Bronze Donors"));
-	const char *const *donor_src[] = { DONORS_SPONSOR_PLATINUM, DONORS_SPONSOR_GOLD,
-		DONORS_SPONSOR_SILVER, DONORS_SPONSOR_BRONZE, DONORS_SPONSOR_MINI,
-		DONORS_GOLD, DONORS_SILVER, DONORS_BRONZE };
+	donor_sections.push_back(TTR("Diamond Members"));
+	donor_sections.push_back(TTR("Titanium Members"));
+	donor_sections.push_back(TTR("Platinum Members"));
+	donor_sections.push_back(TTR("Gold Members"));
+	const char *const *donor_src[] = {
+		DONORS_PATRONS,
+		DONORS_SPONSORS_PLATINUM,
+		DONORS_SPONSORS_GOLD,
+		DONORS_SPONSORS_SILVER,
+		DONORS_MEMBERS_DIAMOND,
+		DONORS_MEMBERS_TITANIUM,
+		DONORS_MEMBERS_PLATINUM,
+		DONORS_MEMBERS_GOLD,
+	};
 	tc->add_child(_populate_list(TTR("Donors"), donor_sections, donor_src, 3));
 
 	// License


### PR DESCRIPTION
The new list includes all donors listed on fund.godotengine.org, together with the ones still on Patreon on matching tiers.

We haven't yet updated Patreon tiers to match the Dev Fund, so donors who used to be listed under "Silver donors" are now grandfathered under the "Gold members" category from the Dev Fund.

https://github.com/godotengine/godot/assets/4701338/59599d10-52e2-4ff8-a6f9-a48a2c881fdc

