### PR TITLE
Replace `//` with `\\` before sending path to Blender

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -134,7 +134,19 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 
 	// Get global paths for source and sink.
 	// Escape paths to be valid Python strings to embed in the script.
-	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path).c_escape();
+	String source_global = ProjectSettings::get_singleton()->globalize_path(p_path);
+
+#ifdef WINDOWS_ENABLED
+	// On Windows, when using a network share path, the above will return a path starting with "//"
+	// which once handed to Blender will be treated like a relative path. So we need to replace the
+	// first two characters with "\\" to make it absolute again.
+	if (source_global.is_network_share_path()) {
+		source_global = "\\\\" + source_global.substr(2);
+	}
+#endif
+
+	source_global = source_global.c_escape();
+
 	const String blend_basename = p_path.get_file().get_basename();
 	const String sink = ProjectSettings::get_singleton()->get_imported_files_path().path_join(
 			vformat("%s-%s.gltf", blend_basename, p_path.md5_text()));


### PR DESCRIPTION
# Why?

I was having an issue using the blend importer and realized it was the fact that I keep my files on a network drive. Using wireshark I was able to see both the http RPC call and the SMB traffic and could tell that Blender was attempting to open a file at `//fileshare/game/fileshare/game/assets/model.blend` and not finding it. I can see that the path sent is `//fileshare/game/assets/model.blend` but unfortunately, without the backslashes, Blender just treats it as a relative path.

Interesting too, because `c_escape()` is being called which says to me that someone expected this to return backslashes.

Then I noticed in [`ProjectSettings`](https://github.com/godotengine/godot/blob/master/core/config/project_settings.cpp#L524) that `\` is replaced with `/`.

# What?

Instead, when the path begins with `//`, replace the first two chars with `\\` which when escaped becomes `\\\\`.

Resolves #85334