### PR TITLE
Use disabled icons for CheckBox in DefaultTheme

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -737,9 +737,7 @@ void PopupMenu::_draw_items() {
 			}
 		}
 
-		Color icon_color(1, 1, 1, items[i].disabled && !items[i].separator ? 0.5 : 1);
-
-		icon_color *= items[i].icon_modulate;
+		Color icon_color = items[i].icon_modulate;
 
 		// For non-separator items, add some padding for the content.
 		if (!items[i].separator) {

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -299,13 +299,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("focus", "CheckBox", cbx_focus);
 
 	theme->set_icon("checked", "CheckBox", icons["checked"]);
-	theme->set_icon("checked_disabled", "CheckBox", icons["checked"]);
+	theme->set_icon("checked_disabled", "CheckBox", icons["checked_disabled"]);
 	theme->set_icon("unchecked", "CheckBox", icons["unchecked"]);
-	theme->set_icon("unchecked_disabled", "CheckBox", icons["unchecked"]);
+	theme->set_icon("unchecked_disabled", "CheckBox", icons["unchecked_disabled"]);
 	theme->set_icon("radio_checked", "CheckBox", icons["radio_checked"]);
-	theme->set_icon("radio_checked_disabled", "CheckBox", icons["radio_checked"]);
+	theme->set_icon("radio_checked_disabled", "CheckBox", icons["radio_checked_disabled"]);
 	theme->set_icon("radio_unchecked", "CheckBox", icons["radio_unchecked"]);
-	theme->set_icon("radio_unchecked_disabled", "CheckBox", icons["radio_unchecked"]);
+	theme->set_icon("radio_unchecked_disabled", "CheckBox", icons["radio_unchecked_disabled"]);
 
 	theme->set_font("font", "CheckBox", Ref<Font>());
 	theme->set_font_size("font_size", "CheckBox", -1);
@@ -685,13 +685,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("labeled_separator_right", "PopupMenu", separator_horizontal);
 
 	theme->set_icon("checked", "PopupMenu", icons["checked"]);
-	theme->set_icon("checked_disabled", "PopupMenu", icons["checked"]);
+	theme->set_icon("checked_disabled", "PopupMenu", icons["checked_disabled"]);
 	theme->set_icon("unchecked", "PopupMenu", icons["unchecked"]);
-	theme->set_icon("unchecked_disabled", "PopupMenu", icons["unchecked"]);
+	theme->set_icon("unchecked_disabled", "PopupMenu", icons["unchecked_disabled"]);
 	theme->set_icon("radio_checked", "PopupMenu", icons["radio_checked"]);
-	theme->set_icon("radio_checked_disabled", "PopupMenu", icons["radio_checked"]);
+	theme->set_icon("radio_checked_disabled", "PopupMenu", icons["radio_checked_disabled"]);
 	theme->set_icon("radio_unchecked", "PopupMenu", icons["radio_unchecked"]);
-	theme->set_icon("radio_unchecked_disabled", "PopupMenu", icons["radio_unchecked"]);
+	theme->set_icon("radio_unchecked_disabled", "PopupMenu", icons["radio_unchecked_disabled"]);
 	theme->set_icon("submenu", "PopupMenu", icons["popup_menu_arrow_right"]);
 	theme->set_icon("submenu_mirrored", "PopupMenu", icons["popup_menu_arrow_left"]);
 


### PR DESCRIPTION
### CheckBox
| After | Before |
| --- | --- |
| ![image](https://github.com/godotengine/godot/assets/1756388/250712c8-db22-4909-bcad-39aa4ac17e0e) | ![image](https://github.com/godotengine/godot/assets/1756388/f2cca904-b176-4285-8736-c98993d8d54c) |

### PopupMenu
| After | Before |
| --- | --- |
| ![image](https://github.com/godotengine/godot/assets/1756388/3a87d4d6-e8b4-43bd-bf4c-0d470051f9a3) | ![image](https://github.com/godotengine/godot/assets/1756388/9bbca602-d695-4597-b021-dc7348b12e33) |

P.S. I found that PopupMenu modulates the icon color for the disabled state. Is this necessary when using separate icons for each state?
