### PR TITLE
SCons: Add two new `COMSTR` environment variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -930,17 +930,17 @@ if selected_platform in platform_list:
 
     GLSL_BUILDERS = {
         "RD_GLSL": env.Builder(
-            action=env.Run(glsl_builders.build_rd_headers, 'Building RD_GLSL header: "$TARGET"'),
+            action=env.Run(glsl_builders.build_rd_headers),
             suffix="glsl.gen.h",
             src_suffix=".glsl",
         ),
         "GLSL_HEADER": env.Builder(
-            action=env.Run(glsl_builders.build_raw_headers, 'Building GLSL header: "$TARGET"'),
+            action=env.Run(glsl_builders.build_raw_headers),
             suffix="glsl.gen.h",
             src_suffix=".glsl",
         ),
         "GLES3_GLSL": env.Builder(
-            action=env.Run(gles3_builders.build_gles3_headers, 'Building GLES3 GLSL header: "$TARGET"'),
+            action=env.Run(gles3_builders.build_gles3_headers),
             suffix="glsl.gen.h",
             src_suffix=".glsl",
         ),

--- a/core/SCsub
+++ b/core/SCsub
@@ -202,27 +202,23 @@ env.Depends(
 env.CommandNoCache(
     "#core/io/certs_compressed.gen.h",
     "#thirdparty/certs/ca-certificates.crt",
-    env.Run(core_builders.make_certs_header, "Building ca-certificates header."),
+    env.Run(core_builders.make_certs_header),
 )
 
 # Authors
 env.Depends("#core/authors.gen.h", "../AUTHORS.md")
-env.CommandNoCache(
-    "#core/authors.gen.h", "../AUTHORS.md", env.Run(core_builders.make_authors_header, "Generating authors header.")
-)
+env.CommandNoCache("#core/authors.gen.h", "../AUTHORS.md", env.Run(core_builders.make_authors_header))
 
 # Donors
 env.Depends("#core/donors.gen.h", "../DONORS.md")
-env.CommandNoCache(
-    "#core/donors.gen.h", "../DONORS.md", env.Run(core_builders.make_donors_header, "Generating donors header.")
-)
+env.CommandNoCache("#core/donors.gen.h", "../DONORS.md", env.Run(core_builders.make_donors_header))
 
 # License
 env.Depends("#core/license.gen.h", ["../COPYRIGHT.txt", "../LICENSE.txt"])
 env.CommandNoCache(
     "#core/license.gen.h",
     ["../COPYRIGHT.txt", "../LICENSE.txt"],
-    env.Run(core_builders.make_license_header, "Generating license header."),
+    env.Run(core_builders.make_license_header),
 )
 
 # Chain load SCsubs

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -14,7 +14,7 @@ controller_databases = [
 gensource = env.CommandNoCache(
     "default_controller_mappings.gen.cpp",
     controller_databases,
-    env.Run(input_builders.make_default_controller_mappings, "Generating default controller mappings."),
+    env.Run(input_builders.make_default_controller_mappings),
 )
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -68,7 +68,7 @@ if env.editor_build:
     env.CommandNoCache(
         "#editor/doc_data_compressed.gen.h",
         docs,
-        env.Run(editor_builders.make_doc_header, "Generating documentation header."),
+        env.Run(editor_builders.make_doc_header),
     )
 
     # Editor interface and class reference translations incur a significant size
@@ -83,7 +83,7 @@ if env.editor_build:
     env.CommandNoCache(
         "#editor/editor_translations.gen.h",
         tlist,
-        env.Run(editor_builders.make_editor_translations_header, "Generating editor translations header."),
+        env.Run(editor_builders.make_editor_translations_header),
     )
 
     # Property translations
@@ -92,7 +92,7 @@ if env.editor_build:
     env.CommandNoCache(
         "#editor/property_translations.gen.h",
         tlist,
-        env.Run(editor_builders.make_property_translations_header, "Generating property translations header."),
+        env.Run(editor_builders.make_property_translations_header),
     )
 
     # Documentation translations
@@ -101,7 +101,7 @@ if env.editor_build:
     env.CommandNoCache(
         "#editor/doc_translations.gen.h",
         tlist,
-        env.Run(editor_builders.make_doc_translations_header, "Generating translations header."),
+        env.Run(editor_builders.make_doc_translations_header),
     )
 
     # Extractable translations
@@ -110,7 +110,7 @@ if env.editor_build:
     env.CommandNoCache(
         "#editor/extractable_translations.gen.h",
         tlist,
-        env.Run(editor_builders.make_extractable_translations_header, "Generating extractable translations header."),
+        env.Run(editor_builders.make_extractable_translations_header),
     )
 
     env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -7,7 +7,7 @@ import editor_icons_builders
 
 
 env["BUILDERS"]["MakeEditorIconsBuilder"] = Builder(
-    action=env.Run(editor_icons_builders.make_editor_icons_action, "Generating editor icons header."),
+    action=env.Run(editor_icons_builders.make_editor_icons_action),
     suffix=".h",
     src_suffix=".svg",
 )

--- a/editor/themes/SCsub
+++ b/editor/themes/SCsub
@@ -16,7 +16,7 @@ env.Depends("#editor/themes/builtin_fonts.gen.h", flist)
 env.CommandNoCache(
     "#editor/themes/builtin_fonts.gen.h",
     flist,
-    env.Run(editor_theme_builders.make_fonts_header, "Generating builtin fonts header."),
+    env.Run(editor_theme_builders.make_fonts_header),
 )
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/main/SCsub
+++ b/main/SCsub
@@ -17,7 +17,7 @@ env_main.Depends("#main/splash.gen.h", "#main/splash.png")
 env_main.CommandNoCache(
     "#main/splash.gen.h",
     "#main/splash.png",
-    env.Run(main_builders.make_splash, "Building splash screen header."),
+    env.Run(main_builders.make_splash),
 )
 
 if not env_main["no_editor_splash"]:
@@ -25,14 +25,14 @@ if not env_main["no_editor_splash"]:
     env_main.CommandNoCache(
         "#main/splash_editor.gen.h",
         "#main/splash_editor.png",
-        env.Run(main_builders.make_splash_editor, "Building editor splash screen header."),
+        env.Run(main_builders.make_splash_editor),
     )
 
 env_main.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
 env_main.CommandNoCache(
     "#main/app_icon.gen.h",
     "#main/app_icon.png",
-    env.Run(main_builders.make_app_icon, "Building application icon."),
+    env.Run(main_builders.make_app_icon),
 )
 
 lib = env_main.add_library("main", env.main_sources)

--- a/methods.py
+++ b/methods.py
@@ -607,6 +607,12 @@ def no_verbose(sys, env):
     java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
     )
+    compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    generated_file_message = "{}Generating {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
 
     env.Append(CXXCOMSTR=[compile_source_message])
     env.Append(CCCOMSTR=[compile_source_message])
@@ -618,6 +624,8 @@ def no_verbose(sys, env):
     env.Append(LINKCOMSTR=[link_program_message])
     env.Append(JARCOMSTR=[java_library_message])
     env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(RCCOMSTR=[compiled_resource_message])
+    env.Append(GENCOMSTR=[generated_file_message])
 
 
 def detect_visual_c_compiler_version(tools_env):
@@ -817,15 +825,14 @@ def CommandNoCache(env, target, sources, command, **args):
     return result
 
 
-def Run(env, function, short_message, subprocess=True):
+def Run(env, function, subprocess=True):
     from SCons.Script import Action
     from platform_methods import run_in_subprocess
 
-    output_print = short_message if not env["verbose"] else ""
     if not subprocess:
-        return Action(function, output_print)
+        return Action(function, "$GENCOMSTR")
     else:
-        return Action(run_in_subprocess(function), output_print)
+        return Action(run_in_subprocess(function), "$GENCOMSTR")
 
 
 def detect_darwin_sdk_path(platform, env):

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -19,7 +19,6 @@ env.CommandNoCache(
     Value(env.module_list),
     env.Run(
         modules_builders.generate_modules_enabled,
-        "Generating enabled modules header.",
         # NOTE: No need to run in subprocess since this is still executed serially.
         subprocess=False,
     ),
@@ -58,7 +57,6 @@ if env["tests"]:
         test_headers,
         env.Run(
             modules_builders.generate_modules_tests,
-            "Generating modules tests header.",
             # NOTE: No need to run in subprocess since this is still executed serially.
             subprocess=False,
         ),

--- a/modules/gdscript/editor/script_templates/SCsub
+++ b/modules/gdscript/editor/script_templates/SCsub
@@ -5,7 +5,7 @@ Import("env")
 import editor.template_builders as build_template_gd
 
 env["BUILDERS"]["MakeGDTemplateBuilder"] = Builder(
-    action=env.Run(build_template_gd.make_templates, "Generating GDScript templates header."),
+    action=env.Run(build_template_gd.make_templates),
     suffix=".h",
     src_suffix=".gd",
 )

--- a/modules/mono/editor/script_templates/SCsub
+++ b/modules/mono/editor/script_templates/SCsub
@@ -5,7 +5,7 @@ Import("env")
 import editor.template_builders as build_template_cs
 
 env["BUILDERS"]["MakeCSharpTemplateBuilder"] = Builder(
-    action=env.Run(build_template_cs.make_templates, "Generating C# templates header."),
+    action=env.Run(build_template_cs.make_templates),
     suffix=".h",
     src_suffix=".cs",
 )

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -42,6 +42,12 @@ def no_verbose(sys, env):
     java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
     )
+    compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    generated_file_message = "{}Generating {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
 
     env.Append(CXXCOMSTR=[compile_source_message])
     env.Append(CCCOMSTR=[compile_source_message])
@@ -53,6 +59,8 @@ def no_verbose(sys, env):
     env.Append(LINKCOMSTR=[link_program_message])
     env.Append(JARCOMSTR=[java_library_message])
     env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(RCCOMSTR=[compiled_resource_message])
+    env.Append(GENCOMSTR=[generated_file_message])
 
 
 def disable_warnings(self):

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -42,6 +42,12 @@ def no_verbose(sys, env):
     java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
     )
+    compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    generated_file_message = "{}Generating {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
 
     env.Append(CXXCOMSTR=[compile_source_message])
     env.Append(CCCOMSTR=[compile_source_message])
@@ -53,6 +59,8 @@ def no_verbose(sys, env):
     env.Append(LINKCOMSTR=[link_program_message])
     env.Append(JARCOMSTR=[java_library_message])
     env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(RCCOMSTR=[compiled_resource_message])
+    env.Append(GENCOMSTR=[generated_file_message])
 
 
 def disable_warnings(self):

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -6,9 +6,7 @@ import default_theme_icons_builders
 
 
 env["BUILDERS"]["MakeDefaultThemeIconsBuilder"] = Builder(
-    action=env.Run(
-        default_theme_icons_builders.make_default_theme_icons_action, "Generating default project theme icons header."
-    ),
+    action=env.Run(default_theme_icons_builders.make_default_theme_icons_action),
     suffix=".h",
     src_suffix=".svg",
 )


### PR DESCRIPTION
This PR aims to make the output logs of a non-verbose build more uniform by adding two new environment variables: `RCCOMSTR` and `GENCOMSTR`. `RCCOMSTR` is an existing keyword for SCons, used for compiling `.rc` files into `.res`/`.o`, so adding it eliminates the last remaining verbose output (on Windows anyway). `GENCOMSTR` is a bit more involved, as it effectively replaces the `methods.Run` "short_message" argument. However, because it's now formatted to automatically reference the generated file, the original messages are no longer needed