### PR TITLE
[3.x] [iOS] Make `OSIPhone::get_screen_refresh_rate` respect iOS Low Power Mode

### DIFF
--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -653,7 +653,11 @@ int OSIPhone::get_screen_dpi(int p_screen) const {
 }
 
 float OSIPhone::get_screen_refresh_rate(int p_screen) const {
-	return [UIScreen mainScreen].maximumFramesPerSecond;
+	float fps = [UIScreen mainScreen].maximumFramesPerSecond;
+	if ([NSProcessInfo processInfo].lowPowerModeEnabled) {
+		fps = 60;
+	}
+	return fps;
 }
 
 Rect2 OSIPhone::get_window_safe_area() const {


### PR DESCRIPTION
Backport of #85026 for 3.x.