### PR TITLE
Added Project Setting to disable cutting entire line when there is no text selected.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -830,6 +830,9 @@
 			The indentation style to use (tabs or spaces).
 			[b]Note:[/b] The [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url] recommends using tabs for indentation. It is advised to change this setting only if you need to work on a project that currently uses spaces for indentation.
 		</member>
+		<member name="text_editor/behavior/navigation/cut_line_on_empty_selection" type="bool" setter="" getter="">
+			If [code]true[/code], cutting while no text is selected will cut the entire line the caret is on.
+		</member>
 		<member name="text_editor/behavior/navigation/drag_and_drop_selection" type="bool" setter="" getter="">
 			If [code]true[/code], allows drag-and-dropping text in the script editor to move text. Disable this if you find yourself accidentally drag-and-dropping text in the script editor.
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1060,6 +1060,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_smooth_scroll_enabled(EDITOR_GET("text_editor/behavior/navigation/smooth_scrolling"));
 	text_editor->set_v_scroll_speed(EDITOR_GET("text_editor/behavior/navigation/v_scroll_speed"));
 	text_editor->set_drag_and_drop_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/drag_and_drop_selection"));
+	text_editor->set_cut_line_on_empty_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/cut_line_on_empty_selection"));
 
 	// Behavior: indent
 	text_editor->set_indent_using_spaces(EDITOR_GET("text_editor/behavior/indent/type"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -586,6 +586,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/navigation/v_scroll_speed", 80, "1,10000,1")
 	_initial_set("text_editor/behavior/navigation/drag_and_drop_selection", true);
 	_initial_set("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected", true);
+	_initial_set("text_editor/behavior/navigation/cut_line_on_empty_selection", true);
 
 	// Behavior: Indent
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3338,6 +3338,14 @@ bool TextEdit::is_middle_mouse_paste_enabled() const {
 	return middle_mouse_paste_enabled;
 }
 
+void TextEdit::set_cut_line_on_empty_selection_enabled(bool p_enabled) {
+	cut_line_on_empty_selection = p_enabled;
+}
+
+bool TextEdit::is_cut_line_on_empty_selection_enabled() const {
+	return cut_line_on_empty_selection;
+}
+
 // Text manipulation
 void TextEdit::clear() {
 	setting_text = true;
@@ -6663,6 +6671,10 @@ void TextEdit::_cut_internal(int p_caret) {
 		DisplayServer::get_singleton()->clipboard_set(get_selected_text(p_caret));
 		delete_selection(p_caret);
 		cut_copy_line = "";
+		return;
+	}
+
+	if (!cut_line_on_empty_selection) {
 		return;
 	}
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -299,6 +299,7 @@ private:
 	bool shortcut_keys_enabled = true;
 	bool virtual_keyboard_enabled = true;
 	bool middle_mouse_paste_enabled = true;
+	bool cut_line_on_empty_selection = true;
 
 	// Overridable actions.
 	String cut_copy_line = "";
@@ -729,6 +730,9 @@ public:
 
 	void set_middle_mouse_paste_enabled(bool p_enabled);
 	bool is_middle_mouse_paste_enabled() const;
+
+	void set_cut_line_on_empty_selection_enabled(bool p_enabled);
+	bool is_cut_line_on_empty_selection_enabled() const;
 
 	// Text manipulation
 	void clear();


### PR DESCRIPTION
Fixes #59441

By default, the Godot text/code editor will behave exactly as it has before. This default and continuing behaviour is that when the user issues a cut command while no text is selected, the entire line the caret is on will be cut (VSCode, for example, has such behaviour).

However, there is now a setting (Project Settings -> GUI -> Common -> Cut Line on Empty Selection) which when disabled (true by default) will prevent this from happening. Cutting with no text selected will simply do nothing.