### PR TITLE
[iOS] Fix dotnet export.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/iOSNativeAOT.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/iOSNativeAOT.targets
@@ -33,9 +33,9 @@
     <Message Importance="normal" Text="Found XCode at $(XcodeSelect)"  Condition=" '$(FindXCode)' == 'true' "/>
     
     <ItemGroup>
-      <LinkerArg Include="-isysroot %22$(XCodePath)Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk%22"
+      <LinkerArg Include="-mios-simulator-version-min=12.0 -isysroot %22$(XCodePath)Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk%22"
                  Condition=" $(RuntimeIdentifier.Contains('simulator')) "/>
-      <LinkerArg Include="-isysroot %22$(XCodePath)Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk%22"
+      <LinkerArg Include="-miphoneos-version-min=12.0 -isysroot %22$(XCodePath)Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk%22"
                  Condition=" !$(RuntimeIdentifier.Contains('simulator')) "/>
     </ItemGroup>
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -195,7 +195,7 @@ namespace GodotTools.Export
                     bool isSim = arch == "i386" || arch == "x86_64"; // Shouldn't really happen as we don't do AOT for the simulator
                     string versionMinName = isSim ? "iphonesimulator" : "iphoneos";
                     string iOSPlatformName = isSim ? "iPhoneSimulator" : "iPhoneOS";
-                    const string versionMin = "10.0"; // TODO: Turn this hard-coded version into an exporter setting
+                    const string versionMin = "12.0"; // TODO: Turn this hard-coded version into an exporter setting
                     string iOSSdkPath = Path.Combine(XcodeHelper.XcodePath,
                             $"Contents/Developer/Platforms/{iOSPlatformName}.platform/Developer/SDKs/{iOSPlatformName}.sdk");
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -194,7 +194,7 @@ namespace GodotTools.Export
                     BundleOutputs = false,
                     IncludeDebugSymbols = publishConfig.IncludeDebugSymbols,
                     RidOS = OS.DotNetOS.iOSSimulator,
-                    UseTempDir = true,
+                    UseTempDir = false,
                 });
             }
 
@@ -361,7 +361,7 @@ namespace GodotTools.Export
                 }
 
                 var xcFrameworkPath = Path.Combine(GodotSharpDirs.ProjectBaseOutputPath, publishConfig.BuildConfig,
-                    $"{GodotSharpDirs.ProjectAssemblyName}.xcframework");
+                    $"{GodotSharpDirs.ProjectAssemblyName}_aot.xcframework");
                 if (!BuildManager.GenerateXCFrameworkBlocking(outputPaths,
                         Path.Combine(GodotSharpDirs.ProjectBaseOutputPath, publishConfig.BuildConfig, xcFrameworkPath)))
                 {

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -68,7 +68,9 @@ class GDMono {
 
 	String project_assembly_path;
 	uint64_t project_assembly_modified_time = 0;
+#ifdef GD_MONO_HOT_RELOAD
 	int project_load_failure_count = 0;
+#endif
 
 #ifdef TOOLS_ENABLED
 	bool _load_project_assembly();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/83628

- Fixes `xcframework` build.
- Fixes location of AOT files in the Xcode project.
- Fixes embedding settings for frameworks.
- Fixes exporting `.xarchive` and `.ipa` (with "Export Project Only" unchecked).