### PR TITLE
Add ShadowCastingSetting to MeshLibrary / GridMap items

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -45,6 +45,13 @@
 				Returns the item's mesh.
 			</description>
 		</method>
+		<method name="get_item_mesh_cast_shadow" qualifiers="const">
+			<return type="int" enum="RenderingServer.ShadowCastingSetting" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the item's shadow casting mode. See [enum RenderingServer.ShadowCastingSetting] for possible values.
+			</description>
+		</method>
 		<method name="get_item_mesh_transform" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="id" type="int" />
@@ -114,6 +121,14 @@
 			<param index="1" name="mesh" type="Mesh" />
 			<description>
 				Sets the item's mesh.
+			</description>
+		</method>
+		<method name="set_item_mesh_cast_shadow">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="shadow_casting_setting" type="int" enum="RenderingServer.ShadowCastingSetting" />
+			<description>
+				Sets the item's shadow casting mode. See [enum RenderingServer.ShadowCastingSetting] for possible values.
 			</description>
 		</method>
 		<method name="set_item_mesh_transform">

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -156,6 +156,25 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 	}
 	p_library->set_item_mesh(item_id, item_mesh);
 
+	GeometryInstance3D::ShadowCastingSetting gi3d_cast_shadows_setting = mesh_instance_node->get_cast_shadows_setting();
+	switch (gi3d_cast_shadows_setting) {
+		case GeometryInstance3D::ShadowCastingSetting::SHADOW_CASTING_SETTING_OFF: {
+			p_library->set_item_mesh_cast_shadow(item_id, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_OFF);
+		} break;
+		case GeometryInstance3D::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON: {
+			p_library->set_item_mesh_cast_shadow(item_id, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
+		} break;
+		case GeometryInstance3D::ShadowCastingSetting::SHADOW_CASTING_SETTING_DOUBLE_SIDED: {
+			p_library->set_item_mesh_cast_shadow(item_id, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
+		} break;
+		case GeometryInstance3D::ShadowCastingSetting::SHADOW_CASTING_SETTING_SHADOWS_ONLY: {
+			p_library->set_item_mesh_cast_shadow(item_id, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
+		} break;
+		default: {
+			p_library->set_item_mesh_cast_shadow(item_id, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
+		} break;
+	}
+
 	Transform3D item_mesh_transform;
 	if (p_apply_xforms) {
 		item_mesh_transform = mesh_instance_node->get_transform();

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1233,6 +1233,8 @@ void GridMapEditor::_update_cursor_instance() {
 			Ref<Mesh> mesh = node->get_mesh_library()->get_item_mesh(selected_palette);
 			if (!mesh.is_null() && mesh->get_rid().is_valid()) {
 				cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world_3d()->get_scenario());
+				RS::ShadowCastingSetting cast_shadows = (RS::ShadowCastingSetting)node->get_mesh_library()->get_item_mesh_cast_shadow(selected_palette);
+				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(cursor_instance, cast_shadows);
 			}
 		}
 	} else if (mode_buttons_group->get_pressed_button() == select_mode_button) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -714,6 +714,9 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				RS::get_singleton()->instance_set_transform(instance, get_global_transform());
 			}
 
+			RS::ShadowCastingSetting cast_shadows = (RS::ShadowCastingSetting)mesh_library->get_item_mesh_cast_shadow(E.key);
+			RS::get_singleton()->instance_geometry_set_cast_shadows_setting(instance, cast_shadows);
+
 			mmi.multimesh = mm;
 			mmi.instance = instance;
 

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -35,6 +35,7 @@
 #include "core/templates/rb_map.h"
 #include "scene/3d/navigation_region_3d.h"
 #include "scene/resources/mesh.h"
+#include "servers/rendering_server.h"
 #include "shape_3d.h"
 
 class MeshLibrary : public Resource {
@@ -50,6 +51,7 @@ public:
 		String name;
 		Ref<Mesh> mesh;
 		Transform3D mesh_transform;
+		RS::ShadowCastingSetting mesh_cast_shadow = RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON;
 		Vector<ShapeData> shapes;
 		Ref<Texture2D> preview;
 		Ref<NavigationMesh> navigation_mesh;
@@ -75,6 +77,7 @@ public:
 	void set_item_name(int p_item, const String &p_name);
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
+	void set_item_mesh_cast_shadow(int p_item, RS::ShadowCastingSetting p_shadow_casting_setting);
 	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
 	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
@@ -83,6 +86,7 @@ public:
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
+	RS::ShadowCastingSetting get_item_mesh_cast_shadow(int p_item) const;
 	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
 	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	uint32_t get_item_navigation_layers(int p_item) const;


### PR DESCRIPTION
Adds `ShadowCastingSetting` to MeshLibrary / GridMap items.

Implements https://github.com/godotengine/godot/issues/78344

This change allows to use certain MeshLibrary items that do not cast shadows in GridMaps.

![meshlib_cast_shadow_items](https://github.com/godotengine/godot/assets/52464204/ad396a60-77fc-4a53-89bd-fe0c1e205ec6)


The MeshLibrary scene exporter will export the `cast_shadow` property of each MeshInstance3D item.

The property can also be set in the MeshLibrary inspector.

![meshlib_cast_shadow](https://github.com/godotengine/godot/assets/52464204/3cebb128-3f7b-4977-9e8c-0a9bd0674226)

Can also be done with script with the integer values of the `RenderingServer.ShadowCastingSetting` enum.

```gdscript
var cast_shadow_settings: int = RenderingServer.SHADOW_CASTING_SETTING_OFF
cast_shadow_settings = RenderingServer.SHADOW_CASTING_SETTING_ON
cast_shadow_settings = RenderingServer.SHADOW_CASTING_SETTING_DOUBLE_SIDED
cast_shadow_settings = RenderingServer.SHADOW_CASTING_SETTING_SHADOWS_ONLY

mesh_lib.set_item_mesh_cast_shadow(item_index, cast_shadow_settings)
cast_shadow_settings = mesh_lib.get_item_mesh_cast_shadow(item_index)
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
