### PR TITLE
Update default_theme_builders.py - More efficient importing

### DIFF
--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -3,8 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
-import os
-import os.path
+from os.path import splitext, basename
 from platform_methods import subprocess_main
 
 
@@ -22,7 +21,7 @@ def make_fonts_header(target, source, env):
         with open(source[i], "rb") as f:
             buf = f.read()
 
-        name = os.path.splitext(os.path.basename(source[i]))[0]
+        name = splitext(basename(source[i]))[0]
 
         g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
         g.write("static const unsigned char _font_" + name + "[] = {\n")


### PR DESCRIPTION
Slightly faster due to only having to import functions from os/os.path instead of the entire package. Ran with no errors on my system.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
