### PR TITLE
Don't add shader context keywords when `DEBUG_ENABLED`

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10027,28 +10027,6 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 	shader = alloc_node<ShaderNode>();
 	_parse_shader(p_info.functions, p_info.render_modes, p_info.shader_types);
 
-#ifdef DEBUG_ENABLED
-	// Adds context keywords.
-	if (keyword_completion_context != CF_UNSPECIFIED) {
-		int sz = sizeof(keyword_list) / sizeof(KeyWord);
-		for (int i = 0; i < sz; i++) {
-			if (keyword_list[i].flags == CF_UNSPECIFIED) {
-				break; // Ignore hint keywords (parsed below).
-			}
-			if (keyword_list[i].flags & keyword_completion_context) {
-				if (keyword_list[i].excluded_shader_types.has(shader_type_identifier)) {
-					continue;
-				}
-				if (!keyword_list[i].functions.is_empty() && !keyword_list[i].functions.has(current_function)) {
-					continue;
-				}
-				ScriptLanguage::CodeCompletionOption option(keyword_list[i].text, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
-				r_options->push_back(option);
-			}
-		}
-	}
-#endif // DEBUG_ENABLED
-
 	switch (completion_type) {
 		case COMPLETION_NONE: {
 			//do nothing


### PR DESCRIPTION
For communicating in #84941 , tested in debug build and release build, it seems the auto-completion is not triggered anymore.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
