### PR TITLE
Add option to apply instance changes to base scene

### DIFF
--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -76,6 +76,7 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_AUTO_EXPAND,
 		TOOL_SCENE_EDITABLE_CHILDREN,
 		TOOL_SCENE_USE_PLACEHOLDER,
+		TOOL_SCENE_APPLY_TO_BASE,
 		TOOL_SCENE_MAKE_LOCAL,
 		TOOL_SCENE_OPEN,
 		TOOL_SCENE_CLEAR_INHERITANCE,
@@ -150,6 +151,7 @@ class SceneTreeDock : public VBoxContainer {
 	Label *delete_dialog_label = nullptr;
 	CheckBox *delete_tracks_checkbox = nullptr;
 	ConfirmationDialog *editable_instance_remove_dialog = nullptr;
+	ConfirmationDialog *apply_changes_confirm = nullptr;
 	ConfirmationDialog *placeholder_editable_instance_remove_dialog = nullptr;
 
 	ReparentDialog *reparent_dialog = nullptr;
@@ -215,13 +217,14 @@ class SceneTreeDock : public VBoxContainer {
 	void _shader_creation_closed();
 
 	void _delete_confirm(bool p_cut = false);
-	void _delete_dialog_closed();
 
 	void _toggle_editable_children_from_selection();
 
 	void _reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner);
 	void _reparent_nodes_to_paths_with_transform_and_name(Node *p_root, const Array &p_nodes, const Array &p_paths, const Array &p_transforms, const Array &p_names, Node *p_owner);
 	void _toggle_editable_children(Node *p_node);
+	void _apply_editable_children();
+	void _apply_changes_to_base_scene();
 
 	void _toggle_placeholder_from_selection();
 
@@ -243,7 +246,7 @@ class SceneTreeDock : public VBoxContainer {
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _scene_tree_gui_input(Ref<InputEvent> p_event);
 
-	void _new_scene_from(const String &p_file);
+	void _new_scene_from(const String &p_file, bool p_apply_changes = false, const Dictionary &p_custom_options = Dictionary());
 	void _set_node_owner_recursive(Node *p_node, Node *p_owner, const HashMap<const Node *, Node *> &p_inverse_duplimap);
 
 	bool _validate_no_foreign();

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -143,6 +143,7 @@ private:
 	int last_created_scene = 1;
 
 	bool _find_updated_instances(Node *p_root, Node *p_node, HashSet<String> &checked_paths);
+	bool _find_specified_instance(Node *p_root, Node *p_node, const String &p_instance_path);
 
 	HashMap<StringName, String> _script_class_icon_paths;
 	HashMap<String, StringName> _script_class_file_to_path;
@@ -219,6 +220,7 @@ public:
 	void set_edited_scene_live_edit_root(const NodePath &p_root);
 	NodePath get_edited_scene_live_edit_root();
 	bool check_and_update_scene(int p_idx);
+	void update_scenes_with_instance(const String &p_instance_path);
 	void move_edited_scene_to_index(int p_idx);
 
 	bool call_build();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7649

https://github.com/godotengine/godot/assets/2223172/d4a87c9b-757e-4f70-a5cb-af8c8b024a79

This is an experimental approach. I was wondering about best way to update properties in a scene and what I did is simply overwriting the original scene with instance branch 🤷‍♂️ There are some problems with editor not reloading properly, but overall it seems to work. Unless I'm missing some use-case that's completely broken with this solution?

Putting as draft for now. I'll finish up UX (e.g. by adding "Apply Changes" checkbox when disabling editable children) when the base idea turns out ok.