### PR TITLE
Perform safe copies in `AnimatedValuesBackup::get_cache_copy()`

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2166,8 +2166,7 @@ AnimationMixer::TrackCache *AnimatedValuesBackup::get_cache_copy(AnimationMixer:
 	switch (p_cache->type) {
 		case Animation::TYPE_VALUE: {
 			AnimationMixer::TrackCacheValue *src = static_cast<AnimationMixer::TrackCacheValue *>(p_cache);
-			AnimationMixer::TrackCacheValue *tc = memnew(AnimationMixer::TrackCacheValue);
-			memcpy((void *)tc, (void *)src, sizeof(AnimationMixer::TrackCacheValue));
+			AnimationMixer::TrackCacheValue *tc = memnew(AnimationMixer::TrackCacheValue(*src));
 			return tc;
 		}
 
@@ -2175,29 +2174,25 @@ AnimationMixer::TrackCache *AnimatedValuesBackup::get_cache_copy(AnimationMixer:
 		case Animation::TYPE_ROTATION_3D:
 		case Animation::TYPE_SCALE_3D: {
 			AnimationMixer::TrackCacheTransform *src = static_cast<AnimationMixer::TrackCacheTransform *>(p_cache);
-			AnimationMixer::TrackCacheTransform *tc = memnew(AnimationMixer::TrackCacheTransform);
-			memcpy((void *)tc, (void *)src, sizeof(AnimationMixer::TrackCacheTransform));
+			AnimationMixer::TrackCacheTransform *tc = memnew(AnimationMixer::TrackCacheTransform(*src));
 			return tc;
 		}
 
 		case Animation::TYPE_BLEND_SHAPE: {
 			AnimationMixer::TrackCacheBlendShape *src = static_cast<AnimationMixer::TrackCacheBlendShape *>(p_cache);
-			AnimationMixer::TrackCacheBlendShape *tc = memnew(AnimationMixer::TrackCacheBlendShape);
-			memcpy((void *)tc, (void *)src, sizeof(AnimationMixer::TrackCacheBlendShape));
+			AnimationMixer::TrackCacheBlendShape *tc = memnew(AnimationMixer::TrackCacheBlendShape(*src));
 			return tc;
 		}
 
 		case Animation::TYPE_BEZIER: {
 			AnimationMixer::TrackCacheBezier *src = static_cast<AnimationMixer::TrackCacheBezier *>(p_cache);
-			AnimationMixer::TrackCacheBezier *tc = memnew(AnimationMixer::TrackCacheBezier);
-			memcpy((void *)tc, (void *)src, sizeof(AnimationMixer::TrackCacheBezier));
+			AnimationMixer::TrackCacheBezier *tc = memnew(AnimationMixer::TrackCacheBezier(*src));
 			return tc;
 		}
 
 		case Animation::TYPE_AUDIO: {
 			AnimationMixer::TrackCacheAudio *src = static_cast<AnimationMixer::TrackCacheAudio *>(p_cache);
-			AnimationMixer::TrackCacheAudio *tc = memnew(AnimationMixer::TrackCacheAudio);
-			memcpy((void *)tc, (void *)src, sizeof(AnimationMixer::TrackCacheAudio));
+			AnimationMixer::TrackCacheAudio *tc = memnew(AnimationMixer::TrackCacheAudio(*src));
 			return tc;
 		}
 

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -142,6 +142,15 @@ protected:
 		ObjectID object_id;
 		real_t total_weight = 0.0;
 
+		TrackCache() = default;
+		TrackCache(const TrackCache &p_other) :
+				root_motion(p_other.root_motion),
+				setup_pass(p_other.setup_pass),
+				type(p_other.type),
+				object(p_other.object),
+				object_id(p_other.object_id),
+				total_weight(p_other.total_weight) {}
+
 		virtual ~TrackCache() {}
 	};
 
@@ -161,6 +170,24 @@ protected:
 		Quaternion rot;
 		Vector3 scale;
 
+		TrackCacheTransform(const TrackCacheTransform &p_other) :
+				TrackCache(p_other),
+#ifndef _3D_DISABLED
+				node_3d(p_other.node_3d),
+				skeleton(p_other.skeleton),
+#endif
+				bone_idx(p_other.bone_idx),
+				loc_used(p_other.loc_used),
+				rot_used(p_other.rot_used),
+				scale_used(p_other.scale_used),
+				init_loc(p_other.init_loc),
+				init_rot(p_other.init_rot),
+				init_scale(p_other.init_scale),
+				loc(p_other.loc),
+				rot(p_other.rot),
+				scale(p_other.scale) {
+		}
+
 		TrackCacheTransform() {
 			type = Animation::TYPE_POSITION_3D;
 		}
@@ -178,6 +205,14 @@ protected:
 		float init_value = 0;
 		float value = 0;
 		int shape_index = -1;
+
+		TrackCacheBlendShape(const TrackCacheBlendShape &p_other) :
+				TrackCache(p_other),
+				mesh_3d(p_other.mesh_3d),
+				init_value(p_other.init_value),
+				value(p_other.value),
+				shape_index(p_other.shape_index) {}
+
 		TrackCacheBlendShape() { type = Animation::TYPE_BLEND_SHAPE; }
 		~TrackCacheBlendShape() {}
 	};
@@ -189,6 +224,16 @@ protected:
 		bool is_continuous = false;
 		bool is_using_angle = false;
 		Variant element_size;
+
+		TrackCacheValue(const TrackCacheValue &p_other) :
+				TrackCache(p_other),
+				init_value(p_other.init_value),
+				value(p_other.value),
+				subpath(p_other.subpath),
+				is_continuous(p_other.is_continuous),
+				is_using_angle(p_other.is_using_angle),
+				element_size(p_other.element_size) {}
+
 		TrackCacheValue() { type = Animation::TYPE_VALUE; }
 		~TrackCacheValue() {
 			// Clear ref to avoid leaking.
@@ -206,6 +251,13 @@ protected:
 		real_t init_value = 0.0;
 		real_t value = 0.0;
 		Vector<StringName> subpath;
+
+		TrackCacheBezier(const TrackCacheBezier &p_other) :
+				TrackCache(p_other),
+				init_value(p_other.init_value),
+				value(p_other.value),
+				subpath(p_other.subpath) {}
+
 		TrackCacheBezier() {
 			type = Animation::TYPE_BEZIER;
 		}
@@ -234,6 +286,12 @@ protected:
 		Ref<AudioStreamPolyphonic> audio_stream;
 		Ref<AudioStreamPlaybackPolyphonic> audio_stream_playback;
 		HashMap<ObjectID, PlayingAudioTrackInfo> playing_streams; // Key is Animation resource ObjectID.
+
+		TrackCacheAudio(const TrackCacheAudio &p_other) :
+				TrackCache(p_other),
+				audio_stream(p_other.audio_stream),
+				audio_stream_playback(p_other.audio_stream_playback),
+				playing_streams(p_other.playing_streams) {}
 
 		TrackCacheAudio() {
 			type = Animation::TYPE_AUDIO;


### PR DESCRIPTION
`memcpy()`ing those types is potentially catastrophic.

For more context, see the discussion here: https://github.com/godotengine/godot/pull/85266#discussion_r1403526910