### PR TITLE
Fix GDScript thread-exit routine assuming thread-enter was called

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2106,6 +2106,12 @@ void GDScriptLanguage::thread_enter() {
 }
 
 void GDScriptLanguage::thread_exit() {
+	// This thread may have been created before GDScript was up
+	// (which also means it can't have run any GDScript code at all).
+	if (!GDScript::func_ptrs_to_update_thread_local) {
+		return;
+	}
+
 	GDScript::_fixup_thread_function_bookkeeping();
 
 	bool destroy = false;


### PR DESCRIPTION
Just as simple as that: the engine can create threads before even GDScript has been lifted up. `GDScript::thread_exit()` will be called regardless.

Fixes #85377.

@akien-mga: This is simple enough to be safe for 4.2. For 4.3 I'll submit a more comprehensive PR.