### PR TITLE
[RTL] Fix CharFX character offset calculation.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3121,6 +3121,8 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 		current_char_ofs += t->text.length();
 	} else if (p_item->type == ITEM_IMAGE) {
 		current_char_ofs++;
+	} else if (p_item->type == ITEM_NEWLINE) {
+		current_char_ofs++;
 	}
 
 	if (p_enter) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85328, new lines were not accounted toward FX character offset.
