### PR TITLE
[iOS] Add changing of OS UI settings at runtime

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -853,6 +853,13 @@
 				[b]Note:[/b] Currently only implemented on Android and iOS. On other platforms, [code]screen_get_usable_rect(SCREEN_OF_MAIN_WINDOW)[/code] will be returned as a fallback. See also [method screen_get_usable_rect].
 			</description>
 		</method>
+		<method name="get_gesture_state" qualifiers="const">
+			<return type="int" enum="DisplayServer.UIGestureState" />
+			<description>
+				Returns the state of the UI gestures currently in effect.
+				[b]Note:[/b] This method is only implemented on iOS.
+			</description>
+		</method>
 		<method name="get_keyboard_focus_screen" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -883,6 +890,13 @@
 			<param index="0" name="rect" type="Rect2" />
 			<description>
 				Returns the index of the screen that overlaps the most with the given rectangle. Returns [code]-1[/code] if the rectangle doesn't overlap with any screen or has no area.
+			</description>
+		</method>
+		<method name="get_status_bar_appearance" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns if the status bar is currently hidden. This can be used to modify [code]display/window/ios/hide_status_bar[/code] at runtime.
+				[b]Note:[/b] This method is only implemented on iOS.
 			</description>
 		</method>
 		<method name="get_swap_cancel_ok">
@@ -1828,6 +1842,14 @@
 				[b]Note:[/b] On iOS, this method has no effect if [member ProjectSettings.display/window/handheld/orientation] is not set to [constant SCREEN_SENSOR].
 			</description>
 		</method>
+		<method name="set_gesture_state">
+			<return type="void" />
+			<param index="0" name="ios_gesture_set" type="int" enum="DisplayServer.UIGestureState" />
+			<description>
+				Sets the UI gesture state. This can be used to modify [code]display/window/ios/ui_gesture_state[/code] at runtime.
+				[b]Note:[/b] This method is only implemented on iOS.
+			</description>
+		</method>
 		<method name="set_hardware_keyboard_connection_change_callback">
 			<return type="void" />
 			<param index="0" name="callable" type="Callable" />
@@ -1850,6 +1872,15 @@
 			<description>
 				Sets the window icon (usually displayed in the top-left corner) in the operating system's [i]native[/i] format. The file at [param filename] must be in [code].ico[/code] format on Windows or [code].icns[/code] on macOS. By using specially crafted [code].ico[/code] or [code].icns[/code] icons, [method set_native_icon] allows specifying different icons depending on the size the icon is displayed at. This size is determined by the operating system and user preferences (including the display scale factor). To use icons in other formats, use [method set_icon] instead.
 				[b]Note:[/b] Requires support for [constant FEATURE_NATIVE_ICON].
+			</description>
+		</method>
+		<method name="set_status_bar_appearance">
+			<return type="void" />
+			<param index="0" name="hide_status_bar" type="bool" default="false" />
+			<param index="1" name="status_bar_fade_time" type="float" default="0.2" />
+			<description>
+				Sets the appearance of the status bar. [param status_bar_fade_time] allows changing speed at which it appears or disappears, [code]0[/code] is instant.
+				[b]Note:[/b] This method is only implemented on iOS.
 			</description>
 		</method>
 		<method name="set_system_theme_change_callback">
@@ -2906,6 +2937,24 @@
 		</constant>
 		<constant name="INVALID_INDICATOR_ID" value="-1">
 			The ID that refers to a nonexistent application status indicator.
+		</constant>
+		<constant name="IOS_DEFAULT_GESTURE_STATE" value="0" enum="UIGestureState">
+			Shows home indicator and a single swipe closes the app. Control Center and Notification Center only require a single swipe to open.
+		</constant>
+		<constant name="IOS_SUPPRESS_GESTURE_ALL" value="1" enum="UIGestureState">
+			Shows the home indicator and two swipes are required to close to app. Control Center and Notification Center also require two swipes.
+		</constant>
+		<constant name="IOS_HIDE_GESTURE_INDICATOR" value="2" enum="UIGestureState">
+			Hides the home indicator and a single swipe closes the app. Control Center and Notification Center only requires a single swipe to open.
+		</constant>
+		<constant name="IOS_SUPPRESS_GESTURE_HOME_ONLY" value="3" enum="UIGestureState">
+			Shows the home indicator and two swipes are required to close to app. Control Center and Notification Center only require a single swipe to open.
+		</constant>
+		<constant name="IOS_SUPPRESS_GESTURE_STATUS_ONLY" value="4" enum="UIGestureState">
+			Shows the home indicator and a single swipe closes the app. Control Center and Notification Center require two swipes.
+		</constant>
+		<constant name="IOS_SUPPRESS_GESTURE_STATUS_ONLY_HIDE_GESTURE_INDICATOR" value="5" enum="UIGestureState">
+			Hides the home indicator and a single swipe closes the app. Control Center and Notification Center require two swipes.
 		</constant>
 		<constant name="SCREEN_LANDSCAPE" value="0" enum="ScreenOrientation">
 			Default landscape orientation.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -926,15 +926,13 @@
 		<member name="display/window/ios/allow_high_refresh_rate" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], iOS devices that support high refresh rate/"ProMotion" will be allowed to render at up to 120 frames per second.
 		</member>
-		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
-		</member>
 		<member name="display/window/ios/hide_status_bar" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the status bar is hidden while the app is running.
+			If [code]true[/code], the status bar is hidden while the app is running. This can be changed at runtime with [method DisplayServer.set_status_bar_appearance].
 		</member>
-		<member name="display/window/ios/suppress_ui_gesture" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], it will require two swipes to access iOS UI that uses gestures.
-			[b]Note:[/b] This setting has no effect on the home indicator if [code]hide_home_indicator[/code] is [code]true[/code].
+		<member name="display/window/ios/ui_gesture_state" type="int" setter="" getter="" default="1">
+			Sets which gestures require a swipe, double swipe, or hiding home indicator on iOS.
+			See [enum DisplayServer.UIGestureState] for possible values and how they affect the behavior of your application.
+			This can be changed at runtime with [method DisplayServer.set_gesture_state].
 		</member>
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/size/transparent] and [member rendering/viewport/transparent_background].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2732,9 +2732,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	GLOBAL_DEF("display/window/ios/allow_high_refresh_rate", true);
-	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
-	GLOBAL_DEF("display/window/ios/hide_status_bar", true);
-	GLOBAL_DEF("display/window/ios/suppress_ui_gesture", true);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/ios/ui_gesture_state", PROPERTY_HINT_ENUM, "Allow All,Suppress All,Hide Home Indicator,Suppress Home Only,Suppress Status Only,Suppress Status Only and Hide Home"), 1);
+	GLOBAL_DEF_BASIC("display/window/ios/hide_status_bar", true);
 
 #ifndef _3D_DISABLED
 	// XR project settings.

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -59,5 +59,6 @@
 	$additional_plist_content
 	$plist_launch_screen_name
 	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
+	<key>UIViewControllerBasedStatusBarApperance</key><true/>
 </dict>
 </plist>

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -81,6 +81,9 @@ class DisplayServerIOS : public DisplayServer {
 
 	int virtual_keyboard_height = 0;
 
+	UIGestureState ui_gesture_state = IOS_DEFAULT_GESTURE_STATE;
+	bool status_bar_hidden = false;
+
 	void perform_event(const Ref<InputEvent> &p_event);
 
 	void initialize_tts() const;
@@ -162,6 +165,13 @@ public:
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+
+	virtual UIGestureState get_gesture_state() const override;
+	virtual void set_gesture_state(UIGestureState p_ios_gesture_set) override;
+
+	virtual bool get_status_bar_appearance() const override;
+	virtual void set_status_bar_appearance(bool p_hide_status_bar = false, float p_status_bar_fade_time = 0.2) override;
+
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	virtual Vector<DisplayServer::WindowID> get_window_list() const override;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -65,6 +65,9 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 	}
 	native_menu = memnew(NativeMenu);
 
+	status_bar_hidden = GLOBAL_GET("display/window/ios/hide_status_bar");
+	ui_gesture_state = static_cast<UIGestureState>((int)GLOBAL_GET("display/window/ios/ui_gesture_state"));
+
 #if defined(RD_ENABLED)
 	rendering_context = nullptr;
 	rendering_device = nullptr;
@@ -551,6 +554,35 @@ int DisplayServerIOS::screen_get_dpi(int p_screen) const {
 		}
 		default:
 			return 72;
+	}
+}
+
+DisplayServerIOS::UIGestureState DisplayServerIOS::get_gesture_state() const {
+	return ui_gesture_state;
+}
+
+void DisplayServerIOS::set_gesture_state(UIGestureState p_ios_gesture_set) {
+	if (ui_gesture_state == p_ios_gesture_set) {
+		return;
+	}
+	ui_gesture_state = p_ios_gesture_set;
+	[AppDelegate.viewController setNeedsUpdateOfHomeIndicatorAutoHidden];
+	[AppDelegate.viewController setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+}
+
+bool DisplayServerIOS::get_status_bar_appearance() const {
+	return status_bar_hidden;
+}
+
+void DisplayServerIOS::set_status_bar_appearance(bool p_hide_status_bar, float p_status_bar_fade_time) {
+	status_bar_hidden = p_hide_status_bar;
+	if (p_status_bar_fade_time > 0) {
+		[UIView animateWithDuration:p_status_bar_fade_time
+						 animations:^{
+							 [AppDelegate.viewController setNeedsStatusBarAppearanceUpdate];
+						 }];
+	} else {
+		[AppDelegate.viewController setNeedsStatusBarAppearanceUpdate];
 	}
 }
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -571,6 +571,24 @@ float DisplayServer::screen_get_scale(int p_screen) const {
 	return 1.0f;
 }
 
+DisplayServer::UIGestureState DisplayServer::get_gesture_state() const {
+	WARN_PRINT("iOS UI not supported by this display server.");
+	return IOS_DEFAULT_GESTURE_STATE;
+}
+
+void DisplayServer::set_gesture_state(UIGestureState p_ios_gesture_set) {
+	WARN_PRINT("iOS UI not supported by this display server.");
+}
+
+bool DisplayServer::get_status_bar_appearance() const {
+	WARN_PRINT("iOS UI not supported by this display server.");
+	return false;
+}
+
+void DisplayServer::set_status_bar_appearance(bool p_hide_status_bar, float p_status_bar_fade_time) {
+	WARN_PRINT("iOS UI not supported by this display server.");
+}
+
 bool DisplayServer::is_touchscreen_available() const {
 	return Input::get_singleton() && Input::get_singleton()->is_emulating_touch_from_mouse();
 }
@@ -1397,6 +1415,12 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("screen_get_scale", "screen"), &DisplayServer::screen_get_scale, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("is_touchscreen_available"), &DisplayServer::is_touchscreen_available);
 	ClassDB::bind_method(D_METHOD("screen_get_max_scale"), &DisplayServer::screen_get_max_scale);
+
+	ClassDB::bind_method(D_METHOD("set_gesture_state", "ios_gesture_set"), &DisplayServer::set_gesture_state);
+	ClassDB::bind_method(D_METHOD("get_gesture_state"), &DisplayServer::get_gesture_state);
+	ClassDB::bind_method(D_METHOD("set_status_bar_appearance", "hide_status_bar", "status_bar_fade_time"), &DisplayServer::set_status_bar_appearance, DEFVAL(false), DEFVAL(0.2));
+	ClassDB::bind_method(D_METHOD("get_status_bar_appearance"), &DisplayServer::get_status_bar_appearance);
+
 	ClassDB::bind_method(D_METHOD("screen_get_refresh_rate", "screen"), &DisplayServer::screen_get_refresh_rate, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_pixel", "position"), &DisplayServer::screen_get_pixel);
 	ClassDB::bind_method(D_METHOD("screen_get_image", "screen"), &DisplayServer::screen_get_image, DEFVAL(SCREEN_OF_MAIN_WINDOW));
@@ -1766,6 +1790,13 @@ void DisplayServer::_bind_methods() {
 	BIND_CONSTANT(MAIN_WINDOW_ID);
 	BIND_CONSTANT(INVALID_WINDOW_ID);
 	BIND_CONSTANT(INVALID_INDICATOR_ID);
+
+	BIND_ENUM_CONSTANT(IOS_DEFAULT_GESTURE_STATE);
+	BIND_ENUM_CONSTANT(IOS_SUPPRESS_GESTURE_ALL);
+	BIND_ENUM_CONSTANT(IOS_HIDE_GESTURE_INDICATOR);
+	BIND_ENUM_CONSTANT(IOS_SUPPRESS_GESTURE_HOME_ONLY);
+	BIND_ENUM_CONSTANT(IOS_SUPPRESS_GESTURE_STATUS_ONLY);
+	BIND_ENUM_CONSTANT(IOS_SUPPRESS_GESTURE_STATUS_ONLY_HIDE_GESTURE_INDICATOR);
 
 	BIND_ENUM_CONSTANT(SCREEN_LANDSCAPE);
 	BIND_ENUM_CONSTANT(SCREEN_PORTRAIT);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -364,6 +364,22 @@ public:
 		}
 		return scale;
 	}
+
+	enum UIGestureState {
+		IOS_DEFAULT_GESTURE_STATE,
+		IOS_SUPPRESS_GESTURE_ALL,
+		IOS_HIDE_GESTURE_INDICATOR,
+		IOS_SUPPRESS_GESTURE_HOME_ONLY,
+		IOS_SUPPRESS_GESTURE_STATUS_ONLY,
+		IOS_SUPPRESS_GESTURE_STATUS_ONLY_HIDE_GESTURE_INDICATOR,
+	};
+
+	virtual UIGestureState get_gesture_state() const;
+	virtual void set_gesture_state(UIGestureState p_ios_gesture_set);
+
+	virtual bool get_status_bar_appearance() const;
+	virtual void set_status_bar_appearance(bool p_hide_status_bar = false, float p_status_bar_fade_time = 0.2);
+
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual Color screen_get_pixel(const Point2i &p_position) const { return Color(); }
 	virtual Ref<Image> screen_get_image(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return Ref<Image>(); }
@@ -986,6 +1002,7 @@ VARIANT_ENUM_CAST(DisplayServer::AccessibilityRole)
 VARIANT_ENUM_CAST(DisplayServer::WindowEvent)
 VARIANT_ENUM_CAST(DisplayServer::Feature)
 VARIANT_ENUM_CAST(DisplayServer::MouseMode)
+VARIANT_ENUM_CAST(DisplayServer::UIGestureState)
 VARIANT_ENUM_CAST(DisplayServer::ScreenOrientation)
 VARIANT_ENUM_CAST(DisplayServer::WindowMode)
 VARIANT_ENUM_CAST(DisplayServer::WindowFlags)


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8556.

Allows changing the state of gesture suppression and visibility of the status bar/home indicator at runtime. The use of this could be to only show or hide these functions in certain contexts, such as making only one swipe be required to leave a main menu or pause screen, but while the game is running it requires a double swipe. This is currently impossible as it requires signals to be sent to the OS that were not implemented before.

**2025-03-21 Edit**: An example I posed in the thread for the potential use of this is Roblox, which allows standard iOS gestures while in the game selection part of the app, but once you enter a game it enables the mode that requires a double swipe.

Another example includes a shareable code. While on the screen for sharing, you can swipe out with a single swipe. Once the user dismisses that screen, it goes back to needing a double swipe.