### PR TITLE
Fix a crash when trying to restore uncopyable animation tracks

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2143,14 +2143,22 @@ void AnimatedValuesBackup::set_data(const HashMap<NodePath, AnimationMixer::Trac
 	clear_data();
 
 	for (const KeyValue<NodePath, AnimationMixer::TrackCache *> &E : p_data) {
-		data.insert(E.key, get_cache_copy(E.value));
+		AnimationMixer::TrackCache *track = get_cache_copy(E.value);
+		if (!track) {
+			continue; // Some types of tracks do not get a copy and must be ignored.
+		}
+
+		data.insert(E.key, track);
 	}
 }
 
 HashMap<NodePath, AnimationMixer::TrackCache *> AnimatedValuesBackup::get_data() const {
 	HashMap<NodePath, AnimationMixer::TrackCache *> ret;
 	for (const KeyValue<NodePath, AnimationMixer::TrackCache *> &E : data) {
-		ret.insert(E.key, get_cache_copy(E.value));
+		AnimationMixer::TrackCache *track = get_cache_copy(E.value);
+		ERR_CONTINUE(!track); // Backup shouldn't contain tracks that cannot be copied, this is a mistake.
+
+		ret.insert(E.key, track);
 	}
 	return ret;
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85307. A regression from https://github.com/godotengine/godot/pull/85266.

We don't really care about those tracks anyway, so we don't need to keep them in the backup. I made getting them from the backup an error, though, because that shouldn't be possible in the first place.