### PR TITLE
Validate texture format selection when exporting to Windows or Linux

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -34,17 +34,14 @@
 #include "scene/resources/image_texture.h"
 
 void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
-	if (p_preset->get("texture_format/bptc")) {
+	if (p_preset->get("texture_format/bptc") || p_preset->get("texture_format/s3tc")) {
 		r_features->push_back("bptc");
-	}
-	if (p_preset->get("texture_format/s3tc")) {
 		r_features->push_back("s3tc");
 	}
-	if (p_preset->get("texture_format/etc")) {
-		r_features->push_back("etc");
-	}
+
 	if (p_preset->get("texture_format/etc2")) {
 		r_features->push_back("etc2");
+		r_features->push_back("astc");
 	}
 	// PC platforms only have one architecture per export, since
 	// we export a single executable instead of a bundle.
@@ -102,6 +99,21 @@ bool EditorExportPlatformPC::has_valid_export_configuration(const Ref<EditorExpo
 
 	valid = dvalid || rvalid;
 	r_missing_templates = !valid;
+
+	bool uses_s3tc = p_preset->get("texture_format/s3tc");
+	bool uses_bptc = p_preset->get("texture_format/bptc");
+
+	if (uses_s3tc != uses_bptc) {
+		valid = false;
+		err += TTR("If using either s3tc or bptc texture format, you must use both s3tc and bptc.");
+	}
+
+	bool uses_etc2 = p_preset->get("texture_format/etc2");
+
+	if (!uses_s3tc && !uses_bptc && !uses_etc2) {
+		valid = false;
+		err += TTR("A texture format must be selected to export the project. Please select at least one texture format.");
+	}
 
 	if (!err.is_empty()) {
 		r_error = err;

--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -58,16 +58,16 @@
 			- [code]{cmd_args}[/code] - Array of the command line argument for the application.
 		</member>
 		<member name="texture_format/bptc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the BPTC format.
+			If [code]true[/code], project textures are exported in the BPTC format. If used, [member texture_format/s3tc] must be used as well.
 		</member>
 		<member name="texture_format/etc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the ETC format.
+			This option does not do anything and may be removed in the future.
 		</member>
 		<member name="texture_format/etc2" type="bool" setter="" getter="">
 			If [code]true[/code], project textures are exported in the ETC2 format.
 		</member>
 		<member name="texture_format/s3tc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the S3TC format.
+			If [code]true[/code], project textures are exported in the S3TC format. If used, [member texture_format/bptc] must be used as well.
 		</member>
 	</members>
 </class>

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -124,16 +124,16 @@
 			- [code]{cmd_args}[/code] - Array of the command line argument for the application.
 		</member>
 		<member name="texture_format/bptc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the BPTC format.
+			If [code]true[/code], project textures are exported in the BPTC format. If used, [member texture_format/s3tc] must be used as well.
 		</member>
 		<member name="texture_format/etc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the ETC format.
+			This option does not do anything and may be removed in the future.
 		</member>
 		<member name="texture_format/etc2" type="bool" setter="" getter="">
 			If [code]true[/code], project textures are exported in the ETC2 format.
 		</member>
 		<member name="texture_format/s3tc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the S3TC format.
+			If [code]true[/code], project textures are exported in the S3TC format. If used, [member texture_format/bptc] must be used as well.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/81234
Closes: https://github.com/godotengine/godot-proposals/issues/7230

In https://github.com/godotengine/godot/pull/73829 we made s3tc + bptc the default export options. But we exposed users to the risk that, if they disable one or the other, their games would not load. 

In Godot 4.x, it is not possible to use S3TC without BPTC (or vice versa). Nor is it possible to use ETC2 without ASTC (or vice versa). 

This change validates that S3TC and BPTC have the same value (either both on or both off) and either S3TC/BPTC or ETC2/ASTC are used at export time. 

Finally it updates the docs for the settings and removes "etc" from the feature list (as ETC textures are no longer used by the engine).
