### PR TITLE
Fix invalid `frame` index when Sprite2D's `hframes` or `vframes` change

### DIFF
--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -60,13 +60,13 @@
 			If [code]true[/code], texture is flipped vertically.
 		</member>
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">
-			Current frame to display from sprite sheet. [member hframes] or [member vframes] must be greater than 1.
+			Current frame to display from sprite sheet. [member hframes] or [member vframes] must be greater than 1. This property is automatically adjusted when [member hframes] or [member vframes] are changed to keep pointing to the same visual frame (same column and row). If that's impossible, this value is reset to [code]0[/code].
 		</member>
 		<member name="frame_coords" type="Vector2i" setter="set_frame_coords" getter="get_frame_coords" default="Vector2i(0, 0)">
 			Coordinates of the frame to display from sprite sheet. This is as an alias for the [member frame] property. [member hframes] or [member vframes] must be greater than 1.
 		</member>
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
-			The number of columns in the sprite sheet.
+			The number of columns in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
@@ -84,7 +84,7 @@
 			[Texture2D] object to draw.
 		</member>
 		<member name="vframes" type="int" setter="set_vframes" getter="get_vframes" default="1">
-			The number of rows in the sprite sheet.
+			The number of rows in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -10,13 +10,13 @@
 	</tutorials>
 	<members>
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">
-			Current frame to display from sprite sheet. [member hframes] or [member vframes] must be greater than 1.
+			Current frame to display from sprite sheet. [member hframes] or [member vframes] must be greater than 1. This property is automatically adjusted when [member hframes] or [member vframes] are changed to keep pointing to the same visual frame (same column and row). If that's impossible, this value is reset to [code]0[/code].
 		</member>
 		<member name="frame_coords" type="Vector2i" setter="set_frame_coords" getter="get_frame_coords" default="Vector2i(0, 0)">
 			Coordinates of the frame to display from sprite sheet. This is as an alias for the [member frame] property. [member hframes] or [member vframes] must be greater than 1.
 		</member>
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
-			The number of columns in the sprite sheet.
+			The number of columns in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], the sprite will use [member region_rect] and display only the specified part of its texture.
@@ -28,7 +28,7 @@
 			[Texture2D] object to draw. If [member GeometryInstance3D.material_override] is used, this will be overridden. The size information is still used.
 		</member>
 		<member name="vframes" type="int" setter="set_vframes" getter="get_vframes" default="1">
-			The number of rows in the sprite sheet.
+			The number of rows in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
 	</members>
 	<signals>

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -261,6 +261,9 @@ Vector2i Sprite2D::get_frame_coords() const {
 void Sprite2D::set_vframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of vframes cannot be smaller than 1.");
 	vframes = p_amount;
+	if (frame >= vframes * hframes) {
+		frame = 0;
+	}
 	queue_redraw();
 	item_rect_changed();
 	notify_property_list_changed();
@@ -272,7 +275,21 @@ int Sprite2D::get_vframes() const {
 
 void Sprite2D::set_hframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of hframes cannot be smaller than 1.");
+	if (vframes > 1) {
+		// Adjust the frame to fit new sheet dimensions.
+		int original_column = frame % hframes;
+		if (original_column >= p_amount) {
+			// Frame's column was dropped, reset.
+			frame = 0;
+		} else {
+			int original_row = frame / hframes;
+			frame = original_row * p_amount + original_column;
+		}
+	}
 	hframes = p_amount;
+	if (frame >= vframes * hframes) {
+		frame = 0;
+	}
 	queue_redraw();
 	item_rect_changed();
 	notify_property_list_changed();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -804,8 +804,11 @@ Vector2i Sprite3D::get_frame_coords() const {
 }
 
 void Sprite3D::set_vframes(int p_amount) {
-	ERR_FAIL_COND(p_amount < 1);
+	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of vframes cannot be smaller than 1.");
 	vframes = p_amount;
+	if (frame >= vframes * hframes) {
+		frame = 0;
+	}
 	_queue_redraw();
 	notify_property_list_changed();
 }
@@ -815,8 +818,22 @@ int Sprite3D::get_vframes() const {
 }
 
 void Sprite3D::set_hframes(int p_amount) {
-	ERR_FAIL_COND(p_amount < 1);
+	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of hframes cannot be smaller than 1.");
+	if (vframes > 1) {
+		// Adjust the frame to fit new sheet dimensions.
+		int original_column = frame % hframes;
+		if (original_column >= p_amount) {
+			// Frame's column was dropped, reset.
+			frame = 0;
+		} else {
+			int original_row = frame / hframes;
+			frame = original_row * p_amount + original_column;
+		}
+	}
 	hframes = p_amount;
+	if (frame >= vframes * hframes) {
+		frame = 0;
+	}
 	_queue_redraw();
 	notify_property_list_changed();
 }


### PR DESCRIPTION
This is my test sprite sheet:

![kuva](https://github.com/godotengine/godot/assets/49998025/9fb09cdd-9fe9-4799-9b18-edf5e35d3123)

In master this code causes an error as expected:

```gdscript
	sprite_using_sheet.hframes = 2
	sprite_using_sheet.vframes = 2

	sprite_using_sheet.frame = 4 
# --> main.gd:15 @ test2(): Index p_frame = 4 is out of bounds (vframes * hframes = 4).
```

But this is fine:

```gdscript
	sprite_using_sheet.hframes = 2
	sprite_using_sheet.vframes = 2 # now there are frames 0-3
	
	sprite_using_sheet.frame = 3
	
	sprite_using_sheet.hframes = 1 # now there are frames 0-1, but frame is still 3 
```

Now the sprite looks very odd. The size and shape match to the spritesheet's current frame size and shape, but the content is garbage.

![kuva](https://github.com/godotengine/godot/assets/49998025/79702cc8-7713-44e5-874c-018cc2277197)

If the same is done in editor's property Inspector, the result is more or less the same. Editor however changes the `frame` property to 1, but still the sprite looks wrong.

With this PR the sprite looks like this when the code above is run:

![kuva](https://github.com/godotengine/godot/assets/49998025/2f499e81-c227-4c7a-ac10-9f9bfe10d7d9)

## How `vframes` and `hframes` changes can affect `frame`

What cases this PR handles and how. The goal is to make sure that the frame value keeps valid (must be smaller than `hframes * vframes`) and if possible, to keep `frame` referencing the same row and column in the texture sheet even if `vframes` or `hframes` changes.

### `vframes` changes 

```
         (a)       (b)

OOO  ->  OOO  or  OOO
OOO      OOO      OOO
OOO      OOO
         OOO
```

(a) `frame`'s validity or value cannot change.
(b) `frame` can become invalid, if its row is dropped. `frame`'s value cannot change.


### `hframes` changes

Special case where `vframes` is 1:

```
          (c)          (d)

OOOO  ->  OOOOOOO  or  OO
```

(c) `frame`'s validity or value cannot change.
(d) `frame` can become invalid, if its column is dropped. `frame`'s value cannot change.


When `vframes` > 1:
```
          (e)          (f)

OOOO  ->  OOOOOOO  or  OO
OOOO      OOOOOOO      OO 
OOOO      OOOOOOO      OO
```

(e) `frame` cannot become invalid, but its value can change.
(f) `frame` can become invalid if its column is dropped, also `frame`'s value can change.
      

- Cases (a) and (c) require no handling.
- Cases (b) and (d) are handled simply by checking `if frame <= hframes * vframes`. If not, `frame` is reset to 0.
- Only the cases (e) and (f) need more special handling. If the frame was located in a column that was dropped, reset `frame` to 0. Otherwise calculate original row and column and then calculate new frame value using new `hframes` values. Finally the `if frame <= hframes * vframes` check is done.

