### PR TITLE
Highlight error lines in minimap

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -770,7 +770,14 @@ void TextEdit::_notification(int p_what) {
 					Dictionary color_map = _get_line_syntax_highlighting(minimap_line);
 
 					Color line_background_color = text.get_line_background_color(minimap_line);
-					line_background_color.a *= 0.6;
+
+					if (line_background_color != theme_cache.background_color) {
+						// Make non-default background colors more visible, such as error markers.
+						line_background_color.a = 1.0;
+					} else {
+						line_background_color.a *= 0.6;
+					}
+
 					Color current_color = theme_cache.font_color;
 					if (!editable) {
 						current_color = theme_cache.font_readonly_color;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -4118,7 +4118,7 @@ TEST_CASE("[SceneTree][TextEdit] setter getters") {
 		CHECK_FALSE(text_edit->is_drawing_spaces());
 	}
 
-	SUBCASE("[TextEdit] draw minimao") {
+	SUBCASE("[TextEdit] draw minimap") {
 		text_edit->set_draw_minimap(true);
 		CHECK(text_edit->is_drawing_minimap());
 		text_edit->set_draw_minimap(false);


### PR DESCRIPTION
Implements this enhancement: https://github.com/godotengine/godot-proposals/issues/8444

Error lines (= lines with non-default background color) are using alpha = 1.0 instead of alpha *= 0.6 as other lines, thus making the error lines more brighter.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/8444_