### PR TITLE
Remove differences of the code between old AnimationTree and AnimationMixer

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -860,7 +860,7 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 			pi.time = 0;
 			pi.seeked = true;
 		}
-		fading_from_rem = p_state_machine->blend_node(p_state_machine->states[fading_from].node, fading_from, pi, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		fading_from_rem = p_state_machine->blend_node(p_state_machine->states[fading_from].node, fading_from, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 		// Guess playback position.
 		if (fading_from_rem > len_fade_from) { /// Weird but ok.
@@ -976,7 +976,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 			pi.seeked = true;
 			pi.is_external_seeking = false;
 			pi.weight = 0;
-			p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true);
+			p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
 		}
 
 		// Just get length to find next recursive.

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -85,7 +85,7 @@ public:
 	void _set_filters(const Array &p_filters);
 	friend class AnimationNodeBlendTree;
 	double _blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationNode *p_new_parent, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false, real_t *r_activity = nullptr);
-	double _pre_process(ProcessState *p_process_state, AnimationMixer::PlaybackInfo p_playback_info);
+	double _pre_process(ProcessState *p_process_state, AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false);
 
 protected:
 	virtual double _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/85640

A few lines were overlooked during those porting, sorry. I think the problem only occurred in complex use cases.

It would be helpful if someone could test on other complex trees besides the above issues.
