### PR TITLE
Use vertex input mask for creating vertex arrays

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2968,17 +2968,17 @@ void SceneShaderData::set_code(const String &p_code) {
 	depth_test = DepthTest(depth_testi);
 	cull_mode = Cull(cull_modei);
 
-	vertex_input_mask = uint64_t(uses_normal);
-	vertex_input_mask |= uses_tangent << 1;
-	vertex_input_mask |= uses_color << 2;
-	vertex_input_mask |= uses_uv << 3;
-	vertex_input_mask |= uses_uv2 << 4;
-	vertex_input_mask |= uses_custom0 << 5;
-	vertex_input_mask |= uses_custom1 << 6;
-	vertex_input_mask |= uses_custom2 << 7;
-	vertex_input_mask |= uses_custom3 << 8;
-	vertex_input_mask |= uses_bones << 9;
-	vertex_input_mask |= uses_weights << 10;
+	vertex_input_mask = RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_NORMAL; // We can always read vertices and normals.
+	vertex_input_mask |= uses_tangent << RS::ARRAY_TANGENT;
+	vertex_input_mask |= uses_color << RS::ARRAY_COLOR;
+	vertex_input_mask |= uses_uv << RS::ARRAY_TEX_UV;
+	vertex_input_mask |= uses_uv2 << RS::ARRAY_TEX_UV2;
+	vertex_input_mask |= uses_custom0 << RS::ARRAY_CUSTOM0;
+	vertex_input_mask |= uses_custom1 << RS::ARRAY_CUSTOM1;
+	vertex_input_mask |= uses_custom2 << RS::ARRAY_CUSTOM2;
+	vertex_input_mask |= uses_custom3 << RS::ARRAY_CUSTOM3;
+	vertex_input_mask |= uses_bones << RS::ARRAY_BONES;
+	vertex_input_mask |= uses_weights << RS::ARRAY_WEIGHTS;
 
 	uses_screen_texture = gen_code.uses_screen_texture;
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/85053

The issue is that the calculation of skeletons became super slow after https://github.com/godotengine/godot/pull/81138. The root cause was how we cache and retrieve vertex array objects. Prior to https://github.com/godotengine/godot/pull/81138 we created a special vertex array object for skeletons which only ever contained vertices, normals, and tangents. After https://github.com/godotengine/godot/pull/81138 we used the regular mesh caching approach so we could automatically get the correct vertex array object. 

However, the caching approach was subtly broken. It always returned a vertex array object with all available attributes enabled. That means, if the mesh has colors, UVs, etc. The VAO would also contain them. For skeletons, this created a huge amount of unnecessary overhead as only positions, normals, and tangents (at most) are needed. 

Once I added the code to take the vertex input mask into account. I noticed it was broken as the indices were off by one. 

This PR fixes the performance regression in https://github.com/godotengine/godot/issues/85053 and might also increase performance in other cases as well. 

This PR is slightly too risky for RCs, so let's plan on merging for 4.3 and cherry picking to 4.2.1