### PR TITLE
Add show_error param to script reload

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -134,7 +134,7 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_source_code"), &Script::has_source_code);
 	ClassDB::bind_method(D_METHOD("get_source_code"), &Script::get_source_code);
 	ClassDB::bind_method(D_METHOD("set_source_code", "source"), &Script::set_source_code);
-	ClassDB::bind_method(D_METHOD("reload", "keep_state"), &Script::reload, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("reload", "keep_state", "show_error"), &Script::reload, DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_base_script"), &Script::get_base_script);
 	ClassDB::bind_method(D_METHOD("get_instance_base_type"), &Script::get_instance_base_type);
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -138,7 +138,7 @@ public:
 	virtual bool has_source_code() const = 0;
 	virtual String get_source_code() const = 0;
 	virtual void set_source_code(const String &p_code) = 0;
-	virtual Error reload(bool p_keep_state = false) = 0;
+	virtual Error reload(bool p_keep_state = false, bool p_show_error = true) = 0;
 
 #ifdef TOOLS_ENABLED
 	virtual Vector<DocData::ClassDoc> get_documentation() const = 0;

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -49,7 +49,7 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_source_code);
 
 	GDVIRTUAL_BIND(_set_source_code, "code");
-	GDVIRTUAL_BIND(_reload, "keep_state");
+	GDVIRTUAL_BIND(_reload, "keep_state", "show_error");
 
 	GDVIRTUAL_BIND(_get_documentation);
 	GDVIRTUAL_BIND(_get_class_icon_path);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -74,7 +74,7 @@ public:
 	EXBIND0RC(bool, has_source_code)
 	EXBIND0RC(String, get_source_code)
 	EXBIND1(set_source_code, const String &)
-	EXBIND1R(Error, reload, bool)
+	EXBIND2R(Error, reload, bool, bool)
 
 	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_documentation)
 	GDVIRTUAL0RC(String, _get_class_icon_path)

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -96,6 +96,7 @@
 		<method name="reload">
 			<return type="int" enum="Error" />
 			<param index="0" name="keep_state" type="bool" default="false" />
+			<param index="1" name="show_error" type="bool" default="true" />
 			<description>
 				Reloads the script's class implementation. Returns an error code.
 			</description>

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -183,6 +183,7 @@
 		<method name="_reload" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="keep_state" type="bool" />
+			<param index="1" name="show_error" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -755,14 +755,16 @@ Error GDScript::reload(bool p_keep_state, bool p_show_error) {
 	err = analyzer.analyze();
 
 	if (err) {
-		if (EngineDebugger::is_active()) {
-			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
-		}
+		if (p_show_error) {
+			if (EngineDebugger::is_active()) {
+				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
+			}
 
-		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
-		while (e != nullptr) {
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
-			e = e->next();
+			const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
+			while (e != nullptr) {
+				_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+				e = e->next();
+			}
 		}
 		reloading = false;
 		return ERR_PARSE_ERROR;
@@ -774,9 +776,12 @@ Error GDScript::reload(bool p_keep_state, bool p_show_error) {
 	err = compiler.compile(&parser, this, p_keep_state);
 
 	if (err) {
-		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+		if (p_show_error) {
+			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+		}
+
 		if (can_run) {
-			if (EngineDebugger::is_active()) {
+			if (p_show_error && EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
 			reloading = false;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -683,7 +683,7 @@ void GDScript::_restore_old_static_data() {
 
 #endif
 
-Error GDScript::reload(bool p_keep_state) {
+Error GDScript::reload(bool p_keep_state, bool p_show_error) {
 	if (reloading) {
 		return OK;
 	}
@@ -740,11 +740,13 @@ Error GDScript::reload(bool p_keep_state) {
 	GDScriptParser parser;
 	Error err = parser.parse(source, path, false);
 	if (err) {
-		if (EngineDebugger::is_active()) {
-			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
+		if (p_show_error) {
+			if (EngineDebugger::is_active()) {
+				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
+			}
+			// TODO: Show all error messages.
+			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		}
-		// TODO: Show all error messages.
-		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		reloading = false;
 		return ERR_PARSE_ERROR;
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -291,7 +291,7 @@ public:
 	virtual String get_class_icon_path() const override;
 #endif // TOOLS_ENABLED
 
-	virtual Error reload(bool p_keep_state = false) override;
+	virtual Error reload(bool p_keep_state = false, bool p_show_error = true) override;
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2631,7 +2631,7 @@ Variant CSharpScript::callp(const StringName &p_method, const Variant **p_args, 
 	return Script::callp(p_method, p_args, p_argcount, r_error);
 }
 
-Error CSharpScript::reload(bool p_keep_state) {
+Error CSharpScript::reload(bool p_keep_state, bool p_show_error) {
 	if (!reload_invalidated) {
 		return OK;
 	}

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -170,7 +170,7 @@ public:
 	}
 #endif // TOOLS_ENABLED
 
-	Error reload(bool p_keep_state = false) override;
+	Error reload(bool p_keep_state = false, bool p_show_error = true) override;
 
 	bool has_script_signal(const StringName &p_signal) const override;
 	void get_script_signal_list(List<MethodInfo> *r_signals) const override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

A pr to resolve the issues in this proposal: https://github.com/godotengine/godot-proposals/issues/8548.

We're adding an extra optional param to the `GDScript.reload()` function. 
Now we can pass (like the Expression class) a param `show_error:bool`.

This is useful for parsing scripts in game or in editor tools were we don't want the error output in the console or the debugger to trigger if a script fails to parse.
