### PR TITLE
AnimationMixer: Validate ObjectID before blend in case the object was freed

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1708,7 +1708,12 @@ void AnimationMixer::_blend_apply() {
 						}
 					}
 				}
-				t->object->set_indexed(t->subpath, Animation::cast_from_blendwise(t->value, t->init_value.get_type()));
+
+				// t->object isn't safe here, get instance from id (GH-85365).
+				Object *obj = ObjectDB::get_instance(t->object_id);
+				if (obj) {
+					obj->set_indexed(t->subpath, Animation::cast_from_blendwise(t->value, t->init_value.get_type()));
+				}
 
 			} break;
 			case Animation::TYPE_BEZIER: {


### PR DESCRIPTION
Works around #85365, but it's likely only a partial fix. The proper fix would be to remove the Object pointer from the TrackCache and always go back to the ObjectID before doing operations like this.

Thanks @bitsawer for the help debugging.

I'd say this doesn't full address #85365 as there are many other cases where `t->object` is dereferenced without being sure it's valid. But for 4.2 this might be a suitable workaround for at least one known crash, until this is refactored for 4.3.

I confirmed this fixes the crash in Liblast and in the MRPs of #85365.