### PR TITLE
Add ability to show inherited child nodes in scene tree

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -201,6 +201,8 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		if ((show_enabled_subscene || can_open_instance) && p_node->get_owner() && (get_scene_node()->is_editable_instance(p_node->get_owner()))) {
 			part_of_subscene = true;
 			//allow
+		} else if (p_node->has_meta("is_inherited") && (bool)p_node->get_meta("is_inherited")) {
+			part_of_subscene = true;
 		} else {
 			return;
 		}

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -201,7 +201,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		if ((show_enabled_subscene || can_open_instance) && p_node->get_owner() && (get_scene_node()->is_editable_instance(p_node->get_owner()))) {
 			part_of_subscene = true;
 			//allow
-		} else if (p_node->has_meta("is_inherited") && (bool)p_node->get_meta("is_inherited")) {
+		} else if (p_node->has_meta("is_inherited") && (bool)p_node->get_meta("is_inherited", false)) {
 			part_of_subscene = true;
 		} else {
 			return;

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -201,7 +201,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		if ((show_enabled_subscene || can_open_instance) && p_node->get_owner() && (get_scene_node()->is_editable_instance(p_node->get_owner()))) {
 			part_of_subscene = true;
 			//allow
-		} else if (p_node->has_meta("is_inherited") && (bool)p_node->get_meta("is_inherited", false)) {
+		} else if ((bool)p_node->get_meta("is_inherited", false)) {
 			part_of_subscene = true;
 		} else {
 			return;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR adds the ability to show script-added / inherited child nodes in the editor scene tree (without saving them to the scene file).

See the following usage example: 
Consider we have to class file `base_class.gd` and `my_class.gd`
MyClass extends BaseClass:

```gdscript
# base_class.gd
class_name BaseClass
extends Node

func _init():
	var childA = Node.new();
	childA.name = "ChildA"
	add_child(childA)
	
	var childB = Node.new();
	childB.name = "ChildB"
	childB.set_meta("is_inherited", true)
	add_child(childB)
	
```
```gdscript
# my_class.gd
@tool
class_name MyClass
extends BaseClass

func _ready():
	var childC = Node.new();
	childC.name = "ChildC"
	add_child(childC)
	childC.owner = self

```

![image](https://github.com/godotengine/godot/assets/7690321/943e4406-e8ec-4c6e-bd7c-f74ed5ec48a4)

Resulting Script Behaviour:
1. ChildA will not show up in scene tree
2. ChildB will show up highlighted as inherited in the scene tree. It will not be saved to the scene file. And it is not editable in the editor.
3. ChildC will show up normally to the scene tree. It will be saved to the scene file. A duplicated ChildC will be created when the scene file is opened again.

This PR enables scenario 2 by marking the added node as 'is_inherited' via metadata
Related to this proposal: https://github.com/godotengine/godot-proposals/issues/8522
