### PR TITLE
Fix missing heading in translated online class reference

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1552,16 +1552,11 @@ def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_
 
     f.write(".. _doc_class_reference:\n\n")
 
-    main_title = translate("All classes")
-    f.write(f"{main_title}\n")
-    f.write(f"{'=' * len(main_title)}\n\n")
+    f.write(make_heading("All classes", "="))
 
     for group_name in CLASS_GROUPS:
         if group_name in grouped_classes:
-            group_title = translate(CLASS_GROUPS[group_name])
-
-            f.write(f"{group_title}\n")
-            f.write(f"{'=' * len(group_title)}\n\n")
+            f.write(make_heading(CLASS_GROUPS[group_name], "="))
 
             f.write(".. toctree::\n")
             f.write("    :maxdepth: 1\n")


### PR DESCRIPTION
The RST format has a quirk that requires the section header's marker to be at least the same _visual_ length as the header's text. We can't use the text's length to generate markers because, for example, east Asian wide and fullwidth characters take twice the visual length.

Currently, the "Resources" section is missing in the index of zh_CN class reference:

![ksnip_20231207-111049](https://github.com/godotengine/godot/assets/372476/8e1c87b9-be62-42d6-a08c-4b8b68275ecf)

Because the name becomes two characters after translation, but requires four `=`s.

```
资源
====
```

We made a dedicated `make_heading()` function that simply doubles the marker's length to solve this problem :stuck_out_tongue_closed_eyes: 