### PR TITLE
MeshInstance3D no longer uses any parent as skeleton

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -106,7 +106,7 @@
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] resource for the instance.
 		</member>
-		<member name="skeleton" type="NodePath" setter="set_skeleton_path" getter="get_skeleton_path" default="NodePath(&quot;..&quot;)">
+		<member name="skeleton" type="NodePath" setter="set_skeleton_path" getter="get_skeleton_path" default="NodePath(&quot;&quot;)">
 			[NodePath] to the [Skeleton3D] associated with the instance.
 		</member>
 		<member name="skin" type="Skin" setter="set_skin" getter="get_skin">

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -167,8 +167,12 @@ void MeshInstance3D::set_blend_shape_value(int p_blend_shape, float p_value) {
 void MeshInstance3D::_resolve_skeleton_path() {
 	Ref<SkinReference> new_skin_reference;
 
-	if (!skeleton_path.is_empty()) {
-		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(get_node(skeleton_path));
+	// attempt to resolve skeleton from parent as default fallback for imported scenes
+	NodePath resolve_path = skeleton_path.is_empty() ? NodePath("..") : skeleton_path;
+
+	Node *skeleton_node = get_node_or_null(skeleton_path);
+	if (skeleton_node) {
+		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(skeleton_node);
 		if (skeleton) {
 			if (skin_internal.is_null()) {
 				new_skin_reference = skeleton->register_skin(skeleton->create_skin_from_rest_transforms());

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -44,7 +44,7 @@ protected:
 	Ref<Skin> skin;
 	Ref<Skin> skin_internal;
 	Ref<SkinReference> skin_ref;
-	NodePath skeleton_path = NodePath("..");
+	NodePath skeleton_path = NodePath();
 
 	LocalVector<float> blend_shape_tracks;
 	HashMap<StringName, int> blend_shape_properties;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixes https://github.com/godotengine/godot/issues/42267

I assumed that the default behaviour is still required so that imported scenes correctly resolve skins/skeletons from their parent (even if not then it's atleast legacy behaviour compatible), so it's mostly a user facing change in that it doesn't incorrectly display whatever parent the node has as skeleton.