### PR TITLE
Fix for UndoRedo system not preserving Script Properties from Editor Inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3701,6 +3701,23 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 			undo_redo->add_undo_property(object, p_name, value);
 		}
 
+		if (p_name == "script" && value) {
+			List<Pair<StringName, Variant>> property_list;
+			ScriptInstance *si = object->get_script_instance();
+			si->get_property_state(property_list);
+			if (si) {
+				for (const Pair<StringName, Variant> &E : property_list) {
+					Variant current_prop;
+					if (si->get(E.first, current_prop) && current_prop.get_type() == E.second.get_type()) {
+						undo_redo->add_undo_property(object, E.first, E.second);
+						if (p_value) {
+							undo_redo->add_do_property(object, E.first, E.second);
+						}
+					}
+				}
+			}
+		}
+
 		List<StringName> linked_properties;
 		ClassDB::get_linked_properties_info(object->get_class_name(), p_name, &linked_properties);
 


### PR DESCRIPTION
Fixes #79430 

Previously if you removed a script from an object in the Editor Inspector, and then used "Undo", the script would be restored but all its custom properties would be lost. This Pull Request ensures that any properties of a script are saved to the Undo history when the script is changed or removed.

It should be noted that this only fixes this in the Editor Inspector. The Scene Tree has the exact same bug but since is a completely different code path, I'm keeping the fixes separate.

Also, some may be confused by what I did on line 3715. Godot has established behaviour that when you replace one script for another, properties that have the same name in both scripts have their values copied over from the older to the newer. That line is to preserve this behaviour in the redo queue.