### PR TITLE
Fix crash on late mouse enter/exit event arrival.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -681,6 +681,9 @@ void Window::_propagate_window_notification(Node *p_node, int p_notification) {
 void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 	switch (p_event) {
 		case DisplayServer::WINDOW_EVENT_MOUSE_ENTER: {
+			if (!is_inside_tree()) {
+				return;
+			}
 			Window *root = get_tree()->get_root();
 			if (root->gui.windowmanager_window_over) {
 #ifdef DEV_ENABLED
@@ -696,6 +699,9 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 			}
 		} break;
 		case DisplayServer::WINDOW_EVENT_MOUSE_EXIT: {
+			if (!is_inside_tree()) {
+				return;
+			}
 			Window *root = get_tree()->get_root();
 			if (!root->gui.windowmanager_window_over) {
 #ifdef DEV_ENABLED


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/85395 (crash part).

On export errors, mouse leave/enter events can arrive after the window is removed from the tree (probably due to editor popup repainting logic and export process blocking main thread for the long periods).