### PR TITLE
Update joint after GrooveJoint2D's length is set

### DIFF
--- a/doc/classes/GrooveJoint2D.xml
+++ b/doc/classes/GrooveJoint2D.xml
@@ -11,9 +11,11 @@
 	<members>
 		<member name="initial_offset" type="float" setter="set_initial_offset" getter="get_initial_offset" default="25.0">
 			The body B's initial anchor position defined by the joint's origin and a local offset [member initial_offset] along the joint's Y axis (along the groove).
+			[b]Note:[/b] Setting initial offset will cause the joint to be reconfigured.
 		</member>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="50.0">
 			The groove's length. The groove is from the joint's origin towards [member length] along the joint's local Y axis.
+			[b]Note:[/b] Setting the groove's length will cause the joint to be reconfigured.
 		</member>
 	</members>
 </class>

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -436,6 +436,10 @@ void GrooveJoint2D::_configure_joint(RID p_joint, PhysicsBody2D *body_a, Physics
 void GrooveJoint2D::set_length(real_t p_length) {
 	length = p_length;
 	queue_redraw();
+	if (is_configured()) {
+		_disconnect_signals();
+		_update_joint(false);
+	}
 }
 
 real_t GrooveJoint2D::get_length() const {
@@ -445,6 +449,10 @@ real_t GrooveJoint2D::get_length() const {
 void GrooveJoint2D::set_initial_offset(real_t p_initial_offset) {
 	initial_offset = p_initial_offset;
 	queue_redraw();
+	if (is_configured()) {
+		_disconnect_signals();
+		_update_joint(false);
+	}
 }
 
 real_t GrooveJoint2D::get_initial_offset() const {


### PR DESCRIPTION
Fixes #85144

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
