### PR TITLE
Fix the documentation of `Bone2D::apply_rest`

### DIFF
--- a/doc/classes/Bone2D.xml
+++ b/doc/classes/Bone2D.xml
@@ -15,7 +15,7 @@
 		<method name="apply_rest">
 			<return type="void" />
 			<description>
-				Stores the node's current transforms in [member rest].
+				Resets the bone to the rest pose. This is equivalent to setting [member Node2D.transform] to [member rest].
 			</description>
 		</method>
 		<method name="get_autocalculate_length_and_angle" qualifiers="const">


### PR DESCRIPTION
`apply_rest`'s current description is highly misleading. `Stores the node's current transforms in [member rest].` implies `rest = transform` when it in fact performs `transform = rest`.

This change is compatible with, and should be backported to, `3.x` along with to any relevant engine branches.
