### PR TITLE
Add an option to center children around the new parent when reparenting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -220,6 +220,9 @@
 		<member name="docks/scene_tree/auto_expand_to_selected" type="bool" setter="" getter="">
 			If [code]true[/code], the scene tree dock will automatically unfold nodes when a node that has folded parents is selected.
 		</member>
+		<member name="docks/scene_tree/center_node_on_reparent" type="bool" setter="" getter="">
+			If [code]true[/code], new node created when reparenting node(s) will be positioned at the average position of the selected node(s).
+		</member>
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
 			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -538,6 +538,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// SceneTree
 	_initial_set("docks/scene_tree/start_create_dialog_fully_expanded", false);
 	_initial_set("docks/scene_tree/auto_expand_to_selected", true);
+	_initial_set("docks/scene_tree/center_node_on_reparent", false);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -94,6 +94,7 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_CREATE_3D_SCENE,
 		TOOL_CREATE_USER_INTERFACE,
 		TOOL_CREATE_FAVORITE,
+		TOOL_CENTER_PARENT,
 
 	};
 


### PR DESCRIPTION
Adds the functionality of proposal [#8449](https://github.com/godotengine/godot-proposals/issues/8449), in the case that others feel this would be a good enhancement.

This enhances the "Reparent to New Node" tool in the Scene view by adding the ability to create a new based around the selected node(s) rather than always adding the new parent node at the origin. 

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/8449_