### PR TITLE
Expose a way to get the topmost Control node under the mouse

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -116,6 +116,13 @@
 				Returns the visible rectangle in global screen coordinates.
 			</description>
 		</method>
+		<method name="gui_find_control">
+			<return type="Control" />
+			<param index="0" name="point" type="Vector2" />
+			<description>
+				Returns the top-level [Control] at the given point within this viewport. If no [Control] is at the point, returns null.
+			</description>
+		</method>
 		<method name="gui_get_drag_data" qualifiers="const">
 			<return type="Variant" />
 			<description>
@@ -126,6 +133,12 @@
 			<return type="Control" />
 			<description>
 				Returns the [Control] having the focus within this viewport. If no [Control] has the focus, returns null.
+			</description>
+		</method>
+		<method name="gui_get_mouse_over" qualifiers="const">
+			<return type="Control" />
+			<description>
+				Returns the top-level [Control] at the mouse cursor position within this viewport. If no [Control] is at the mouse cursor location, returns null.
 			</description>
 		</method>
 		<method name="gui_is_drag_successful" qualifiers="const">

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3491,6 +3491,11 @@ Control *Viewport::gui_get_focus_owner() const {
 	return gui.key_focus;
 }
 
+Control *Viewport::gui_get_mouse_over() const {
+	ERR_READ_THREAD_GUARD_V(nullptr);
+	return gui.mouse_over;
+}
+
 void Viewport::set_msaa_2d(MSAA p_msaa) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_INDEX(p_msaa, MSAA_MAX);
@@ -4530,6 +4535,10 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("gui_release_focus"), &Viewport::gui_release_focus);
 	ClassDB::bind_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner);
+
+	ClassDB::bind_method(D_METHOD("gui_get_mouse_over"), &Viewport::gui_get_mouse_over);
+
+	ClassDB::bind_method(D_METHOD("gui_find_control", "point"), &Viewport::gui_find_control);
 
 	ClassDB::bind_method(D_METHOD("set_disable_input", "disable"), &Viewport::set_disable_input);
 	ClassDB::bind_method(D_METHOD("is_input_disabled"), &Viewport::is_input_disabled);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -610,6 +610,8 @@ public:
 	void gui_release_focus();
 	Control *gui_get_focus_owner() const;
 
+	Control *gui_get_mouse_over() const;
+
 	PackedStringArray get_configuration_warnings() const override;
 
 	void set_debug_draw(DebugDraw p_debug_draw);


### PR DESCRIPTION
I've exposed a way to get Viewport::gui.mouse_over and call Viewport::gui_find_control to GDScript to facilitate being able to implement the following features:
- Gamepad control of mouse where speed of mouse should slow down when the cursor is over certain types of controls
- Allowing for a generic service that can provide contextual help based on the Control under the mouse cursor

From GDScript, the following can now be done to get the control under the mouse cursor (or possibly at another location):
```
var mouse_over_control = get_viewport().gui_get_mouse_over()
var found_control = get_viewport().gui_find_control(get_global_mouse_position())
```