### PR TITLE
Add item ID to GridMap MeshLibrary palette tooltip

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -907,10 +907,12 @@ void GridMapEditor::update_palette() {
 			continue;
 		}
 
+		String tooltip_text = vformat(TTR("%s (Item ID: %d)"), name, id);
+
 		mesh_library_palette->add_item("");
 		if (!preview.is_null()) {
 			mesh_library_palette->set_item_icon(item, preview);
-			mesh_library_palette->set_item_tooltip(item, name);
+			mesh_library_palette->set_item_tooltip(item, tooltip_text);
 		}
 		mesh_library_palette->set_item_text(item, name);
 		mesh_library_palette->set_item_metadata(item, id);


### PR DESCRIPTION
Adds item ID to GridMap MeshLibrary palette tooltip.

Implements proposal https://github.com/godotengine/godot-proposals/issues/5866.

![gridmap_item_id_tooltip](https://github.com/godotengine/godot/assets/52464204/6d2f9a23-904d-4a1d-9197-6ebb1d71ed95)


_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/5866_
