### PR TITLE
Fix particle spread values affecting particle velocity

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -740,26 +740,33 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "vec3 get_random_direction_from_spread(inout uint alt_seed, float spread_angle){\n";
 	code += "	float pi = 3.14159;\n";
 	code += "	float degree_to_rad = pi / 180.0;\n";
-	code += "	vec3 velocity = vec3(0.);\n";
 	code += "	float spread_rad = spread_angle * degree_to_rad;\n";
-	code += "	float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
-	code += "	float angle2_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad * (1.0 - flatness);\n";
-	code += "	vec3 direction_xz = vec3(sin(angle1_rad), 0.0, cos(angle1_rad));\n";
-	code += "	vec3 direction_yz = vec3(0.0, sin(angle2_rad), cos(angle2_rad));\n";
-	code += "	direction_yz.z = direction_yz.z / max(0.0001,sqrt(abs(direction_yz.z))); // better uniform distribution\n";
-	code += "	vec3 spread_direction = vec3(direction_xz.x * direction_yz.z, direction_yz.y, direction_xz.z * direction_yz.z);\n";
-	code += "	vec3 direction_nrm = length(direction) > 0.0 ? normalize(direction) : vec3(0.0, 0.0, 1.0);\n";
-	code += "	// rotate spread to direction\n";
-	code += "	vec3 binormal = cross(vec3(0.0, 1.0, 0.0), direction_nrm);\n";
-	code += "	if (length(binormal) < 0.0001) {\n";
-	code += "		// direction is parallel to Y. Choose Z as the binormal.\n";
-	code += "		binormal = vec3(0.0, 0.0, 1.0);\n";
-	code += "	}\n";
-	code += "	binormal = normalize(binormal);\n";
-	code += "	vec3 normal = cross(binormal, direction_nrm);\n";
-	code += "	spread_direction = binormal * spread_direction.x + normal * spread_direction.y + direction_nrm * spread_direction.z;\n";
-	code += "	return spread_direction;\n";
-
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		// Spread calculation for 2D.
+		code += "	float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
+		code += "	angle1_rad += direction.x != 0.0 ? atan(direction.y, direction.x) : sign(direction.y) * (pi / 2.0);\n";
+		code += "	vec3 spread_direction = vec3(cos(angle1_rad), sin(angle1_rad), 0.0);\n";
+		code += "	return spread_direction;\n";
+	} else {
+		// Spread calculation for 3D.
+		code += "	float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
+		code += "	float angle2_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad * (1.0 - flatness);\n";
+		code += "	vec3 direction_xz = vec3(sin(angle1_rad), 0.0, cos(angle1_rad));\n";
+		code += "	vec3 direction_yz = vec3(0.0, sin(angle2_rad), cos(angle2_rad));\n";
+		code += "	direction_yz.z = direction_yz.z / max(0.0001,sqrt(abs(direction_yz.z))); // better uniform distribution\n";
+		code += "	vec3 spread_direction = vec3(direction_xz.x * direction_yz.z, direction_yz.y, direction_xz.z * direction_yz.z);\n";
+		code += "	vec3 direction_nrm = length(direction) > 0.0 ? normalize(direction) : vec3(0.0, 0.0, 1.0);\n";
+		code += "	// rotate spread to direction\n";
+		code += "	vec3 binormal = cross(vec3(0.0, 1.0, 0.0), direction_nrm);\n";
+		code += "	if (length(binormal) < 0.0001) {\n";
+		code += "		// direction is parallel to Y. Choose Z as the binormal.\n";
+		code += "		binormal = vec3(0.0, 0.0, 1.0);\n";
+		code += "	}\n";
+		code += "	binormal = normalize(binormal);\n";
+		code += "	vec3 normal = cross(binormal, direction_nrm);\n";
+		code += "	spread_direction = binormal * spread_direction.x + normal * spread_direction.y + direction_nrm * spread_direction.z;\n";
+		code += "	return normalize(spread_direction);\n";
+	}
 	code += "}\n";
 
 	code += "vec3 process_radial_displacement(DynamicsParameters param, float lifetime, inout uint alt_seed, mat4 transform, mat4 emission_transform, float delta){\n";


### PR DESCRIPTION
Resolves #85744 and partially #85620

The spread direction vector for a particle had affected the particles velocity. This was caused by `spread_direction` not being normalized before it was returned from `get_random_direction_from_spread()`. A compounding issue to this was that `get_random_direction_from_spread()` still generated a 3D `spread_direction` even when `PARTICLE_FLAG_DISABLE_Z` is set.

I made changes to `get_random_direction_from_spread()` so that it:
- Uses a dedicated 2D spread calculation (used in the 4.1 release)
- Normalize the 3D `spread_direction` before returning it.