### PR TITLE
Use the flat button style on switches in scene and node docks

### DIFF
--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -104,7 +104,7 @@ NodeDock::NodeDock() {
 	mode_hb->hide();
 
 	connections_button = memnew(Button);
-	connections_button->set_flat(true);
+	connections_button->set_theme_type_variation("FlatButton");
 	connections_button->set_text(TTR("Signals"));
 	connections_button->set_toggle_mode(true);
 	connections_button->set_pressed(true);
@@ -114,7 +114,7 @@ NodeDock::NodeDock() {
 	connections_button->connect("pressed", callable_mp(this, &NodeDock::show_connections));
 
 	groups_button = memnew(Button);
-	groups_button->set_flat(true);
+	groups_button->set_theme_type_variation("FlatButton");
 	groups_button->set_text(TTR("Groups"));
 	groups_button->set_toggle_mode(true);
 	groups_button->set_pressed(false);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -4031,21 +4031,21 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	vbc->add_child(button_hb);
 
 	edit_remote = memnew(Button);
-	edit_remote->set_flat(true);
-	button_hb->add_child(edit_remote);
+	edit_remote->set_theme_type_variation("FlatButton");
 	edit_remote->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_remote->set_text(TTR("Remote"));
 	edit_remote->set_toggle_mode(true);
 	edit_remote->set_tooltip_text(TTR("If selected, the Remote scene tree dock will cause the project to stutter every time it updates.\nSwitch back to the Local scene tree dock to improve performance."));
+	button_hb->add_child(edit_remote);
 	edit_remote->connect("pressed", callable_mp(this, &SceneTreeDock::_remote_tree_selected));
 
 	edit_local = memnew(Button);
-	edit_local->set_flat(true);
-	button_hb->add_child(edit_local);
+	edit_local->set_theme_type_variation("FlatButton");
 	edit_local->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_local->set_text(TTR("Local"));
 	edit_local->set_toggle_mode(true);
 	edit_local->set_pressed(true);
+	button_hb->add_child(edit_local);
 	edit_local->connect("pressed", callable_mp(this, &SceneTreeDock::_local_tree_selected));
 
 	remote_tree = nullptr;


### PR DESCRIPTION
A follow-up to https://github.com/godotengine/godot/pull/81939.

So I have always found these two buttons to be awkwardly designed. A lot of empty space, no panels, just accented text to show which is active. Never arrived to a better design myself, but now that we have the `FlatButton` style, thanks to https://github.com/godotengine/godot/pull/81939, I think it would be appropriate to use it here.

It still feels a bit disconnected, but I think this is still better and it uses a consistent style from other parts of the editor. So should be a safe choice for now.

<img width="218" alt="NVIDIA_Share_2023-11-22_19-40-00" src="https://github.com/godotengine/godot/assets/11782833/c31fb285-a6fa-4a41-9960-1a2ca44de59b">



https://github.com/godotengine/godot/assets/11782833/a53e2d47-7a1f-4195-af63-60a440d8ab77

