### PR TITLE
[Core] Prevent copying of `SelfList` and `SelfList::List`

### DIFF
--- a/core/templates/self_list.h
+++ b/core/templates/self_list.h
@@ -159,6 +159,9 @@ public:
 		_FORCE_INLINE_ SelfList<T> *first() { return _first; }
 		_FORCE_INLINE_ const SelfList<T> *first() const { return _first; }
 
+		// Forbid copying, which has broken behavior.
+		void operator=(const List &) = delete;
+
 		_FORCE_INLINE_ List() {}
 		_FORCE_INLINE_ ~List() {
 			// A self list must be empty on destruction.
@@ -184,6 +187,9 @@ public:
 	_FORCE_INLINE_ const SelfList<T> *next() const { return _next; }
 	_FORCE_INLINE_ const SelfList<T> *prev() const { return _prev; }
 	_FORCE_INLINE_ T *self() const { return _self; }
+
+	// Forbid copying, which has broken behavior.
+	void operator=(const SelfList<T> &) = delete;
 
 	_FORCE_INLINE_ SelfList(T *p_self) {
 		_self = p_self;

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -173,14 +173,6 @@ public:
 
 	SelfList<DebugQuadrant> dirty_quadrant_list_element;
 
-	// For those, copy everything but SelfList elements.
-	DebugQuadrant(const DebugQuadrant &p_other) :
-			dirty_quadrant_list_element(this) {
-		quadrant_coords = p_other.quadrant_coords;
-		cells = p_other.cells;
-		canvas_item = p_other.canvas_item;
-	}
-
 	DebugQuadrant() :
 			dirty_quadrant_list_element(this) {
 	}
@@ -212,14 +204,6 @@ public:
 	Vector2 canvas_items_position;
 
 	SelfList<RenderingQuadrant> dirty_quadrant_list_element;
-
-	// For those, copy everything but SelfList elements.
-	RenderingQuadrant(const RenderingQuadrant &p_other) :
-			dirty_quadrant_list_element(this) {
-		quadrant_coords = p_other.quadrant_coords;
-		cells = p_other.cells;
-		canvas_items = p_other.canvas_items;
-	}
 
 	RenderingQuadrant() :
 			dirty_quadrant_list_element(this) {


### PR DESCRIPTION
Copying of these types is unsafe and should be detected

Also removed unnecessary constructors for `TileMap` `DebugQuadrant` and `RenderingQuadrant` which used copying of `SelfList::List`

Bug identified while researching:
* https://github.com/godotengine/godot/issues/84892

Unable to reliably replicate this crash so can't confirm this is a fix, will continue to investigate that fix

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
