### PR TITLE
Lazily create GDScript thread lambda bookkeeping block

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -39,6 +39,7 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/script_language.h"
+#include "core/templates/paged_allocator.h"
 #include "core/templates/rb_set.h"
 
 class GDScriptNativeClass : public RefCounted {
@@ -133,6 +134,7 @@ class GDScript : public Script {
 	};
 	static UpdatableFuncPtr func_ptrs_to_update_main_thread;
 	static thread_local UpdatableFuncPtr *func_ptrs_to_update_thread_local;
+	static PagedAllocator<UpdatableFuncPtr> updatable_func_ptrs_allocator;
 	List<UpdatableFuncPtr *> func_ptrs_to_update;
 	Mutex func_ptrs_to_update_mutex;
 
@@ -564,7 +566,6 @@ public:
 
 	/* MULTITHREAD FUNCTIONS */
 
-	virtual void thread_enter() override;
 	virtual void thread_exit() override;
 
 	/* DEBUGGER FUNCTIONS */


### PR DESCRIPTION
This is an extension to #85432 (which is included to conflicts are pre-solved), but for 4.3, given it's slightly less safe.

This avoids every thread that does not even run GDScript or doesn't use lambdas using memory for some bookkeeping they don't need.