### PR TITLE
Make AnimationPlaybackTrack keep state when stopping

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -563,7 +563,7 @@ void AnimationMixer::_clear_audio_streams() {
 void AnimationMixer::_clear_playing_caches() {
 	for (const TrackCache *E : playing_caches) {
 		if (ObjectDB::get_instance(E->object_id)) {
-			E->object->call(SNAME("stop"));
+			E->object->call(SNAME("stop"), true);
 		}
 	}
 	playing_caches.clear();


### PR DESCRIPTION
Fixes #85410.

The `p_keep_state` argument of stop of the child AniamtionPlayer should be `true`.