### PR TITLE
CI: Install Android NDK r23c explicitly, with caching

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -26,6 +26,13 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Install Android NDK r23c
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r23c
+          link-to-sdk: true
+          local-cache: true
+
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache
         continue-on-error: true

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: 17
 
       - name: Install Android NDK r23c
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@v1.4.2
         with:
           ndk-version: r23c
           link-to-sdk: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Godot Engine
-
+test
 <p align="center">
   <a href="https://godotengine.org">
     <img src="logo_outlined.svg" width="400" alt="Godot Engine logo">


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-cpp/pull/1314, where we don't rely on scons to download the NDK.

I wanted to enable the caching feature from https://github.com/nttld/setup-ndk, but it doesn't seem to work together with `link-sdk`. So the gain from this change is just some clarity, it may not speed things up.

*Edit:* Keeping as draft for now, blocked by https://github.com/nttld/setup-ndk/issues/518. If we can get the cache to work, then this becomes useful.