### PR TITLE
Improve Control hiding in PluginConfigDialog

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -146,7 +146,7 @@ void PluginConfigDialog::_notification(int p_what) {
 }
 
 void PluginConfigDialog::config(const String &p_config_path) {
-	if (p_config_path.length()) {
+	if (!p_config_path.is_empty()) {
 		Ref<ConfigFile> cf = memnew(ConfigFile);
 		Error err = cf->load(p_config_path);
 		ERR_FAIL_COND_MSG(err != OK, "Cannot load config file from path '" + p_config_path + "'.");
@@ -159,20 +159,17 @@ void PluginConfigDialog::config(const String &p_config_path) {
 		script_edit->set_text(cf->get_value("plugin", "script", ""));
 
 		_edit_mode = true;
-		active_edit->hide();
-		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 1))->hide();
-		subfolder_edit->hide();
-		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 1))->hide();
 		set_title(TTR("Edit a Plugin"));
 	} else {
 		_clear_fields();
 		_edit_mode = false;
-		active_edit->show();
-		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 1))->show();
-		subfolder_edit->show();
-		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 1))->show();
 		set_title(TTR("Create a Plugin"));
 	}
+
+	for (Control *control : plugin_edit_hidden_controls) {
+		control->set_visible(!_edit_mode);
+	}
+
 	validation_panel->update();
 
 	get_ok_button()->set_disabled(!_edit_mode);
@@ -214,12 +211,14 @@ PluginConfigDialog::PluginConfigDialog() {
 	subfolder_lb->set_text(TTR("Subfolder:"));
 	subfolder_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(subfolder_lb);
+	plugin_edit_hidden_controls.push_back(subfolder_lb);
 
 	subfolder_edit = memnew(LineEdit);
 	subfolder_edit->set_placeholder("\"my_plugin\" -> res://addons/my_plugin");
 	subfolder_edit->set_tooltip_text(TTR("Optional. The folder name should generally use `snake_case` naming (avoid spaces and special characters).\nIf left empty, the folder will be named after the plugin name converted to `snake_case`."));
 	subfolder_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(subfolder_edit);
+	plugin_edit_hidden_controls.push_back(subfolder_edit);
 
 	// Description
 	Label *desc_lb = memnew(Label);
@@ -296,10 +295,12 @@ PluginConfigDialog::PluginConfigDialog() {
 	active_lb->set_text(TTR("Activate now?"));
 	active_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(active_lb);
+	plugin_edit_hidden_controls.push_back(active_lb);
 
 	active_edit = memnew(CheckBox);
 	active_edit->set_pressed(true);
 	grid->add_child(active_edit);
+	plugin_edit_hidden_controls.push_back(active_edit);
 
 	Control *spacing = memnew(Control);
 	vbox->add_child(spacing);

--- a/editor/plugin_config_dialog.h
+++ b/editor/plugin_config_dialog.h
@@ -59,6 +59,8 @@ class PluginConfigDialog : public ConfirmationDialog {
 	LineEdit *script_edit = nullptr;
 	CheckBox *active_edit = nullptr;
 
+	LocalVector<Control *> plugin_edit_hidden_controls;
+
 	EditorValidationPanel *validation_panel = nullptr;
 
 	bool _edit_mode = false;


### PR DESCRIPTION
PluginConfigDialog was doing some shady stuff with `get_child()` method.