### PR TITLE
Suppress surface upgrade warnings when showing SurfaceUpgradeTool warning

### DIFF
--- a/editor/surface_upgrade_tool.cpp
+++ b/editor/surface_upgrade_tool.cpp
@@ -76,6 +76,7 @@ void SurfaceUpgradeTool::_try_show_popup() {
 	} else {
 		singleton->_show_popup();
 	}
+	RS::get_singleton()->set_warn_on_surface_upgrade(false);
 }
 
 void SurfaceUpgradeTool::_show_popup() {
@@ -122,11 +123,13 @@ void SurfaceUpgradeTool::finish_upgrade() {
 
 	// Update all meshes here.
 	Vector<String> resave_paths = EditorSettings::get_singleton()->get_project_metadata("surface_upgrade_tool", "resave_paths", Vector<String>());
-	EditorProgress ep("surface_upgrade_resave", TTR("Upgrading All Meshes in Project"), resave_paths.size());
+	Vector<String> reimport_paths = EditorSettings::get_singleton()->get_project_metadata("surface_upgrade_tool", "reimport_paths", Vector<String>());
+	EditorProgress ep("surface_upgrade_resave", TTR("Upgrading All Meshes in Project"), resave_paths.size() + reimport_paths.size());
 
+	int step = 0;
 	for (const String &file_path : resave_paths) {
 		Ref<Resource> res = ResourceLoader::load(file_path);
-		ep.step(TTR("Attempting to re-save ") + file_path);
+		ep.step(TTR("Attempting to re-save ") + file_path, step++);
 		if (res.is_valid()) {
 			// Ignore things that fail to load.
 			ResourceSaver::save(res);
@@ -135,7 +138,6 @@ void SurfaceUpgradeTool::finish_upgrade() {
 	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "resave_paths", Vector<String>());
 
 	// Remove the imported scenes/meshes from .import so they will be reimported automatically after this.
-	Vector<String> reimport_paths = EditorSettings::get_singleton()->get_project_metadata("surface_upgrade_tool", "reimport_paths", Vector<String>());
 	for (const String &file_path : reimport_paths) {
 		Ref<ConfigFile> config;
 		config.instantiate();
@@ -149,6 +151,8 @@ void SurfaceUpgradeTool::finish_upgrade() {
 		if (remap_path.is_empty()) {
 			continue;
 		}
+
+		ep.step(TTR("Attempting to remove ") + remap_path, step++);
 
 		String path = OS::get_singleton()->get_resource_dir() + remap_path.replace_first("res://", "/");
 		print_verbose("Moving to trash: " + path);


### PR DESCRIPTION
This fixes the warning spam reported here: https://github.com/godotengine/godot/pull/85222#issuecomment-1823451782

The problem comes from the fact that the SurfaceUpgradeTool callback was called for each out of date surface and the old surface-specific warning was still shown to the user.

This PR ensures that, if the surface update callback is handled, the only warning shown to the user is the own pointing them at the SurfaceUpgradeTool. We don't need the old per-surface warning in this case as the user can fix all meshes by running the tool. 

The RenderingServer still has the warning for cases where the scene is run outside the editor. 

![Screenshot from 2023-11-22 15-10-26](https://github.com/godotengine/godot/assets/16521339/c30a34d8-d131-4b76-acb0-9dabb13c3372)

This also updates the EditorProgress dialogue that runs after the upgrade tool is run. Previously it would start at 100%, then run through re-saving all the files (locked at 100%), then would appear to freeze while deleting the .import files. Now it properly progresses through re-saving all the files, and shows progress while deleting files. 
