### PR TITLE
[iOS] Fix GDExtension init callback array reallocation.

### DIFF
--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -72,16 +72,15 @@ HashMap<String, void *> OS_IOS::dynamic_symbol_lookup_table;
 
 void add_ios_init_callback(init_callback cb) {
 	if (ios_init_callbacks_count == ios_init_callbacks_capacity) {
-		void *new_ptr = realloc(ios_init_callbacks, sizeof(cb) * 32);
+		void *new_ptr = realloc(ios_init_callbacks, sizeof(cb) * (ios_init_callbacks_capacity + 32));
 		if (new_ptr) {
 			ios_init_callbacks = (init_callback *)(new_ptr);
 			ios_init_callbacks_capacity += 32;
+		} else {
+			ERR_FAIL_MSG("Unable to allocate memory for extension callbacks.");
 		}
 	}
-	if (ios_init_callbacks_capacity > ios_init_callbacks_count) {
-		ios_init_callbacks[ios_init_callbacks_count] = cb;
-		++ios_init_callbacks_count;
-	}
+	ios_init_callbacks[ios_init_callbacks_count++] = cb;
 }
 
 void register_dynamic_symbol(char *name, void *address) {


### PR DESCRIPTION
It was always allocating 32 items, instead of adding 32.