### PR TITLE
Fix property groups overriding real properties

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -631,6 +631,10 @@ bool PlaceHolderScriptInstance::has_method(const StringName &p_method) const {
 void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, const HashMap<StringName, Variant> &p_values) {
 	HashSet<StringName> new_values;
 	for (const PropertyInfo &E : p_properties) {
+		if (E.usage & (PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_CATEGORY)) {
+			continue;
+		}
+
 		StringName n = E.name;
 		new_values.insert(n);
 


### PR DESCRIPTION
With the following script, each rebuild reverts the exported value to its default.
```cs
public partial class Foo : Node
{
    [ExportGroup("Test")]
    [Export]
    private string Test;
}
```
The same thing happens in GDScript. With the following script, modifying the default value in the code overwrites any value defined through the inspector.
```gdscript
extends Node

@export_group("test")
@export
var test : String = "Hello World!"
```
It is triggered by the group using the same name as the actual property (changing the group names above prevents the weird behaviour).