### PR TITLE
Make copy & paste params skip `resource_path`

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -283,7 +283,7 @@ void EditorData::copy_object_params(Object *p_object) {
 	p_object->get_property_list(&pinfo);
 
 	for (const PropertyInfo &E : pinfo) {
-		if (!(E.usage & PROPERTY_USAGE_EDITOR) || E.name == "script" || E.name == "scripts") {
+		if (!(E.usage & PROPERTY_USAGE_EDITOR) || E.name == "script" || E.name == "scripts" || E.name == "resource_path") {
 			continue;
 		}
 


### PR DESCRIPTION
Resource path should not be attempted to be taken over, as that's not intended for copy-paste and fails anyway, but this results in the whole paste operation failing as well.
This change skips it in the copy part, but there could be an argument for skipping it in the paste operation.

fixes https://github.com/godotengine/godot/issues/42415

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
