### PR TITLE
Refactor and fix `make_virtuals.py`

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -1,78 +1,74 @@
-proto = """
-#define GDVIRTUAL$VER($RET m_name $ARG) \\
-StringName _gdvirtual_##m_name##_sn = #m_name;\\
-mutable bool _gdvirtual_##m_name##_initialized = false;\\
-mutable void* _gdvirtual_##m_name = nullptr;\\
-template<bool required>\\
-_FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
-	ScriptInstance *_script_instance = ((Object*)(this))->get_script_instance();\\
-	if (_script_instance) {\\
-		Callable::CallError ce; \\
-		$CALLSIARGS\\
-		$CALLSIBEGIN_script_instance->callp(_gdvirtual_##m_name##_sn, $CALLSIARGPASS, ce);\\
-		if (ce.error == Callable::CallError::CALL_OK) {\\
-			$CALLSIRET\\
+proto = """#define GDVIRTUAL$VER($RET m_name $ARG)\\
+	StringName _gdvirtual_##m_name##_sn = #m_name;\\
+	mutable bool _gdvirtual_##m_name##_initialized = false;\\
+	mutable void *_gdvirtual_##m_name = nullptr;\\
+	template <bool required>\\
+	_FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST {\\
+		ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
+		if (_script_instance) {\\
+			Callable::CallError ce;\\
+			$CALLSIARGS\\
+			$CALLSIBEGIN_script_instance->callp(_gdvirtual_##m_name##_sn, $CALLSIARGPASS, ce);\\
+			if (ce.error == Callable::CallError::CALL_OK) {\\
+				$CALLSIRET\\
+				return true;\\
+			}\\
+		}\\
+		if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
+			_gdvirtual_##m_name = nullptr;\\
+			if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
+				_gdvirtual_##m_name = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
+			} else if (_get_extension()->get_virtual) {\\
+				_gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
+			}\\
+			GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized);\\
+			_gdvirtual_##m_name##_initialized = true;\\
+		}\\
+		if (_gdvirtual_##m_name) {\\
+			$CALLPTRARGS\\
+			$CALLPTRRETDEF\\
+			if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
+				_get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##m_name##_sn, _gdvirtual_##m_name, $CALLPTRARGPASS, $CALLPTRRETPASS);\\
+				$CALLPTRRET\\
+			} else {\\
+				((GDExtensionClassCallVirtual)_gdvirtual_##m_name)(_get_extension_instance(), $CALLPTRARGPASS, $CALLPTRRETPASS);\\
+				$CALLPTRRET\\
+			}\\
 			return true;\\
-		}    \\
+		}\\
+		if (required) {\\
+			ERR_PRINT_ONCE("Required virtual method " + get_class() + "::" + #m_name + " must be overridden before calling.");\\
+			$RVOID\\
+		}\\
+		return false;\\
 	}\\
-    if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
-        _gdvirtual_##m_name = nullptr;\\
-        if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
-            _gdvirtual_##m_name = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
-        } else if (_get_extension()->get_virtual) {\\
-            _gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
-        }\\
-        GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized); \\
-        _gdvirtual_##m_name##_initialized = true;\\
-    }\\
-	if (_gdvirtual_##m_name) {\\
-		$CALLPTRARGS\\
-		$CALLPTRRETDEF\\
-        if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
-            _get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##m_name##_sn, _gdvirtual_##m_name, $CALLPTRARGPASS,$CALLPTRRETPASS);\\
-            $CALLPTRRET\\
-        } else {\\
-		    ((GDExtensionClassCallVirtual)_gdvirtual_##m_name)(_get_extension_instance(),$CALLPTRARGPASS,$CALLPTRRETPASS);\\
-            $CALLPTRRET\\
-        }\\
-		return true;\\
+	_FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const {\\
+		ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
+		if (_script_instance && _script_instance->has_method(_gdvirtual_##m_name##_sn)) {\\
+			return true;\\
+		}\\
+		if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
+			_gdvirtual_##m_name = nullptr;\\
+			if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
+				_gdvirtual_##m_name = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
+			} else if (_get_extension()->get_virtual) {\\
+				_gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
+			}\\
+			GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized);\\
+			_gdvirtual_##m_name##_initialized = true;\\
+		}\\
+		if (_gdvirtual_##m_name) {\\
+			return true;\\
+		}\\
+		return false;\\
 	}\\
-	\\
-	if (required) {\\
-	        ERR_PRINT_ONCE("Required virtual method " + get_class() + "::" + #m_name + " must be overridden before calling.");\\
-	        $RVOID\\
-    }\\
-\\
-    return false;\\
-}\\
-_FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const { \\
-	ScriptInstance *_script_instance = ((Object*)(this))->get_script_instance();\\
-	if (_script_instance && _script_instance->has_method(_gdvirtual_##m_name##_sn)) {\\
-		return true;\\
-	}\\
-    if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
-         _gdvirtual_##m_name = nullptr;\\
-        if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
-             _gdvirtual_##m_name = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
-        } else if (_get_extension()->get_virtual) {\\
-             _gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
-        }\\
-        GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized); \\
-        _gdvirtual_##m_name##_initialized = true;\\
-    }\\
-	if (_gdvirtual_##m_name) {\\
-	    return true;\\
-	}\\
-	return false;\\
-}\\
-\\
-_FORCE_INLINE_ static MethodInfo _gdvirtual_##m_name##_get_method_info() { \\
-    MethodInfo method_info;\\
-    method_info.name = #m_name;\\
-    method_info.flags = METHOD_FLAG_VIRTUAL;\\
-    $FILL_METHOD_INFO\\
-    return method_info;\\
-}
+	_FORCE_INLINE_ static MethodInfo _gdvirtual_##m_name##_get_method_info() {\\
+		MethodInfo method_info;\\
+		method_info.name = #m_name;\\
+		method_info.flags = $METHOD_FLAGS;\\
+		$FILL_METHOD_INFO\\
+		return method_info;\\
+	}
 
 """
 
@@ -83,22 +79,23 @@ def generate_version(argcount, const=False, returns=False):
     method_info = ""
     if returns:
         sproto += "R"
-        s = s.replace("$RET", "m_ret, ")
+        s = s.replace("$RET", "m_ret,")
         s = s.replace("$RVOID", "(void)r_ret;")  # If required, may lead to uninitialized errors
         s = s.replace("$CALLPTRRETDEF", "PtrToArg<m_ret>::EncodeT ret;")
-        method_info += "\tmethod_info.return_val = GetTypeInfo<m_ret>::get_class_info();\\\n"
-        method_info += "\tmethod_info.return_val_metadata = GetTypeInfo<m_ret>::METADATA;\\\n"
+        method_info += "method_info.return_val = GetTypeInfo<m_ret>::get_class_info();\\\n"
+        method_info += "\t\tmethod_info.return_val_metadata = GetTypeInfo<m_ret>::METADATA;"
     else:
-        s = s.replace("$RET", "")
-        s = s.replace("$RVOID", "")
-        s = s.replace("$CALLPTRRETDEF", "")
+        s = s.replace("$RET ", "")
+        s = s.replace("\t\t\t$RVOID\\\n", "")
+        s = s.replace("\t\t\t$CALLPTRRETDEF\\\n", "")
 
     if const:
         sproto += "C"
         s = s.replace("$CONST", "const")
-        method_info += "\tmethod_info.flags|=METHOD_FLAG_CONST;\\\n"
+        s = s.replace("$METHOD_FLAGS", "METHOD_FLAG_VIRTUAL | METHOD_FLAG_CONST")
     else:
-        s = s.replace("$CONST", "")
+        s = s.replace("$CONST ", "")
+        s = s.replace("$METHOD_FLAGS", "METHOD_FLAG_VIRTUAL")
 
     s = s.replace("$VER", sproto)
     argtext = ""
@@ -108,9 +105,9 @@ def generate_version(argcount, const=False, returns=False):
     callptrargsptr = ""
     if argcount > 0:
         argtext += ", "
-        callsiargs = "Variant vargs[" + str(argcount) + "]={"
-        callsiargptrs = "\t\tconst Variant *vargptrs[" + str(argcount) + "]={"
-        callptrargsptr = "\t\tGDExtensionConstTypePtr argptrs[" + str(argcount) + "]={"
+        callsiargs = f"Variant vargs[{argcount}] = {{ "
+        callsiargptrs = f"\t\t\tconst Variant *vargptrs[{argcount}] = {{ "
+        callptrargsptr = f"\t\t\tGDExtensionConstTypePtr argptrs[{argcount}] = {{ "
     callptrargs = ""
     for i in range(argcount):
         if i > 0:
@@ -118,52 +115,53 @@ def generate_version(argcount, const=False, returns=False):
             callargtext += ", "
             callsiargs += ", "
             callsiargptrs += ", "
-            callptrargs += "\t\t"
+            callptrargs += "\t\t\t"
             callptrargsptr += ", "
-        argtext += "m_type" + str(i + 1)
-        callargtext += "m_type" + str(i + 1) + " arg" + str(i + 1)
-        callsiargs += "Variant(arg" + str(i + 1) + ")"
-        callsiargptrs += "&vargs[" + str(i) + "]"
-        callptrargs += (
-            "PtrToArg<m_type" + str(i + 1) + ">::EncodeT argval" + str(i + 1) + " = arg" + str(i + 1) + ";\\\n"
-        )
-        callptrargsptr += "&argval" + str(i + 1)
-        method_info += "\tmethod_info.arguments.push_back(GetTypeInfo<m_type" + str(i + 1) + ">::get_class_info());\\\n"
-        method_info += (
-            "\tmethod_info.arguments_metadata.push_back(GetTypeInfo<m_type" + str(i + 1) + ">::METADATA);\\\n"
-        )
+        argtext += f"m_type{i + 1}"
+        callargtext += f"m_type{i + 1} arg{i + 1}"
+        callsiargs += f"Variant(arg{i + 1})"
+        callsiargptrs += f"&vargs[{i}]"
+        callptrargs += f"PtrToArg<m_type{i + 1}>::EncodeT argval{i + 1} = arg{i + 1};\\\n"
+        callptrargsptr += f"&argval{i + 1}"
+        if method_info:
+            method_info += "\\\n\t\t"
+        method_info += f"method_info.arguments.push_back(GetTypeInfo<m_type{i + 1}>::get_class_info());\\\n"
+        method_info += f"\t\tmethod_info.arguments_metadata.push_back(GetTypeInfo<m_type{i + 1}>::METADATA);"
 
     if argcount:
-        callsiargs += "};\\\n"
-        callsiargptrs += "};\\\n"
+        callsiargs += " };\\\n"
+        callsiargptrs += " };"
         s = s.replace("$CALLSIARGS", callsiargs + callsiargptrs)
-        s = s.replace("$CALLSIARGPASS", "(const Variant **)vargptrs," + str(argcount))
-        callptrargsptr += "};\\\n"
+        s = s.replace("$CALLSIARGPASS", f"(const Variant **)vargptrs, {argcount}")
+        callptrargsptr += " };"
         s = s.replace("$CALLPTRARGS", callptrargs + callptrargsptr)
-        s = s.replace("$CALLPTRARGPASS", "reinterpret_cast<GDExtensionConstTypePtr*>(argptrs)")
+        s = s.replace("$CALLPTRARGPASS", "reinterpret_cast<GDExtensionConstTypePtr *>(argptrs)")
     else:
-        s = s.replace("$CALLSIARGS", "")
+        s = s.replace("\t\t\t$CALLSIARGS\\\n", "")
         s = s.replace("$CALLSIARGPASS", "nullptr, 0")
-        s = s.replace("$CALLPTRARGS", "")
+        s = s.replace("\t\t\t$CALLPTRARGS\\\n", "")
         s = s.replace("$CALLPTRARGPASS", "nullptr")
 
     if returns:
         if argcount > 0:
-            callargtext += ","
-        callargtext += " m_ret& r_ret"
+            callargtext += ", "
+        callargtext += "m_ret &r_ret"
         s = s.replace("$CALLSIBEGIN", "Variant ret = ")
         s = s.replace("$CALLSIRET", "r_ret = VariantCaster<m_ret>::cast(ret);")
         s = s.replace("$CALLPTRRETPASS", "&ret")
         s = s.replace("$CALLPTRRET", "r_ret = (m_ret)ret;")
     else:
         s = s.replace("$CALLSIBEGIN", "")
-        s = s.replace("$CALLSIRET", "")
+        s = s.replace("\t\t\t\t$CALLSIRET\\\n", "")
         s = s.replace("$CALLPTRRETPASS", "nullptr")
-        s = s.replace("$CALLPTRRET", "")
+        s = s.replace("\t\t\t\t$CALLPTRRET\\\n", "")
 
-    s = s.replace("$ARG", argtext)
+    s = s.replace(" $ARG", argtext)
     s = s.replace("$CALLARGS", callargtext)
-    s = s.replace("$FILL_METHOD_INFO", method_info)
+    if method_info:
+        s = s.replace("$FILL_METHOD_INFO", method_info)
+    else:
+        s = s.replace("\t\t$FILL_METHOD_INFO\\\n", method_info)
 
     return s
 
@@ -171,21 +169,21 @@ def generate_version(argcount, const=False, returns=False):
 def run(target, source, env):
     max_versions = 12
 
-    txt = """
+    txt = """/* THIS FILE IS GENERATED DO NOT EDIT */
 #ifndef GDVIRTUAL_GEN_H
 #define GDVIRTUAL_GEN_H
 
 #include "core/object/script_instance.h"
 
 #ifdef TOOLS_ENABLED
-#define GDVIRTUAL_TRACK(m_virtual, m_initialized) \\
-    if (_get_extension()->reloadable) {\\
-        VirtualMethodTracker *tracker = memnew(VirtualMethodTracker);\\
-        tracker->method = (void **)&m_virtual;\\
-        tracker->initialized = &m_initialized;\\
-        tracker->next = virtual_method_list;\\
-        virtual_method_list = tracker;\\
-    }
+#define GDVIRTUAL_TRACK(m_virtual, m_initialized)\\
+	if (_get_extension()->reloadable) {\\
+		VirtualMethodTracker *tracker = memnew(VirtualMethodTracker);\\
+		tracker->method = (void **)&m_virtual;\\
+		tracker->initialized = &m_initialized;\\
+		tracker->next = virtual_method_list;\\
+		virtual_method_list = tracker;\\
+	}
 #else
 #define GDVIRTUAL_TRACK(m_virtual, m_initialized)
 #endif
@@ -193,13 +191,13 @@ def run(target, source, env):
 """
 
     for i in range(max_versions + 1):
-        txt += "/* " + str(i) + " Arguments */\n\n"
+        txt += f"/* {i} Arguments */\n\n"
         txt += generate_version(i, False, False)
         txt += generate_version(i, False, True)
         txt += generate_version(i, True, False)
         txt += generate_version(i, True, True)
 
-    txt += "#endif"
+    txt += "#endif // GDVIRTUAL_GEN_H\n"
 
     with open(target[0], "w") as f:
         f.write(txt)

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -121,7 +121,9 @@ def generate_version(argcount, const=False, returns=False):
         callargtext += f"m_type{i + 1} arg{i + 1}"
         callsiargs += f"Variant(arg{i + 1})"
         callsiargptrs += f"&vargs[{i}]"
-        callptrargs += f"PtrToArg<m_type{i + 1}>::EncodeT argval{i + 1} = arg{i + 1};\\\n"
+        callptrargs += (
+            f"PtrToArg<m_type{i + 1}>::EncodeT argval{i + 1} = (PtrToArg<m_type{i + 1}>::EncodeT)arg{i + 1};\\\n"
+        )
         callptrargsptr += f"&argval{i + 1}"
         if method_info:
             method_info += "\\\n\t\t"


### PR DESCRIPTION
- Adds `EncodeT` type casting on `EncodeT` assignment in order to support enum classes as arguments. Went unnoticed because there's currently no enum classes as arguments for any `GDVIRTUAL`, but if that changes in the future they'll be supported.
- Generated output reformatted to be comparable to clang-formatted code, without compromising readability in the python file. Most notably unified inconsistencies in tabs/spaces & removed any blank lines after formatting finalized.