### PR TITLE
Enable non-multiview advanced shader group whenever advanced shaders are requested

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -853,7 +853,6 @@ void SceneShaderForwardClustered::set_default_specialization_constants(const Vec
 void SceneShaderForwardClustered::enable_advanced_shader_group(bool p_needs_multiview) {
 	if (p_needs_multiview || RendererCompositorRD::get_singleton()->is_xr_enabled()) {
 		shader.enable_group(SHADER_GROUP_ADVANCED_MULTIVIEW);
-	} else {
-		shader.enable_group(SHADER_GROUP_ADVANCED);
 	}
+	shader.enable_group(SHADER_GROUP_ADVANCED);
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84999

This is needed because xr_enabled does not guarantee that we won't use the non-multiview variants