### PR TITLE
[3.x] Fix touch events in WebXR with an "immersive-ar" session

### DIFF
--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -561,8 +561,15 @@ Vector2 WebXRInterfaceJS::_get_joy_vector_from_axes(int *p_axes) {
 }
 
 Vector2 WebXRInterfaceJS::_get_screen_position_from_joy_vector(const Vector2 &p_joy_vector) {
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
+	if (!scene_tree) {
+		return Vector2();
+	}
+
+	Viewport *viewport = scene_tree->get_root();
+
 	Vector2 position_percentage((p_joy_vector.x + 1.0f) / 2.0f, ((p_joy_vector.y) + 1.0f) / 2.0f);
-	Vector2 position = get_render_targetsize() * position_percentage;
+	Vector2 position = viewport->get_size() * position_percentage;
 
 	return position;
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85482

This was a problem with calculating the position of touch events. It looks like the bug was introduced in PR https://github.com/godotengine/godot/pull/56819, and was fixed for Godot 4 as part of PR https://github.com/godotengine/godot/pull/68870, but the fix never got backported to Godot 3.

This PR is backporting the fix!