### PR TITLE
GLES3: Fix iOS Simulator by removing incorrect `system_fbo` overwrite

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -61,8 +61,6 @@ static const GLenum _cube_side_enum[6] = {
 TextureStorage::TextureStorage() {
 	singleton = this;
 
-	system_fbo = 0;
-
 	{ //create default textures
 		{ // White Textures
 


### PR DESCRIPTION
The system_fbo static field is already initialized to zero, it should not be initialized again, when a TextureStorage instance is created, because it interferes with the iOS OpenGL initialization (see platform/ios/display_layer.mm).

This change fixes the OpenGL backend for the iOS Simulator and iOS devices. 

Developed by [Migeran](https://migeran.com), sponsored by [Smirk Software](https://smirk.gg).

Fixes https://github.com/godotengine/godot/issues/82917