### PR TITLE
[Navigation] Do not use travel cost for minimum when re-selecting end point

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -372,7 +372,7 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 
 		// Stores the further reachable end polygon, in case our goal is not reachable.
 		if (is_reachable) {
-			real_t d = navigation_polys[least_cost_id].entry.distance_to(p_destination) * navigation_polys[least_cost_id].poly->owner->get_travel_cost();
+			real_t d = navigation_polys[least_cost_id].entry.distance_to(p_destination);
 			if (reachable_d > d) {
 				reachable_d = d;
 				reachable_end = navigation_polys[least_cost_id].poly;


### PR DESCRIPTION
This one liner PR fixes the bug, explained here https://github.com/godotengine/godot/issues/85238

Here is a screenshot of the same scene mentioned in the bug, but with the fix applied, please read the [attached bug](https://github.com/godotengine/godot/issues/85238) for an explanation of the issue and for a minimal project to test.

<img width="962" alt="image" src="https://github.com/godotengine/godot/assets/6596836/f8ccf993-493e-4cb4-b09b-072a569a5534">

*Bugsquad edit:*
- Fixes #85238