### PR TITLE
GLES3: Skip batches with zero instance count while rendering canvas

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -661,6 +661,11 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	state.current_tex = RID();
 
 	for (uint32_t i = 0; i <= state.current_batch_index; i++) {
+		// Skipping when there is no instances.
+		if (state.canvas_instance_batches[i].instance_count == 0) {
+			continue;
+		}
+
 		//setup clip
 		if (current_clip != state.canvas_instance_batches[i].clip) {
 			current_clip = state.canvas_instance_batches[i].clip;


### PR DESCRIPTION
Fixes #74115 
Replaces #85533 

This PR fixes unintended batch rendering by skipping batches with zero instance count (`instance_count == 0`).

Actually this is the 3rd attempt of fixing a bug, and I believe this is the best approach. Maybe I should have been more careful...

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
