### PR TITLE
Fix crash when hiding a Control during mouse-entering

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3207,7 +3207,9 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 			}
 
 			// Send Mouse Enter Self notification.
-			gui.mouse_over->notification(Control::NOTIFICATION_MOUSE_ENTER_SELF);
+			if (gui.mouse_over) {
+				gui.mouse_over->notification(Control::NOTIFICATION_MOUSE_ENTER_SELF);
+			}
 
 			notify_embedded_viewports = true;
 		}


### PR DESCRIPTION
`gui.mouse_over` can be set to `nullptr` in the `NOTIFICATION_MOUSE_ENTER`- user-callback a few lines above. This case was previously not handled.

resolve #85277