### PR TITLE
Fix project name being overwritten every time `show_dialog` is called

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -727,9 +727,12 @@ void ProjectDialog::show_dialog() {
 			project_path->set_text(d->get_current_dir());
 			fdialog->set_current_dir(d->get_current_dir());
 		}
-		String proj = TTR("New Game Project");
-		project_name->set_text(proj);
-		_text_changed(proj);
+
+		if (project_name->get_text().is_empty()) {
+			String proj = TTR("New Game Project");
+			project_name->set_text(proj);
+			_text_changed(proj);
+		}
 
 		project_path->set_editable(true);
 		browse->set_disabled(false);


### PR DESCRIPTION
Fixes #83605

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
