### PR TITLE
Fix updating delimiter cache of `CodeEdit` when typing on the first line

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2904,7 +2904,7 @@ void CodeEdit::_update_delimiter_cache(int p_from_line, int p_to_line) {
 
 	int in_region = -1;
 	for (int i = start_line; i < MIN(end_line + 1, line_count); i++) {
-		int current_end_region = (i <= 0 || delimiter_cache[i].size() < 1) ? -1 : delimiter_cache[i].back()->value();
+		int current_end_region = (i < 0 || delimiter_cache[i].size() < 1) ? -1 : delimiter_cache[i].back()->value();
 		in_region = (i <= 0 || delimiter_cache[i - 1].size() < 1) ? -1 : delimiter_cache[i - 1].back()->value();
 
 		const String &str = get_line(i);

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -1503,6 +1503,19 @@ TEST_CASE("[SceneTree][CodeEdit] delimiters") {
 			CHECK(code_edit->is_in_string(1) == -1);
 			CHECK(code_edit->is_in_string(2) != -1);
 			CHECK(code_edit->is_in_string(3) == -1);
+
+			/* Next check updating the delimiter cache while typing. */
+			code_edit->set_text("\n\n");
+			code_edit->set_caret_line(0);
+			code_edit->set_caret_column(0);
+			CHECK(code_edit->is_in_string(0) == -1);
+			CHECK(code_edit->is_in_string(1) == -1);
+			code_edit->insert_text_at_caret("#");
+			CHECK(code_edit->is_in_string(0) != -1);
+			CHECK(code_edit->is_in_string(1) != -1);
+			code_edit->insert_text_at_caret("#");
+			CHECK(code_edit->is_in_string(0) != -1);
+			CHECK(code_edit->is_in_string(1) == -1);
 		}
 
 		SUBCASE("[CodeEdit] multiline comment delimiters") {
@@ -1692,6 +1705,19 @@ TEST_CASE("[SceneTree][CodeEdit] delimiters") {
 			CHECK(code_edit->is_in_comment(1) == -1);
 			CHECK(code_edit->is_in_comment(2) != -1);
 			CHECK(code_edit->is_in_comment(3) == -1);
+
+			/* Next check updating the delimiter cache while typing. */
+			code_edit->set_text("\n\n");
+			code_edit->set_caret_line(0);
+			code_edit->set_caret_column(0);
+			CHECK(code_edit->is_in_comment(0) == -1);
+			CHECK(code_edit->is_in_comment(1) == -1);
+			code_edit->insert_text_at_caret("#");
+			CHECK(code_edit->is_in_comment(0) != -1);
+			CHECK(code_edit->is_in_comment(1) != -1);
+			code_edit->insert_text_at_caret("#");
+			CHECK(code_edit->is_in_comment(0) != -1);
+			CHECK(code_edit->is_in_comment(1) == -1);
 		}
 
 		SUBCASE("[CodeEdit] multiline mixed delimiters") {


### PR DESCRIPTION
Fixes: #77726
Fixes: #75774

When typing on the first line of a `CodeEdit` the delimiter cache would not be updated beyond that line.
