### PR TITLE
Prevent crash in `_nvapi_disable_threaded_optimization` when attached to renderdoc

### DIFF
--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -104,8 +104,8 @@ static bool nvapi_err_check(const char *msg, int status) {
 }
 
 // On windows we have to disable threaded optimization when using NVIDIA graphics cards
-// to avoid stuttering, see https://github.com/microsoft/vscode-cpptools/issues/6592
-// also see https://github.com/Ryujinx/Ryujinx/blob/master/Ryujinx.Common/GraphicsDriver/NVThreadedOptimization.cs
+// to avoid stuttering, see see https://stackoverflow.com/questions/36959508/nvidia-graphics-driver-causing-noticeable-frame-stuttering/37632948
+// also see https://github.com/Ryujinx/Ryujinx/blob/master/src/Ryujinx.Common/GraphicsDriver/NVThreadedOptimization.cs
 void GLManagerNative_Windows::_nvapi_disable_threaded_optimization() {
 	HMODULE nvapi = 0;
 #ifdef _WIN64
@@ -148,6 +148,10 @@ void GLManagerNative_Windows::_nvapi_disable_threaded_optimization() {
 	print_verbose("NVAPI: Init OK!");
 
 	NvDRSSessionHandle session_handle;
+
+	if (NvAPI_DRS_CreateSession == nullptr) {
+		return;
+	}
 
 	if (!nvapi_err_check("NVAPI: Error creating DRS session", NvAPI_DRS_CreateSession(&session_handle))) {
 		NvAPI_Unload();


### PR DESCRIPTION
A workaround, should fix #84880 when `nvidia_disable_threaded_optimization` is disabled in project setting ( although the root cause is still not solved ) . And this change should probably be there at the first place, it will sightly increase start up time if the user did not want to disable nv's optimization, it's a double win anyway.

cc @EIREXE You might want to take a look.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
