### PR TITLE
Fix memory corruption and assert failures in convex decomposition

### DIFF
--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -969,7 +969,7 @@ Vector<Ref<Shape3D>> ImporterMesh::convex_decompose(const Ref<MeshConvexDecompos
 				if (found_vertex) {
 					index = found_vertex->value;
 				} else {
-					index = ++vertex_count;
+					index = vertex_count++;
 					vertex_map[vertex] = index;
 					vertex_w[index] = vertex;
 				}


### PR DESCRIPTION
This PR fixes [issue 85439](https://github.com/godotengine/godot/issues/85439) by changing the index pre-increment to post-increment so index 0 is not skipped and preventing a potential overrun past the end of the vertices vector.

Testing involved constructing a GLB file consisting of a single triangle:
![image](https://github.com/godotengine/godot/assets/1863707/ae95eafa-efc4-4c2c-8b9f-34a43491ba14)

Before this change the code allocates vertices and indices arrays of size 3 and writes the following:
| Vertices (size=3) | Indices (size=3) |
| ---- | ---- |
| 0 = unused | 1 |
| 1 = [-1,-1,-1] | 2 |
| 2= [1,-1,-1] | 3 |
| 3 = [0,1,-1] (BUFFER OVERRUN) | unused |

After this change the code writes the following:
| Vertices (size=3) | Indices (size=3) |
| ---- | ---- |
| 0 = [-1,-1,-1] | 0 |
| 1 = [1,-1,-1] | 1 |
| 2= [0,1,-1] | 2 |

The collision shape with this new data appears correct:
![image](https://github.com/godotengine/godot/assets/1863707/cde64e43-de9e-4735-943b-9c40a93d9d10)


[offset_triangle.zip](https://github.com/godotengine/godot/files/13532122/offset_triangle.zip)
