### PR TITLE
Fix some legacy code

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -416,21 +416,15 @@ void Resource::_take_over_path(const String &p_path) {
 }
 
 RID Resource::get_rid() const {
-	if (get_script_instance()) {
-		Callable::CallError ce;
-		RID ret = get_script_instance()->callp(SNAME("_get_rid"), nullptr, 0, ce);
-		if (ce.error == Callable::CallError::CALL_OK && ret.is_valid()) {
-			return ret;
+	RID ret;
+	if (!GDVIRTUAL_CALL(_get_rid, ret)) {
+#ifndef DISABLE_DEPRECATED
+		if (_get_extension() && _get_extension()->get_rid) {
+			ret = RID::from_uint64(_get_extension()->get_rid(_get_extension_instance()));
 		}
+#endif
 	}
-	if (_get_extension() && _get_extension()->get_rid) {
-		RID ret = RID::from_uint64(_get_extension()->get_rid(_get_extension_instance()));
-		if (ret.is_valid()) {
-			return ret;
-		}
-	}
-
-	return RID();
+	return ret;
 }
 
 #ifdef TOOLS_ENABLED
@@ -558,11 +552,8 @@ void Resource::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_name"), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_scene_unique_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_scene_unique_id", "get_scene_unique_id");
 
-	MethodInfo get_rid_bind("_get_rid");
-	get_rid_bind.return_val.type = Variant::RID;
-
-	::ClassDB::add_virtual_method(get_class_static(), get_rid_bind, true, Vector<String>(), true);
 	GDVIRTUAL_BIND(_setup_local_to_scene);
+	GDVIRTUAL_BIND(_get_rid);
 }
 
 Resource::Resource() :

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -87,6 +87,8 @@ protected:
 	virtual void reset_local_to_scene();
 	GDVIRTUAL0(_setup_local_to_scene);
 
+	GDVIRTUAL0RC(RID, _get_rid);
+
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor
 	static void (*_update_configuration_warning)(); //used by editor

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -14,7 +14,7 @@
 		<link title="When and how to avoid using nodes for everything">$DOCS_URL/tutorials/best_practices/node_alternatives.html</link>
 	</tutorials>
 	<methods>
-		<method name="_get_rid" qualifiers="virtual">
+		<method name="_get_rid" qualifiers="virtual const">
 			<return type="RID" />
 			<description>
 				Override this method to return a custom [RID] when [method get_rid] is called.

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4412,13 +4412,9 @@ bool ScriptEditorPlugin::handles(Object *p_object) const {
 void ScriptEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		window_wrapper->show();
-		script_editor->set_process(true);
 		script_editor->ensure_select_current();
 	} else {
 		window_wrapper->hide();
-		if (!window_wrapper->get_window_enabled()) {
-			script_editor->set_process(false);
-		}
 	}
 }
 


### PR DESCRIPTION
This PR takes care of some legacy code that I had noted over time.
- remove unnecessary binds from EditorNode and SceneTreeEditor
  - in case of the latter I had to make one method public
- make Resource's `_get_rid()` into a proper virtual function (using GDVIRTUAL stuff wasn't possible in that file until recently)
  - I also made the method `const` for consistency with C++
- remove `set_process()` calls in script editor (nothing uses it anymore)
- ~~change `has_theme_stylebox()` to theme cache checks~~