### PR TITLE
Fix invalid Python escape sequences

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1361,7 +1361,7 @@ def make_enum(t: str, is_bitfield: bool, state: State) -> str:
         if is_bitfield:
             if not state.classes[c].enums[e].is_bitfield:
                 print_error(f'{state.current_class}.xml: Enum "{t}" is not bitfield.', state)
-            return f"|bitfield|\<:ref:`{e}<enum_{c}_{e}>`\>"
+            return f"|bitfield|\\<:ref:`{e}<enum_{c}_{e}>`\\>"
         else:
             return f":ref:`{e}<enum_{c}_{e}>`"
 
@@ -2082,9 +2082,9 @@ def format_text_block(
                     post_text = text[endurl_pos + 6 :]
 
                     if pre_text and pre_text[-1] not in MARKUP_ALLOWED_PRECEDENT:
-                        pre_text += "\ "
+                        pre_text += "\\ "
                     if post_text and post_text[0] not in MARKUP_ALLOWED_SUBSEQUENT:
-                        post_text = "\ " + post_text
+                        post_text = "\\ " + post_text
 
                     text = pre_text + tag_text + post_text
                     pos = len(pre_text) + len(tag_text)
@@ -2162,9 +2162,9 @@ def format_text_block(
 
         # Properly escape things like `[Node]s`
         if escape_pre and pre_text and pre_text[-1] not in MARKUP_ALLOWED_PRECEDENT:
-            pre_text += "\ "
+            pre_text += "\\ "
         if escape_post and post_text and post_text[0] not in MARKUP_ALLOWED_SUBSEQUENT:
-            post_text = "\ " + post_text
+            post_text = "\\ " + post_text
 
         next_brac_pos = post_text.find("[", 0)
         iter_pos = 0
@@ -2172,7 +2172,7 @@ def format_text_block(
             iter_pos = post_text.find("*", iter_pos, next_brac_pos)
             if iter_pos == -1:
                 break
-            post_text = f"{post_text[:iter_pos]}\*{post_text[iter_pos + 1 :]}"
+            post_text = f"{post_text[:iter_pos]}\\*{post_text[iter_pos + 1 :]}"
             iter_pos += 2
 
         iter_pos = 0
@@ -2181,7 +2181,7 @@ def format_text_block(
             if iter_pos == -1:
                 break
             if not post_text[iter_pos + 1].isalnum():  # don't escape within a snake_case word
-                post_text = f"{post_text[:iter_pos]}\_{post_text[iter_pos + 1 :]}"
+                post_text = f"{post_text[:iter_pos]}\\_{post_text[iter_pos + 1 :]}"
                 iter_pos += 2
             else:
                 iter_pos += 1
@@ -2222,7 +2222,7 @@ def escape_rst(text: str, until_pos: int = -1) -> str:
         pos = text.find("*", pos, until_pos)
         if pos == -1:
             break
-        text = f"{text[:pos]}\*{text[pos + 1 :]}"
+        text = f"{text[:pos]}\\*{text[pos + 1 :]}"
         pos += 2
 
     # Escape _ character at the end of a word to avoid interpreting it as an inline hyperlink
@@ -2232,7 +2232,7 @@ def escape_rst(text: str, until_pos: int = -1) -> str:
         if pos == -1:
             break
         if not text[pos + 1].isalnum():  # don't escape within a snake_case word
-            text = f"{text[:pos]}\_{text[pos + 1 :]}"
+            text = f"{text[:pos]}\\_{text[pos + 1 :]}"
             pos += 2
         else:
             pos += 1

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -481,7 +481,7 @@ def configure_msvc(env, vcvars_msvc_config):
     env["BUILDERS"]["ProgramOriginal"] = env["BUILDERS"]["Program"]
     env["BUILDERS"]["Program"] = methods.precious_program
 
-    env.Append(LINKFLAGS=["/NATVIS:platform\windows\godot.natvis"])
+    env.Append(LINKFLAGS=["/NATVIS:platform\\windows\\godot.natvis"])
     env.AppendUnique(LINKFLAGS=["/STACK:" + str(STACK_SIZE)])
 
 


### PR DESCRIPTION
Python leaves the backslash in invalid escape sequences so the results have so far functioned the same as properly escaping the backslashes. In Python 3.12 this causes SyntaxWarnings but future Python versions will raise SyntaxErrors (https://docs.python.org/3/whatsnew/3.12.html).

Running
`% pycodestyle --select W605 $(find godot/ -name "*.py")`

to find offending code yields:

>godot//platform/windows/detect.py:484:44: W605 invalid escape sequence '\w'
godot//platform/windows/detect.py:484:52: W605 invalid escape sequence '\g'
godot//doc/tools/make_rst.py:1364:32: W605 invalid escape sequence '\<'
godot//doc/tools/make_rst.py:1364:58: W605 invalid escape sequence '\>'
godot//doc/tools/make_rst.py:2085:38: W605 invalid escape sequence '\ '
godot//doc/tools/make_rst.py:2087:38: W605 invalid escape sequence '\ '
godot//doc/tools/make_rst.py:2165:26: W605 invalid escape sequence '\ '
godot//doc/tools/make_rst.py:2167:26: W605 invalid escape sequence '\ '
godot//doc/tools/make_rst.py:2175:49: W605 invalid escape sequence '\*'
godot//doc/tools/make_rst.py:2184:53: W605 invalid escape sequence '\_'
godot//doc/tools/make_rst.py:2225:30: W605 invalid escape sequence '\*'
godot//doc/tools/make_rst.py:2235:34: W605 invalid escape sequence '\_'

This PR fixes all those issues by escaping the backslash.