### PR TITLE
Improve CodeEdit to allow folding comment blocks

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -519,6 +519,15 @@
 		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[&quot;&apos; &apos;&quot;, &quot;\&quot; \&quot;&quot;]">
 			Sets the string delimiters. All existing string delimiters will be removed.
 		</member>
+		<member name="fold_blocks_enable" type="bool" setter="set_fold_blocks_enabled" getter="is_fold_blocks_enabled" default="false">
+			Sets whether code blocks folding enabled, this code blocks are added [member fold_blocks_prefixes].
+		</member>
+		<member name="fold_blocks_minimum_size" type="int" setter="set_fold_blocks_minimum_size" getter="get_fold_blocks_minimum_size" default="0">
+			Sets minimum size of a code block before it is considered foldable.
+		</member>
+		<member name="fold_blocks_prefixes" type="PackedStringArray" setter="set_fold_blocks_prefixes" getter="get_fold_blocks_prefixes" default="PackedStringArray(&quot;#&quot;, &quot;##&quot;)">
+			Sets prefixes that will identify code blocks that can be fold/unfold, [member fold_blocks_enable] should be set to [code]true[/code] to take affect.
+		</member>
 		<member name="gutters_draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
 			Sets if bookmarked should be drawn in the gutter. This gutter is shared with breakpoints and executing lines.
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -805,6 +805,12 @@
 		<member name="text_editor/appearance/whitespace/line_spacing" type="int" setter="" getter="">
 			The space to add between lines (in pixels). Greater line spacing can help improve readability at the cost of displaying fewer lines on screen.
 		</member>
+		<member name="text_editor/behavior/comments/foldable" type="bool" setter="" getter="">
+			If [code]true[/code], allows foldable comments, include documentation comments.
+		</member>
+		<member name="text_editor/behavior/comments/minimum_foldable_size" type="int" setter="" getter="">
+			Sets minimum size of comments before it is considered foldable.
+		</member>
 		<member name="text_editor/behavior/files/auto_reload_scripts_on_external_change" type="bool" setter="" getter="">
 			If [code]true[/code], automatically reloads scripts in the editor when they have been modified and saved by external editors.
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1066,6 +1066,10 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_indent_size(EDITOR_GET("text_editor/behavior/indent/size"));
 	text_editor->set_auto_indent_enabled(EDITOR_GET("text_editor/behavior/indent/auto_indent"));
 
+	// Behavior: Folding Block
+	text_editor->set_fold_blocks_enabled(EDITOR_GET("text_editor/behavior/comments/foldable"));
+	text_editor->set_fold_blocks_minimum_size(EDITOR_GET("text_editor/behavior/comments/minimum_foldable_size"));
+
 	// Completion
 	text_editor->set_auto_brace_completion_enabled(EDITOR_GET("text_editor/completion/auto_brace_complete"));
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -599,6 +599,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/convert_indent_on_save", true);
 	_initial_set("text_editor/behavior/files/auto_reload_scripts_on_external_change", false);
 
+	// Behavior: Folding Block
+	_initial_set("text_editor/behavior/comments/foldable", true);
+	_initial_set("text_editor/behavior/comments/minimum_foldable_size", 3);
+
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true);
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false);

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -62,6 +62,15 @@ public:
 	};
 
 private:
+	/* Folding Block*/
+	bool enable_fold_blocks = false;
+	PackedStringArray fold_blocks_prefixes;
+	int fold_blocks_minimum_size = 0;
+
+	String _get_fold_block_prefix(int p_line) const;
+	int _size_fold_block(int p_start_line) const;
+	bool _is_fold_blocks_start(int p_line) const;
+
 	/* Indent management */
 	int indent_size = 4;
 	String indent_text = "\t";
@@ -319,6 +328,16 @@ protected:
 	GDVIRTUAL1RC(TypedArray<Dictionary>, _filter_code_completion_candidates, TypedArray<Dictionary>)
 
 public:
+	/* Folding Block*/
+	void set_fold_blocks_enabled(bool p_enabled);
+	bool is_fold_blocks_enabled() const;
+
+	void set_fold_blocks_prefixes(const PackedStringArray &p_prefixes);
+	PackedStringArray get_fold_blocks_prefixes() const;
+
+	void set_fold_blocks_minimum_size(int size);
+	int get_fold_blocks_minimum_size();
+
 	/* General overrides */
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
![folding_comments](https://github.com/godotengine/godot/assets/58259212/b93d4ea4-9035-4a92-b90a-86b52f658c65)
allows foldable comments and extensible by taking prefix of a desired code block to make it foldable

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8538*