### PR TITLE
Add property change guards to Sprite2D, Sprite3D and AnimatedSprite2D

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -381,6 +381,10 @@ float AnimatedSprite2D::get_playing_speed() const {
 }
 
 void AnimatedSprite2D::set_centered(bool p_center) {
+	if (centered == p_center) {
+		return;
+	}
+
 	centered = p_center;
 	queue_redraw();
 	item_rect_changed();
@@ -391,6 +395,10 @@ bool AnimatedSprite2D::is_centered() const {
 }
 
 void AnimatedSprite2D::set_offset(const Point2 &p_offset) {
+	if (offset == p_offset) {
+		return;
+	}
+
 	offset = p_offset;
 	queue_redraw();
 	item_rect_changed();
@@ -401,6 +409,10 @@ Point2 AnimatedSprite2D::get_offset() const {
 }
 
 void AnimatedSprite2D::set_flip_h(bool p_flip) {
+	if (hflip == p_flip) {
+		return;
+	}
+
 	hflip = p_flip;
 	queue_redraw();
 }
@@ -410,6 +422,10 @@ bool AnimatedSprite2D::is_flipped_h() const {
 }
 
 void AnimatedSprite2D::set_flip_v(bool p_flip) {
+	if (vflip == p_flip) {
+		return;
+	}
+
 	vflip = p_flip;
 	queue_redraw();
 }

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -155,6 +155,10 @@ Ref<Texture2D> Sprite2D::get_texture() const {
 }
 
 void Sprite2D::set_centered(bool p_center) {
+	if (centered == p_center) {
+		return;
+	}
+
 	centered = p_center;
 	queue_redraw();
 	item_rect_changed();
@@ -165,6 +169,10 @@ bool Sprite2D::is_centered() const {
 }
 
 void Sprite2D::set_offset(const Point2 &p_offset) {
+	if (offset == p_offset) {
+		return;
+	}
+
 	offset = p_offset;
 	queue_redraw();
 	item_rect_changed();
@@ -175,6 +183,10 @@ Point2 Sprite2D::get_offset() const {
 }
 
 void Sprite2D::set_flip_h(bool p_flip) {
+	if (hflip == p_flip) {
+		return;
+	}
+
 	hflip = p_flip;
 	queue_redraw();
 }
@@ -184,6 +196,10 @@ bool Sprite2D::is_flipped_h() const {
 }
 
 void Sprite2D::set_flip_v(bool p_flip) {
+	if (vflip == p_flip) {
+		return;
+	}
+
 	vflip = p_flip;
 	queue_redraw();
 }
@@ -193,7 +209,7 @@ bool Sprite2D::is_flipped_v() const {
 }
 
 void Sprite2D::set_region_enabled(bool p_region_enabled) {
-	if (p_region_enabled == region_enabled) {
+	if (region_enabled == p_region_enabled) {
 		return;
 	}
 
@@ -223,6 +239,10 @@ Rect2 Sprite2D::get_region_rect() const {
 }
 
 void Sprite2D::set_region_filter_clip_enabled(bool p_region_filter_clip_enabled) {
+	if (region_filter_clip_enabled == p_region_filter_clip_enabled) {
+		return;
+	}
+
 	region_filter_clip_enabled = p_region_filter_clip_enabled;
 	queue_redraw();
 }
@@ -234,12 +254,12 @@ bool Sprite2D::is_region_filter_clip_enabled() const {
 void Sprite2D::set_frame(int p_frame) {
 	ERR_FAIL_INDEX(p_frame, vframes * hframes);
 
-	if (frame != p_frame) {
-		item_rect_changed();
+	if (frame == p_frame) {
+		return;
 	}
 
 	frame = p_frame;
-
+	item_rect_changed();
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 
@@ -260,6 +280,11 @@ Vector2i Sprite2D::get_frame_coords() const {
 
 void Sprite2D::set_vframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of vframes cannot be smaller than 1.");
+
+	if (vframes == p_amount) {
+		return;
+	}
+
 	vframes = p_amount;
 	if (frame >= vframes * hframes) {
 		frame = 0;
@@ -275,6 +300,11 @@ int Sprite2D::get_vframes() const {
 
 void Sprite2D::set_hframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of hframes cannot be smaller than 1.");
+
+	if (hframes == p_amount) {
+		return;
+	}
+
 	if (vframes > 1) {
 		// Adjust the frame to fit new sheet dimensions.
 		int original_column = frame % hframes;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -286,6 +286,10 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 }
 
 void SpriteBase3D::set_centered(bool p_center) {
+	if (centered == p_center) {
+		return;
+	}
+
 	centered = p_center;
 	_queue_redraw();
 }
@@ -295,6 +299,10 @@ bool SpriteBase3D::is_centered() const {
 }
 
 void SpriteBase3D::set_offset(const Point2 &p_offset) {
+	if (offset == p_offset) {
+		return;
+	}
+
 	offset = p_offset;
 	_queue_redraw();
 }
@@ -304,6 +312,10 @@ Point2 SpriteBase3D::get_offset() const {
 }
 
 void SpriteBase3D::set_flip_h(bool p_flip) {
+	if (hflip == p_flip) {
+		return;
+	}
+
 	hflip = p_flip;
 	_queue_redraw();
 }
@@ -313,6 +325,10 @@ bool SpriteBase3D::is_flipped_h() const {
 }
 
 void SpriteBase3D::set_flip_v(bool p_flip) {
+	if (vflip == p_flip) {
+		return;
+	}
+
 	vflip = p_flip;
 	_queue_redraw();
 }
@@ -322,6 +338,10 @@ bool SpriteBase3D::is_flipped_v() const {
 }
 
 void SpriteBase3D::set_modulate(const Color &p_color) {
+	if (modulate == p_color) {
+		return;
+	}
+
 	modulate = p_color;
 	_propagate_color_changed();
 	_queue_redraw();
@@ -333,6 +353,11 @@ Color SpriteBase3D::get_modulate() const {
 
 void SpriteBase3D::set_render_priority(int p_priority) {
 	ERR_FAIL_COND(p_priority < RS::MATERIAL_RENDER_PRIORITY_MIN || p_priority > RS::MATERIAL_RENDER_PRIORITY_MAX);
+
+	if (render_priority == p_priority) {
+		return;
+	}
+
 	render_priority = p_priority;
 	_queue_redraw();
 }
@@ -342,6 +367,10 @@ int SpriteBase3D::get_render_priority() const {
 }
 
 void SpriteBase3D::set_pixel_size(real_t p_amount) {
+	if (pixel_size == p_amount) {
+		return;
+	}
+
 	pixel_size = p_amount;
 	_queue_redraw();
 }
@@ -352,6 +381,11 @@ real_t SpriteBase3D::get_pixel_size() const {
 
 void SpriteBase3D::set_axis(Vector3::Axis p_axis) {
 	ERR_FAIL_INDEX(p_axis, 3);
+
+	if (axis == p_axis) {
+		return;
+	}
+
 	axis = p_axis;
 	_queue_redraw();
 }
@@ -445,6 +479,11 @@ Ref<TriangleMesh> SpriteBase3D::generate_triangle_mesh() const {
 
 void SpriteBase3D::set_draw_flag(DrawFlags p_flag, bool p_enable) {
 	ERR_FAIL_INDEX(p_flag, FLAG_MAX);
+
+	if (flags[p_flag] == p_enable) {
+		return;
+	}
+
 	flags[p_flag] = p_enable;
 	_queue_redraw();
 }
@@ -456,6 +495,11 @@ bool SpriteBase3D::get_draw_flag(DrawFlags p_flag) const {
 
 void SpriteBase3D::set_alpha_cut_mode(AlphaCutMode p_mode) {
 	ERR_FAIL_INDEX(p_mode, ALPHA_CUT_MAX);
+
+	if (alpha_cut == p_mode) {
+		return;
+	}
+
 	alpha_cut = p_mode;
 	_queue_redraw();
 }
@@ -465,10 +509,12 @@ SpriteBase3D::AlphaCutMode SpriteBase3D::get_alpha_cut_mode() const {
 }
 
 void SpriteBase3D::set_alpha_hash_scale(float p_hash_scale) {
-	if (alpha_hash_scale != p_hash_scale) {
-		alpha_hash_scale = p_hash_scale;
-		_queue_redraw();
+	if (alpha_hash_scale == p_hash_scale) {
+		return;
 	}
+
+	alpha_hash_scale = p_hash_scale;
+	_queue_redraw();
 }
 
 float SpriteBase3D::get_alpha_hash_scale() const {
@@ -476,10 +522,12 @@ float SpriteBase3D::get_alpha_hash_scale() const {
 }
 
 void SpriteBase3D::set_alpha_scissor_threshold(float p_threshold) {
-	if (alpha_scissor_threshold != p_threshold) {
-		alpha_scissor_threshold = p_threshold;
-		_queue_redraw();
+	if (alpha_scissor_threshold == p_threshold) {
+		return;
 	}
+
+	alpha_scissor_threshold = p_threshold;
+	_queue_redraw();
 }
 
 float SpriteBase3D::get_alpha_scissor_threshold() const {
@@ -487,10 +535,12 @@ float SpriteBase3D::get_alpha_scissor_threshold() const {
 }
 
 void SpriteBase3D::set_alpha_antialiasing(BaseMaterial3D::AlphaAntiAliasing p_alpha_aa) {
-	if (alpha_antialiasing_mode != p_alpha_aa) {
-		alpha_antialiasing_mode = p_alpha_aa;
-		_queue_redraw();
+	if (alpha_antialiasing_mode == p_alpha_aa) {
+		return;
 	}
+
+	alpha_antialiasing_mode = p_alpha_aa;
+	_queue_redraw();
 }
 
 BaseMaterial3D::AlphaAntiAliasing SpriteBase3D::get_alpha_antialiasing() const {
@@ -498,10 +548,12 @@ BaseMaterial3D::AlphaAntiAliasing SpriteBase3D::get_alpha_antialiasing() const {
 }
 
 void SpriteBase3D::set_alpha_antialiasing_edge(float p_edge) {
-	if (alpha_antialiasing_edge != p_edge) {
-		alpha_antialiasing_edge = p_edge;
-		_queue_redraw();
+	if (alpha_antialiasing_edge == p_edge) {
+		return;
 	}
+
+	alpha_antialiasing_edge = p_edge;
+	_queue_redraw();
 }
 
 float SpriteBase3D::get_alpha_antialiasing_edge() const {
@@ -510,6 +562,11 @@ float SpriteBase3D::get_alpha_antialiasing_edge() const {
 
 void SpriteBase3D::set_billboard_mode(StandardMaterial3D::BillboardMode p_mode) {
 	ERR_FAIL_INDEX(p_mode, 3); // Cannot use BILLBOARD_PARTICLES.
+
+	if (billboard_mode == p_mode) {
+		return;
+	}
+
 	billboard_mode = p_mode;
 	_queue_redraw();
 }
@@ -519,10 +576,12 @@ StandardMaterial3D::BillboardMode SpriteBase3D::get_billboard_mode() const {
 }
 
 void SpriteBase3D::set_texture_filter(StandardMaterial3D::TextureFilter p_filter) {
-	if (texture_filter != p_filter) {
-		texture_filter = p_filter;
-		_queue_redraw();
+	if (texture_filter == p_filter) {
+		return;
 	}
+
+	texture_filter = p_filter;
+	_queue_redraw();
 }
 
 StandardMaterial3D::TextureFilter SpriteBase3D::get_texture_filter() const {
@@ -767,9 +826,12 @@ bool Sprite3D::is_region_enabled() const {
 }
 
 void Sprite3D::set_region_rect(const Rect2 &p_region_rect) {
-	bool changed = region_rect != p_region_rect;
+	if (region_rect == p_region_rect) {
+		return;
+	}
+
 	region_rect = p_region_rect;
-	if (region && changed) {
+	if (region) {
 		_queue_redraw();
 	}
 }
@@ -781,10 +843,12 @@ Rect2 Sprite3D::get_region_rect() const {
 void Sprite3D::set_frame(int p_frame) {
 	ERR_FAIL_INDEX(p_frame, int64_t(vframes) * hframes);
 
+	if (frame == p_frame) {
+		return;
+	}
+
 	frame = p_frame;
-
 	_queue_redraw();
-
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 
@@ -805,6 +869,11 @@ Vector2i Sprite3D::get_frame_coords() const {
 
 void Sprite3D::set_vframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of vframes cannot be smaller than 1.");
+
+	if (vframes == p_amount) {
+		return;
+	}
+
 	vframes = p_amount;
 	if (frame >= vframes * hframes) {
 		frame = 0;
@@ -819,6 +888,11 @@ int Sprite3D::get_vframes() const {
 
 void Sprite3D::set_hframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of hframes cannot be smaller than 1.");
+
+	if (hframes == p_amount) {
+		return;
+	}
+
 	if (vframes > 1) {
 		// Adjust the frame to fit new sheet dimensions.
 		int original_column = frame % hframes;


### PR DESCRIPTION
Implements this proposal: https://github.com/godotengine/godot-proposals/issues/8510

If a property's setter is called with the property's current value, return immediately instead of doing anything costly.

My test creates 10000 Sprite2Ds.

```gdscript
func _ready():
	for y in 100:
		for x in 100:
			var s = SPRITE.instantiate()
			s.position = Vector2(x* 10, y* 10)
			add_child(s)
```

Each sprite has a script which does some combination of these simple setters (or just `pass`).

```gdscript
func _process(delta):
	pass
	flip_h = true
	frame = 0
```

My test version was built with Visual Studio and it's performance seems to be a bit lower than the official version. "% compared to pass" numbers are calculated from release version fps numbers.

|                                 | master, debug fps | master, release fps | % compared to pass | PR, debug fps | PR, release fps | % compared to pass |
|---------------------------------|------------------:|--------------------:|-------------------:|--------------:|----------------:|-------------------:|
| `pass`                          |                73 |                 105 |               100% |            74 |              98 |               100% |
| `flip_h = true`                 |                35 |                  48 |                46% |            32 |              92 |                94% |
| `frame = 0`                     |                50 |                  95 |                91% |            60 |              91 |                93% |
| `flip_h = true` and `frame = 0` |                31 |                  47 |                45% |            30 |              89 |                91% |

It may seem odd to just to set `flip_h = true`, but it is a very common practice to set sprite's direction in every frame like this:
```gdscript
	flip_h = velocity.x > 0
```
So there are a lot of 2D games which are setting `flip_h` in every frame without actually changing it.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/8510_