### PR TITLE
Disable a prohibitively slow code branch when reparenting nodes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1762,6 +1762,8 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 			}
 		} break;
 
+// FIXME: This approach causes a significant performance regression, see GH-84910.
+#if 0
 		case Variant::OBJECT: {
 			Resource *resource = Object::cast_to<Resource>(r_variant);
 			if (!resource) {
@@ -1792,6 +1794,7 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 			}
 			break;
 		};
+#endif
 
 		default: {
 		}


### PR DESCRIPTION
Addresses (but doesn't fix) https://github.com/godotengine/godot/issues/84910 by temporarily disabling enhancements added in https://github.com/godotengine/godot/pull/80721 and its two follow-ups (https://github.com/godotengine/godot/pull/83934, https://github.com/godotengine/godot/pull/83263).

This temporarily reopens https://github.com/godotengine/godot/issues/74155.

----

We still want this functionality, but some improvements to the approach are necessary. We discussed https://github.com/godotengine/godot/pull/85502 as well, but it only addresses the issue by ignoring a handful of potentially valid cases. So for the time being we have to disable the feature, until a better solution is available.