### PR TITLE
Issue template: Change version field to "Tested versions", asking to test earlier versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,19 +5,25 @@ body:
 - type: markdown
   attributes:
     value: |
-      - When reporting bugs, you'll make our life simpler (and the fix will come sooner) if you follow the guidelines in this template.
+      When reporting bugs, please follow the guidelines in this template. This helps identify the problem precisely and thus enables contributors to fix it faster.
       - Write a descriptive issue title above.
       - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
       - Search [open](https://github.com/godotengine/godot/issues) and [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
-      - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/stable/about/release_policy.html).
+      - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/stable/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
+      - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
 
-- type: input
+- type: textarea
   attributes:
-    label: Godot version
-    description: >
-      Specify the Godot version, including the Git commit hash if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
-      If you use a custom build, please test if your issue is reproducible in official builds too.
-    placeholder: 3.5.stable, 4.0.dev [3041becc6]
+    label: Tested versions
+    description: |
+      To properly fix a bug, we need to identify if the bug was recently introduced in the engine, or if it was always present.
+      - Please specify the Godot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
+      - If you can, **please test earlier Godot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Godot releases in our [download archive](https://godotengine.org/download/archive/).
+      - The aim is for us to identify whether a bug is a **regression**, i.e. an issue that didn't exist in a previous version, but was introduced later on, breaking existing functionality. For example, if a bug is reproducible in 4.2.stable but not in 4.1.stable, we would like you to test intermediate 4.2 dev and beta snapshots to find which snapshot is the first one where the issue can be reproduced.
+    placeholder: |
+
+      - Reproducible in: 4.3.dev [d76c1d0e5], 4.2.stable, 4.2.dev5 and later 4.2 snapshots.
+      - Not reproducible in: 4.1.3.stable, 4.2.dev4 and earlier 4.2 snapshots.
   validations:
     required: true
 
@@ -54,12 +60,12 @@ body:
 
 - type: textarea
   attributes:
-    label: Minimal reproduction project
+    label: Minimal reproduction project (MRP)
     description: |
       - A small Godot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
-      - Required, unless the reproduction steps are trivial and don't require any project files to be followed. In this case, write "N/A" in the field.
-      - Drag and drop a ZIP archive to upload it. **Do not select another field until the project is done uploading.**
+      - Having an MRP is very important for contributors to be able to reproduce the bug in the same way that you are experiencing it. When testing a potential fix for the issue, contributors will use the MRP to validate that the fix is working as intended.
+      - If the reproduction steps are not project dependent (e.g. the bug is visible in a brand new project), you can write "N/A" in the field.
+      - Drag and drop a ZIP archive to upload it (max 10 MB). **Do not select another field until the project is done uploading.**
       - **Note for C# users:** If your issue is *not* C#-specific, please upload a minimal reproduction project written in GDScript. This will make it easier for contributors to reproduce the issue locally as not everyone has a .NET setup available.
-      - **If you've been asked by a maintainer to upload a minimal reproduction project, you *must* do so within 7 days.** Otherwise, your bug report will be closed as it'll be considered too difficult to diagnose.
   validations:
     required: true


### PR DESCRIPTION
We very often end up asking users to test different versions to pinpoint if it's a regression, or need to test ourselves. Let's ask explicitly upfront.

Here's how it looks like:

*Edit:* Older version moved at the end in *Details*.

![image](https://github.com/godotengine/godot/assets/4701338/1af99410-bbcc-4daf-9f17-1e7b1b82097b)

---

Some things to discuss:
- Is "Reproducibility" the best name for this?
- Should it be mandatory to fill? If so, should we suggest what to write if users can't test other versions for any reason?
- Where should it be located? It's related to the "Godot version" field, but I felt that putting it up there is jarring and will be a problem for users already familiar with our template.

<details>

First version:

![image](https://github.com/godotengine/godot/assets/4701338/811ae383-6117-42e8-91e2-6116f302b3aa)

</details>

