### PR TITLE
OpenGL: Implement rendering of lightmaps

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -130,9 +130,27 @@ void RasterizerSceneGLES3::GeometryInstanceGLES3::_mark_dirty() {
 }
 
 void RasterizerSceneGLES3::GeometryInstanceGLES3::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) {
+	lightmap_instance = p_lightmap_instance;
+	lightmap_uv_scale = p_lightmap_uv_scale;
+	lightmap_slice_index = p_lightmap_slice_index;
+
+	_mark_dirty();
 }
 
 void RasterizerSceneGLES3::GeometryInstanceGLES3::set_lightmap_capture(const Color *p_sh9) {
+	if (p_sh9) {
+		if (lightmap_sh == nullptr) {
+			lightmap_sh = memnew(GeometryInstanceLightmapSH);
+		}
+
+		memcpy(lightmap_sh->sh, p_sh9, sizeof(Color) * 9);
+	} else {
+		if (lightmap_sh != nullptr) {
+			memdelete(lightmap_sh);
+			lightmap_sh = nullptr;
+		}
+	}
+	_mark_dirty();
 }
 
 void RasterizerSceneGLES3::_update_dirty_geometry_instances() {
@@ -1271,12 +1289,15 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					int32_t shadow_id = GLES3::LightStorage::get_singleton()->light_instance_get_shadow_id(light_instance);
 
 					if (GLES3::LightStorage::get_singleton()->light_has_shadow(light) && shadow_id >= 0) {
-						GeometryInstanceGLES3::LightPass pass;
-						pass.light_id = GLES3::LightStorage::get_singleton()->light_instance_get_gl_id(light_instance);
-						pass.shadow_id = shadow_id;
-						pass.light_instance_rid = light_instance;
-						pass.is_omni = true;
-						inst->light_passes.push_back(pass);
+						// Skip static lights when a lightmap is used.
+						if (!inst->lightmap_instance.is_valid() || GLES3::LightStorage::get_singleton()->light_get_bake_mode(light) != RenderingServer::LIGHT_BAKE_STATIC) {
+							GeometryInstanceGLES3::LightPass pass;
+							pass.light_id = GLES3::LightStorage::get_singleton()->light_instance_get_gl_id(light_instance);
+							pass.shadow_id = shadow_id;
+							pass.light_instance_rid = light_instance;
+							pass.is_omni = true;
+							inst->light_passes.push_back(pass);
+						}
 					} else {
 						// Lights without shadow can all go in base pass.
 						inst->omni_light_gl_cache.push_back((uint32_t)GLES3::LightStorage::get_singleton()->light_instance_get_gl_id(light_instance));
@@ -1294,11 +1315,14 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					int32_t shadow_id = GLES3::LightStorage::get_singleton()->light_instance_get_shadow_id(light_instance);
 
 					if (GLES3::LightStorage::get_singleton()->light_has_shadow(light) && shadow_id >= 0) {
-						GeometryInstanceGLES3::LightPass pass;
-						pass.light_id = GLES3::LightStorage::get_singleton()->light_instance_get_gl_id(light_instance);
-						pass.shadow_id = shadow_id;
-						pass.light_instance_rid = light_instance;
-						inst->light_passes.push_back(pass);
+						// Skip static lights when a lightmap is used.
+						if (!inst->lightmap_instance.is_valid() || GLES3::LightStorage::get_singleton()->light_get_bake_mode(light) != RenderingServer::LIGHT_BAKE_STATIC) {
+							GeometryInstanceGLES3::LightPass pass;
+							pass.light_id = GLES3::LightStorage::get_singleton()->light_instance_get_gl_id(light_instance);
+							pass.shadow_id = shadow_id;
+							pass.light_instance_rid = light_instance;
+							inst->light_passes.push_back(pass);
+						}
 					} else {
 						// Lights without shadow can all go in base pass.
 						inst->spot_light_gl_cache.push_back((uint32_t)GLES3::LightStorage::get_singleton()->light_instance_get_gl_id(light_instance));
@@ -1610,6 +1634,8 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 				light_data.direction[1] = direction.y;
 				light_data.direction[2] = direction.z;
 
+				light_data.bake_mode = light_storage->light_get_bake_mode(base);
+
 				float sign = light_storage->light_is_negative(base) ? -1 : 1;
 
 				light_data.energy = sign * light_storage->light_get_param(base, RS::LIGHT_PARAM_ENERGY);
@@ -1757,6 +1783,8 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 		light_data.position[0] = pos.x;
 		light_data.position[1] = pos.y;
 		light_data.position[2] = pos.z;
+
+		light_data.bake_mode = light_storage->light_get_bake_mode(base);
 
 		float radius = MAX(0.001, light_storage->light_get_param(base, RS::LIGHT_PARAM_RANGE));
 		light_data.inv_radius = 1.0 / radius;
@@ -2621,6 +2649,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 		bool uses_additive_lighting = (inst->light_passes.size() + p_render_data->directional_shadow_count) > 0;
 		uses_additive_lighting = uses_additive_lighting && !shader->unshaded;
+
 		// TODOS
 		/*
 		 * Still a bug when atlas space is limited. Somehow need to evict light when it doesn't have a spot on the atlas, current check isn't enough
@@ -2648,6 +2677,12 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					RID light_instance_rid = inst->light_passes[pass].light_instance_rid;
 					if (!GLES3::LightStorage::get_singleton()->light_instance_has_shadow_atlas(light_instance_rid, p_render_data->shadow_atlas)) {
 						// Shadow wasn't able to get a spot on the atlas. So skip it.
+						continue;
+					}
+				} else if (pass > 0) {
+					uint32_t shadow_id = MAX_DIRECTIONAL_LIGHTS - 1 - (pass - int32_t(inst->light_passes.size()));
+					if (inst->lightmap_instance.is_valid() && scene_state.directional_lights[shadow_id].bake_mode == RenderingServer::LIGHT_BAKE_STATIC) {
+						// Skip shadows for static lights on meshes with a lightmap.
 						continue;
 					}
 				}
@@ -2738,12 +2773,16 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 			GLuint vertex_array_gl = 0;
 			GLuint index_array_gl = 0;
+			uint64_t vertex_input_mask = shader->vertex_input_mask;
+			if (inst->lightmap_instance.is_valid()) {
+				vertex_input_mask |= 1 << RS::ARRAY_TEX_UV2;
+			}
 
-			//skeleton and blend shape
+			// Skeleton and blend shapes.
 			if (surf->owner->mesh_instance.is_valid()) {
-				mesh_storage->mesh_instance_surface_get_vertex_arrays_and_format(surf->owner->mesh_instance, surf->surface_index, shader->vertex_input_mask, vertex_array_gl);
+				mesh_storage->mesh_instance_surface_get_vertex_arrays_and_format(surf->owner->mesh_instance, surf->surface_index, vertex_input_mask, vertex_array_gl);
 			} else {
-				mesh_storage->mesh_surface_get_vertex_arrays_and_format(mesh_surface, shader->vertex_input_mask, vertex_array_gl);
+				mesh_storage->mesh_surface_get_vertex_arrays_and_format(mesh_surface, vertex_input_mask, vertex_array_gl);
 			}
 
 			index_array_gl = mesh_storage->mesh_surface_get_index_buffer(mesh_surface, surf->lod_index);
@@ -2803,12 +2842,28 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					if (p_render_data->directional_light_count == p_render_data->directional_shadow_count) {
 						spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
 					}
+
+					if (inst->lightmap_instance.is_valid()) {
+						spec_constants |= SceneShaderGLES3::USE_LIGHTMAP;
+
+						GLES3::LightmapInstance *li = GLES3::LightStorage::get_singleton()->get_lightmap_instance(inst->lightmap_instance);
+						GLES3::Lightmap *lm = GLES3::LightStorage::get_singleton()->get_lightmap(li->lightmap);
+
+						if (lm->uses_spherical_harmonics) {
+							spec_constants |= SceneShaderGLES3::USE_SH_LIGHTMAP;
+						}
+					} else if (inst->lightmap_sh) {
+						spec_constants |= SceneShaderGLES3::USE_LIGHTMAP_CAPTURE;
+					} else {
+						spec_constants |= SceneShaderGLES3::DISABLE_LIGHTMAP;
+					}
 				} else {
 					// Only base pass uses the radiance map.
 					spec_constants &= ~SceneShaderGLES3::USE_RADIANCE_MAP;
 					spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_OMNI;
 					spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_SPOT;
 					spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
+					spec_constants |= SceneShaderGLES3::DISABLE_LIGHTMAP;
 				}
 
 				if (uses_additive_lighting) {
@@ -2831,6 +2886,10 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						// Render directional lights.
 
 						uint32_t shadow_id = MAX_DIRECTIONAL_LIGHTS - 1 - (pass - int32_t(inst->light_passes.size()));
+						if (pass == 0 && inst->lightmap_instance.is_valid() && scene_state.directional_lights[shadow_id].bake_mode == RenderingServer::LIGHT_BAKE_STATIC) {
+							// Disable additive lighting with a static light and a lightmap.
+							spec_constants &= ~SceneShaderGLES3::USE_ADDITIVE_LIGHTING;
+						}
 						if (scene_state.directional_shadows[shadow_id].shadow_split_offsets[0] == scene_state.directional_shadows[shadow_id].shadow_split_offsets[1]) {
 							// Orthogonal, do nothing.
 						} else if (scene_state.directional_shadows[shadow_id].shadow_split_offsets[1] == scene_state.directional_shadows[shadow_id].shadow_split_offsets[2]) {
@@ -2918,6 +2977,46 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 					if (inst->spot_light_gl_cache.size()) {
 						glUniform1uiv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::SPOT_LIGHT_INDICES, shader->version, instance_variant, spec_constants), inst->spot_light_gl_cache.size(), inst->spot_light_gl_cache.ptr());
+					}
+
+					if (inst->lightmap_instance.is_valid()) {
+						GLES3::LightmapInstance *li = GLES3::LightStorage::get_singleton()->get_lightmap_instance(inst->lightmap_instance);
+						GLES3::Lightmap *lm = GLES3::LightStorage::get_singleton()->get_lightmap(li->lightmap);
+
+						GLuint tex = GLES3::TextureStorage::get_singleton()->texture_get_texid(lm->light_texture);
+						glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
+						glBindTexture(GL_TEXTURE_2D_ARRAY, tex);
+
+						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_SLICE, inst->lightmap_slice_index, shader->version, instance_variant, spec_constants);
+
+						Vector4 uv_scale(inst->lightmap_uv_scale.position.x, inst->lightmap_uv_scale.position.y, inst->lightmap_uv_scale.size.x, inst->lightmap_uv_scale.size.y);
+						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_UV_SCALE, uv_scale, shader->version, instance_variant, spec_constants);
+
+						float exposure_normalization = 1.0;
+						if (p_render_data->camera_attributes.is_valid()) {
+							float enf = RSG::camera_attributes->camera_attributes_get_exposure_normalization_factor(p_render_data->camera_attributes);
+							exposure_normalization = enf / lm->baked_exposure;
+						}
+						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_EXPOSURE_NORMALIZATION, exposure_normalization, shader->version, instance_variant, spec_constants);
+
+						if (lm->uses_spherical_harmonics) {
+							Basis to_lm = li->transform.basis.inverse() * p_render_data->cam_transform.basis;
+							to_lm = to_lm.inverse().transposed();
+							GLfloat matrix[9] = {
+								(GLfloat)to_lm.rows[0][0],
+								(GLfloat)to_lm.rows[1][0],
+								(GLfloat)to_lm.rows[2][0],
+								(GLfloat)to_lm.rows[0][1],
+								(GLfloat)to_lm.rows[1][1],
+								(GLfloat)to_lm.rows[2][1],
+								(GLfloat)to_lm.rows[0][2],
+								(GLfloat)to_lm.rows[1][2],
+								(GLfloat)to_lm.rows[2][2],
+							};
+							glUniformMatrix3fv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::LIGHTMAP_NORMAL_XFORM, shader->version, instance_variant, spec_constants), 1, GL_FALSE, matrix);
+						}
+					} else if (inst->lightmap_sh) {
+						glUniform4fv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::LIGHTMAP_CAPTURES, shader->version, instance_variant, spec_constants), 9, reinterpret_cast<const GLfloat *>(inst->lightmap_sh->sh));
 					}
 
 					prev_inst = inst;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -170,6 +170,9 @@ private:
 		float cos_spot_angle;
 		float specular_amount;
 		float shadow_opacity;
+
+		float pad[3];
+		uint32_t bake_mode;
 	};
 	static_assert(sizeof(LightData) % 16 == 0, "LightData size must be a multiple of 16 bytes");
 
@@ -181,7 +184,7 @@ private:
 		float size;
 
 		uint32_t enabled; // For use by SkyShaders
-		float pad;
+		uint32_t bake_mode;
 		float shadow_opacity;
 		float specular;
 	};
@@ -269,6 +272,10 @@ private:
 		GeometryInstanceGLES3 *owner = nullptr;
 	};
 
+	struct GeometryInstanceLightmapSH {
+		Color sh[9];
+	};
+
 	class GeometryInstanceGLES3 : public RenderGeometryInstanceBase {
 	public:
 		//used during rendering
@@ -295,6 +302,11 @@ private:
 		LocalVector<RID> paired_spot_lights;
 		LocalVector<uint32_t> omni_light_gl_cache;
 		LocalVector<uint32_t> spot_light_gl_cache;
+
+		RID lightmap_instance;
+		Rect2 lightmap_uv_scale;
+		uint32_t lightmap_slice_index;
+		GeometryInstanceLightmapSH *lightmap_sh = nullptr;
 
 		// Used during setup.
 		GeometryInstanceSurface *surface_caches = nullptr;

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -569,69 +569,171 @@ void LightStorage::lightmap_initialize(RID p_rid) {
 
 void LightStorage::lightmap_free(RID p_rid) {
 	Lightmap *lightmap = lightmap_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(lightmap);
 	lightmap->dependency.deleted_notify(p_rid);
 	lightmap_owner.free(p_rid);
 }
 
 void LightStorage::lightmap_set_textures(RID p_lightmap, RID p_light, bool p_uses_spherical_haromics) {
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(lightmap);
+	lightmap->light_texture = p_light;
+	lightmap->uses_spherical_harmonics = p_uses_spherical_haromics;
+
+	GLuint tex = GLES3::TextureStorage::get_singleton()->texture_get_texid(lightmap->light_texture);
+	glBindTexture(GL_TEXTURE_2D_ARRAY, tex);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
 }
 
 void LightStorage::lightmap_set_probe_bounds(RID p_lightmap, const AABB &p_bounds) {
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(lightmap);
+	lightmap->bounds = p_bounds;
 }
 
 void LightStorage::lightmap_set_probe_interior(RID p_lightmap, bool p_interior) {
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(lightmap);
+	lightmap->interior = p_interior;
 }
 
 void LightStorage::lightmap_set_probe_capture_data(RID p_lightmap, const PackedVector3Array &p_points, const PackedColorArray &p_point_sh, const PackedInt32Array &p_tetrahedra, const PackedInt32Array &p_bsp_tree) {
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(lightmap);
+
+	if (p_points.size()) {
+		ERR_FAIL_COND(p_points.size() * 9 != p_point_sh.size());
+		ERR_FAIL_COND((p_tetrahedra.size() % 4) != 0);
+		ERR_FAIL_COND((p_bsp_tree.size() % 6) != 0);
+	}
+
+	lightmap->points = p_points;
+	lightmap->point_sh = p_point_sh;
+	lightmap->tetrahedra = p_tetrahedra;
+	lightmap->bsp_tree = p_bsp_tree;
 }
 
 void LightStorage::lightmap_set_baked_exposure_normalization(RID p_lightmap, float p_exposure) {
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(lightmap);
+
+	lightmap->baked_exposure = p_exposure;
 }
 
 PackedVector3Array LightStorage::lightmap_get_probe_capture_points(RID p_lightmap) const {
-	return PackedVector3Array();
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lightmap, PackedVector3Array());
+	return lightmap->points;
 }
 
 PackedColorArray LightStorage::lightmap_get_probe_capture_sh(RID p_lightmap) const {
-	return PackedColorArray();
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lightmap, PackedColorArray());
+	return lightmap->point_sh;
 }
 
 PackedInt32Array LightStorage::lightmap_get_probe_capture_tetrahedra(RID p_lightmap) const {
-	return PackedInt32Array();
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lightmap, PackedInt32Array());
+	return lightmap->tetrahedra;
 }
 
 PackedInt32Array LightStorage::lightmap_get_probe_capture_bsp_tree(RID p_lightmap) const {
-	return PackedInt32Array();
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lightmap, PackedInt32Array());
+	return lightmap->bsp_tree;
 }
 
 AABB LightStorage::lightmap_get_aabb(RID p_lightmap) const {
-	return AABB();
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lightmap, AABB());
+	return lightmap->bounds;
 }
 
 void LightStorage::lightmap_tap_sh_light(RID p_lightmap, const Vector3 &p_point, Color *r_sh) {
+	Lightmap *lm = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(lm);
+
+	for (int i = 0; i < 9; i++) {
+		r_sh[i] = Color(0, 0, 0, 0);
+	}
+
+	if (!lm->points.size() || !lm->bsp_tree.size() || !lm->tetrahedra.size()) {
+		return;
+	}
+
+	static_assert(sizeof(Lightmap::BSP) == 24);
+
+	const Lightmap::BSP *bsp = (const Lightmap::BSP *)lm->bsp_tree.ptr();
+	int32_t node = 0;
+	while (node >= 0) {
+		if (Plane(bsp[node].plane[0], bsp[node].plane[1], bsp[node].plane[2], bsp[node].plane[3]).is_point_over(p_point)) {
+#ifdef DEBUG_ENABLED
+			ERR_FAIL_COND(bsp[node].over >= 0 && bsp[node].over < node);
+#endif
+
+			node = bsp[node].over;
+		} else {
+#ifdef DEBUG_ENABLED
+			ERR_FAIL_COND(bsp[node].under >= 0 && bsp[node].under < node);
+#endif
+			node = bsp[node].under;
+		}
+	}
+
+	if (node == Lightmap::BSP::EMPTY_LEAF) {
+		return; // Nothing could be done.
+	}
+
+	node = ABS(node) - 1;
+
+	uint32_t *tetrahedron = (uint32_t *)&lm->tetrahedra[node * 4];
+	Vector3 points[4] = { lm->points[tetrahedron[0]], lm->points[tetrahedron[1]], lm->points[tetrahedron[2]], lm->points[tetrahedron[3]] };
+	const Color *sh_colors[4]{ &lm->point_sh[tetrahedron[0] * 9], &lm->point_sh[tetrahedron[1] * 9], &lm->point_sh[tetrahedron[2] * 9], &lm->point_sh[tetrahedron[3] * 9] };
+	Color barycentric = Geometry3D::tetrahedron_get_barycentric_coords(points[0], points[1], points[2], points[3], p_point);
+
+	for (int i = 0; i < 4; i++) {
+		float c = CLAMP(barycentric[i], 0.0, 1.0);
+		for (int j = 0; j < 9; j++) {
+			r_sh[j] += sh_colors[i][j] * c;
+		}
+	}
 }
 
 bool LightStorage::lightmap_is_interior(RID p_lightmap) const {
-	return false;
+	Lightmap *lightmap = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lightmap, false);
+	return lightmap->interior;
 }
 
 void LightStorage::lightmap_set_probe_capture_update_speed(float p_speed) {
+	lightmap_probe_capture_update_speed = p_speed;
 }
 
 float LightStorage::lightmap_get_probe_capture_update_speed() const {
-	return 0;
+	return lightmap_probe_capture_update_speed;
 }
 
 /* LIGHTMAP INSTANCE */
 
 RID LightStorage::lightmap_instance_create(RID p_lightmap) {
-	return RID();
+	LightmapInstance li;
+	li.lightmap = p_lightmap;
+	return lightmap_instance_owner.make_rid(li);
 }
 
 void LightStorage::lightmap_instance_free(RID p_lightmap) {
+	lightmap_instance_owner.free(p_lightmap);
 }
 
 void LightStorage::lightmap_instance_set_transform(RID p_lightmap, const Transform3D &p_transform) {
+	LightmapInstance *li = lightmap_instance_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL(li);
+	li->transform = p_transform;
 }
 
 /* SHADOW ATLAS API */

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -155,6 +155,11 @@ struct Lightmap {
 	Dependency dependency;
 };
 
+struct LightmapInstance {
+	RID lightmap;
+	Transform3D transform;
+};
+
 class LightStorage : public RendererLightStorage {
 public:
 	enum ShadowAtlastQuadrant {
@@ -179,8 +184,13 @@ private:
 	/* LIGHTMAP */
 
 	Vector<RID> lightmap_textures;
+	float lightmap_probe_capture_update_speed = 4;
 
 	mutable RID_Owner<Lightmap, true> lightmap_owner;
+
+	/* LIGHTMAP INSTANCE */
+
+	mutable RID_Owner<LightmapInstance> lightmap_instance_owner;
 
 	/* SHADOW ATLAS */
 
@@ -621,6 +631,9 @@ public:
 	virtual float lightmap_get_probe_capture_update_speed() const override;
 
 	/* LIGHTMAP INSTANCE */
+
+	LightmapInstance *get_lightmap_instance(RID p_rid) { return lightmap_instance_owner.get_or_null(p_rid); };
+	bool owns_lightmap_instance(RID p_rid) { return lightmap_instance_owner.owns(p_rid); };
 
 	virtual RID lightmap_instance_create(RID p_lightmap) override;
 	virtual void lightmap_instance_free(RID p_lightmap) override;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1523,7 +1523,7 @@ PackedStringArray LightmapGI::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
-		warnings.push_back(RTR("LightmapGI nodes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
+		warnings.push_back(RTR("Lightmap cannot be baked when using the GL Compatibility backend yet. Support will be added in a future release."));
 		return warnings;
 	}
 


### PR DESCRIPTION
This PR aims to add rendering of lightmaps (via `LightmapGI`) when using the GL Compatibility renderer.

**Note: This doesn't add lightmap baking when using the GL Compatibility renderer. Lightmaps still need to be baked using Vulkan.**

~~This marked as a draft because while it's "working", the result looks worse than I'd expect. I want to see if I can get to the bottom of that first.~~

~~**UPDATE:** Eh, it looks good enough to get some review :-)~~

**UPDATE 2:** In [a comment below](https://github.com/godotengine/godot/pull/85120#issuecomment-1819250042), @Calinou (who knows rendering much better than me) says it looks as good as he'd expect given the way the Compatibility renderer works, so I guess this just needs code review now!