### PR TITLE
Added proper timeout for blender rpc connection

### DIFF
--- a/modules/gltf/editor/editor_import_blend_runner.h
+++ b/modules/gltf/editor/editor_import_blend_runner.h
@@ -33,6 +33,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "core/io/http_client.h"
 #include "core/os/os.h"
 #include "scene/main/node.h"
 #include "scene/main/timer.h"
@@ -60,6 +61,7 @@ public:
 	bool is_running() { return blender_pid != 0 && OS::get_singleton()->is_process_running(blender_pid); }
 	bool is_using_rpc() { return rpc_port != 0; }
 	Error do_import(const Dictionary &p_options);
+	HTTPClient::Status connect_blender_rpc(const Ref<HTTPClient> &p_client, int p_timeout_usecs);
 
 	EditorImportBlendRunner();
 };


### PR DESCRIPTION
Ran into a bug where blender rpc server would not start fast enough and cause Godot editor to think that it was not running, more details here: in #85446

This simply adds a 1 second delay between starting the rpc server and initiating the connection via HTTP.

I thought about checking the STDOUT of the rpc command, but `OS::create_process` does not have a way to read the STDOUT that I can see in the codebase.

_Production edit: Closes https://github.com/godotengine/godot/issues/85446_