### PR TITLE
GDAP: Allow for custom maven repos to be private, accepting a set of credentials for each url

### DIFF
--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -235,6 +235,8 @@ public:
 
 	String _resolve_export_plugin_android_library_path(const String &p_android_library_path) const;
 
+	String _serialize_android_dependencies_maven_repos(const Vector<Dictionary> &p_maven_repos_definitions) const;
+
 	bool _is_clean_build_required(const Ref<EditorExportPreset> &p_preset);
 
 	String get_apk_expansion_fullpath(const Ref<EditorExportPreset> &p_preset, const String &p_path);

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -136,7 +136,10 @@ PluginConfigAndroid PluginConfigAndroid::load_plugin_config(Ref<ConfigFile> conf
 				}
 
 				plugin_config.remote_dependencies = config_file->get_value(PluginConfigAndroid::DEPENDENCIES_SECTION, PluginConfigAndroid::DEPENDENCIES_REMOTE_KEY, Vector<String>());
-				plugin_config.custom_maven_repos = config_file->get_value(PluginConfigAndroid::DEPENDENCIES_SECTION, PluginConfigAndroid::DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY, Vector<String>());
+				Vector<Variant> custom_maven_repos_variant = config_file->get_value(PluginConfigAndroid::DEPENDENCIES_SECTION, PluginConfigAndroid::DEPENDENCIES_CUSTOM_MAVEN_REPOS_KEY, Vector<Variant>());
+				for (int k = 0; k < custom_maven_repos_variant.size(); k++) {
+					plugin_config.custom_maven_repos.push_back(Dictionary(custom_maven_repos_variant[k]));
+				}
 			}
 
 			plugin_config.valid_config = is_plugin_config_valid(plugin_config);
@@ -170,7 +173,7 @@ void PluginConfigAndroid::get_plugins_binaries(String binary_type, Vector<Plugin
 	}
 }
 
-void PluginConfigAndroid::get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result) {
+void PluginConfigAndroid::get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs, Vector<Dictionary> &r_result) {
 	if (!plugins_configs.is_empty()) {
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfigAndroid config = plugins_configs[i];

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -82,7 +82,7 @@ struct PluginConfigAndroid {
 	// Optional dependencies section
 	Vector<String> local_dependencies;
 	Vector<String> remote_dependencies;
-	Vector<String> custom_maven_repos;
+	Vector<Dictionary> custom_maven_repos;
 
 	static String resolve_local_dependency_path(String plugin_config_dir, String dependency_path);
 
@@ -98,7 +98,7 @@ struct PluginConfigAndroid {
 
 	static void get_plugins_binaries(String binary_type, Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result);
 
-	static void get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result);
+	static void get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs, Vector<Dictionary> &r_result);
 
 	static void get_plugins_names(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result);
 };

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -25,11 +25,20 @@ allprojects {
         mavenCentral()
 
         // Godot user plugins custom maven repos
-        String[] mavenRepos = getGodotPluginsMavenRepos()
-        if (mavenRepos != null && mavenRepos.size() > 0) {
-            for (String repoUrl : mavenRepos) {
+        Map<String, String>[] mavenRepos = getGodotPluginsMavenRepos()
+        if (mavenRepos != null && mavenRepos.length > 0) {
+            mavenRepos.each { repo ->
+                String url = repo.get("url")
+                String username = repo.get("username")
+                String password = repo.get("password")
                 maven {
-                    url repoUrl
+                    url url
+                    if (username && password) {
+                        credentials {
+                            username username
+                            password password
+                        }
+                    }
                 }
             }
         }

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -28,15 +28,15 @@ allprojects {
         Map<String, String>[] mavenRepos = getGodotPluginsMavenRepos()
         if (mavenRepos != null && mavenRepos.length > 0) {
             mavenRepos.each { repo ->
-                String url = repo.get("url")
-                String username = repo.get("username")
-                String password = repo.get("password")
+                String repoUrl = repo.get("url")
+                String repoUsername = repo.get("username")
+                String repoPassword = repo.get("password")
                 maven {
-                    url url
-                    if (username && password) {
+                    url repoUrl
+                    if (repoUsername && repoPassword) {
                         credentials {
-                            username username
-                            password password
+                            username repoUsername
+                            password repoPassword
                         }
                     }
                 }

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -235,14 +235,17 @@ ext.getExportFilename = {
  * of maven repos.
  */
 ext.getGodotPluginsMavenRepos = { ->
-    Set<String> mavenRepos = []
+    List<Map<String, String>> mavenRepos = []
 
     // Retrieve the list of maven repos.
     if (project.hasProperty("plugins_maven_repos")) {
         String mavenReposProperty = project.property("plugins_maven_repos")
         if (mavenReposProperty != null && !mavenReposProperty.trim().isEmpty()) {
-            for (String mavenRepoUrl : mavenReposProperty.split(VALUE_SEPARATOR_REGEX)) {
-                mavenRepos += mavenRepoUrl.trim()
+            for (String mavenRepoData : mavenReposProperty.split(VALUE_SEPARATOR_REGEX)) {
+                mavenRepos += Arrays.stream(mavenRepoData.split(","))
+                     .map(s -> s.split("=", 2))
+                     .filter(arr -> arr.length == 2)
+                     .collect(Collectors.toMap(arr -> arr[0].trim(), arr -> arr[1].trim()));
             }
         }
     }

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -241,11 +241,19 @@ ext.getGodotPluginsMavenRepos = { ->
     if (project.hasProperty("plugins_maven_repos")) {
         String mavenReposProperty = project.property("plugins_maven_repos")
         if (mavenReposProperty != null && !mavenReposProperty.trim().isEmpty()) {
+            // parse maven repo definitions... url=<url>,password=<password>...|...
             for (String mavenRepoData : mavenReposProperty.split(VALUE_SEPARATOR_REGEX)) {
-                mavenRepos += Arrays.stream(mavenRepoData.split(","))
-                     .map(s -> s.split("=", 2))
-                     .filter(arr -> arr.length == 2)
-                     .collect(Collectors.toMap(arr -> arr[0].trim(), arr -> arr[1].trim()));
+                List<String> entries = mavenRepoData.split(",");
+                def repoDefinition = [:];
+                for (String entry : entries) {
+                    List<String> keyValue = entry.split("=", 2);
+                    if (keyValue.size() == 2) {
+                        String key   = keyValue[0].trim();
+                        String value = keyValue[1].trim();
+                        repoDefinition[key] = value;
+                    }
+                }
+                mavenRepos += repoDefinition;
             }
         }
     }


### PR DESCRIPTION
This PR allows for the definition of private custom maven dependency repositories in the context of android plugins. This needed a way to pass a set of credentials for a given url, had a look at the code and found out the parser used for `.gdap` config files supports the parsing of Dictionaries. With this in mind I have changed the way the `custom_maven_repos` property is represented in android plugin config files and made it an array of dictionaries instead of strings. If credentials are required for a repo url, there should be a "credentials" entry otherwise it is acknowledged as a public repo.

example gdap:
```
[config]
name="SimplePlugin"
binary_type="local"
binary="app-debug.aar"

[dependencies]
local=[]
remote=["com.simple.plugin:legacy-impl:1.1.0"]
custom_maven_repos=[{
  "url": "https://public-repo.dev/public-aars"  # <-- public repo
},
{
  "url": "https://private-repo.dev/private-aars"
  "credentials": {
    "username": "godot",
    "password": "duckduckgodot"
  }
}]
```

I have made a [proposal](https://github.com/godotengine/godot-proposals/issues/8443) already, but having the change ready and available at hand I thought of opening a PR just for overviewing what changes the implementation would bring. Turns out it's quite simple in practice. Only thing that leaves me wondering tho, is how great is this in terms of retro-compatibility.