### PR TITLE
Fix `PhysicsShapeQueryParameters3D.motion` type wrongly set to Vector2

### DIFF
--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -14,3 +14,10 @@ Validate extension JSON: Error: Field 'classes/TileData/methods/get_navigation_p
 Validate extension JSON: Error: Field 'classes/TileData/methods/get_occluder/arguments': size changed value in new API, from 1 to 4.
 
 Added optional argument to get_navigation_polygon and get_occluder to specify a polygon transform.
+
+
+GH-85393
+--------
+Validate extension JSON: Error: Field 'classes/PhysicsShapeQueryParameters3D/properties/motion': type changed value in new API, from "Vector2" to "Vector3".
+
+The type was registered wrongly, this was a bug.

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -343,7 +343,7 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion"), "set_motion", "get_motion");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "motion"), "set_motion", "get_motion");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "shape_rid"), "set_shape_rid", "get_shape_rid");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform"), "set_transform", "get_transform");


### PR DESCRIPTION
Maybe I'm missing something, but according to the [getter/setter](https://github.com/godotengine/godot/blob/master/servers/physics_server_3d.h#L903) and [documentation](https://docs.godotengine.org/en/stable/classes/class_physicsshapequeryparameters3d.html), this should be a Vector3.
