### PR TITLE
Remove GridMap navigation_layers leftover

### DIFF
--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -155,7 +155,6 @@ class GridMap : public Node3D {
 	Ref<PhysicsMaterial> physics_material;
 	bool bake_navigation = false;
 	RID map_override;
-	uint32_t navigation_layers = 1;
 
 	Transform3D last_transform;
 


### PR DESCRIPTION
Removes GridMap navigation_layers leftover.

Leftover from pr https://github.com/godotengine/godot/pull/69351 that moved the `navigation_layers` from the GridMap node to the GridMap cells.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
