### PR TITLE
Fix updating cached singletons when reloading GDScripts

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2323,6 +2323,19 @@ void GDScriptLanguage::reload_all_scripts() {
 			}
 			elem = elem->next();
 		}
+
+#ifdef TOOLS_ENABLED
+		if (Engine::get_singleton()->is_editor_hint()) {
+			// Reload all pointers to existing singletons so that tool scripts can work with the reloaded extensions.
+			List<Engine::Singleton> singletons;
+			Engine::get_singleton()->get_singletons(&singletons);
+			for (const Engine::Singleton &E : singletons) {
+				if (globals.has(E.name)) {
+					_add_global(E.name, E.ptr);
+				}
+			}
+		}
+#endif
 	}
 
 	//as scripts are going to be reloaded, must proceed without locking here


### PR DESCRIPTION
Fixes #85004

Since `GDScriptLanguage::reload_all_scripts()` is always called when the `GDExtension` reload is completed, I decided to update the singleton cache there.
I used the [original singleton caching](https://github.com/godotengine/godot/blob/5df98679672c12d96b4ac4d96ee17f1559207401/modules/gdscript/gdscript.cpp#L2149-L2155) code, added a key existence check, and just overwrite the values.

Without `globals.has(E.name)` singletons that were registered via `GDScript` itself or for example `GDScriptLanguageProtocol` can be added to the cache after the `GDExtension` reload and used as the rest of the singletons in `GDScript`.

#52162 could be fixed if calling `reload_all_scripts` somewhere after loading the editor ([there?](https://github.com/godotengine/godot/blob/5df98679672c12d96b4ac4d96ee17f1559207401/main/main.cpp#L3287-L3289)) and remove `globals.has(E.name)`. I tried updating scripts in `Engine::add_singleton`, but it is advisable to do it deferred, and `Engine` is a regular class that cannot call methods via `callable_mp` (although it was possible to add a static method and a static boolean variable to prevent multiple calls in one frame). This can be tested in a separate PR, but I'm not really interested in it.

It would be cool to merge this before the 4.2 release.