### PR TITLE
Improve engine startup/shutdown benchmarks

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -626,17 +626,22 @@ String OS::get_benchmark_file() {
 	return benchmark_file;
 }
 
-void OS::benchmark_begin_measure(const String &p_what) {
+void OS::benchmark_begin_measure(const String &p_context, const String &p_what) {
 #ifdef TOOLS_ENABLED
-	start_benchmark_from[p_what] = OS::get_singleton()->get_ticks_usec();
+	Pair<String, String> mark_key(p_context, p_what);
+	ERR_FAIL_COND_MSG(benchmark_marks_from.has(mark_key), vformat("Benchmark key '%s:%s' already exists.", p_context, p_what));
+
+	benchmark_marks_from[mark_key] = OS::get_singleton()->get_ticks_usec();
 #endif
 }
-void OS::benchmark_end_measure(const String &p_what) {
+void OS::benchmark_end_measure(const String &p_context, const String &p_what) {
 #ifdef TOOLS_ENABLED
-	uint64_t total = OS::get_singleton()->get_ticks_usec() - start_benchmark_from[p_what];
-	double total_f = double(total) / double(1000000);
+	Pair<String, String> mark_key(p_context, p_what);
+	ERR_FAIL_COND_MSG(!benchmark_marks_from.has(mark_key), vformat("Benchmark key '%s:%s' doesn't exist.", p_context, p_what));
 
-	startup_benchmark_json[p_what] = total_f;
+	uint64_t total = OS::get_singleton()->get_ticks_usec() - benchmark_marks_from[mark_key];
+	double total_f = double(total) / double(1000000);
+	benchmark_marks_final[mark_key] = total_f;
 #endif
 }
 
@@ -645,19 +650,33 @@ void OS::benchmark_dump() {
 	if (!use_benchmark) {
 		return;
 	}
+
 	if (!benchmark_file.is_empty()) {
 		Ref<FileAccess> f = FileAccess::open(benchmark_file, FileAccess::WRITE);
 		if (f.is_valid()) {
+			Dictionary benchmark_marks;
+			for (const KeyValue<Pair<String, String>, double> &E : benchmark_marks_final) {
+				const String mark_key = vformat("[%s] %s", E.key.first, E.key.second);
+				benchmark_marks[mark_key] = E.value;
+			}
+
 			Ref<JSON> json;
 			json.instantiate();
-			f->store_string(json->stringify(startup_benchmark_json, "\t", false, true));
+			f->store_string(json->stringify(benchmark_marks, "\t", false, true));
 		}
 	} else {
-		List<Variant> keys;
-		startup_benchmark_json.get_key_list(&keys);
+		HashMap<String, String> results;
+		for (const KeyValue<Pair<String, String>, double> &E : benchmark_marks_final) {
+			if (E.key.first == "Startup" && !results.has(E.key.first)) {
+				results.insert(E.key.first, "", true); // Hack to make sure "Startup" always comes first.
+			}
+
+			results[E.key.first] += vformat("\t\t- %s: %.3f msec.\n", E.key.second, (E.value * 1000));
+		}
+
 		print_line("BENCHMARK:");
-		for (const Variant &K : keys) {
-			print_line("\t-", K, ": ", startup_benchmark_json[K], +" sec.");
+		for (const KeyValue<String, String> &E : results) {
+			print_line(vformat("\t[%s]\n%s", E.key, E.value));
 		}
 	}
 #endif

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -79,8 +79,8 @@ class OS {
 	// For tracking benchmark data
 	bool use_benchmark = false;
 	String benchmark_file;
-	HashMap<String, uint64_t> start_benchmark_from;
-	Dictionary startup_benchmark_json;
+	HashMap<Pair<String, String>, uint64_t, PairHash<String, String>> benchmark_marks_from;
+	HashMap<Pair<String, String>, double, PairHash<String, String>> benchmark_marks_final;
 
 protected:
 	void _set_logger(CompositeLogger *p_logger);
@@ -313,8 +313,8 @@ public:
 	bool is_use_benchmark_set();
 	void set_benchmark_file(const String &p_benchmark_file);
 	String get_benchmark_file();
-	virtual void benchmark_begin_measure(const String &p_what);
-	virtual void benchmark_end_measure(const String &p_what);
+	virtual void benchmark_begin_measure(const String &p_context, const String &p_what);
+	virtual void benchmark_end_measure(const String &p_context, const String &p_what);
 	virtual void benchmark_dump();
 
 	virtual void process_and_drop_events() {}

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -120,7 +120,8 @@ static ResourceUID *resource_uid = nullptr;
 static bool _is_core_extensions_registered = false;
 
 void register_core_types() {
-	OS::get_singleton()->benchmark_begin_measure("register_core_types");
+	OS::get_singleton()->benchmark_begin_measure("Core", "Register Types");
+
 	//consistency check
 	static_assert(sizeof(Callable) <= 16);
 
@@ -296,7 +297,7 @@ void register_core_types() {
 
 	worker_thread_pool = memnew(WorkerThreadPool);
 
-	OS::get_singleton()->benchmark_end_measure("register_core_types");
+	OS::get_singleton()->benchmark_end_measure("Core", "Register Types");
 }
 
 void register_core_settings() {
@@ -311,6 +312,8 @@ void register_core_settings() {
 }
 
 void register_core_singletons() {
+	OS::get_singleton()->benchmark_begin_measure("Core", "Register Singletons");
+
 	GDREGISTER_CLASS(ProjectSettings);
 	GDREGISTER_ABSTRACT_CLASS(IP);
 	GDREGISTER_CLASS(core_bind::Geometry2D);
@@ -346,25 +349,35 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDExtensionManager", GDExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", worker_thread_pool));
+
+	OS::get_singleton()->benchmark_end_measure("Core", "Register Singletons");
 }
 
 void register_core_extensions() {
+	OS::get_singleton()->benchmark_begin_measure("Core", "Register Extensions");
+
 	// Hardcoded for now.
 	GDExtension::initialize_gdextensions();
 	gdextension_manager->load_extensions();
 	gdextension_manager->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_CORE);
 	_is_core_extensions_registered = true;
+
+	OS::get_singleton()->benchmark_end_measure("Core", "Register Extensions");
 }
 
 void unregister_core_extensions() {
+	OS::get_singleton()->benchmark_begin_measure("Core", "Unregister Extensions");
+
 	if (_is_core_extensions_registered) {
 		gdextension_manager->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_CORE);
 	}
 	GDExtension::finalize_gdextensions();
+
+	OS::get_singleton()->benchmark_end_measure("Core", "Unregister Extensions");
 }
 
 void unregister_core_types() {
-	OS::get_singleton()->benchmark_begin_measure("unregister_core_types");
+	OS::get_singleton()->benchmark_begin_measure("Core", "Unregister Types");
 
 	// Destroy singletons in reverse order to ensure dependencies are not broken.
 
@@ -435,5 +448,5 @@ void unregister_core_types() {
 	CoreStringNames::free();
 	StringName::cleanup();
 
-	OS::get_singleton()->benchmark_end_measure("unregister_core_types");
+	OS::get_singleton()->benchmark_end_measure("Core", "Unregister Types");
 }

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -107,7 +107,7 @@ Ref<FontVariation> make_bold_font(const Ref<Font> &p_font, double p_embolden, Ty
 }
 
 void editor_register_fonts(Ref<Theme> p_theme) {
-	OS::get_singleton()->benchmark_begin_measure("editor_register_fonts");
+	OS::get_singleton()->benchmark_begin_measure("EditorTheme", "Register Fonts");
 	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 
 	TextServer::FontAntialiasing font_antialiasing = (TextServer::FontAntialiasing)(int)EDITOR_GET("interface/editor/font_antialiasing");
@@ -445,5 +445,5 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	p_theme->set_font_size("status_source_size", EditorStringName(EditorFonts), default_font_size);
 	p_theme->set_font("status_source", EditorStringName(EditorFonts), mono_other_fc);
 
-	OS::get_singleton()->benchmark_end_measure("editor_register_fonts");
+	OS::get_singleton()->benchmark_end_measure("EditorTheme", "Register Fonts");
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2360,6 +2360,7 @@ void EditorHelp::_add_text(const String &p_bbcode) {
 	_add_text_to_rt(p_bbcode, class_desc, this, edited_class);
 }
 
+int EditorHelp::doc_generation_count = 0;
 String EditorHelp::doc_version_hash;
 Thread EditorHelp::worker_thread;
 
@@ -2392,6 +2393,8 @@ void EditorHelp::_load_doc_thread(void *p_udata) {
 		// We have to go back to the main thread to start from scratch, bypassing any possibly existing cache.
 		callable_mp_static(&EditorHelp::generate_doc).bind(false).call_deferred();
 	}
+
+	OS::get_singleton()->benchmark_end_measure("EditorHelp", vformat("Generate Documentation (Run %d)", doc_generation_count));
 }
 
 void EditorHelp::_gen_doc_thread(void *p_udata) {
@@ -2417,6 +2420,8 @@ void EditorHelp::_gen_doc_thread(void *p_udata) {
 	if (err) {
 		ERR_PRINT("Cannot save editor help cache (" + get_cache_full_path() + ").");
 	}
+
+	OS::get_singleton()->benchmark_end_measure("EditorHelp", vformat("Generate Documentation (Run %d)", doc_generation_count));
 }
 
 void EditorHelp::_gen_extensions_docs() {
@@ -2424,7 +2429,8 @@ void EditorHelp::_gen_extensions_docs() {
 }
 
 void EditorHelp::generate_doc(bool p_use_cache) {
-	OS::get_singleton()->benchmark_begin_measure("EditorHelp::generate_doc");
+	doc_generation_count++;
+	OS::get_singleton()->benchmark_begin_measure("EditorHelp", vformat("Generate Documentation (Run %d)", doc_generation_count));
 
 	// In case not the first attempt.
 	_wait_for_thread();
@@ -2444,8 +2450,6 @@ void EditorHelp::generate_doc(bool p_use_cache) {
 		doc->generate();
 		worker_thread.start(_gen_doc_thread, nullptr);
 	}
-
-	OS::get_singleton()->benchmark_end_measure("EditorHelp::generate_doc");
 }
 
 void EditorHelp::_toggle_scripts_pressed() {

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -187,6 +187,7 @@ class EditorHelp : public VBoxContainer {
 	String _fix_constant(const String &p_constant) const;
 	void _toggle_scripts_pressed();
 
+	static int doc_generation_count;
 	static String doc_version_hash;
 	static Thread worker_thread;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -627,7 +627,7 @@ void EditorNode::_notification(int p_what) {
 			if (requested_first_scan) {
 				requested_first_scan = false;
 
-				OS::get_singleton()->benchmark_begin_measure("editor_scan_and_import");
+				OS::get_singleton()->benchmark_begin_measure("Editor", "First Scan");
 
 				if (run_surface_upgrade_tool) {
 					run_surface_upgrade_tool = false;
@@ -1041,7 +1041,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 	if (waiting_for_first_scan) {
 		waiting_for_first_scan = false;
 
-		OS::get_singleton()->benchmark_end_measure("editor_scan_and_import");
+		OS::get_singleton()->benchmark_end_measure("Editor", "First Scan");
 
 		// Reload the global shader variables, but this time
 		// loading textures, as they are now properly imported.
@@ -1050,11 +1050,12 @@ void EditorNode::_sources_changed(bool p_exist) {
 		_load_editor_layout();
 
 		if (!defer_load_scene.is_empty()) {
-			OS::get_singleton()->benchmark_begin_measure("editor_load_scene");
+			OS::get_singleton()->benchmark_begin_measure("Editor", "Load Scene");
+
 			load_scene(defer_load_scene);
 			defer_load_scene = "";
-			OS::get_singleton()->benchmark_end_measure("editor_load_scene");
 
+			OS::get_singleton()->benchmark_end_measure("Editor", "Load Scene");
 			OS::get_singleton()->benchmark_dump();
 		}
 
@@ -4665,7 +4666,7 @@ void EditorNode::_begin_first_scan() {
 	// In headless mode, scan right away.
 	// This allows users to continue using `godot --headless --editor --quit` to prepare a project.
 	if (!DisplayServer::get_singleton()->window_can_draw()) {
-		OS::get_singleton()->benchmark_begin_measure("editor_scan_and_import");
+		OS::get_singleton()->benchmark_begin_measure("Editor", "First Scan");
 		EditorFileSystem::get_singleton()->scan();
 		return;
 	}

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -403,7 +403,9 @@ float get_gizmo_handle_scale(const String &gizmo_handle_name = "") {
 }
 
 void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme, float p_icon_saturation, int p_thumb_size, bool p_only_thumbs = false) {
-	OS::get_singleton()->benchmark_begin_measure("editor_register_and_generate_icons_" + String((p_only_thumbs ? "with_only_thumbs" : "all")));
+	const String benchmark_key = vformat("Generate Icons (%s)", (p_only_thumbs ? "Only Thumbs" : "All"));
+	OS::get_singleton()->benchmark_begin_measure("EditorTheme", benchmark_key);
+
 	// Before we register the icons, we adjust their colors and saturation.
 	// Most icons follow the standard rules for color conversion to follow the editor
 	// theme's polarity (dark/light). We also adjust the saturation for most icons,
@@ -531,11 +533,11 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme, f
 			p_theme->set_icon(editor_icons_names[index], EditorStringName(EditorIcons), icon);
 		}
 	}
-	OS::get_singleton()->benchmark_end_measure("editor_register_and_generate_icons_" + String((p_only_thumbs ? "with_only_thumbs" : "all")));
+	OS::get_singleton()->benchmark_end_measure("EditorTheme", benchmark_key);
 }
 
 Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
-	OS::get_singleton()->benchmark_begin_measure("create_editor_theme");
+	OS::get_singleton()->benchmark_begin_measure("EditorTheme", "Create Editor Theme");
 	Ref<EditorTheme> theme = memnew(EditorTheme);
 
 	// Controls may rely on the scale for their internal drawing logic.
@@ -2360,14 +2362,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("search_result_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/search_result_color"));
 	theme->set_color("search_result_border_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/search_result_border_color"));
 
-	OS::get_singleton()->benchmark_end_measure("create_editor_theme");
+	OS::get_singleton()->benchmark_end_measure("EditorTheme", "Create Editor Theme");
 
 	return theme;
 }
 
 Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
-	OS::get_singleton()->benchmark_begin_measure("create_custom_theme");
 	Ref<Theme> theme = create_editor_theme(p_theme);
+
+	OS::get_singleton()->benchmark_begin_measure("EditorTheme", "Create Custom Theme");
 
 	const String custom_theme_path = EDITOR_GET("interface/theme/custom_theme");
 	if (!custom_theme_path.is_empty()) {
@@ -2377,7 +2380,7 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 		}
 	}
 
-	OS::get_singleton()->benchmark_end_measure("create_custom_theme");
+	OS::get_singleton()->benchmark_end_measure("EditorTheme", "Create Custom Theme");
 	return theme;
 }
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -129,7 +129,7 @@
 #include "editor/register_exporters.h"
 
 void register_editor_types() {
-	OS::get_singleton()->benchmark_begin_measure("register_editor_types");
+	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");
 
 	ResourceLoader::set_timestamp_on_load(true);
 	ResourceSaver::set_timestamp_on_save(true);
@@ -282,11 +282,11 @@ void register_editor_types() {
 	ei_singleton.editor_only = true;
 	Engine::get_singleton()->add_singleton(ei_singleton);
 
-	OS::get_singleton()->benchmark_end_measure("register_editor_types");
+	OS::get_singleton()->benchmark_end_measure("Editor", "Register Types");
 }
 
 void unregister_editor_types() {
-	OS::get_singleton()->benchmark_begin_measure("unregister_editor_types");
+	OS::get_singleton()->benchmark_begin_measure("Editor", "Unregister Types");
 
 	EditorNode::cleanup();
 	EditorInterface::free();
@@ -296,5 +296,5 @@ void unregister_editor_types() {
 	}
 	EditorStringNames::free();
 
-	OS::get_singleton()->benchmark_end_measure("unregister_editor_types");
+	OS::get_singleton()->benchmark_end_measure("Editor", "Unregister Types");
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -766,6 +766,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Benchmark tracking must be done after `OS::get_singleton()->initialize()` as on some
 	// platforms, it's used to set up the time utilities.
 	OS::get_singleton()->benchmark_begin_measure("Startup", "Total");
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Setup");
 
 	engine = memnew(Engine);
 
@@ -2185,6 +2186,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		return setup2();
 	}
 
+	OS::get_singleton()->benchmark_end_measure("Startup", "Setup");
 	return OK;
 
 error:
@@ -2239,6 +2241,7 @@ error:
 	}
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Core");
+	OS::get_singleton()->benchmark_end_measure("Startup", "Setup");
 
 	OS::get_singleton()->finalize_core();
 	locale = String();
@@ -2272,25 +2275,10 @@ Error Main::setup2() {
 	// Print engine name and version
 	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
 
-	OS::get_singleton()->benchmark_begin_measure("Startup", "Servers");
-
-	tsman = memnew(TextServerManager);
-
-	if (tsman) {
-		Ref<TextServerDummy> ts;
-		ts.instantiate();
-		tsman->add_interface(ts);
-	}
-
-	physics_server_3d_manager = memnew(PhysicsServer3DManager);
-	physics_server_2d_manager = memnew(PhysicsServer2DManager);
-
-	register_server_types();
-	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
-	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
-
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager || cmdline_tool) {
+		OS::get_singleton()->benchmark_begin_measure("Startup", "Initialize Early Settings");
+
 		EditorPaths::create();
 
 		// Editor setting class is not available, load config directly.
@@ -2352,16 +2340,49 @@ Error Main::setup2() {
 				return FAILED;
 			}
 		}
+
+		OS::get_singleton()->benchmark_end_measure("Startup", "Initialize Early Settings");
 	}
 #endif
 
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Servers");
+
+	tsman = memnew(TextServerManager);
+	if (tsman) {
+		Ref<TextServerDummy> ts;
+		ts.instantiate();
+		tsman->add_interface(ts);
+	}
+
+	physics_server_3d_manager = memnew(PhysicsServer3DManager);
+	physics_server_2d_manager = memnew(PhysicsServer2DManager);
+
+	register_server_types();
+	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "Modules and Extensions");
+
+		initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
+		GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
+
+		OS::get_singleton()->benchmark_end_measure("Servers", "Modules and Extensions");
+	}
+
 	/* Initialize Input */
 
-	input = memnew(Input);
+	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "Input");
+
+		input = memnew(Input);
+		OS::get_singleton()->initialize_joypads();
+
+		OS::get_singleton()->benchmark_end_measure("Servers", "Input");
+	}
 
 	/* Initialize Display Server */
 
 	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "Display");
+
 		String display_driver = DisplayServer::get_create_function_name(display_driver_idx);
 
 		Vector2i *window_position = nullptr;
@@ -2395,10 +2416,12 @@ Error Main::setup2() {
 			ERR_PRINT("Unable to create DisplayServer, all display drivers failed.");
 			return err;
 		}
-	}
 
-	if (display_server->has_feature(DisplayServer::FEATURE_ORIENTATION)) {
-		display_server->screen_set_orientation(window_orientation);
+		if (display_server->has_feature(DisplayServer::FEATURE_ORIENTATION)) {
+			display_server->screen_set_orientation(window_orientation);
+		}
+
+		OS::get_singleton()->benchmark_end_measure("Servers", "Display");
 	}
 
 	if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
@@ -2426,48 +2449,58 @@ Error Main::setup2() {
 	/* Initialize Pen Tablet Driver */
 
 	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "Tablet Driver");
+
 		GLOBAL_DEF_RST_NOVAL("input_devices/pen_tablet/driver", "");
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "wintab,winink"), "");
-	}
 
-	if (tablet_driver.is_empty()) { // specified in project.godot
-		tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
-		if (tablet_driver.is_empty()) {
-			tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
+		if (tablet_driver.is_empty()) { // specified in project.godot
+			tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
+			if (tablet_driver.is_empty()) {
+				tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
+			}
 		}
-	}
 
-	for (int i = 0; i < DisplayServer::get_singleton()->tablet_get_driver_count(); i++) {
-		if (tablet_driver == DisplayServer::get_singleton()->tablet_get_driver_name(i)) {
-			DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(i));
-			break;
+		for (int i = 0; i < DisplayServer::get_singleton()->tablet_get_driver_count(); i++) {
+			if (tablet_driver == DisplayServer::get_singleton()->tablet_get_driver_name(i)) {
+				DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(i));
+				break;
+			}
 		}
-	}
 
-	if (DisplayServer::get_singleton()->tablet_get_current_driver().is_empty()) {
-		DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
-	}
+		if (DisplayServer::get_singleton()->tablet_get_current_driver().is_empty()) {
+			DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
+		}
 
-	print_verbose("Using \"" + tablet_driver + "\" pen tablet driver...");
+		print_verbose("Using \"" + tablet_driver + "\" pen tablet driver...");
+
+		OS::get_singleton()->benchmark_end_measure("Servers", "Tablet Driver");
+	}
 
 	/* Initialize Rendering Server */
 
-	rendering_server = memnew(RenderingServerDefault(OS::get_singleton()->get_render_thread_mode() == OS::RENDER_SEPARATE_THREAD));
+	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "Rendering");
 
-	rendering_server->init();
-	//rendering_server->call_set_use_vsync(OS::get_singleton()->_use_vsync);
-	rendering_server->set_render_loop_enabled(!disable_render_loop);
+		rendering_server = memnew(RenderingServerDefault(OS::get_singleton()->get_render_thread_mode() == OS::RENDER_SEPARATE_THREAD));
 
-	if (profile_gpu || (!editor && bool(GLOBAL_GET("debug/settings/stdout/print_gpu_profile")))) {
-		rendering_server->set_print_gpu_profile(true);
-	}
+		rendering_server->init();
+		//rendering_server->call_set_use_vsync(OS::get_singleton()->_use_vsync);
+		rendering_server->set_render_loop_enabled(!disable_render_loop);
 
-	if (Engine::get_singleton()->get_write_movie_path() != String()) {
-		movie_writer = MovieWriter::find_writer_for_file(Engine::get_singleton()->get_write_movie_path());
-		if (movie_writer == nullptr) {
-			ERR_PRINT("Can't find movie writer for file type, aborting: " + Engine::get_singleton()->get_write_movie_path());
-			Engine::get_singleton()->set_write_movie_path(String());
+		if (profile_gpu || (!editor && bool(GLOBAL_GET("debug/settings/stdout/print_gpu_profile")))) {
+			rendering_server->set_print_gpu_profile(true);
 		}
+
+		if (Engine::get_singleton()->get_write_movie_path() != String()) {
+			movie_writer = MovieWriter::find_writer_for_file(Engine::get_singleton()->get_write_movie_path());
+			if (movie_writer == nullptr) {
+				ERR_PRINT("Can't find movie writer for file type, aborting: " + Engine::get_singleton()->get_write_movie_path());
+				Engine::get_singleton()->set_write_movie_path(String());
+			}
+		}
+
+		OS::get_singleton()->benchmark_end_measure("Servers", "Rendering");
 	}
 
 #ifdef UNIX_ENABLED
@@ -2477,206 +2510,242 @@ Error Main::setup2() {
 	}
 #endif
 
-	OS::get_singleton()->initialize_joypads();
-
 	/* Initialize Audio Driver */
 
-	AudioDriverManager::initialize(audio_driver_idx);
+	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "Audio");
 
-	print_line(" "); //add a blank line for readability
+		AudioDriverManager::initialize(audio_driver_idx);
 
-	// right moment to create and initialize the audio server
+		print_line(" "); // Add a blank line for readability.
 
-	audio_server = memnew(AudioServer);
-	audio_server->init();
+		// Right moment to create and initialize the audio server.
+		audio_server = memnew(AudioServer);
+		audio_server->init();
 
-	// also init our xr_server from here
-	xr_server = memnew(XRServer);
-
-	register_core_singletons();
-
-	MAIN_PRINT("Main: Setup Logo");
-
-#if !defined(TOOLS_ENABLED) && (defined(WEB_ENABLED) || defined(ANDROID_ENABLED))
-	bool show_logo = false;
-#else
-	bool show_logo = true;
-#endif
-
-	if (init_windowed) {
-		//do none..
-	} else if (init_maximized) {
-		DisplayServer::get_singleton()->window_set_mode(DisplayServer::WINDOW_MODE_MAXIMIZED);
-	} else if (init_fullscreen) {
-		DisplayServer::get_singleton()->window_set_mode(DisplayServer::WINDOW_MODE_FULLSCREEN);
-	}
-	if (init_always_on_top) {
-		DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP, true);
+		OS::get_singleton()->benchmark_end_measure("Servers", "Audio");
 	}
 
-	MAIN_PRINT("Main: Load Boot Image");
+	/* Initialize XR Server */
 
-	Color clear = GLOBAL_DEF_BASIC("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
-	RenderingServer::get_singleton()->set_default_clear_color(clear);
+	{
+		OS::get_singleton()->benchmark_begin_measure("Servers", "XR");
 
-	if (show_logo) { //boot logo!
-		const bool boot_logo_image = GLOBAL_DEF_BASIC("application/boot_splash/show_image", true);
-		const String boot_logo_path = String(GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String())).strip_edges();
-		const bool boot_logo_scale = GLOBAL_DEF_BASIC("application/boot_splash/fullsize", true);
-		const bool boot_logo_filter = GLOBAL_DEF_BASIC("application/boot_splash/use_filter", true);
+		xr_server = memnew(XRServer);
 
-		Ref<Image> boot_logo;
-
-		if (boot_logo_image) {
-			if (!boot_logo_path.is_empty()) {
-				boot_logo.instantiate();
-				Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
-				if (load_err) {
-					ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
-				}
-			}
-		} else {
-			// Create a 1×1 transparent image. This will effectively hide the splash image.
-			boot_logo.instantiate();
-			boot_logo->initialize_data(1, 1, false, Image::FORMAT_RGBA8);
-			boot_logo->set_pixel(0, 0, Color(0, 0, 0, 0));
-		}
-
-		Color boot_bg_color = GLOBAL_GET("application/boot_splash/bg_color");
-
-#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
-		boot_bg_color =
-				GLOBAL_DEF_BASIC("application/boot_splash/bg_color",
-						(editor || project_manager) ? boot_splash_editor_bg_color : boot_splash_bg_color);
-#endif
-		if (boot_logo.is_valid()) {
-			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
-					boot_logo_filter);
-
-		} else {
-#ifndef NO_DEFAULT_BOOT_LOGO
-			MAIN_PRINT("Main: Create bootsplash");
-#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
-			Ref<Image> splash = (editor || project_manager) ? memnew(Image(boot_splash_editor_png)) : memnew(Image(boot_splash_png));
-#else
-			Ref<Image> splash = memnew(Image(boot_splash_png));
-#endif
-
-			MAIN_PRINT("Main: ClearColor");
-			RenderingServer::get_singleton()->set_default_clear_color(boot_bg_color);
-			MAIN_PRINT("Main: Image");
-			RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, false);
-#endif
-		}
-
-#if defined(TOOLS_ENABLED) && defined(MACOS_ENABLED)
-		if (OS::get_singleton()->get_bundle_icon_path().is_empty()) {
-			Ref<Image> icon = memnew(Image(app_icon_png));
-			DisplayServer::get_singleton()->set_icon(icon);
-		}
-#endif
-	}
-
-	DisplayServer::set_early_window_clear_color_override(false);
-
-	MAIN_PRINT("Main: DCC");
-	RenderingServer::get_singleton()->set_default_clear_color(
-			GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
-
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/icon", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), String());
-	GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/macos_native_icon", PROPERTY_HINT_FILE, "*.icns"), String());
-	GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/windows_native_icon", PROPERTY_HINT_FILE, "*.ico"), String());
-
-	Input *id = Input::get_singleton();
-	if (id) {
-		agile_input_event_flushing = GLOBAL_DEF("input_devices/buffering/agile_event_flushing", false);
-
-		if (bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_touch_from_mouse", false)) &&
-				!(editor || project_manager)) {
-			if (!DisplayServer::get_singleton()->is_touchscreen_available()) {
-				//only if no touchscreen ui hint, set emulation
-				id->set_emulate_touch_from_mouse(true);
-			}
-		}
-
-		id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_mouse_from_touch", true)));
-	}
-
-	GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_long_press_as_right_click", false);
-	GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_pan_and_scale_gestures", false);
-
-	MAIN_PRINT("Main: Load Translations and Remaps");
-
-	translation_server->setup(); //register translations, load them, etc.
-	if (!locale.is_empty()) {
-		translation_server->set_locale(locale);
-	}
-	translation_server->load_translations();
-	ResourceLoader::load_translation_remaps(); //load remaps for resources
-
-	ResourceLoader::load_path_remaps();
-
-	MAIN_PRINT("Main: Load TextServer");
-
-	/* Enum text drivers */
-	GLOBAL_DEF_RST("internationalization/rendering/text_driver", "");
-	String text_driver_options;
-	for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
-		const String driver_name = TextServerManager::get_singleton()->get_interface(i)->get_name();
-		if (driver_name == "Dummy") {
-			// Dummy text driver cannot draw any text, making the editor unusable if selected.
-			continue;
-		}
-		if (!text_driver_options.is_empty() && text_driver_options.find(",") == -1) {
-			// Not the first option; add a comma before it as a separator for the property hint.
-			text_driver_options += ",";
-		}
-		text_driver_options += driver_name;
-	}
-	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "internationalization/rendering/text_driver", PROPERTY_HINT_ENUM, text_driver_options));
-
-	/* Determine text driver */
-	if (text_driver.is_empty()) {
-		text_driver = GLOBAL_GET("internationalization/rendering/text_driver");
-	}
-
-	if (!text_driver.is_empty()) {
-		/* Load user selected text server. */
-		for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
-			if (TextServerManager::get_singleton()->get_interface(i)->get_name() == text_driver) {
-				text_driver_idx = i;
-				break;
-			}
-		}
-	}
-
-	if (text_driver_idx < 0) {
-		/* If not selected, use one with the most features available. */
-		int max_features = 0;
-		for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
-			uint32_t features = TextServerManager::get_singleton()->get_interface(i)->get_features();
-			int feature_number = 0;
-			while (features) {
-				feature_number += features & 1;
-				features >>= 1;
-			}
-			if (feature_number >= max_features) {
-				max_features = feature_number;
-				text_driver_idx = i;
-			}
-		}
-	}
-	if (text_driver_idx >= 0) {
-		Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(text_driver_idx);
-		TextServerManager::get_singleton()->set_primary_interface(ts);
-		if (ts->has_feature(TextServer::FEATURE_USE_SUPPORT_DATA)) {
-			ts->load_support_data("res://" + ts->get_support_data_filename());
-		}
-	} else {
-		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "TextServer: Unable to create TextServer interface.");
+		OS::get_singleton()->benchmark_end_measure("Servers", "XR");
 	}
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Servers");
+
+	register_core_singletons();
+
+	/* Initialize the main window and boot screen */
+
+	{
+		OS::get_singleton()->benchmark_begin_measure("Startup", "Setup Window and Boot");
+
+		MAIN_PRINT("Main: Setup Logo");
+
+#if !defined(TOOLS_ENABLED) && (defined(WEB_ENABLED) || defined(ANDROID_ENABLED))
+		bool show_logo = false;
+#else
+		bool show_logo = true;
+#endif
+
+		if (init_windowed) {
+			//do none..
+		} else if (init_maximized) {
+			DisplayServer::get_singleton()->window_set_mode(DisplayServer::WINDOW_MODE_MAXIMIZED);
+		} else if (init_fullscreen) {
+			DisplayServer::get_singleton()->window_set_mode(DisplayServer::WINDOW_MODE_FULLSCREEN);
+		}
+		if (init_always_on_top) {
+			DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP, true);
+		}
+
+		MAIN_PRINT("Main: Load Boot Image");
+
+		Color clear = GLOBAL_DEF_BASIC("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
+		RenderingServer::get_singleton()->set_default_clear_color(clear);
+
+		if (show_logo) { //boot logo!
+			const bool boot_logo_image = GLOBAL_DEF_BASIC("application/boot_splash/show_image", true);
+			const String boot_logo_path = String(GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String())).strip_edges();
+			const bool boot_logo_scale = GLOBAL_DEF_BASIC("application/boot_splash/fullsize", true);
+			const bool boot_logo_filter = GLOBAL_DEF_BASIC("application/boot_splash/use_filter", true);
+
+			Ref<Image> boot_logo;
+
+			if (boot_logo_image) {
+				if (!boot_logo_path.is_empty()) {
+					boot_logo.instantiate();
+					Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
+					if (load_err) {
+						ERR_PRINT("Non-existing or invalid boot splash at '" + boot_logo_path + "'. Loading default splash.");
+					}
+				}
+			} else {
+				// Create a 1×1 transparent image. This will effectively hide the splash image.
+				boot_logo.instantiate();
+				boot_logo->initialize_data(1, 1, false, Image::FORMAT_RGBA8);
+				boot_logo->set_pixel(0, 0, Color(0, 0, 0, 0));
+			}
+
+			Color boot_bg_color = GLOBAL_GET("application/boot_splash/bg_color");
+
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
+			boot_bg_color =
+					GLOBAL_DEF_BASIC("application/boot_splash/bg_color",
+							(editor || project_manager) ? boot_splash_editor_bg_color : boot_splash_bg_color);
+#endif
+			if (boot_logo.is_valid()) {
+				RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
+						boot_logo_filter);
+
+			} else {
+#ifndef NO_DEFAULT_BOOT_LOGO
+				MAIN_PRINT("Main: Create bootsplash");
+#if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
+				Ref<Image> splash = (editor || project_manager) ? memnew(Image(boot_splash_editor_png)) : memnew(Image(boot_splash_png));
+#else
+				Ref<Image> splash = memnew(Image(boot_splash_png));
+#endif
+
+				MAIN_PRINT("Main: ClearColor");
+				RenderingServer::get_singleton()->set_default_clear_color(boot_bg_color);
+				MAIN_PRINT("Main: Image");
+				RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, false);
+#endif
+			}
+
+#if defined(TOOLS_ENABLED) && defined(MACOS_ENABLED)
+			if (OS::get_singleton()->get_bundle_icon_path().is_empty()) {
+				Ref<Image> icon = memnew(Image(app_icon_png));
+				DisplayServer::get_singleton()->set_icon(icon);
+			}
+#endif
+		}
+
+		MAIN_PRINT("Main: Clear Color");
+
+		DisplayServer::set_early_window_clear_color_override(false);
+		RenderingServer::get_singleton()->set_default_clear_color(
+				GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/icon", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), String());
+		GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/macos_native_icon", PROPERTY_HINT_FILE, "*.icns"), String());
+		GLOBAL_DEF(PropertyInfo(Variant::STRING, "application/config/windows_native_icon", PROPERTY_HINT_FILE, "*.ico"), String());
+
+		MAIN_PRINT("Main: Touch Input");
+
+		Input *id = Input::get_singleton();
+		if (id) {
+			agile_input_event_flushing = GLOBAL_DEF("input_devices/buffering/agile_event_flushing", false);
+
+			if (bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_touch_from_mouse", false)) &&
+					!(editor || project_manager)) {
+				if (!DisplayServer::get_singleton()->is_touchscreen_available()) {
+					//only if no touchscreen ui hint, set emulation
+					id->set_emulate_touch_from_mouse(true);
+				}
+			}
+
+			id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_mouse_from_touch", true)));
+		}
+
+		GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_long_press_as_right_click", false);
+		GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_pan_and_scale_gestures", false);
+
+		OS::get_singleton()->benchmark_end_measure("Startup", "Setup Window and Boot");
+	}
+
+	MAIN_PRINT("Main: Load Translations and Remaps");
+
+	/* Setup translations and remaps */
+
+	{
+		OS::get_singleton()->benchmark_begin_measure("Startup", "Translations and Remaps");
+
+		translation_server->setup(); //register translations, load them, etc.
+		if (!locale.is_empty()) {
+			translation_server->set_locale(locale);
+		}
+		translation_server->load_translations();
+		ResourceLoader::load_translation_remaps(); //load remaps for resources
+
+		ResourceLoader::load_path_remaps();
+
+		OS::get_singleton()->benchmark_end_measure("Startup", "Translations and Remaps");
+	}
+
+	MAIN_PRINT("Main: Load TextServer");
+
+	/* Setup Text Server */
+
+	{
+		OS::get_singleton()->benchmark_begin_measure("Startup", "Text Server");
+
+		/* Enum text drivers */
+		GLOBAL_DEF_RST("internationalization/rendering/text_driver", "");
+		String text_driver_options;
+		for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
+			const String driver_name = TextServerManager::get_singleton()->get_interface(i)->get_name();
+			if (driver_name == "Dummy") {
+				// Dummy text driver cannot draw any text, making the editor unusable if selected.
+				continue;
+			}
+			if (!text_driver_options.is_empty() && text_driver_options.find(",") == -1) {
+				// Not the first option; add a comma before it as a separator for the property hint.
+				text_driver_options += ",";
+			}
+			text_driver_options += driver_name;
+		}
+		ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "internationalization/rendering/text_driver", PROPERTY_HINT_ENUM, text_driver_options));
+
+		/* Determine text driver */
+		if (text_driver.is_empty()) {
+			text_driver = GLOBAL_GET("internationalization/rendering/text_driver");
+		}
+
+		if (!text_driver.is_empty()) {
+			/* Load user selected text server. */
+			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
+				if (TextServerManager::get_singleton()->get_interface(i)->get_name() == text_driver) {
+					text_driver_idx = i;
+					break;
+				}
+			}
+		}
+
+		if (text_driver_idx < 0) {
+			/* If not selected, use one with the most features available. */
+			int max_features = 0;
+			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
+				uint32_t features = TextServerManager::get_singleton()->get_interface(i)->get_features();
+				int feature_number = 0;
+				while (features) {
+					feature_number += features & 1;
+					features >>= 1;
+				}
+				if (feature_number >= max_features) {
+					max_features = feature_number;
+					text_driver_idx = i;
+				}
+			}
+		}
+		if (text_driver_idx >= 0) {
+			Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(text_driver_idx);
+			TextServerManager::get_singleton()->set_primary_interface(ts);
+			if (ts->has_feature(TextServer::FEATURE_USE_SUPPORT_DATA)) {
+				ts->load_support_data("res://" + ts->get_support_data_filename());
+			}
+		} else {
+			ERR_FAIL_V_MSG(ERR_CANT_CREATE, "TextServer: Unable to create TextServer interface.");
+		}
+
+		OS::get_singleton()->benchmark_end_measure("Startup", "Text Server");
+	}
 
 	MAIN_PRINT("Main: Load Scene Types");
 
@@ -2691,22 +2760,41 @@ Error Main::setup2() {
 
 	register_scene_singletons();
 
-	initialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
-	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
+	{
+		OS::get_singleton()->benchmark_begin_measure("Scene", "Modules and Extensions");
+
+		initialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
+		GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
+
+		OS::get_singleton()->benchmark_end_measure("Scene", "Modules and Extensions");
+	}
+
+	OS::get_singleton()->benchmark_end_measure("Startup", "Scene");
 
 #ifdef TOOLS_ENABLED
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
 	register_editor_types();
-	initialize_modules(MODULE_INITIALIZATION_LEVEL_EDITOR);
-	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_EDITOR);
+
+	{
+		OS::get_singleton()->benchmark_begin_measure("Editor", "Modules and Extensions");
+
+		initialize_modules(MODULE_INITIALIZATION_LEVEL_EDITOR);
+		GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_EDITOR);
+
+		OS::get_singleton()->benchmark_end_measure("Editor", "Modules and Extensions");
+	}
 
 	ClassDB::set_current_api(ClassDB::API_CORE);
 
 #endif
 
-	MAIN_PRINT("Main: Load Modules");
+	MAIN_PRINT("Main: Load Platforms");
+
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Platforms");
 
 	register_platform_apis();
+
+	OS::get_singleton()->benchmark_end_measure("Startup", "Platforms");
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/mouse_cursor/custom_image", PROPERTY_HINT_FILE, "*.png,*.webp"), String());
 	GLOBAL_DEF_BASIC("display/mouse_cursor/custom_image_hotspot", Vector2());
@@ -2721,12 +2809,18 @@ Error Main::setup2() {
 		}
 	}
 
+	OS::get_singleton()->benchmark_begin_measure("Startup", "Finalize Setup");
+
 	camera_server = CameraServer::create();
 
 	MAIN_PRINT("Main: Load Physics");
 
 	initialize_physics();
+
+	MAIN_PRINT("Main: Load Navigation");
+
 	initialize_navigation_server();
+
 	register_server_singletons();
 
 	// This loads global classes, so it must happen before custom loaders and savers are registered
@@ -2758,6 +2852,8 @@ Error Main::setup2() {
 		rendering_server->global_shader_parameters_load_settings(!editor);
 	}
 
+	OS::get_singleton()->benchmark_end_measure("Startup", "Finalize Setup");
+
 	_start_success = true;
 
 	ClassDB::set_current_api(ClassDB::API_NONE); //no more APIs are registered at this point
@@ -2766,7 +2862,7 @@ Error Main::setup2() {
 	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
 	MAIN_PRINT("Main: Done");
 
-	OS::get_singleton()->benchmark_end_measure("Startup", "Scene");
+	OS::get_singleton()->benchmark_end_measure("Startup", "Setup");
 
 	return OK;
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -184,7 +184,7 @@ class Godot(private val context: Context) : SensorEventListener {
 			return
 		}
 
-		beginBenchmarkMeasure("Godot::onCreate")
+		beginBenchmarkMeasure("Startup", "Godot::onCreate")
 		try {
 			this.primaryHost = primaryHost
 			val activity = requireActivity()
@@ -286,7 +286,7 @@ class Godot(private val context: Context) : SensorEventListener {
 			initializationStarted = false
 			throw e
 		} finally {
-			endBenchmarkMeasure("Godot::onCreate");
+			endBenchmarkMeasure("Startup", "Godot::onCreate");
 		}
 	}
 
@@ -1016,13 +1016,13 @@ class Godot(private val context: Context) : SensorEventListener {
 	}
 
 	@Keep
-	private fun nativeBeginBenchmarkMeasure(label: String) {
-		beginBenchmarkMeasure(label)
+	private fun nativeBeginBenchmarkMeasure(scope: String, label: String) {
+		beginBenchmarkMeasure(scope, label)
 	}
 
 	@Keep
-	private fun nativeEndBenchmarkMeasure(label: String) {
-		endBenchmarkMeasure(label)
+	private fun nativeEndBenchmarkMeasure(scope: String, label: String) {
+		endBenchmarkMeasure(scope, label)
 	}
 
 	@Keep

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -172,7 +172,7 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 
 	@Override
 	public void onCreate(Bundle icicle) {
-		BenchmarkUtils.beginBenchmarkMeasure("GodotFragment::onCreate");
+		BenchmarkUtils.beginBenchmarkMeasure("Startup", "GodotFragment::onCreate");
 		super.onCreate(icicle);
 
 		final Activity activity = getActivity();
@@ -180,7 +180,7 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 
 		godot = new Godot(requireContext());
 		performEngineInitialization();
-		BenchmarkUtils.endBenchmarkMeasure("GodotFragment::onCreate");
+		BenchmarkUtils.endBenchmarkMeasure("Startup", "GodotFragment::onCreate");
 	}
 
 	private void performEngineInitialization() {

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/BenchmarkUtils.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/BenchmarkUtils.kt
@@ -41,7 +41,7 @@ import org.godotengine.godot.io.file.FileAccessFlags
 import org.godotengine.godot.io.file.FileAccessHandler
 import org.json.JSONObject
 import java.nio.ByteBuffer
-import java.util.concurrent.ConcurrentSkipListMap
+import java.util.Collections
 
 /**
  * Contains benchmark related utilities methods
@@ -51,44 +51,47 @@ private const val TAG = "GodotBenchmark"
 var useBenchmark = false
 var benchmarkFile = ""
 
-private val startBenchmarkFrom = ConcurrentSkipListMap<String, Long>()
-private val benchmarkTracker = ConcurrentSkipListMap<String, Double>()
+private val startBenchmarkFrom = Collections.synchronizedMap(LinkedHashMap<Pair<String, String>, Long>())
+private val benchmarkTracker = Collections.synchronizedMap(LinkedHashMap<Pair<String, String>, Double>())
 
 /**
- * Start measuring and tracing the execution of a given section of code using the given label.
+ * Start measuring and tracing the execution of a given section of code using the given label
+ * within the given scope.
  *
  * Must be followed by a call to [endBenchmarkMeasure].
  *
  * Note: Only enabled on 'editorDev' build variant.
  */
-fun beginBenchmarkMeasure(label: String) {
+fun beginBenchmarkMeasure(scope: String, label: String) {
 	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
 		return
 	}
-	startBenchmarkFrom[label] = SystemClock.elapsedRealtime()
+	val key = Pair(scope, label)
+	startBenchmarkFrom[key] = SystemClock.elapsedRealtime()
 
 	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-		Trace.beginAsyncSection(label, 0)
+		Trace.beginAsyncSection("[$scope] $label", 0)
 	}
 }
 
 /**
- * End measuring and tracing of the section of code with the given label.
+ * End measuring and tracing of the section of code with the given label within the given scope.
  *
  * Must be preceded by a call [beginBenchmarkMeasure]
  *
  * * Note: Only enabled on 'editorDev' build variant.
  */
-fun endBenchmarkMeasure(label: String) {
+fun endBenchmarkMeasure(scope: String, label: String) {
 	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
 		return
 	}
-	val startTime = startBenchmarkFrom[label] ?: return
+	val key = Pair(scope, label)
+	val startTime = startBenchmarkFrom[key] ?: return
 	val total = SystemClock.elapsedRealtime() - startTime
-	benchmarkTracker[label] = total / 1000.0
+	benchmarkTracker[key] = total / 1_000.0
 
 	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-		Trace.endAsyncSection(label, 0)
+		Trace.endAsyncSection("[$scope] $label", 0)
 	}
 }
 
@@ -107,8 +110,16 @@ fun dumpBenchmark(fileAccessHandler: FileAccessHandler?, filepath: String? = ben
 		return
 	}
 
+	val results = LinkedHashMap<String, String>()
+	for (entry in benchmarkTracker) {
+		if (!results.containsKey(entry.key.first)) {
+			results[entry.key.first] = ""
+		}
+		results[entry.key.first] += "\t\t- ${entry.key.second}: ${entry.value * 1_000.0} msec.\n"
+	}
+
 	val printOut =
-		benchmarkTracker.map { "\t- ${it.key} : ${it.value} sec." }.joinToString("\n")
+		results.map { "\t- [${it.key}]\n ${it.value}" }.joinToString("\n")
 	Log.i(TAG, "BENCHMARK:\n$printOut")
 
 	if (fileAccessHandler != null && !filepath.isNullOrBlank()) {

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -78,8 +78,8 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
 	_create_new_godot_instance = p_env->GetMethodID(godot_class, "createNewGodotInstance", "([Ljava/lang/String;)I");
 	_get_render_view = p_env->GetMethodID(godot_class, "getRenderView", "()Lorg/godotengine/godot/GodotRenderView;");
-	_begin_benchmark_measure = p_env->GetMethodID(godot_class, "nativeBeginBenchmarkMeasure", "(Ljava/lang/String;)V");
-	_end_benchmark_measure = p_env->GetMethodID(godot_class, "nativeEndBenchmarkMeasure", "(Ljava/lang/String;)V");
+	_begin_benchmark_measure = p_env->GetMethodID(godot_class, "nativeBeginBenchmarkMeasure", "(Ljava/lang/String;Ljava/lang/String;)V");
+	_end_benchmark_measure = p_env->GetMethodID(godot_class, "nativeEndBenchmarkMeasure", "(Ljava/lang/String;Ljava/lang/String;)V");
 	_dump_benchmark = p_env->GetMethodID(godot_class, "nativeDumpBenchmark", "(Ljava/lang/String;)V");
 	_get_gdextension_list_config_file = p_env->GetMethodID(godot_class, "getGDExtensionConfigFiles", "()[Ljava/lang/String;");
 	_has_feature = p_env->GetMethodID(godot_class, "hasFeature", "(Ljava/lang/String;)Z");
@@ -348,21 +348,23 @@ int GodotJavaWrapper::create_new_godot_instance(List<String> args) {
 	}
 }
 
-void GodotJavaWrapper::begin_benchmark_measure(const String &p_label) {
+void GodotJavaWrapper::begin_benchmark_measure(const String &p_context, const String &p_label) {
 	if (_begin_benchmark_measure) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL(env);
+		jstring j_context = env->NewStringUTF(p_context.utf8().get_data());
 		jstring j_label = env->NewStringUTF(p_label.utf8().get_data());
-		env->CallVoidMethod(godot_instance, _begin_benchmark_measure, j_label);
+		env->CallVoidMethod(godot_instance, _begin_benchmark_measure, j_context, j_label);
 	}
 }
 
-void GodotJavaWrapper::end_benchmark_measure(const String &p_label) {
+void GodotJavaWrapper::end_benchmark_measure(const String &p_context, const String &p_label) {
 	if (_end_benchmark_measure) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL(env);
+		jstring j_context = env->NewStringUTF(p_context.utf8().get_data());
 		jstring j_label = env->NewStringUTF(p_label.utf8().get_data());
-		env->CallVoidMethod(godot_instance, _end_benchmark_measure, j_label);
+		env->CallVoidMethod(godot_instance, _end_benchmark_measure, j_context, j_label);
 	}
 }
 

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -105,8 +105,8 @@ public:
 	void vibrate(int p_duration_ms);
 	String get_input_fallback_mapping();
 	int create_new_godot_instance(List<String> args);
-	void begin_benchmark_measure(const String &p_label);
-	void end_benchmark_measure(const String &p_label);
+	void begin_benchmark_measure(const String &p_context, const String &p_label);
+	void end_benchmark_measure(const String &p_context, const String &p_label);
 	void dump_benchmark(const String &benchmark_file);
 
 	// Return the list of gdextensions config file.

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -708,15 +708,15 @@ String OS_Android::get_config_path() const {
 	return get_user_data_dir().path_join("config");
 }
 
-void OS_Android::benchmark_begin_measure(const String &p_what) {
+void OS_Android::benchmark_begin_measure(const String &p_context, const String &p_what) {
 #ifdef TOOLS_ENABLED
-	godot_java->begin_benchmark_measure(p_what);
+	godot_java->begin_benchmark_measure(p_context, p_what);
 #endif
 }
 
-void OS_Android::benchmark_end_measure(const String &p_what) {
+void OS_Android::benchmark_end_measure(const String &p_context, const String &p_what) {
 #ifdef TOOLS_ENABLED
-	godot_java->end_benchmark_measure(p_what);
+	godot_java->end_benchmark_measure(p_context, p_what);
 #endif
 }
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -165,8 +165,8 @@ public:
 
 	virtual Error setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path) override;
 
-	virtual void benchmark_begin_measure(const String &p_what) override;
-	virtual void benchmark_end_measure(const String &p_what) override;
+	virtual void benchmark_begin_measure(const String &p_context, const String &p_what) override;
+	virtual void benchmark_end_measure(const String &p_context, const String &p_what) override;
 	virtual void benchmark_dump() override;
 
 	virtual void load_platform_gdextensions() const override;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -293,6 +293,8 @@ static Ref<ResourceFormatSaverShaderInclude> resource_saver_shader_include;
 static Ref<ResourceFormatLoaderShaderInclude> resource_loader_shader_include;
 
 void register_scene_types() {
+	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Types");
+
 	SceneStringNames::create();
 
 	OS::get_singleton()->yield(); // may take time to init
@@ -1182,9 +1184,13 @@ void register_scene_types() {
 	}
 
 	SceneDebugger::initialize();
+
+	OS::get_singleton()->benchmark_end_measure("Scene", "Register Types");
 }
 
 void unregister_scene_types() {
+	OS::get_singleton()->benchmark_begin_measure("Scene", "Unregister Types");
+
 	SceneDebugger::deinitialize();
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
@@ -1227,10 +1233,16 @@ void unregister_scene_types() {
 	CanvasItemMaterial::finish_shaders();
 	ColorPicker::finish_shaders();
 	SceneStringNames::free();
+
+	OS::get_singleton()->benchmark_end_measure("Scene", "Unregister Types");
 }
 
 void register_scene_singletons() {
+	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Singletons");
+
 	GDREGISTER_CLASS(ThemeDB);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ThemeDB", ThemeDB::get_singleton()));
+
+	OS::get_singleton()->benchmark_end_measure("Scene", "Register Singletons");
 }

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -117,6 +117,8 @@ static MovieWriterMJPEG *writer_mjpeg = nullptr;
 static MovieWriterPNGWAV *writer_pngwav = nullptr;
 
 void register_server_types() {
+	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Extensions");
+
 	shader_types = memnew(ShaderTypes);
 
 	GDREGISTER_CLASS(TextServerManager);
@@ -293,16 +295,24 @@ void register_server_types() {
 
 	writer_pngwav = memnew(MovieWriterPNGWAV);
 	MovieWriter::add_writer(writer_pngwav);
+
+	OS::get_singleton()->benchmark_end_measure("Servers", "Register Extensions");
 }
 
 void unregister_server_types() {
+	OS::get_singleton()->benchmark_begin_measure("Servers", "Unregister Extensions");
+
 	ServersDebugger::deinitialize();
 	memdelete(shader_types);
 	memdelete(writer_mjpeg);
 	memdelete(writer_pngwav);
+
+	OS::get_singleton()->benchmark_end_measure("Servers", "Unregister Extensions");
 }
 
 void register_server_singletons() {
+	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Singletons");
+
 	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServer", DisplayServer::get_singleton(), "DisplayServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
@@ -312,4 +322,6 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton(), "NavigationServer3D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
+
+	OS::get_singleton()->benchmark_end_measure("Servers", "Register Singletons");
 }


### PR DESCRIPTION
So I was working on the project manager and wanted to learn why does it take a whopping 3 seconds to load, with most time spent outside of PM code and in other `main.cpp` activities instead. As I did before, I tried to use our existing benchmarking system that is supposed to track startup and shutdown processes and report on time taken.

I have already discovered previously that it is not a very useful system. Many things are not tracked correctly, with begin or end points of measurement being misplaced; many other things are not tracked at all and missing. Those which are tracked are reported in a disorganized manner and are hard to make use of. For example, most of the time of the PM startup is taken by "servers", and that's pretty much all that I can tell from our current benchmark:

```
BENCHMARK:
	- register_core_types :  0.014811  sec.
	- servers :  2.620844  sec.
	- register_editor_types :  0.003172  sec.
	- scene :  0.209155  sec.
	- editor_register_and_generate_icons_all :  0.254266  sec.
	- editor_register_and_generate_icons_with_only_thumbs :  0.003362  sec.
	- editor_register_fonts :  0.005924  sec.
	- create_editor_theme :  0.606796  sec.
	- create_custom_theme :  0.606828  sec.
	- project_manager :  0.782145  sec.
	- startup_begin :  3.649693  sec.
	- unregister_editor_types :  0.000009  sec.
	- unregister_core_types :  0.02886  sec.
	- Main::cleanup :  0.118794  sec.
```

_Measured on battery with a build of 2f73a059cefadcd944b6874f2557ec82e46a562d_

So I set to try and improve all of that. First of all, I added grouping to the measurements. This makes the data structure a bit more complex, which I guess will increase the impact of using the benchmark on the benchmarked code. But what are you going to do, the observer is a part of the observed process.

I went with a Pair key for intermediate records instead of using nested HashMaps, because I think it would be slightly faster. But I didn't... benchmark it. I also replaced the Dictionary with a HashMap. I think it should be more efficient too, with no Variant marshalling required. We only needed a Dictionary when creating the JSON file, but we can fabricate one when we do the dump, which is one part of the process where it's okay to be slow.

I then went through benchmarked areas and adjusted/added measure points to make sure they track sensible data. There shouldn't be anything controversial about these changes here.

However, there is the second commit where I go through the `main.cpp` code and reorganize it a bit, fixing benchmarks in the process. There should be no functional difference, but changes to main are always sensitive. So I can drop it if needed. To summarize, I shifted some little things around which should not affect the initialization order, but help keep things grouped and organized. I then added subscopes throughout, or adjusted existing subscopes, to make the code a bit easier to follow, making it more segmented. Each scope and some other areas received their own benchmark measurements.

And the end result of everything is this:

```
BENCHMARK:
	[Startup]
		- Core: 0.034283 sec.
		- Initialize Early Settings: 0.003121 sec.
		- Servers: 2.497262 sec.
		- Setup Window and Boot: 0.169309 sec.
		- Translations and Remaps: 0.000249 sec.
		- Text Server: 0.000077 sec.
		- Scene: 0.156916 sec.
		- Platforms: 0.000099 sec.
		- Finalize Setup: 0.017886 sec.
		- Setup: 2.913917 sec.
		- Project Manager: 0.737702 sec.
		- Total: 3.659916 sec.

	[Core]
		- Register Types: 0.016540 sec.
		- Register Extensions: 0.000283 sec.
		- Register Singletons: 0.000196 sec.
		- Unregister Extensions: 0.000062 sec.
		- Unregister Types: 0.031384 sec.

	[Servers]
		- Register Extensions: 0.023551 sec.
		- Modules and Extensions: 0.001781 sec.
		- Input: 0.043722 sec.
		- Display: 2.327309 sec.
		- Tablet Driver: 0.000084 sec.
		- Rendering: 0.035946 sec.
		- Audio: 0.061223 sec.
		- XR: 0.000015 sec.
		- Unregister Extensions: 0.000071 sec.

	[Scene]
		- Register Types: 0.093715 sec.
		- Register Singletons: 0.000016 sec.
		- Modules and Extensions: 0.062997 sec.
		- Unregister Types: 0.000087 sec.

	[Editor]
		- Register Types: 0.004205 sec.
		- Modules and Extensions: 0.000099 sec.
		- Unregister Types: 0.000014 sec.

	[EditorTheme]
		- Generate Icons (All): 0.228809 sec.
		- Generate Icons (Only Thumbs): 0.002707 sec.
		- Register Fonts: 0.009642 sec.
		- Create Editor Theme: 0.558997 sec.
		- Create Custom Theme: 0.000004 sec.

	[Shutdown]
		- Total: 0.137982 sec.
```


And here's an example of before and after for the editor:

<details>

```
BENCHMARK:
	- register_core_types :  0.014213  sec.
	- servers :  2.866646  sec.
	- register_editor_types :  0.003511  sec.
	- scene :  0.207836  sec.
	- editor_register_and_generate_icons_all :  0.30274  sec.
	- editor_register_and_generate_icons_with_only_thumbs :  0.003226  sec.
	- editor_register_fonts :  0.00616  sec.
	- create_editor_theme :  0.656456  sec.
	- create_custom_theme :  0.656477  sec.
	- EditorHelp::generate_doc :  1.493546  sec.
	- editor :  2.832077  sec.
	- startup_begin :  6.004947  sec.
	- editor_scan_and_import :  0.074878  sec.
	- unregister_editor_types :  0.000009  sec.
	- unregister_core_types :  0.043799  sec.
	- Main::cleanup :  0.282018  sec.
```

```
BENCHMARK:
	[Startup]
		- Core: 0.089364 sec.
		- Initialize Early Settings: 0.001495 sec.
		- Servers: 2.686693 sec.
		- Setup Window and Boot: 0.175628 sec.
		- Translations and Remaps: 0.000184 sec.
		- Text Server: 0.000043 sec.
		- Scene: 0.188522 sec.
		- Platforms: 0.000116 sec.
		- Finalize Setup: 0.028329 sec.
		- Setup: 3.174505 sec.
		- Editor: 2.998649 sec.
		- Total: 6.180127 sec.

	[Core]
		- Register Types: 0.014588 sec.
		- Register Extensions: 0.061387 sec.
		- Register Singletons: 0.000177 sec.
		- Unregister Extensions: 0.000103 sec.
		- Unregister Types: 0.051921 sec.

	[Servers]
		- Register Extensions: 0.022540 sec.
		- Modules and Extensions: 0.001457 sec.
		- Input: 0.044165 sec.
		- Display: 2.185309 sec.
		- Tablet Driver: 0.000059 sec.
		- Rendering: 0.356325 sec.
		- Audio: 0.073410 sec.
		- XR: 0.000011 sec.
		- Unregister Extensions: 0.000087 sec.

	[Scene]
		- Register Types: 0.128215 sec.
		- Register Singletons: 0.000012 sec.
		- Modules and Extensions: 0.060110 sec.
		- Unregister Types: 0.000342 sec.

	[Editor]
		- Register Types: 0.003734 sec.
		- Modules and Extensions: 0.000110 sec.
		- First Scan: 0.087209 sec.
		- Unregister Types: 0.000012 sec.

	[EditorTheme]
		- Generate Icons (All): 0.285813 sec.
		- Generate Icons (Only Thumbs): 0.004107 sec.
		- Register Fonts: 0.007346 sec.
		- Create Editor Theme: 0.637479 sec.
		- Create Custom Theme: 0.000004 sec.

	[EditorHelp]
		- Generate Documentation: 7.012339 sec.

	[Shutdown]
		- Total: 0.247288 sec.
```

</details>

-----

We support overriding OS benchmark methods in platform OS implementations, and Android so far is the only one that does. Naturally, platforms may not have support for contexts. I don't know if Android has it, so to be the least disruptive I can, I just `vformat` both strings and pass it onto the platform wrapper. Maybe it can be done better, cc @m4gr3d 