### PR TITLE
[4.2] Fix SubViewport physics picking

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -739,6 +739,14 @@ void Viewport::_process_picking() {
 
 	while (physics_picking_events.size()) {
 		local_input_handled = false;
+		if (!handle_input_locally) {
+			Viewport *vp = this;
+			while (!Object::cast_to<Window>(vp) && vp->get_parent()) {
+				vp = vp->get_parent()->get_viewport();
+			}
+			vp->local_input_handled = false;
+		}
+
 		Ref<InputEvent> ev = physics_picking_events.front()->get();
 		physics_picking_events.pop_front();
 


### PR DESCRIPTION
Apply the logic of `handle_input_locally` for physics picking (as done in #77730).

resolve in 4.2 issue #84258

For master I consider #77926 the better approach, but in order to not break compatibility in 4.2, I consider this a viable option to fix this in 4.2.