### PR TITLE
Defer creating new editor process in "Quit to Project List" just like in "Reload Current Project"

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3189,8 +3189,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 			}
 			args.push_back("--project-manager");
 
-			Error err = OS::get_singleton()->create_instance(args);
-			ERR_FAIL_COND(err);
+			OS::get_singleton()->set_restart_on_exit(true, args);
 		} break;
 		case RELOAD_CURRENT_PROJECT: {
 			restart_editor();


### PR DESCRIPTION
Possible fix for https://github.com/godotengine/godot/issues/40968
`Reload Current Project` creates new editor process when all of the files used by editor are closed (as in `FileAccess` closed).
I was investigating the issue https://github.com/godotengine/godot/issues/40968 - why `Quit to Project List` was wiping my editor settings and the list of recently opened projects. I've noticed that my debug logs from closing files were mixed with new editor instance logs, meaning that in some cases they could collide in file locks.
Using the solution from `Reload Current Project` (deferring with `OS::get_singleton()->set_restart_on_exit(true, args);`) prevents it.

It has to be applied to 3.x too, originally I've encountered the #40968 issue in multiple 3.x versions (recently in 3.5.2 Mono).

*Bugsquad edit:*
- Fixes #40968