### PR TITLE
[3.x] [Core] Fix `File.get_buffer` returning wrong length

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2177,7 +2177,7 @@ PoolVector<uint8_t> _File::get_buffer(int64_t p_length) const {
 	w.release();
 
 	if (len < p_length) {
-		data.resize(p_length);
+		data.resize(len);
 	}
 
 	return data;


### PR DESCRIPTION
File.get_buffer always returned as many bytes as requested (even when EOF was reached), this resulted in random bytes being returned when overflowing.

This caused #51959 in 3.x when the user requested more bytes than the one available in the file.

*Bugsquad edit:*
- Fixes #51959