### PR TITLE
Only allow MeshInstance3D-based nodes in particles emission shape node selector

### DIFF
--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -223,6 +223,9 @@ GPUParticles3DEditorBase::GPUParticles3DEditorBase() {
 	emission_dialog->connect("confirmed", callable_mp(this, &GPUParticles3DEditorBase::_generate_emission_points));
 
 	emission_tree_dialog = memnew(SceneTreeDialog);
+	Vector<StringName> valid_types;
+	valid_types.push_back("MeshInstance3D");
+	emission_tree_dialog->set_valid_types(valid_types);
 	add_child(emission_tree_dialog);
 	emission_tree_dialog->connect("selected", callable_mp(this, &GPUParticles3DEditorBase::_node_selected));
 }


### PR DESCRIPTION
This applies to both GPUParticles3D and CPUParticles3D, as CPUParticles3DEditor inherits from GPUParticles3DEditorBase.

- This closes https://github.com/godotengine/godot/issues/84889.

## Preview

![Screenshot_20231114_161246](https://github.com/godotengine/godot/assets/180032/d94aa04f-7c9c-4957-b2fa-548254b2cb7f)
