### PR TITLE
Clarify difference between Capture and Record audio effects

### DIFF
--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -6,11 +6,10 @@
 	<description>
 		AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
 		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating point PCM.
-		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
+		Unlike [AudioEffectRecord], this effect only returns the raw audio samples instead of encoding them into an [AudioStream].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
-		<link title="Audio Mic Record Demo">https://github.com/godotengine/godot-demo-projects/tree/master/audio/mic_record</link>
 	</tutorials>
 	<methods>
 		<method name="can_get_buffer" qualifiers="const">

--- a/doc/classes/AudioEffectRecord.xml
+++ b/doc/classes/AudioEffectRecord.xml
@@ -4,9 +4,10 @@
 		Audio effect used for recording the sound from an audio bus.
 	</brief_description>
 	<description>
-		Allows the user to record the sound from an audio bus. This can include all audio output by Godot when used on the "Master" audio bus.
+		Allows the user to record the sound from an audio bus into an [AudioStreamWAV]. When used on the "Master" audio bus, this includes all audio output by Godot.
+		Unlike [AudioEffectCapture], this effect encodes the recording with the given format (8-bit, 16-bit, or compressed) instead of giving access to the raw audio samples.
 		Can be used (with an [AudioStreamMicrophone]) to record from a microphone.
-		It sets and gets the format in which the audio file will be recorded (8-bit, 16-bit, or compressed). It checks whether or not the recording is active, and if it is, records the sound. It then returns the recorded sample.
+		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 	</description>
 	<tutorials>
 		<link title="Recording with microphone">$DOCS_URL/tutorials/audio/recording_with_microphone.html</link>


### PR DESCRIPTION
Updated documentation of AudioEffectCapture and AudioEffectRecord:

- Capture returns a raw audio buffer, while Record encodes it into an audio stream.
- The note about `enable_input` setting was confusing in Capture docs, since the microphone use-case is only one of the many listed.
- Additionally, the demo project listed uses the Record effect, not Capture! So moved that note and link to the Record effect instead.
- Record also had a very weird wording in its docs ("It sets, It checks, It returns"...) which I cleaned up.