### PR TITLE
Don't insert newline while saving

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1812,9 +1812,7 @@ static void _reset_animation_mixers(Node *p_node, List<Pair<AnimationMixer *, Re
 }
 
 void EditorNode::_save_scene(String p_file, int idx) {
-	if (!saving_scene.is_empty() && saving_scene == p_file) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!saving_scene.is_empty() && saving_scene == p_file, "Scene saved while already being saved!");
 
 	Node *scene = editor_data.get_edited_scene_root(idx);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1012,8 +1012,6 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			se->trim_final_newlines();
 		}
 
-		se->insert_final_newline();
-
 		if (convert_indent_on_save) {
 			se->convert_indent();
 		}
@@ -1409,8 +1407,6 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (trim_final_newlines_on_save) {
 					current->trim_final_newlines();
 				}
-
-				current->insert_final_newline();
 
 				if (convert_indent_on_save) {
 					current->convert_indent();
@@ -2614,8 +2610,6 @@ void ScriptEditor::save_current_script() {
 		current->trim_final_newlines();
 	}
 
-	current->insert_final_newline();
-
 	if (convert_indent_on_save) {
 		current->convert_indent();
 	}
@@ -2661,8 +2655,6 @@ void ScriptEditor::save_all_scripts() {
 		if (trim_final_newlines_on_save) {
 			se->trim_final_newlines();
 		}
-
-		se->insert_final_newline();
 
 		if (!se->is_unsaved()) {
 			continue;
@@ -2713,6 +2705,7 @@ void ScriptEditor::apply_scripts() const {
 		if (!se) {
 			continue;
 		}
+		se->insert_final_newline();
 		se->apply_code();
 	}
 }


### PR DESCRIPTION
Follow-up to #85154

Changes the new check into an error; saving while saving is now invalid behavior. I tweaked Script Editor to avoid the new error. There might be some cases when the newline is not applied correctly, but it's probably rare and harmless. Saving script in Script Editor does call `apply_changes()`.