### PR TITLE
SCons: Implement `get_mingw_tool` to fix mingw prefix ambiguity (reverted)

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -18,36 +18,30 @@ def get_name():
     return "Windows"
 
 
-def try_cmd(test, prefix, arch):
-    if arch:
+def get_mingw_tool(tool, prefix="", arch="", test="--version"):
+    if not prefix:
+        prefix = os.getenv("MINGW_PREFIX", "")
+    supported_arches = ["x86_64", "x86_32", "arm64", "arm32"]
+    if arch in supported_arches:
+        arches = [arch, ""]
+    else:
+        arches = ["x86_64", "x86_32", "arm64", "arm32", ""]
+    for a in arches:
         try:
+            path = f"{get_mingw_bin_prefix(prefix, a)}{tool}"
             out = subprocess.Popen(
-                get_mingw_bin_prefix(prefix, arch) + test,
+                f"{path} {test}",
                 shell=True,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
             )
             out.communicate()
             if out.returncode == 0:
-                return True
+                return path
         except Exception:
             pass
-    else:
-        for a in ["x86_64", "x86_32", "arm64", "arm32"]:
-            try:
-                out = subprocess.Popen(
-                    get_mingw_bin_prefix(prefix, a) + test,
-                    shell=True,
-                    stderr=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                )
-                out.communicate()
-                if out.returncode == 0:
-                    return True
-            except Exception:
-                pass
 
-    return False
+    return ""
 
 
 def can_build():
@@ -65,9 +59,7 @@ def can_build():
 
     if os.name == "posix":
         # Cross-compiling with MinGW-w64 (old MinGW32 is not supported)
-        prefix = os.getenv("MINGW_PREFIX", "")
-
-        if try_cmd("gcc --version", prefix, "") or try_cmd("clang --version", prefix, ""):
+        if get_mingw_tool("gcc") or get_mingw_tool("clang"):
             return True
 
     return False
@@ -255,36 +247,26 @@ def get_flags():
 
 
 def build_res_file(target, source, env: "SConsEnvironment"):
+    cmdbase = get_mingw_tool("windres", env["mingw_prefix"], env["arch"])
+    if not cmdbase:
+        return -1
+
     arch_aliases = {
         "x86_32": "pe-i386",
         "x86_64": "pe-x86-64",
         "arm32": "armv7-w64-mingw32",
         "arm64": "aarch64-w64-mingw32",
     }
-    cmdbase = "windres --include-dir . --target=" + arch_aliases[env["arch"]]
-
-    mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
+    cmdbase += " --include-dir . --target=" + arch_aliases[env["arch"]]
 
     for x in range(len(source)):
-        ok = True
-        # Try prefixed executable (MinGW on Linux).
-        cmd = mingw_bin_prefix + cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+        cmd = f"{cmdbase} -i {source[x]} -o {target[x]}"
         try:
             out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
             if len(out[1]):
-                ok = False
-        except Exception:
-            ok = False
-
-        # Try generic executable (MSYS2).
-        if not ok:
-            cmd = cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
-            try:
-                out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
-                if len(out[1]):
-                    return -1
-            except Exception:
                 return -1
+        except Exception:
+            return -1
 
     return 0
 
@@ -358,8 +340,8 @@ def setup_mingw(env: "SConsEnvironment"):
         )
         sys.exit(255)
 
-    if not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]) and not try_cmd(
-        "clang --version", env["mingw_prefix"], env["arch"]
+    if not get_mingw_tool("gcc", env["mingw_prefix"], env["arch"]) and not get_mingw_tool(
+        "clang", env["mingw_prefix"], env["arch"]
     ):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)
@@ -600,10 +582,10 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Build type
 
-    if not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):
+    if not env["use_llvm"] and not get_mingw_tool("gcc", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = True
 
-    if env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
+    if env["use_llvm"] and not get_mingw_tool("clang", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = False
 
     # TODO: Re-evaluate the need for this / streamline with common config.
@@ -638,27 +620,26 @@ def configure_mingw(env: "SConsEnvironment"):
     if env["arch"] in ["x86_32", "x86_64"]:
         env["x86_libtheora_opt_gcc"] = True
 
-    mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
-
     if env["use_llvm"]:
-        env["CC"] = mingw_bin_prefix + "clang"
-        env["CXX"] = mingw_bin_prefix + "clang++"
-        if try_cmd("as --version", env["mingw_prefix"], env["arch"]):
-            env["AS"] = mingw_bin_prefix + "as"
-        if try_cmd("ar --version", env["mingw_prefix"], env["arch"]):
-            env["AR"] = mingw_bin_prefix + "ar"
-        if try_cmd("ranlib --version", env["mingw_prefix"], env["arch"]):
-            env["RANLIB"] = mingw_bin_prefix + "ranlib"
+        env["CC"] = get_mingw_tool("clang", env["mingw_prefix"], env["arch"])
+        env["CXX"] = get_mingw_tool("clang++", env["mingw_prefix"], env["arch"])
+        tool_as = get_mingw_tool("as", env["mingw_prefix"], env["arch"])
+        tool_ar = get_mingw_tool("ar", env["mingw_prefix"], env["arch"])
+        tool_ranlib = get_mingw_tool("ranlib", env["mingw_prefix"], env["arch"])
         env.extra_suffix = ".llvm" + env.extra_suffix
     else:
-        env["CC"] = mingw_bin_prefix + "gcc"
-        env["CXX"] = mingw_bin_prefix + "g++"
-        if try_cmd("as --version", env["mingw_prefix"], env["arch"]):
-            env["AS"] = mingw_bin_prefix + "as"
-        if try_cmd("gcc-ar --version", env["mingw_prefix"], env["arch"]):
-            env["AR"] = mingw_bin_prefix + "gcc-ar"
-        if try_cmd("gcc-ranlib --version", env["mingw_prefix"], env["arch"]):
-            env["RANLIB"] = mingw_bin_prefix + "gcc-ranlib"
+        env["CC"] = get_mingw_tool("gcc", env["mingw_prefix"], env["arch"])
+        env["CXX"] = get_mingw_tool("g++", env["mingw_prefix"], env["arch"])
+        tool_as = get_mingw_tool("as", env["mingw_prefix"], env["arch"])
+        tool_ar = get_mingw_tool("gcc-ar", env["mingw_prefix"], env["arch"])
+        tool_ranlib = get_mingw_tool("gcc-ranlib", env["mingw_prefix"], env["arch"])
+
+    if tool_as:
+        env["AS"] = tool_as
+    if tool_ar:
+        env["AR"] = tool_ar
+    if tool_ranlib:
+        env["RANLIB"] = tool_ranlib
 
     ## LTO
 

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -1,24 +1,17 @@
 """Functions used to generate source files during build time"""
 
 import os
-from detect import get_mingw_bin_prefix
-from detect import try_cmd
+from detect import get_mingw_tool
 
 
 def make_debug_mingw(target, source, env):
-    dst = str(target[0])
-    # Force separate debug symbols if executable size is larger than 1.9 GB.
-    if env["separate_debug_symbols"] or os.stat(dst).st_size >= 2040109465:
-        mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
-        if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
-            os.system(mingw_bin_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))
-        else:
-            os.system("objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))
-        if try_cmd("strip --version", env["mingw_prefix"], env["arch"]):
-            os.system(mingw_bin_prefix + "strip --strip-debug --strip-unneeded {0}".format(dst))
-        else:
-            os.system("strip --strip-debug --strip-unneeded {0}".format(dst))
-        if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
-            os.system(mingw_bin_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(dst))
-        else:
-            os.system("objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(dst))
+    objcopy = get_mingw_tool("objcopy", env["mingw_prefix"], env["arch"])
+    strip = get_mingw_tool("strip", env["mingw_prefix"], env["arch"])
+
+    if not objcopy or not strip:
+        print('`separate_debug_symbols` requires both "objcopy" and "strip" to function.')
+        return
+
+    os.system("{0} --only-keep-debug {1} {1}.debugsymbols".format(objcopy, target[0]))
+    os.system("{0} --strip-debug --strip-unneeded {1}".format(strip, target[0]))
+    os.system("{0} --add-gnu-debuglink={1}.debugsymbols {1}".format(objcopy, target[0]))


### PR DESCRIPTION
Expands upon the #79871 fix. Instead of separately checking for if a tool exists with/without a prefix, and using that to manually check for a tool, this PR consolidates that logic into a single function: `get_mingw_tool`. Now it returns a path outright to whatever tool it finds, or an empty path if no tool was found whatsoever. Because an empty string will function as `False` in conditionals, this was sufficent to remove the need for `get_mingw_bin_prefix` in isolation & replace `try_cmd` outright

The primary change compared to `try_cmd` is that only the leading argument needs to be supplied; as such, the argument was renamed from "test" to "tool". `--version` is now implicitly what gets tested, but can be changed if needed via a new argument. This new function was applied to all the areas where `get_mingw_bin_prefix` and/or `try_cmd` were directly called, consolidating the relevant code in the process