### PR TITLE
X11: Send IME update notification deferred

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3875,7 +3875,7 @@ void DisplayServerX11::_xim_preedit_draw_callback(::XIM xim, ::XPointer client_d
 			ds->im_selection = Point2i();
 		}
 
-		OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+		OS_Unix::get_singleton()->get_main_loop()->call_deferred(SNAME("notification"), MainLoop::NOTIFICATION_OS_IME_UPDATE);
 	}
 }
 


### PR DESCRIPTION
Fixes #82338
Fixes #82608

I suggest only merging this once the `ibus` issue is resolved. The error message is not directly linked to the problem with accented characters not inserting, but it will help users who encounter the problem to find the related issue on Github.