### PR TITLE
Revert "Fix transform notification not getting sent out for RigidBody2D"

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -891,18 +891,22 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 	 * notification anyway).
 	 */
 
-	if (p_node->block_transform_notify || p_node->_is_global_invalid()) {
+	if (/*p_node->xform_change.in_list() &&*/ p_node->_is_global_invalid()) {
 		return; //nothing to do
 	}
 
 	p_node->_set_global_invalid(true);
 
-	if (p_node->notify_transform && !p_node->xform_change.in_list() && p_node->is_inside_tree()) {
-		if (is_accessible_from_caller_thread()) {
-			get_tree()->xform_change_list.add(&p_node->xform_change);
-		} else {
-			// Should be rare, but still needs to be handled.
-			MessageQueue::get_singleton()->push_callable(callable_mp(p_node, &CanvasItem::_notify_transform_deferred));
+	if (p_node->notify_transform && !p_node->xform_change.in_list()) {
+		if (!p_node->block_transform_notify) {
+			if (p_node->is_inside_tree()) {
+				if (is_accessible_from_caller_thread()) {
+					get_tree()->xform_change_list.add(&p_node->xform_change);
+				} else {
+					// Should be rare, but still needs to be handled.
+					MessageQueue::get_singleton()->push_callable(callable_mp(p_node, &CanvasItem::_notify_transform_deferred));
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This reverts #84856.

It turns out that #84856 traded in one `RigidBody2D` regression for another (much worse) regression, namely that the global transform now doesn't get updated at all unless something else writes to it that isn't `RigidBody2D::_sync_body_state`.

Which means that this snippet:

```gdscript
extends RigidBody2D

func _ready():
	angular_velocity = deg_to_rad(1080)

func _process(delta):
	print("Rotation from _process: ", global_rotation_degrees)

func _physics_process(delta):
	print("Rotation from _physics_process: ", global_rotation_degrees)

func _integrate_forces(state):
	print("Rotation from _integrate_forces: ", global_rotation_degrees)
```

... will only ever print zeroes, which is not great.

I'll try to come up with some alternative solution to the problem described in #84856 in the meantime.

If you need me to create a formal issue for the regression that would now be brought back (seeing as how there's no issue to reopen) I'd be happy to do that.