### PR TITLE
Flush delete queue after process frame timers

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -471,12 +471,12 @@ bool SceneTree::physics_process(double p_time) {
 	MessageQueue::get_singleton()->flush(); //small little hack
 
 	process_timers(p_time, true); //go through timers
-
 	process_tweens(p_time, true);
 
 	flush_transform_notifications();
 	root_lock--;
 
+	// This should happen last because any processing that deletes something beforehand might expect the object to be removed in the same frame.
 	_flush_delete_queue();
 	_call_idle_callbacks();
 
@@ -513,17 +513,17 @@ bool SceneTree::process(double p_time) {
 
 	root_lock--;
 
-	_flush_delete_queue();
-
 	if (unlikely(pending_new_scene)) {
 		_flush_scene_change();
 	}
 
 	process_timers(p_time, false); //go through timers
-
 	process_tweens(p_time, false);
 
-	flush_transform_notifications(); //additional transforms after timers update
+	flush_transform_notifications(); // Additional transforms after timers update.
+
+	// This should happen last because any processing that deletes something beforehand might expect the object to be removed in the same frame.
+	_flush_delete_queue();
 
 	_call_idle_callbacks();
 


### PR DESCRIPTION
After timers are processed in process frame, the delete queue is not flushed, which makes queued nodes exist until next frame, leading to unwanted behaviors. This is unlike physics frame, where the queue does flush after timers.

This is surprisingly easy to run into, because SceneTreeTimer defaults to process frame. Consider this code:
```GDScript
await get_tree().create_timer(0.1).timeout
queue_free()
```
The node will be freed one frame after it was queued, instead of the same frame as usually happens.

I made a reproduction project for a case where this is relevant:
[NodeStayer.zip](https://github.com/godotengine/godot/files/13536934/NodeStayer.zip)
Run `bug.tscn` and `nobug.tscn` and compare the results.