### PR TITLE
Prevent race condition on initial breakpoints from DAP

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -44,7 +44,7 @@ void DebugAdapterParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("req_attach", "params"), &DebugAdapterParser::req_attach);
 	ClassDB::bind_method(D_METHOD("req_restart", "params"), &DebugAdapterParser::req_restart);
 	ClassDB::bind_method(D_METHOD("req_terminate", "params"), &DebugAdapterParser::req_terminate);
-	ClassDB::bind_method(D_METHOD("req_configurationDone", "params"), &DebugAdapterParser::prepare_success_response);
+	ClassDB::bind_method(D_METHOD("req_configurationDone", "params"), &DebugAdapterParser::req_configurationDone);
 	ClassDB::bind_method(D_METHOD("req_pause", "params"), &DebugAdapterParser::req_pause);
 	ClassDB::bind_method(D_METHOD("req_continue", "params"), &DebugAdapterParser::req_continue);
 	ClassDB::bind_method(D_METHOD("req_threads", "params"), &DebugAdapterParser::req_threads);
@@ -180,6 +180,13 @@ Dictionary DebugAdapterParser::req_launch(const Dictionary &p_params) const {
 		DebugAdapterProtocol::get_singleton()->get_current_peer()->supportsCustomData = args["godot/custom_data"];
 	}
 
+	DebugAdapterProtocol::get_singleton()->get_current_peer()->pending_launch = p_params;
+
+	return Dictionary();
+}
+
+Dictionary DebugAdapterParser::_launch_process(const Dictionary &p_params) const {
+	Dictionary args = p_params["arguments"];
 	ScriptEditorDebugger *dbg = EditorDebuggerNode::get_singleton()->get_default_debugger();
 	if ((bool)args["noDebug"] != dbg->is_skip_breakpoints()) {
 		dbg->debug_skip_breakpoints();
@@ -246,7 +253,7 @@ Dictionary DebugAdapterParser::req_restart(const Dictionary &p_params) const {
 	args = args["arguments"];
 	params["arguments"] = args;
 
-	Dictionary response = DebugAdapterProtocol::get_singleton()->get_current_peer()->attached ? req_attach(params) : req_launch(params);
+	Dictionary response = DebugAdapterProtocol::get_singleton()->get_current_peer()->attached ? req_attach(params) : _launch_process(params);
 	if (!response["success"]) {
 		response["command"] = p_params["command"];
 		return response;
@@ -257,6 +264,16 @@ Dictionary DebugAdapterParser::req_restart(const Dictionary &p_params) const {
 
 Dictionary DebugAdapterParser::req_terminate(const Dictionary &p_params) const {
 	EditorRunBar::get_singleton()->stop_playing();
+
+	return prepare_success_response(p_params);
+}
+
+Dictionary DebugAdapterParser::req_configurationDone(const Dictionary &p_params) const {
+	Ref<DAPeer> peer = DebugAdapterProtocol::get_singleton()->get_current_peer();
+	if (!peer->pending_launch.is_empty()) {
+		peer->res_queue.push_back(_launch_process(peer->pending_launch));
+		peer->pending_launch.clear();
+	}
 
 	return prepare_success_response(p_params);
 }

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -71,6 +71,7 @@ public:
 	Dictionary req_attach(const Dictionary &p_params) const;
 	Dictionary req_restart(const Dictionary &p_params) const;
 	Dictionary req_terminate(const Dictionary &p_params) const;
+	Dictionary req_configurationDone(const Dictionary &p_params) const;
 	Dictionary req_pause(const Dictionary &p_params) const;
 	Dictionary req_continue(const Dictionary &p_params) const;
 	Dictionary req_threads(const Dictionary &p_params) const;
@@ -83,6 +84,9 @@ public:
 	Dictionary req_stepIn(const Dictionary &p_params) const;
 	Dictionary req_evaluate(const Dictionary &p_params) const;
 	Dictionary req_godot_put_msg(const Dictionary &p_params) const;
+
+	// Internal requests
+	Dictionary _launch_process(const Dictionary &p_params) const;
 
 	// Events
 	Dictionary ev_initialized() const;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -678,7 +678,10 @@ bool DebugAdapterProtocol::process_message(const String &p_text) {
 		if (!response.is_empty()) {
 			_current_peer->res_queue.push_front(response);
 		} else {
-			completed = false;
+			// Launch request needs to be deferred until we receive a configurationDone request.
+			if (command != "req_launch") {
+				completed = false;
+			}
 		}
 	}
 

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -63,6 +63,7 @@ struct DAPeer : RefCounted {
 
 	// Internal client info
 	bool attached = false;
+	Dictionary pending_launch;
 
 	Error handle_data();
 	Error send_data();


### PR DESCRIPTION
When investigating debugging issues being reported on [godot-vscode-plugin](https://github.com/godotengine/godot-vscode-plugin), I've encountered a race condition regarding initial breakpoints. As far as I can tell, there were no reported issues here on **godot** and **godot-vscode-plugin** regarding this.

The DAP implementation assumes all configuration is done before launching the debuggee. Particularly, that breakpoints are set before launching the project. However, that's not the case in, for instance, VSCode, which seems to set breakpoints after requesting DAP to launch a process. Initially I thought this was their issue, but https://github.com/microsoft/vscode/issues/4902, https://github.com/microsoft/vscode/issues/4567 and https://github.com/microsoft/vscode/issues/4902#issuecomment-368583522 seem to suggest we cannot rely on clients to adhere to a specific ordering.

This causes a race condition that happened reliably on a Windows machine: setting a breakpoint on a `_ready` function did not trigger at all, since this information was not sent to the launched Godot instance on CLI (e.g. `--breakpoints res://Button.gd:6`), and by the point the Godot editor communicated these breakpoints at runtime, it was too late.

I'm still confused about this whole ordeal and whether the reasoning in the linked comments is actually correct, but one thing we can actually do to adress this is to wait for a `configurationDone` request that signals the end of configuration before launching the debuggee. This is also the solution implemented for [`vscode-mock-debug`](
https://github.com/microsoft/vscode-mock-debug/commit/9d378d6aa00982c565b9c19323a7882538a6063a#diff-a5084a6369857a870a66194d07e804149f4aa012e2c1fe95ea9c733cae6d123dR127-R129), and so this change essentially defers the `launch` request to when we receive the `configurationDone` request.

This comes with the implication that if a DAP client that does not support/send a `configurationDone` request, then Godot will remain stuck waiting for it. However, this request was added very early on [v1.2.x](https://microsoft.github.io/debug-adapter-protocol/changelog), so I believe this scenario is extremely unlikely.