### PR TITLE
Save external data even without scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1693,7 +1693,7 @@ bool EditorNode::_validate_scene_recursive(const String &p_filename, Node *p_nod
 	return false;
 }
 
-int EditorNode::_save_external_resources() {
+int EditorNode::_save_external_resources(bool p_also_save_external_data) {
 	// Save external resources and its subresources if any was modified.
 
 	int flg = 0;
@@ -1737,6 +1737,16 @@ int EditorNode::_save_external_resources() {
 		}
 		ResourceSaver::save(res, res->get_path(), flg);
 		saved++;
+	}
+
+	if (p_also_save_external_data) {
+		for (int i = 0; i < editor_data.get_editor_plugin_count(); i++) {
+			EditorPlugin *plugin = editor_data.get_editor_plugin(i);
+			if (!plugin->get_unsaved_status().is_empty()) {
+				plugin->save_external_data();
+				saved++;
+			}
+		}
 	}
 
 	EditorUndoRedoManager::get_singleton()->set_history_as_saved(EditorUndoRedoManager::GLOBAL_HISTORY);
@@ -2634,10 +2644,10 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					ScriptEditor::get_singleton()->save_current_script();
 				}
 
-				const int saved = _save_external_resources();
+				const int saved = _save_external_resources(true);
 				if (saved > 0) {
 					show_accept(
-							vformat(TTR("The current scene has no root node, but %d modified external resource(s) were saved anyway."), saved),
+							vformat(TTR("The current scene has no root node, but %d modified external resource(s) and/or plugin data were saved anyway."), saved),
 							TTR("OK"));
 				} else if (p_option == FILE_SAVE_AS_SCENE) {
 					// Don't show this dialog when pressing Ctrl + S to avoid interfering with script saving.

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -581,7 +581,7 @@ private:
 
 	void _update_undo_redo_allowed();
 
-	int _save_external_resources();
+	int _save_external_resources(bool p_also_save_external_data = false);
 
 	void _set_current_scene(int p_idx);
 	void _set_current_scene_nocheck(int p_idx);


### PR DESCRIPTION
When using Ctrl+S without scene opened, it saves all modified resources. However it doesn't save external data of editor plugins that don't modify Resources.

This PR ensures that unsaved external data (based on `get_unsaved_status()`) is still saved even when there is no scene. This is mostly relevant for user plugins, as none of Godot's plugins modify non-Resource data AFAIK.

Probably a better solution would be modifying EditorData's `save_editor_external_data()` to work like `_save_external_resources()`, i.e. only save modified external data and return how many plugins were saved, but `get_unsaved_status()` is a recent addition and almost no plugin implements it.