### PR TITLE
Ensure slider grabs focus only when it can

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -88,10 +88,14 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		} else if (scrollable) {
 			if (mb->is_pressed() && mb->get_button_index() == MouseButton::WHEEL_UP) {
-				grab_focus();
+				if (get_focus_mode() != FOCUS_NONE) {
+					grab_focus();
+				}
 				set_value(get_value() + get_step());
 			} else if (mb->is_pressed() && mb->get_button_index() == MouseButton::WHEEL_DOWN) {
-				grab_focus();
+				if (get_focus_mode() != FOCUS_NONE) {
+					grab_focus();
+				}
 				set_value(get_value() - get_step());
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85638

Slider attempts to grab focus when the user scrolls them with the mouse wheel (https://github.com/godotengine/godot/pull/38918). This check ensures it only does that when the focus mode allows it to.