### PR TITLE
Make unstore AnimationLibrary if AnimationTree is assigned AnimationPlayer

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -799,6 +799,9 @@ void AnimationTree::_validate_property(PropertyInfo &p_property) const {
 		if (p_property.name == "root_node" || p_property.name.begins_with("libraries")) {
 			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
+		if (p_property.name.begins_with("libraries")) {
+			p_property.usage &= ~PROPERTY_USAGE_STORAGE;
+		}
 	}
 }
 


### PR DESCRIPTION
Reported a problem regarding when to enable EditableChildren from @Mickeon.

AnimationTree should not store `libraries` in .tres when it has an AnimationPlayer, as the AnimationLibrary resource may be stored duplicately.

Since this fix concerns of data lost, I would appreciate if someone could please carefully test this fix.

*Bugsquad edit:*
- Should solve #85602