### PR TITLE
Add the option to make textures immutable.

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3225,9 +3225,11 @@
 		<method name="texture_2d_create">
 			<return type="RID" />
 			<param index="0" name="image" type="Image" />
+			<param index="1" name="immutable" type="bool" default="false" />
 			<description>
 				Creates a 2-dimensional texture and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]texture_2d_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] method.
+				Consider creating this texture as immutable (which prevents further updates via [method RenderingServer.texture_2d_update]) if you don't plan on modifying it later. This can significantly improve performance.
 				[b]Note:[/b] The equivalent resource is [Texture2D].
 				[b]Note:[/b] Not to be confused with [method RenderingDevice.texture_create], which creates the graphics API's own texture type as opposed to the Godot-specific [Texture2D] resource.
 			</description>
@@ -3257,9 +3259,11 @@
 			<return type="RID" />
 			<param index="0" name="layers" type="Image[]" />
 			<param index="1" name="layered_type" type="int" enum="RenderingServer.TextureLayeredType" />
+			<param index="2" name="immutable" type="bool" default="false" />
 			<description>
 				Creates a 2-dimensional layered texture and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]texture_2d_layered_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] method.
+				Consider creating this texture as immutable (which prevents further updates via [method RenderingServer.texture_2d_update]) if you don't plan on modifying it later. This can significantly improve performance.
 				[b]Note:[/b] The equivalent resource is [TextureLayered].
 			</description>
 		</method>
@@ -3297,7 +3301,9 @@
 			<param index="3" name="depth" type="int" />
 			<param index="4" name="mipmaps" type="bool" />
 			<param index="5" name="data" type="Image[]" />
+			<param index="6" name="immutable" type="bool" default="false" />
 			<description>
+				Consider creating this texture as immutable (which prevents further updates via [method RenderingServer.texture_3d_update]) if you don't plan on modifying it later. This can significantly improve performance.
 				[b]Note:[/b] The equivalent resource is [Texture3D].
 			</description>
 		</method>

--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -50,6 +50,8 @@
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
 			Unimplemented. This currently has no effect when changed.
 		</member>
+		<member name="optimization/immutable" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="slices/arrangement" type="int" setter="" getter="" default="1">
 			Controls how the cubemap's texture is internally laid out. When using high-resolution cubemaps, [b]2×3[/b] and [b]3×2[/b] are less prone to exceeding hardware texture size limits compared to [b]1×6[/b] and [b]6×1[/b].
 		</member>

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -65,6 +65,8 @@
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
 			Unimplemented. This currently has no effect when changed.
 		</member>
+		<member name="optimization/immutable" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="process/fix_alpha_border" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], puts pixels of the same surrounding color in transition from transparent to opaque areas. For textures displayed with bilinear filtering, this helps mitigate the outline effect when exporting images from an image editor.
 			It's recommended to leave this enabled (as it is by default), unless this causes issues for a particular image.

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -148,6 +148,7 @@ struct Texture {
 	bool is_proxy = false;
 	bool is_external = false;
 	bool is_render_target = false;
+	bool is_immutable = false;
 
 	RID proxy_to;
 	Vector<RID> proxies;
@@ -498,9 +499,9 @@ public:
 	virtual RID texture_allocate() override;
 	virtual void texture_free(RID p_rid) override;
 
-	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) override;
-	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override;
-	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override;
+	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image, bool p_immutable = true) override;
+	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type, bool p_immutable = true) override;
+	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data, bool p_immutable = true) override;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override; //all slices, then all the mipmaps, must be coherent
 
 	RID texture_create_external(Texture::Type p_type, Image::Format p_format, unsigned int p_image, int p_width, int p_height, int p_depth, int p_layers, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY);

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -53,6 +53,7 @@ public:
 	int hdr_compression = 0;
 	bool mipmaps = true;
 	bool high_quality = false;
+	bool immutable = true;
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
 	virtual ~LayeredTextureImport() {}
 };
@@ -110,7 +111,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
+	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2, bool p_immutable);
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -74,7 +74,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel, bool p_immutable);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -312,3 +312,12 @@ GH-84419
 Validate extension JSON: API was removed: classes/Node/constants/NOTIFICATION_NODE_RECACHE_REQUESTED
 
 Removed unused NOTIFICATION_NODE_RECACHE_REQUESTED notification. It also used to conflict with CanvasItem.NOTIFICATION_DRAW and Window.NOTIFICATION_VISIBILITY_CHANGED (which still need to be resolved).
+
+
+GH-85830
+--------
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/texture_2
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/texture_2
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/texture_3
+
+Added `immutable` argument with default value.

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -57,6 +57,7 @@ public:
 		//FORMAT_BIT_DETECT_SRGB = 1 << 25,
 		FORMAT_BIT_DETECT_NORMAL = 1 << 26,
 		FORMAT_BIT_DETECT_ROUGNESS = 1 << 27,
+		FORMAT_BIT_IMMUTABLE = 1 << 28,
 	};
 
 private:
@@ -67,7 +68,7 @@ private:
 	int h = 0;
 	mutable Ref<BitMap> alpha_cache;
 
-	Error _load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit = 0);
+	Error _load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit, bool &r_immutable);
 	virtual void reload_from_file() override;
 
 	static void _requested_3d(void *p_ud);
@@ -137,10 +138,11 @@ public:
 	enum FormatBits {
 		FORMAT_BIT_STREAM = 1 << 22,
 		FORMAT_BIT_HAS_MIPMAPS = 1 << 23,
+		FORMAT_BIT_IMMUTABLE = 1 << 24,
 	};
 
 private:
-	Error _load_data(const String &p_path, Vector<Ref<Image>> &images, int &mipmap_limit, int p_size_limit = 0);
+	Error _load_data(const String &p_path, Vector<Ref<Image>> &images, int &mipmap_limit, int p_size_limit, bool &r_immutable);
 	String path_to_file;
 	mutable RID texture;
 	Image::Format format = Image::FORMAT_L8;
@@ -225,10 +227,11 @@ public:
 	enum FormatBits {
 		FORMAT_BIT_STREAM = 1 << 22,
 		FORMAT_BIT_HAS_MIPMAPS = 1 << 23,
+		FORMAT_BIT_IMMUTABLE = 1 << 24,
 	};
 
 private:
-	Error _load_data(const String &p_path, Vector<Ref<Image>> &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps);
+	Error _load_data(const String &p_path, Vector<Ref<Image>> &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps, bool &r_immutable);
 	String path_to_file;
 	mutable RID texture;
 	Image::Format format = Image::FORMAT_L8;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -85,13 +85,13 @@ public:
 		memdelete(texture);
 	};
 
-	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) override {
+	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image, bool p_immutable = true) override {
 		DummyTexture *t = texture_owner.get_or_null(p_texture);
 		ERR_FAIL_NULL(t);
 		t->image = p_image->duplicate();
 	};
-	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override{};
-	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override{};
+	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type, bool p_immutable = true) override{};
+	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data, bool p_immutable = true) override{};
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override{}; //all slices, then all the mipmaps, must be coherent
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override{};

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -789,7 +789,7 @@ void TextureStorage::texture_free(RID p_texture) {
 	texture_owner.free(p_texture);
 }
 
-void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) {
+void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_image, bool p_immutable) {
 	ERR_FAIL_COND(p_image.is_null());
 
 	TextureToRDFormat ret_format;
@@ -806,6 +806,7 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 	texture.depth = 1;
 	texture.format = p_image->get_format();
 	texture.validated_format = image->get_format();
+	texture.is_immutable = p_immutable;
 
 	texture.rd_type = RD::TEXTURE_TYPE_2D;
 	texture.rd_format = ret_format.format;
@@ -822,7 +823,11 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 		rd_format.mipmaps = texture.mipmaps;
 		rd_format.texture_type = texture.rd_type;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
-		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+		if (!p_immutable) {
+			rd_format.usage_bits |= RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+		}
+
 		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
 			rd_format.shareable_formats.push_back(texture.rd_format);
 			rd_format.shareable_formats.push_back(texture.rd_format_srgb);
@@ -858,7 +863,7 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 	texture_owner.initialize_rid(p_texture, texture);
 }
 
-void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) {
+void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type, bool p_immutable) {
 	ERR_FAIL_COND(p_layers.size() == 0);
 
 	ERR_FAIL_COND(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP && p_layers.size() != 6);
@@ -903,6 +908,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	texture.depth = 1;
 	texture.format = p_layers[0]->get_format();
 	texture.validated_format = images[0]->get_format();
+	texture.is_immutable = p_immutable;
 
 	switch (p_layered_type) {
 		case RS::TEXTURE_LAYERED_2D_ARRAY: {
@@ -932,7 +938,11 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 		rd_format.mipmaps = texture.mipmaps;
 		rd_format.texture_type = texture.rd_type;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
-		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+		if (!p_immutable) {
+			rd_format.usage_bits |= RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+		}
+
 		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
 			rd_format.shareable_formats.push_back(texture.rd_format);
 			rd_format.shareable_formats.push_back(texture.rd_format_srgb);
@@ -970,7 +980,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	texture_owner.initialize_rid(p_texture, texture);
 }
 
-void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) {
+void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data, bool p_immutable) {
 	ERR_FAIL_COND(p_data.size() == 0);
 
 	Image::Image3DValidateError verr = Image::validate_3d_image(p_format, p_width, p_height, p_depth, p_mipmaps, p_data);
@@ -1032,6 +1042,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 	texture.mipmaps = mipmap_count;
 	texture.format = p_data[0]->get_format();
 	texture.validated_format = validated_format;
+	texture.is_immutable = p_immutable;
 
 	texture.buffer_size_3d = all_data.size();
 	texture.buffer_slices_3d = slices;
@@ -1051,7 +1062,11 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 		rd_format.mipmaps = texture.mipmaps;
 		rd_format.texture_type = texture.rd_type;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
-		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+		if (!p_immutable) {
+			rd_format.usage_bits |= RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+		}
+
 		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
 			rd_format.shareable_formats.push_back(texture.rd_format);
 			rd_format.shareable_formats.push_back(texture.rd_format_srgb);
@@ -1116,6 +1131,7 @@ void TextureStorage::_texture_2d_update(RID p_texture, const Ref<Image> &p_image
 	ERR_FAIL_COND(tex->is_render_target);
 	ERR_FAIL_COND(p_image->get_width() != tex->width || p_image->get_height() != tex->height);
 	ERR_FAIL_COND(p_image->get_format() != tex->format);
+	ERR_FAIL_COND_MSG(tex->is_immutable, "Texture was created immutable so it can't be further updated. See import options or RenderingServer::texture_*_create arguments.");
 
 	if (tex->type == TextureStorage::TYPE_LAYERED) {
 		ERR_FAIL_INDEX(p_layer, tex->layers);
@@ -1138,6 +1154,7 @@ void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_NULL(tex);
 	ERR_FAIL_COND(tex->type != TextureStorage::TYPE_3D);
+	ERR_FAIL_COND_MSG(tex->is_immutable, "Texture was created immutable so it can't be further updated. See import options or RenderingServer::texture_*_create arguments.");
 
 	Image::Image3DValidateError verr = Image::validate_3d_image(tex->format, tex->width, tex->height, tex->depth, tex->mipmaps > 1, p_data);
 	if (verr != Image::VALIDATE_3D_OK) {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -147,8 +147,9 @@ private:
 		uint32_t buffer_size_3d = 0;
 
 		RenderTarget *render_target = nullptr;
-		bool is_render_target;
-		bool is_proxy;
+		bool is_render_target = false;
+		bool is_proxy = false;
+		bool is_immutable = false;
 
 		Ref<Image> image_cache_2d;
 		String path;
@@ -487,9 +488,9 @@ public:
 	virtual RID texture_allocate() override;
 	virtual void texture_free(RID p_rid) override;
 
-	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) override;
-	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override;
-	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override;
+	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image, bool p_immutable = true) override;
+	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type, bool p_immutable = true) override;
+	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data, bool p_immutable = true) override;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override; //all slices, then all the mipmaps, must be coherent
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -167,6 +167,17 @@ public:
 		return ret;                                                                                              \
 	}
 
+#define FUNCRIDTEX3(m_type, m_type1, m_type2, m_type3)                                                               \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3) override {                                       \
+		RID ret = RSG::texture_storage->texture_allocate();                                                          \
+		if (Thread::get_caller_id() == server_thread || RSG::texture_storage->can_create_resources_async()) {        \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3);                                              \
+		} else {                                                                                                     \
+			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2, p3); \
+		}                                                                                                            \
+		return ret;                                                                                                  \
+	}
+
 #define FUNCRIDTEX6(m_type, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                                                \
 	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4, m_type5 p5, m_type6 p6) override {               \
 		RID ret = RSG::texture_storage->texture_allocate();                                                                      \
@@ -178,10 +189,21 @@ public:
 		return ret;                                                                                                              \
 	}
 
+#define FUNCRIDTEX7(m_type, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7)                                           \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4, m_type5 p5, m_type6 p6, m_type7 p7) override {       \
+		RID ret = RSG::texture_storage->texture_allocate();                                                                          \
+		if (Thread::get_caller_id() == server_thread || RSG::texture_storage->can_create_resources_async()) {                        \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4, p5, p6, p7);                                              \
+		} else {                                                                                                                     \
+			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2, p3, p4, p5, p6, p7); \
+		}                                                                                                                            \
+		return ret;                                                                                                                  \
+	}
+
 	//these go pass-through, as they can be called from any thread
-	FUNCRIDTEX1(texture_2d, const Ref<Image> &)
-	FUNCRIDTEX2(texture_2d_layered, const Vector<Ref<Image>> &, TextureLayeredType)
-	FUNCRIDTEX6(texture_3d, Image::Format, int, int, int, bool, const Vector<Ref<Image>> &)
+	FUNCRIDTEX2(texture_2d, const Ref<Image> &, bool)
+	FUNCRIDTEX3(texture_2d_layered, const Vector<Ref<Image>> &, TextureLayeredType, bool)
+	FUNCRIDTEX7(texture_3d, Image::Format, int, int, int, bool, const Vector<Ref<Image>> &, bool)
 	FUNCRIDTEX1(texture_proxy, RID)
 
 	//these go through command queue if they are in another thread

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -66,9 +66,9 @@ public:
 	virtual RID texture_allocate() = 0;
 	virtual void texture_free(RID p_rid) = 0;
 
-	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) = 0;
-	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) = 0;
-	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) = 0;
+	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image, bool p_immutable = true) = 0;
+	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type, bool p_immutable = true) = 0;
+	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data, bool p_immutable = true) = 0;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) = 0; //all slices, then all the mipmaps, must be coherent
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;

--- a/servers/rendering_server.compat.inc
+++ b/servers/rendering_server.compat.inc
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  rendering_server.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+RID RenderingServer::_texture_2d_create_85830(const Ref<Image> &p_image) {
+	return texture_2d_create(p_image);
+}
+
+RID RenderingServer::_texture_2d_layered_create_85830(const TypedArray<Image> &p_layers, TextureLayeredType p_layered_type) {
+	return _texture_2d_layered_create(p_layers, p_layered_type, false);
+}
+RID RenderingServer::_texture_3d_create_85830(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data) {
+	return _texture_3d_create(p_format, p_width, p_height, p_depth, p_mipmaps, p_data, false);
+}
+
+void RenderingServer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("texture_2d_create", "image"), &RenderingServer::_texture_2d_create_85830);
+	ClassDB::bind_compatibility_method(D_METHOD("texture_2d_layered_create", "layers", "layered_type"), &RenderingServer::_texture_2d_layered_create_85830);
+	ClassDB::bind_compatibility_method(D_METHOD("texture_3d_create", "format", "width", "height", "depth", "mipmaps", "data"), &RenderingServer::_texture_3d_create_85830);
+}
+
+#endif

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -29,13 +29,13 @@
 /**************************************************************************/
 
 #include "rendering_server.h"
-
 #include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/variant/typed_array.h"
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/rendering/shader_language.h"
 #include "servers/rendering/shader_warnings.h"
+#include "servers/rendering_server.compat.inc"
 
 RenderingServer *RenderingServer::singleton = nullptr;
 RenderingServer *(*RenderingServer::create_func)() = nullptr;
@@ -1886,11 +1886,11 @@ static Vector<Ref<Image>> _get_imgvec(const TypedArray<Image> &p_layers) {
 	}
 	return images;
 }
-RID RenderingServer::_texture_2d_layered_create(const TypedArray<Image> &p_layers, TextureLayeredType p_layered_type) {
-	return texture_2d_layered_create(_get_imgvec(p_layers), p_layered_type);
+RID RenderingServer::_texture_2d_layered_create(const TypedArray<Image> &p_layers, TextureLayeredType p_layered_type, bool p_immutable) {
+	return texture_2d_layered_create(_get_imgvec(p_layers), p_layered_type, p_immutable);
 }
-RID RenderingServer::_texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data) {
-	return texture_3d_create(p_format, p_width, p_height, p_depth, p_mipmaps, _get_imgvec(p_data));
+RID RenderingServer::_texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data, bool p_immutable) {
+	return texture_3d_create(p_format, p_width, p_height, p_depth, p_mipmaps, _get_imgvec(p_data), p_immutable);
 }
 
 void RenderingServer::_texture_3d_update(RID p_texture, const TypedArray<Image> &p_data) {
@@ -2207,9 +2207,9 @@ void RenderingServer::_bind_methods() {
 
 	/* TEXTURE */
 
-	ClassDB::bind_method(D_METHOD("texture_2d_create", "image"), &RenderingServer::texture_2d_create);
-	ClassDB::bind_method(D_METHOD("texture_2d_layered_create", "layers", "layered_type"), &RenderingServer::_texture_2d_layered_create);
-	ClassDB::bind_method(D_METHOD("texture_3d_create", "format", "width", "height", "depth", "mipmaps", "data"), &RenderingServer::_texture_3d_create);
+	ClassDB::bind_method(D_METHOD("texture_2d_create", "image", "immutable"), &RenderingServer::texture_2d_create, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("texture_2d_layered_create", "layers", "layered_type", "immutable"), &RenderingServer::_texture_2d_layered_create, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("texture_3d_create", "format", "width", "height", "depth", "mipmaps", "data", "immutable"), &RenderingServer::_texture_3d_create, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("texture_proxy_create", "base"), &RenderingServer::texture_proxy_create);
 
 	ClassDB::bind_method(D_METHOD("texture_2d_update", "texture", "image", "layer"), &RenderingServer::texture_2d_update);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -103,9 +103,9 @@ public:
 		CUBEMAP_LAYER_BACK
 	};
 
-	virtual RID texture_2d_create(const Ref<Image> &p_image) = 0;
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, TextureLayeredType p_layered_type) = 0;
-	virtual RID texture_3d_create(Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) = 0; //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_2d_create(const Ref<Image> &p_image, bool p_immutable = false) = 0;
+	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, TextureLayeredType p_layered_type, bool p_immutable = false) = 0;
+	virtual RID texture_3d_create(Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data, bool p_immutable = false) = 0; //all slices, then all the mipmaps, must be coherent
 	virtual RID texture_proxy_create(RID p_base) = 0;
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
@@ -1646,8 +1646,8 @@ public:
 
 private:
 	// Binder helpers
-	RID _texture_2d_layered_create(const TypedArray<Image> &p_layers, TextureLayeredType p_layered_type);
-	RID _texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data);
+	RID _texture_2d_layered_create(const TypedArray<Image> &p_layers, TextureLayeredType p_layered_type, bool p_immutable);
+	RID _texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data, bool p_immutable);
 	void _texture_3d_update(RID p_texture, const TypedArray<Image> &p_data);
 	TypedArray<Image> _texture_3d_get(RID p_texture) const;
 	TypedArray<Dictionary> _shader_get_shader_parameter_list(RID p_shader) const;
@@ -1660,6 +1660,13 @@ private:
 #ifdef TOOLS_ENABLED
 	SurfaceUpgradeCallback surface_upgrade_callback = nullptr;
 	bool warn_on_surface_upgrade = true;
+#endif
+
+#ifndef DISABLE_DEPRECATED
+	RID _texture_2d_create_85830(const Ref<Image> &p_image);
+	RID _texture_2d_layered_create_85830(const TypedArray<Image> &p_layers, TextureLayeredType p_layered_type);
+	RID _texture_3d_create_85830(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data);
+	static void _bind_compatibility_methods();
 #endif
 };
 


### PR DESCRIPTION
By making them immutable, the upcoming acyclic render graph (#84976) can simply not have them in consideration and greatly improve performance.

**NOTE:**: This PR is slightly compat breaking. If you have imported textures from disk and later attempt to modify them via texture_update, this will throw an error and you will need to reimport textures by switching the immutable flag off (the error will instruct you to do this). I am pretty sure nobody is doing this, but just in case this is good to mention.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
