### PR TITLE
Remove unnessecerary cast of GraphNode

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -951,9 +951,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 			idx = i + port_offset;
 		}
 		if (!is_comment) {
-			GraphNode *graph_node = Object::cast_to<GraphNode>(node);
-
-			graph_node->set_slot(idx, valid_left, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
+			node->set_slot(idx, valid_left, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
 
 			if (vsnode->_is_output_port_expanded(i)) {
 				switch (vsnode->get_output_port_type(i)) {
@@ -964,7 +962,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 1);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[0]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[0]);
 						port_offset++;
 
 						valid_left = (i + 2) < vsnode->get_input_port_count();
@@ -972,7 +970,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 2);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[1]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[1]);
 
 						expanded_type = VisualShaderNode::PORT_TYPE_VECTOR_2D;
 					} break;
@@ -983,7 +981,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 1);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[0]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[0]);
 						port_offset++;
 
 						valid_left = (i + 2) < vsnode->get_input_port_count();
@@ -991,7 +989,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 2);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[1]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[1]);
 						port_offset++;
 
 						valid_left = (i + 3) < vsnode->get_input_port_count();
@@ -999,7 +997,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 3);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[2]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[2]);
 
 						expanded_type = VisualShaderNode::PORT_TYPE_VECTOR_3D;
 					} break;
@@ -1010,7 +1008,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 1);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[0]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[0]);
 						port_offset++;
 
 						valid_left = (i + 2) < vsnode->get_input_port_count();
@@ -1018,7 +1016,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 2);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[1]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[1]);
 						port_offset++;
 
 						valid_left = (i + 3) < vsnode->get_input_port_count();
@@ -1026,7 +1024,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 3);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[2]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[2]);
 						port_offset++;
 
 						valid_left = (i + 4) < vsnode->get_input_port_count();
@@ -1034,7 +1032,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 						if (valid_left) {
 							port_left = vsnode->get_input_port_type(i + 4);
 						}
-						graph_node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[3]);
+						node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], true, VisualShaderNode::PORT_TYPE_SCALAR, vector_expanded_color[3]);
 
 						expanded_type = VisualShaderNode::PORT_TYPE_VECTOR_4D;
 					} break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This cast is doing nothing, node is already of type `GraphNode*`