### PR TITLE
Enhance SpinLock

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -851,6 +851,7 @@ if env.msvc and not methods.using_clang(env):  # MSVC
                 "/wd4245",
                 "/wd4267",
                 "/wd4305",  # C4305 (truncation): double to float or real_t, too hard to avoid.
+                "/wd4324",  # C4820 (structure was padded due to alignment specifier)
                 "/wd4514",  # C4514 (unreferenced inline function has been removed)
                 "/wd4714",  # C4714 (function marked as __forceinline not inlined)
                 "/wd4820",  # C4820 (padding added after construct)

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -42,6 +42,8 @@
 #include "core/templates/safe_refcount.h"
 #include "core/typedefs.h"
 
+#include <new>
+
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
 #include "thirdparty/mingw-std-threads/mingw.thread.h"
@@ -84,6 +86,20 @@ public:
 		void (*wrapper)(Thread::Callback, void *) = nullptr;
 		void (*term)() = nullptr;
 	};
+
+#if defined(__cpp_lib_hardware_interference_size) && !defined(ANDROID_ENABLED) // This would be OK with NDK >= 26.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winterference-size"
+#endif
+	static constexpr size_t CACHE_LINE_BYTES = std::hardware_destructive_interference_size;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#else
+	// At a negligible memory cost, we use a conservatively high value.
+	static constexpr size_t CACHE_LINE_BYTES = 128;
+#endif
 
 private:
 	friend class Main;
@@ -134,6 +150,8 @@ public:
 	typedef void (*Callback)(void *p_userdata);
 
 	typedef uint64_t ID;
+
+	static constexpr size_t CACHE_LINE_BYTES = sizeof(void *);
 
 	enum : ID {
 		UNASSIGNED_ID = 0,


### PR DESCRIPTION
As advised by https://rigtorp.se/spinlock/ and other resources, a good spinlock should do the following at least (and the following points are what this PR adds):
- Use the CPU pause instruction while looping, to inform the hardware we are spinning so it does the right thing. Depending on architectures, this may improve power efficiency, for instance (better usage of phone/laptop battery). Not only that, but hyper-threaded cores can also work better since one of the logical hardware threads knows the other isn't doing anything particularly useful while the latter is just spinning around.
- If the first attempt to lock fails, instead of blindlessly retrying, loop with relaxed memory ordering until it seems the lock is available again and, only then, retry with acquire semantics. This avoids wasteful sync operations, and may improve performanve.

**2024-10-23:**
~As a disclaimer, I haven't benchmarked this for either performance nor power usage. Maybe the Production team can lend a hand.~
Using a benchmark I've written for this (https://github.com/godotengine/godot-benchmarks/pull/95), these are the results on a Windows 10 PC, before (`a`) and after (`b`) this PR (unit is time, lower is better; note how this PR highly improves the contended cases):

**2024-11-04:** Benchmarked after going back to the CPU pause approach:
```
{
        "category": "Core > Object Db",
        "name": "12 Threads Full Contention",
        "results": {
                "time": {
                        "a": 1631,
                        "b": 1227,
                        "a_div_b": 1.3292583537082314
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "12 Threads Half Contention",
        "results": {
                "time": {
                        "a": 834.1,
                        "b": 631.4,
                        "a_div_b": 1.3210326259106748
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "12 Threads Little Contention",
        "results": {
                "time": {
                        "a": 186.8,
                        "b": 149.9,
                        "a_div_b": 1.246164109406271
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "12 Threads Slope Contention",
        "results": {
                "time": {
                        "a": 760.3,
                        "b": 614.2,
                        "a_div_b": 1.2378704005210028
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "2 Threads Full Contention",
        "results": {
                "time": {
                        "a": 57.44,
                        "b": 61.74,
                        "a_div_b": 0.9303530936183997
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "2 Threads Half Contention",
        "results": {
                "time": {
                        "a": 45.44,
                        "b": 47.77,
                        "a_div_b": 0.9512246179610633
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "2 Threads Little Contention",
        "results": {
                "time": {
                        "a": 33.54,
                        "b": 34.96,
                        "a_div_b": 0.9593821510297482
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "4 Threads Full Contention",
        "results": {
                "time": {
                        "a": 178.1,
                        "b": 189.9,
                        "a_div_b": 0.9378620326487624
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "4 Threads Half Contention",
        "results": {
                "time": {
                        "a": 103.3,
                        "b": 102.3,
                        "a_div_b": 1.0097751710654936
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "4 Threads Little Contention",
        "results": {
                "time": {
                        "a": 44.67,
                        "b": 46.76,
                        "a_div_b": 0.9553036783575707
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "4 Threads Slope Contention",
        "results": {
                "time": {
                        "a": 132.5,
                        "b": 139.6,
                        "a_div_b": 0.9491404011461319
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "8 Threads Full Contention",
        "results": {
                "time": {
                        "a": 741.4,
                        "b": 636.9,
                        "a_div_b": 1.1640759930915372
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "8 Threads Half Contention",
        "results": {
                "time": {
                        "a": 381.3,
                        "b": 327.2,
                        "a_div_b": 1.1653422982885087
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "8 Threads Little Contention",
        "results": {
                "time": {
                        "a": 99.02,
                        "b": 89.99,
                        "a_div_b": 1.1003444827203022
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "8 Threads Slope Contention",
        "results": {
                "time": {
                        "a": 389.2,
                        "b": 343.2,
                        "a_div_b": 1.134032634032634
                }
        }
}
{
        "category": "Core > Object Db",
        "name": "Single",
        "results": {
                "time": {
                        "a": 30.13,
                        "b": 31.28,
                        "a_div_b": 0.963235294117647
                }
        }
}
```