### PR TITLE
Expose get_global_name() method to the editor

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -129,6 +129,7 @@ PropertyInfo Script::get_class_category() const {
 
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
+	ClassDB::bind_method(D_METHOD("get_global_name"), &Script::get_global_name);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);
 	ClassDB::bind_method(D_METHOD("instance_has", "base_object"), &Script::instance_has);
 	ClassDB::bind_method(D_METHOD("has_source_code"), &Script::has_source_code);

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -24,6 +24,12 @@
 				Returns the script directly inherited by this script.
 			</description>
 		</method>
+		<method name="get_global_name" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the global class name of this script.
+			</description>
+		</method>
 		<method name="get_instance_base_type" qualifiers="const">
 			<return type="StringName" />
 			<description>


### PR DESCRIPTION
Thought this would be useful, as currently there isn't an easy way to get the global class name of a a given script.