### PR TITLE
Mono/.net: Add exported inherited duplicates analyzer

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -492,5 +492,14 @@ namespace Godot.SourceGenerators
                 classSyntax.GetLocation(),
                 classSyntax.SyntaxTree.FilePath));
         }
+
+        public static readonly DiagnosticDescriptor ExportedMemberMustNotBeDuplicateRule =
+            new DiagnosticDescriptor(id: "GD0501",
+                title: "Duplicate exported member in class",
+                messageFormat: "Duplicate exported {0} '{1}' in: {2} and {3}",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                description: "The same member is exported multiple times, this will lead to serialization inconsistencies. Remove or rename one.");
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExportMemberAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExportMemberAnalyzer.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Godot.SourceGenerators
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ExportMemberAnalyzer : DiagnosticAnalyzer
+    {
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ClassDeclaration);
+        }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Common.ExportedMemberMustNotBeDuplicateRule);
+
+        static readonly SymbolDisplayFormat namespaceTypeSymolDisplayFormat =
+            new SymbolDisplayFormat(
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+
+        void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var godotClasses = context
+                .Compilation.SyntaxTrees
+                .SelectMany(tree =>
+                    tree.GetRoot().DescendantNodes()
+                        .OfType<ClassDeclarationSyntax>()
+                        .SelectGodotScriptClasses(context.Compilation)
+                        // Report and skip non-partial classes
+                        .Where(x => x.cds.IsPartial() && (!x.cds.IsNested() || x.cds.AreAllOuterTypesPartial(out _)))
+                        .Select(x => x.symbol)
+                )
+                .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
+                .ToArray();
+
+            foreach (var godotClass in godotClasses)
+            {
+                var members = new List<ISymbol>();
+                var potentialMemberContainer = godotClass;
+                while (potentialMemberContainer != null)
+                {
+                    var exportedFieldsAndProperties = potentialMemberContainer.GetMembers()
+                        .Where(s => !s.IsStatic
+                                    && ((s is IPropertySymbol ps && !ps.IsIndexer &&
+                                         ps.ExplicitInterfaceImplementations.Length == 0)
+                                        || s is IFieldSymbol fs && !fs.IsImplicitlyDeclared)
+                                    && s.GetAttributes().Any(attr =>
+                                        attr.AttributeClass?.ToDisplayString(namespaceTypeSymolDisplayFormat) ==
+                                        "Godot.ExportAttribute")
+                        );
+                    members.AddRange(exportedFieldsAndProperties);
+                    potentialMemberContainer = potentialMemberContainer.BaseType;
+                }
+                FindAndReportDuplicates(members, context);
+            }
+        }
+
+        private static void FindAndReportDuplicates(IEnumerable<ISymbol> symbols,
+            SyntaxNodeAnalysisContext context)
+        {
+            var groupedDuplicates = symbols.GroupBy(
+                sym => sym switch
+                {
+                    IPropertySymbol p => sym.Name + p.Type,
+                    IFieldSymbol f => sym.Name + f.Type,
+                    _ => string.Empty
+                }).Where(g => g.Key != string.Empty && g.Count() > 1);
+
+            foreach (var duplicateGroup in groupedDuplicates)
+            {
+#pragma warning disable RS1024
+                var distinctPerContainer = duplicateGroup.Distinct(SymbolContainerEqualityComparer.Instance).ToArray();
+#pragma warning restore RS1024
+                foreach (var duplicateSymbol in distinctPerContainer)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Common.ExportedMemberMustNotBeDuplicateRule,
+                        duplicateSymbol.Locations.FirstOrDefault() ?? context.Node.GetLocation(),
+                        duplicateSymbol.Kind,
+                        duplicateSymbol.Name,
+                        duplicateSymbol.ContainingType.ToDisplayString(),
+                        (distinctPerContainer.FirstOrDefault(s =>
+                            !SymbolEqualityComparer.Default.Equals(s, duplicateSymbol)) ?? duplicateSymbol)
+                        .ContainingType.ToDisplayString()
+                    ));
+                }
+            }
+        }
+
+        private class SymbolContainerEqualityComparer : IEqualityComparer<ISymbol>
+        {
+            public static readonly SymbolContainerEqualityComparer Instance = new SymbolContainerEqualityComparer();
+
+            public bool Equals(ISymbol x, ISymbol y) =>
+                SymbolEqualityComparer.Default.Equals(x.ContainingSymbol, y.ContainingSymbol);
+
+            public int GetHashCode(ISymbol obj) => SymbolEqualityComparer.Default.GetHashCode(obj.ContainingSymbol);
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/42244

This is not a literal fix as the issue is not fixable by automation, but a helper that reports the issue, which i think should maybe even be part of core editor behaviour (if this also applies to gdscript), as the underlying misbehaviour can easily go unnoticed.

~~This currently only reports whether a duplicate exists for a member and should probably be improved to report the exact location of the opposing duplicates at each location (using IDEs it's relatively easy to spot those then-marked locations, so it's useful in its current form nonetheless).~~
This now reports the locations.
![grafik](https://github.com/godotengine/godot/assets/8841352/db21d441-0295-452f-b197-cf8882c1de17)


The ideal behaviour in my opinion would be that building the solution logged those issues as warnings, but as i haven't worked with analyzers or source generators before i'm not sure how to do that. 
But this is a first start to even begin addressing this.

I made this an error (as it caused some hard to debug situation when it happened to me), but it could as well just be a (high priority) warning.
I also gave it an unassigned id that seemed fitting, not sure if there's a system behind it.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
