### PR TITLE
Alias `platform=javascript` SCons option to `platform=web`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -299,18 +299,14 @@ else:
     if selected_platform != "":
         print("Automatically detected platform: " + selected_platform)
 
-if selected_platform in ["macos", "osx"]:
-    if selected_platform == "osx":
-        # Deprecated alias kept for compatibility.
-        print('Platform "osx" has been renamed to "macos" in Godot 4. Building for platform "macos".')
-    # Alias for convenience.
+if selected_platform == "osx":
+    # Deprecated alias kept for compatibility.
+    print('Platform "osx" has been renamed to "macos" in Godot 4. Building for platform "macos".')
     selected_platform = "macos"
 
-if selected_platform in ["ios", "iphone"]:
-    if selected_platform == "iphone":
-        # Deprecated alias kept for compatibility.
-        print('Platform "iphone" has been renamed to "ios" in Godot 4. Building for platform "ios".')
-    # Alias for convenience.
+if selected_platform == "iphone":
+    # Deprecated alias kept for compatibility.
+    print('Platform "iphone" has been renamed to "ios" in Godot 4. Building for platform "ios".')
     selected_platform = "ios"
 
 if selected_platform in ["linux", "bsd", "x11"]:
@@ -319,6 +315,11 @@ if selected_platform in ["linux", "bsd", "x11"]:
         print('Platform "x11" has been renamed to "linuxbsd" in Godot 4. Building for platform "linuxbsd".')
     # Alias for convenience.
     selected_platform = "linuxbsd"
+
+if selected_platform == "javascript":
+    # Deprecated alias kept for compatibility.
+    print('Platform "javascript" has been renamed to "web" in Godot 4. Building for platform "web".')
+    selected_platform = "web"
 
 # Make sure to update this to the found, valid platform as it's used through the buildsystem as the reference.
 # It should always be re-set after calling `opts.Update()` otherwise it uses the original input value.


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/84978.

This makes build scripts backward-compatible, as was already done for other platforms that were renamed in 4.0.
