### PR TITLE
Check that `GDExtensionCompatHashes` are valid when generating `extension_api.json`

### DIFF
--- a/core/extension/gdextension_compat_hashes.h
+++ b/core/extension/gdextension_compat_hashes.h
@@ -50,7 +50,7 @@ public:
 	static void initialize();
 	static void finalize();
 	static bool lookup_current_hash(const StringName &p_class, const StringName &p_method, uint32_t p_legacy_hash, uint32_t *r_current_hash);
-	static bool get_legacy_hashes(const StringName &p_class, const StringName &p_method, Array &r_hashes);
+	static bool get_legacy_hashes(const StringName &p_class, const StringName &p_method, Array &r_hashes, bool p_check_valid = true);
 };
 
 #endif // DISABLE_DEPRECATED


### PR DESCRIPTION
Our CI uses the `extension_api.json` to check that we haven't broken GDExtension binary compatibility by removing a method with a particular hash. We're also using `GDExtensionCompatHashes` to map from some old broken hashes to some new ones.

However, there isn't anything presently that checks that these mapped hashes are actually valid, which could hide compatibility breakages until runtime.

This PR attempts to validate the mapped hashes when generating the `extension_api.json`.