### PR TITLE
Improve search/replace bar behavior

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -96,9 +96,9 @@ class FindReplaceBar : public HBoxContainer {
 
 	void _get_search_from(int &r_line, int &r_col, bool p_is_searching_next = false);
 	void _update_results_count();
-	void _update_matches_label();
+	void _update_matches_display();
 
-	void _show_search(bool p_focus_replace = false, bool p_show_only = false);
+	void _show_search(bool p_with_replace, bool p_show_only);
 	void _hide_bar(bool p_force_focus = false);
 
 	void _editor_text_changed();


### PR DESCRIPTION
- When multiple lines are selected before CTRL-F / CTRL-R:
  - Find: Keep previous search instead of putting the selected lines into the find input.
  - Replace: Focus find input instead of replace input.
- Add placeholder and tooltip for the two LineEdits and icon buttons.
- Disable related buttons when the operation makes no sense.