### PR TITLE
SCons: Change `Environment` type hints to `SConsEnvironment`

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -6,7 +6,7 @@ import subprocess
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from SCons import Environment
+    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -51,7 +51,7 @@ def get_min_sdk_version(platform):
     return int(platform.split("-")[1])
 
 
-def get_android_ndk_root(env):
+def get_android_ndk_root(env: "SConsEnvironment"):
     return env["ANDROID_HOME"] + "/ndk/" + get_ndk_version()
 
 
@@ -74,7 +74,7 @@ def get_flags():
 
 # Check if Android NDK version is installed
 # If not, install it.
-def install_ndk_if_needed(env):
+def install_ndk_if_needed(env: "SConsEnvironment"):
     print("Checking for Android NDK...")
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
@@ -96,7 +96,7 @@ def install_ndk_if_needed(env):
     env["ANDROID_NDK_ROOT"] = get_android_ndk_root(env)
 
 
-def configure(env: "Environment"):
+def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -5,7 +5,7 @@ from methods import detect_darwin_sdk_path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from SCons import Environment
+    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -54,7 +54,7 @@ def get_flags():
     ]
 
 
-def configure(env: "Environment"):
+def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -7,7 +7,7 @@ from platform_methods import detect_arch
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from SCons import Environment
+    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -70,7 +70,7 @@ def get_flags():
     ]
 
 
-def configure(env: "Environment"):
+def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     if env["arch"] not in supported_arches:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -6,7 +6,7 @@ from platform_methods import detect_arch, detect_mvk
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from SCons import Environment
+    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -59,7 +59,7 @@ def get_flags():
     ]
 
 
-def configure(env: "Environment"):
+def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -15,7 +15,7 @@ from SCons.Util import WhereIs
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from SCons import Environment
+    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -81,7 +81,7 @@ def get_flags():
     ]
 
 
-def configure(env: "Environment"):
+def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["wasm32"]
     if env["arch"] not in supported_arches:


### PR DESCRIPTION
Fixes an inconsistency in the `detect.py` type checking, as the wrong type was being checked; the actual type passed through the argument is `SCons.Script.SConscript.SConsEnvironment`, not `SCons.Environment`. In addition to assigning the proper type, this PR also adds type hints to the files' other arguments that expected an `env`, as those uniformly expect `SConsEnvironment` as well