### PR TITLE
Fix order of operations for macOS template check

### DIFF
--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2026,9 +2026,9 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 bool EditorExportPlatformMacOS::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
 	String err;
-	// Look for export templates (custom templates).
-	bool dvalid = false;
-	bool rvalid = false;
+	// Look for export templates (official templates first, then custom).
+	bool dvalid = exists_export_template("macos.zip", &err);
+	bool rvalid = dvalid; // Both in the same ZIP.
 
 	if (p_preset->get("custom_template/debug") != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
@@ -2041,12 +2041,6 @@ bool EditorExportPlatformMacOS::has_valid_export_configuration(const Ref<EditorE
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";
 		}
-	}
-
-	// Look for export templates (official templates, check only is custom templates are not set).
-	if (!dvalid || !rvalid) {
-		dvalid = exists_export_template("macos.zip", &err);
-		rvalid = dvalid; // Both in the same ZIP.
 	}
 
 	bool valid = dvalid || rvalid;


### PR DESCRIPTION
Potentially resolves https://github.com/godotengine/godot/issues/62873.

I'm not a mac user myself, but looks like the order of operations was just wrong. If one of the custom template configs was missing, it'd force a check for the official templates, and if not present, lead to `valid = false`. In the issue, the workaround of specifying both custom template configs ensured the check for the official templates wouldn't happen.

Looking at all the other platforms, they check for the official templates first, _then_ the custom templates. Made it consistent here