### PR TITLE
Bump the `JetBrains.Rider.PathLocator` PackageReference to 1.0.8

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="JetBrains.Rider.PathLocator" Version="1.0.4" />
+    <PackageReference Include="JetBrains.Rider.PathLocator" Version="1.0.8" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <Reference Include="GodotSharp">


### PR DESCRIPTION
There were some fixes over time and also new version targets `netstandard2.0` instead of `net6`