### PR TITLE
Prevent the surface upgrade tool from running during export

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3048,6 +3048,9 @@ void EditorNode::_tool_menu_option(int p_idx) {
 		case TOOLS_ORPHAN_RESOURCES: {
 			orphan_resources->show();
 		} break;
+		case TOOLS_SURFACE_UPGRADE: {
+			surface_upgrade_dialog->popup_centered(Size2(750 * EDSCALE, 0));
+		} break;
 		case TOOLS_CUSTOM: {
 			if (tool_menu->get_item_submenu(p_idx) == "") {
 				Callable callback = tool_menu->get_item_metadata(p_idx);
@@ -4669,6 +4672,10 @@ Error EditorNode::export_preset(const String &p_preset, const String &p_path, bo
 	export_defer.pack_only = p_pack_only;
 	cmdline_export_mode = true;
 	return OK;
+}
+
+bool EditorNode::is_project_exporting() const {
+	return project_export && project_export->is_exporting();
 }
 
 void EditorNode::show_accept(const String &p_text, const String &p_title) {
@@ -7429,6 +7436,7 @@ EditorNode::EditorNode() {
 	project_menu->add_child(tool_menu);
 	project_menu->add_submenu_item(TTR("Tools"), "Tools");
 	tool_menu->add_item(TTR("Orphan Resource Explorer..."), TOOLS_ORPHAN_RESOURCES);
+	tool_menu->add_item(TTR("Upgrade Mesh Surfaces..."), TOOLS_SURFACE_UPGRADE);
 
 	project_menu->add_separator();
 	project_menu->add_shortcut(ED_SHORTCUT("editor/reload_current_project", TTR("Reload Current Project")), RELOAD_CURRENT_PROJECT);
@@ -7767,6 +7775,9 @@ EditorNode::EditorNode() {
 
 	orphan_resources = memnew(OrphanResourcesDialog);
 	gui_base->add_child(orphan_resources);
+
+	surface_upgrade_dialog = memnew(SurfaceUpgradeDialog);
+	gui_base->add_child(surface_upgrade_dialog);
 
 	confirmation = memnew(ConfirmationDialog);
 	gui_base->add_child(confirmation);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -114,6 +114,7 @@ class RunSettingsDialog;
 class SceneImportSettings;
 class ScriptCreateDialog;
 class SurfaceUpgradeTool;
+class SurfaceUpgradeDialog;
 class WindowWrapper;
 
 class EditorNode : public Node {
@@ -192,6 +193,7 @@ private:
 		EDIT_RELOAD_SAVED_SCENE,
 		TOOLS_ORPHAN_RESOURCES,
 		TOOLS_BUILD_PROFILE_MANAGER,
+		TOOLS_SURFACE_UPGRADE,
 		TOOLS_CUSTOM,
 		RESOURCE_SAVE,
 		RESOURCE_SAVE_AS,
@@ -496,6 +498,7 @@ private:
 	HashMap<String, Ref<Texture2D>> icon_type_cache;
 
 	SurfaceUpgradeTool *surface_upgrade_tool = nullptr;
+	SurfaceUpgradeDialog *surface_upgrade_dialog = nullptr;
 	bool run_surface_upgrade_tool = false;
 
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
@@ -875,6 +878,7 @@ public:
 	void _copy_warning(const String &p_str);
 
 	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only);
+	bool is_project_exporting() const;
 
 	Control *get_gui_base() { return gui_base; }
 

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -70,7 +70,6 @@ public:
 class ProjectExportDialog : public ConfirmationDialog {
 	GDCLASS(ProjectExportDialog, ConfirmationDialog);
 
-private:
 	TabContainer *sections = nullptr;
 
 	MenuButton *add_preset = nullptr;
@@ -117,6 +116,8 @@ private:
 	HBoxContainer *export_templates_error = nullptr;
 
 	String default_filename;
+
+	bool exporting = false;
 
 	void _runnable_pressed();
 	void _update_parameters(const String &p_edited_property);
@@ -198,6 +199,8 @@ public:
 	String get_export_path();
 
 	Ref<EditorExportPreset> get_current_preset() const;
+
+	bool is_exporting() const { return exporting; };
 
 	ProjectExportDialog();
 	~ProjectExportDialog();

--- a/editor/surface_upgrade_tool.h
+++ b/editor/surface_upgrade_tool.h
@@ -31,7 +31,7 @@
 #ifndef SURFACE_UPGRADE_TOOL_H
 #define SURFACE_UPGRADE_TOOL_H
 
-#include "scene/main/node.h"
+#include "scene/gui/dialogs.h"
 
 class EditorFileSystemDirectory;
 
@@ -57,11 +57,22 @@ public:
 	bool is_show_requested() const { return show_requested; };
 	void show_popup() { _show_popup(); }
 
+	void prepare_upgrade();
 	void begin_upgrade();
 	void finish_upgrade();
 
 	SurfaceUpgradeTool();
 	~SurfaceUpgradeTool();
+};
+
+class SurfaceUpgradeDialog : public ConfirmationDialog {
+	GDCLASS(SurfaceUpgradeDialog, ConfirmationDialog);
+
+protected:
+	void _notification(int p_what);
+
+public:
+	SurfaceUpgradeDialog();
 };
 
 #endif // SURFACE_UPGRADE_TOOL_H


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/84171. This also adds a new "Project > Tools" menu option to trigger the tool on demand.


<img width="446" alt="godot windows editor dev x86_64_2023-11-20_14-43-17" src="https://github.com/godotengine/godot/assets/11782833/741651a9-7d0d-48ba-8db9-3ff40163caa1">


Implemented very quickly, please test.