### PR TITLE
Only allow MeshInstance3D-inherited nodes in MultiMesh Populate Surface dialog

### DIFF
--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -354,6 +354,9 @@ MultiMeshEditor::MultiMeshEditor() {
 
 	populate_dialog->get_ok_button()->connect("pressed", callable_mp(this, &MultiMeshEditor::_populate));
 	std = memnew(SceneTreeDialog);
+	Vector<StringName> valid_types;
+	valid_types.push_back("MeshInstance3D");
+	std->set_valid_types(valid_types);
 	populate_dialog->add_child(std);
 	std->connect("selected", callable_mp(this, &MultiMeshEditor::_browsed));
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/84891.
- This closes https://github.com/godotengine/godot/issues/84893.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/34b9eb22-ddbf-4f3c-9782-48a3ebebcaaf)