### PR TITLE
Move "Expected indented block" error message's line number back to where the error is

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -165,7 +165,7 @@ void GDScriptParser::push_error(const String &p_message, const Node *p_origin) {
 	panic_mode = true;
 	// TODO: Improve positional information.
 	if (p_origin == nullptr) {
-		errors.push_back({ p_message, current.start_line, current.start_column });
+		errors.push_back({ p_message, previous.start_line, previous.start_column });
 	} else {
 		errors.push_back({ p_message, p_origin->start_line, p_origin->leftmost_column });
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/81046

In master "Expected indented block ..." error messages are assigned to code lines likes this:

![kuva](https://github.com/godotengine/godot/assets/49998025/e8cca656-0f9b-4c5b-be30-6964aa43f1db)

The error message at line 7 tells that "Expected indented block after class declaration". The class declaration mentioned in error messages in not at line 7, it is at line 4. Other errors in screenshot are similar. The most confusing (I have seen this at Reddit discussions several times) is the error at line 16 which mentions function declaration. But the problem is not the function declaration at line 16, the problematic function declaration is at line 11.

In master, the error message line is obviously the line where the missing indented block is noticed.

This PR fixes this problem and now the same errors look like this:

![kuva](https://github.com/godotengine/godot/assets/49998025/3ae54d16-0fd4-453b-bfd7-b816b6b93bd9)

Now all "Expected indented block ..." error messages are pointing to lines which are actually expecting something.

Other kind of errors _seem_ to be unaffected by this change:

![kuva](https://github.com/godotengine/godot/assets/49998025/b48ec59a-5f99-450d-b0a6-c2bdb2ed975f)

But I haven't tested with every different error message and I don't have deep understanding about GDScript parser, so something may have broken. If there exists somewhere a test project which contains all possible GDScript error, I would be interested about that.


It might also be worth considering about changing these "Expected indented block ..." error messages a bit.

`"Expected indented block after class declaration"`
--> 
`"Expected indented block after this class declaration"`

Adding "this" would emphasize the fact that it is exactly _this_ function that needs indented block after it. But I may be overcautious here.
