### PR TITLE
Added TextEditMenu for handling menu for TextEdit and LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -252,9 +252,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		if (b->is_pressed() && b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_update_context_menu();
-			menu->set_position(get_screen_position() + get_local_mouse_position());
-			menu->reset_size();
-			menu->popup();
+			context_menu.popup_at(get_screen_position() + get_local_mouse_position());
 			grab_focus();
 			accept_event();
 			return;
@@ -464,10 +462,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (k->is_action("ui_menu", true)) {
 				_update_context_menu();
 				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2);
-				menu->set_position(get_screen_position() + pos);
-				menu->reset_size();
-				menu->popup();
-				menu->grab_focus();
+				context_menu.popup_at(get_screen_position() + pos, true);
 
 				accept_event();
 				return;
@@ -1472,7 +1467,7 @@ void LineEdit::_validate_caret_can_draw() {
 		draw_caret = true;
 		caret_blink_timer = 0.0;
 	}
-	caret_can_draw = editable && (window_has_focus || (menu && menu->has_focus())) && (has_focus() || caret_force_displayed);
+	caret_can_draw = editable && (window_has_focus || context_menu.has_focus()) && (has_focus() || caret_force_displayed);
 }
 
 void LineEdit::delete_char() {
@@ -1540,12 +1535,10 @@ void LineEdit::set_text_direction(Control::TextDirection p_text_direction) {
 		}
 		_shape();
 
-		if (menu_dir) {
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_INHERITED), text_direction == TEXT_DIRECTION_INHERITED);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_AUTO), text_direction == TEXT_DIRECTION_AUTO);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), text_direction == TEXT_DIRECTION_LTR);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), text_direction == TEXT_DIRECTION_RTL);
+		if (context_menu.is_initialized()) {
+			context_menu.set_text_direction(text_direction);
 		}
+
 		queue_redraw();
 	}
 }
@@ -1569,9 +1562,7 @@ String LineEdit::get_language() const {
 void LineEdit::set_draw_control_chars(bool p_draw_control_chars) {
 	if (draw_control_chars != p_draw_control_chars) {
 		draw_control_chars = p_draw_control_chars;
-		if (menu && menu->get_item_index(MENU_DISPLAY_UCC) >= 0) {
-			menu->set_item_checked(menu->get_item_index(MENU_DISPLAY_UCC), draw_control_chars);
-		}
+		context_menu.set_draw_control_chars(draw_control_chars);
 		_shape();
 		queue_redraw();
 	}
@@ -2105,14 +2096,14 @@ bool LineEdit::is_context_menu_enabled() {
 }
 
 bool LineEdit::is_menu_visible() const {
-	return menu && menu->is_visible();
+	return context_menu.is_visible();
 }
 
 PopupMenu *LineEdit::get_menu() const {
-	if (!menu) {
+	if (!context_menu.is_initialized()) {
 		const_cast<LineEdit *>(this)->_generate_context_menu();
 	}
-	return menu;
+	return context_menu.get_main_menu();
 }
 
 void LineEdit::_editor_settings_changed() {
@@ -2363,138 +2354,17 @@ void LineEdit::_create_undo_state() {
 	undo_stack.push_back(op);
 }
 
-Key LineEdit::_get_menu_action_accelerator(const String &p_action) {
-	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(p_action);
-	if (!events) {
-		return Key::NONE;
-	}
-
-	// Use first event in the list for the accelerator.
-	const List<Ref<InputEvent>>::Element *first_event = events->front();
-	if (!first_event) {
-		return Key::NONE;
-	}
-
-	const Ref<InputEventKey> event = first_event->get();
-	if (event.is_null()) {
-		return Key::NONE;
-	}
-
-	// Use physical keycode if non-zero.
-	if (event->get_physical_keycode() != Key::NONE) {
-		return event->get_physical_keycode_with_modifiers();
-	} else {
-		return event->get_keycode_with_modifiers();
-	}
-}
-
 void LineEdit::_generate_context_menu() {
-	menu = memnew(PopupMenu);
-	add_child(menu, false, INTERNAL_MODE_FRONT);
-
-	menu_dir = memnew(PopupMenu);
-	menu_dir->set_name("DirMenu");
-	menu_dir->add_radio_check_item(RTR("Same as Layout Direction"), MENU_DIR_INHERITED);
-	menu_dir->add_radio_check_item(RTR("Auto-Detect Direction"), MENU_DIR_AUTO);
-	menu_dir->add_radio_check_item(RTR("Left-to-Right"), MENU_DIR_LTR);
-	menu_dir->add_radio_check_item(RTR("Right-to-Left"), MENU_DIR_RTL);
-	menu->add_child(menu_dir, false, INTERNAL_MODE_FRONT);
-
-	menu_ctl = memnew(PopupMenu);
-	menu_ctl->set_name("CTLMenu");
-	menu_ctl->add_item(RTR("Left-to-Right Mark (LRM)"), MENU_INSERT_LRM);
-	menu_ctl->add_item(RTR("Right-to-Left Mark (RLM)"), MENU_INSERT_RLM);
-	menu_ctl->add_item(RTR("Start of Left-to-Right Embedding (LRE)"), MENU_INSERT_LRE);
-	menu_ctl->add_item(RTR("Start of Right-to-Left Embedding (RLE)"), MENU_INSERT_RLE);
-	menu_ctl->add_item(RTR("Start of Left-to-Right Override (LRO)"), MENU_INSERT_LRO);
-	menu_ctl->add_item(RTR("Start of Right-to-Left Override (RLO)"), MENU_INSERT_RLO);
-	menu_ctl->add_item(RTR("Pop Direction Formatting (PDF)"), MENU_INSERT_PDF);
-	menu_ctl->add_separator();
-	menu_ctl->add_item(RTR("Arabic Letter Mark (ALM)"), MENU_INSERT_ALM);
-	menu_ctl->add_item(RTR("Left-to-Right Isolate (LRI)"), MENU_INSERT_LRI);
-	menu_ctl->add_item(RTR("Right-to-Left Isolate (RLI)"), MENU_INSERT_RLI);
-	menu_ctl->add_item(RTR("First Strong Isolate (FSI)"), MENU_INSERT_FSI);
-	menu_ctl->add_item(RTR("Pop Direction Isolate (PDI)"), MENU_INSERT_PDI);
-	menu_ctl->add_separator();
-	menu_ctl->add_item(RTR("Zero-Width Joiner (ZWJ)"), MENU_INSERT_ZWJ);
-	menu_ctl->add_item(RTR("Zero-Width Non-Joiner (ZWNJ)"), MENU_INSERT_ZWNJ);
-	menu_ctl->add_item(RTR("Word Joiner (WJ)"), MENU_INSERT_WJ);
-	menu_ctl->add_item(RTR("Soft Hyphen (SHY)"), MENU_INSERT_SHY);
-	menu->add_child(menu_ctl, false, INTERNAL_MODE_FRONT);
-
-	menu->add_item(RTR("Cut"), MENU_CUT);
-	menu->add_item(RTR("Copy"), MENU_COPY);
-	menu->add_item(RTR("Paste"), MENU_PASTE);
-	menu->add_separator();
-	menu->add_item(RTR("Select All"), MENU_SELECT_ALL);
-	menu->add_item(RTR("Clear"), MENU_CLEAR);
-	menu->add_separator();
-	menu->add_item(RTR("Undo"), MENU_UNDO);
-	menu->add_item(RTR("Redo"), MENU_REDO);
-	menu->add_separator();
-	menu->add_submenu_item(RTR("Text Writing Direction"), "DirMenu", MENU_SUBMENU_TEXT_DIR);
-	menu->add_separator();
-	menu->add_check_item(RTR("Display Control Characters"), MENU_DISPLAY_UCC);
-	menu->add_submenu_item(RTR("Insert Control Character"), "CTLMenu", MENU_SUBMENU_INSERT_UCC);
-
-	menu->connect("id_pressed", callable_mp(this, &LineEdit::menu_option));
-	menu_dir->connect("id_pressed", callable_mp(this, &LineEdit::menu_option));
-	menu_ctl->connect("id_pressed", callable_mp(this, &LineEdit::menu_option));
-
-	menu->connect(SNAME("focus_entered"), callable_mp(this, &LineEdit::_validate_caret_can_draw));
-	menu->connect(SNAME("focus_exited"), callable_mp(this, &LineEdit::_validate_caret_can_draw));
+	context_menu.generate_menu(this);
+	context_menu.add_option_selected_callback(callable_mp(this, &LineEdit::menu_option));
+	context_menu.add_focus_changed_callback(callable_mp(this, &LineEdit::_validate_caret_can_draw));
 }
 
 void LineEdit::_update_context_menu() {
-	if (!menu) {
+	if (!context_menu.is_initialized()) {
 		_generate_context_menu();
 	}
-
-	int idx = -1;
-
-#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled)                                                  \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
-		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-		m_menu->set_item_disabled(idx, m_disabled);                                                                    \
-	}
-
-#define MENU_ITEM_ACTION(m_menu, m_id, m_action)                                                                       \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
-		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-	}
-
-#define MENU_ITEM_DISABLED(m_menu, m_id, m_disabled) \
-	idx = m_menu->get_item_index(m_id);              \
-	if (idx >= 0) {                                  \
-		m_menu->set_item_disabled(idx, m_disabled);  \
-	}
-
-#define MENU_ITEM_CHECKED(m_menu, m_id, m_checked) \
-	idx = m_menu->get_item_index(m_id);            \
-	if (idx >= 0) {                                \
-		m_menu->set_item_checked(idx, m_checked);  \
-	}
-
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_CUT, "ui_cut", !editable)
-	MENU_ITEM_ACTION(menu, MENU_COPY, "ui_copy")
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_PASTE, "ui_paste", !editable)
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_SELECT_ALL, "ui_text_select_all", !selecting_enabled)
-	MENU_ITEM_DISABLED(menu, MENU_CLEAR, !editable)
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_UNDO, "ui_undo", !editable || !has_undo())
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_REDO, "ui_redo", !editable || !has_redo())
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_INHERITED, text_direction == TEXT_DIRECTION_INHERITED)
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_AUTO, text_direction == TEXT_DIRECTION_AUTO)
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_LTR, text_direction == TEXT_DIRECTION_LTR)
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_RTL, text_direction == TEXT_DIRECTION_RTL)
-	MENU_ITEM_CHECKED(menu, MENU_DISPLAY_UCC, draw_control_chars)
-	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_INSERT_UCC, !editable)
-
-#undef MENU_ITEM_ACTION_DISABLED
-#undef MENU_ITEM_ACTION
-#undef MENU_ITEM_DISABLED
-#undef MENU_ITEM_CHECKED
+	context_menu.update(editable, selecting_enabled, is_shortcut_keys_enabled(), text_direction, draw_control_chars, has_undo(), has_redo());
 }
 
 void LineEdit::_validate_property(PropertyInfo &p_property) const {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -33,43 +33,44 @@
 
 #include "scene/gui/control.h"
 #include "scene/gui/popup_menu.h"
+#include "scene/gui/text_edit_menu.h"
 
 class LineEdit : public Control {
 	GDCLASS(LineEdit, Control);
 
 public:
 	enum MenuItems {
-		MENU_CUT,
-		MENU_COPY,
-		MENU_PASTE,
-		MENU_CLEAR,
-		MENU_SELECT_ALL,
-		MENU_UNDO,
-		MENU_REDO,
-		MENU_SUBMENU_TEXT_DIR,
-		MENU_DIR_INHERITED,
-		MENU_DIR_AUTO,
-		MENU_DIR_LTR,
-		MENU_DIR_RTL,
-		MENU_DISPLAY_UCC,
-		MENU_SUBMENU_INSERT_UCC,
-		MENU_INSERT_LRM,
-		MENU_INSERT_RLM,
-		MENU_INSERT_LRE,
-		MENU_INSERT_RLE,
-		MENU_INSERT_LRO,
-		MENU_INSERT_RLO,
-		MENU_INSERT_PDF,
-		MENU_INSERT_ALM,
-		MENU_INSERT_LRI,
-		MENU_INSERT_RLI,
-		MENU_INSERT_FSI,
-		MENU_INSERT_PDI,
-		MENU_INSERT_ZWJ,
-		MENU_INSERT_ZWNJ,
-		MENU_INSERT_WJ,
-		MENU_INSERT_SHY,
-		MENU_MAX
+		MENU_CUT = TextEditMenu::MENU_CUT,
+		MENU_COPY = TextEditMenu::MENU_COPY,
+		MENU_PASTE = TextEditMenu::MENU_PASTE,
+		MENU_CLEAR = TextEditMenu::MENU_CLEAR,
+		MENU_SELECT_ALL = TextEditMenu::MENU_SELECT_ALL,
+		MENU_UNDO = TextEditMenu::MENU_UNDO,
+		MENU_REDO = TextEditMenu::MENU_REDO,
+		MENU_SUBMENU_TEXT_DIR = TextEditMenu::MENU_SUBMENU_TEXT_DIR,
+		MENU_DIR_INHERITED = TextEditMenu::MENU_DIR_INHERITED,
+		MENU_DIR_AUTO = TextEditMenu::MENU_DIR_AUTO,
+		MENU_DIR_LTR = TextEditMenu::MENU_DIR_LTR,
+		MENU_DIR_RTL = TextEditMenu::MENU_DIR_RTL,
+		MENU_DISPLAY_UCC = TextEditMenu::MENU_DISPLAY_UCC,
+		MENU_SUBMENU_INSERT_UCC = TextEditMenu::MENU_SUBMENU_INSERT_UCC,
+		MENU_INSERT_LRM = TextEditMenu::MENU_INSERT_LRM,
+		MENU_INSERT_RLM = TextEditMenu::MENU_INSERT_RLM,
+		MENU_INSERT_LRE = TextEditMenu::MENU_INSERT_LRE,
+		MENU_INSERT_RLE = TextEditMenu::MENU_INSERT_RLE,
+		MENU_INSERT_LRO = TextEditMenu::MENU_INSERT_LRO,
+		MENU_INSERT_RLO = TextEditMenu::MENU_INSERT_RLO,
+		MENU_INSERT_PDF = TextEditMenu::MENU_INSERT_PDF,
+		MENU_INSERT_ALM = TextEditMenu::MENU_INSERT_ALM,
+		MENU_INSERT_LRI = TextEditMenu::MENU_INSERT_LRI,
+		MENU_INSERT_RLI = TextEditMenu::MENU_INSERT_RLI,
+		MENU_INSERT_FSI = TextEditMenu::MENU_INSERT_FSI,
+		MENU_INSERT_PDI = TextEditMenu::MENU_INSERT_PDI,
+		MENU_INSERT_ZWJ = TextEditMenu::MENU_INSERT_ZWJ,
+		MENU_INSERT_ZWNJ = TextEditMenu::MENU_INSERT_ZWNJ,
+		MENU_INSERT_WJ = TextEditMenu::MENU_INSERT_WJ,
+		MENU_INSERT_SHY = TextEditMenu::MENU_INSERT_SHY,
+		MENU_MAX = TextEditMenu::MENU_MAX
 	};
 
 	enum VirtualKeyboardType {
@@ -109,9 +110,7 @@ private:
 	bool drag_and_drop_selection_enabled = true;
 
 	bool context_menu_enabled = true;
-	PopupMenu *menu = nullptr;
-	PopupMenu *menu_dir = nullptr;
-	PopupMenu *menu_ctl = nullptr;
+	TextEditMenu context_menu;
 
 	bool caret_mid_grapheme_enabled = false;
 
@@ -209,7 +208,6 @@ private:
 	void _clear_redo();
 	void _create_undo_state();
 
-	Key _get_menu_action_accelerator(const String &p_action);
 	void _generate_context_menu();
 	void _update_context_menu();
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -512,7 +512,7 @@ void TextEdit::_notification(int p_what) {
 
 			Size2 size = get_size();
 			bool rtl = is_layout_rtl();
-			if ((!has_focus() && !(menu && menu->has_focus())) || !window_has_focus) {
+			if ((!has_focus() && !context_menu.has_focus()) || !window_has_focus) {
 				draw_caret = false;
 			}
 
@@ -1895,9 +1895,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				if (context_menu_enabled) {
 					_update_context_menu();
-					menu->set_position(get_screen_position() + mpos);
-					menu->reset_size();
-					menu->popup();
+					context_menu.popup_at(get_screen_position() + mpos);
 					grab_focus();
 				}
 			}
@@ -2176,10 +2174,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (context_menu_enabled) {
 				_update_context_menu();
 				adjust_viewport_to_caret();
-				menu->set_position(get_screen_position() + get_caret_draw_pos());
-				menu->reset_size();
-				menu->popup();
-				menu->grab_focus();
+				context_menu.popup_at(get_screen_position() + get_caret_draw_pos(), true);
 			}
 			accept_event();
 			return;
@@ -3213,12 +3208,10 @@ void TextEdit::set_text_direction(Control::TextDirection p_text_direction) {
 		text.invalidate_font();
 		_update_placeholder();
 
-		if (menu_dir) {
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_INHERITED), text_direction == TEXT_DIRECTION_INHERITED);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_AUTO), text_direction == TEXT_DIRECTION_AUTO);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), text_direction == TEXT_DIRECTION_LTR);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), text_direction == TEXT_DIRECTION_RTL);
+		if (context_menu.is_initialized()) {
+			context_menu.set_text_direction(text_direction);
 		}
+
 		queue_redraw();
 	}
 }
@@ -3742,14 +3735,14 @@ void TextEdit::paste_primary_clipboard(int p_caret) {
 
 // Context menu.
 PopupMenu *TextEdit::get_menu() const {
-	if (!menu) {
+	if (!context_menu.is_initialized()) {
 		const_cast<TextEdit *>(this)->_generate_context_menu();
 	}
-	return menu;
+	return context_menu.get_main_menu();
 }
 
 bool TextEdit::is_menu_visible() const {
-	return menu && menu->is_visible();
+	return context_menu.is_visible();
 }
 
 void TextEdit::menu_option(int p_option) {
@@ -5975,9 +5968,9 @@ bool TextEdit::is_highlight_all_occurrences_enabled() const {
 void TextEdit::set_draw_control_chars(bool p_enabled) {
 	if (draw_control_chars != p_enabled) {
 		draw_control_chars = p_enabled;
-		if (menu) {
-			menu->set_item_checked(menu->get_item_index(MENU_DISPLAY_UCC), draw_control_chars);
-		}
+
+		context_menu.set_draw_control_chars(draw_control_chars);
+
 		text.set_draw_control_chars(draw_control_chars);
 		text.invalidate_font();
 		_update_placeholder();
@@ -6821,135 +6814,16 @@ void TextEdit::_paste_primary_clipboard_internal(int p_caret) {
 
 // Context menu.
 
-Key TextEdit::_get_menu_action_accelerator(const String &p_action) {
-	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(p_action);
-	if (!events) {
-		return Key::NONE;
-	}
-
-	// Use first event in the list for the accelerator.
-	const List<Ref<InputEvent>>::Element *first_event = events->front();
-	if (!first_event) {
-		return Key::NONE;
-	}
-
-	const Ref<InputEventKey> event = first_event->get();
-	if (event.is_null()) {
-		return Key::NONE;
-	}
-
-	// Use physical keycode if non-zero.
-	if (event->get_physical_keycode() != Key::NONE) {
-		return event->get_physical_keycode_with_modifiers();
-	} else {
-		return event->get_keycode_with_modifiers();
-	}
-}
-
 void TextEdit::_generate_context_menu() {
-	menu = memnew(PopupMenu);
-	add_child(menu, false, INTERNAL_MODE_FRONT);
-
-	menu_dir = memnew(PopupMenu);
-	menu_dir->set_name("DirMenu");
-	menu_dir->add_radio_check_item(RTR("Same as Layout Direction"), MENU_DIR_INHERITED);
-	menu_dir->add_radio_check_item(RTR("Auto-Detect Direction"), MENU_DIR_AUTO);
-	menu_dir->add_radio_check_item(RTR("Left-to-Right"), MENU_DIR_LTR);
-	menu_dir->add_radio_check_item(RTR("Right-to-Left"), MENU_DIR_RTL);
-	menu->add_child(menu_dir, false, INTERNAL_MODE_FRONT);
-
-	menu_ctl = memnew(PopupMenu);
-	menu_ctl->set_name("CTLMenu");
-	menu_ctl->add_item(RTR("Left-to-Right Mark (LRM)"), MENU_INSERT_LRM);
-	menu_ctl->add_item(RTR("Right-to-Left Mark (RLM)"), MENU_INSERT_RLM);
-	menu_ctl->add_item(RTR("Start of Left-to-Right Embedding (LRE)"), MENU_INSERT_LRE);
-	menu_ctl->add_item(RTR("Start of Right-to-Left Embedding (RLE)"), MENU_INSERT_RLE);
-	menu_ctl->add_item(RTR("Start of Left-to-Right Override (LRO)"), MENU_INSERT_LRO);
-	menu_ctl->add_item(RTR("Start of Right-to-Left Override (RLO)"), MENU_INSERT_RLO);
-	menu_ctl->add_item(RTR("Pop Direction Formatting (PDF)"), MENU_INSERT_PDF);
-	menu_ctl->add_separator();
-	menu_ctl->add_item(RTR("Arabic Letter Mark (ALM)"), MENU_INSERT_ALM);
-	menu_ctl->add_item(RTR("Left-to-Right Isolate (LRI)"), MENU_INSERT_LRI);
-	menu_ctl->add_item(RTR("Right-to-Left Isolate (RLI)"), MENU_INSERT_RLI);
-	menu_ctl->add_item(RTR("First Strong Isolate (FSI)"), MENU_INSERT_FSI);
-	menu_ctl->add_item(RTR("Pop Direction Isolate (PDI)"), MENU_INSERT_PDI);
-	menu_ctl->add_separator();
-	menu_ctl->add_item(RTR("Zero-Width Joiner (ZWJ)"), MENU_INSERT_ZWJ);
-	menu_ctl->add_item(RTR("Zero-Width Non-Joiner (ZWNJ)"), MENU_INSERT_ZWNJ);
-	menu_ctl->add_item(RTR("Word Joiner (WJ)"), MENU_INSERT_WJ);
-	menu_ctl->add_item(RTR("Soft Hyphen (SHY)"), MENU_INSERT_SHY);
-	menu->add_child(menu_ctl, false, INTERNAL_MODE_FRONT);
-
-	menu->add_item(RTR("Cut"), MENU_CUT);
-	menu->add_item(RTR("Copy"), MENU_COPY);
-	menu->add_item(RTR("Paste"), MENU_PASTE);
-	menu->add_separator();
-	menu->add_item(RTR("Select All"), MENU_SELECT_ALL);
-	menu->add_item(RTR("Clear"), MENU_CLEAR);
-	menu->add_separator();
-	menu->add_item(RTR("Undo"), MENU_UNDO);
-	menu->add_item(RTR("Redo"), MENU_REDO);
-	menu->add_separator();
-	menu->add_submenu_item(RTR("Text Writing Direction"), "DirMenu", MENU_SUBMENU_TEXT_DIR);
-	menu->add_separator();
-	menu->add_check_item(RTR("Display Control Characters"), MENU_DISPLAY_UCC);
-	menu->add_submenu_item(RTR("Insert Control Character"), "CTLMenu", MENU_SUBMENU_INSERT_UCC);
-
-	menu->connect("id_pressed", callable_mp(this, &TextEdit::menu_option));
-	menu_dir->connect("id_pressed", callable_mp(this, &TextEdit::menu_option));
-	menu_ctl->connect("id_pressed", callable_mp(this, &TextEdit::menu_option));
+	context_menu.generate_menu(this);
+	context_menu.add_option_selected_callback(callable_mp(this, &TextEdit::menu_option));
 }
 
 void TextEdit::_update_context_menu() {
-	if (!menu) {
+	if (!context_menu.is_initialized()) {
 		_generate_context_menu();
 	}
-
-	int idx = -1;
-
-#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled)                                                  \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
-		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-		m_menu->set_item_disabled(idx, m_disabled);                                                                    \
-	}
-
-#define MENU_ITEM_ACTION(m_menu, m_id, m_action)                                                                       \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
-		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-	}
-
-#define MENU_ITEM_DISABLED(m_menu, m_id, m_disabled) \
-	idx = m_menu->get_item_index(m_id);              \
-	if (idx >= 0) {                                  \
-		m_menu->set_item_disabled(idx, m_disabled);  \
-	}
-
-#define MENU_ITEM_CHECKED(m_menu, m_id, m_checked) \
-	idx = m_menu->get_item_index(m_id);            \
-	if (idx >= 0) {                                \
-		m_menu->set_item_checked(idx, m_checked);  \
-	}
-
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_CUT, "ui_cut", !editable)
-	MENU_ITEM_ACTION(menu, MENU_COPY, "ui_copy")
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_PASTE, "ui_paste", !editable)
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_SELECT_ALL, "ui_text_select_all", !selecting_enabled)
-	MENU_ITEM_DISABLED(menu, MENU_CLEAR, !editable)
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_UNDO, "ui_undo", !editable || !has_undo())
-	MENU_ITEM_ACTION_DISABLED(menu, MENU_REDO, "ui_redo", !editable || !has_redo())
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_INHERITED, text_direction == TEXT_DIRECTION_INHERITED)
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_AUTO, text_direction == TEXT_DIRECTION_AUTO)
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_LTR, text_direction == TEXT_DIRECTION_LTR)
-	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_RTL, text_direction == TEXT_DIRECTION_RTL)
-	MENU_ITEM_CHECKED(menu, MENU_DISPLAY_UCC, draw_control_chars)
-	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_INSERT_UCC, !editable)
-
-#undef MENU_ITEM_ACTION_DISABLED
-#undef MENU_ITEM_ACTION
-#undef MENU_ITEM_DISABLED
-#undef MENU_ITEM_CHECKED
+	context_menu.update(editable, selecting_enabled, is_shortcut_keys_enabled(), text_direction, draw_control_chars, has_undo(), has_redo());
 }
 
 /* Versioning */

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -34,6 +34,7 @@
 #include "scene/gui/control.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/scroll_bar.h"
+#include "scene/gui/text_edit_menu.h"
 #include "scene/main/timer.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/text_paragraph.h"
@@ -80,38 +81,37 @@ public:
 
 	/* Context Menu. */
 	enum MenuItems {
-		MENU_CUT,
-		MENU_COPY,
-		MENU_PASTE,
-		MENU_CLEAR,
-		MENU_SELECT_ALL,
-		MENU_UNDO,
-		MENU_REDO,
-		MENU_SUBMENU_TEXT_DIR,
-		MENU_DIR_INHERITED,
-		MENU_DIR_AUTO,
-		MENU_DIR_LTR,
-		MENU_DIR_RTL,
-		MENU_DISPLAY_UCC,
-		MENU_SUBMENU_INSERT_UCC,
-		MENU_INSERT_LRM,
-		MENU_INSERT_RLM,
-		MENU_INSERT_LRE,
-		MENU_INSERT_RLE,
-		MENU_INSERT_LRO,
-		MENU_INSERT_RLO,
-		MENU_INSERT_PDF,
-		MENU_INSERT_ALM,
-		MENU_INSERT_LRI,
-		MENU_INSERT_RLI,
-		MENU_INSERT_FSI,
-		MENU_INSERT_PDI,
-		MENU_INSERT_ZWJ,
-		MENU_INSERT_ZWNJ,
-		MENU_INSERT_WJ,
-		MENU_INSERT_SHY,
-		MENU_MAX
-
+		MENU_CUT = TextEditMenu::MENU_CUT,
+		MENU_COPY = TextEditMenu::MENU_COPY,
+		MENU_PASTE = TextEditMenu::MENU_PASTE,
+		MENU_CLEAR = TextEditMenu::MENU_CLEAR,
+		MENU_SELECT_ALL = TextEditMenu::MENU_SELECT_ALL,
+		MENU_UNDO = TextEditMenu::MENU_UNDO,
+		MENU_REDO = TextEditMenu::MENU_REDO,
+		MENU_SUBMENU_TEXT_DIR = TextEditMenu::MENU_SUBMENU_TEXT_DIR,
+		MENU_DIR_INHERITED = TextEditMenu::MENU_DIR_INHERITED,
+		MENU_DIR_AUTO = TextEditMenu::MENU_DIR_AUTO,
+		MENU_DIR_LTR = TextEditMenu::MENU_DIR_LTR,
+		MENU_DIR_RTL = TextEditMenu::MENU_DIR_RTL,
+		MENU_DISPLAY_UCC = TextEditMenu::MENU_DISPLAY_UCC,
+		MENU_SUBMENU_INSERT_UCC = TextEditMenu::MENU_SUBMENU_INSERT_UCC,
+		MENU_INSERT_LRM = TextEditMenu::MENU_INSERT_LRM,
+		MENU_INSERT_RLM = TextEditMenu::MENU_INSERT_RLM,
+		MENU_INSERT_LRE = TextEditMenu::MENU_INSERT_LRE,
+		MENU_INSERT_RLE = TextEditMenu::MENU_INSERT_RLE,
+		MENU_INSERT_LRO = TextEditMenu::MENU_INSERT_LRO,
+		MENU_INSERT_RLO = TextEditMenu::MENU_INSERT_RLO,
+		MENU_INSERT_PDF = TextEditMenu::MENU_INSERT_PDF,
+		MENU_INSERT_ALM = TextEditMenu::MENU_INSERT_ALM,
+		MENU_INSERT_LRI = TextEditMenu::MENU_INSERT_LRI,
+		MENU_INSERT_RLI = TextEditMenu::MENU_INSERT_RLI,
+		MENU_INSERT_FSI = TextEditMenu::MENU_INSERT_FSI,
+		MENU_INSERT_PDI = TextEditMenu::MENU_INSERT_PDI,
+		MENU_INSERT_ZWJ = TextEditMenu::MENU_INSERT_ZWJ,
+		MENU_INSERT_ZWNJ = TextEditMenu::MENU_INSERT_ZWNJ,
+		MENU_INSERT_WJ = TextEditMenu::MENU_INSERT_WJ,
+		MENU_INSERT_SHY = TextEditMenu::MENU_INSERT_SHY,
+		MENU_MAX = TextEditMenu::MENU_MAX
 	};
 
 	/* Search. */
@@ -304,11 +304,8 @@ private:
 	String cut_copy_line = "";
 
 	// Context menu.
-	PopupMenu *menu = nullptr;
-	PopupMenu *menu_dir = nullptr;
-	PopupMenu *menu_ctl = nullptr;
+	TextEditMenu context_menu;
 
-	Key _get_menu_action_accelerator(const String &p_action);
 	void _generate_context_menu();
 	void _update_context_menu();
 

--- a/scene/gui/text_edit_menu.cpp
+++ b/scene/gui/text_edit_menu.cpp
@@ -1,0 +1,215 @@
+/**************************************************************************/
+/*  text_edit_menu.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "text_edit_menu.h"
+
+#include "core/input/input_map.h"
+#include "scene/gui/popup_menu.h"
+
+Key TextEditMenu::_get_menu_action_accelerator(const String &p_action) {
+	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(p_action);
+	if (!events) {
+		return Key::NONE;
+	}
+
+	// Use first event in the list for the accelerator.
+	const List<Ref<InputEvent>>::Element *first_event = events->front();
+	if (!first_event) {
+		return Key::NONE;
+	}
+
+	const Ref<InputEventKey> event = first_event->get();
+	if (event.is_null()) {
+		return Key::NONE;
+	}
+
+	// Use physical keycode if non-zero.
+	if (event->get_physical_keycode() != Key::NONE) {
+		return event->get_physical_keycode_with_modifiers();
+	} else {
+		return event->get_keycode_with_modifiers();
+	}
+}
+
+void TextEditMenu::generate_menu(Control *p_control) {
+	menu = memnew(PopupMenu);
+	p_control->add_child(menu, false, Node::INTERNAL_MODE_FRONT);
+
+	menu_dir = memnew(PopupMenu);
+	menu_dir->set_name("DirMenu");
+	menu_dir->add_radio_check_item(RTR("Same as Layout Direction"), MENU_DIR_INHERITED);
+	menu_dir->add_radio_check_item(RTR("Auto-Detect Direction"), MENU_DIR_AUTO);
+	menu_dir->add_radio_check_item(RTR("Left-to-Right"), MENU_DIR_LTR);
+	menu_dir->add_radio_check_item(RTR("Right-to-Left"), MENU_DIR_RTL);
+	menu->add_child(menu_dir, false, Node::INTERNAL_MODE_FRONT);
+
+	menu_ctl = memnew(PopupMenu);
+	menu_ctl->set_name("CTLMenu");
+	menu_ctl->add_item(RTR("Left-to-Right Mark (LRM)"), MENU_INSERT_LRM);
+	menu_ctl->add_item(RTR("Right-to-Left Mark (RLM)"), MENU_INSERT_RLM);
+	menu_ctl->add_item(RTR("Start of Left-to-Right Embedding (LRE)"), MENU_INSERT_LRE);
+	menu_ctl->add_item(RTR("Start of Right-to-Left Embedding (RLE)"), MENU_INSERT_RLE);
+	menu_ctl->add_item(RTR("Start of Left-to-Right Override (LRO)"), MENU_INSERT_LRO);
+	menu_ctl->add_item(RTR("Start of Right-to-Left Override (RLO)"), MENU_INSERT_RLO);
+	menu_ctl->add_item(RTR("Pop Direction Formatting (PDF)"), MENU_INSERT_PDF);
+	menu_ctl->add_separator();
+	menu_ctl->add_item(RTR("Arabic Letter Mark (ALM)"), MENU_INSERT_ALM);
+	menu_ctl->add_item(RTR("Left-to-Right Isolate (LRI)"), MENU_INSERT_LRI);
+	menu_ctl->add_item(RTR("Right-to-Left Isolate (RLI)"), MENU_INSERT_RLI);
+	menu_ctl->add_item(RTR("First Strong Isolate (FSI)"), MENU_INSERT_FSI);
+	menu_ctl->add_item(RTR("Pop Direction Isolate (PDI)"), MENU_INSERT_PDI);
+	menu_ctl->add_separator();
+	menu_ctl->add_item(RTR("Zero-Width Joiner (ZWJ)"), MENU_INSERT_ZWJ);
+	menu_ctl->add_item(RTR("Zero-Width Non-Joiner (ZWNJ)"), MENU_INSERT_ZWNJ);
+	menu_ctl->add_item(RTR("Word Joiner (WJ)"), MENU_INSERT_WJ);
+	menu_ctl->add_item(RTR("Soft Hyphen (SHY)"), MENU_INSERT_SHY);
+	menu->add_child(menu_ctl, false, Node::INTERNAL_MODE_FRONT);
+
+	menu->add_item(RTR("Cut"), MENU_CUT);
+	menu->add_item(RTR("Copy"), MENU_COPY);
+	menu->add_item(RTR("Paste"), MENU_PASTE);
+	menu->add_separator();
+	menu->add_item(RTR("Select All"), MENU_SELECT_ALL);
+	menu->add_item(RTR("Clear"), MENU_CLEAR);
+	menu->add_separator();
+	menu->add_item(RTR("Undo"), MENU_UNDO);
+	menu->add_item(RTR("Redo"), MENU_REDO);
+	menu->add_separator();
+	menu->add_submenu_item(RTR("Text Writing Direction"), "DirMenu", MENU_SUBMENU_TEXT_DIR);
+	menu->add_separator();
+	menu->add_check_item(RTR("Display Control Characters"), MENU_DISPLAY_UCC);
+	menu->add_submenu_item(RTR("Insert Control Character"), "CTLMenu", MENU_SUBMENU_INSERT_UCC);
+}
+
+void TextEditMenu::add_option_selected_callback(const Callable &p_option_selected_callback) {
+	ERR_FAIL_NULL(menu);
+	ERR_FAIL_NULL(menu_dir);
+	ERR_FAIL_NULL(menu_ctl);
+
+	menu->connect(SNAME("id_pressed"), p_option_selected_callback);
+	menu_dir->connect(SNAME("id_pressed"), p_option_selected_callback);
+	menu_ctl->connect(SNAME("id_pressed"), p_option_selected_callback);
+}
+void TextEditMenu::add_focus_changed_callback(const Callable &p_focus_changed_callback) {
+	ERR_FAIL_NULL(menu);
+	menu->connect(SNAME("focus_entered"), p_focus_changed_callback);
+	menu->connect(SNAME("focus_exited"), p_focus_changed_callback);
+}
+
+void TextEditMenu::update(bool p_editable, bool p_selecting_enabled, bool p_shortcut_keys_enabled, Control::TextDirection p_text_direction, bool p_draw_control_chars, bool p_has_undo, bool p_has_redo) {
+	ERR_FAIL_NULL(menu);
+
+	int idx = -1;
+
+#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled)                                                    \
+	idx = m_menu->get_item_index(m_id);                                                                                  \
+	if (idx >= 0) {                                                                                                      \
+		m_menu->set_item_accelerator(idx, p_shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
+		m_menu->set_item_disabled(idx, m_disabled);                                                                      \
+	}
+
+#define MENU_ITEM_ACTION(m_menu, m_id, m_action)                                                                         \
+	idx = m_menu->get_item_index(m_id);                                                                                  \
+	if (idx >= 0) {                                                                                                      \
+		m_menu->set_item_accelerator(idx, p_shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
+	}
+
+#define MENU_ITEM_DISABLED(m_menu, m_id, m_disabled) \
+	idx = m_menu->get_item_index(m_id);              \
+	if (idx >= 0) {                                  \
+		m_menu->set_item_disabled(idx, m_disabled);  \
+	}
+
+#define MENU_ITEM_CHECKED(m_menu, m_id, m_checked) \
+	idx = m_menu->get_item_index(m_id);            \
+	if (idx >= 0) {                                \
+		m_menu->set_item_checked(idx, m_checked);  \
+	}
+
+	MENU_ITEM_ACTION_DISABLED(menu, MENU_CUT, "ui_cut", !p_editable)
+	MENU_ITEM_ACTION(menu, MENU_COPY, "ui_copy")
+	MENU_ITEM_ACTION_DISABLED(menu, MENU_PASTE, "ui_paste", !p_editable)
+	MENU_ITEM_ACTION_DISABLED(menu, MENU_SELECT_ALL, "ui_text_select_all", !p_selecting_enabled)
+	MENU_ITEM_DISABLED(menu, MENU_CLEAR, !p_editable)
+	MENU_ITEM_ACTION_DISABLED(menu, MENU_UNDO, "ui_undo", !p_editable || !p_has_undo)
+	MENU_ITEM_ACTION_DISABLED(menu, MENU_REDO, "ui_redo", !p_editable || !p_has_redo)
+	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_INHERITED, p_text_direction == Control::TEXT_DIRECTION_INHERITED)
+	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_AUTO, p_text_direction == Control::TEXT_DIRECTION_AUTO)
+	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_LTR, p_text_direction == Control::TEXT_DIRECTION_LTR)
+	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_RTL, p_text_direction == Control::TEXT_DIRECTION_RTL)
+	MENU_ITEM_CHECKED(menu, MENU_DISPLAY_UCC, p_draw_control_chars)
+	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_INSERT_UCC, !p_editable)
+
+#undef MENU_ITEM_ACTION_DISABLED
+#undef MENU_ITEM_ACTION
+#undef MENU_ITEM_DISABLED
+#undef MENU_ITEM_CHECKED
+}
+
+void TextEditMenu::popup_at(const Point2 &p_point, bool p_grab_focus) {
+	ERR_FAIL_NULL(menu);
+	menu->set_position(p_point);
+	menu->reset_size();
+	menu->popup();
+	if (p_grab_focus) {
+		menu->grab_focus();
+	}
+}
+
+bool TextEditMenu::has_focus() {
+	return menu && menu->has_focus();
+}
+
+void TextEditMenu::set_text_direction(Control::TextDirection p_text_direction) {
+	ERR_FAIL_NULL(menu_dir);
+	menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_INHERITED), p_text_direction == Control::TEXT_DIRECTION_INHERITED);
+	menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_AUTO), p_text_direction == Control::TEXT_DIRECTION_AUTO);
+	menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), p_text_direction == Control::TEXT_DIRECTION_LTR);
+	menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), p_text_direction == Control::TEXT_DIRECTION_RTL);
+}
+
+void TextEditMenu::set_draw_control_chars(bool p_draw_control_chars) {
+	ERR_FAIL_NULL(menu);
+	if (menu->get_item_index(MENU_DISPLAY_UCC) >= 0) {
+		menu->set_item_checked(menu->get_item_index(MENU_DISPLAY_UCC), p_draw_control_chars);
+	}
+}
+
+bool TextEditMenu::is_visible() const {
+	return menu && menu->is_visible();
+}
+
+bool TextEditMenu::is_initialized() const {
+	return menu;
+}
+
+PopupMenu *TextEditMenu::get_main_menu() const {
+	return menu;
+}

--- a/scene/gui/text_edit_menu.h
+++ b/scene/gui/text_edit_menu.h
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*  text_edit_menu.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEXT_EDIT_MENU_H
+#define TEXT_EDIT_MENU_H
+
+#include "scene/gui/control.h"
+
+enum class Key;
+class PopupMenu;
+
+class TextEditMenu {
+private:
+	Key _get_menu_action_accelerator(const String &p_action);
+
+public:
+	enum MenuItems {
+		MENU_CUT,
+		MENU_COPY,
+		MENU_PASTE,
+		MENU_CLEAR,
+		MENU_SELECT_ALL,
+		MENU_UNDO,
+		MENU_REDO,
+		MENU_SUBMENU_TEXT_DIR,
+		MENU_DIR_INHERITED,
+		MENU_DIR_AUTO,
+		MENU_DIR_LTR,
+		MENU_DIR_RTL,
+		MENU_DISPLAY_UCC,
+		MENU_SUBMENU_INSERT_UCC,
+		MENU_INSERT_LRM,
+		MENU_INSERT_RLM,
+		MENU_INSERT_LRE,
+		MENU_INSERT_RLE,
+		MENU_INSERT_LRO,
+		MENU_INSERT_RLO,
+		MENU_INSERT_PDF,
+		MENU_INSERT_ALM,
+		MENU_INSERT_LRI,
+		MENU_INSERT_RLI,
+		MENU_INSERT_FSI,
+		MENU_INSERT_PDI,
+		MENU_INSERT_ZWJ,
+		MENU_INSERT_ZWNJ,
+		MENU_INSERT_WJ,
+		MENU_INSERT_SHY,
+		MENU_MAX
+	};
+
+	PopupMenu *menu = nullptr;
+	PopupMenu *menu_dir = nullptr;
+	PopupMenu *menu_ctl = nullptr;
+
+	void generate_menu(Control *p_control);
+	void add_option_selected_callback(const Callable &p_option_selected_callback);
+	void add_focus_changed_callback(const Callable &p_focus_changed_callback);
+	void update(bool p_editable, bool p_selecting_enabled, bool p_shortcut_keys_enabled, Control::TextDirection p_text_direction, bool p_draw_control_chars, bool p_has_undo, bool p_has_redo);
+
+	void popup_at(const Point2 &p_point, bool p_grab_focus = false);
+	bool has_focus();
+	void set_text_direction(Control::TextDirection p_text_direction);
+	void set_draw_control_chars(bool p_draw_control_chars);
+	bool is_visible() const;
+	bool is_initialized() const;
+	PopupMenu *get_main_menu() const;
+};
+
+#endif // TEXT_EDIT_MENU_H


### PR DESCRIPTION
Fixes #85511

This PR creates a new class TextEditMenu which contains code that was previously duplicated in TextEdit and LineEdit. Specifically, it's for handling the context menu that pops up when you (for example) right click on a text field.