### PR TITLE
Fix example in `NodePath.get_name()` documentation

### DIFF
--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -121,13 +121,13 @@
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D")
 				print(node_path.get_name(0)) # Path2D
 				print(node_path.get_name(1)) # PathFollow2D
-				print(node_path.get_name(2)) # Sprite
+				print(node_path.get_name(2)) # Sprite2D
 				[/gdscript]
 				[csharp]
 				var nodePath = new NodePath("Path2D/PathFollow2D/Sprite2D");
 				GD.Print(nodePath.GetName(0)); // Path2D
 				GD.Print(nodePath.GetName(1)); // PathFollow2D
-				GD.Print(nodePath.GetName(2)); // Sprite
+				GD.Print(nodePath.GetName(2)); // Sprite2D
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
The output of `node_path.get_name(2)` is stated to be `Sprite`, but the actual output is `Sprite2D`.