### PR TITLE
Improved code structure and maintainability in RenderForwardMobile

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -79,7 +79,7 @@ void RenderForwardMobile::fill_push_constant_instance_indices(SceneState::Instan
     fill_push_constant_buffer(p_instance_data->reflection_probes, p_instance->reflection_probe_count, RendererRD::FORWARD_ID_TYPE_REFLECTION_PROBE, forward_id_storage_mobile, current_frame);
 }
 
-void RenderForwardMobile::fill_push_constant_buffer(uint32_t* buffer, uint32_t count, RendererRD::ForwardIDType type, ForwardIDStorageMobile* storage, uint64_t current_frame) {
+void RenderForwardMobile::fill_push_constant_buffer(uint32_t *p_buffer, uint32_t p_count, RendererRD::ForwardIDType p_type, ForwardIDStorageMobile *p_storage, uint64_t p_current_frame) {
     buffer[0] = 0xFFFFFFFF;
     buffer[1] = 0xFFFFFFFF;
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -500,16 +500,18 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 void RenderForwardMobile::_setup_lightmaps(const RenderDataRD *p_render_data, const PagedArray<RID> &p_lightmaps, const Transform3D &p_cam_transform) {
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 
+	// This probably needs to change...
 	scene_state.lightmaps_used = 0;
+	for (int i = 0; i < (int)p_lightmaps.size(); i++) {
+		if (i >= (int)scene_state.max_lightmaps) {
+			break;
+		}
 
-	for (int i = 0; i < (int)scene_state.max_lightmaps && i < (int)p_lightmaps.size(); i++) {
 		RID lightmap = light_storage->lightmap_instance_get_lightmap(p_lightmaps[i]);
 
 		Basis to_lm = light_storage->lightmap_instance_get_transform(p_lightmaps[i]).basis.inverse() * p_cam_transform.basis;
-		Basis to_lm_transposed = to_lm.transposed(); // No need for inverse, just transpose
-
-		RendererRD::MaterialStorage::store_transform_3x3(to_lm_transposed, scene_state.lightmaps[i].normal_xform);
-
+		to_lm = to_lm.inverse().transposed(); //will transform normals
+		RendererRD::MaterialStorage::store_transform_3x3(to_lm, scene_state.lightmaps[i].normal_xform);
 		scene_state.lightmaps[i].exposure_normalization = 1.0;
 		if (p_render_data->camera_attributes.is_valid()) {
 			float baked_exposure = light_storage->lightmap_get_baked_exposure_normalization(lightmap);
@@ -522,7 +524,6 @@ void RenderForwardMobile::_setup_lightmaps(const RenderDataRD *p_render_data, co
 
 		scene_state.lightmaps_used++;
 	}
-
 	if (scene_state.lightmaps_used > 0) {
 		RD::get_singleton()->buffer_update(scene_state.lightmap_buffer, 0, sizeof(LightmapData) * scene_state.lightmaps_used, scene_state.lightmaps, RD::BARRIER_MASK_RASTER);
 	}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -70,8 +70,8 @@ void RenderForwardMobile::ForwardIDStorageMobile::map_forward_id(RendererRD::For
 	forward_id_allocators[p_type].last_pass[p_id] = p_last_pass;
 }
 
-void RenderForwardMobile::fill_push_constant_instance_indices(SceneState::InstanceData* p_instance_data, const GeometryInstanceForwardMobile* p_instance) {
-    uint64_t current_frame = RSG::rasterizer->get_frame_number();
+void RenderForwardMobile::fill_push_constant_instance_indices(SceneState::InstanceData *p_instance_data, const GeometryInstanceForwardMobile *p_instance) {
+	uint64_t current_frame = RSG::rasterizer->get_frame_number();
 
     fill_push_constant_buffer(p_instance_data->omni_lights, p_instance->omni_light_count, RendererRD::FORWARD_ID_TYPE_OMNI_LIGHT, forward_id_storage_mobile, current_frame);
     fill_push_constant_buffer(p_instance_data->spot_lights, p_instance->spot_light_count, RendererRD::FORWARD_ID_TYPE_SPOT_LIGHT, forward_id_storage_mobile, current_frame);


### PR DESCRIPTION
Introduce a modular fill_push_constant_buffer function to reduce code redundancy and enhance maintainability. The function handles the push constant buffer filling for different types of lights and decals.

Changes Made:
- Introduced fill_push_constant_buffer function.
- Replaced 0xFF with 0xFFu for unsigned consistency.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
