### PR TITLE
Fix `mouse_in_window` state with confined mouse

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2632,8 +2632,8 @@ bool Window::is_attached_in_viewport() const {
 
 void Window::_update_mouse_over(Vector2 p_pos) {
 	if (!mouse_in_window) {
+		mouse_in_window = true;
 		if (is_embedded()) {
-			mouse_in_window = true;
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_ENTER);
 		} else {
 			// Prevent update based on delayed InputEvents from DisplayServer.


### PR DESCRIPTION
`_update_mouse_over` is called whenever the mouse is over the Window. So `mouse_in_window` needs to be set in all cases.

resolve #85713
regression from #80334

