### PR TITLE
When saving a resource with an exported typed array, check whether the type is an external resource

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2016,6 +2016,7 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 
 		case Variant::ARRAY: {
 			Array varray = p_variant;
+			_find_resources(varray.get_typed_script());
 			int len = varray.size();
 			for (int i = 0; i < len; i++) {
 				const Variant &v = varray.get(i);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1951,6 +1951,7 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 		} break;
 		case Variant::ARRAY: {
 			Array varray = p_variant;
+			_find_resources(varray.get_typed_script());
 			int len = varray.size();
 			for (int i = 0; i < len; i++) {
 				const Variant &v = varray.get(i);


### PR DESCRIPTION
Fix #84498

A type of an exported typed array (when it is a script) would not get recognized as an external resource if it was one, which prevented the script from being recognized as a dependency of the resource, which prevented the script path from being updated when moved (since scripts don't have UIDs, that couldn't help either).

Test with [test_proj.zip](https://github.com/godotengine/godot/files/13394931/test_proj.zip) by moving `res.gd` in and out of the additional dir.

Before:
```
[gd_scene load_steps=3 format=3 uid="uid://c3fdfa0an52aa"]

[ext_resource type="Script" path="res://main_scene.gd" id="1_vwyik"]
[ext_resource type="Resource" uid="uid://blikieqcyffrc" path="res://new_res.tres" id="3_88yrl"]

[node name="MainScene" type="Node2D"]
script = ExtResource("1_vwyik")
res_twos = Array[Resource("res://res.gd")]([ExtResource("3_88yrl")])
```
This doesn't allow the script path for the array type to be updated when that script is moved, making the scene unopenable.

After:
```
[gd_scene load_steps=4 format=3 uid="uid://c3fdfa0an52aa"]

[ext_resource type="Script" path="res://main_scene.gd" id="1_vwyik"]
[ext_resource type="Script" path="res://res.gd" id="2_e4r82"]
[ext_resource type="Resource" uid="uid://blikieqcyffrc" path="res://new_res.tres" id="3_88yrl"]

[node name="MainScene" type="Node2D"]
script = ExtResource("1_vwyik")
res_twos = Array[ExtResource("2_e4r82")]([ExtResource("3_88yrl")])
```