### PR TITLE
Clarify Shapecast safe/unsafe fraction difference in class reference

### DIFF
--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -48,6 +48,7 @@
 			<return type="float" />
 			<description>
 				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
+				In ideal conditions this would be the same as [method get_closest_collision_safe_fraction], however shape casting is calculated in discrete steps, so the precise point of collision can occur between two calculated positions.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -48,6 +48,7 @@
 			<return type="float" />
 			<description>
 				The fraction from the [ShapeCast3D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
+				In ideal conditions this would be the same as [method get_closest_collision_safe_fraction], however shape casting is calculated in discrete steps, so the precise point of collision can occur between two calculated positions.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">


### PR DESCRIPTION
This clarifies the difference between `get_closest_collision_safe_fraction` and the equivalent `unsafe` version in the class reference for both `Shapecast2D` and `Shapecast3D` classes.
I've added some explanation of the implementation to the `unsafe` descriptions, since if one isn't aware of the implementation, the current descriptions seem linguistically equivalent!

Issue: https://github.com/godotengine/godot-docs/issues/8552

Current documentation: https://docs.godotengine.org/en/latest/classes/class_shapecast2d.html#class-shapecast2d-method-get-closest-collision-safe-fraction