### PR TITLE
Fix uint's suffix is not highlighted in text shader editor

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -334,6 +334,8 @@ void ShaderTextEditor::_load_theme_settings() {
 		warnings_panel->add_theme_font_override("normal_font", EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("main"), EditorStringName(EditorFonts)));
 		warnings_panel->add_theme_font_size_override("normal_font_size", EditorNode::get_singleton()->get_editor_theme()->get_font_size(SNAME("main_size"), EditorStringName(EditorFonts)));
 	}
+
+	syntax_highlighter->set_uint_suffix_enabled();
 }
 
 void ShaderTextEditor::_check_shader_mode() {

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -303,7 +303,7 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 		}
 
 		// Check for dot or underscore or 'x' for hex notation in floating point number or 'e' for scientific notation.
-		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'f' || str[j] == 'e') && !in_word && prev_is_number && !is_number) {
+		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'f' || str[j] == 'e' || (uint_suffix_enabled && str[j] == 'u')) && !in_word && prev_is_number && !is_number) {
 			is_number = true;
 			is_a_symbol = false;
 			is_char = false;
@@ -615,6 +615,10 @@ void CodeHighlighter::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "keyword_colors"), "set_keyword_colors", "get_keyword_colors");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "member_keyword_colors"), "set_member_keyword_colors", "get_member_keyword_colors");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_regions"), "set_color_regions", "get_color_regions");
+}
+
+void CodeHighlighter::set_uint_suffix_enabled(bool p_enabled) {
+	uint_suffix_enabled = p_enabled;
 }
 
 void CodeHighlighter::set_number_color(Color p_color) {

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -93,6 +93,8 @@ private:
 	Color symbol_color;
 	Color number_color;
 
+	bool uint_suffix_enabled = false;
+
 protected:
 	static void _bind_methods();
 
@@ -139,6 +141,8 @@ public:
 
 	void set_member_variable_color(Color p_color);
 	Color get_member_variable_color() const;
+
+	void set_uint_suffix_enabled(bool p_enabled = true);
 };
 
 #endif // SYNTAX_HIGHLIGHTER_H


### PR DESCRIPTION
Fixes #75161

`GDShaderSyntaxHighlighter` uses `CodeHighlighter` which doesn't recognize this suffix syntax, there are other ways to fix this, IMHO add a bool in the base class to distinguish the behaviour is the one introduces least change.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
