### PR TITLE
Fix `find_children` doesn't work with class names

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -45,6 +45,7 @@
 #include "scene/scene_string_names.h"
 #include "viewport.h"
 
+#include <modules/gdscript/gdscript.h>
 #include <stdint.h>
 
 int Node::orphan_node_count = 0;
@@ -1695,8 +1696,10 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 				ret.append(cptr[i]);
 			} else if (cptr[i]->get_script_instance()) {
 				Ref<Script> scr = cptr[i]->get_script_instance()->get_script();
+				Ref<GDScript> gd_script = scr;
 				while (scr.is_valid()) {
-					if ((ScriptServer::is_global_class(p_type) && ScriptServer::get_global_class_path(p_type) == scr->get_path()) || p_type == scr->get_path()) {
+					if ((ScriptServer::is_global_class(p_type) && ScriptServer::get_global_class_path(p_type) == scr->get_path()) || p_type == scr->get_path() ||
+							(!gd_script.is_valid() && scr->get_path().get_file().contains(p_type)) || (gd_script.is_valid() && p_type == gd_script->get_local_name())) {
 						ret.append(cptr[i]);
 						break;
 					}


### PR DESCRIPTION
`Script::get_name()` and `Script::get_path()` of inner classes return empty values. I'm unsure whether this is a bug with scripting languages or by design. This PR only addresses the bug for the outer class.

Fix: #85690