### PR TITLE
Make sure `Window`'s title is respected before we compute the size

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -101,12 +101,6 @@ void ProjectDialog::_set_message(const String &p_msg, MessageType p_type, InputT
 	} else if (current_install_icon != new_icon && input_type == INSTALL_PATH) {
 		install_status_rect->set_texture(new_icon);
 	}
-
-	Size2i window_size = get_size();
-	Size2 contents_min_size = get_contents_minimum_size();
-	if (window_size.x < contents_min_size.x || window_size.y < contents_min_size.y) {
-		set_size(window_size.max(contents_min_size));
-	}
 }
 
 String ProjectDialog::_test_path() {
@@ -868,6 +862,7 @@ ProjectDialog::ProjectDialog() {
 
 	msg = memnew(Label);
 	msg->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	msg->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	vb->add_child(msg);
 
 	// Renderer selection.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -955,6 +955,10 @@ Size2i Window::_clamp_window_size(const Size2i &p_size) {
 
 void Window::_update_window_size() {
 	Size2i size_limit = get_clamped_minimum_size();
+	if (!embedder && window_id != DisplayServer::INVALID_WINDOW_ID && keep_title_visible) {
+		Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(tr_title, window_id);
+		size_limit = size_limit.max(title_size);
+	}
 
 	size = size.max(size_limit);
 
@@ -986,12 +990,6 @@ void Window::_update_window_size() {
 		}
 
 		DisplayServer::get_singleton()->window_set_max_size(max_size_used, window_id);
-
-		if (keep_title_visible) {
-			Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(tr_title, window_id);
-			size_limit = size_limit.max(title_size);
-		}
-
 		DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
 		DisplayServer::get_singleton()->window_set_size(size, window_id);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85118.

Like the title says, we used to first apply the size limit, and then we would update said limit without it affecting the actual size. So the window would be displayed with one size, and window's contents would refer to another size. Good old DisplayServer/Window de-sync.

It may not be Windows specific, as far as OSes go, highly depends on how window management is implemented on each platform. But since we are only reproducing it on Windows for now, I'm marking it as such. Also I guess we can say it's a regression because it's been introduced with the feature to keep the title visible in 4.2: https://github.com/godotengine/godot/pull/80409.

----

Also removes some suspicious and outdated code that forced this particular dialog to change size when the warning message changed.
