### PR TITLE
Fix overriding `CollisionObject3D::_mouse_enter()` and `_mouse_exit()` from GDExtension

### DIFF
--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -291,16 +291,12 @@ void CollisionObject3D::_input_event_call(Camera3D *p_camera, const Ref<InputEve
 }
 
 void CollisionObject3D::_mouse_enter() {
-	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_enter);
-	}
+	GDVIRTUAL_CALL(_mouse_enter);
 	emit_signal(SceneStringNames::get_singleton()->mouse_entered);
 }
 
 void CollisionObject3D::_mouse_exit() {
-	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_exit);
-	}
+	GDVIRTUAL_CALL(_mouse_exit);
 	emit_signal(SceneStringNames::get_singleton()->mouse_exited);
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1325

Currently, this code is explicitly calling these virtual methods on a script. This needs to be switched to `GDVIRTUAL_CALL()` in order to work for both scripts and GDExtension.