### PR TITLE
[macOS] Process events before changing title style to update window frame.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8091,6 +8091,7 @@ EditorNode::EditorNode() {
 
 	// Extend menu bar to window title.
 	if (can_expand) {
+		DisplayServer::get_singleton()->process_events();
 		DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_EXTEND_TO_TITLE, true, DisplayServer::MAIN_WINDOW_ID);
 		title_bar->set_can_move_window(true);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76628, seems like macOS do not update window frame rect until move event is processed, and changing frame style were resetting it to old position.