### PR TITLE
Fix the Web platform team's codeowners link

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -140,10 +140,9 @@ doc_classes/*                       @godotengine/documentation
 
 /platform/android/                  @godotengine/android
 /platform/ios/                      @godotengine/ios
-/platform/javascript/               @godotengine/html5
 /platform/linuxbsd/                 @godotengine/linux-bsd
 /platform/macos/                    @godotengine/macos
-/platform/uwp/                      @godotengine/uwp
+/platform/web/                      @godotengine/web
 /platform/windows/                  @godotengine/windows
 
 # Scene


### PR DESCRIPTION
Noticed GitHub complains about it.