### PR TITLE
Fix IME key event being erased in macOS

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -725,7 +725,8 @@ void DisplayServerMacOS::update_mouse_pos(DisplayServerMacOS::WindowData &p_wd, 
 }
 
 void DisplayServerMacOS::pop_last_key_event() {
-	if (key_event_pos > 0) {
+	// Does not pop last key event when it is an IME key event.
+	if (key_event_pos > 0 && key_event_buffer[key_event_pos - 1].raw) {
 		key_event_pos--;
 	}
 }


### PR DESCRIPTION
This PR fixes IME input in macOS, especially Korean IME which calls `insertText` and `setMarkedText` at the same time.

**Before:**

https://github.com/godotengine/godot/assets/30334834/5af8356c-782a-4180-884f-4374c069a394

**After:**

https://github.com/godotengine/godot/assets/30334834/f08fb0d6-92ea-4307-b5fc-34a143cb4532

*Bugsquad edit:*
- Addresses macOS native part of #85597