### PR TITLE
Faster exit from `_cull_canvas_item` if alpha is zero

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -239,6 +239,19 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		ci->children_order_dirty = false;
 	}
 
+	if (ci->use_parent_material && p_material_owner) {
+		ci->material_owner = p_material_owner;
+	} else {
+		p_material_owner = ci;
+		ci->material_owner = nullptr;
+	}
+
+	Color modulate = ci->modulate * p_modulate;
+
+	if (modulate.a < 0.007) {
+		return;
+	}
+
 	Rect2 rect = ci->get_rect();
 
 	if (ci->visibility_notifier) {
@@ -255,19 +268,6 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 
 	Rect2 global_rect = xform.xform(rect);
 	global_rect.position += p_clip_rect.position;
-
-	if (ci->use_parent_material && p_material_owner) {
-		ci->material_owner = p_material_owner;
-	} else {
-		p_material_owner = ci;
-		ci->material_owner = nullptr;
-	}
-
-	Color modulate(ci->modulate.r * p_modulate.r, ci->modulate.g * p_modulate.g, ci->modulate.b * p_modulate.b, ci->modulate.a * p_modulate.a);
-
-	if (modulate.a < 0.007) {
-		return;
-	}
 
 	int child_item_count = ci->child_items.size();
 	Item **child_items = ci->child_items.ptrw();


### PR DESCRIPTION
This is a tiny optimization for `RendererCanvasCull::_cull_canvas_item()`. There are a few checks in the beginning of that function which exit early if the item is not visible. Later in the function there is a check if `modulate.a < 0.007` and if yes, that also means exit. Between the other checks and this alpha check some calculations are being made. Unless there are some very sneaky side effects, those calculations seem to be unnecessary if the `modulate.a < 0.007` causes exit.

This PR moves `modulate.a < 0.007` to be made right after other visibility checks.

My test project has 10000 sprites total, half of them (5000) have `modulate.a = 0` and thus they are not visible. Results of my Visual Studio release build:

|         | fps |
|---------|:---:|
| master  | 310 |
| this PR | 340 |

I don't believe having a huge amount of sprites with alpha = 0 is a common use case. but this should not make any use case slower either.