### PR TITLE
Do not consume mouse messages in windows with `no_focus` on Windows OS

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2958,9 +2958,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 		} break;
 		case WM_MOUSEACTIVATE: {
-			if (windows[window_id].no_focus) {
-				return MA_NOACTIVATEANDEAT; // Do not activate, and discard mouse messages.
-			} else if (windows[window_id].is_popup) {
+			if (windows[window_id].no_focus || windows[window_id].is_popup) {
 				return MA_NOACTIVATE; // Do not activate, but process mouse messages.
 			}
 		} break;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84725
Fixes: https://github.com/godotengine/godot/issues/78760
Fixes: https://github.com/godotengine/godot/issues/74055

Window's with the `no_focus` flag set should still process mouse events and not consume (eat) them. 
Otherwise all mouse pressed operations will not work inside Godot's own `PopupMenu` (which will spawn a Window with `no_focus`).
As a consequence e.g. a `ScrollBar` can not be pressed/dragged inside a `PopupMenu`, see the linked issues for some examples. 

This problem is Windows only, all other platforms do process mouse events for `PopupMenu`'s correctly. 
(Tested on Linux on my Steam Deck and on MacOS on my friends Macbook 😄)

More Details:
- `WM_LBUTTONDOWN` was never send to `PopupMenu` on Windows
- This only happened for `PopupMenu`s as only those set the `no_focus` flag
- Can only be reproduced when `display/window/subwindows/embed_subwindows` is set to false, since then the underlying window manager will create the window (otherwise Godot will use the embedder logic and not create a native window)
- 'Regression' from long ago: https://github.com/godotengine/godot/pull/58490

https://github.com/godotengine/godot/assets/66004280/f15c3b9c-efb6-452f-9593-1424e94a943d