### PR TITLE
Add sorting script previews by modified date

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2065,7 +2065,7 @@ void ScriptEditor::_update_script_names() {
 					sd.sort_key = path;
 				} break;
 				case SORT_BY_MODIFIED: {
-					// XOR with UINT64_MAX results in descending order
+					// XOR with UINT64_MAX results in descending order.
 					uint64_t modified_time_desc = se->get_edited_resource()->get_last_modified_time() ^ UINT64_MAX;
 					sd.sort_key = String::num_uint64(modified_time_desc);
 				} break;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1000,6 +1000,7 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 		}
 	}
 
+	_sort_list_on_update = true;
 	_update_script_names();
 	trigger_live_script_reload();
 }
@@ -2062,6 +2063,11 @@ void ScriptEditor::_update_script_names() {
 				} break;
 				case SORT_BY_PATH: {
 					sd.sort_key = path;
+				} break;
+				case SORT_BY_MODIFIED: {
+					// XOR with UINT64_MAX results in descending order
+					uint64_t modified_time_desc = se->get_edited_resource()->get_last_modified_time() ^ UINT64_MAX;
+					sd.sort_key = String::num_uint64(modified_time_desc);
 				} break;
 				case SORT_BY_NONE: {
 					sd.sort_key = "";
@@ -4373,7 +4379,7 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 	EDITOR_DEF("text_editor/script_list/script_temperature_enabled", true);
 	EDITOR_DEF("text_editor/script_list/script_temperature_history_size", 15);
 	EDITOR_DEF("text_editor/script_list/group_help_pages", true);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/sort_scripts_by", PROPERTY_HINT_ENUM, "Name,Path,None"));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/sort_scripts_by", PROPERTY_HINT_ENUM, "Name,Path,Modified,None"));
 	EDITOR_DEF("text_editor/script_list/sort_scripts_by", 0);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/list_script_names_as", PROPERTY_HINT_ENUM, "Name,Parent Directory And Name,Full Path"));
 	EDITOR_DEF("text_editor/script_list/list_script_names_as", 0);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4379,7 +4379,7 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 	EDITOR_DEF("text_editor/script_list/script_temperature_enabled", true);
 	EDITOR_DEF("text_editor/script_list/script_temperature_history_size", 15);
 	EDITOR_DEF("text_editor/script_list/group_help_pages", true);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/sort_scripts_by", PROPERTY_HINT_ENUM, "Name,Path,Modified,None"));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/sort_scripts_by", PROPERTY_HINT_ENUM, "Name,Path,Last Modified Time,None"));
 	EDITOR_DEF("text_editor/script_list/sort_scripts_by", 0);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "text_editor/script_list/list_script_names_as", PROPERTY_HINT_ENUM, "Name,Parent Directory And Name,Full Path"));
 	EDITOR_DEF("text_editor/script_list/list_script_names_as", 0);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2064,7 +2064,7 @@ void ScriptEditor::_update_script_names() {
 				case SORT_BY_PATH: {
 					sd.sort_key = path;
 				} break;
-				case SORT_BY_MODIFIED: {
+				case SORT_BY_MODIFIED_TIME: {
 					// XOR with UINT64_MAX results in descending order.
 					uint64_t modified_time_desc = se->get_edited_resource()->get_last_modified_time() ^ UINT64_MAX;
 					sd.sort_key = String::num_uint64(modified_time_desc);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -255,7 +255,7 @@ class ScriptEditor : public PanelContainer {
 	enum ScriptSortBy {
 		SORT_BY_NAME,
 		SORT_BY_PATH,
-		SORT_BY_MODIFIED,
+		SORT_BY_MODIFIED_TIME,
 		SORT_BY_NONE
 	};
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -255,6 +255,7 @@ class ScriptEditor : public PanelContainer {
 	enum ScriptSortBy {
 		SORT_BY_NAME,
 		SORT_BY_PATH,
+		SORT_BY_MODIFIED,
 		SORT_BY_NONE
 	};
 


### PR DESCRIPTION
Adds an option for sorting the scripts preview by modified time (descending), so that the latest modified files appear on top.

The default sorting by name works well, but often I have a lot of scripts open and I want to quickly jump between the last few I'm working on without having to remember which one is which. This pull request adds this functionality. In the video I modify one of the scripts, press `Cmd + S` and it jumps to the top of the preview.

https://github.com/godotengine/godot/assets/49688205/7474c0c7-1644-4b10-bfd2-b9e1953f371c

## Consideration: The scripts are sorted on save

As you can see in the code changes, the _actual sorting_ of the script items inside the preview now happens every time the script is saved (`ScriptEditor::_res_saved_callback`). For the other sorting methods this is absolutely **not** needed, but is performed anyway. I think this is not a performance bottleneck (there will likely not be _thousands_ of scripts in the preview at any one time and they are saved/sorted on demand with a user action). Since this is an editor thing, it doesn't affect games at all.

One solution to this would be to check if we are in the _SORT_BY_MODIFIED_ mode and only perform the sorting then, but that seems dirty to me. Stray if conditions like that are not very maintainable imo.

---

**This is my first real contribution**, so please double check if the changes are sane. If naming is OK, if I'm using things for what they are supposed to be used, etc.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8602.*
