### PR TITLE
Set ReflectionProbe frame before mapping id in mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1669,6 +1669,8 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 	for (uint32_t i = 0; i < reflection_count; i++) {
 		ReflectionProbeInstance *rpi = reflection_sort[i].probe_instance;
 
+		rpi->last_pass = RSG::rasterizer->get_frame_number();
+
 		if (using_forward_ids) {
 			forward_id_storage->map_forward_id(FORWARD_ID_TYPE_REFLECTION_PROBE, rpi->forward_id, i, rpi->last_pass);
 		}
@@ -1717,8 +1719,6 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 
 		// hook for subclass to do further processing.
 		RendererSceneRenderRD::get_singleton()->setup_added_reflection_probe(transform, extents);
-
-		rpi->last_pass = RSG::rasterizer->get_frame_number();
 	}
 
 	if (reflection_count) {


### PR DESCRIPTION
Fixes an unreported regression from https://github.com/godotengine/godot/pull/83493

The `last_pass` of the ReflectionProbe was set after mapping the ID. Which means that it was always out of date, resulting in the ReflectionProbe being culled at draw time. 

I'm very surprised that this hasn't been reported as it totally breaks ReflectionProbes in the mobile renderer.

*Bugsquad edit:*
- Fixes #85873