### PR TITLE
Expose `Node.is_part_of_edited_scene()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -619,6 +619,12 @@
 				[method request_ready] resets it back to [code]false[/code].
 			</description>
 		</method>
+		<method name="is_part_of_edited_scene" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the node is part of the scene currently opened in the editor.
+			</description>
+		</method>
 		<method name="is_physics_interpolated" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/scene/2d/audio_listener_2d.cpp
+++ b/scene/2d/audio_listener_2d.cpp
@@ -45,7 +45,7 @@ bool AudioListener2D::_set(const StringName &p_name, const Variant &p_value) {
 
 bool AudioListener2D::_get(const StringName &p_name, Variant &r_ret) const {
 	if (p_name == "current") {
-		if (is_inside_tree() && get_tree()->is_node_being_edited(this)) {
+		if (is_part_of_edited_scene()) {
 			r_ret = current;
 		} else {
 			r_ret = is_current();
@@ -63,13 +63,13 @@ void AudioListener2D::_get_property_list(List<PropertyInfo> *p_list) const {
 void AudioListener2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			if (!get_tree()->is_node_being_edited(this) && current) {
+			if (!is_part_of_edited_scene() && current) {
 				make_current();
 			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			if (!get_tree()->is_node_being_edited(this)) {
+			if (!is_part_of_edited_scene()) {
 				if (is_current()) {
 					clear_current();
 					current = true; // Keep it true.
@@ -98,7 +98,7 @@ void AudioListener2D::clear_current() {
 }
 
 bool AudioListener2D::is_current() const {
-	if (is_inside_tree() && !get_tree()->is_node_being_edited(this)) {
+	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		return get_viewport()->get_audio_listener_2d() == this;
 	} else {
 		return current;

--- a/scene/3d/audio_listener_3d.cpp
+++ b/scene/3d/audio_listener_3d.cpp
@@ -55,7 +55,7 @@ bool AudioListener3D::_set(const StringName &p_name, const Variant &p_value) {
 
 bool AudioListener3D::_get(const StringName &p_name, Variant &r_ret) const {
 	if (p_name == "current") {
-		if (is_inside_tree() && get_tree()->is_node_being_edited(this)) {
+		if (is_part_of_edited_scene()) {
 			r_ret = current;
 		} else {
 			r_ret = is_current();
@@ -81,7 +81,7 @@ void AudioListener3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
 			bool first_listener = get_viewport()->_audio_listener_3d_add(this);
-			if (!get_tree()->is_node_being_edited(this) && (current || first_listener)) {
+			if (!is_part_of_edited_scene() && (current || first_listener)) {
 				make_current();
 			}
 		} break;
@@ -91,7 +91,7 @@ void AudioListener3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_WORLD: {
-			if (!get_tree()->is_node_being_edited(this)) {
+			if (!is_part_of_edited_scene()) {
 				if (is_current()) {
 					clear_current();
 					current = true; //keep it true
@@ -133,7 +133,7 @@ void AudioListener3D::clear_current() {
 }
 
 bool AudioListener3D::is_current() const {
-	if (is_inside_tree() && !get_tree()->is_node_being_edited(this)) {
+	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		return get_viewport()->get_audio_listener_3d() == this;
 	} else {
 		return current;

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -90,7 +90,7 @@ void Camera3D::_update_camera() {
 
 	RenderingServer::get_singleton()->camera_set_transform(camera, get_camera_transform());
 
-	if (get_tree()->is_node_being_edited(this) || !is_current()) {
+	if (is_part_of_edited_scene() || !is_current()) {
 		return;
 	}
 
@@ -126,7 +126,7 @@ void Camera3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_WORLD: {
-			if (!get_tree()->is_node_being_edited(this)) {
+			if (!is_part_of_edited_scene()) {
 				if (is_current()) {
 					clear_current();
 					current = true; //keep it true
@@ -286,7 +286,7 @@ void Camera3D::set_current(bool p_enabled) {
 }
 
 bool Camera3D::is_current() const {
-	if (is_inside_tree() && !get_tree()->is_node_being_edited(this)) {
+	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		return get_viewport()->get_camera_3d() == this;
 	} else {
 		return current;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -197,7 +197,7 @@ void Node3D::_notification(int p_what) {
 			}
 
 #ifdef TOOLS_ENABLED
-			if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
+			if (is_part_of_edited_scene()) {
 				get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SNAME("_request_gizmo_for_id"), get_instance_id());
 			}
 #endif
@@ -582,7 +582,7 @@ void Node3D::set_subgizmo_selection(Ref<Node3DGizmo> p_gizmo, int p_id, Transfor
 		return;
 	}
 
-	if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
+	if (is_part_of_edited_scene()) {
 		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_set_subgizmo_selection, this, p_gizmo, p_id, p_transform);
 	}
 #endif
@@ -599,7 +599,7 @@ void Node3D::clear_subgizmo_selection() {
 		return;
 	}
 
-	if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
+	if (is_part_of_edited_scene()) {
 		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_clear_subgizmo_selection, this);
 	}
 #endif

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -53,7 +53,7 @@ void FileDialog::_focus_file_text() {
 	int lp = file->get_text().rfind(".");
 	if (lp != -1) {
 		file->select(0, lp);
-		if (file->is_inside_tree() && !get_tree()->is_node_being_edited(file)) {
+		if (file->is_inside_tree() && !is_part_of_edited_scene()) {
 			file->grab_focus();
 		}
 	}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -771,7 +771,7 @@ void LineEdit::_notification(int p_what) {
 	switch (p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
-			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
+			if (Engine::get_singleton()->is_editor_hint() && !is_part_of_edited_scene()) {
 				set_caret_blink_enabled(EDITOR_GET("text_editor/appearance/caret/caret_blink"));
 				set_caret_blink_interval(EDITOR_GET("text_editor/appearance/caret/caret_blink_interval"));
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3520,6 +3520,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
 
 	ClassDB::bind_method(D_METHOD("is_inside_tree"), &Node::is_inside_tree);
+	ClassDB::bind_method(D_METHOD("is_part_of_edited_scene"), &Node::is_part_of_edited_scene);
 	ClassDB::bind_method(D_METHOD("is_ancestor_of", "node"), &Node::is_ancestor_of);
 	ClassDB::bind_method(D_METHOD("is_greater_than", "node"), &Node::is_greater_than);
 	ClassDB::bind_method(D_METHOD("get_path"), &Node::get_path);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -525,6 +525,8 @@ public:
 	bool is_property_pinned(const StringName &p_property) const;
 	virtual StringName get_property_store_alias(const StringName &p_property) const;
 	bool is_part_of_edited_scene() const;
+#else
+	bool is_part_of_edited_scene() const { return false; }
 #endif
 	void get_storable_properties(HashSet<StringName> &r_storable_properties) const;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -729,13 +729,6 @@ void SceneTree::set_quit_on_go_back(bool p_enable) {
 	quit_on_go_back = p_enable;
 }
 
-#ifdef TOOLS_ENABLED
-
-bool SceneTree::is_node_being_edited(const Node *p_node) const {
-	return Engine::get_singleton()->is_editor_hint() && edited_scene_root && (edited_scene_root->is_ancestor_of(p_node) || edited_scene_root == p_node);
-}
-#endif
-
 #ifdef DEBUG_ENABLED
 void SceneTree::set_debug_collisions_hint(bool p_enabled) {
 	debug_collisions_hint = p_enabled;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -330,12 +330,6 @@ public:
 	_FORCE_INLINE_ double get_physics_process_time() const { return physics_process_time; }
 	_FORCE_INLINE_ double get_process_time() const { return process_time; }
 
-#ifdef TOOLS_ENABLED
-	bool is_node_being_edited(const Node *p_node) const;
-#else
-	bool is_node_being_edited(const Node *p_node) const { return false; }
-#endif
-
 	void set_pause(bool p_enabled);
 	bool is_paused() const;
 


### PR DESCRIPTION
This PR does 3 things:
- Remove `SceneTree::is_node_being_edited()`. It's function is the same as the newly added `is_part_of_edited_scene()`, but it requires a check whether node is inside scene tree
- `is_part_of_edited_scene()` is now available outside editor, where it will always return `false`
- Exposed `is_part_of_edited_scene()` to scripting

Closes https://github.com/godotengine/godot-proposals/issues/8216
Closes (?) https://github.com/godotengine/godot-proposals/issues/900