### PR TITLE
Add wireframe for compatibility mode

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2758,6 +2758,15 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				prev_index_array_gl = 0;
 			}
 
+			bool use_wireframe = false;
+			if (p_params->force_wireframe) {
+				GLuint wireframe_index_array_gl = mesh_storage->mesh_surface_get_index_buffer_wireframe(mesh_surface);
+				if (wireframe_index_array_gl) {
+					index_array_gl = wireframe_index_array_gl;
+					use_wireframe = true;
+				}
+			}
+
 			bool use_index_buffer = index_array_gl != 0;
 			if (prev_index_array_gl != index_array_gl) {
 				if (index_array_gl != 0) {
@@ -2946,6 +2955,11 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				count = mesh_storage->mesh_surface_get_vertices_drawn_count(mesh_surface);
 			}
 
+			if (use_wireframe) {
+				// In this case we are using index count, and we need double the indices for the wireframe mesh.
+				count = count * 2;
+			}
+
 			if constexpr (p_pass_mode != PASS_MODE_DEPTH) {
 				// Don't count draw calls during depth pre-pass to match the RD renderers.
 				if (p_render_data->render_info) {
@@ -3000,17 +3014,25 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					glVertexAttribI4ui(15, default_color, default_color, default_custom, default_custom);
 				}
 
-				if (use_index_buffer) {
-					glDrawElementsInstanced(primitive_gl, count, mesh_storage->mesh_surface_get_index_type(mesh_surface), 0, inst->instance_count);
+				if (use_wireframe) {
+					glDrawElementsInstanced(GL_LINES, count, GL_UNSIGNED_INT, 0, inst->instance_count);
 				} else {
-					glDrawArraysInstanced(primitive_gl, 0, count, inst->instance_count);
+					if (use_index_buffer) {
+						glDrawElementsInstanced(primitive_gl, count, mesh_storage->mesh_surface_get_index_type(mesh_surface), 0, inst->instance_count);
+					} else {
+						glDrawArraysInstanced(primitive_gl, 0, count, inst->instance_count);
+					}
 				}
 			} else {
 				// Using regular Mesh.
-				if (use_index_buffer) {
-					glDrawElements(primitive_gl, count, mesh_storage->mesh_surface_get_index_type(mesh_surface), 0);
+				if (use_wireframe) {
+					glDrawElements(GL_LINES, count, GL_UNSIGNED_INT, 0);
 				} else {
-					glDrawArrays(primitive_gl, 0, count);
+					if (use_index_buffer) {
+						glDrawElements(primitive_gl, count, mesh_storage->mesh_surface_get_index_type(mesh_surface), 0);
+					} else {
+						glDrawArrays(primitive_gl, 0, count);
+					}
 				}
 			}
 

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -63,8 +63,7 @@ public:
 	int64_t max_renderable_lights = 0;
 	int64_t max_lights_per_object = 0;
 
-	// TODO implement wireframe in OpenGL
-	// bool generate_wireframes;
+	bool generate_wireframes = false;
 
 	HashSet<String> extensions;
 

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -84,6 +84,14 @@ struct Mesh {
 		uint32_t index_count = 0;
 		uint32_t index_buffer_size = 0;
 
+		struct Wireframe {
+			GLuint index_buffer = 0;
+			uint32_t index_count = 0;
+			uint32_t index_buffer_size = 0;
+		};
+
+		Wireframe *wireframe = nullptr;
+
 		struct LOD {
 			float edge_length = 0.0;
 			uint32_t index_count = 0;
@@ -374,6 +382,16 @@ public:
 		} else {
 			return s->lods[p_lod - 1].index_buffer;
 		}
+	}
+
+	_FORCE_INLINE_ GLuint mesh_surface_get_index_buffer_wireframe(void *p_surface) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+
+		if (s->wireframe) {
+			return s->wireframe->index_buffer;
+		}
+
+		return 0;
 	}
 
 	_FORCE_INLINE_ GLenum mesh_surface_get_index_type(void *p_surface) const {

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -327,6 +327,8 @@ void Utilities::update_dirty_resources() {
 }
 
 void Utilities::set_debug_generate_wireframes(bool p_generate) {
+	Config *config = Config::get_singleton();
+	config->generate_wireframes = p_generate;
 }
 
 bool Utilities::has_os_feature(const String &p_feature) const {


### PR DESCRIPTION
The implementation for wireframe mode is mostly the same as the one in https://github.com/godotengine/godot/commit/4d50c7ad8c77efd304d343edf81a81c596958d7d
which is used in Godot 3.5

- *Production edit: This partially addresses https://github.com/godotengine/godot/issues/82485.*