### PR TITLE
Avoid dangling lambda-script links when former destroyed earlier

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -125,16 +125,17 @@ class GDScript : public Script {
 	};
 	struct UpdatableFuncPtrElement {
 		List<GDScriptFunction **>::Element *element = nullptr;
-		Mutex *mutex = nullptr;
+		List<UpdatableFuncPtrElement>::Element **element_ptr = nullptr;
+		Mutex *thread_mutex = nullptr;
+		Mutex *script_mutex = nullptr;
 	};
 	static thread_local UpdatableFuncPtr func_ptrs_to_update_thread_local;
-	static thread_local LocalVector<List<UpdatableFuncPtr *>::Element> func_ptrs_to_update_entries_thread_local;
 	static UpdatableFuncPtr *func_ptrs_to_update_main_thread;
 	List<UpdatableFuncPtr *> func_ptrs_to_update;
 	List<UpdatableFuncPtrElement> func_ptrs_to_update_elems;
 	Mutex func_ptrs_to_update_mutex;
 
-	List<UpdatableFuncPtrElement>::Element *_add_func_ptr_to_update(GDScriptFunction **p_func_ptr_ptr);
+	void _add_func_ptr_to_update(GDScriptFunction **p_func_ptr_ptr, List<UpdatableFuncPtrElement>::Element **r_element_ptr);
 	static void _remove_func_ptr_to_update(List<UpdatableFuncPtrElement>::Element *p_func_ptr_element);
 
 	static void _fixup_thread_function_bookkeeping();

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -148,11 +148,13 @@ GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptF
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 
-	updatable_func_ptr_element = p_script->_add_func_ptr_to_update(&function);
+	p_script->_add_func_ptr_to_update(&function, &updatable_func_ptr_element);
 }
 
 GDScriptLambdaCallable::~GDScriptLambdaCallable() {
-	GDScript::_remove_func_ptr_to_update(updatable_func_ptr_element);
+	if (updatable_func_ptr_element) {
+		GDScript::_remove_func_ptr_to_update(updatable_func_ptr_element);
+	}
 }
 
 bool GDScriptLambdaSelfCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
@@ -276,7 +278,7 @@ GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, G
 
 	GDScript *gds = p_function->get_script();
 	if (gds != nullptr) {
-		updatable_func_ptr_element = gds->_add_func_ptr_to_update(&function);
+		gds->_add_func_ptr_to_update(&function, &updatable_func_ptr_element);
 	}
 }
 
@@ -291,7 +293,7 @@ GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Object *p_self, GDScriptF
 
 	GDScript *gds = p_function->get_script();
 	if (gds != nullptr) {
-		updatable_func_ptr_element = gds->_add_func_ptr_to_update(&function);
+		gds->_add_func_ptr_to_update(&function, &updatable_func_ptr_element);
 	}
 }
 


### PR DESCRIPTION
Additionally, mutex usage is made more correct.

Fixes #85151.

Tested the following recent related bugs are still gone after this PR (plus no address sanitizer issues detected);
- #84046
- #84190
- #85112

Again, given how convoluted all this is, serious testing is welcome with real-world projects, hot reloading, etc., etc.