### PR TITLE
[4.2] Fix crash when using incompatible versions of Godot Jolt

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -912,6 +912,11 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 		return ERR_FILE_NOT_FOUND;
 	}
 
+	if (library_path.get_file().begins_with("godot-jolt_") && compatibility_minimum[0] == 4 && compatibility_minimum[1] == 1) {
+		ERR_PRINT("Godot Jolt failed to load, as the currently installed version is incompatible with Godot 4.2. You can update it to a compatible version by deleting it and installing it again.");
+		return ERR_INVALID_DATA;
+	}
+
 	bool is_static_library = library_path.ends_with(".a") || library_path.ends_with(".xcframework");
 
 	if (!library_path.is_resource_file() && !library_path.is_absolute_path()) {


### PR DESCRIPTION
Related to #85576, #85580 and #85581.

As per [the discussion](https://chat.godotengine.org/channel/gdextension?msg=jCpK5kNQeEgsgseWG) on Rocket Chat, This introduces a somewhat hacky check to see if the GDExtension library being loaded has its filename beginning with `godot_jolt_` and is also targeting a `compatibility_minimum` of `4.1`, which indicates that it's a version that was never officially supported to work with Godot 4.2.

Note that this PR targets the `4.2` branch, since it seemed like this would/should be a temporary hack for 4.2 specifically.

Also note that this will technically reject Godot Jolt version 0.9.0 and 0.10.0, despite those technically being (somewhat) compatible with Godot 4.2.

Let me know what you think of the error message.

CC: @akien-mga @YuriSizov @dsnopek 