### PR TITLE
Workaround (temporarily) ScriptServer mutex issues

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -53,7 +53,14 @@ class ScriptServer {
 	static ScriptLanguage *_languages[MAX_LANGUAGES];
 	static int _language_count;
 	static bool languages_ready;
-	static Mutex languages_mutex;
+	static SpinLock languages_lock;
+
+	// RAII-style SpinLock, for convenience in a temporary workaround.
+	class LanguagesSpinLockHolder {
+	public:
+		LanguagesSpinLockHolder() { languages_lock.lock(); }
+		~LanguagesSpinLockHolder() { languages_lock.unlock(); }
+	};
 
 	static bool scripting_enabled;
 	static bool reload_scripts_on_save;


### PR DESCRIPTION
This is an intended workaround to some issues due to some underlying MinGW bug coupled with #84657. #85039 aims to address them for good, but so late in the release cycle we need a compromise solution.

Fixes #78734.
Fixes #85105.
