### PR TITLE
Allow dragging selection when selecting whole words in `RichTextLabel`

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -534,6 +534,7 @@ private:
 		Item *to_item = nullptr;
 		int to_char = 0;
 
+		bool double_click = false; // Selecting whole words?
 		bool active = false; // anything selected? i.e. from, to, etc. valid?
 		bool enabled = false; // allow selections?
 		bool drag_attempt = false;


### PR DESCRIPTION
With this PR the following is possible:

[Screencast](https://github.com/godotengine/godot/assets/99511741/f353f9d0-7c2e-4ef5-a6fe-a8932f38f3e5)

Before it was not possible to drag the selection after double clicking.