### PR TITLE
refresh scene tabs on fail to load scene due to missing deps

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3799,6 +3799,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 			_set_current_scene(prev);
 			editor_data.remove_scene(idx);
 		}
+		scene_tabs->update_scene_tabs();
 		return ERR_FILE_MISSING_DEPENDENCIES;
 	}
 


### PR DESCRIPTION
resolves https://github.com/godotengine/godot/issues/85173

alternative to https://github.com/godotengine/godot/pull/85333

not sure if this is a good solution or not, but it sure is a simple one!

If we're exiting the function at this point, force reload the tabs so they account for the fact `editor_data.edited_scene` has had a scene removed 
