### PR TITLE
Fix AnimationPlayer seeking for Discrete keys

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -233,7 +233,7 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 		pi.delta = delta;
 		pi.seeked = p_seeked;
 	}
-	pi.is_external_seeking = false;
+	pi.is_external_seeking = true; // AnimationPlayer doesn't have internal seeking.
 	pi.looped_flag = looped_flag;
 	pi.weight = p_blend;
 	make_animation_instance(cd.from->name, pi);


### PR DESCRIPTION
- Fixes #85483
- Fixes #85632

Internal seeking exists to determine the start of playback in AnimationNodes on the AnimationTree. So in the AnimationPlayer, this should always be true, since AnimationPlayer doesn't have internal seeking.

Also the playback process has changed with the AnimationMixer implementation, and the timing of the animation time advance has changed, so the fix in #80708 should not need to be considered.

Tested with https://github.com/godotengine/godot/issues/80640 and confirm it is working correctly.