### PR TITLE
SCons: Update mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,9 @@ gmon.out
 # Kdevelop
 *.kdev4
 
+# Mypy
+.mypy_cache
+
 # Qt Creator
 *.config
 *.creator

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -199,7 +199,7 @@ def build_gles3_header(
     filename: str,
     include: str,
     class_suffix: str,
-    optional_output_filename: str = None,
+    optional_output_filename: Optional[str] = None,
     header_data: Optional[GLES3HeaderStruct] = None,
 ):
     header_data = header_data or GLES3HeaderStruct()

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -114,7 +114,7 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
 
 
 def build_rd_header(
-    filename: str, optional_output_filename: str = None, header_data: Optional[RDHeaderStruct] = None
+    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RDHeaderStruct] = None
 ) -> None:
     header_data = header_data or RDHeaderStruct()
     include_file_in_rd_header(filename, header_data, 0)
@@ -198,7 +198,7 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
 
 
 def build_raw_header(
-    filename: str, optional_output_filename: str = None, header_data: Optional[RAWHeaderStruct] = None
+    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
 ):
     header_data = header_data or RAWHeaderStruct()
     include_file_in_raw_header(filename, header_data, 0)

--- a/misc/scripts/mypy.ini
+++ b/misc/scripts/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
-ignore_missing_imports = true
+ignore_missing_imports = True
 disallow_any_generics = True
+no_implicit_optional = True
 pretty = True
 show_column_numbers = True
 warn_redundant_casts = True


### PR DESCRIPTION
Implements a handful of minor adjustments all revolving around mypy
- Added a new section to the `.gitignore` to explicitly handle the mypy cache after running the mypy test script (or mypy in general)
- Added a new value to the mypy config: `no_implicit_optional = True`. This is because mypy made this their default value in later versions[^1], so adding a rule one way or the other clears up ambiguity for mypy installed from other sources (eg: vscode extension)
- Fixes two files that weren't conforming to `no_implicit_optional = True`. While they could've been left alone if the value was changed to `false`, all cases of changed arguments were right beside another argument that was *already* using an explicit optional wrapper; as such, the changes were sensible in-context & just so happened to be the only offending areas in the entire repo to begin with

[^1]: https://github.com/hauntsaninja/no_implicit_optional#whats-going-on