### PR TITLE
Fix unnecessarily quantizing current color in color picker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -556,16 +556,17 @@ void ColorPicker::_html_submitted(const String &p_html) {
 		return;
 	}
 
-	const Color previous_color = color;
-	color = Color::from_string(p_html.strip_edges(), previous_color);
+	Color new_color = Color::from_string(p_html.strip_edges(), color);
 
 	if (!is_editing_alpha()) {
-		color.a = previous_color.a;
+		new_color.a = color.a;
 	}
 
-	if (color == previous_color) {
+	if (new_color.to_argb32() == color.to_argb32()) {
 		return;
 	}
+	color = new_color;
+
 	if (!is_inside_tree()) {
 		return;
 	}


### PR DESCRIPTION
Fixes #85743.

The color picker would update the current color to match the HTML string whenever the parsed value did not match the current color. Since Godot Colors have a 16 bit resolution, this would quantize the current value to the nearest HTML color even when no change was made. And since this happened whenever the HTML input lost focus, just opening and closing the color picker was enough to change a 16-bit value to the nearest 8-bit value.

With this PR, the HTML input only updates the current color when the HTML representation is different from the current color's HTML representation (and not whenever the HTML representation represents a different color than the current one).