### PR TITLE
Do not bother with line colors if `line_number_gutter` is not yet calculated

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -341,7 +341,9 @@ void ScriptTextEditor::reload_text() {
 	te->tag_saved_version();
 
 	code_editor->update_line_and_column();
-	_validate_script();
+	if (editor_enabled) {
+		_validate_script();
+	}
 }
 
 void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray p_args) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/81135

When code files are changed with an external editor, all files in script list are reloaded. Files are validated and then `_update_errors()` is called for each file and type safe lines are colored by `_update_errors()` calling `TextEdit`'s `set_line_gutter_item_color()` with `line_number_gutter` as a parameter. `line_number_gutter` is however calculated only when a file is opened to the edit view. When a project is opened, only one file is opened to edit view and only that file's `line_number_gutter` is calculated. If any file is now saved in external editor, all other files have `line_number_gutter == -1` and the error message "Index p_gutter = -1 is out of bounds" is spawned for every line of those files. If the user opens all files in script list to the edit view _before_ saving in the external editor, every file will have it's `line_number_gutter` calculated and there will be no errors.

~~This is now fixed simply by skipping the setting of line colors altogether if the `line_number_gutter` is not yet calculated. The script is not shown, so it doesn't matter. When the user opens the script file to the edit view, `line_number_gutter` is calculated and also `_update_errors()` is called again.~~

This is now fixed by not calling `_validate_script()` from `reload_text()` if `editor_enabled == false`.
