### PR TITLE
Detect proxy settings from environment variables

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -57,6 +57,10 @@ void HTTPClient::set_https_proxy(const String &p_host, int p_port) {
 	WARN_PRINT("HTTPS proxy feature is not available");
 }
 
+void HTTPClient::load_default_proxies() {
+	// Do nothing if not implemented.
+}
+
 Error HTTPClient::_request_raw(Method p_method, const String &p_url, const Vector<String> &p_headers, const Vector<uint8_t> &p_body) {
 	int size = p_body.size();
 	return request(p_method, p_url, p_headers, size > 0 ? p_body.ptr() : nullptr, size);
@@ -164,6 +168,7 @@ void HTTPClient::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPClient::set_http_proxy);
 	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPClient::set_https_proxy);
+	ClassDB::bind_method(D_METHOD("load_default_proxies"), &HTTPClient::load_default_proxies);
 
 	ClassDB::bind_method(D_METHOD("query_string_from_dict", "fields"), &HTTPClient::query_string_from_dict);
 

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -197,6 +197,7 @@ public:
 	// Use empty string or -1 to unset
 	virtual void set_http_proxy(const String &p_host, int p_port);
 	virtual void set_https_proxy(const String &p_host, int p_port);
+	virtual void load_default_proxies();
 
 	HTTPClient() {}
 	virtual ~HTTPClient() {}

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -98,6 +98,7 @@ public:
 	Error poll() override;
 	void set_http_proxy(const String &p_host, int p_port) override;
 	void set_https_proxy(const String &p_host, int p_port) override;
+	void load_default_proxies() override;
 	HTTPClientTCP();
 };
 

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -700,13 +700,17 @@
 		<member name="network/debug/remote_port" type="int" setter="" getter="">
 			The port to listen to when starting the remote debugger. Godot will try to use port numbers above the configured number if the configured number is already taken by another application.
 		</member>
+		<member name="network/http_proxy/auto_detect" type="bool" setter="" getter="">
+			If [code]true[/code], detects system proxy settings (for the asset library and export template downloads).
+			[b]Note:[/b] Godot currently supports loading proxy settings from environment variables. See [method HTTPClient.load_default_proxies].
+		</member>
 		<member name="network/http_proxy/host" type="String" setter="" getter="">
 			The host to use to contact the HTTP and HTTPS proxy in the editor (for the asset library and export template downloads). See also [member network/http_proxy/port].
-			[b]Note:[/b] Godot currently doesn't automatically use system proxy settings, so you have to enter them manually here if needed.
+			[b]Note:[/b] This overrides the system proxy settings detected by [member network/http_proxy/auto_detect].
 		</member>
 		<member name="network/http_proxy/port" type="int" setter="" getter="">
 			The port number to use to contact the HTTP and HTTPS proxy in the editor (for the asset library and export template downloads). See also [member network/http_proxy/host].
-			[b]Note:[/b] Godot currently doesn't automatically use system proxy settings, so you have to enter them manually here if needed.
+			[b]Note:[/b] This overrides the system proxy settings detected by [member network/http_proxy/auto_detect].
 		</member>
 		<member name="network/tls/editor_tls_certificates" type="String" setter="" getter="">
 			The TLS certificate bundle to use for HTTP requests made within the editor (e.g. from the AssetLib tab). If left empty, the [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]included Mozilla certificate bundle[/url] will be used.

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -87,6 +87,14 @@
 				If [code]true[/code], this [HTTPClient] has a response that is chunked.
 			</description>
 		</method>
+		<method name="load_default_proxies">
+			<return type="void" />
+			<description>
+				Sets HTTP and HTTPS proxies according to environment variables. Does not override existing proxies.
+				[b]Note:[/b] HTTP proxy is detected from [code]http_proxy[/code], [code]HTTP_PROXY[/code], [code]all_proxy[/code], [code]ALL_PROXY[/code] environment variables. HTTPS proxy is detected from [code]https_proxy[/code], [code]HTTPS_PROXY[/code], [code]all_proxy[/code], [code]ALL_PROXY[/code] environment variables.
+				[b]Note:[/b] This method is not supported on the web platform. It does nothing.
+			</description>
+		</method>
 		<method name="poll">
 			<return type="int" enum="Error" />
 			<description>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -182,6 +182,14 @@
 				Returns the current status of the underlying [HTTPClient]. See [enum HTTPClient.Status].
 			</description>
 		</method>
+		<method name="load_default_proxies">
+			<return type="void" />
+			<description>
+				Sets HTTP and HTTPS proxies according to environment variables. Does not override existing proxies.
+				[b]Note:[/b] HTTP proxy is detected from [code]http_proxy[/code], [code]HTTP_PROXY[/code], [code]all_proxy[/code], [code]ALL_PROXY[/code] environment variables. HTTPS proxy is detected from [code]https_proxy[/code], [code]HTTPS_PROXY[/code], [code]all_proxy[/code], [code]ALL_PROXY[/code] environment variables.
+				[b]Note:[/b] This method is not supported on the web platform. It does nothing.
+			</description>
+		</method>
 		<method name="request">
 			<return type="int" enum="Error" />
 			<param index="0" name="url" type="String" />
@@ -238,6 +246,10 @@
 			Any Response body declaring a [code]Content-Encoding[/code] of either [code]gzip[/code] or [code]deflate[/code] will then be automatically decompressed, and the uncompressed bytes will be delivered via [signal request_completed].
 			If the user has specified their own [code]Accept-Encoding[/code] header, then no header will be added regardless of [member accept_gzip].
 			If [code]false[/code] no header will be added, and no decompression will be performed on response bodies. The raw bytes of the response body will be returned via [signal request_completed].
+		</member>
+		<member name="auto_detect_proxies" type="bool" setter="set_auto_detect_proxies" getter="get_auto_detect_proxies" default="true">
+			If [code]true[/code], detects system proxy when the scene loads.
+			[b]Note:[/b] Godot currently supports loading proxy settings from environment variables. See [method load_default_proxies].
 		</member>
 		<member name="body_size_limit" type="int" setter="set_body_size_limit" getter="get_body_size_limit" default="-1">
 			Maximum allowed size for response bodies. If the response body is compressed, this will be used as the maximum allowed size for the decompressed body.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -776,6 +776,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "debugger/remote_inspect_refresh_interval", 0.2, "0.02,10,0.01,or_greater")
 
 	// HTTP Proxy
+	_initial_set("network/http_proxy/auto_detect", true);
 	_initial_set("network/http_proxy/host", "");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "network/http_proxy/port", 8080, "1,65535,1")
 

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -155,6 +155,9 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 	const int proxy_port = EDITOR_GET("network/http_proxy/port");
 	download_templates->set_http_proxy(proxy_host, proxy_port);
 	download_templates->set_https_proxy(proxy_host, proxy_port);
+	if (EDITOR_GET("network/http_proxy/auto_detect")) {
+		download_templates->load_default_proxies();
+	}
 
 	Error err = download_templates->request(p_url);
 	if (err != OK) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -52,6 +52,10 @@ static inline void setup_http_request(HTTPRequest *request) {
 	const int proxy_port = EDITOR_GET("network/http_proxy/port");
 	request->set_http_proxy(proxy_host, proxy_port);
 	request->set_https_proxy(proxy_host, proxy_port);
+
+	if (EDITOR_GET("network/http_proxy/auto_detect")) {
+		request->load_default_proxies();
+	}
 }
 
 void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost) {

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -101,6 +101,8 @@ private:
 
 	double timeout = 0;
 
+	bool auto_detect_proxies = true;
+
 	void _redirect_request(const String &p_new_url);
 
 	bool _handle_response(bool *ret_value);
@@ -160,6 +162,9 @@ public:
 
 	void set_http_proxy(const String &p_host, int p_port);
 	void set_https_proxy(const String &p_host, int p_port);
+	void load_default_proxies();
+	void set_auto_detect_proxies(bool p_enable);
+	bool get_auto_detect_proxies() const;
 
 	void set_tls_options(const Ref<TLSOptions> &p_options);
 


### PR DESCRIPTION
- Adds `load_default_proxies()` method to `HTTPClient` and `HTTPRequest`.
- Adds `auto_detect_proxy` property to `HTTPRequest`.
- Adds `network/http_proxy/auto_detect` setting to the editor.