### PR TITLE
Use render method from OS instead of project settings in compositor RD

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -613,6 +613,7 @@ private:
 
 	void _renderer_selected(int);
 	void _update_renderer_color();
+	void _add_renderer_entry(const String &p_renderer_name, bool p_mark_overridden);
 
 	void _exit_editor(int p_exit_code);
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -306,7 +306,7 @@ RendererCompositorRD::RendererCompositorRD() {
 	fog = memnew(RendererRD::Fog);
 	canvas = memnew(RendererCanvasRenderRD());
 
-	String rendering_method = GLOBAL_GET("rendering/renderer/rendering_method");
+	String rendering_method = OS::get_singleton()->get_current_rendering_method();
 	uint64_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
 
 	if (rendering_method == "mobile" || textures_per_stage < 48) {


### PR DESCRIPTION
Fixes #85376

Not sure why Godot doesn't use the rendering method stored in OS in the first place, it's the correct one after all ( as it is computed in main.cpp ) . Feel free to correct me.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- *Production edit: This closes https://github.com/godotengine/godot/issues/85143.*
