### PR TITLE
[macOS] Check Apple specific version instead of generic clang version.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1012,6 +1012,11 @@ def get_compiler_version(env):
         "metadata1": None,
         "metadata2": None,
         "date": None,
+        "apple_major": -1,
+        "apple_minor": -1,
+        "apple_patch1": -1,
+        "apple_patch2": -1,
+        "apple_patch3": -1,
     }
 
     if not env.msvc:
@@ -1039,8 +1044,32 @@ def get_compiler_version(env):
         for key, value in match.groupdict().items():
             if value is not None:
                 ret[key] = value
+
+    match_apple = re.search(
+        r"(?:(?<=clang-)|(?<=\) )|(?<=^))"
+        r"(?P<apple_major>\d+)"
+        r"(?:\.(?P<apple_minor>\d*))?"
+        r"(?:\.(?P<apple_patch1>\d*))?"
+        r"(?:\.(?P<apple_patch2>\d*))?"
+        r"(?:\.(?P<apple_patch3>\d*))?",
+        version,
+    )
+    if match_apple is not None:
+        for key, value in match_apple.groupdict().items():
+            if value is not None:
+                ret[key] = value
+
     # Transform semantic versioning to integers
-    for key in ["major", "minor", "patch"]:
+    for key in [
+        "major",
+        "minor",
+        "patch",
+        "apple_major",
+        "apple_minor",
+        "apple_patch1",
+        "apple_patch2",
+        "apple_patch3",
+    ]:
         ret[key] = int(ret[key] or -1)
     return ret
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -121,12 +121,12 @@ def configure(env: "Environment"):
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
     cc_version = get_compiler_version(env)
-    cc_version_major = cc_version["major"]
-    cc_version_minor = cc_version["minor"]
+    cc_version_major = cc_version["apple_major"]
+    cc_version_minor = cc_version["apple_minor"]
     vanilla = is_vanilla_clang(env)
 
     # Workaround for Xcode 15 linker bug.
-    if not vanilla and cc_version_major == 15 and cc_version_minor == 0:
+    if not vanilla and cc_version_major == 1500 and cc_version_minor == 0:
         env.Prepend(LINKFLAGS=["-ld_classic"])
 
     env.Append(CCFLAGS=["-fobjc-arc"])


### PR DESCRIPTION
Follow up to #81968 (see https://github.com/godotengine/godot/issues/81948#issuecomment-1822205076). Should ensure that legacy linker is only used on Xcode 15.0.0 and 15.0.1, but not 15.1.x.