### PR TITLE
GLES3: Mark CLIP_IGNORE command while batching

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -661,6 +661,13 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	state.current_tex = RID();
 
 	for (uint32_t i = 0; i <= state.current_batch_index; i++) {
+		// Ignoring CLIP_IGNORE command.
+		// Normally this type of command should not exist in here, but
+		// in some cases it will exist as the debris of prior canvas item.
+		if (state.canvas_instance_batches[i].command_type == Item::Command::TYPE_CLIP_IGNORE) {
+			continue;
+		}
+
 		//setup clip
 		if (current_clip != state.canvas_instance_batches[i].clip) {
 			current_clip = state.canvas_instance_batches[i].clip;
@@ -1204,6 +1211,8 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				if (current_clip) {
 					if (ci->ignore != reclip) {
 						_new_batch(r_batch_broken);
+						state.canvas_instance_batches[state.current_batch_index].command = c;
+						state.canvas_instance_batches[state.current_batch_index].command_type = Item::Command::TYPE_CLIP_IGNORE;
 						if (ci->ignore) {
 							state.canvas_instance_batches[state.current_batch_index].clip = nullptr;
 							reclip = true;


### PR DESCRIPTION
Fixes #74115 

EDITED: This PR marks `CLIP_IGNORE` command while batching to prevent unintended drawing when a canvas item's drawing ends with this command.

---

First attempt(was not a good approach):

This PR allows `TYPE_CLIP_IGNORE`(only when it is saying `false` and actually changes clipping state) being into GLES3 canvas item batch array. In theory, `TYPE_CLIP_IGNORE` batch should do nothing, only updating clipping information inside `_render_items()`.

The reason of not adding it when it is saying `true` is that it changes next batch's clipping data which updates clipping information inside `_render_items()`. So it is meaningless to add `true` state into batch array.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
