### PR TITLE
Fix transform sync in `RigidBody*D::_body_state_changed`

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -451,10 +451,14 @@ void RigidBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
 		_sync_body_state(p_state);
 
+		Transform2D old_transform = get_global_transform();
 		GDVIRTUAL_CALL(_integrate_forces, p_state);
+		Transform2D new_transform = get_global_transform();
 
-		// Update the physics server with any new transform, to prevent it from being overwritten at the sync below.
-		force_update_transform();
+		if (new_transform != old_transform) {
+			// Update the physics server with the new transform, to prevent it from being overwritten at the sync below.
+			PhysicsServer2D::get_singleton()->body_set_state(get_rid(), PhysicsServer2D::BODY_STATE_TRANSFORM, new_transform);
+		}
 	}
 
 	_sync_body_state(p_state);

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -506,10 +506,14 @@ void RigidBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
 		_sync_body_state(p_state);
 
+		Transform3D old_transform = get_global_transform();
 		GDVIRTUAL_CALL(_integrate_forces, p_state);
+		Transform3D new_transform = get_global_transform();
 
-		// Update the physics server with any new transform, to prevent it from being overwritten at the sync below.
-		force_update_transform();
+		if (new_transform != old_transform) {
+			// Update the physics server with the new transform, to prevent it from being overwritten at the sync below.
+			PhysicsServer3D::get_singleton()->body_set_state(get_rid(), PhysicsServer3D::BODY_STATE_TRANSFORM, new_transform);
+		}
 	}
 
 	_sync_body_state(p_state);
@@ -2945,10 +2949,14 @@ void PhysicalBone3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
 		_sync_body_state(p_state);
 
+		Transform3D old_transform = get_global_transform();
 		GDVIRTUAL_CALL(_integrate_forces, p_state);
+		Transform3D new_transform = get_global_transform();
 
-		// Update the physics server with any new transform, to prevent it from being overwritten at the sync below.
-		force_update_transform();
+		if (new_transform != old_transform) {
+			// Update the physics server with the new transform, to prevent it from being overwritten at the sync below.
+			PhysicsServer3D::get_singleton()->body_set_state(get_rid(), PhysicsServer3D::BODY_STATE_TRANSFORM, new_transform);
+		}
 	}
 
 	_sync_body_state(p_state);


### PR DESCRIPTION
Fixes #84919.

This replaces the `force_update_transform` that was added as part of #84799 with the more crude solution of comparing the before-and-after of the global transform to determine whether we need to push any new updates to the physics server or not, thereby skirting around the problem of the `global_invalid` flag mentioned in #84856.

Note that this is not strictly necessary in the 3D bodies, as `force_update_transform` works just fine there, but I figured it's better to keep things consistent.