### PR TITLE
Clear seeked/started flag after seeking/advancing in AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -534,10 +534,17 @@ void AnimationPlayer::seek(double p_time, bool p_update, bool p_update_only) {
 		}
 	}
 
+	playback.started = false; // Start has already gone by seeking, delta does not need to be 0 in the internal process.
 	playback.seeked = true;
 	if (p_update) {
 		_process_animation(0, p_update_only);
+		playback.seeked = false; // If animation was proceeded here, no more seek in internal process.
 	}
+}
+
+void AnimationPlayer::advance(double p_time) {
+	playback.started = false; // Start has already gone by advancing, delta does not need to be 0 in the internal process.
+	AnimationMixer::advance(p_time);
 }
 
 bool AnimationPlayer::is_valid() const {

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -183,6 +183,8 @@ public:
 
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
+	virtual void advance(double p_time) override;
+
 	AnimationPlayer();
 	~AnimationPlayer();
 };


### PR DESCRIPTION
- Fixes #85050
- Fixes #85052

`play()` does not immediately process the animation, but waits for the internal process. The flags are cleared at this time, but if a process is interrupted by `seek()` or `advance()` in the meantime, the flags will become broken. Fixed.