### PR TITLE
Mark `SubViewportContainer::_propagate_input_event` experimental

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -11,7 +11,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_propagate_input_event" qualifiers="virtual const">
+		<method name="_propagate_input_event" qualifiers="virtual const" is_experimental="true">
 			<return type="bool" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>


### PR DESCRIPTION
The function got introduced during 4.2-dev and it was discussed, if it could be implemented in a way that also allows InputEvent filtering during `Node._process`. Let's keep this function experimental for the moment, in case we implement a general solution and want to deprecate this function.

follow-up to #78762