### PR TITLE
AnimationMixer: Remove Object pointer from TrackCache

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -15,10 +15,10 @@
 			<param index="0" name="animation" type="Animation" />
 			<param index="1" name="track" type="int" />
 			<param index="2" name="value" type="Variant" />
-			<param index="3" name="object" type="Object" />
-			<param index="4" name="object_idx" type="int" />
+			<param index="3" name="object_id" type="int" />
+			<param index="4" name="object_sub_idx" type="int" />
 			<description>
-				A virtual function for processing after key getting during playback.
+				A virtual function for processing after getting a key during playback.
 			</description>
 		</method>
 		<method name="add_animation_library">

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "scene/3d/skeleton_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/menu_button.h"

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "scene/3d/skeleton_3d.h"
 #include "scene/animation/animation_mixer.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -33,6 +33,8 @@
 
 #include "../gltf_state.h"
 
+#include "scene/3d/node_3d.h"
+
 class GLTFDocumentExtension : public Resource {
 	GDCLASS(GLTFDocumentExtension, Resource);
 

--- a/modules/gltf/structures/gltf_skin.h
+++ b/modules/gltf/structures/gltf_skin.h
@@ -34,6 +34,7 @@
 #include "../gltf_defines.h"
 
 #include "core/io/resource.h"
+#include "scene/resources/skin.h"
 
 template <typename T>
 class TypedArray;

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -31,9 +31,7 @@
 #ifndef ANIMATION_MIXER_H
 #define ANIMATION_MIXER_H
 
-#include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/node_3d.h"
-#include "scene/3d/skeleton_3d.h"
+#include "scene/main/node.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/animation_library.h"
 #include "scene/resources/audio_stream_polyphonic.h"
@@ -138,7 +136,6 @@ protected:
 		bool root_motion = false;
 		uint64_t setup_pass = 0;
 		Animation::TrackType type = Animation::TrackType::TYPE_ANIMATION;
-		Object *object = nullptr;
 		ObjectID object_id;
 		real_t total_weight = 0.0;
 
@@ -147,7 +144,6 @@ protected:
 				root_motion(p_other.root_motion),
 				setup_pass(p_other.setup_pass),
 				type(p_other.type),
-				object(p_other.object),
 				object_id(p_other.object_id),
 				total_weight(p_other.total_weight) {}
 
@@ -156,8 +152,7 @@ protected:
 
 	struct TrackCacheTransform : public TrackCache {
 #ifndef _3D_DISABLED
-		Node3D *node_3d = nullptr;
-		Skeleton3D *skeleton = nullptr;
+		ObjectID skeleton_id;
 #endif // _3D_DISABLED
 		int bone_idx = -1;
 		bool loc_used = false;
@@ -173,8 +168,7 @@ protected:
 		TrackCacheTransform(const TrackCacheTransform &p_other) :
 				TrackCache(p_other),
 #ifndef _3D_DISABLED
-				node_3d(p_other.node_3d),
-				skeleton(p_other.skeleton),
+				skeleton_id(p_other.skeleton_id),
 #endif
 				bone_idx(p_other.bone_idx),
 				loc_used(p_other.loc_used),
@@ -201,14 +195,12 @@ protected:
 	};
 
 	struct TrackCacheBlendShape : public TrackCache {
-		MeshInstance3D *mesh_3d = nullptr;
 		float init_value = 0;
 		float value = 0;
 		int shape_index = -1;
 
 		TrackCacheBlendShape(const TrackCacheBlendShape &p_other) :
 				TrackCache(p_other),
-				mesh_3d(p_other.mesh_3d),
 				init_value(p_other.init_value),
 				value(p_other.value),
 				shape_index(p_other.shape_index) {}
@@ -351,9 +343,9 @@ protected:
 
 	/* ---- Blending processor ---- */
 	virtual void _process_animation(double p_delta, bool p_update_only = false);
-	virtual Variant _post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, const Object *p_object, int p_object_idx = -1);
-	Variant post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, const Object *p_object, int p_object_idx = -1);
-	GDVIRTUAL5RC(Variant, _post_process_key_value, Ref<Animation>, int, Variant, Object *, int);
+	virtual Variant _post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
+	Variant post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
+	GDVIRTUAL5RC(Variant, _post_process_key_value, Ref<Animation>, int, Variant, ObjectID, int);
 
 	void _blend_init();
 	virtual bool _blend_pre_process(double p_delta, int p_track_count, const HashMap<NodePath, int> &p_track_map);
@@ -361,7 +353,7 @@ protected:
 	void _blend_process(double p_delta, bool p_update_only = false);
 	void _blend_apply();
 	virtual void _blend_post_process();
-	void _call_object(Object *p_object, const StringName &p_method, const Vector<Variant> &p_params, bool p_deferred);
+	void _call_object(ObjectID p_object_id, const StringName &p_method, const Vector<Variant> &p_params, bool p_deferred);
 
 public:
 	/* ---- Data lists ---- */


### PR DESCRIPTION
Using it could easily lead to use-after-free crashes, as the object may have been freed. Caching object pointers like this is unsafe.

Instead, we rely only on the ObjectID and query ObjectDB with it each time we need access to the instance.

- Fixes #85365.
- Fixes #85572.

---

I'm not familiar with this code, so please review thoroughly @TokageItLab.
Feel free to amend or supersede my PR if you'd like to do some of these checks differently.