### PR TITLE
Fix leak in the bookkeeping of GDScript lambdas (reverted)

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -134,8 +134,8 @@ class GDScript : public Script {
 	List<UpdatableFuncPtrElement> func_ptrs_to_update_elems;
 	Mutex func_ptrs_to_update_mutex;
 
-	UpdatableFuncPtrElement *_add_func_ptr_to_update(GDScriptFunction **p_func_ptr_ptr);
-	static void _remove_func_ptr_to_update(const UpdatableFuncPtrElement *p_func_ptr_element);
+	List<UpdatableFuncPtrElement>::Element *_add_func_ptr_to_update(GDScriptFunction **p_func_ptr_ptr);
+	static void _remove_func_ptr_to_update(List<UpdatableFuncPtrElement>::Element *p_func_ptr_element);
 
 	static void _fixup_thread_function_bookkeeping();
 

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -45,7 +45,7 @@ class GDScriptLambdaCallable : public CallableCustom {
 	GDScriptFunction *function = nullptr;
 	Ref<GDScript> script;
 	uint32_t h;
-	GDScript::UpdatableFuncPtrElement *updatable_func_ptr_element = nullptr;
+	List<GDScript::UpdatableFuncPtrElement>::Element *updatable_func_ptr_element = nullptr;
 
 	Vector<Variant> captures;
 
@@ -72,7 +72,7 @@ class GDScriptLambdaSelfCallable : public CallableCustom {
 	Ref<RefCounted> reference; // For objects that are RefCounted, keep a reference.
 	Object *object = nullptr; // For non RefCounted objects, use a direct pointer.
 	uint32_t h;
-	GDScript::UpdatableFuncPtrElement *updatable_func_ptr_element = nullptr;
+	List<GDScript::UpdatableFuncPtrElement>::Element *updatable_func_ptr_element = nullptr;
 
 	Vector<Variant> captures;
 


### PR DESCRIPTION
In #84659 I failed to add code to fix one of the list elements created. This PR solves that.

I've tested the MRPs corresponding to the issues fixed by the former PR are still fixed and work well, in addition to the MRP in the directly addressed issue.

Fixes #85112.