### PR TITLE
Fix translation po file not found when `make rst LANGARG=zh_CN`

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@ OUTPUTDIR = $(BASEDIR)/_build
 TOOLSDIR = $(BASEDIR)/tools
 JSDIR = "$(BASEDIR)/../platform/web"
 LANGARG ?= en
-LANGCMD = -l $(LANGARG)
+TOOLSOPT ?=
 
 .ONESHELL:
 
@@ -19,7 +19,10 @@ doxygen:
 rst:
 	rm -rf "$(OUTPUTDIR)/rst"
 	mkdir -p "$(OUTPUTDIR)/rst"
-	python3 "$(TOOLSDIR)/make_rst.py" -o "$(OUTPUTDIR)/rst" "$(LANGCMD)" $(CLASSES)
+	python3 "$(TOOLSDIR)/make_rst.py" -o "$(OUTPUTDIR)/rst" -l "$(LANGARG)" $(TOOLSOPT) $(CLASSES)
+
+xml-check:
+	python3 "$(TOOLSDIR)/make_rst.py" --dry-run -l "$(LANGARG)" $(TOOLSOPT) $(CLASSES)
 
 rstjs:
 	rm -rf "$(OUTPUTDIR)/rstjs"


### PR DESCRIPTION
The parsed language parameters contain unstripped spaces. This will generate a wrong path.

Before:

```
...
python3 "./tools/make_rst.py" -o "./_build/rst" "-l zh_CN" "./classes/" "./../modules/" "./../platform/"
No PO file at "/opt/godot/godot/doc/tools/../translations/ zh_CN.po" for language " zh_CN".
...
```
After:

```
...
python3 "./tools/make_rst.py" -o "./_build/rst" -l "zh_CN" "./classes/" "./../modules/" "./../platform/"
...
```

Provide a `TOOLSOPT` to allow overriding the default values of parameters of the `make_rst.py` script.

```
make rst TOOLSOPT="-l 'zh_CN' --color"
```

The xml generated by `godot --doctool -l LANG` can be checked for errors using `make xml-check LANGARG=LANG`, which may be useful for checking errors in po files.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
