### PR TITLE
Make `FileDialog` filtering case insensitive

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -127,7 +127,7 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 				int filter_slice_count = flt.get_slice_count(",");
 				for (int j = 0; j < filter_slice_count; j++) {
 					String str = (flt.get_slice(",", j).strip_edges());
-					if (f.match(str)) {
+					if (f.matchn(str)) {
 						valid = true;
 						break;
 					}
@@ -565,7 +565,7 @@ void EditorFileDialog::_action_pressed() {
 				String flt = filters[i].get_slice(";", 0);
 				for (int j = 0; j < flt.get_slice_count(","); j++) {
 					String str = flt.get_slice(",", j).strip_edges();
-					if (f.match(str)) {
+					if (f.matchn(str)) {
 						valid = true;
 						break;
 					}
@@ -584,7 +584,7 @@ void EditorFileDialog::_action_pressed() {
 				int filterSliceCount = flt.get_slice_count(",");
 				for (int j = 0; j < filterSliceCount; j++) {
 					String str = (flt.get_slice(",", j).strip_edges());
-					if (f.match(str)) {
+					if (f.matchn(str)) {
 						valid = true;
 						break;
 					}

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -138,7 +138,7 @@ void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files, int
 				int filter_slice_count = flt.get_slice_count(",");
 				for (int j = 0; j < filter_slice_count; j++) {
 					String str = (flt.get_slice(",", j).strip_edges());
-					if (f.match(str)) {
+					if (f.matchn(str)) {
 						valid = true;
 						break;
 					}
@@ -473,7 +473,7 @@ void FileDialog::_action_pressed() {
 				String flt = filters[i].get_slice(";", 0);
 				for (int j = 0; j < flt.get_slice_count(","); j++) {
 					String str = flt.get_slice(",", j).strip_edges();
-					if (f.match(str)) {
+					if (f.matchn(str)) {
 						valid = true;
 						break;
 					}
@@ -492,7 +492,7 @@ void FileDialog::_action_pressed() {
 				int filterSliceCount = flt.get_slice_count(",");
 				for (int j = 0; j < filterSliceCount; j++) {
 					String str = (flt.get_slice(",", j).strip_edges());
-					if (f.match(str)) {
+					if (f.matchn(str)) {
 						valid = true;
 						break;
 					}


### PR DESCRIPTION
When using FileDialog to save files on non-case-sensitive file systems (Windows and often macOS), a file may have an uppercase file extension ( `file.TXT` ) but the filter is set as lowercase ( `*.txt ; Text Files` ). The FileDialog will list the file but selecting it to overwrite will not detect that the file matches the filter and append the lowercase extension after the existing uppercase file extension and would result in the selected file being `file.TXT.txt`

As most other operating systems can be case sensitive, my suggestion is to add a `CaseSensitivity` enum with the values of `True`, `False` and `OS Default` to the FileDialog for toggling between using `f.match(str)` and `f.matchn(str)` in the checks which would allow it to either be explicit based on the developer intent or implicit based on the standard of the operating system.

![filedialog-case-sensitivity](https://github.com/godotengine/godot/assets/7022889/d0553db2-073a-47c4-b0d2-34cf05b82040)

Currently if `OS Default` is used then the code uses a case-sensitive check if the OS is not Windows or macOS. Is there a better approach for this? Are there any other supported OS's are not case-sensitive by default?

Attached is an MRP similar to the one provided in the issue, with the addition of an OptionButton for changing between the CaseSensitivity setting when running the project.
[FileDialogCaseSensitivity.zip](https://github.com/godotengine/godot/files/13561697/FileDialogCaseSensitivity.zip)

Fixes #85788