### PR TITLE
Add `change_scene_to_node()`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -45,7 +45,21 @@
 			<description>
 				Changes the running scene to the one at the given [param path], after loading it into a [PackedScene] and creating a new instance.
 				Returns [constant OK] on success, [constant ERR_CANT_OPEN] if the [param path] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if that scene cannot be instantiated.
-				[b]Note:[/b] See [method change_scene_to_packed] for details on the order of operations.
+				[b]Note:[/b] See [method change_scene_to_node] for details on the order of operations.
+			</description>
+		</method>
+		<method name="change_scene_to_node">
+			<return type="int" enum="Error" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Changes the running scene to the provided [Node]. Useful when you want to set up the new scene before changing.
+				Returns [constant OK] on success, [constant ERR_INVALID_PARAMETER] if the [param node] is [code]null[/code], or [constant ERR_UNCONFIGURED] if the [param node] is already inside the scene tree.
+				[b]Note:[/b] Operations happen in the following order when [method change_scene_to_node] is called:
+				1. The current scene node is immediately removed from the tree. From that point, [method Node.get_tree] called on the current (outgoing) scene will return [code]null[/code]. [member current_scene] will be [code]null[/code] too, because the new scene is not available yet.
+				2. At the end of the frame, the formerly current scene, already removed from the tree, will be deleted (freed from memory) and then the new scene node will be added to the tree. [method Node.get_tree] and [member current_scene] will be back to working as usual.
+				This ensures that both scenes aren't running at the same time, while still freeing the previous scene in a safe way similar to [method Node.queue_free].
+				If you want to reliably access the new scene, await the [signal scene_changed] signal.
+				[b]Warning:[/b] After using this method, the [SceneTree] will take ownership of the node and will free it automatically when changing scene again. Any references you had to that node will become invalid.
 			</description>
 		</method>
 		<method name="change_scene_to_packed">
@@ -54,11 +68,7 @@
 			<description>
 				Changes the running scene to a new instance of the given [PackedScene] (which must be valid).
 				Returns [constant OK] on success, [constant ERR_CANT_CREATE] if the scene cannot be instantiated, or [constant ERR_INVALID_PARAMETER] if the scene is invalid.
-				[b]Note:[/b] Operations happen in the following order when [method change_scene_to_packed] is called:
-				1. The current scene node is immediately removed from the tree. From that point, [method Node.get_tree] called on the current (outgoing) scene will return [code]null[/code]. [member current_scene] will be [code]null[/code], too, because the new scene is not available yet.
-				2. At the end of the frame, the formerly current scene, already removed from the tree, will be deleted (freed from memory) and then the new scene will be instantiated and added to the tree. [method Node.get_tree] and [member current_scene] will be back to working as usual.
-				This ensures that both scenes aren't running at the same time, while still freeing the previous scene in a safe way similar to [method Node.queue_free].
-				If you want to reliably access the new scene, await the [signal scene_changed] signal.
+				[b]Note:[/b] See [method change_scene_to_node] for details on the order of operations.
 			</description>
 		</method>
 		<method name="create_timer">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1690,6 +1690,13 @@ Error SceneTree::change_scene_to_packed(const Ref<PackedScene> &p_scene) {
 	Node *new_scene = p_scene->instantiate();
 	ERR_FAIL_NULL_V(new_scene, ERR_CANT_CREATE);
 
+	return change_scene_to_node(new_scene);
+}
+
+Error SceneTree::change_scene_to_node(Node *p_node) {
+	ERR_FAIL_NULL_V_MSG(p_node, ERR_INVALID_PARAMETER, "Can't change to a null node. Use unload_current_scene() if you wish to unload it.");
+	ERR_FAIL_COND_V_MSG(p_node->is_inside_tree(), ERR_UNCONFIGURED, "The new scene node can't already be inside scene tree.");
+
 	// If called again while a change is pending.
 	if (pending_new_scene_id.is_valid()) {
 		Node *pending_new_scene = ObjectDB::get_instance<Node>(pending_new_scene_id);
@@ -1707,7 +1714,7 @@ Error SceneTree::change_scene_to_packed(const Ref<PackedScene> &p_scene) {
 	}
 	DEV_ASSERT(!current_scene);
 
-	pending_new_scene_id = new_scene->get_instance_id();
+	pending_new_scene_id = p_node->get_instance_id();
 	return OK;
 }
 
@@ -1922,6 +1929,7 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("change_scene_to_file", "path"), &SceneTree::change_scene_to_file);
 	ClassDB::bind_method(D_METHOD("change_scene_to_packed", "packed_scene"), &SceneTree::change_scene_to_packed);
+	ClassDB::bind_method(D_METHOD("change_scene_to_node", "node"), &SceneTree::change_scene_to_node);
 
 	ClassDB::bind_method(D_METHOD("reload_current_scene"), &SceneTree::reload_current_scene);
 	ClassDB::bind_method(D_METHOD("unload_current_scene"), &SceneTree::unload_current_scene);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -424,6 +424,7 @@ public:
 	Node *get_current_scene() const;
 	Error change_scene_to_file(const String &p_path);
 	Error change_scene_to_packed(const Ref<PackedScene> &p_scene);
+	Error change_scene_to_node(Node *p_node);
 	Error reload_current_scene();
 	void unload_current_scene();
 


### PR DESCRIPTION
This PR adds a new method: `change_scene_to_node()`, which changes the scene to node. The code already existed, this change just extracts part of it into a new method. Thus calling `change_scene_to_file()` will call `change_scene_to_packed()`, which now calls `change_scene_to_node()`.
The new method is useful when you want to do some setup to the new scene before changing.
Also corrected the docs, which claimed that the new scene is instantiated after the old one is removed, which wasn't true.

Closes https://github.com/godotengine/godot-proposals/issues/921
Closes https://github.com/godotengine/godot-proposals/issues/9243

This does not implement the part where the old scene can be left intact, because it's not very useful. My current approach to the problem mentioned in the proposal is adding the menu scene on top of game and pausing the game; changing scenes temporarily is not a good practice.