### PR TITLE
Fix corrupt resource preventing opening other resources

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2282,7 +2282,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 					pr.step(reimport_files[i].path.get_file(), i);
 					_reimport_file(reimport_files[i].path);
 				} else {
-					Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(reimport_files[from].importer);
+					Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(reimport_files[i].importer);
 					ERR_CONTINUE(!importer.is_valid());
 
 					importer->import_threaded_begin();


### PR DESCRIPTION
Fixed #84473

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Its just index mistake, instead of `from` index it should be `i`.
`from` is always 0, so if the first resource (index 0) is corrupt, its import is NULL, which causes other resources (like `icon.svg`) to also have `Ref<ResourceImporter> importer` NULL.
