### PR TITLE
Avoid conflict between mingw-std-threads and Clang's own

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -530,7 +530,8 @@ Files extracted from upstream repository:
 - `mingw.shared_mutex.h`
 - `mingw.thread.h`
 
-Once copied, apply `no_except.patch` (needed because Godot is built without exceptions).
+Once copied, apply `godot.patch` (needed because Godot is built without exceptions
+and to avoid std:: replacements leak in Clang builds).
 
 
 ## minimp3

--- a/thirdparty/mingw-std-threads/godot.patch
+++ b/thirdparty/mingw-std-threads/godot.patch
@@ -1,7 +1,16 @@
 diff --git a/thirdparty/mingw-std-threads/mingw.condition_variable.h b/thirdparty/mingw-std-threads/mingw.condition_variable.h
-index 50c5ebd6df..f9e248c154 100644
+index 50c5ebd6df..d099fad2ec 100644
 --- a/thirdparty/mingw-std-threads/mingw.condition_variable.h
 +++ b/thirdparty/mingw-std-threads/mingw.condition_variable.h
+@@ -58,7 +58,7 @@
+ 
+ namespace mingw_stdthread
+ {
+-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
++#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
+ enum class cv_status { no_timeout, timeout };
+ #else
+ using std::cv_status;
 @@ -87,12 +87,12 @@ public:
          :   mSemaphore(CreateSemaphoreA(NULL, 0, 0xFFFF, NULL))
      {
@@ -26,8 +35,17 @@ index 50c5ebd6df..f9e248c154 100644
          }
      }
  public:
+@@ -547,7 +547,7 @@ namespace std
+ //  was none. Direct specification (std::), however, would be unaffected.
+ //    Take the safe option, and include only in the presence of MinGW's win32
+ //  implementation.
+-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
++#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
+ using mingw_stdthread::cv_status;
+ using mingw_stdthread::condition_variable;
+ using mingw_stdthread::condition_variable_any;
 diff --git a/thirdparty/mingw-std-threads/mingw.mutex.h b/thirdparty/mingw-std-threads/mingw.mutex.h
-index 03efa13f8b..73698d13cb 100644
+index 03efa13f8b..1e881e6c7d 100644
 --- a/thirdparty/mingw-std-threads/mingw.mutex.h
 +++ b/thirdparty/mingw-std-threads/mingw.mutex.h
 @@ -132,7 +132,7 @@ struct _OwnerThread
@@ -55,8 +73,17 @@ index 03efa13f8b..73698d13cb 100644
      }
      bool try_lock()
      {
+@@ -480,7 +480,7 @@ namespace std
+ //  was none. Direct specification (std::), however, would be unaffected.
+ //    Take the safe option, and include only in the presence of MinGW's win32
+ //  implementation.
+-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
++#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
+ using mingw_stdthread::recursive_mutex;
+ using mingw_stdthread::mutex;
+ using mingw_stdthread::recursive_timed_mutex;
 diff --git a/thirdparty/mingw-std-threads/mingw.shared_mutex.h b/thirdparty/mingw-std-threads/mingw.shared_mutex.h
-index ff1ac65135..5375b0fbd1 100644
+index ff1ac65135..ddc46bb826 100644
 --- a/thirdparty/mingw-std-threads/mingw.shared_mutex.h
 +++ b/thirdparty/mingw-std-threads/mingw.shared_mutex.h
 @@ -134,7 +134,7 @@ public:
@@ -98,12 +125,28 @@ index ff1ac65135..5375b0fbd1 100644
          mMutex->unlock_shared();
          mOwns = false;
      }
+@@ -484,10 +484,10 @@ namespace std
+ //  was none. Direct specification (std::), however, would be unaffected.
+ //    Take the safe option, and include only in the presence of MinGW's win32
+ //  implementation.
+-#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
++#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__))
+ using mingw_stdthread::shared_mutex;
+ #endif
+-#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
++#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__))
+ using mingw_stdthread::shared_timed_mutex;
+ using mingw_stdthread::shared_lock;
+ #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
 diff --git a/thirdparty/mingw-std-threads/mingw.thread.h b/thirdparty/mingw-std-threads/mingw.thread.h
-index bcdd1a36a8..7ca09e25f5 100644
+index bcdd1a36a8..60d2200db2 100644
 --- a/thirdparty/mingw-std-threads/mingw.thread.h
 +++ b/thirdparty/mingw-std-threads/mingw.thread.h
-@@ -196,7 +196,7 @@ public:
-             int errnum = errno;
+@@ -193,10 +193,9 @@ public:
+         if (int_handle == 0)
+         {
+             mHandle = kInvalidHandle;
+-            int errnum = errno;
              delete call;
  //  Note: Should only throw EINVAL, EAGAIN, EACCES
 -            throw std::system_error(errnum, std::generic_category());
@@ -111,7 +154,7 @@ index bcdd1a36a8..7ca09e25f5 100644
          } else {
              mThreadId.mId = id_receiver;
              mHandle = reinterpret_cast<HANDLE>(int_handle);
-@@ -213,11 +213,11 @@ public:
+@@ -213,11 +212,11 @@ public:
      {
          using namespace std;
          if (get_id() == id(GetCurrentThreadId()))
@@ -126,7 +169,7 @@ index bcdd1a36a8..7ca09e25f5 100644
          WaitForSingleObject(mHandle, kInfinite);
          CloseHandle(mHandle);
          mHandle = kInvalidHandle;
-@@ -266,7 +266,7 @@ moving another thread to it.\n");
+@@ -266,7 +265,7 @@ moving another thread to it.\n");
          if (!joinable())
          {
              using namespace std;
@@ -135,3 +178,12 @@ index bcdd1a36a8..7ca09e25f5 100644
          }
          if (mHandle != kInvalidHandle)
          {
+@@ -326,7 +325,7 @@ namespace std
+ //  was none. Direct specification (std::), however, would be unaffected.
+ //    Take the safe option, and include only in the presence of MinGW's win32
+ //  implementation.
+-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
++#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
+ using mingw_stdthread::thread;
+ //    Remove ambiguity immediately, to avoid problems arising from the above.
+ //using std::thread;

--- a/thirdparty/mingw-std-threads/mingw.condition_variable.h
+++ b/thirdparty/mingw-std-threads/mingw.condition_variable.h
@@ -58,7 +58,7 @@
 
 namespace mingw_stdthread
 {
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
 enum class cv_status { no_timeout, timeout };
 #else
 using std::cv_status;
@@ -547,7 +547,7 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
 using mingw_stdthread::cv_status;
 using mingw_stdthread::condition_variable;
 using mingw_stdthread::condition_variable_any;

--- a/thirdparty/mingw-std-threads/mingw.mutex.h
+++ b/thirdparty/mingw-std-threads/mingw.mutex.h
@@ -480,7 +480,7 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
 using mingw_stdthread::recursive_mutex;
 using mingw_stdthread::mutex;
 using mingw_stdthread::recursive_timed_mutex;

--- a/thirdparty/mingw-std-threads/mingw.shared_mutex.h
+++ b/thirdparty/mingw-std-threads/mingw.shared_mutex.h
@@ -484,10 +484,10 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__))
 using mingw_stdthread::shared_mutex;
 #endif
-#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__))
 using mingw_stdthread::shared_timed_mutex;
 using mingw_stdthread::shared_lock;
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition

--- a/thirdparty/mingw-std-threads/mingw.thread.h
+++ b/thirdparty/mingw-std-threads/mingw.thread.h
@@ -193,7 +193,6 @@ public:
         if (int_handle == 0)
         {
             mHandle = kInvalidHandle;
-            int errnum = errno;
             delete call;
 //  Note: Should only throw EINVAL, EAGAIN, EACCES
             __builtin_trap();
@@ -326,7 +325,7 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)
 using mingw_stdthread::thread;
 //    Remove ambiguity immediately, to avoid problems arising from the above.
 //using std::thread;


### PR DESCRIPTION
Since mingw-std-threads would inject its symbols into `std` if it thinks there's no other implementation around while using a MinGW compiler (`#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))`, it will break LLVM-MinGW builds. The reason is that LLVM-MinGW provides implementations but doesn't define `_GLIBCXX_HAS_GTHREADS`.

This PR rewrites the patch to change the check to ~`#if defined(__MINGW32__ ) && !(defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__))`~ (`#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS) && !defined(__clang__)`).

Another option would have been just not to use mingw-std-threads at all on LLVM-MinGW, but I see value in using the same implemention in both MinGW-style compilers. Other opinions welcome.