### PR TITLE
.NET: Add a warning in the inspector when properties might be out of sync

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -788,9 +788,7 @@ static void _find_changed_scripts_for_external_editor(Node *p_base, Node *p_curr
 }
 
 void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_for_script) {
-	if (!bool(EDITOR_GET("text_editor/external/use_external_editor"))) {
-		return;
-	}
+	bool use_external_editor = bool(EDITOR_GET("text_editor/external/use_external_editor"));
 
 	ERR_FAIL_NULL(get_tree());
 
@@ -803,6 +801,10 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 
 	for (const Ref<Script> &E : scripts) {
 		Ref<Script> scr = E;
+
+		if (!use_external_editor && !scr->get_language()->overrides_external_editor()) {
+			continue; // We're not using an external editor for this script.
+		}
 
 		if (p_for_script.is_valid() && p_for_script != scr) {
 			continue;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2246,6 +2246,17 @@ bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_upda
 			} else {
 				p_instance_to_update->update(propnames, values);
 			}
+		} else if (placeholders.size()) {
+			uint64_t script_modified_time = FileAccess::get_modified_time(get_path());
+			uint64_t last_valid_build_time = GDMono::get_singleton()->get_project_assembly_modified_time();
+			if (script_modified_time > last_valid_build_time) {
+				for (PlaceHolderScriptInstance *instance : placeholders) {
+					Object *owner = instance->get_owner();
+					if (owner->get_script_instance() == instance) {
+						owner->notify_property_list_changed();
+					}
+				}
+			}
 		}
 	}
 #endif

--- a/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorOutOfSyncWarning.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorOutOfSyncWarning.cs
@@ -1,0 +1,37 @@
+using Godot;
+using GodotTools.Internals;
+
+namespace GodotTools.Inspector
+{
+    public partial class InspectorOutOfSyncWarning : HBoxContainer
+    {
+        public override void _Ready()
+        {
+            SetAnchorsPreset(LayoutPreset.TopWide);
+
+            var iconTexture = GetThemeIcon("StatusWarning", "EditorIcons");
+
+            var icon = new TextureRect()
+            {
+                Texture = iconTexture,
+                ExpandMode = TextureRect.ExpandModeEnum.FitWidthProportional,
+                CustomMinimumSize = iconTexture.GetSize(),
+            };
+
+            icon.SizeFlagsVertical = SizeFlags.ShrinkCenter;
+
+            var label = new Label()
+            {
+                Text = "This inspector might be out of date. Please build the C# project.".TTR(),
+                AutowrapMode = TextServer.AutowrapMode.WordSmart,
+                CustomMinimumSize = new Vector2(100f, 0f),
+            };
+
+            label.AddThemeColorOverride("font_color", GetThemeColor("warning_color", "Editor"));
+            label.SizeFlagsHorizontal = SizeFlags.Fill | SizeFlags.Expand;
+
+            AddChild(icon);
+            AddChild(label);
+        }
+    }
+}

--- a/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorPlugin.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Godot;
+using GodotTools.Utils;
+
+namespace GodotTools.Inspector
+{
+    public partial class InspectorPlugin : EditorInspectorPlugin
+    {
+        public override bool _CanHandle(GodotObject godotObject)
+        {
+            foreach (var script in EnumerateScripts(godotObject))
+            {
+                if (script is CSharpScript)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public override void _ParseBegin(GodotObject godotObject)
+        {
+            foreach (var script in EnumerateScripts(godotObject))
+            {
+                if (script is not CSharpScript) continue;
+
+                if (File.GetLastWriteTime(script.ResourcePath) > GodotSharpEditor.Instance.LastValidBuildDateTime)
+                {
+                    AddCustomControl(new InspectorOutOfSyncWarning());
+                    break;
+                }
+            }
+        }
+
+        private static IEnumerable<Script> EnumerateScripts(GodotObject godotObject)
+        {
+            var script = godotObject.GetScript().As<Script>();
+            while (script != null)
+            {
+                yield return script;
+                script = script.GetBaseScript();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a small warning in the inspector when C# scripts are out of sync with data we gathered during compilation. The warning is displayed if any C# script in the class hierarchy was modified since the last compilation, and disappears as soon as possible.  

Sadly, the inspector is not refreshed ATM when the window is refocused (e.g. if you tab back from your external code editor). From my tests, this behaviour is not language-dependent, so it'd probably warrant a fix higher up (therefore, I didn't look how to do so in this PR).

I gladly take any suggestion for UI and wording. E.g. someone suggested to directly add a button/link to build directly from the warning. But I'm not sure how I feel about that.  

![godot windows editor dev x86_64 mono_ElbJvjZ2Lp](https://github.com/godotengine/godot/assets/437025/7bdb0370-62dc-4c6f-8e6c-5a849ba3b2cf)
