### PR TITLE
Fix DAP breakpoints being cleared on closed scripts

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -544,7 +544,7 @@ void ScriptEditor::_set_breakpoint(Ref<RefCounted> p_script, int p_line, bool p_
 		}
 		state["breakpoints"] = breakpoints;
 		script_editor_cache->set_value(scr->get_path(), "state", state);
-		EditorDebuggerNode::get_singleton()->set_breakpoint(scr->get_path(), p_line + 1, false);
+		EditorDebuggerNode::get_singleton()->set_breakpoint(scr->get_path(), p_line + 1, p_enabled);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/83614

When a breakpoint is set for a closed file, that state was saved but the breakpoint was disabled. This honors the `p_enabled` setting in order to fix the issue. I'm not sure where there are other scenarios where one could set breakpoints on closed files, so this might impact more than I'm expecting.