### PR TITLE
Renderer Viewport correct `sizeof` usage.

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1387,7 +1387,7 @@ void RendererViewport::viewport_set_sdf_oversize_and_scale(RID p_viewport, RS::V
 RID RendererViewport::viewport_find_from_screen_attachment(DisplayServer::WindowID p_id) const {
 	RID *rids = nullptr;
 	uint32_t rid_count = viewport_owner.get_rid_count();
-	rids = (RID *)alloca(sizeof(RID *) * rid_count);
+	rids = (RID *)alloca(sizeof(RID) * rid_count);
 	viewport_owner.fill_owned_buffer(rids);
 	for (uint32_t i = 0; i < rid_count; i++) {
 		Viewport *viewport = viewport_owner.get_or_null(rids[i]);


### PR DESCRIPTION
The current usage.

In viewport_find_from_screen_attachment
- Allocates a list of pointers, eg sizeof(RID*) * ridcount.

We need fill that buffer
viewport_owner.fill_owned_buffer(rids);
...
 p_rid_buffer[idx] = _make_from_id((validator << 32) | i);

_make_from_id returns an RID object, not a pointer.

Since there isn't a copy constructor, a bitwise copy of the object occurs.

This issue will only present itself under 32bit builds.
sizeof(RID)  : 8
sizeof(RID*) : 4

whereas 64bit builds they are both 8.

