### PR TITLE
Fix horizontal scroll in editor's 2D view

### DIFF
--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -43,12 +43,14 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 		if (scroll_vec != Vector2() && mb->is_pressed()) {
 			if (control_scheme == SCROLL_PANS) {
 				if (mb->is_ctrl_pressed()) {
-					// Compute the zoom factor.
-					float zoom_factor = mb->get_factor() <= 0 ? 1.0 : mb->get_factor();
-					zoom_factor = ((scroll_zoom_factor - 1.0) * zoom_factor) + 1.0;
-					float zoom = (scroll_vec.x + scroll_vec.y) > 0 ? 1.0 / scroll_zoom_factor : scroll_zoom_factor;
-					zoom_callback.call(zoom, mb->get_position(), p_event);
-					return true;
+					if (scroll_vec.y != 0) {
+						// Compute the zoom factor.
+						float zoom_factor = mb->get_factor() <= 0 ? 1.0 : mb->get_factor();
+						zoom_factor = ((scroll_zoom_factor - 1.0) * zoom_factor) + 1.0;
+						float zoom = scroll_vec.y > 0 ? 1.0 / scroll_zoom_factor : scroll_zoom_factor;
+						zoom_callback.call(zoom, mb->get_position(), p_event);
+						return true;
+					}
 				} else {
 					Vector2 panning = scroll_vec * mb->get_factor();
 					if (pan_axis == PAN_AXIS_HORIZONTAL) {
@@ -73,11 +75,11 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 					}
 					pan_callback.call(-panning * scroll_speed, p_event);
 					return true;
-				} else if (!mb->is_shift_pressed()) {
+				} else if (!mb->is_shift_pressed() && scroll_vec.y != 0) {
 					// Compute the zoom factor.
 					float zoom_factor = mb->get_factor() <= 0 ? 1.0 : mb->get_factor();
 					zoom_factor = ((scroll_zoom_factor - 1.0) * zoom_factor) + 1.0;
-					float zoom = (scroll_vec.x + scroll_vec.y) > 0 ? 1.0 / scroll_zoom_factor : scroll_zoom_factor;
+					float zoom = scroll_vec.y > 0 ? 1.0 / scroll_zoom_factor : scroll_zoom_factor;
 					zoom_callback.call(zoom, mb->get_position(), p_event);
 					return true;
 				}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77212

Some mouses (for example Logitech G502) have wheels with horizontal scrolling feature. A slight horizonal click of wheel will send WHEEL_RIGHT and WHEEL_LEFT messages. When using the wheel for zooming (by rotating it, WHEEL_UP/WHEEL_DOWN) and clicking the wheel (for panning) it is very easy to unintentionally to activate the horizontal scrolling.

Currently horizontal scrolling in editor's 2D view causes zooming. No other view (3D, code) works like this. 2D view is pretty much unusable with a mouse which has horizontal scrolling feature, you are almost constantly doing unintentional zooming while trying to pan the view. In Godot 3.5 horizontal scrolling does not cause zooming in 2D view.

This PR fixes this problem by using only vertical scrolling for zooming.