### PR TITLE
Show names of files in the remove files confirmation dialog

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_settings.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "scene/gui/margin_container.h"
+#include "scene/gui/separator.h"
 
 void DependencyEditor::_searched(const String &p_path) {
 	HashMap<String, String> dep_rename;
@@ -531,6 +532,22 @@ void DependencyRemoveDialog::_build_removed_dependency_tree(const Vector<Removed
 	}
 }
 
+void DependencyRemoveDialog::show_delete_list() {
+	to_be_deleted_files->clear();
+
+	for (const String &s : files_to_delete) {
+		String t = s.substr(s.rfind("/") + 1);
+		to_be_deleted_files->add_item(t);
+	}
+
+	for (const String &s : dirs_to_delete) {
+		String t = s.substr(s.rfind("/", s.length() - 2) + 1);
+		to_be_deleted_files->add_item(t);
+	}
+
+	to_be_deleted_files->show();
+}
+
 void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<String> &p_files) {
 	all_remove_files.clear();
 	dirs_to_delete.clear();
@@ -551,6 +568,9 @@ void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<
 	_find_all_removed_dependencies(EditorFileSystem::get_singleton()->get_filesystem(), removed_deps);
 	_find_localization_remaps_of_removed_files(removed_deps);
 	removed_deps.sort();
+
+	show_delete_list();
+
 	if (removed_deps.is_empty()) {
 		owners->hide();
 		text->set_text(TTR("Remove the selected files from the project? (Cannot be undone.)\nDepending on your filesystem configuration, the files will either be moved to the system trash or deleted permanently."));
@@ -665,10 +685,22 @@ DependencyRemoveDialog::DependencyRemoveDialog() {
 	set_ok_button_text(TTR("Remove"));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
+	vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_child(vb);
 
 	text = memnew(Label);
 	vb->add_child(text);
+
+	Label *lbl = memnew(Label);
+	lbl->set_theme_type_variation("HeaderSmall");
+	lbl->set_text("Files to be deleted:");
+	vb->add_child(lbl);
+
+	to_be_deleted_files = memnew(ItemList);
+	to_be_deleted_files->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	to_be_deleted_files->set_auto_height(true);
+	to_be_deleted_files->hide();
+	vb->add_child(to_be_deleted_files);
 
 	owners = memnew(Tree);
 	owners->set_hide_root(true);

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -103,6 +103,8 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 	Label *text = nullptr;
 	Tree *owners = nullptr;
 
+	ItemList *to_be_deleted_files = nullptr;
+
 	HashMap<String, String> all_remove_files;
 	Vector<String> dirs_to_delete;
 	Vector<String> files_to_delete;
@@ -126,6 +128,7 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 	void _find_all_removed_dependencies(EditorFileSystemDirectory *efsd, Vector<RemovedDependency> &p_removed);
 	void _find_localization_remaps_of_removed_files(Vector<RemovedDependency> &p_removed);
 	void _build_removed_dependency_tree(const Vector<RemovedDependency> &p_removed);
+	void show_delete_list();
 
 	void ok_pressed() override;
 


### PR DESCRIPTION
Resolves #85261

Note the whole message is a TTR and I think it's better not break it, so have to add the filenames below that messgae.

It looks like this now:

![image](https://github.com/godotengine/godot/assets/8315986/e6d146d6-c715-4bbd-a97f-bcf0c85acb85)

I do feel it's can be improved in UX perspective, maybe I should use RichTextlabel and at least make theses filenames bold.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
