### PR TITLE
[Editor] Add support for readable names to the string enum property editor.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1367,10 +1367,10 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("physics/2d/run_on_separate_thread", false);
 	GLOBAL_DEF("physics/3d/run_on_separate_thread", false);
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/mode", PROPERTY_HINT_ENUM, "disabled,canvas_items,viewport"), "disabled");
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "ignore,keep,keep_width,keep_height,expand"), "keep");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/mode", PROPERTY_HINT_ENUM, "Disabled:disabled,Canvas Items:canvas_items,Viewport:viewport"), "disabled");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "Ignore:ignore,Keep:keep,Keep Width:keep_width,Keep Height:keep_height,Expand:expand"), "keep");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "display/window/stretch/scale", PROPERTY_HINT_RANGE, "0.5,8.0,0.01"), 1.0);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/scale_mode", PROPERTY_HINT_ENUM, "fractional,integer"), "fractional");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/scale_mode", PROPERTY_HINT_ENUM, "Fractional:fractional,Integer:integer"), "fractional");
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1"), 16384);
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4112,6 +4112,24 @@ String String::c_escape_multiline() const {
 	return escaped;
 }
 
+String String::enum_hint_escape() const {
+	String escaped = *this;
+	escaped = escaped.replace("\\", "\\\\");
+	escaped = escaped.replace(",", "\\C");
+	escaped = escaped.replace(":", "\\S");
+
+	return escaped;
+}
+
+String String::enum_hint_unescape() const {
+	String escaped = *this;
+	escaped = escaped.replace("\\C", ",");
+	escaped = escaped.replace("\\S", ":");
+	escaped = escaped.replace("\\\\", "\\");
+
+	return escaped;
+}
+
 String String::json_escape() const {
 	String escaped = *this;
 	escaped = escaped.replace("\\", "\\\\");

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -432,6 +432,8 @@ public:
 	String c_escape_multiline() const;
 	String c_unescape() const;
 	String json_escape() const;
+	String enum_hint_escape() const;
+	String enum_hint_unescape() const;
 	Error parse_url(String &r_scheme, String &r_host, int &r_port, String &r_path) const;
 
 	String property_name_encode() const;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -607,7 +607,7 @@ void AnimationTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) const
 							animations += ",";
 						}
 
-						animations += String(E);
+						animations += String(E).enum_hint_escape();
 					}
 				}
 			}
@@ -1209,7 +1209,7 @@ void AnimationMultiTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) 
 								animations += ",";
 							}
 
-							animations += String(G->get());
+							animations += String(G->get()).enum_hint_escape();
 						}
 					}
 				}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -262,7 +262,11 @@ void EditorPropertyTextEnum::_emit_changed_value(String p_string) {
 }
 
 void EditorPropertyTextEnum::_option_selected(int p_which) {
-	_emit_changed_value(option_button->get_item_text(p_which));
+	if (p_which < values.size()) {
+		_emit_changed_value(values[p_which]);
+	} else {
+		_emit_changed_value("");
+	}
 }
 
 void EditorPropertyTextEnum::_edit_custom_value() {
@@ -292,7 +296,7 @@ void EditorPropertyTextEnum::_custom_value_canceled() {
 
 void EditorPropertyTextEnum::update_property() {
 	String current_value = get_edited_property_value();
-	int default_option = options.find(current_value);
+	int default_option = values.find(current_value);
 
 	// The list can change in the loose mode.
 	if (loose_mode) {
@@ -311,8 +315,15 @@ void EditorPropertyTextEnum::update_property() {
 		option_button->add_item("", options.size() + 1000);
 
 		for (int i = 0; i < options.size(); i++) {
-			option_button->add_item(options[i], i);
-			if (options[i] == current_value) {
+			Vector<String> text_split = options[i].split(":");
+			if (text_split.size() == 2) {
+				option_button->add_item(text_split[0].enum_hint_unescape(), i);
+				values.append(text_split[1]);
+			} else {
+				option_button->add_item(options[i].enum_hint_unescape(), i);
+				values.append(options[i]);
+			}
+			if (values[i] == current_value) {
 				option_button->select(option_button->get_item_count() - 1);
 			}
 		}
@@ -326,6 +337,7 @@ void EditorPropertyTextEnum::setup(const Vector<String> &p_options, bool p_strin
 	loose_mode = p_loose_mode;
 
 	options.clear();
+	values.clear();
 
 	if (loose_mode) {
 		// Add an explicit empty value for clearing the property in the loose mode.
@@ -333,8 +345,15 @@ void EditorPropertyTextEnum::setup(const Vector<String> &p_options, bool p_strin
 	}
 
 	for (int i = 0; i < p_options.size(); i++) {
+		Vector<String> text_split = p_options[i].split(":");
 		options.append(p_options[i]);
-		option_button->add_item(p_options[i], i);
+		if (text_split.size() == 2) {
+			option_button->add_item(text_split[0].enum_hint_unescape(), i);
+			values.append(text_split[1]);
+		} else {
+			option_button->add_item(p_options[i].enum_hint_unescape(), i);
+			values.append(p_options[i]);
+		}
 	}
 
 	if (loose_mode) {
@@ -710,7 +729,7 @@ void EditorPropertyEnum::setup(const Vector<String> &p_options) {
 		if (text_split.size() != 1) {
 			current_val = text_split[1].to_int();
 		}
-		options->add_item(text_split[0]);
+		options->add_item(text_split[0].enum_hint_escape());
 		options->set_item_metadata(i, current_val);
 		current_val += 1;
 	}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -113,6 +113,7 @@ class EditorPropertyTextEnum : public EditorProperty {
 	Button *cancel_button = nullptr;
 
 	Vector<String> options;
+	Vector<String> values;
 	bool string_name = false;
 	bool loose_mode = false;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -341,7 +341,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Languages */
 
 	{
-		String lang_hint = "en";
+		String lang_hint = vformat("[en] %s:en", TranslationServer::get_singleton()->get_locale_name("en").enum_hint_escape());
 		String host_lang = OS::get_singleton()->get_locale();
 
 		// Skip locales if Text server lack required features.
@@ -378,7 +378,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			}
 
 			lang_hint += ",";
-			lang_hint += locale;
+			lang_hint += vformat("[%s] %s:%s", locale, TranslationServer::get_singleton()->get_locale_name(locale).enum_hint_escape(), locale);
 
 			int score = TranslationServer::get_singleton()->compare_locales(host_lang, locale);
 			if (score > 0 && score >= best_score) {
@@ -786,12 +786,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "gl_compatibility", "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "gl_compatibility", "Forward+:forward_plus,Mobile:mobile,OpenGL (Compatibility):gl_compatibility")
 #elif defined(ANDROID_ENABLED)
 	// Use more suitable rendering method by default.
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "mobile", "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "mobile", "Forward+:forward_plus,Mobile:mobile,OpenGL (Compatibility):gl_compatibility")
 #else
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "forward_plus", "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "forward_plus", "Forward+:forward_plus,Mobile:mobile,OpenGL (Compatibility):gl_compatibility")
 #endif
 
 	if (p_extra_config.is_valid()) {
@@ -1286,7 +1286,7 @@ void EditorSettings::list_text_editor_themes() {
 
 		custom_themes.sort();
 		for (const String &E : custom_themes) {
-			themes += "," + E;
+			themes += "," + E.enum_hint_escape();
 		}
 	}
 	add_property_hint(PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, themes));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1731,15 +1731,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_cmdline(execpath, main_args, user_args);
 
 	{
-		String driver_hints = "";
 #ifdef VULKAN_ENABLED
-		driver_hints = "vulkan";
+		String driver_hints = "Vulkan:vulkan";
+		String default_driver = "vulkan";
+#else
+		String driver_hints = "";
+		String default_driver = "";
 #endif
 
-		String default_driver = driver_hints.get_slice(",", 0);
-
 		// For now everything defaults to vulkan when available. This can change in future updates.
-		GLOBAL_DEF_RST_NOVAL("rendering/rendering_device/driver", default_driver);
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver", PROPERTY_HINT_ENUM, driver_hints), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.windows", PROPERTY_HINT_ENUM, driver_hints), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.linuxbsd", PROPERTY_HINT_ENUM, driver_hints), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/rendering_device/driver.android", PROPERTY_HINT_ENUM, driver_hints), default_driver);
@@ -1748,19 +1749,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	{
+#ifdef GLES3_ENABLED
+		String driver_hints = "OpenGL 3:opengl3";
+		String driver_hints_angle = "OpenGL 3:opengl3,OpenGLES 3 (ANGLE):opengl3_angle"; // macOS, Windows.
+		String driver_hints_egl = "OpenGL 3:opengl3,OpenGLES 3:opengl3_es"; // Linux.
+		String default_driver = "opengl3";
+		String default_driver_macos = "opengl3_angle";
+#else
 		String driver_hints = "";
 		String driver_hints_angle = "";
 		String driver_hints_egl = "";
-#ifdef GLES3_ENABLED
-		driver_hints = "opengl3";
-		driver_hints_angle = "opengl3,opengl3_angle"; // macOS, Windows.
-		driver_hints_egl = "opengl3,opengl3_es"; // Linux.
+		String default_driver = "";
+		String default_driver_macos = "";
 #endif
 
-		String default_driver = driver_hints.get_slice(",", 0);
-		String default_driver_macos = driver_hints_angle.get_slice(",", 1);
-
-		GLOBAL_DEF_RST_NOVAL("rendering/gl_compatibility/driver", default_driver);
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver", PROPERTY_HINT_ENUM, driver_hints), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.windows", PROPERTY_HINT_ENUM, driver_hints_angle), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.linuxbsd", PROPERTY_HINT_ENUM, driver_hints_egl), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.web", PROPERTY_HINT_ENUM, driver_hints), default_driver);
@@ -2427,7 +2430,7 @@ Error Main::setup2() {
 
 	{
 		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
-		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "wintab,winink"), "");
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "Wacom WinTab:wintab,Windows Ink:winink"), "");
 	}
 
 	if (tablet_driver.is_empty()) { // specified in project.godot

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -48,7 +48,7 @@ void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 				if (i > 0) {
 					names += ",";
 				}
-				names += parent->get_bone_name(i);
+				names += parent->get_bone_name(i).enum_hint_escape();
 			}
 
 			p_property.hint = PROPERTY_HINT_ENUM;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2888,7 +2888,7 @@ void PhysicalBone3D::_get_property_list(List<PropertyInfo> *p_list) const {
 			if (i > 0) {
 				names += ",";
 			}
-			names += parent->get_bone_name(i);
+			names += parent->get_bone_name(i).enum_hint_escape();
 		}
 
 		p_list->push_back(PropertyInfo(Variant::STRING_NAME, PNAME("bone_name"), PROPERTY_HINT_ENUM, names));

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -337,7 +337,7 @@ void SkeletonIK3D::_validate_property(PropertyInfo &p_property) const {
 				if (i > 0) {
 					names += ",";
 				}
-				names += skeleton->get_bone_name(i);
+				names += skeleton->get_bone_name(i).enum_hint_escape();
 			}
 
 			p_property.hint = PROPERTY_HINT_ENUM;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -55,7 +55,7 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const 
 			if (i > 0) {
 				anims += ",";
 			}
-			anims += String(names[i]);
+			anims += String(names[i]).enum_hint_escape();
 		}
 		if (!anims.is_empty()) {
 			p_property.hint = PROPERTY_HINT_ENUM;
@@ -873,7 +873,7 @@ void AnimationNodeTransition::get_parameter_list(List<PropertyInfo> *r_list) con
 		if (i > 0) {
 			anims += ",";
 		}
-		anims += inputs[i].name;
+		anims += inputs[i].name.enum_hint_escape();
 	}
 
 	r_list->push_back(PropertyInfo(Variant::STRING, current_state, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY)); // For interface.

--- a/scene/resources/skeleton_profile.cpp
+++ b/scene/resources/skeleton_profile.cpp
@@ -157,7 +157,7 @@ void SkeletonProfile::_get_property_list(List<PropertyInfo> *p_list) const {
 		if (i > 0) {
 			group_names = group_names + ",";
 		}
-		group_names = group_names + groups[i].group_name;
+		group_names = group_names + String(groups[i].group_name).enum_hint_escape();
 	}
 	for (int i = 0; i < bones.size(); i++) {
 		String path = "bones/" + itos(i) + "/";

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -920,7 +920,7 @@ const String PhysicsServer2DManager::setting_property_name(PNAME("physics/2d/phy
 void PhysicsServer2DManager::on_servers_changed() {
 	String physics_servers("DEFAULT");
 	for (int i = get_servers_count() - 1; 0 <= i; --i) {
-		physics_servers += "," + get_server_name(i);
+		physics_servers += "," + get_server_name(i).enum_hint_escape();
 	}
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, setting_property_name, PROPERTY_HINT_ENUM, physics_servers));
 	ProjectSettings::get_singleton()->set_restart_if_changed(setting_property_name, true);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -1083,7 +1083,7 @@ const String PhysicsServer3DManager::setting_property_name(PNAME("physics/3d/phy
 void PhysicsServer3DManager::on_servers_changed() {
 	String physics_servers2("DEFAULT");
 	for (int i = get_servers_count() - 1; 0 <= i; --i) {
-		physics_servers2 += "," + get_server_name(i);
+		physics_servers2 += "," + get_server_name(i).enum_hint_escape();
 	}
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, setting_property_name, PROPERTY_HINT_ENUM, physics_servers2));
 	ProjectSettings::get_singleton()->set_restart_if_changed(setting_property_name, true);


### PR DESCRIPTION
Add support for `name:value` format in the string enum hints (already supported by in enums), and use it for to make some of the editor and project settings more readable.

<img width="1047" alt="Screenshot 2023-11-20 at 12 30 38" src="https://github.com/godotengine/godot/assets/7645683/c266d791-3e0e-4f70-b653-2f123e2b2478">
