### PR TITLE
Correctly enforce minimum window size in editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6852,7 +6852,9 @@ EditorNode::EditorNode() {
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
 	if (w) {
-		w->set_min_size(Size2(1024, 600) * EDSCALE);
+		const Size2 minimum_size = Size2(1024, 600) * EDSCALE;
+		w->set_min_size(minimum_size); // Calling it this early doesn't sync the property with DS.
+		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
 	}
 
 	EditorFileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -330,6 +330,8 @@ class ProjectManager : public Control {
 
 	static ProjectManager *singleton;
 
+	void _update_size_limits();
+
 	Panel *background_panel = nullptr;
 	TabContainer *tabs = nullptr;
 	ProjectList *_project_list = nullptr;


### PR DESCRIPTION
Calling `Window`'s size methods this early doesn't sync the values with the DisplayServer because the main window doesn't have a valid ID yet. So we have to do the sync manually, otherwise the minimum size is not actually enforced.

As an extra usability improvement, and the reason why I noticed this issue, I added the upper cap on the language picker popup in the project manager. By default it just takes as much space as possible, which doesn't seem very usable to me. I made it to cap the size at half the screen resolution, but no less than the minimum window size. The result:

![image](https://github.com/godotengine/godot/assets/11782833/3c6ba68d-2eaf-49b6-8709-7204b288787a)

----

I refactored the PM's code related to this a bit and removed some bits which I think we no longer need.