### PR TITLE
[3.x] Enhance mobile suspend MainLoop notifications

### DIFF
--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -201,11 +201,12 @@
 		</constant>
 		<constant name="NOTIFICATION_APP_RESUMED" value="1014">
 			Notification received from the OS when the app is resumed.
-			Specific to the Android platform.
+			Specific to mobile platforms.
 		</constant>
 		<constant name="NOTIFICATION_APP_PAUSED" value="1015">
 			Notification received from the OS when the app is paused.
-			Specific to the Android platform.
+			Specific to mobile platforms.
+			[b]Note:[/b] On iOS, you only have approximately 5 seconds to finish a task started by this signal. If you go over this allotment, iOS will kill the app instead of pausing it.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -928,11 +928,12 @@
 		</constant>
 		<constant name="NOTIFICATION_APP_RESUMED" value="1014">
 			Notification received from the OS when the app is resumed.
-			Specific to the Android platform.
+			Specific to mobile platforms.
 		</constant>
 		<constant name="NOTIFICATION_APP_PAUSED" value="1015">
 			Notification received from the OS when the app is paused.
-			Specific to the Android platform.
+			Specific to mobile platforms.
+			[b]Note:[/b] On iOS, you only have approximately 5 seconds to finish a task started by this signal. If you go over this allotment, iOS will kill the app instead of pausing it.
 		</constant>
 		<constant name="PAUSE_MODE_INHERIT" value="0" enum="PauseMode">
 			Inherits pause mode from the node's parent. For the root node, it is equivalent to [constant PAUSE_MODE_STOP]. Default.

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -145,6 +145,14 @@ static ViewController *mainViewController = nil;
 	OSIPhone::get_singleton()->on_focus_in();
 }
 
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+	OSIPhone::get_singleton()->on_enter_background();
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+	OSIPhone::get_singleton()->on_exit_background();
+}
+
 - (void)dealloc {
 	self.window = nil;
 }

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -204,6 +204,9 @@ public:
 
 	void on_focus_out();
 	void on_focus_in();
+
+	void on_enter_background();
+	void on_exit_background();
 };
 
 #endif // IPHONE_ENABLED

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -861,4 +861,24 @@ void OSIPhone::on_focus_in() {
 	}
 }
 
+void OSIPhone::on_enter_background() {
+	// Do not check for is_focused, because on_focus_out will always be fired first by applicationWillResignActive.
+
+	if (get_main_loop()) {
+		get_main_loop()->notification(MainLoop::NOTIFICATION_APP_PAUSED);
+	}
+
+	on_focus_out();
+}
+
+void OSIPhone::on_exit_background() {
+	if (!is_focused) {
+		on_focus_in();
+
+		if (get_main_loop()) {
+			get_main_loop()->notification(MainLoop::NOTIFICATION_APP_RESUMED);
+		}
+	}
+}
+
 #endif


### PR DESCRIPTION
Backport of #85100 for 3.x. `NOTIFICATION_APPLICATION_FOCUS_OUT` and `NOTIFICATION_APPLICATION_FOCUS_IN` do not exist in 3.x, so it is just adding `APP_PAUSED` and `APP_RESUMED` to iOS.