### PR TITLE
Fix permanently selected audio bus effects

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -912,6 +912,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	vb->add_child(effects);
 	effects->connect("item_edited", callable_mp(this, &EditorAudioBus::_effect_edited));
 	effects->connect("cell_selected", callable_mp(this, &EditorAudioBus::_effect_selected));
+	effects->connect("focus_exited", callable_mp(effects, &Tree::deselect_all));
 	effects->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 	SET_DRAG_FORWARDING_GCD(effects, EditorAudioBus);
 	effects->connect("item_mouse_selected", callable_mp(this, &EditorAudioBus::_effect_rmb));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This allows the audio bus effects to be deselected if the focus changes to fix [this bug](https://github.com/godotengine/godot/issues/85478). Here is a recording of the new behavior:

https://github.com/godotengine/godot/assets/10054174/54ced10a-6fb5-45a4-b9fd-d284821f90c6

This is my first PR, and I wasn't sure if this was the best way to do it. I'm open to any feedback. Thanks for taking a look!

*Bugsquad edit:*
- Fixes #85478