### PR TITLE
Add a specific error when creating a ViewportTexture in a Texture2D node

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -56,6 +56,7 @@
 #include "scene/resources/font.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/packed_scene.h"
+#include "scene/resources/visual_shader_nodes.h"
 
 ///////////////////// Nil /////////////////////////
 
@@ -3196,6 +3197,13 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 	Ref<ViewportTexture> vpt = p_resource;
 	if (vpt.is_valid()) {
 		r = Object::cast_to<Resource>(get_edited_object());
+		if (Object::cast_to<VisualShaderNodeTexture>(r)) {
+			EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture in a Texture2D node because the texture will not be bound to a scene.\nUse a Texture2DParameter node instead and set the texture in the \"Shader Parameters\" tab."));
+			emit_changed(get_edited_property(), Ref<Resource>());
+			update_property();
+			return;
+		}
+
 		if (r && r->get_path().is_resource_file()) {
 			EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on resources saved as a file.\nResource needs to belong to a scene."));
 			emit_changed(get_edited_property(), Ref<Resource>());


### PR DESCRIPTION
Now, the "Can't create a ViewportTexture on this resource because it's not set as local to scene" error message is shown when you try to set a ViewportTexture as a texture in a Texture2D node in Visual shader

This error message is wrong - the user should not create such a texture because it would be saved to a file, which would not work and is already forbidden (and also because nodes are resources themselves which are not possible to set as local to scene, as discussed in the corresponding issue #84609)

In the PR I've added a check on parent resource type and a verbose error message which tells the user what the correct way to add a ViewportTexture is (with a Texture2DParameter node)