### PR TITLE
SCons: Implement more type hints in build scripts

### DIFF
--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -1,7 +1,7 @@
 import zlib
 
 
-def run(target, source, env):
+def run(target, source, env) -> None:
     src = source[0]
     dst = target[0]
     f = open(src, "rb")

--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -7,7 +7,7 @@ _FORCE_INLINE_ virtual $RETVAL m_name($FUNCARGS) $CONST override { \\
 """
 
 
-def generate_mod_version(argcount, const=False, returns=False):
+def generate_mod_version(argcount: int, const: bool = False, returns: bool = False) -> str:
     s = proto_mod
     sproto = str(argcount)
     method_info = ""
@@ -65,7 +65,7 @@ virtual $RETVAL m_name($FUNCARGS) $CONST override { \\
 """
 
 
-def generate_ex_version(argcount, const=False, returns=False):
+def generate_ex_version(argcount: int, const: bool = False, returns: bool = False) -> str:
     s = proto_ex
     sproto = str(argcount)
     method_info = ""
@@ -118,7 +118,7 @@ def generate_ex_version(argcount, const=False, returns=False):
     return s
 
 
-def run(target, source, env):
+def run(target, source, env) -> None:
     max_versions = 12
 
     txt = """

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -3,11 +3,11 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 """
 
-from platform_methods import subprocess_main
 from collections import OrderedDict
+from typing import Dict
 
 
-def make_default_controller_mappings(target, source, env):
+def make_default_controller_mappings(target, source, env) -> None:
     dst = target[0]
     g = open(dst, "w")
 
@@ -16,7 +16,7 @@ def make_default_controller_mappings(target, source, env):
     g.write('#include "core/input/default_controller_mappings.h"\n')
 
     # ensure mappings have a consistent order
-    platform_mappings: dict = OrderedDict()
+    platform_mappings: Dict[str, Dict[str, str]] = OrderedDict()
     for src_path in source:
         with open(src_path, "r") as f:
             # read mapping file and skip header
@@ -66,4 +66,6 @@ def make_default_controller_mappings(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -73,7 +73,7 @@ proto = """#define GDVIRTUAL$VER($RET m_name $ARG)\\
 """
 
 
-def generate_version(argcount, const=False, returns=False):
+def generate_version(argcount: int, const: bool = False, returns: bool = False) -> str:
     s = proto
     sproto = str(argcount)
     method_info = ""
@@ -168,7 +168,7 @@ def generate_version(argcount, const=False, returns=False):
     return s
 
 
-def run(target, source, env):
+def run(target, source, env) -> None:
     max_versions = 12
 
     txt = """/* THIS FILE IS GENERATED DO NOT EDIT */

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -10,13 +10,12 @@ import subprocess
 import tempfile
 import uuid
 import zlib
-from platform_methods import subprocess_main
 
 
-def make_doc_header(target, source, env):
+def make_doc_header(target, source, env) -> None:
     dst = target[0]
     g = open(dst, "w", encoding="utf-8")
-    buf = ""
+    doc = ""
     docbegin = ""
     docend = ""
     for src in source:
@@ -24,9 +23,9 @@ def make_doc_header(target, source, env):
             continue
         with open(src, "r", encoding="utf-8") as f:
             content = f.read()
-        buf += content
+        doc += content
 
-    buf = (docbegin + buf + docend).encode("utf-8")
+    buf = (docbegin + doc + docend).encode("utf-8")
     decomp_size = len(buf)
 
     # Use maximum zlib compression level to further reduce file size
@@ -49,7 +48,7 @@ def make_doc_header(target, source, env):
     g.close()
 
 
-def make_fonts_header(target, source, env):
+def make_fonts_header(target, source, env) -> None:
     dst = target[0]
 
     g = open(dst, "w", encoding="utf-8")
@@ -77,7 +76,7 @@ def make_fonts_header(target, source, env):
     g.close()
 
 
-def make_translations_header(target, source, env, category):
+def make_translations_header(target, source, env, category: str) -> None:
     dst = target[0]
 
     g = open(dst, "w", encoding="utf-8")
@@ -86,7 +85,7 @@ def make_translations_header(target, source, env, category):
     g.write("#ifndef _{}_TRANSLATIONS_H\n".format(category.upper()))
     g.write("#define _{}_TRANSLATIONS_H\n".format(category.upper()))
 
-    sorted_paths = sorted(source, key=lambda path: os.path.splitext(os.path.basename(path))[0])
+    sorted_paths = sorted(source, key=lambda path: os.path.splitext(os.path.basename(path))[0])  # type: ignore
 
     msgfmt_available = shutil.which("msgfmt") is not None
 
@@ -155,17 +154,19 @@ def make_translations_header(target, source, env, category):
     g.close()
 
 
-def make_editor_translations_header(target, source, env):
+def make_editor_translations_header(target, source, env) -> None:
     make_translations_header(target, source, env, "editor")
 
 
-def make_property_translations_header(target, source, env):
+def make_property_translations_header(target, source, env) -> None:
     make_translations_header(target, source, env, "property")
 
 
-def make_doc_translations_header(target, source, env):
+def make_doc_translations_header(target, source, env) -> None:
     make_translations_header(target, source, env, "doc")
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/editor/icons/editor_icons_builders.py
+++ b/editor/icons/editor_icons_builders.py
@@ -6,11 +6,10 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 import os
 from io import StringIO
-from platform_methods import subprocess_main
 
 
 # See also `scene/theme/icons/default_theme_icons_builders.py`.
-def make_editor_icons_action(target, source, env):
+def make_editor_icons_action(target, source, env) -> None:
     dst = target[0]
     svg_icons = source
 
@@ -92,4 +91,6 @@ def make_editor_icons_action(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/editor/template_builders.py
+++ b/editor/template_builders.py
@@ -4,10 +4,9 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 import os
 from io import StringIO
-from platform_methods import subprocess_main
 
 
-def parse_template(inherits, source, delimiter):
+def parse_template(inherits: str, source: str, delimiter: str) -> str:
     script_template = {
         "inherits": inherits,
         "name": "",
@@ -52,7 +51,7 @@ def parse_template(inherits, source, delimiter):
         )
 
 
-def make_templates(target, source, env):
+def make_templates(target, source, env) -> None:
     dst = target[0]
     s = StringIO()
     s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n\n")
@@ -92,4 +91,6 @@ def make_templates(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -5,37 +5,35 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 """
 import os.path
 
-from typing import Optional
-
-from platform_methods import subprocess_main
+from typing import Optional, List, Tuple
 
 
 class GLES3HeaderStruct:
-    def __init__(self):
-        self.vertex_lines = []
-        self.fragment_lines = []
-        self.uniforms = []
-        self.fbos = []
-        self.texunits = []
-        self.texunit_names = []
-        self.ubos = []
-        self.ubo_names = []
-        self.feedbacks = []
+    def __init__(self) -> None:
+        self.vertex_lines: List[str] = []
+        self.fragment_lines: List[str] = []
+        self.uniforms: List[str] = []
+        self.fbos: List[str] = []
+        self.texunits: List[Tuple[str, str]] = []
+        self.texunit_names: List[str] = []
+        self.ubos: List[Tuple[str, str]] = []
+        self.ubo_names: List[str] = []
+        self.feedbacks: List[Tuple[str, str]] = []
 
-        self.vertex_included_files = []
-        self.fragment_included_files = []
+        self.vertex_included_files: List[str] = []
+        self.fragment_included_files: List[str] = []
 
-        self.reading = ""
-        self.line_offset = 0
-        self.vertex_offset = 0
-        self.fragment_offset = 0
-        self.variant_defines = []
-        self.variant_names = []
-        self.specialization_names = []
-        self.specialization_values = []
+        self.reading: str = ""
+        self.line_offset: int = 0
+        self.vertex_offset: int = 0
+        self.fragment_offset: int = 0
+        self.variant_defines: List[str] = []
+        self.variant_names: List[str] = []
+        self.specialization_names: List[str] = []
+        self.specialization_values: List[str] = []
 
 
-def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, depth: int):
+def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, depth: int) -> GLES3HeaderStruct:
     fs = open(filename, "r")
     line = fs.readline()
 
@@ -201,7 +199,7 @@ def build_gles3_header(
     class_suffix: str,
     optional_output_filename: Optional[str] = None,
     header_data: Optional[GLES3HeaderStruct] = None,
-):
+) -> None:
     header_data = header_data or GLES3HeaderStruct()
     include_file_in_gles3_header(filename, header_data, 0)
 
@@ -509,16 +507,16 @@ def build_gles3_header(
 
     if header_data.texunits:
         fd.write("\t\tstatic TexUnitPair _texunit_pairs[]={\n")
-        for x in header_data.texunits:
-            fd.write('\t\t\t{"' + x[0] + '",' + x[1] + "},\n")
+        for x, y in header_data.texunits:
+            fd.write('\t\t\t{"' + x + '",' + y + "},\n")
         fd.write("\t\t};\n\n")
     else:
         fd.write("\t\tstatic TexUnitPair *_texunit_pairs=nullptr;\n")
 
     if header_data.ubos:
         fd.write("\t\tstatic UBOPair _ubo_pairs[]={\n")
-        for x in header_data.ubos:
-            fd.write('\t\t\t{"' + x[0] + '",' + x[1] + "},\n")
+        for x, y in header_data.ubos:
+            fd.write('\t\t\t{"' + x + '",' + y + "},\n")
         fd.write("\t\t};\n\n")
     else:
         fd.write("\t\tstatic UBOPair *_ubo_pairs=nullptr;\n")
@@ -544,9 +542,7 @@ def build_gles3_header(
 
     if header_data.feedbacks:
         fd.write("\t\tstatic const Feedback _feedbacks[]={\n")
-        for x in header_data.feedbacks:
-            name = x[0]
-            spec = x[1]
+        for name, spec in header_data.feedbacks:
             if spec in specializations_found:
                 fd.write('\t\t\t{"' + name + '",' + str(1 << specializations_found.index(spec)) + "},\n")
             else:
@@ -599,10 +595,12 @@ def build_gles3_header(
     fd.close()
 
 
-def build_gles3_headers(target, source, env):
+def build_gles3_headers(target, source, env) -> None:
     for x in source:
         build_gles3_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3")
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -4,12 +4,11 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 """
 import os.path
-from typing import Optional, Iterable
 
-from platform_methods import subprocess_main
+from typing import Optional, Iterable, List
 
 
-def generate_inline_code(input_lines: Iterable[str], insert_newline: bool = True):
+def generate_inline_code(input_lines: Iterable[str], insert_newline: bool = True) -> str:
     """Take header data and generate inline code
 
     :param: input_lines: values for shared inline code
@@ -26,20 +25,20 @@ def generate_inline_code(input_lines: Iterable[str], insert_newline: bool = True
 
 
 class RDHeaderStruct:
-    def __init__(self):
-        self.vertex_lines = []
-        self.fragment_lines = []
-        self.compute_lines = []
+    def __init__(self) -> None:
+        self.vertex_lines: List[str] = []
+        self.fragment_lines: List[str] = []
+        self.compute_lines: List[str] = []
 
-        self.vertex_included_files = []
-        self.fragment_included_files = []
-        self.compute_included_files = []
+        self.vertex_included_files: List[str] = []
+        self.fragment_included_files: List[str] = []
+        self.compute_included_files: List[str] = []
 
-        self.reading = ""
-        self.line_offset = 0
-        self.vertex_offset = 0
-        self.fragment_offset = 0
-        self.compute_offset = 0
+        self.reading: str = ""
+        self.line_offset: int = 0
+        self.vertex_offset: int = 0
+        self.fragment_offset: int = 0
+        self.compute_offset: int = 0
 
 
 def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth: int) -> RDHeaderStruct:
@@ -168,14 +167,14 @@ public:
         fd.write(shader_template)
 
 
-def build_rd_headers(target, source, env):
+def build_rd_headers(target, source, env) -> None:
     for x in source:
         build_rd_header(filename=str(x))
 
 
 class RAWHeaderStruct:
-    def __init__(self):
-        self.code = ""
+    def __init__(self) -> None:
+        self.code: str = ""
 
 
 def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, depth: int) -> None:
@@ -199,7 +198,7 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
 
 def build_raw_header(
     filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
-):
+) -> None:
     header_data = header_data or RAWHeaderStruct()
     include_file_in_raw_header(filename, header_data, 0)
 
@@ -227,10 +226,12 @@ static const char {out_file_base}[] = {{
         f.write(shader_template)
 
 
-def build_raw_headers(target, source, env):
+def build_raw_headers(target, source, env) -> None:
     for x in source:
         build_raw_header(filename=str(x))
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -3,10 +3,9 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
-from platform_methods import subprocess_main
 
 
-def make_splash(target, source, env):
+def make_splash(target, source, env) -> None:
     src = source[0]
     dst = target[0]
 
@@ -26,7 +25,7 @@ def make_splash(target, source, env):
         g.write("#endif")
 
 
-def make_splash_editor(target, source, env):
+def make_splash_editor(target, source, env) -> None:
     src = source[0]
     dst = target[0]
 
@@ -47,7 +46,7 @@ def make_splash_editor(target, source, env):
         g.write("#endif")
 
 
-def make_app_icon(target, source, env):
+def make_app_icon(target, source, env) -> None:
     src = source[0]
     dst = target[0]
 
@@ -66,4 +65,6 @@ def make_app_icon(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -3,8 +3,6 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 """
 
-from platform_methods import subprocess_main
-
 
 def generate_modules_enabled(target, source, env):
     with open(target[0].path, "w") as f:
@@ -21,4 +19,6 @@ def generate_modules_tests(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -2,19 +2,19 @@ import os
 import os.path
 
 
-def is_desktop(platform):
+def is_desktop(platform: str) -> bool:
     return platform in ["windows", "macos", "linuxbsd"]
 
 
-def is_unix_like(platform):
+def is_unix_like(platform: str) -> bool:
     return platform in ["macos", "linuxbsd", "android", "ios"]
 
 
-def module_supports_tools_on(platform):
+def module_supports_tools_on(platform: str) -> bool:
     return is_desktop(platform)
 
 
-def configure(env, env_mono):
+def configure(env, env_mono) -> None:
     # is_android = env["platform"] == "android"
     # is_web = env["platform"] == "web"
     # is_ios = env["platform"] == "ios"

--- a/platform/linuxbsd/platform_linuxbsd_builders.py
+++ b/platform/linuxbsd/platform_linuxbsd_builders.py
@@ -4,7 +4,6 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 """
 import os
-from platform_methods import subprocess_main
 
 
 def make_debug_linuxbsd(target, source, env):
@@ -14,4 +13,6 @@ def make_debug_linuxbsd(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -4,7 +4,6 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 """
 import os
-from platform_methods import subprocess_main
 
 
 def make_debug_macos(target, source, env):
@@ -18,4 +17,6 @@ def make_debug_macos(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -20,7 +20,7 @@ def get_build_version():
 
     name = "custom_build"
     if os.getenv("BUILD_NAME") != None:
-        name = os.getenv("BUILD_NAME")
+        name = str(os.getenv("BUILD_NAME"))
     v = "%d.%d" % (version.major, version.minor)
     if version.patch > 0:
         v += ".%d" % version.patch

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -6,7 +6,6 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 import os
 from detect import get_mingw_bin_prefix
 from detect import try_cmd
-from platform_methods import subprocess_main
 
 
 def make_debug_mingw(target, source, env):
@@ -26,4 +25,6 @@ def make_debug_mingw(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -5,6 +5,8 @@ import platform
 import uuid
 import functools
 import subprocess
+from typing import List, Dict, Any
+
 
 # NOTE: The multiprocessing module is not compatible with SCons due to conflict on cPickle
 
@@ -25,7 +27,7 @@ def run_in_subprocess(builder_function):
         # Identify module
         module_name = builder_function.__module__
         function_name = builder_function.__name__
-        module_path = sys.modules[module_name].__file__
+        module_path = str(sys.modules[module_name].__file__)
         if module_path.endswith(".pyc") or module_path.endswith(".pyo"):
             module_path = module_path[:-1]
 
@@ -70,7 +72,7 @@ def run_in_subprocess(builder_function):
     return wrapper
 
 
-def subprocess_main(namespace):
+def subprocess_main(namespace: Dict[str, Any]) -> None:
     with open(sys.argv[1]) as json_file:
         data = json.load(json_file)
 
@@ -79,8 +81,8 @@ def subprocess_main(namespace):
 
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
-architecture_aliases = {
+architectures: List[str] = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
+architecture_aliases: Dict[str, str] = {
     "x86": "x86_32",
     "x64": "x86_64",
     "amd64": "x86_64",
@@ -97,7 +99,7 @@ architecture_aliases = {
 }
 
 
-def detect_arch():
+def detect_arch() -> str:
     host_machine = platform.machine().lower()
     if host_machine in architectures:
         return host_machine
@@ -112,12 +114,12 @@ def detect_arch():
         return "x86_64"
 
 
-def generate_export_icons(platform_path, platform_name):
+def generate_export_icons(platform_path: str, platform_name: str) -> None:
     """
     Generate headers for logo and run icon for the export plugin.
     """
     export_path = platform_path + "/export"
-    svg_names = []
+    svg_names: List[str] = []
     if os.path.isfile(export_path + "/logo.svg"):
         svg_names.append("logo")
     if os.path.isfile(export_path + "/run_icon.svg"):

--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -5,10 +5,9 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 """
 import os
 import os.path
-from platform_methods import subprocess_main
 
 
-def make_fonts_header(target, source, env):
+def make_fonts_header(target, source, env) -> None:
     dst = target[0]
 
     g = open(dst, "w", encoding="utf-8")
@@ -37,4 +36,6 @@ def make_fonts_header(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/scene/theme/icons/default_theme_icons_builders.py
+++ b/scene/theme/icons/default_theme_icons_builders.py
@@ -6,11 +6,10 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 import os
 from io import StringIO
-from platform_methods import subprocess_main
 
 
 # See also `editor/icons/editor_icons_builders.py`.
-def make_default_theme_icons_action(target, source, env):
+def make_default_theme_icons_action(target, source, env) -> None:
     dst = target[0]
     svg_icons = source
 
@@ -72,4 +71,6 @@ def make_default_theme_icons_action(target, source, env):
 
 
 if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
     subprocess_main(globals())

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -4,15 +4,16 @@ import glob, os
 import math
 from pathlib import Path
 from os.path import normpath, basename
+from typing import List, Set, Tuple
 
 base_folder_path = str(Path(__file__).parent) + "/"
 base_folder_only = os.path.basename(os.path.normpath(base_folder_path))
 _verbose = True  # Set manually for debug prints
-_scu_folders = set()
+_scu_folders: Set[str] = set()
 _max_includes_per_scu = 1024
 
 
-def clear_out_existing_files(output_folder, extension):
+def clear_out_existing_files(output_folder: str, extension: str) -> None:
     output_folder = os.path.abspath(output_folder)
     # print("clear_out_existing_files from folder: " + output_folder)
 
@@ -26,12 +27,19 @@ def clear_out_existing_files(output_folder, extension):
         os.remove(file)
 
 
-def folder_not_found(folder):
+def folder_not_found(folder: str) -> bool:
     abs_folder = base_folder_path + folder + "/"
     return not os.path.isdir(abs_folder)
 
 
-def find_files_in_folder(folder, sub_folder, include_list, extension, sought_exceptions, found_exceptions):
+def find_files_in_folder(
+    folder: str,
+    sub_folder: str,
+    include_list: List[str],
+    extension: str,
+    sought_exceptions: List[str],
+    found_exceptions: List[str],
+) -> Tuple[List[str], List[str]]:
     abs_folder = base_folder_path + folder + "/" + sub_folder
 
     if not os.path.isdir(abs_folder):
@@ -60,7 +68,15 @@ def find_files_in_folder(folder, sub_folder, include_list, extension, sought_exc
     return include_list, found_exceptions
 
 
-def write_output_file(file_count, include_list, start_line, end_line, output_folder, output_filename_prefix, extension):
+def write_output_file(
+    file_count: int,
+    include_list: List[str],
+    start_line: int,
+    end_line: int,
+    output_folder: str,
+    output_filename_prefix: str,
+    extension: str,
+) -> None:
     output_folder = os.path.abspath(output_folder)
 
     if not os.path.isdir(output_folder):
@@ -93,7 +109,9 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
     output_path.write_text(file_text, encoding="utf8")
 
 
-def write_exception_output_file(file_count, exception_string, output_folder, output_filename_prefix, extension):
+def write_exception_output_file(
+    file_count: int, exception_string: str, output_folder: str, output_filename_prefix: str, extension: str
+) -> None:
     output_folder = os.path.abspath(output_folder)
     if not os.path.isdir(output_folder):
         print("SCU: ERROR: %s does not exist." % output_folder)
@@ -115,7 +133,7 @@ def write_exception_output_file(file_count, exception_string, output_folder, out
     output_path.write_text(file_text, encoding="utf8")
 
 
-def find_section_name(sub_folder):
+def find_section_name(sub_folder: str) -> str:
     # Construct a useful name for the section from the path for debug logging
     section_path = os.path.abspath(base_folder_path + sub_folder) + "/"
 
@@ -157,7 +175,9 @@ def find_section_name(sub_folder):
 
 
 # "extension" will usually be cpp, but can also be set to c (for e.g. third party libraries that use c)
-def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension="cpp"):
+def process_folder(
+    folders: List[str], sought_exceptions: List[str] = [], includes_per_scu: int = 0, extension: str = "cpp"
+) -> None:
     if len(folders) == 0:
         return
 
@@ -165,8 +185,8 @@ def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension=
     # e.g. "scene_3d"
     out_filename = find_section_name(folders[0])
 
-    found_includes = []
-    found_exceptions = []
+    found_includes: List[str] = []
+    found_exceptions: List[str] = []
 
     main_folder = folders[0]
     abs_main_folder = base_folder_path + main_folder
@@ -239,7 +259,7 @@ def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension=
         )
 
 
-def generate_scu_files(max_includes_per_scu):
+def generate_scu_files(max_includes_per_scu: int) -> Set[str]:
     print("=============================")
     print("Single Compilation Unit Build")
     print("=============================")
@@ -254,7 +274,6 @@ def generate_scu_files(max_includes_per_scu):
     # check we are running from the correct folder
     if folder_not_found("core") or folder_not_found("platform") or folder_not_found("scene"):
         raise RuntimeError("scu_builders.py must be run from the godot folder.")
-        return
 
     process_folder(["core"])
     process_folder(["core/crypto"])

--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -7,7 +7,7 @@ import sys
 from subprocess import call
 
 
-def main():
+def main() -> None:
     # Change to the directory where the script is located,
     # so that the script can be run from any location.
     os.chdir(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
Adds type hints to several build script files/functions that were previously lacking them. I attempted to keep the contents as unaffected as possible, but a handful of them needed reformatting to account for a given type staying consistent throughout. Additionally, while this could be further expanded by making most `env` arguments the `SConsEnvironment` type, this was more about ironing out the concrete types without needing to introduce any new `TYPE_CHECKING` checks