### PR TITLE
Fix crash caused by conflicting menu option IDs

### DIFF
--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -146,8 +146,8 @@ class EditorScriptPicker : public EditorResourcePicker {
 	GDCLASS(EditorScriptPicker, EditorResourcePicker);
 
 	enum ExtraMenuOption {
-		OBJ_MENU_NEW_SCRIPT = 10,
-		OBJ_MENU_EXTEND_SCRIPT = 11
+		OBJ_MENU_NEW_SCRIPT = 50,
+		OBJ_MENU_EXTEND_SCRIPT = 51
 	};
 
 	Node *script_owner = nullptr;
@@ -169,7 +169,7 @@ class EditorShaderPicker : public EditorResourcePicker {
 	GDCLASS(EditorShaderPicker, EditorResourcePicker);
 
 	enum ExtraMenuOption {
-		OBJ_MENU_NEW_SHADER = 10,
+		OBJ_MENU_NEW_SHADER = 50,
 	};
 
 	ShaderMaterial *edited_material = nullptr;


### PR DESCRIPTION
Regression from #85150
Trying to make new Script or new Shader was interpreted as Show in Filesystem (which shifted to 10) and resulted in `get_path()` call on null resource.