### PR TITLE
Fix for Cmd-B shortcut conflict on macOS

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2482,7 +2482,10 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT_OVERRIDE("script_text_editor/contextual_help", "macos", KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::SPACE);
 
 	ED_SHORTCUT("script_text_editor/toggle_bookmark", TTR("Toggle Bookmark"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::B);
+
 	ED_SHORTCUT("script_text_editor/goto_next_bookmark", TTR("Go to Next Bookmark"), KeyModifierMask::CMD_OR_CTRL | Key::B);
+	ED_SHORTCUT_OVERRIDE("script_text_editor/goto_next_bookmark", "macos", KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::B);
+
 	ED_SHORTCUT("script_text_editor/goto_previous_bookmark", TTR("Go to Previous Bookmark"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::B);
 	ED_SHORTCUT("script_text_editor/remove_all_bookmarks", TTR("Remove All Bookmarks"), Key::NONE);
 


### PR DESCRIPTION
Fix for https://github.com/godotengine/godot/issues/56961 / https://github.com/godotengine/godot/issues/35429 where the shortcuts on macOS have a conflict with Cmd-B: "Build Project" and "Go to Next Bookmark".  Moves "Go to Next Bookmark" to Shift+Option+Cmd-B. Not great, but the B key is fairly overloaded.

Rationale for changing it is that Cmd-B is one of the most important hotkeys and having it not work out of the box, sometimes, is frustrating.

Discussed briefly here: https://github.com/godotengine/godot/issues/35429#issuecomment-1831917271

_Production edit:_
- Fixes https://github.com/godotengine/godot/issues/56961
- Fixes https://github.com/godotengine/godot/issues/35429
