### PR TITLE
Make `screen_get_refresh_rate()` respect iOS Low Power Mode

### DIFF
--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -443,7 +443,11 @@ int DisplayServerIOS::screen_get_dpi(int p_screen) const {
 }
 
 float DisplayServerIOS::screen_get_refresh_rate(int p_screen) const {
-	return [UIScreen mainScreen].maximumFramesPerSecond;
+	float fps = [UIScreen mainScreen].maximumFramesPerSecond;
+	if ([NSProcessInfo processInfo].lowPowerModeEnabled) {
+		fps = 60;
+	}
+	return fps;
 }
 
 float DisplayServerIOS::screen_get_scale(int p_screen) const {


### PR DESCRIPTION
Fixes #84634.

iOS/iPadOS ramps down from 120hz to 60hz when on low power mode, and DisplayServer.screen_get_refresh_rate() didn't account for this.