### PR TITLE
Fix an issue causing the running project window to loop-restart when closed

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -221,16 +221,9 @@ open class GodotEditor : GodotActivity() {
 		val runningProcesses = activityManager.runningAppProcesses
 		for (runningProcess in runningProcesses) {
 			if (runningProcess.processName.endsWith(processNameSuffix)) {
-				if (targetClass == null) {
-					// Killing process directly
-					Log.v(TAG, "Killing Godot process ${runningProcess.processName}")
-					Process.killProcess(runningProcess.pid)
-				} else {
-					// Activity is running; sending a request for self termination.
-					Log.v(TAG, "Sending force quit request to $targetClass running on process ${runningProcess.processName}")
-					val forceQuitIntent = Intent(this, targetClass).putExtra(EXTRA_FORCE_QUIT, true)
-					startActivity(forceQuitIntent)
-				}
+				// Killing process directly
+				Log.v(TAG, "Killing Godot process ${runningProcess.processName}")
+				Process.killProcess(runningProcess.pid)
 				return true
 			}
 		}


### PR DESCRIPTION
One of the methods used to close the running project window on the Android editor was to dispatch an [Intent](https://developer.android.com/reference/android/content/Intent) to request the process closes itself.
In certain scenarios, this creates a race condition where the process receives the intent after closing itself causing it to restart itself again.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
