### PR TITLE
Add support for stopping `SceneTreeTimer`

### DIFF
--- a/doc/classes/SceneTreeTimer.xml
+++ b/doc/classes/SceneTreeTimer.xml
@@ -27,6 +27,20 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="is_stopped" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true in case this timer has been stopped.
+			</description>
+		</method>
+		<method name="stop">
+			<return type="void" />
+			<description>
+				Stops this timer at the next time this timer would be processed. No further signals will be emitted.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="time_left" type="float" setter="set_time_left" getter="get_time_left">
 			The time remaining (in seconds).

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -68,10 +68,20 @@
 void SceneTreeTimer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_time_left", "time"), &SceneTreeTimer::set_time_left);
 	ClassDB::bind_method(D_METHOD("get_time_left"), &SceneTreeTimer::get_time_left);
+	ClassDB::bind_method(D_METHOD("stop"), &SceneTreeTimer::stop);
+	ClassDB::bind_method(D_METHOD("is_stopped"), &SceneTreeTimer::is_stopped);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left", PROPERTY_HINT_NONE, "suffix:s"), "set_time_left", "get_time_left");
 
 	ADD_SIGNAL(MethodInfo("timeout"));
+}
+
+void SceneTreeTimer::stop() {
+	stopped = true;
+}
+
+bool SceneTreeTimer::is_stopped() const {
+	return stopped;
 }
 
 void SceneTreeTimer::set_time_left(double p_time) {
@@ -562,6 +572,12 @@ void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 	List<Ref<SceneTreeTimer>>::Element *L = timers.back(); //last element
 
 	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E;) {
+		if (E->get()->is_stopped()) {
+			//timer got stopped, let's remove it.
+			timers.erase(E);
+			continue;
+		}
+
 		List<Ref<SceneTreeTimer>>::Element *N = E->next();
 		if ((paused && !E->get()->is_process_always()) || (E->get()->is_process_in_physics() != p_physics_frame)) {
 			if (E == L) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -57,10 +57,16 @@ class SceneTreeTimer : public RefCounted {
 	bool process_in_physics = false;
 	bool ignore_time_scale = false;
 
+private:
+	bool stopped = false;
+
 protected:
 	static void _bind_methods();
 
 public:
+	void stop();
+	bool is_stopped() const;
+
 	void set_time_left(double p_time);
 	double get_time_left() const;
 


### PR DESCRIPTION
The `SceneTreeTween` (3.5+) / `Tween` (4.x+) exposes a `stop()` [method already](hhttps://docs.godotengine.org/en/4.2/classes/class_tween.html#class-tween-method-stop), however, `SceneTreeTimer` does not currently. This pull request aims to fix this inconsistency and give users the option to stop scene tree timers.

**EDIT** this pull request is the result from suggestions of people in my community as they were unable to stop SceneTreeTimer and it caused confusion why e.g. `Timer` and `Tween` can be stopped, but not `SceneTreeTimer`. A proposal to this addition will be linked up separately to facilitate discussion on this change.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8577*