### PR TITLE
Don't abort loading when `ext_resource` is missing

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1026,7 +1026,10 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				Ref<Resource> res;
 				Error err = p_res_parser->ext_func(p_res_parser->userdata, p_stream, res, line, r_err_str);
 				if (err) {
-					return err;
+					// If the file is missing, the error can be ignored.
+					if (err != ERR_FILE_NOT_FOUND && err != ERR_CANT_OPEN) {
+						return err;
+					}
 				}
 
 				value = res;


### PR DESCRIPTION
Fixes #85152
*Bugsquad edit:* Fixes #86154
Resource loaders have inconsistent error values in case of missing files. If a loader returns error that indicates missing file, it's safe to ignore it; the resource will be replaced by null when you Open Anyway.

There are more errors related to files, not sure if ignore them all (the premise is technically the same).