### PR TITLE
Fix squish RGTC_R decompression corruption

### DIFF
--- a/thirdparty/squish/colourblock.cpp
+++ b/thirdparty/squish/colourblock.cpp
@@ -24,9 +24,9 @@
    -------------------------------------------------------------------------- */
 
 #include "colourblock.h"
-// -- Godot start --
+// -- GODOT start --
 #include "alpha.h"
-// -- Godot end --
+// -- GODOT end --
 
 namespace squish {
 
@@ -214,7 +214,18 @@ void DecompressColour( u8* rgba, void const* block, bool isDxt1 )
     }
 }
 
-// -- Godot start --
+// -- GODOT start --
+void DecompressColourBc4( u8* rgba, void const* block)
+{
+    DecompressAlphaDxt5(rgba,block);
+    for ( int i = 0; i < 16; ++i ) {
+        rgba[i*4] = rgba[i*4 + 3];
+		rgba[i*4 + 1] = 0;
+		rgba[i*4 + 2] = 0;
+        rgba[i*4 + 3] = 255;
+    }
+}
+
 void DecompressColourBc5( u8* rgba, void const* block)
 {
     void const* rblock = block;

--- a/thirdparty/squish/colourblock.h
+++ b/thirdparty/squish/colourblock.h
@@ -36,6 +36,7 @@ void WriteColourBlock4( Vec3::Arg start, Vec3::Arg end, u8 const* indices, void*
 
 void DecompressColour( u8* rgba, void const* block, bool isDxt1 );
 // -- GODOT start --
+void DecompressColourBc4( u8* rgba, void const* block );
 void DecompressColourBc5( u8* rgba, void const* block );
 // -- GODOT end --
 

--- a/thirdparty/squish/godot-changes.patch
+++ b/thirdparty/squish/godot-changes.patch
@@ -100,3 +100,112 @@ index 1d22a64ad..fd11a147d 100644
  
      // decompress alpha separately if necessary
      if( ( flags & kDxt3 ) != 0 )
+
+diff --git a/thirdparty/squish/colourblock.cpp b/thirdparty/squish/colourblock.cpp
+index 49401358bc..f14c9362bd 100644
+--- a/thirdparty/squish/colourblock.cpp
++++ b/thirdparty/squish/colourblock.cpp
+@@ -24,9 +24,9 @@
+    -------------------------------------------------------------------------- */
+ 
+ #include "colourblock.h"
+-// -- Godot start --
++// -- GODOT start --
+ #include "alpha.h"
+-// -- Godot end --
++// -- GODOT end --
+ 
+ namespace squish {
+ 
+diff --git a/thirdparty/squish/godot-changes.patch b/thirdparty/squish/godot-changes.patch
+index ef7bafb4b4..655a8cffc2 100644
+--- a/thirdparty/squish/godot-changes.patch
++++ b/thirdparty/squish/godot-changes.patch
+@@ -1,22 +1,33 @@
+ diff --git a/thirdparty/squish/colourblock.cpp b/thirdparty/squish/colourblock.cpp
+-index af8b98036..3d87adaa7 100644
++index af8b980365..f14c9362bd 100644
+ --- a/thirdparty/squish/colourblock.cpp
+ +++ b/thirdparty/squish/colourblock.cpp
+ @@ -24,6 +24,9 @@
+     -------------------------------------------------------------------------- */
+  
+  #include "colourblock.h"
+-+// -- Godot start --
+++// -- GODOT start --
+ +#include "alpha.h"
+-+// -- Godot end --
+++// -- GODOT end --
+  
+  namespace squish {
+  
+-@@ -211,4 +214,23 @@ void DecompressColour( u8* rgba, void const* block, bool isDxt1 )
++@@ -211,4 +214,34 @@ void DecompressColour( u8* rgba, void const* block, bool isDxt1 )
+      }
+  }
+  
+-+// -- Godot start --
+++// -- GODOT start --
+++void DecompressColourBc4( u8* rgba, void const* block)
+++{
+++    DecompressAlphaDxt5(rgba,block);
+++    for ( int i = 0; i < 16; ++i ) {
+++        rgba[i*4] = rgba[i*4 + 3];
+++		rgba[i*4 + 1] = 0;
+++		rgba[i*4 + 2] = 0;
+++        rgba[i*4 + 3] = 255;
+++    }
+++}
+++
+ +void DecompressColourBc5( u8* rgba, void const* block)
+ +{
+ +    void const* rblock = block;
+@@ -37,21 +48,22 @@ index af8b98036..3d87adaa7 100644
+ +
+  } // namespace squish
+ diff --git a/thirdparty/squish/colourblock.h b/thirdparty/squish/colourblock.h
+-index fee2cd7c5..3cb9b7e3b 100644
++index fee2cd7c5d..e1eb9e4917 100644
+ --- a/thirdparty/squish/colourblock.h
+ +++ b/thirdparty/squish/colourblock.h
+-@@ -35,6 +35,9 @@ void WriteColourBlock3( Vec3::Arg start, Vec3::Arg end, u8 const* indices, void*
++@@ -35,6 +35,10 @@ void WriteColourBlock3( Vec3::Arg start, Vec3::Arg end, u8 const* indices, void*
+  void WriteColourBlock4( Vec3::Arg start, Vec3::Arg end, u8 const* indices, void* block );
+  
+  void DecompressColour( u8* rgba, void const* block, bool isDxt1 );
+ +// -- GODOT start --
+++void DecompressColourBc4( u8* rgba, void const* block );
+ +void DecompressColourBc5( u8* rgba, void const* block );
+ +// -- GODOT end --
+  
+  } // namespace squish
+  
+ diff --git a/thirdparty/squish/config.h b/thirdparty/squish/config.h
+-index 92edefe96..05f8d7259 100644
++index 92edefe966..05f8d72598 100644
+ --- a/thirdparty/squish/config.h
+ +++ b/thirdparty/squish/config.h
+ @@ -32,6 +32,26 @@
+@@ -82,17 +94,19 @@ index 92edefe96..05f8d7259 100644
+  #define SQUISH_USE_SSE 0
+  #endif
+ diff --git a/thirdparty/squish/squish.cpp b/thirdparty/squish/squish.cpp
+-index 1d22a64ad..fd11a147d 100644
++index 1d22a64ad6..086ba11cd0 100644
+ --- a/thirdparty/squish/squish.cpp
+ +++ b/thirdparty/squish/squish.cpp
+-@@ -135,7 +135,13 @@ void Decompress( u8* rgba, void const* block, int flags )
++@@ -135,7 +135,15 @@ void Decompress( u8* rgba, void const* block, int flags )
+          colourBlock = reinterpret_cast< u8 const* >( block ) + 8;
+  
+      // decompress colour
+ -    DecompressColour( rgba, colourBlock, ( flags & kDxt1 ) != 0 );
+ +    // -- GODOT start --
+ +    //DecompressColour( rgba, colourBlock, ( flags & kDxt1 ) != 0 );
+-+    if(( flags & ( kBc5 ) ) != 0)
+++    if(( flags & ( kBc4 ) ) != 0)
+++        DecompressColourBc4( rgba, colourBlock);
+++	else if(( flags & ( kBc5 ) ) != 0)
+ +        DecompressColourBc5( rgba, colourBlock);
+ +    else
+ +        DecompressColour( rgba, colourBlock, ( flags & kDxt1 ) != 0 );

--- a/thirdparty/squish/squish.cpp
+++ b/thirdparty/squish/squish.cpp
@@ -137,7 +137,9 @@ void Decompress( u8* rgba, void const* block, int flags )
     // decompress colour
     // -- GODOT start --
     //DecompressColour( rgba, colourBlock, ( flags & kDxt1 ) != 0 );
-    if(( flags & ( kBc5 ) ) != 0)
+    if(( flags & ( kBc4 ) ) != 0)
+        DecompressColourBc4( rgba, colourBlock);
+    else if(( flags & ( kBc5 ) ) != 0)
         DecompressColourBc5( rgba, colourBlock);
     else
         DecompressColour( rgba, colourBlock, ( flags & kDxt1 ) != 0 );


### PR DESCRIPTION
The custom Godot code for `squish` only allows for decompressing BC5 (RGTC_RG) textures. This means attempting to decompress BC4-compressed images (for the minature texture views, for example) would result in corrupted images:

| master | PR |
|--------|----|
| <img width="56" alt="aa" src="https://github.com/godotengine/godot/assets/53150244/5942bf53-0adc-435b-8acf-80b6da1667b5"> |<img width="59" alt="bb" src="https://github.com/godotengine/godot/assets/53150244/6b7b04e4-8450-4efb-8763-f0159b10a125"> |

An MRP for testing the changes: [RGTCSquishError.zip](https://github.com/godotengine/godot/files/13590517/RGTCSquishError.zip)
Steps to reproduce:
1. Load the project and open Main.tscn
2. Select the mesh instance and look at the Albedo texture preview in the material inspector.