### PR TITLE
Stop caching packed scenes in GDScript cache (on preload)

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4144,21 +4144,14 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 		} else {
 			// TODO: Don't load if validating: use completion cache.
 
-			// Must load GDScript and PackedScenes separately to permit cyclic references
-			// as ResourceLoader::load() detect and reject those.
+			// Must load GDScript separately to permit cyclic references
+			// as ResourceLoader::load() detects and rejects those.
 			if (ResourceLoader::get_resource_type(p_preload->resolved_path) == "GDScript") {
 				Error err = OK;
 				Ref<GDScript> res = GDScriptCache::get_shallow_script(p_preload->resolved_path, err, parser->script_path);
 				p_preload->resource = res;
 				if (err != OK) {
 					push_error(vformat(R"(Could not preload resource script "%s".)", p_preload->resolved_path), p_preload->path);
-				}
-			} else if (ResourceLoader::get_resource_type(p_preload->resolved_path) == "PackedScene") {
-				Error err = OK;
-				Ref<PackedScene> res = GDScriptCache::get_packed_scene(p_preload->resolved_path, err, parser->script_path);
-				p_preload->resource = res;
-				if (err != OK) {
-					push_error(vformat(R"(Could not preload resource scene "%s".)", p_preload->resolved_path), p_preload->path);
 				}
 			} else {
 				p_preload->resource = ResourceLoader::load(p_preload->resolved_path);

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -37,7 +37,6 @@
 
 #include "core/io/file_access.h"
 #include "core/templates/vector.h"
-#include "scene/resources/packed_scene.h"
 
 bool GDScriptParserRef::is_valid() const {
 	return parser != nullptr;
@@ -139,13 +138,6 @@ void GDScriptCache::move_script(const String &p_from, const String &p_to) {
 		return;
 	}
 
-	for (KeyValue<String, HashSet<String>> &E : singleton->packed_scene_dependencies) {
-		if (E.value.has(p_from)) {
-			E.value.insert(p_to);
-			E.value.erase(p_from);
-		}
-	}
-
 	if (singleton->parser_map.has(p_from) && !p_from.is_empty()) {
 		singleton->parser_map[p_to] = singleton->parser_map[p_from];
 	}
@@ -172,15 +164,6 @@ void GDScriptCache::remove_script(const String &p_path) {
 	if (singleton->cleared) {
 		return;
 	}
-
-	for (KeyValue<String, HashSet<String>> &E : singleton->packed_scene_dependencies) {
-		if (!E.value.has(p_path)) {
-			continue;
-		}
-		E.value.erase(p_path);
-	}
-
-	GDScriptCache::clear_unreferenced_packed_scenes();
 
 	if (singleton->parser_map.has(p_path)) {
 		singleton->parser_map[p_path]->clear();
@@ -361,62 +344,6 @@ void GDScriptCache::remove_static_script(const String &p_fqcn) {
 	singleton->static_gdscript_cache.erase(p_fqcn);
 }
 
-Ref<PackedScene> GDScriptCache::get_packed_scene(const String &p_path, Error &r_error, const String &p_owner) {
-	MutexLock lock(singleton->mutex);
-
-	String path = p_path;
-	if (path.begins_with("uid://")) {
-		path = ResourceUID::get_singleton()->get_id_path(ResourceUID::get_singleton()->text_to_id(path));
-	}
-
-	if (singleton->packed_scene_cache.has(path)) {
-		singleton->packed_scene_dependencies[path].insert(p_owner);
-		return singleton->packed_scene_cache[path];
-	}
-
-	Ref<PackedScene> scene = ResourceCache::get_ref(path);
-	if (scene.is_valid()) {
-		singleton->packed_scene_cache[path] = scene;
-		singleton->packed_scene_dependencies[path].insert(p_owner);
-		return scene;
-	}
-	scene.instantiate();
-
-	r_error = OK;
-	if (path.is_empty()) {
-		r_error = ERR_FILE_BAD_PATH;
-		return scene;
-	}
-
-	scene->set_path(path);
-	singleton->packed_scene_cache[path] = scene;
-	singleton->packed_scene_dependencies[path].insert(p_owner);
-
-	scene->reload_from_file();
-	return scene;
-}
-
-void GDScriptCache::clear_unreferenced_packed_scenes() {
-	if (singleton == nullptr) {
-		return;
-	}
-
-	MutexLock lock(singleton->mutex);
-
-	if (singleton->cleared) {
-		return;
-	}
-
-	for (KeyValue<String, HashSet<String>> &E : singleton->packed_scene_dependencies) {
-		if (E.value.size() > 0 || !ResourceLoader::is_imported(E.key)) {
-			continue;
-		}
-
-		singleton->packed_scene_dependencies.erase(E.key);
-		singleton->packed_scene_cache.erase(E.key);
-	}
-}
-
 void GDScriptCache::clear() {
 	if (singleton == nullptr) {
 		return;
@@ -439,16 +366,10 @@ void GDScriptCache::clear() {
 			E->clear();
 	}
 
-	singleton->packed_scene_dependencies.clear();
-	singleton->packed_scene_cache.clear();
-
 	parser_map_refs.clear();
 	singleton->parser_map.clear();
 	singleton->shallow_gdscript_cache.clear();
 	singleton->full_gdscript_cache.clear();
-
-	singleton->packed_scene_cache.clear();
-	singleton->packed_scene_dependencies.clear();
 }
 
 GDScriptCache::GDScriptCache() {

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -37,7 +37,6 @@
 #include "core/os/mutex.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
-#include "scene/resources/packed_scene.h"
 
 class GDScriptAnalyzer;
 class GDScriptParser;
@@ -81,8 +80,6 @@ class GDScriptCache {
 	HashMap<String, Ref<GDScript>> full_gdscript_cache;
 	HashMap<String, Ref<GDScript>> static_gdscript_cache;
 	HashMap<String, HashSet<String>> dependencies;
-	HashMap<String, Ref<PackedScene>> packed_scene_cache;
-	HashMap<String, HashSet<String>> packed_scene_dependencies;
 
 	friend class GDScript;
 	friend class GDScriptParserRef;
@@ -105,9 +102,6 @@ public:
 	static Error finish_compiling(const String &p_owner);
 	static void add_static_script(Ref<GDScript> p_script);
 	static void remove_static_script(const String &p_fqcn);
-
-	static Ref<PackedScene> get_packed_scene(const String &p_path, Error &r_error, const String &p_owner = "");
-	static void clear_unreferenced_packed_scenes();
 
 	static void clear();
 


### PR DESCRIPTION
Adresses #85081

This code was added in #67714, with the goal of resolving problems with cyclic references is `preload()`.

However, cyclic scene references still don't work, as illustrated by #70985 and other preload related issues.

Being resources, scenes don't support cyclic references, and caching seems to just make the problem appear a little bit later, and make it harder to debug (unlike with scripts, where this should be fine, because `get_shallow_script()` is designed to deal with the cyclic reference problem).

IMO this problem cannot be solved from outside core resource functionality and the GDScript module should not try. Pinging @adamscott as the original implementer, please do correct me if I have misunderstood the intent of this code.

Most posted issues regarding preload have no reproduction steps and just include already corrupted scenes, which makes it very hard to tell which this change fixes, however it should improve recovery and consistency of behavior as scenes will for sure be reloaded when the script is recompiled.

*Bugsquad edit:* Fixes #79545 Fixes #84981 Fixes #79840