### PR TITLE
Fix wrong reference link in `_nvapi_disable_threaded_optimization`

### DIFF
--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -104,7 +104,7 @@ static bool nvapi_err_check(const char *msg, int status) {
 }
 
 // On windows we have to disable threaded optimization when using NVIDIA graphics cards
-// to avoid stuttering, see https://github.com/microsoft/vscode-cpptools/issues/6592
+// to avoid stuttering, see https://stackoverflow.com/questions/36959508/nvidia-graphics-driver-causing-noticeable-frame-stuttering/37632948
 // also see https://github.com/Ryujinx/Ryujinx/blob/master/Ryujinx.Common/GraphicsDriver/NVThreadedOptimization.cs
 void GLManagerNative_Windows::_nvapi_disable_threaded_optimization() {
 	HMODULE nvapi = 0;


### PR DESCRIPTION
As discussed in https://github.com/godotengine/godot/pull/71472#discussion_r1393097865, the correct link should be provided for reference.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
