### PR TITLE
Fix issue by changing direction for the arrows of one way collisions for 2d collision shapes and polygons

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -154,12 +154,12 @@ void CollisionPolygon2D::_notification(int p_what) {
 			if (one_way_collision) {
 				Color dcol = get_tree()->get_debug_collisions_color(); //0.9,0.2,0.2,0.4);
 				dcol.a = 1.0;
-				Vector2 line_to(0, 20);
+				Vector2 line_to(0, -20);
 				draw_line(Vector2(), line_to, dcol, 3);
 				real_t tsize = 8;
 
 				Vector<Vector2> pts = {
-					line_to + Vector2(0, tsize),
+					line_to + Vector2(0, -tsize),
 					line_to + Vector2(Math_SQRT12 * tsize, 0),
 					line_to + Vector2(-Math_SQRT12 * tsize, 0)
 				};

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -119,12 +119,12 @@ void CollisionShape2D::_notification(int p_what) {
 				if (disabled) {
 					draw_col = draw_col.darkened(0.25);
 				}
-				Vector2 line_to(0, 20);
+				Vector2 line_to(0, -20);
 				draw_line(Vector2(), line_to, draw_col, 2);
 				real_t tsize = 8;
 
 				Vector<Vector2> pts{
-					line_to + Vector2(0, tsize),
+					line_to + Vector2(0, -tsize),
 					line_to + Vector2(Math_SQRT12 * tsize, 0),
 					line_to + Vector2(-Math_SQRT12 * tsize, 0)
 				};


### PR DESCRIPTION
This pull request fixes and closes https://github.com/godotengine/godot/issues/84542.

I am fairly certain that what the issue requests makes sense and is more clear than the current implementation. What was fixed is that in both the files changed, the arrows were reversed by changing the coordinates of line_to(). This felt like the simplest and clearest way of doing it. Now, the arrows show which way an object can pass through the shape/polygon instead of the opposite. Please comment on this if you feel the opposite.