### PR TITLE
Permit overriding the projection matrix passed to shaders without affecting culling logic.

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -202,6 +202,11 @@
 		<member name="near" type="float" setter="set_near" getter="get_near" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis. Lower values allow the camera to see objects more up close to its origin, at the cost of lower precision across the [i]entire[/i] range. Values lower than the default can lead to increased Z-fighting.
 		</member>
+		<member name="override_projection" type="Projection" setter="set_override_projection" getter="get_override_projection" default="Projection(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)">
+			If set to a non-zero Projection, overrides the view-projection matrix passed to shaders with this custom matrix. This *only* overrides the projection passed to shaders on the GPU. The [constant PROJECTION_PERSPECTIVE], [constant PROJECTION_ORTHOGONAL], or [constant PROJECTION_FRUSTUM] values are still used for CPU-side operations such as culling, which can be used to provide a separate culling frustum.
+			To clear the overridden projection, set to [code]Projection(Vector4.ZERO, Vector4.ZERO, Vector4.ZERO, Vector4.ZERO)[/code].
+			[member override_projection] does not currently support stereo cameras.
+		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera3D.ProjectionType" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -163,6 +163,16 @@
 				Sets camera to use orthogonal projection, also known as orthographic projection. Objects remain the same size on the screen no matter how far away they are.
 			</description>
 		</method>
+		<method name="camera_set_override_projection">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="matrix" type="Projection" />
+			<description>
+				If set to a non-zero Projection, overrides the view-projection matrix passed to shaders with this custom matrix. This *only* overrides the projection passed to shaders on the GPU. The [method camera_set_frustum], [method camera_set_orthogonal], or [method camera_set_frustum] values are still used for CPU-side operations such as culling, which can be used to provide a separate culling frustum.
+				To clear the overridden projection, set to [code]Projection(Vector4.ZERO, Vector4.ZERO, Vector4.ZERO, Vector4.ZERO)[/code].
+				[method camera_set_override_projection] does not currently support stereo cameras.
+			</description>
+		</method>
 		<method name="camera_set_perspective">
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1451,7 +1451,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_data, bool p_no_fog, const Size2i &p_screen_size, bool p_flip_y, const Color &p_default_bg_color, bool p_pancake_shadows, float p_shadow_bias) {
 	Projection correction;
 	correction.set_depth_correction(p_flip_y, true, false);
-	Projection projection = correction * p_render_data->cam_projection;
+	Projection projection = correction * p_render_data->view_projection[0];
 	//store camera into ubo
 	GLES3::MaterialStorage::store_camera(projection, scene_state.ubo.projection_matrix);
 	GLES3::MaterialStorage::store_camera(projection.inverse(), scene_state.ubo.inv_projection_matrix);

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -368,6 +368,15 @@ void Camera3D::set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, rea
 	update_gizmos();
 }
 
+Projection Camera3D::get_override_projection() const {
+	return override_projection;
+}
+
+void Camera3D::set_override_projection(const Projection &p_matrix) {
+	override_projection = p_matrix;
+	RenderingServer::get_singleton()->camera_set_override_projection(camera, override_projection);
+}
+
 void Camera3D::set_projection(ProjectionType p_mode) {
 	if (p_mode == PROJECTION_PERSPECTIVE || p_mode == PROJECTION_ORTHOGONAL || p_mode == PROJECTION_FRUSTUM) {
 		mode = p_mode;
@@ -672,6 +681,8 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_near", "near"), &Camera3D::set_near);
 	ClassDB::bind_method(D_METHOD("get_projection"), &Camera3D::get_projection);
 	ClassDB::bind_method(D_METHOD("set_projection", "mode"), &Camera3D::set_projection);
+	ClassDB::bind_method(D_METHOD("get_override_projection"), &Camera3D::get_override_projection);
+	ClassDB::bind_method(D_METHOD("set_override_projection", "projection_matrix"), &Camera3D::set_override_projection);
 	ClassDB::bind_method(D_METHOD("set_h_offset", "offset"), &Camera3D::set_h_offset);
 	ClassDB::bind_method(D_METHOD("get_h_offset"), &Camera3D::get_h_offset);
 	ClassDB::bind_method(D_METHOD("set_v_offset", "offset"), &Camera3D::set_v_offset);
@@ -709,6 +720,7 @@ void Camera3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_v_offset", "get_v_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "projection", PROPERTY_HINT_ENUM, "Perspective,Orthogonal,Frustum"), "set_projection", "get_projection");
+	ADD_PROPERTY(PropertyInfo(Variant::PROJECTION, "override_projection"), "set_override_projection", "get_override_projection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "current"), "set_current", "is_current");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fov", PROPERTY_HINT_RANGE, "1,179,0.1,degrees"), "set_fov", "get_fov");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_size", "get_size");
@@ -888,6 +900,7 @@ RID Camera3D::get_pyramid_shape_rid() {
 
 Camera3D::Camera3D() {
 	camera = RenderingServer::get_singleton()->camera_create();
+	override_projection.set_zero();
 	set_perspective(75.0, 0.05, 4000.0);
 	RenderingServer::get_singleton()->camera_set_cull_mask(camera, layers);
 	//active=false;

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -73,6 +73,7 @@ private:
 	real_t v_offset = 0.0;
 	real_t h_offset = 0.0;
 	KeepAspect keep_aspect = KEEP_HEIGHT;
+	Projection override_projection;
 
 	RID camera;
 	RID scenario_id;
@@ -166,6 +167,7 @@ public:
 	real_t get_far() const;
 	real_t get_near() const;
 	Vector2 get_frustum_offset() const;
+	Projection get_override_projection() const;
 
 	ProjectionType get_projection() const;
 
@@ -174,6 +176,7 @@ public:
 	void set_far(real_t p_far);
 	void set_near(real_t p_near);
 	void set_frustum_offset(Vector2 p_offset);
+	void set_override_projection(const Projection &p_matrix);
 
 	virtual Transform3D get_camera_transform() const;
 	virtual Projection get_camera_projection() const;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -82,7 +82,7 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 	Projection correction;
 	correction.set_depth_correction(flip_y);
 	correction.add_jitter_offset(taa_jitter);
-	Projection projection = correction * cam_projection;
+	Projection projection = correction * view_projection[0];
 
 	//store camera into ubo
 	RendererRD::MaterialStorage::store_camera(projection, ubo.projection_matrix);
@@ -266,7 +266,7 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 		Projection prev_correction;
 		prev_correction.set_depth_correction(true);
 		prev_correction.add_jitter_offset(prev_taa_jitter);
-		Projection prev_projection = prev_correction * prev_cam_projection;
+		Projection prev_projection = prev_correction * view_projection[0];
 
 		//store camera into ubo
 		RendererRD::MaterialStorage::store_camera(prev_projection, prev_ubo.projection_matrix);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -106,6 +106,15 @@ void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->zfar = p_z_far;
 }
 
+void RendererSceneCull::camera_set_override_projection(RID p_camera, const Projection &p_matrix) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	Projection zero;
+	zero.set_zero();
+	camera->has_override_projection = (p_matrix != zero);
+	camera->override_projection = p_matrix;
+}
+
 void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform) {
 	Camera *camera = camera_owner.get_or_null(p_camera);
 	ERR_FAIL_NULL(camera);
@@ -2726,6 +2735,9 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		}
 
 		camera_data.set_camera(transform, projection, is_orthogonal, is_frustum, vaspect, jitter, taa_frame_count, camera->visible_layers);
+		if (camera->has_override_projection) {
+			camera_data.set_override_projection(camera->override_projection);
+		}
 #ifndef XR_DISABLED
 	} else {
 		XRServer *xr_server = XRServer::get_singleton();

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -83,11 +83,13 @@ public:
 		Vector2 offset;
 		uint32_t visible_layers;
 		bool vaspect;
+		bool has_override_projection;
 		RID env;
 		RID attributes;
 		RID compositor;
 
 		Transform3D transform;
+		Projection override_projection;
 
 		Camera() {
 			visible_layers = 0xFFFFFFFF;
@@ -98,6 +100,8 @@ public:
 			size = 1.0;
 			offset = Vector2();
 			vaspect = false;
+			has_override_projection = false;
+			override_projection.set_zero();
 		}
 	};
 
@@ -109,6 +113,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
+	virtual void camera_set_override_projection(RID p_camera, const Projection &p_matrix);
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -49,6 +49,12 @@ void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, 
 	taa_frame_count = p_taa_frame_count;
 }
 
+void RendererSceneRender::CameraData::set_override_projection(const Projection &p_projection) {
+	if (view_count == 1) {
+		view_projection[0] = p_projection;
+	}
+}
+
 void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect) {
 	ERR_FAIL_COND_MSG(p_view_count != 2, "Incorrect view count for stereoscopic view");
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -313,6 +313,7 @@ public:
 
 		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
 		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect);
+		void set_override_projection(const Projection &p_projection);
 	};
 
 	virtual void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingMethod::RenderInfo *r_render_info = nullptr) = 0;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -49,6 +49,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_override_projection(RID p_camera, const Projection &p_matrix) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -658,6 +658,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
+	FUNC2(camera_set_override_projection, RID, const Projection &)
 	FUNC2(camera_set_transform, RID, const Transform3D &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2793,6 +2793,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
+	ClassDB::bind_method(D_METHOD("camera_set_override_projection", "camera", "matrix"), &RenderingServer::camera_set_override_projection);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -892,6 +892,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_override_projection(RID p_camera, const Projection &p_matrix) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;


### PR DESCRIPTION
Implements the functionality godotengine/godot-proposals#4932 but takes a slightly different approach.

This provides the option to provide a Projection matrix which will be used only for graphics operations, while keeping existing frustum/perspective/orthogonal modes for CPU-side camera logic such as culling.

When this PR is used with the frustum camera projection mode, we were able to build a functional screen-space mirror which efficiently culls geometry (on the CPU) outside of the visible view frustum of the mirror. You can see our addon here https://github.com/V-Sekai/avatar_vr_demo/tree/master/addons/V-Sekai.xr-mirror and clone this repository to try the demo for yourself. Currently, the demo requires XR due to the XR apis for accessing the camera projection being easier to use than traditional viewport APIs (we weren't able to figure out how to access the non-XR viewport reliably from script, but it does work if configured manually)

Status quo (without this PR) strictly using `set_frustum` projection mode without `override_projection`. Notice the aliasing artifacts that are caused by rendering from the frustum perspective and then transforming the mirror to screen coordinates. Notice the aliasing artifacts on the back wall due to sampling. These are more noticeable as the player walks around.
![mirror_implementation_frustum_mode2](https://github.com/godotengine/godot/assets/39946030/11a107a5-f8fb-4c1a-a1b0-e3752fdda92f)

With this PR, using a screenspace oblique frustum traditionally used for planar reflections in `override_projection`, while using the aforementioned `set_frustum` projection on the Camera node itself. Everything in the reflection looks pixel-perfect.
![mirror_implementation_screenspace_mode2](https://github.com/godotengine/godot/assets/39946030/ccf94dc7-a98e-44a2-ae82-6fd43eda8e3e)


When I find time, I can attempt to summarize the differences in implementation into a counter-proposal, as well as why I think this is a preferable implementation.

The main difference between this and that proposal 4932 is that this implementation provides the ability to have fine-grained control over geometry culling. For example, as you can see in the attached screenshot, if I extend the mirror mesh (shown with noise dithering outside of the pink mirror border), all geometry instances outside of the frustum are not rendered, despite the matrix set as the `override_projection` having a full-screen frustum (as this is a screenspace mirror)
![godot_mirror_dither_illustration](https://github.com/godotengine/godot/assets/39946030/2712992a-a988-4746-b012-4114234b6937)
I walked slightly to the right in this screenshot such that the lamp and right hand were no longer visible in the reflection. Now, you can see here only the left hand is visible in the reflection, and the right hand, lamp, doors, windows and shelves are being frustum-culled. This is exactly what we want.