### PR TITLE
Limit window size updates on title change.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -284,7 +284,13 @@ void Window::set_title(const String &p_title) {
 		embedder->_sub_window_update(this);
 	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
-		_update_window_size();
+		if (keep_title_visible) {
+			Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(tr_title, window_id);
+			Size2i size_limit = get_clamped_minimum_size();
+			if (title_size.x > size_limit.x || title_size.y > size_limit.y) {
+				_update_window_size();
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85537

Changes `set_title` to update window size only if `keep_title_visible` is set and title size is bigger than current limit.