### PR TITLE
GDScript: Ensure super() is called in constructors

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1803,6 +1803,19 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 		}
 	}
 
+	// If this is a constructor and the super class has a custom constructor, ensure `super()` is called.
+	if (p_function->identifier != nullptr && p_function->identifier->name == GDScriptLanguage::get_singleton()->strings._init) {
+		GDScriptParser::ClassNode *base_class = parser->current_class->base_type.class_type;
+
+		while (base_class) {
+			if (base_class->has_function(GDScriptLanguage::get_singleton()->strings._init) && !p_function->has_super_call) {
+				push_error(R"*(Constructor must call "super()" to invoke the superclass constructor.)*", p_function);
+				break;
+			}
+			base_class = base_class->base_type.class_type;
+		}
+	}
+
 #ifdef DEBUG_ENABLED
 	parser->ignored_warnings = previously_ignored_warnings;
 #endif

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2978,6 +2978,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 	if (previous.type == GDScriptTokenizer::Token::SUPER) {
 		// Super call.
 		call->is_super = true;
+		if (current_function) {
+			current_function->has_super_call = true;
+		}
 		push_multiline(true);
 		if (match(GDScriptTokenizer::Token::PARENTHESIS_OPEN)) {
 			// Implicit call to the parent method of the same name.

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -844,6 +844,7 @@ public:
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;
 		Vector<Variant> default_arg_values;
+		bool has_super_call = false;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super _indirect.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super _indirect.gd
@@ -1,0 +1,16 @@
+# https://github.com/godotengine/godot/issues/40861
+
+func test():
+	var _sub = SubSubClass.new()
+
+class SuperClass:
+	func _init(param):
+		print(param)
+
+class SubClass extends SuperClass:
+	# No custom constructor.
+	pass
+
+class SubSubClass extends SubClass:
+	func _init():
+		print("Missing super()")

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super _indirect.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super _indirect.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Constructor must call "super()" to invoke the superclass constructor.

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super.gd
@@ -1,0 +1,12 @@
+# https://github.com/godotengine/godot/issues/40861
+
+func test():
+	var _sub = SubClass.new()
+
+class SuperClass:
+	func _init(param):
+		print(param)
+
+class SubClass extends SuperClass:
+	func _init():
+		print("Missing super()")

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_with_params_without_super.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Constructor must call "super()" to invoke the superclass constructor.

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super.gd
@@ -1,0 +1,12 @@
+# https://github.com/godotengine/godot/issues/40861
+
+func test():
+	var _sub = SubClass.new()
+
+class SuperClass:
+	func _init():
+		print("No parameters")
+
+class SubClass extends SuperClass:
+	func _init():
+		print("Missing super()")

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Constructor must call "super()" to invoke the superclass constructor.

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super_indirect.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super_indirect.gd
@@ -1,0 +1,16 @@
+# https://github.com/godotengine/godot/issues/40861
+
+func test():
+	var _sub = SubSubClass.new()
+
+class SuperClass:
+	func _init():
+		print("No parameters")
+
+class SubClass extends SuperClass:
+	# No custom constructor.
+	pass
+
+class SubSubClass extends SubClass:
+	func _init():
+		print("Missing super()")

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super_indirect.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_without_params_without_super_indirect.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Constructor must call "super()" to invoke the superclass constructor.

--- a/modules/gdscript/tests/scripts/analyzer/features/constructor_super.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/constructor_super.gd
@@ -1,0 +1,34 @@
+func test():
+	var _sub1 = SubClass1.new("test")
+	var _sub2 = SubClass2.new()
+	var _sub3 = SubClass3.new()
+
+# Both with params.
+class SuperClass1:
+	func _init(param):
+		prints("SuperClass1 init", param)
+
+class SubClass1 extends SuperClass1:
+	func _init(param):
+		prints("SubClass1 init", param)
+		super(param)
+
+# Only super with params.
+class SuperClass2:
+	func _init(param):
+		prints("SuperClass2 init", param)
+
+class SubClass2 extends SuperClass2:
+	func _init():
+		prints("SubClass2 init")
+		super("super")
+
+# Super without params.
+class SuperClass3:
+	func _init():
+		prints("SuperClass3 init")
+
+class SubClass3 extends SuperClass3:
+	func _init():
+		prints("SubClass3 init")
+		super()

--- a/modules/gdscript/tests/scripts/analyzer/features/constructor_super.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/constructor_super.out
@@ -1,0 +1,11 @@
+GDTEST_OK
+>> WARNING
+>> Line: 14
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the function "_init()" requires the subtype "Variant" but the supertype "Variant" was provided.
+SubClass1 init test
+SuperClass1 init test
+SubClass2 init
+SuperClass2 init super
+SubClass3 init
+SuperClass3 init

--- a/modules/gdscript/tests/scripts/analyzer/features/no_override_constructor_with_arguments.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/no_override_constructor_with_arguments.gd
@@ -1,0 +1,10 @@
+func test():
+	var _sub = SubClass.new("test")
+
+class SuperClass:
+	func _init(param):
+		prints("SuperClass init", param)
+
+class SubClass extends SuperClass:
+	# No _init implementation, will use the superclass one.
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/no_override_constructor_with_arguments.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/no_override_constructor_with_arguments.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+SuperClass init test


### PR DESCRIPTION
This is needed so the super class is properly constructed, especially when it requires arguments.

Fix #40861
