### PR TITLE
Add option to bake a mesh from animated skeleton pose

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -21,6 +21,14 @@
 				[b]Performance:[/b] [Mesh] data needs to be received from the GPU, stalling the [RenderingServer] in the process.
 			</description>
 		</method>
+		<method name="bake_mesh_from_current_skeleton_pose">
+			<return type="ArrayMesh" />
+			<param index="0" name="existing" type="ArrayMesh" default="null" />
+			<description>
+				Takes a snapshot of the current animated skeleton pose of the skinned mesh and bakes it to the provided [param existing] mesh. If no [param existing] mesh is provided a new [ArrayMesh] is created, baked, and returned. Requires a skeleton with a registered skin to work. Blendshapes are ignored. Mesh surface materials are not copied.
+				[b]Performance:[/b] [Mesh] data needs to be retrieved from the GPU, stalling the [RenderingServer] in the process.
+			</description>
+		</method>
 		<method name="create_convex_collision">
 			<return type="void" />
 			<param index="0" name="clean" type="bool" default="true" />

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -102,6 +102,7 @@ public:
 	virtual AABB get_aabb() const override;
 
 	Ref<ArrayMesh> bake_mesh_from_current_blend_shape_mix(Ref<ArrayMesh> p_existing = Ref<ArrayMesh>());
+	Ref<ArrayMesh> bake_mesh_from_current_skeleton_pose(Ref<ArrayMesh> p_existing = Ref<ArrayMesh>());
 
 	MeshInstance3D();
 	~MeshInstance3D();


### PR DESCRIPTION
Adds option to bake a mesh from animated skeleton  pose.

Takes a snapshot of the current animated skeleton pose of the skinned mesh and bakes it to another ArrayMesh.

Implements https://github.com/godotengine/godot-proposals/issues/8120 to make stuff like this:

![skinned_mesh_baking](https://github.com/godotengine/godot-proposals/assets/52464204/db5a44e4-6da7-40cb-926e-d53e6cf357d5)

Pairs with https://github.com/godotengine/godot/pull/76725 to bake the blend shapes.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

_Production edit: closes godotengine/godot-roadmap#58_