### PR TITLE
Fix generating vsproj with SCons 4.6.0+

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -708,25 +708,28 @@ def detect_visual_c_compiler_version(tools_env):
 
 
 def find_visual_c_batch_file(env):
-    from SCons.Tool.MSCommon.vc import (
-        get_default_version,
-        get_host_target,
-        find_batch_file,
-    )
+    from SCons.Tool.MSCommon.vc import get_default_version, get_host_target, find_batch_file, find_vc_pdir
 
     # Syntax changed in SCons 4.4.0.
     from SCons import __version__ as scons_raw_version
 
     scons_ver = env._get_major_minor_revision(scons_raw_version)
 
-    version = get_default_version(env)
+    msvc_version = get_default_version(env)
 
     if scons_ver >= (4, 4, 0):
-        (host_platform, target_platform, _) = get_host_target(env, version)
+        (host_platform, target_platform, _) = get_host_target(env, msvc_version)
     else:
         (host_platform, target_platform, _) = get_host_target(env)
 
-    return find_batch_file(env, version, host_platform, target_platform)[0]
+    if scons_ver < (4, 6, 0):
+        return find_batch_file(env, msvc_version, host_platform, target_platform)[0]
+
+    # Scons 4.6.0+ removed passing env, so we need to get the product_dir ourselves first,
+    # then pass that as the last param instead of env as the first param as before.
+    # We should investigate if we can avoid relying on SCons internals here.
+    product_dir = find_vc_pdir(env, msvc_version)
+    return find_batch_file(msvc_version, host_platform, target_platform, product_dir)[0]
 
 
 def generate_cpp_hint_file(filename):


### PR DESCRIPTION
Visual Studio project generation broke after the signature of `find_batch_file()` was changed in SCons 4.6.0+ (in https://github.com/SCons/scons/commit/7082c53ff6). Thanks to **mwichmann** for pointing that out in https://github.com/godotengine/godot/issues/85262#issuecomment-1826367724.

I can confirm that with these changes, `vsproj=yes` once again produces a VS solution as before, while I could reproduce the build failing without these changes.

I've also renamed the variable `version` to `msvc_version` for clarity. Otherwise, this just avoids passing `env` to `find_batch_file()` in SCons 4.6.0+, where that is no longer accepted. Instead, we need to find the product directory from `env` ourselves, as `find_batch_file()` previously did internally via `find_vc_pdir()`, which we now call ourselves.

`find_vc_pdir()` can in theory throw exceptions if the MSVC version is unsupported (`UnsupportedVersion` exception) or something unexpected occurs, but catching these wouldn't make much sense IMO, as we can't do much besides fail. Just having the build fail with these exceptions as in other cases here should be explicit enough.

We should see if we can remove some of the reliance on SCons internals here in the future. Some other stuff could likely be improved as well, but I tried to keep this minimal to get builds working again ASAP, and considering the time in the 4.2 dev cycle.

Fixes https://github.com/godotengine/godot/issues/85262.