### PR TITLE
Fix `InputEventMouseMotion` is sent to the wrong `Popup` on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3473,13 +3473,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
-			DisplayServer::WindowID receiving_window_id = _get_focused_window_or_popup();
-			if (receiving_window_id == INVALID_WINDOW_ID) {
-				receiving_window_id = window_id;
-			}
 			Ref<InputEventMouseMotion> mm;
 			mm.instantiate();
-			mm->set_window_id(receiving_window_id);
+			mm->set_window_id(window_id);
 			mm->set_ctrl_pressed((wParam & MK_CONTROL) != 0);
 			mm->set_shift_pressed((wParam & MK_SHIFT) != 0);
 			mm->set_alt_pressed(alt_mem);
@@ -3537,11 +3533,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
 
-			if (receiving_window_id != window_id) {
-				// Adjust event position relative to window distance when event is sent to a different window.
-				mm->set_position(mm->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id));
-				mm->set_global_position(mm->get_position());
-			}
 			Input::get_singleton()->parse_input_event(mm);
 
 		} break;


### PR DESCRIPTION
This fixes that a `Popup` may do not get mouse motion events, although it should.
 The consequences were that e.g. a tooltip for a popup item blocked highlighting. (https://github.com/godotengine/godot/issues/70361)
Another issue is, that opening a sub menu blocks the main menu. (https://github.com/godotengine/godot/issues/77246)

The logic now always uses the window that was chosen by Windows itself, which is always the right thing.
The popup behaviour is now the same as on linux and feels much more crisp (tested on a SteamDeck).

I also tested and made sure that bugs like https://github.com/godotengine/godot/issues/69368 do not reappear, since the code written was partly to fix this issue.

Note for testers: `display/window/subwindows/embed_subwindows` needs to be disabled to test this in games.

Fixes: https://github.com/godotengine/godot/issues/70361
Fixes: - https://github.com/godotengine/godot/issues/77246 (only on Windows, not on MacOS)
Fixes: https://github.com/godotengine/godot/issues/66273
Fixes: https://github.com/godotengine/godot/issues/73926