### PR TITLE
Hide Node dock successfully on undo/redo and deletion 

### DIFF
--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -67,14 +67,23 @@ void NodeDock::update_lists() {
 	connections->update_tree();
 }
 
+void NodeDock::_on_node_tree_exited() {
+	set_node(nullptr);
+}
+
 void NodeDock::set_node(Node *p_node) {
-	connections->set_node(p_node);
-	groups->set_current(p_node);
-	if (p_node) {
-		last_valid_node = p_node;
+	if (last_valid_node) {
+		last_valid_node->disconnect("tree_exited", callable_mp(this, &NodeDock::_on_node_tree_exited));
+		last_valid_node = nullptr;
 	}
 
+	connections->set_node(p_node);
+	groups->set_current(p_node);
+
 	if (p_node) {
+		last_valid_node = p_node;
+		last_valid_node->connect("tree_exited", callable_mp(this, &NodeDock::_on_node_tree_exited));
+
 		if (connections_button->is_pressed()) {
 			connections->show();
 		} else {

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -58,6 +58,7 @@ public:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	void _on_node_tree_exited();
 
 public:
 	void set_node(Node *p_node);


### PR DESCRIPTION
This commit solves this specific issue: https://github.com/godotengine/godot/issues/84530

My partner and I located the source from this issue was in the _delete_confirm function in scene_tree_dock.cpp on line 2310.

The solution was to add NodeDock::get_singleton()->set_node(nullptr); to the function to make sure that the node dock isn't displaying signals and groups of the node after its deletion.

This is our first contribution to the project, please let us know if there is anything that we are doing wrong and how we can work to fix it.

*Bugsquad edit:*
- Fixes #84530