### PR TITLE
Copy track update mode when adding reset key

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6038,6 +6038,12 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 					existing_idx = reset->track_find_key(dst_track, 0, Animation::FIND_MODE_APPROX);
 				}
 
+				if (animation->track_get_type(sk.track) == Animation::TYPE_VALUE) {
+					undo_redo->add_do_method(reset.ptr(), "value_track_set_update_mode", dst_track, animation->value_track_get_update_mode(sk.track));
+					undo_redo->add_do_method(reset.ptr(), "track_set_interpolation_type", dst_track, animation->track_get_interpolation_type(sk.track));
+					undo_redo->add_do_method(reset.ptr(), "track_set_interpolation_loop_wrap", dst_track, animation->track_get_interpolation_loop_wrap(sk.track));
+				}
+
 				undo_redo->add_do_method(reset.ptr(), "track_insert_key", dst_track, 0, animation->track_get_key_value(sk.track, sk.key), animation->track_get_key_transition(sk.track, sk.key));
 				undo_redo->add_undo_method(reset.ptr(), "track_remove_key_at_time", dst_track, 0);
 


### PR DESCRIPTION
When adding a reset key (by right-clicking a key in animation track), the value is copied over to RESET animation, but not the update mode, and always created continuous track. After AnimationMixer changes this can result in a warning spam if the update mode does not match.

This PR ensures that when creating a reset key from an existing animation track, the track's update mode is copied to the RESET track (even if it already existed).