### PR TITLE
Explain parameter usage in GPUParticles3D and GPUParticles2D

### DIFF
--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -37,6 +37,7 @@
 			<param index="4" name="flags" type="int" />
 			<description>
 				Emits a single particle. Whether [param xform], [param velocity], [param color] and [param custom] are applied depends on the value of [param flags]. See [enum EmitFlags].
+				The default ParticleProcessMaterial will overwrite [param color] and use the contents of [param custom] as [code](rotation, age, animation, lifetime)[/code].
 			</description>
 		</method>
 		<method name="restart">

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -35,6 +35,7 @@
 			<param index="4" name="flags" type="int" />
 			<description>
 				Emits a single particle. Whether [param xform], [param velocity], [param color] and [param custom] are applied depends on the value of [param flags]. See [enum EmitFlags].
+				The default ParticleProcessMaterial will overwrite [param color] and use the contents of [param custom] as [code](rotation, age, animation, lifetime)[/code].
 			</description>
 		</method>
 		<method name="get_draw_pass_mesh" qualifiers="const">


### PR DESCRIPTION
extended the description to explain how the passed parameters are used by the default ParticleProcessMaterial.
should set correct expectations for issues like [85358](https://github.com/godotengine/godot/issues/85358)
