### PR TITLE
Avoid crashes when engine leaks canvas items and friends

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -2165,6 +2165,30 @@ bool RendererCanvasCull::free(RID p_rid) {
 	return true;
 }
 
+template <class T>
+void RendererCanvasCull::_free_rids(T &p_owner, const char *p_type) {
+	List<RID> owned;
+	p_owner.get_owned_list(&owned);
+	if (owned.size()) {
+		if (owned.size() == 1) {
+			WARN_PRINT(vformat("1 RID of type \"%s\" was leaked.", p_type));
+		} else {
+			WARN_PRINT(vformat("%d RIDs of type \"%s\" were leaked.", owned.size(), p_type));
+		}
+		for (const RID &E : owned) {
+			free(E);
+		}
+	}
+}
+
+void RendererCanvasCull::finalize() {
+	_free_rids(canvas_owner, "Canvas");
+	_free_rids(canvas_item_owner, "CanvasItem");
+	_free_rids(canvas_light_owner, "CanvasLight");
+	_free_rids(canvas_light_occluder_owner, "CanvasLightOccluder");
+	_free_rids(canvas_light_occluder_polygon_owner, "CanvasLightOccluderPolygon");
+}
+
 RendererCanvasCull::RendererCanvasCull() {
 	z_list = (RendererCanvasRender::Item **)memalloc(z_range * sizeof(RendererCanvasRender::Item *));
 	z_last_list = (RendererCanvasRender::Item **)memalloc(z_range * sizeof(RendererCanvasRender::Item *));

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -170,6 +170,9 @@ public:
 	RID_Owner<Item, true> canvas_item_owner;
 	RID_Owner<RendererCanvasRender::Light, true> canvas_light_owner;
 
+	template <class T>
+	void _free_rids(T &p_owner, const char *p_type);
+
 	bool disable_scale;
 	bool sdf_used = false;
 	bool snapping_2d_transforms_to_pixel = false;
@@ -329,6 +332,9 @@ public:
 	Rect2 _debug_canvas_item_get_rect(RID p_item);
 
 	bool free(RID p_rid);
+
+	void finalize();
+
 	RendererCanvasCull();
 	~RendererCanvasCull();
 };

--- a/servers/rendering/renderer_canvas_render.cpp
+++ b/servers/rendering/renderer_canvas_render.cpp
@@ -31,6 +31,8 @@
 #include "renderer_canvas_render.h"
 #include "servers/rendering/rendering_server_globals.h"
 
+RendererCanvasRender *RendererCanvasRender::singleton = nullptr;
+
 const Rect2 &RendererCanvasRender::Item::get_rect() const {
 	if (custom_rect || (!rect_dirty && !update_when_visible && skeleton == RID())) {
 		return rect;

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -31,8 +31,6 @@
 #include "renderer_compositor.h"
 
 #include "core/config/project_settings.h"
-#include "core/os/os.h"
-#include "core/string/print_string.h"
 #include "servers/xr_server.h"
 
 RendererCompositor *RendererCompositor::singleton = nullptr;
@@ -57,5 +55,3 @@ RendererCompositor::RendererCompositor() {
 		xr_enabled = XRServer::get_xr_mode() == XRServer::XRMODE_ON;
 	}
 }
-
-RendererCanvasRender *RendererCanvasRender::singleton = nullptr;

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -214,6 +214,7 @@ void RenderingServerDefault::_finish() {
 		free(test_cube);
 	}
 
+	RSG::canvas->finalize();
 	RSG::rasterizer->finalize();
 }
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/85495. Code is gently stolen from the Vulkan renderer, which does a similar thing.

Now you'll see this with the MRP on exit:

```
servers\rendering\renderer_canvas_cull.cpp:2172 - 28 RIDs of type "CanvasItem" were leaked.
WARNING: 28 RIDs of type "CanvasItem" were leaked.
     at: RendererCanvasCull::_free_rids (servers\rendering\renderer_canvas_cull.cpp:2172)
```
Plus a lot of other leaks.

----

What happens, basically, is that when there is a leak we are left with some data in the `RendererCanvasCull` class. When we try to delete it, it attempts to delete all its memory, including `RendererCanvasRender::Item`s it has in store. These contain commands which contain polygons. When you delete polygons, we need to access the `RendererCanvasRender` singleton. But this singleton is already null at this point (it is removed when the rendering server is finalized, whereas `RendererCanvasCull` is only removed when the rendering server is deleted).

So we need to do these things earlier and with more grace, and report to the user that they have a leak.