### PR TITLE
OpenXR: Add runtime selection dropdown

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6936,10 +6936,9 @@ EditorNode::EditorNode() {
 	renderer = memnew(OptionButton);
 	renderer->set_visible(true);
 	renderer->set_flat(true);
+	renderer->set_theme_type_variation("TopBarOptionButton");
 	renderer->set_fit_to_longest_item(false);
 	renderer->set_focus_mode(Control::FOCUS_NONE);
-	renderer->add_theme_font_override("font", theme->get_font(SNAME("bold"), EditorStringName(EditorFonts)));
-	renderer->add_theme_font_size_override("font_size", theme->get_font_size(SNAME("bold_size"), EditorStringName(EditorFonts)));
 	renderer->set_tooltip_text(TTR("Choose a rendering method.\n\nNotes:\n- On mobile platforms, the Mobile rendering method is used if Forward+ is selected here.\n- On the web platform, the Compatibility rendering method is always used."));
 
 	right_menu_hb->add_child(renderer);

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1690,6 +1690,13 @@ void EditorThemeManager::_populate_editor_styles(const Ref<Theme> &p_theme, Them
 			p_theme->set_stylebox("pressed", "EditorLogFilterButton", editor_log_button_pressed);
 		}
 
+		// Top bar selectors.
+		{
+			p_theme->set_type_variation("TopBarOptionButton", "OptionButton");
+			p_theme->set_font("font", "TopBarOptionButton", p_theme->get_font(SNAME("bold"), EditorStringName(EditorFonts)));
+			p_theme->set_font_size("font_size", "TopBarOptionButton", p_theme->get_font_size(SNAME("bold_size"), EditorStringName(EditorFonts)));
+		}
+
 		// Complex editor windows.
 		{
 			Ref<StyleBoxFlat> style_complex_window = p_config.window_style->duplicate();

--- a/modules/openxr/editor/openxr_editor_plugin.h
+++ b/modules/openxr/editor/openxr_editor_plugin.h
@@ -32,6 +32,7 @@
 #define OPENXR_EDITOR_PLUGIN_H
 
 #include "openxr_action_map_editor.h"
+#include "openxr_select_runtime.h"
 
 #include "editor/editor_plugin.h"
 
@@ -39,6 +40,9 @@ class OpenXREditorPlugin : public EditorPlugin {
 	GDCLASS(OpenXREditorPlugin, EditorPlugin);
 
 	OpenXRActionMapEditor *action_map_editor = nullptr;
+#ifndef ANDROID_ENABLED
+	OpenXRSelectRuntime *select_runtime = nullptr;
+#endif
 
 public:
 	virtual String get_name() const override { return "OpenXRPlugin"; }

--- a/modules/openxr/editor/openxr_select_runtime.cpp
+++ b/modules/openxr/editor/openxr_select_runtime.cpp
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*  openxr_select_runtime.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_select_runtime.h"
+
+#include "core/io/dir_access.h"
+#include "core/os/os.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_string_names.h"
+
+void OpenXRSelectRuntime::_bind_methods() {
+}
+
+void OpenXRSelectRuntime::_update_items() {
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	OS *os = OS::get_singleton();
+	Dictionary runtimes = EDITOR_GET("xr/openxr/runtime_paths");
+
+	int current_runtime = 0;
+	int index = 0;
+	String current_path = os->get_environment("XR_RUNTIME_JSON");
+
+	// Parse the user's home folder.
+	String home_folder = os->get_environment("HOME");
+	if (home_folder.is_empty()) {
+		home_folder = os->get_environment("HOMEDRIVE") + os->get_environment("HOMEPATH");
+	}
+
+	clear();
+	add_item("Default", -1);
+	set_item_metadata(index, "");
+	index++;
+
+	Array keys = runtimes.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		String key = keys[i];
+		String path = runtimes[key];
+		String adj_path = path.replace("~", home_folder);
+
+		if (da->file_exists(adj_path)) {
+			add_item(key, index);
+			set_item_metadata(index, adj_path);
+
+			if (current_path == adj_path) {
+				current_runtime = index;
+			}
+			index++;
+		}
+	}
+
+	select(current_runtime);
+}
+
+void OpenXRSelectRuntime::_item_selected(int p_which) {
+	OS *os = OS::get_singleton();
+
+	if (p_which == 0) {
+		// Return to default runtime
+		os->set_environment("XR_RUNTIME_JSON", "");
+	} else {
+		// Select the runtime we want
+		String runtime_path = get_item_metadata(p_which);
+		os->set_environment("XR_RUNTIME_JSON", runtime_path);
+	}
+}
+
+void OpenXRSelectRuntime::_notification(int p_notification) {
+	switch (p_notification) {
+		case NOTIFICATION_ENTER_TREE: {
+			// Update dropdown
+			_update_items();
+
+			// Connect signal
+			connect("item_selected", callable_mp(this, &OpenXRSelectRuntime::_item_selected));
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			// Disconnect signal
+			disconnect("item_selected", callable_mp(this, &OpenXRSelectRuntime::_item_selected));
+		} break;
+	}
+}
+
+OpenXRSelectRuntime::OpenXRSelectRuntime() {
+	Dictionary default_runtimes;
+
+	// Add known common runtimes by default.
+#ifdef WINDOWS_ENABLED
+	default_runtimes["Meta"] = "C:\\Program Files\\Oculus\\Support\\oculus-runtime\\oculus_openxr_64.json";
+	default_runtimes["SteamVR"] = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\steamxr_win64.json";
+	default_runtimes["Varjo"] = "C:\\Program Files\\Varjo\\varjo-openxr\\VarjoOpenXR.json";
+	default_runtimes["WMR"] = "C:\\WINDOWS\\system32\\MixedRealityRuntime.json";
+#endif
+#ifdef LINUXBSD_ENABLED
+	default_runtimes["Monado"] = "/usr/share/openxr/1/openxr_monado.json";
+	default_runtimes["SteamVR"] = "~/.steam/steam/steamapps/common/SteamVR/steamxr_linux64.json";
+#endif
+
+	EDITOR_DEF_RST("xr/openxr/runtime_paths", default_runtimes);
+
+	set_flat(true);
+	set_theme_type_variation("TopBarOptionButton");
+	set_fit_to_longest_item(false);
+	set_focus_mode(Control::FOCUS_NONE);
+	set_tooltip_text(TTR("Choose an XR runtime."));
+}

--- a/modules/openxr/editor/openxr_select_runtime.h
+++ b/modules/openxr/editor/openxr_select_runtime.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  openxr_editor_plugin.cpp                                              */
+/*  openxr_select_runtime.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,37 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "openxr_editor_plugin.h"
+#ifndef OPENXR_SELECT_RUNTIME_H
+#define OPENXR_SELECT_RUNTIME_H
 
-#include "../action_map/openxr_action_map.h"
+#include "scene/gui/option_button.h"
 
-#include "editor/editor_node.h"
+class OpenXRSelectRuntime : public OptionButton {
+	GDCLASS(OpenXRSelectRuntime, OptionButton);
 
-void OpenXREditorPlugin::edit(Object *p_node) {
-	if (Object::cast_to<OpenXRActionMap>(p_node)) {
-		String path = Object::cast_to<OpenXRActionMap>(p_node)->get_path();
-		if (path.is_resource_file()) {
-			action_map_editor->open_action_map(path);
-		}
-	}
-}
+public:
+	OpenXRSelectRuntime();
 
-bool OpenXREditorPlugin::handles(Object *p_node) const {
-	return (Object::cast_to<OpenXRActionMap>(p_node) != nullptr);
-}
+protected:
+	static void _bind_methods();
+	void _notification(int p_notification);
 
-void OpenXREditorPlugin::make_visible(bool p_visible) {
-}
+private:
+	void _update_items();
+	void _item_selected(int p_which);
+};
 
-OpenXREditorPlugin::OpenXREditorPlugin() {
-	action_map_editor = memnew(OpenXRActionMapEditor);
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("OpenXR Action Map"), action_map_editor);
-
-#ifndef ANDROID_ENABLED
-	select_runtime = memnew(OpenXRSelectRuntime);
-	add_control_to_container(CONTAINER_TOOLBAR, select_runtime);
-#endif
-}
-
-OpenXREditorPlugin::~OpenXREditorPlugin() {
-}
+#endif // OPENXR_SELECT_RUNTIME_H


### PR DESCRIPTION
This PR re-introduces the OpenXR runtime selection dropdown from Godot 3 **IF** OpenXR is enabled:

![image](https://github.com/godotengine/godot/assets/1945449/b0c99914-4493-4a7e-b972-4c753d9e48eb)

This selection **only** applies to the runtime selected when Godot is run in PCVR mode (e.g. when `Run Project` / `F5` is used).

In editor settings there is a section where the user can add runtimes by specifying the locations of the OpenXR runtime configuration json, Godot will only add items to the dropdown if the files are found at startup (e.g. restart is required). A number of default locations is included with this PR:

![image](https://github.com/godotengine/godot/assets/1945449/18cead76-a052-4923-bd01-6b035d825bf2)

> Note, the selection made by the user is **not** saved. OpenXR clearly states that applications should use the system selected OpenXR runtime at all times. The dropdown is offered to allow quick deviation from that default. E.g. The users has SteamVR set as their default OpenXR runtime, but quickly wants to test if their game works on the Meta XR Runtime (Quest over Link). It's a temporary selection. 