### PR TITLE
Provide more context when scene fails to load

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -138,7 +138,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	}
 
 	int nc = nodes.size();
-	ERR_FAIL_COND_V(nc == 0, nullptr);
+	ERR_FAIL_COND_V_MSG(nc == 0, nullptr, vformat("Failed to instantiate scene state of \"%s\", node count is 0. Make sure the PackedScene resource is valid.", path));
 
 	const StringName *snames = nullptr;
 	int sname_count = names.size();
@@ -219,7 +219,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				Ref<PackedScene> sdata = props[n.instance & FLAG_MASK];
 				ERR_FAIL_COND_V(!sdata.is_valid(), nullptr);
 				node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE);
-				ERR_FAIL_NULL_V(node, nullptr);
+				ERR_FAIL_NULL_V_MSG(node, nullptr, vformat("Failed to load scene dependency: \"%s\". Make sure the required scene is valid.", sdata->get_path()));
 			}
 
 		} else if (n.type == TYPE_INSTANTIATED) {


### PR DESCRIPTION
Partially addresses #84981

Before this PR:
```
scene/resources/packed_scene.cpp:141 - Condition "nc == 0" is true. Returning: nullptr
scene/resources/packed_scene.cpp:222 - Parameter "node" is null.
scene/resources/packed_scene.cpp:222 - Parameter "node" is null.
editor/editor_data.cpp:626 - Index p_idx = 1 is out of bounds (edited_scene.size() = 1).
```
After this PR:
```
C:\godot_source\scene/resources/packed_scene.cpp:141 - Condition "nc == 0" is true. Returning: nullptr
Failed to load scene dependency: "res://Content/Cards/Spells/spell_container.tscn". Make sure the required scene is valid.
Failed to load scene dependency: "res://Systems/Characters/Player/player.tscn". Make sure the required scene is valid.
C:\godot_source\editor/editor_data.cpp:626 - Index p_idx = 1 is out of bounds (edited_scene.size() = 1).
```