### PR TITLE
Prevent `Camera3D.current` from being set to `true` automatically in the editor.

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -272,7 +272,7 @@ void Camera3D::clear_current(bool p_enable_next) {
 	if (get_viewport()->get_camera_3d() == this) {
 		get_viewport()->_camera_3d_set(nullptr);
 
-		if (p_enable_next) {
+		if (p_enable_next && !Engine::get_singleton()->is_editor_hint()) {
 			get_viewport()->_camera_3d_make_next_current(this);
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #85593