### PR TITLE
Fix lagging TileSet view for large TileSets in Editor

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -323,21 +323,31 @@ void TileAtlasView::_draw_base_tiles_texture_grid() {
 
 		Size2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
 
-		// Draw each tile texture region.
+		// Draw the grid.
+		for (int x = 0; x <= grid_size.x; x++) {
+			Vector2i origin = margins + (Vector2i(x, 0) * (texture_region_size + separation));
+			Vector2i destination = margins + (Vector2i(x, grid_size.y) * (texture_region_size + separation));
+
+			base_tiles_texture_grid->draw_line(origin, destination, Color(0.7, 0.7, 0.7, 0.1), 1, false);
+		}
+		for (int y = 0; y <= grid_size.y; y++) {
+			Vector2i origin = margins + (Vector2i(0, y) * (texture_region_size + separation));
+			Vector2i destination = margins + (Vector2i(grid_size.x, y) * (texture_region_size + separation));
+
+			base_tiles_texture_grid->draw_line(origin, destination, Color(0.7, 0.7, 0.7, 0.1), 1, false);
+		}
+
+		// Draw existing tiles.
 		for (int x = 0; x < grid_size.x; x++) {
 			for (int y = 0; y < grid_size.y; y++) {
 				Vector2i origin = margins + (Vector2i(x, y) * (texture_region_size + separation));
 				Vector2i base_tile_coords = tile_set_atlas_source->get_tile_at_coords(Vector2i(x, y));
 				if (base_tile_coords != TileSetSource::INVALID_ATLAS_COORDS) {
 					if (base_tile_coords == Vector2i(x, y)) {
-						// Draw existing tile.
 						Vector2i size_in_atlas = tile_set_atlas_source->get_tile_size_in_atlas(base_tile_coords);
 						Vector2 region_size = texture_region_size * size_in_atlas + separation * (size_in_atlas - Vector2i(1, 1));
 						base_tiles_texture_grid->draw_rect(Rect2i(origin, region_size), Color(1.0, 1.0, 1.0, 0.8), false);
 					}
-				} else {
-					// Draw the grid.
-					base_tiles_texture_grid->draw_rect(Rect2i(origin, texture_region_size), Color(0.7, 0.7, 0.7, 0.1), false);
 				}
 			}
 		}


### PR DESCRIPTION
The TileSet panel is lagging on big TileSets since on every draw cycle the whole grid re-draws the rectangles.
For TileSets of size > 100x100 the TileSet panel becomes unusable. 

Relevant discussion:
https://github.com/godotengine/godot/issues/72405#issuecomment-1807527021

This PR replaces the grid made of rectangles (quadratic of the size of TileSet) with grid made of lines (linear) within Atlas view.

This optimisation solves the lag.

Profiling before the fix shows that drawing and removing rectangles eats up all the CPU.
<img width="1025" alt="Screenshot 2023-11-13 at 00 51 55" src="https://github.com/godotengine/godot/assets/3051314/53263a59-f2f7-46aa-ae63-b372b7fc87b1">

Profiling after the fix shows that the grid drawing only takes 1.7% of the CPU time:
<img width="1022" alt="Screenshot 2023-11-16 at 00 06 59" src="https://github.com/godotengine/godot/assets/3051314/fdf6da4a-b904-49a7-8c42-c5e776903267">


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
