### PR TITLE
Support hexagonal cells in `GridMap`

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -70,6 +70,13 @@
 				The orientation of the cell at the given grid coordinates. [code]-1[/code] is returned if the cell is empty.
 			</description>
 		</method>
+		<method name="get_cell_neighbors" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="cell" type="Vector3i" />
+			<description>
+				Returns an array of [Vector3i] map coordinates that neighbor the cell at coordinates [param cell], including unused cells.  Use [method get_cell_item] to check if the cell is used.
+			</description>
+		</method>
 		<method name="get_collision_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -115,6 +122,14 @@
 			<param index="0" name="item" type="int" />
 			<description>
 				Returns an array of all cells with the given item index specified in [param item].
+			</description>
+		</method>
+		<method name="local_region_to_map" qualifiers="const">
+			<return type="Vector3i[]" />
+			<param index="0" name="local_point_a" type="Vector3" />
+			<param index="1" name="local_point_b" type="Vector3" />
+			<description>
+				Returns an array containing map coordinates for all cells within the GridMap's local coordinate space that fall within the axis-aligned bounding box defined by points [param local_point_a] and [param local_point_b].  See also [method local_to_map].
 			</description>
 		</method>
 		<method name="local_to_map" qualifiers="const">
@@ -195,14 +210,8 @@
 		<member name="cell_center_z" type="bool" setter="set_center_z" getter="get_center_z" default="true">
 			If [code]true[/code], grid items are centered on the Z axis.
 		</member>
-		<member name="cell_layout" type="int" setter="set_cell_layout" getter="get_cell_layout" enum="GridMap.CellLayout" default="0">
-			For all half-offset shapes (Hexagonal and Half-Offset square), changes the way cells are indexed in the GridMap grid.
-		</member>
 		<member name="cell_octant_size" type="int" setter="set_octant_size" getter="get_octant_size" default="8">
 			The size of each octant measured in number of cells. This applies to all three axis.
-		</member>
-		<member name="cell_offset_axis" type="int" setter="set_cell_offset_axis" getter="get_cell_offset_axis" enum="GridMap.CellOffsetAxis" default="0">
-			For all half-offset shapes (Hexagonal and Half-Offset square), determines the offset axis.
 		</member>
 		<member name="cell_scale" type="float" setter="set_cell_scale" getter="get_cell_scale" default="1.0">
 			The scale of the cell items.
@@ -213,6 +222,7 @@
 		</member>
 		<member name="cell_size" type="Vector3" setter="set_cell_size" getter="get_cell_size" default="Vector3(2, 2, 2)">
 			The dimensions of the grid's cells.
+			When [member cell_shape] is set to Hexagon, the [code]cell_size.x[/code] value represents the radius of the cell (from center to vertex), and the [code]cell_size.y[/code] value represents the height of the cell.  The [code]cell_size.z[/code] value is ignored for hexagonal cells.
 			This does not affect the size of the meshes. See [member cell_scale].
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
@@ -233,6 +243,11 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="cell_shape_changed">
+			<param index="0" name="cell_shape" type="int" />
+			<description>
+			</description>
+		</signal>
 		<signal name="cell_size_changed">
 			<param index="0" name="cell_size" type="Vector3" />
 			<description>
@@ -254,36 +269,6 @@
 		</constant>
 		<constant name="CELL_SHAPE_MAX" value="2" enum="CellShape">
 			Count of all cell shapes. Not a valid selection.
-		</constant>
-		<constant name="CELL_LAYOUT_STACKED" value="0" enum="CellLayout">
-			Cell coordinates layout where both axes stay consistent with their respective local horizontal and vertical axis.
-		</constant>
-		<constant name="CELL_LAYOUT_STACKED_OFFSET" value="1" enum="CellLayout">
-			Same as [constant CELL_LAYOUT_STACKED], but the first half-offset is negative instead of positive.
-		</constant>
-		<constant name="CELL_LAYOUT_STAIRS_RIGHT" value="2" enum="CellLayout">
-			Cell coordinates layout where the horizontal axis stays horizontal, and the vertical goes down-right.
-		</constant>
-		<constant name="CELL_LAYOUT_STAIRS_DOWN" value="3" enum="CellLayout">
-			Cell coordinates layout where the vertical axis stays vertical, and the horizontal goes down-right.
-		</constant>
-		<constant name="CELL_LAYOUT_DIAMOND_RIGHT" value="4" enum="CellLayout">
-			Cell coordinates layout where the horizontal axis goes up-right, and the vertical  goes down-right.
-		</constant>
-		<constant name="CELL_LAYOUT_DIAMOND_DOWN" value="5" enum="CellLayout">
-			Cell coordinates layout where the horizontal axis goes down-right, and the vertical goes down-left.
-		</constant>
-		<constant name="CELL_LAYOUT_MAX" value="6" enum="CellLayout">
-			Count of all cell layouts. Not a valid selection.
-		</constant>
-		<constant name="CELL_OFFSET_AXIS_HORIZONTAL" value="0" enum="CellOffsetAxis">
-			Horizontal half-offset.
-		</constant>
-		<constant name="CELL_OFFSET_AXIS_VERTICAL" value="1" enum="CellOffsetAxis">
-			Vertical half-offset.
-		</constant>
-		<constant name="CELL_OFFSET_AXIS_MAX" value="2" enum="CellOffsetAxis">
-			Count of all cell offset axes. Not a valid selection.
 		</constant>
 		<constant name="INVALID_CELL_ITEM" value="-1">
 			Invalid cell item that can be used in [method set_cell_item] to clear cells (or represent an empty cell in [method get_cell_item]).

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -195,12 +195,21 @@
 		<member name="cell_center_z" type="bool" setter="set_center_z" getter="get_center_z" default="true">
 			If [code]true[/code], grid items are centered on the Z axis.
 		</member>
+		<member name="cell_layout" type="int" setter="set_cell_layout" getter="get_cell_layout" enum="GridMap.CellLayout" default="0">
+			For all half-offset shapes (Hexagonal and Half-Offset square), changes the way cells are indexed in the GridMap grid.
+		</member>
 		<member name="cell_octant_size" type="int" setter="set_octant_size" getter="get_octant_size" default="8">
 			The size of each octant measured in number of cells. This applies to all three axis.
+		</member>
+		<member name="cell_offset_axis" type="int" setter="set_cell_offset_axis" getter="get_cell_offset_axis" enum="GridMap.CellOffsetAxis" default="0">
+			For all half-offset shapes (Hexagonal and Half-Offset square), determines the offset axis.
 		</member>
 		<member name="cell_scale" type="float" setter="set_cell_scale" getter="get_cell_scale" default="1.0">
 			The scale of the cell items.
 			This does not affect the size of the grid cells themselves, only the items in them. This can be used to make cell items overlap their neighbors.
+		</member>
+		<member name="cell_shape" type="int" setter="set_cell_shape" getter="get_cell_shape" enum="GridMap.CellShape" default="0">
+			The shape of the grid's cells.
 		</member>
 		<member name="cell_size" type="Vector3" setter="set_cell_size" getter="get_cell_size" default="Vector3(2, 2, 2)">
 			The dimensions of the grid's cells.
@@ -237,6 +246,45 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="CELL_SHAPE_SQUARE" value="0" enum="CellShape">
+			Rectangular cell shape.
+		</constant>
+		<constant name="CELL_SHAPE_HEXAGON" value="1" enum="CellShape">
+			Hexagonal cell shape.
+		</constant>
+		<constant name="CELL_SHAPE_MAX" value="2" enum="CellShape">
+			Count of all cell shapes. Not a valid selection.
+		</constant>
+		<constant name="CELL_LAYOUT_STACKED" value="0" enum="CellLayout">
+			Cell coordinates layout where both axes stay consistent with their respective local horizontal and vertical axis.
+		</constant>
+		<constant name="CELL_LAYOUT_STACKED_OFFSET" value="1" enum="CellLayout">
+			Same as [constant CELL_LAYOUT_STACKED], but the first half-offset is negative instead of positive.
+		</constant>
+		<constant name="CELL_LAYOUT_STAIRS_RIGHT" value="2" enum="CellLayout">
+			Cell coordinates layout where the horizontal axis stays horizontal, and the vertical goes down-right.
+		</constant>
+		<constant name="CELL_LAYOUT_STAIRS_DOWN" value="3" enum="CellLayout">
+			Cell coordinates layout where the vertical axis stays vertical, and the horizontal goes down-right.
+		</constant>
+		<constant name="CELL_LAYOUT_DIAMOND_RIGHT" value="4" enum="CellLayout">
+			Cell coordinates layout where the horizontal axis goes up-right, and the vertical  goes down-right.
+		</constant>
+		<constant name="CELL_LAYOUT_DIAMOND_DOWN" value="5" enum="CellLayout">
+			Cell coordinates layout where the horizontal axis goes down-right, and the vertical goes down-left.
+		</constant>
+		<constant name="CELL_LAYOUT_MAX" value="6" enum="CellLayout">
+			Count of all cell layouts. Not a valid selection.
+		</constant>
+		<constant name="CELL_OFFSET_AXIS_HORIZONTAL" value="0" enum="CellOffsetAxis">
+			Horizontal half-offset.
+		</constant>
+		<constant name="CELL_OFFSET_AXIS_VERTICAL" value="1" enum="CellOffsetAxis">
+			Vertical half-offset.
+		</constant>
+		<constant name="CELL_OFFSET_AXIS_MAX" value="2" enum="CellOffsetAxis">
+			Count of all cell offset axes. Not a valid selection.
+		</constant>
 		<constant name="INVALID_CELL_ITEM" value="-1">
 			Invalid cell item that can be used in [method set_cell_item] to clear cells (or represent an empty cell in [method get_cell_item]).
 		</constant>

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -47,6 +47,7 @@
 #include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
 #include "scene/main/window.h"
+#include "scene/resources/3d/primitive_meshes.h"
 
 void GridMapEditor::_configure() {
 	if (!node) {
@@ -61,61 +62,136 @@ void GridMapEditor::_menu_option(int p_option) {
 		case MENU_OPTION_PREV_LEVEL: {
 			floor->set_value(floor->get_value() - 1);
 			if (selection.active && input_action == INPUT_SELECT) {
-				selection.current[edit_axis]--;
-				_validate_selection();
+				_update_selection();
 			}
 		} break;
 
 		case MENU_OPTION_NEXT_LEVEL: {
 			floor->set_value(floor->get_value() + 1);
 			if (selection.active && input_action == INPUT_SELECT) {
-				selection.current[edit_axis]++;
-				_validate_selection();
+				_update_selection();
 			}
 		} break;
 
 		case MENU_OPTION_X_AXIS:
-		case MENU_OPTION_Y_AXIS:
-		case MENU_OPTION_Z_AXIS: {
-			int new_axis = p_option - MENU_OPTION_X_AXIS;
-			for (int i = 0; i < 3; i++) {
-				int idx = options->get_popup()->get_item_index(MENU_OPTION_X_AXIS + i);
-				options->get_popup()->set_item_checked(idx, i == new_axis);
-			}
-
-			if (edit_axis != new_axis) {
-				if (edit_axis == Vector3::AXIS_Y) {
-					floor->set_tooltip_text("Change Grid Plane");
-				} else if (new_axis == Vector3::AXIS_Y) {
-					floor->set_tooltip_text("Change Grid Floor");
-				}
-			}
-			edit_axis = Vector3::Axis(new_axis);
+			edit_axis = AXIS_X;
 			update_grid();
+			break;
+		case MENU_OPTION_Y_AXIS:
+			edit_axis = AXIS_Y;
+			update_grid();
+			break;
+		case MENU_OPTION_Z_AXIS:
+			edit_axis = AXIS_Z;
+			update_grid();
+			break;
+		case MENU_OPTION_Q_AXIS: // hex cell axis, running northwest-southeast
+			edit_axis = AXIS_Q;
+			update_grid();
+			break;
+		case MENU_OPTION_R_AXIS: // hex cell axis, running east-west
+			edit_axis = AXIS_R;
+			update_grid();
+			break;
+		case MENU_OPTION_S_AXIS: // hex cell axis, running southwest-northeast
+			edit_axis = AXIS_S;
+			update_grid();
+			break;
+		// as there are more axis to edit on when working with hex cells, offer
+		// an option to rotate through the non-y axis.
+		case MENU_OPTION_ROTATE_AXIS_CW:
+			switch (edit_axis) {
+				case AXIS_R:
+					edit_axis = AXIS_Q;
+					break;
+				case AXIS_Q:
+					edit_axis = AXIS_X;
+					break;
+				case AXIS_X:
+					edit_axis = AXIS_S;
+					break;
+				default:
+					edit_axis = AXIS_R;
+					break;
+			}
+			update_grid();
+			break;
+		case MENU_OPTION_ROTATE_AXIS_CCW:
+			switch (edit_axis) {
+				case AXIS_X:
+					edit_axis = AXIS_Q;
+					break;
+				case AXIS_Q:
+					edit_axis = AXIS_R;
+					break;
+				case AXIS_R:
+					edit_axis = AXIS_S;
+					break;
+				default:
+					edit_axis = AXIS_X;
+					break;
+			}
+			update_grid();
+			break;
 
-		} break;
+		case MENU_OPTION_CURSOR_ROTATE_Y: {
+			Basis r;
+			real_t rotation = Math_PI / (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? 2.0 : 3.0);
 
-		case MENU_OPTION_CURSOR_ROTATE_X:
-		case MENU_OPTION_CURSOR_ROTATE_Y:
-		case MENU_OPTION_CURSOR_ROTATE_Z:
-		case MENU_OPTION_CURSOR_BACK_ROTATE_X:
-		case MENU_OPTION_CURSOR_BACK_ROTATE_Y:
-		case MENU_OPTION_CURSOR_BACK_ROTATE_Z: {
-			Vector3 rotation_axis;
-			float rotation_angle = -Math::PI / 2.0;
-			if (p_option == MENU_OPTION_CURSOR_ROTATE_X || p_option == MENU_OPTION_CURSOR_BACK_ROTATE_X) {
-				rotation_axis.x = (p_option == MENU_OPTION_CURSOR_ROTATE_X) ? 1 : -1;
-			} else if (p_option == MENU_OPTION_CURSOR_ROTATE_Y || p_option == MENU_OPTION_CURSOR_BACK_ROTATE_Y) {
-				rotation_axis.y = (p_option == MENU_OPTION_CURSOR_ROTATE_Y) ? 1 : -1;
-			} else if (p_option == MENU_OPTION_CURSOR_ROTATE_Z || p_option == MENU_OPTION_CURSOR_BACK_ROTATE_Z) {
-				rotation_axis.z = (p_option == MENU_OPTION_CURSOR_ROTATE_Z) ? 1 : -1;
+			if (input_action == INPUT_PASTE) {
+				r = node->get_basis_with_orthogonal_index(paste_orientation);
+				r.rotate(Vector3(0, 1, 0), -rotation);
+				paste_orientation = node->get_orthogonal_index_from_basis(r);
+				_update_paste_indicator();
+				break;
 			}
 
+			r = node->get_basis_with_orthogonal_index(cursor_rot);
+			r.rotate(Vector3(0, 1, 0), -rotation);
+			cursor_rot = node->get_orthogonal_index_from_basis(r);
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_ROTATE_X: {
 			Basis r;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+
 			if (input_action == INPUT_PASTE) {
-				r = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-				r.rotate(rotation_axis, rotation_angle);
-				paste_indicator.orientation = node->get_orthogonal_index_from_basis(r);
+				r = node->get_basis_with_orthogonal_index(paste_orientation);
+				r.rotate(Vector3(1, 0, 0), -rotation);
+				paste_orientation = node->get_orthogonal_index_from_basis(r);
+				_update_paste_indicator();
+				break;
+			}
+
+			r = node->get_basis_with_orthogonal_index(cursor_rot);
+			r.rotate(Vector3(1, 0, 0), -rotation);
+			cursor_rot = node->get_orthogonal_index_from_basis(r);
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_ROTATE_Z: {
+			Basis r;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+
+			if (input_action == INPUT_PASTE) {
+				r = node->get_basis_with_orthogonal_index(paste_orientation);
+				r.rotate(Vector3(0, 0, 1), -rotation);
+				paste_orientation = node->get_orthogonal_index_from_basis(r);
+				_update_paste_indicator();
+				break;
+			}
+
+			r.rotate(Vector3(0, 0, 1), -rotation);
+			cursor_rot = node->get_orthogonal_index_from_basis(r);
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_BACK_ROTATE_Y: {
+			Basis r;
+			real_t rotation = Math_PI / (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? 2.0 : 3.0);
+
+			if (input_action == INPUT_PASTE) {
+				r = node->get_basis_with_orthogonal_index(paste_orientation);
+				r.rotate(Vector3(0, 1, 0), rotation);
+				paste_orientation = node->get_orthogonal_index_from_basis(r);
 				_update_paste_indicator();
 			} else if (_has_selection()) {
 				Array cells = _get_selected_cells();
@@ -131,11 +207,48 @@ void GridMapEditor::_menu_option(int p_option) {
 				cursor_rot = node->get_orthogonal_index_from_basis(r);
 				_update_cursor_transform();
 			}
-		} break;
 
+			r = node->get_basis_with_orthogonal_index(cursor_rot);
+			r.rotate(Vector3(0, 1, 0), rotation);
+			cursor_rot = node->get_orthogonal_index_from_basis(r);
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_BACK_ROTATE_X: {
+			Basis r;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+
+				r = node->get_basis_with_orthogonal_index(paste_orientation);
+				r.rotate(Vector3(1, 0, 0), rotation);
+				paste_orientation = node->get_orthogonal_index_from_basis(r);
+				_update_paste_indicator();
+				break;
+			}
+
+			r = node->get_basis_with_orthogonal_index(cursor_rot);
+			r.rotate(Vector3(1, 0, 0), rotation);
+			cursor_rot = node->get_orthogonal_index_from_basis(r);
+			_update_cursor_transform();
+		} break;
+		case MENU_OPTION_CURSOR_BACK_ROTATE_Z: {
+			Basis r;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+
+			if (input_action == INPUT_PASTE) {
+				r = node->get_basis_with_orthogonal_index(paste_orientation);
+				r.rotate(Vector3(0, 0, 1), rotation);
+				paste_orientation = node->get_orthogonal_index_from_basis(r);
+				_update_paste_indicator();
+				break;
+			}
+
+			r = node->get_basis_with_orthogonal_index(cursor_rot);
+			r.rotate(Vector3(0, 0, 1), rotation);
+			cursor_rot = node->get_orthogonal_index_from_basis(r);
+			_update_cursor_transform();
+		} break;
 		case MENU_OPTION_CURSOR_CLEAR_ROTATION: {
 			if (input_action == INPUT_PASTE) {
-				paste_indicator.orientation = 0;
+				paste_orientation = 0;
 				_update_paste_indicator();
 				break;
 			}
@@ -162,12 +275,7 @@ void GridMapEditor::_menu_option(int p_option) {
 			}
 
 			input_action = INPUT_PASTE;
-			paste_indicator.click = selection.click;
-			paste_indicator.current = cursor_gridpos;
-			paste_indicator.begin = selection.begin;
-			paste_indicator.end = selection.end;
-			paste_indicator.distance_from_cursor = cursor_gridpos - paste_indicator.begin;
-			paste_indicator.orientation = 0;
+			paste_orientation = 0;
 			_update_paste_indicator();
 		} break;
 		case MENU_OPTION_SELECTION_CLEAR: {
@@ -194,7 +302,7 @@ void GridMapEditor::_menu_option(int p_option) {
 
 void GridMapEditor::_update_cursor_transform() {
 	cursor_transform = Transform3D();
-	cursor_transform.origin = node->map_to_local(cursor_cell);
+	cursor_transform.origin = node->map_to_local(pointer_cell);
 	cursor_transform.basis = node->get_basis_with_orthogonal_index(cursor_rot);
 	cursor_transform.basis *= node->get_cell_scale();
 	cursor_transform = node->get_global_transform() * cursor_transform;
@@ -224,74 +332,82 @@ void GridMapEditor::_update_cursor_transform() {
 	}
 }
 
-void GridMapEditor::_update_selection_transform() {
-	Transform3D xf_zero;
-	xf_zero.basis.set_zero();
+void GridMapEditor::_update_selection() {
+	RenderingServer *rs = RS::get_singleton();
 
-	if (!selection.active) {
-		RenderingServer::get_singleton()->instance_set_transform(selection_instance, xf_zero);
-		for (int i = 0; i < 3; i++) {
-			RenderingServer::get_singleton()->instance_set_transform(selection_level_instance[i], xf_zero);
-		}
-		return;
+	if (selection_multimesh_instance.is_valid()) {
+		rs->free(selection_multimesh_instance);
 	}
+	selection.cells.clear();
 
-	Transform3D xf;
-	xf.scale((Vector3(1, 1, 1) + (selection.end - selection.begin)) * node->get_cell_size());
-	xf.origin = selection.begin * node->get_cell_size();
-
-	RenderingServer::get_singleton()->instance_set_transform(selection_instance, node->get_global_transform() * xf);
-
-	for (int i = 0; i < 3; i++) {
-		if (i != edit_axis || (edit_floor[edit_axis] < selection.begin[edit_axis]) || (edit_floor[edit_axis] > selection.end[edit_axis] + 1)) {
-			RenderingServer::get_singleton()->instance_set_transform(selection_level_instance[i], xf_zero);
-		} else {
-			Vector3 scale = (selection.end - selection.begin + Vector3(1, 1, 1));
-			scale[edit_axis] = 1.0;
-			Vector3 position = selection.begin;
-			position[edit_axis] = edit_floor[edit_axis];
-
-			scale *= node->get_cell_size();
-			position *= node->get_cell_size();
-
-			Transform3D xf2;
-			xf2.basis.scale(scale);
-			xf2.origin = position;
-
-			RenderingServer::get_singleton()->instance_set_transform(selection_level_instance[i], node->get_global_transform() * xf2);
-		}
-	}
-}
-
-void GridMapEditor::_validate_selection() {
 	if (!selection.active) {
 		return;
 	}
-	selection.begin = selection.click;
-	selection.end = selection.current;
 
-	if (selection.begin.x > selection.end.x) {
-		SWAP(selection.begin.x, selection.end.x);
-	}
-	if (selection.begin.y > selection.end.y) {
-		SWAP(selection.begin.y, selection.end.y);
-	}
-	if (selection.begin.z > selection.end.z) {
-		SWAP(selection.begin.z, selection.end.z);
+	// Scaling and translation for the center of the cell mesh.
+	Vector3 cell_center = Vector3(
+			node->get_center_x() ? 0 : node->get_cell_size().x / 2.0,
+			node->get_center_y() ? 0 : node->get_cell_size().y / 2.0,
+			node->get_center_z() ? 0 : node->get_cell_size().z / 2.0);
+	Transform3D cell_transform = Transform3D().scaled_local(node->get_cell_size()).translated(cell_center);
+
+	// We're using `local_region_to_map()` to get a selection of cells, and that
+	// function returns cells within an axis-aligned bounding box.  The Q and S
+	// axis are not axis-aligned (they run diagonal along X/Z, so we'll need to
+	// filter the results from `local_region_map()` to make sure they all fall
+	// along a plane of the edit axis.  To do this, we'll need to use the cell
+	// index of the beginning point.
+	Vector3i begin = node->local_to_map(selection.begin);
+
+	// Get the cells using our selection begin & end points to define an axis-
+	// aligned region of cells.
+	TypedArray<Vector3i> cells = node->local_region_to_map(selection.begin, selection.end);
+
+	// Add the cells to our selection multimesh
+	rs->multimesh_allocate_data(selection_multimesh, cells.size(), RS::MULTIMESH_TRANSFORM_3D);
+	for (int i = 0; i < cells.size(); i++) {
+		Vector3i cell = cells[i];
+		switch (edit_axis) {
+			case AXIS_Q:
+				// We're using knowledge of the internal coordinate system of
+				// hex cells in the GridMap here, which makes this brittle to
+				// change,  The axial Q axis value is stored in the X field.
+				// So exclude any cell that doesn't have the same X value
+				if (cell.x != begin.x) {
+					continue;
+				}
+				break;
+			case AXIS_S:
+				// The S axis value can be calculated from the Q/R values stored
+				// in X & Z.  If the S value of the cell doesn't match that of
+				// the beginning cell, the cell doesn't fall on the same S-axis
+				// plane, so we can exclude it from the selection.
+				if (-cell.x - cell.z != -begin.x - begin.z) {
+					continue;
+				}
+				break;
+
+			default:
+				break;
+		}
+		selection.cells.append(cell);
+		rs->multimesh_instance_set_transform(selection_multimesh, i,
+				cell_transform.translated(node->map_to_local(cell)));
 	}
 
-	_update_selection_transform();
+	// create an instance of the multimesh with the transform of our node
+	selection_multimesh_instance = rs->instance_create2(selection_multimesh, get_tree()->get_root()->get_world_3d()->get_scenario());
+	rs->instance_set_transform(selection_multimesh_instance, node->get_global_transform());
+	rs->instance_set_layer_mask(selection_multimesh_instance, Node3DEditorViewport::MISC_TOOL_LAYER);
 }
 
 void GridMapEditor::_set_selection(bool p_active, const Vector3 &p_begin, const Vector3 &p_end) {
 	selection.active = p_active;
 	selection.begin = p_begin;
 	selection.end = p_end;
-	selection.click = p_begin;
-	selection.current = p_end;
 
 	if (is_visible_in_tree()) {
-		_update_selection_transform();
+		_update_selection();
 	}
 }
 
@@ -355,12 +471,8 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 	from = local_xform.xform(from);
 	normal = local_xform.basis.xform(normal).normalized();
 
-	Plane p;
-	p.normal[edit_axis] = 1.0;
-	p.d = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
-
-	Vector3 inters;
-	if (!p.intersects_segment(from, from + normal * settings_pick_distance->get_value(), &inters)) {
+	Vector3 edit_plane_point;
+	if (!edit_plane.intersects_segment(from, from + normal * settings_pick_distance->get_value(), &edit_plane_point)) {
 		return false;
 	}
 
@@ -368,19 +480,14 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 	// Painting on invisible regions.
 	for (int i = 0; i < planes.size(); i++) {
 		Plane fp = local_xform.xform(planes[i]);
-		if (fp.is_point_over(inters)) {
+		if (fp.is_point_over(edit_plane_point)) {
 			return false;
 		}
 	}
 
-	Vector3 cell = node->local_to_map(inters);
-	cell[edit_axis] = edit_floor[edit_axis];
-	Vector3 cell_size = node->get_cell_size();
-
-	RS::get_singleton()->instance_set_transform(grid_instance[edit_axis], node->get_global_transform() * edit_grid_xform);
+	pointer_cell = node->local_to_map(edit_plane_point);
 
 	if (cursor_instance.is_valid()) {
-		cursor_cell = cell;
 		cursor_visible = true;
 
 		if (input_action == INPUT_PASTE) {
@@ -395,20 +502,19 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 	}
 
 	if (input_action == INPUT_PASTE) {
-		paste_indicator.current = cursor_gridpos;
 		_update_paste_indicator();
 
 	} else if (input_action == INPUT_SELECT) {
-		selection.current = cursor_gridpos;
 		if (p_click) {
-			selection.click = selection.current;
+			selection.begin = edit_plane_point;
 		}
+		selection.end = edit_plane_point;
 		selection.active = true;
-		_validate_selection();
+		_update_selection();
 
 		return true;
 	} else if (input_action == INPUT_PICK) {
-		int item = node->get_cell_item(cursor_gridpos);
+		int item = node->get_cell_item(pointer_cell);
 		if (item >= 0) {
 			selected_palette = item;
 
@@ -428,23 +534,23 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 
 	if (input_action == INPUT_PAINT) {
 		SetItem si;
-		si.position = cursor_gridpos;
+		si.position = pointer_cell;
 		si.new_value = selected_palette;
 		si.new_orientation = cursor_rot;
-		si.old_value = node->get_cell_item(cursor_gridpos);
-		si.old_orientation = node->get_cell_item_orientation(cursor_gridpos);
+		si.old_value = node->get_cell_item(pointer_cell);
+		si.old_orientation = node->get_cell_item_orientation(pointer_cell);
 		set_items.push_back(si);
-		node->set_cell_item(cursor_gridpos, selected_palette, cursor_rot);
+		node->set_cell_item(pointer_cell, selected_palette, cursor_rot);
 		return true;
 	} else if (input_action == INPUT_ERASE) {
 		SetItem si;
-		si.position = cursor_gridpos;
+		si.position = Vector3i(pointer_cell[0], pointer_cell[1], pointer_cell[2]);
 		si.new_value = -1;
 		si.new_orientation = 0;
-		si.old_value = node->get_cell_item(cursor_gridpos);
-		si.old_orientation = node->get_cell_item_orientation(cursor_gridpos);
+		si.old_value = node->get_cell_item(pointer_cell);
+		si.old_orientation = node->get_cell_item_orientation(pointer_cell);
 		set_items.push_back(si);
-		node->set_cell_item(cursor_gridpos, -1);
+		node->set_cell_item(pointer_cell, -1);
 		return true;
 	}
 
@@ -458,15 +564,12 @@ void GridMapEditor::_delete_selection() {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("GridMap Delete Selection"));
-	for (int i = selection.begin.x; i <= selection.end.x; i++) {
-		for (int j = selection.begin.y; j <= selection.end.y; j++) {
-			for (int k = selection.begin.z; k <= selection.end.z; k++) {
-				Vector3i selected = Vector3i(i, j, k);
-				undo_redo->add_do_method(node, "set_cell_item", selected, GridMap::INVALID_CELL_ITEM);
-				undo_redo->add_undo_method(node, "set_cell_item", selected, node->get_cell_item(selected), node->get_cell_item_orientation(selected));
-			}
-		}
+
+	for (const Vector3i cell : selection.cells) {
+		undo_redo->add_do_method(node, "set_cell_item", cell, GridMap::INVALID_CELL_ITEM);
+		undo_redo->add_undo_method(node, "set_cell_item", cell, node->get_cell_item(cell), node->get_cell_item_orientation(cell));
 	}
+
 	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
 	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
 	undo_redo->commit_action();
@@ -479,15 +582,12 @@ void GridMapEditor::_fill_selection() {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("GridMap Fill Selection"));
-	for (int i = selection.begin.x; i <= selection.end.x; i++) {
-		for (int j = selection.begin.y; j <= selection.end.y; j++) {
-			for (int k = selection.begin.z; k <= selection.end.z; k++) {
-				Vector3i selected = Vector3i(i, j, k);
-				undo_redo->add_do_method(node, "set_cell_item", selected, selected_palette, cursor_rot);
-				undo_redo->add_undo_method(node, "set_cell_item", selected, node->get_cell_item(selected), node->get_cell_item_orientation(selected));
-			}
-		}
+
+	for (const Vector3i cell : selection.cells) {
+		undo_redo->add_do_method(node, "set_cell_item", cell, selected_palette, cursor_rot);
+		undo_redo->add_undo_method(node, "set_cell_item", cell, node->get_cell_item(cell), node->get_cell_item_orientation(cell));
 	}
+
 	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
 	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
 	undo_redo->commit_action();
@@ -508,109 +608,93 @@ void GridMapEditor::_set_clipboard_data() {
 	_clear_clipboard_data();
 
 	Ref<MeshLibrary> meshLibrary = node->get_mesh_library();
+	RID root = get_tree()->get_root()->get_world_3d()->get_scenario();
 
-	const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
+	// We're going to duplicate the meshes for the selected region as a chunk
+	// that is centered on the mouse cursor.  To do this, we need to calculate
+	// the center point of the selection region and use the distance from the
+	// origin to the center point to offset our mesh instances.  This
+	// simplifies the math later in `_update_paste_indicator()`.
+	Vector3 begin = node->map_to_local(node->local_to_map(selection.begin));
+	Vector3 end = node->map_to_local(node->local_to_map(selection.end));
+	Vector3 selection_center = (end + begin) / 2.0;
+	Vector3 offset = node->map_to_local(node->local_to_map(selection_center));
 
-	for (int i = selection.begin.x; i <= selection.end.x; i++) {
-		for (int j = selection.begin.y; j <= selection.end.y; j++) {
-			for (int k = selection.begin.z; k <= selection.end.z; k++) {
-				Vector3i selected = Vector3i(i, j, k);
-				int itm = node->get_cell_item(selected);
-				if (itm == GridMap::INVALID_CELL_ITEM) {
-					continue;
-				}
-
-				Ref<Mesh> mesh = meshLibrary->get_item_mesh(itm);
-
-				ClipboardItem item;
-				item.cell_item = itm;
-				item.grid_offset = Vector3(selected) - selection.begin;
-				item.orientation = node->get_cell_item_orientation(selected);
-
-				if (mesh.is_valid()) {
-					item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);
-				}
-
-				clipboard_items.push_back(item);
-			}
+	for (const Vector3i cell : selection.cells) {
+		int cell_item = node->get_cell_item(cell);
+		if (cell_item == GridMap::INVALID_CELL_ITEM) {
+			continue;
 		}
+
+		// create a new mesh instance of the cell that we can move around in
+		// `_update_paste_indicator()`
+		RID mesh = meshLibrary->get_item_mesh(cell_item)->get_rid();
+		RID mesh_instance = RS::get_singleton()->instance_create2(mesh, root);
+
+		ClipboardItem item;
+		item.cell_item = cell_item;
+		item.orientation = node->get_cell_item_orientation(cell);
+		// update the position of the item to center it around the origin
+		item.position = node->map_to_local(cell) - offset;
+		item.instance = mesh_instance;
+		clipboard_items.push_back(item);
 	}
 }
 
 void GridMapEditor::_update_paste_indicator() {
-	if (input_action != INPUT_PASTE) {
-		Transform3D xf;
-		xf.basis.set_zero();
-		RenderingServer::get_singleton()->instance_set_transform(paste_instance, xf);
-		return;
-	}
+	ERR_FAIL_COND_MSG(input_action != INPUT_PASTE, "updating paste while not pasting");
 
-	Vector3 center = 0.5 * Vector3(real_t(node->get_center_x()), real_t(node->get_center_y()), real_t(node->get_center_z()));
-	Vector3 scale = (Vector3(1, 1, 1) + (paste_indicator.end - paste_indicator.begin)) * node->get_cell_size();
-	Transform3D xf;
-	xf.scale(scale);
-	xf.origin = (paste_indicator.current - paste_indicator.distance_from_cursor + center) * node->get_cell_size();
-	Basis rot;
-	rot = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
-	xf.basis = rot * xf.basis;
-	xf.translate_local((-center * node->get_cell_size()) / scale);
-
-	RenderingServer::get_singleton()->instance_set_transform(paste_instance, node->get_global_transform() * xf);
+	Vector3 cursor = node->map_to_local(pointer_cell);
+	Basis paste_rotation = node->get_basis_with_orthogonal_index(paste_orientation);
 
 	for (const ClipboardItem &item : clipboard_items) {
-		if (item.instance.is_null()) {
-			continue;
-		}
-		xf = Transform3D();
-		xf.origin = (paste_indicator.current - paste_indicator.distance_from_cursor + center) * node->get_cell_size();
-		xf.basis = rot * xf.basis;
-		xf.translate_local(item.grid_offset * node->get_cell_size());
+		// move the item to the cursor, then apply paste rotation, then
+		// translate by the item's cell offset.
+		Transform3D transform;
+		transform.origin = cursor;
+		transform.basis = paste_rotation * transform.basis;
+		transform.translate_local(item.position);
 
-		Basis item_rot;
-		item_rot = node->get_basis_with_orthogonal_index(item.orientation);
-		xf.basis = item_rot * xf.basis * node->get_cell_scale();
+		// apply the tile orintation rotation and the paste rotation
+		transform.basis = node->get_basis_with_orthogonal_index(item.orientation) * transform.basis;
 
-		RenderingServer::get_singleton()->instance_set_transform(item.instance, node->get_global_transform() * xf);
+		RS::get_singleton()->instance_set_transform(item.instance, transform);
 	}
 }
 
 void GridMapEditor::_do_paste() {
-	int idx = options->get_popup()->get_item_index(MENU_OPTION_PASTE_SELECTS);
-	bool reselect = options->get_popup()->is_item_checked(idx);
-
-	Basis rot;
-	rot = node->get_basis_with_orthogonal_index(paste_indicator.orientation);
+	Vector3 cursor = node->map_to_local(pointer_cell);
+	Basis paste_rotation = node->get_basis_with_orthogonal_index(paste_orientation);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("GridMap Paste Selection"));
 
+	// track the bounds of the paste region in case we need to select it below
+	AABB bounds;
+	bounds.set_position(cursor);
+
 	for (const ClipboardItem &item : clipboard_items) {
-		Vector3 position = rot.xform(item.grid_offset) + paste_indicator.current - paste_indicator.distance_from_cursor;
+		// apply paste rotation & convert it to a cell index
+		Vector3 position = paste_rotation.xform(item.position) + cursor;
+		Vector3i cell = node->local_to_map(position);
+		bounds.expand_to(position);
 
-		Basis orm;
-		orm = node->get_basis_with_orthogonal_index(item.orientation);
-		orm = rot * orm;
+		// apply paste rotation to existing cell rotation to get cell orientation
+		Basis cell_rotation = paste_rotation *
+				node->get_basis_with_orthogonal_index(item.orientation);
+		int cell_orientation = node->get_orthogonal_index_from_basis(cell_rotation);
 
-		undo_redo->add_do_method(node, "set_cell_item", position, item.cell_item, node->get_orthogonal_index_from_basis(orm));
-		undo_redo->add_undo_method(node, "set_cell_item", position, node->get_cell_item(position), node->get_cell_item_orientation(position));
+		undo_redo->add_do_method(node, "set_cell_item", cell, item.cell_item, cell_orientation);
+		undo_redo->add_undo_method(node, "set_cell_item", cell, node->get_cell_item(cell), node->get_cell_item_orientation(cell));
 	}
 
-	if (reselect) {
-		// We need to rotate the paste_indicator to find the selection begin and end:
-		Vector3 temp_end = rot.xform(paste_indicator.end - paste_indicator.begin) + paste_indicator.current - paste_indicator.distance_from_cursor;
-		Vector3 temp_begin = paste_indicator.current - paste_indicator.distance_from_cursor;
-		// _set_selection expects that selection_begin is the corner closer to the origin:
-		for (int i = 0; i < 3; ++i) {
-			if (temp_begin[i] > temp_end[i]) {
-				float p = temp_begin[i];
-				temp_begin[i] = temp_end[i];
-				temp_end[i] = p;
-			}
-		}
-		undo_redo->add_do_method(this, "_set_selection", true, temp_begin, temp_end);
+	// if "Paste Selects" option is checked, select the new cells
+	int option_index = options->get_popup()->get_item_index(MENU_OPTION_PASTE_SELECTS);
+	if (options->get_popup()->is_item_checked(option_index)) {
+		Vector3 begin = bounds.position, end = bounds.get_end();
+		undo_redo->add_do_method(this, "_set_selection", true, begin, end);
 		undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
 	}
-
 	undo_redo->commit_action();
 
 	_clear_clipboard_data();
@@ -727,7 +811,7 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 				if (input_action == INPUT_PASTE) {
 					_do_paste();
 					input_action = INPUT_NONE;
-					_update_paste_indicator();
+					_clear_clipboard_data();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (mode_buttons_group->get_pressed_button() == select_mode_button && can_edit) {
 					input_action = INPUT_SELECT;
@@ -743,9 +827,8 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 				}
 			} else if (mb->get_button_index() == MouseButton::RIGHT) {
 				if (input_action == INPUT_PASTE) {
-					_clear_clipboard_data();
 					input_action = INPUT_NONE;
-					_update_paste_indicator();
+					_clear_clipboard_data();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (selection.active) {
 					_set_selection(false);
@@ -806,13 +889,45 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
-		// Update the grid, to check if the grid needs to be moved to a tile cursor.
-		update_grid();
-
 		if (do_input_action(p_camera, mm->get_position(), false)) {
 			return EditorPlugin::AFTER_GUI_INPUT_STOP;
 		}
 		return EditorPlugin::AFTER_GUI_INPUT_PASS;
+	}
+
+	Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid()) {
+		if (k->is_pressed()) {
+			if (k->get_keycode() == Key::ESCAPE) {
+				if (input_action == INPUT_PASTE) {
+					input_action = INPUT_NONE;
+					_clear_clipboard_data();
+					return EditorPlugin::AFTER_GUI_INPUT_STOP;
+				} else if (selection.active) {
+					_set_selection(false);
+					return EditorPlugin::AFTER_GUI_INPUT_STOP;
+				} else {
+					selected_palette = -1;
+					mesh_library_palette->deselect_all();
+					update_palette();
+					_update_cursor_instance();
+					return EditorPlugin::AFTER_GUI_INPUT_STOP;
+				}
+			}
+
+			// Consume input to avoid conflicts with other plugins.
+			if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+				for (int i = 0; i < options->get_popup()->get_item_count(); ++i) {
+					const Ref<Shortcut> &shortcut = options->get_popup()->get_item_shortcut(i);
+					if (shortcut.is_valid() && shortcut->matches_event(p_event)) {
+						accept_event();
+						_menu_option(options->get_popup()->get_item_id(i));
+						return EditorPlugin::AFTER_GUI_INPUT_STOP;
+					}
+				}
+			}
+		}
 	}
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
@@ -1001,6 +1116,7 @@ void GridMapEditor::_update_mesh_library() {
 void GridMapEditor::edit(GridMap *p_gridmap) {
 	if (node) {
 		node->disconnect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids));
+		node->disconnect(SNAME("cell_shape_changed"), callable_mp(this, &GridMapEditor::_update_cell_shape));
 		node->disconnect(CoreStringName(changed), callable_mp(this, &GridMapEditor::_update_mesh_library));
 		if (mesh_library.is_valid()) {
 			mesh_library->disconnect_changed(callable_mp(this, &GridMapEditor::update_palette));
@@ -1012,8 +1128,10 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 
 	input_action = INPUT_NONE;
 	selection.active = false;
-	_update_selection_transform();
-	_update_paste_indicator();
+	_build_selection_meshes();
+	_update_selection();
+	_clear_clipboard_data();
+	_update_options_menu();
 
 	spatial_editor = Object::cast_to<Node3DEditorPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_selected_plugin());
 
@@ -1035,134 +1153,385 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 
 	set_process(true);
 
+	// load any previous floor values
+	TypedArray<int> floors = node->get_meta("_editor_floor_", TypedArray<int>());
+	for (int i = 0; i < MIN(floors.size(), AXIS_MAX); i++) {
+		edit_floor[i] = floors[i];
+	}
 	_draw_grids(node->get_cell_size());
 	update_grid();
 
 	node->connect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids));
+	node->connect(SNAME("cell_shape_changed"), callable_mp(this, &GridMapEditor::_update_cell_shape));
 	node->connect(CoreStringName(changed), callable_mp(this, &GridMapEditor::_update_mesh_library));
 	_update_mesh_library();
 }
 
+// update the grid mesh displayed in the editor
 void GridMapEditor::update_grid() {
-	grid_xform.origin.x -= 1; // Force update in hackish way.
+	RenderingServer *rs = RS::get_singleton();
+	Vector3 cell_size = node->get_cell_size();
+	bool is_hex = node->get_cell_shape() == GridMap::CELL_SHAPE_HEXAGON;
 
-	grid_ofs[edit_axis] = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
+	// Hex planes Q, R, and S need to offset the grid by half a cell on even
+	// numbered floors.  We calculate this value here to simplify the code
+	// later.
+	int is_even_floor = (edit_floor[edit_axis] & 1) == 0;
 
-	// If there's a valid tile cursor, offset the grid, otherwise move it back to the node.
-	edit_grid_xform.origin = cursor_instance.is_valid() ? grid_ofs : Vector3();
-	edit_grid_xform.basis = Basis();
-
-	for (int i = 0; i < 3; i++) {
-		RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], i == edit_axis);
+	// hide the active grid
+	if (active_grid_instance.is_valid()) {
+		rs->instance_set_visible(active_grid_instance, false);
+		active_grid_instance = RID();
 	}
 
-	updating = true;
-	floor->set_value(edit_floor[edit_axis]);
-	updating = false;
-}
+	real_t cell_depth;
+	Transform3D grid_transform;
+	Menu menu_axis;
 
-void GridMapEditor::_draw_floor_grid(RID p_mesh_id, int p_floor) {
-	Vector<Vector2> shape_points;
-	if (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE) {
-		shape_points.append(Vector2(-0.5, -0.5));
-		shape_points.append(Vector2(0.5, -0.5));
-		shape_points.append(Vector2(0.5, 0.5));
-		shape_points.append(Vector2(-0.5, 0.5));
-	} else {
-		float overlap = 0.25;
-		shape_points.append(Vector2(0.0, -0.5));
-		shape_points.append(Vector2(-0.5, overlap - 0.5));
-		shape_points.append(Vector2(-0.5, 0.5 - overlap));
-		shape_points.append(Vector2(0.0, 0.5));
-		shape_points.append(Vector2(0.5, 0.5 - overlap));
-		shape_points.append(Vector2(0.5, overlap - 0.5));
-
-		if (node->get_cell_offset_axis() == GridMap::CELL_OFFSET_AXIS_VERTICAL) {
-			for (int i = 0; i < shape_points.size(); i++) {
-				shape_points.write[i] = Vector2(shape_points[i].y, shape_points[i].x);
+	// switch the edit plane and pick the new active grid and rotate if necessary
+	switch (edit_axis) {
+		case AXIS_X:
+			// set which grid to display
+			active_grid_instance = grid_instance[0];
+			// set the edit plane normal, and cell depth (used by the plane)
+			edit_plane.normal = Vector3(1, 0, 0);
+			cell_depth = is_hex ? (SQRT3_2 * cell_size.x) : cell_size.x;
+			// shift the edit grid based on which floor we are on
+			if (is_hex && !is_even_floor) {
+				grid_transform.translate_local(Vector3(0, 0, 1.5 * cell_size.x));
 			}
+			// update the menu
+			menu_axis = MENU_OPTION_X_AXIS;
+			break;
+		case AXIS_Y:
+			active_grid_instance = grid_instance[1];
+			edit_plane.normal = Vector3(0, 1, 0);
+			cell_depth = cell_size.y;
+			menu_axis = MENU_OPTION_Y_AXIS;
+			break;
+		case AXIS_Z:
+			active_grid_instance = grid_instance[2];
+			edit_plane.normal = Vector3(0, 0, 1);
+			cell_depth = cell_size.z;
+			menu_axis = MENU_OPTION_Z_AXIS;
+			break;
+		case AXIS_Q: // hex plane, northwest to southeast
+			active_grid_instance = grid_instance[2];
+			edit_plane.normal = Vector3(SQRT3_2, 0, -0.5).normalized();
+			cell_depth = 1.5 * cell_size.x;
+			grid_transform.rotate(Vector3(0, 1, 0), -Math_PI / 3.0);
+			// offset the edit grid on even numbered floors by half a cell
+			grid_transform.translate_local(Vector3(is_even_floor * SQRT3_2 * cell_size.x, 0, 0));
+			menu_axis = MENU_OPTION_Q_AXIS;
+			break;
+		case AXIS_R: // hex plane, east to west; same as AXIS_Z, but for hex
+			active_grid_instance = grid_instance[2];
+			edit_plane.normal = Vector3(0, 0, 1);
+			cell_depth = 1.5 * cell_size.x;
+			grid_transform.translate_local(Vector3(is_even_floor * SQRT3_2 * cell_size.x, 0, 0));
+			menu_axis = MENU_OPTION_R_AXIS;
+			break;
+		case AXIS_S: // hex plane, southwest to northeast
+			active_grid_instance = grid_instance[2];
+			edit_plane.normal = Vector3(SQRT3_2, 0, 0.5).normalized();
+			cell_depth = 1.5 * cell_size.x;
+			grid_transform.rotate(Vector3(0, 1, 0), Math_PI / 3.0);
+			grid_transform.translate_local(Vector3(is_even_floor * SQRT3_2 * cell_size.x, 0, 0));
+			menu_axis = MENU_OPTION_S_AXIS;
+			break;
+		default:
+			ERR_PRINT_ED("unsupported edit plane axis");
+			return;
+	}
+	ERR_FAIL_COND_MSG(!active_grid_instance.is_valid(), "no active grid mesh instance");
+
+	// update the depth of the edit plane so it matches the floor, and update
+	// the grid transform for the depth.
+	edit_plane.d = edit_floor[edit_axis] * cell_depth;
+	grid_transform.origin += edit_plane.normal * edit_plane.d;
+
+	// shift the edit plane a little into the cell to prevent floating point
+	// errors from causing the raycast to fall into the lower cell.  Note we
+	// only need to do this when the grid is drawn along the edge of a cell,
+	// so the Y & X axis, or any square shape cell.  Hex cells draw the grid
+	// through the middle of the cells for Q/R/S.
+	if (edit_axis == AXIS_Y || edit_axis == AXIS_X || !is_hex) {
+		edit_plane.d += cell_depth * 0.1;
+	}
+
+	// make the editing grid visible
+	RenderingServer::get_singleton()
+			->instance_set_visible(active_grid_instance, true);
+	RenderingServer::get_singleton()->instance_set_transform(active_grid_instance,
+			node->get_global_transform() * grid_transform);
+
+	// update the UI floor indicator
+	floor->set_value(edit_floor[edit_axis]);
+
+	// update the option menu to show the correct axis is selected
+	PopupMenu *popup = options->get_popup();
+	for (int i = MENU_OPTION_X_AXIS; i <= MENU_OPTION_S_AXIS; i++) {
+		int index = popup->get_item_index(i);
+		if (index != -1) {
+			popup->set_item_checked(index, menu_axis == i);
 		}
 	}
+}
 
-	Vector3 cell_size = node->get_cell_size();
+// create a mesh and draw a grid of hexagonal cells on it
+void GridMapEditor::_draw_hex_grid(RID p_mesh_id, const Vector3 &p_cell_size) {
+	// create the points that make up the top of a hex cell
+	Vector<Vector3> shape_points;
+	shape_points.append(Vector3(0.0, 0, -1.0) * p_cell_size);
+	shape_points.append(Vector3(-SQRT3_2, 0, -0.5) * p_cell_size);
+	shape_points.append(Vector3(-SQRT3_2, 0, 0.5) * p_cell_size);
+	shape_points.append(Vector3(0.0, 0, 1.0) * p_cell_size);
+	shape_points.append(Vector3(SQRT3_2, 0, 0.5) * p_cell_size);
+	shape_points.append(Vector3(SQRT3_2, 0, -0.5) * p_cell_size);
 
 	Vector<Vector3> grid_points;
-	Vector<Color> grid_colors;
+	TypedArray<Vector3i> cells = node->local_region_to_map(
+			Vector3i(-GRID_CURSOR_SIZE * Math_SQRT3 * p_cell_size.x,
+					0,
+					-GRID_CURSOR_SIZE * 1.625 * p_cell_size.x),
+			Vector3i(GRID_CURSOR_SIZE * Math_SQRT3 * p_cell_size.x,
+					0,
+					GRID_CURSOR_SIZE * 1.625 * p_cell_size.x));
+	for (const Vector3i cell : cells) {
+		Vector3 center = node->map_to_local(cell);
 
-	for (int x = -GRID_CURSOR_SIZE; x <= GRID_CURSOR_SIZE; x++) {
-		for (int z = -GRID_CURSOR_SIZE; z <= GRID_CURSOR_SIZE; z++) {
-			Vector3 center = node->map_to_local(Vector3(x, p_floor, z));
-
-			for (int i = 1; i < shape_points.size(); i++) {
-				grid_points.append(center + Vector3(shape_points[i - 1].x * cell_size.x, 0, shape_points[i - 1].y * cell_size.z));
-				grid_points.append(center + Vector3(shape_points[i].x * cell_size.x, 0, shape_points[i].y * cell_size.z));
-
-				float a1 = Math::pow(MAX(0, 1.0 - (Vector2(x + 1, z).length() / GRID_CURSOR_SIZE)), 2);
-				float a2 = Math::pow(MAX(0, 1.0 - (Vector2(x, z + 1).length() / GRID_CURSOR_SIZE)), 2);
-				grid_colors.append(Color(1, 1, 1, a1));
-				grid_colors.append(Color(1, 1, 1, a2));
-			}
+		for (int j = 1; j < shape_points.size(); j++) {
+			grid_points.append(center + shape_points[j - 1]);
+			grid_points.append(center + shape_points[j]);
 		}
 	}
 
 	Array d;
 	d.resize(RS::ARRAY_MAX);
 	d[RS::ARRAY_VERTEX] = grid_points;
-	d[RS::ARRAY_COLOR] = grid_colors;
 	RenderingServer::get_singleton()->mesh_add_surface_from_arrays(p_mesh_id, RenderingServer::PRIMITIVE_LINES, d);
 	RenderingServer::get_singleton()->mesh_surface_set_material(p_mesh_id, 0, indicator_mat->get_rid());
 }
 
-void GridMapEditor::_draw_plane_grid(RID p_mesh_id, const Vector3 &p_axis_n1, const Vector3 &p_axis_n2) {
+// create a mesh and draw a grid for R-Axis cells
+void GridMapEditor::_draw_hex_r_axis_grid(RID p_mesh_id, const Vector3 &p_cell_size) {
 	Vector<Vector3> grid_points;
-	Vector<Color> grid_colors;
 
-	Vector3 cell_size = node->get_cell_size();
+	// draw horizontal lines
+	for (int y_index = -GRID_CURSOR_SIZE; y_index <= GRID_CURSOR_SIZE; y_index++) {
+		real_t y = y_index * p_cell_size.y;
+		grid_points.append(Vector3(0, y, -GRID_CURSOR_SIZE * 1.625 * p_cell_size.x));
+		grid_points.append(Vector3(0, y, GRID_CURSOR_SIZE * 1.625 * p_cell_size.x));
+	}
+
+	// for vertical lines, we'll need to know where the center of the cell is
+	// for a line along the Z axis.
+	TypedArray<Vector3i> cells = node->local_region_to_map(
+			Vector3(0, 0.001, -GRID_CURSOR_SIZE * 1.625 * p_cell_size.x),
+			Vector3(0, 0.002, GRID_CURSOR_SIZE * 1.625 * p_cell_size.x));
+
+	// use the cell list to draw the vertical lines
+	for (const Vector3i cell : cells) {
+		// grab the z coordinate for the center of the cell
+		real_t z = node->map_to_local(cell).z;
+
+		// Adjust from the center of the cell to where the line should fall.
+		// We're drawing lines at 1 radius, then 2 radius apart, alternating.
+		if ((cell.z & 1) == 0) {
+			z += p_cell_size.x;
+		} else {
+			z += p_cell_size.x / 2;
+		}
+
+		grid_points.append(Vector3(0, -GRID_CURSOR_SIZE * p_cell_size.y, z));
+		grid_points.append(Vector3(0, GRID_CURSOR_SIZE * p_cell_size.y, z));
+	}
+
+	Array d;
+	d.resize(RS::ARRAY_MAX);
+	d[RS::ARRAY_VERTEX] = grid_points;
+	RenderingServer::get_singleton()->mesh_add_surface_from_arrays(p_mesh_id, RenderingServer::PRIMITIVE_LINES, d);
+	RenderingServer::get_singleton()->mesh_surface_set_material(p_mesh_id, 0, indicator_mat->get_rid());
+}
+
+void GridMapEditor::_draw_plane_grid(
+		RID p_mesh_id,
+		const Vector3 &p_axis_n1,
+		const Vector3 &p_axis_n2,
+		const Vector3 &cell_size) {
+	Vector<Vector3> grid_points;
+
 	Vector3 axis_n1 = p_axis_n1 * cell_size;
 	Vector3 axis_n2 = p_axis_n2 * cell_size;
 
 	for (int j = -GRID_CURSOR_SIZE; j <= GRID_CURSOR_SIZE; j++) {
 		for (int k = -GRID_CURSOR_SIZE; k <= GRID_CURSOR_SIZE; k++) {
 			Vector3 p = axis_n1 * j + axis_n2 * k;
-			float trans = Math::pow(MAX(0, 1.0 - (Vector2(j, k).length() / GRID_CURSOR_SIZE)), 2);
 
 			Vector3 pj = axis_n1 * (j + 1) + axis_n2 * k;
-			float transj = Math::pow(MAX(0, 1.0 - (Vector2(j + 1, k).length() / GRID_CURSOR_SIZE)), 2);
 
 			Vector3 pk = axis_n1 * j + axis_n2 * (k + 1);
-			float transk = Math::pow(MAX(0, 1.0 - (Vector2(j, k + 1).length() / GRID_CURSOR_SIZE)), 2);
 
 			grid_points.push_back(p);
 			grid_points.push_back(pk);
-			grid_colors.push_back(Color(1, 1, 1, trans));
-			grid_colors.push_back(Color(1, 1, 1, transk));
 
 			grid_points.push_back(p);
 			grid_points.push_back(pj);
-			grid_colors.push_back(Color(1, 1, 1, trans));
-			grid_colors.push_back(Color(1, 1, 1, transj));
 		}
 	}
 
 	Array d;
 	d.resize(RS::ARRAY_MAX);
 	d[RS::ARRAY_VERTEX] = grid_points;
-	d[RS::ARRAY_COLOR] = grid_colors;
 	RenderingServer::get_singleton()->mesh_add_surface_from_arrays(p_mesh_id, RenderingServer::PRIMITIVE_LINES, d);
 	RenderingServer::get_singleton()->mesh_surface_set_material(p_mesh_id, 0, indicator_mat->get_rid());
 }
 
 void GridMapEditor::_draw_grids(const Vector3 &p_cell_size) {
-	Vector3 edited_floor = node->get_meta("_editor_floor_", Vector3());
-
 	for (int i = 0; i < 3; i++) {
-		RS::get_singleton()->mesh_clear(grid[i]);
-		edit_floor[i] = edited_floor[i];
+		RS::get_singleton()->mesh_clear(grid_mesh[i]);
 	}
 
-	_draw_plane_grid(grid[0], Vector3(0, 1, 0), Vector3(0, 0, 1));
-	_draw_floor_grid(grid[1], edit_floor[1]);
-	_draw_plane_grid(grid[2], Vector3(1, 0, 0), Vector3(0, 1, 0));
+	switch (node->get_cell_shape()) {
+		case GridMap::CELL_SHAPE_SQUARE:
+			_draw_plane_grid(grid_mesh[0], Vector3(0, 1, 0), Vector3(0, 0, 1), p_cell_size);
+			_draw_plane_grid(grid_mesh[1], Vector3(1, 0, 0), Vector3(0, 0, 1), p_cell_size);
+			_draw_plane_grid(grid_mesh[2], Vector3(1, 0, 0), Vector3(0, 1, 0), p_cell_size);
+			break;
+		case GridMap::CELL_SHAPE_HEXAGON: {
+			real_t radius = p_cell_size.x;
+			Vector3 cell_size = Vector3(Math_SQRT3 * radius, p_cell_size.y, Math_SQRT3 * radius);
+			_draw_hex_r_axis_grid(grid_mesh[0], p_cell_size);
+			_draw_hex_grid(grid_mesh[1], p_cell_size);
+			_draw_plane_grid(grid_mesh[2], Vector3(1, 0, 0), Vector3(0, 1, 0), cell_size);
+			break;
+		}
+		default:
+			ERR_PRINT_ED("unsupported cell shape");
+			return;
+	}
+}
+
+void GridMapEditor::_update_cell_shape(const GridMap::CellShape cell_shape) {
+	_draw_grids(node->get_cell_size());
+	_build_selection_meshes();
+	edit_axis = AXIS_Y;
+	_update_options_menu();
+	selection.active = false;
+	_update_selection();
+}
+
+void GridMapEditor::_build_selection_meshes() {
+	if (selection_tile_mesh.is_valid()) {
+		RS::get_singleton()->free(selection_tile_mesh);
+		selection_tile_mesh = RID();
+	}
+	if (selection_multimesh.is_valid()) {
+		RS::get_singleton()->free(selection_multimesh);
+		selection_multimesh = RID();
+	}
+
+	// we can get called when node is null
+	if (node == NULL) {
+		return;
+	}
+
+	Array mesh_array;
+	mesh_array.resize(RS::ARRAY_MAX);
+	Array lines_array;
+	lines_array.resize(RS::ARRAY_MAX);
+
+	switch (node->get_cell_shape()) {
+		case GridMap::CELL_SHAPE_SQUARE: {
+			BoxMesh::create_mesh_array(mesh_array, Vector3(1, 1, 1));
+
+			/*
+			 *     (2)-----(3)               Y
+			 *      | \     | \              |
+			 *      |  (1)-----(0)           o---X
+			 *      |   |   |   |             \
+			 *     (6)--|--(7)  |              Z
+			 *        \ |     \ |
+			 *         (5)-----(4)
+			 */
+			lines_array[RS::ARRAY_VERTEX] = Vector<Vector3>({
+					Vector3(0.5, 0.5, 0.5), // 0
+					Vector3(-0.5, 0.5, 0.5), // 1
+					Vector3(-0.5, 0.5, -0.5), // 2
+					Vector3(0.5, 0.5, -0.5), // 3
+					Vector3(0.5, -0.5, 0.5), // 4
+					Vector3(-0.5, -0.5, 0.5), // 5
+					Vector3(-0.5, -0.5, -0.5), // 6
+					Vector3(0.5, -0.5, -0.5) // 7
+			});
+			lines_array[RS::ARRAY_INDEX] = Vector<int>({
+					0, 1, 2, 3, // top
+					7, 4, 5, 6, // bottom
+					7, 3, 0, 4, // right
+					5, 1, 2, 6, // left
+			});
+			break;
+		}
+		case GridMap::CELL_SHAPE_HEXAGON:
+			CylinderMesh::create_mesh_array(mesh_array, 1.0, 1.0, 1, 6, 1);
+
+			/*
+			 *               (0)             Y
+			 *              /   \            |
+			 *           (1)     (5)         o---X
+			 *            |       |           \
+			 *           (2)     (4)           Z
+			 *            | \   / |
+			 *            |  (3)  |
+			 *            |   |   |
+			 *            |  (6)  |
+			 *            | / | \ |
+			 *           (7)  |  (b)
+			 *            |   |   |
+			 *           (8)  |  (a)
+			 *              \ | /
+			 *               (9)
+			 */
+
+			lines_array[RS::ARRAY_VERTEX] = Vector<Vector3>({
+					Vector3(0.0, 0.5, -1.0), // 0
+					Vector3(-SQRT3_2, 0.5, -0.5), // 1
+					Vector3(-SQRT3_2, 0.5, 0.5), // 2
+					Vector3(0.0, 0.5, 1.0), // 3
+					Vector3(SQRT3_2, 0.5, 0.5), // 4
+					Vector3(SQRT3_2, 0.5, -0.5), // 5
+					Vector3(0.0, -0.5, -1.0), // 6
+					Vector3(-SQRT3_2, -0.5, -0.5), // 7
+					Vector3(-SQRT3_2, -0.5, 0.5), // 8
+					Vector3(0.0, -0.5, 1.0), // 9
+					Vector3(SQRT3_2, -0.5, 0.5), // 10 (0xa)
+					Vector3(SQRT3_2, -0.5, -0.5), // 11 (0xb)
+			});
+			lines_array[RS::ARRAY_INDEX] = Vector<int>({
+					0, 1, 2, 3, 4, 5, // top
+					11, 6, 7, 8, 9, 10, // bottom
+					11, 5, 0, 6, // northeast face
+					7, 1, 2, 8, // west face
+					9, 3, 4, 10, // southeast face
+			});
+			break;
+		default:
+			ERR_PRINT_ED("unsupported cell shape");
+			return;
+	}
+
+	RenderingServer *rs = RS::get_singleton();
+	selection_tile_mesh = rs->mesh_create();
+	rs->mesh_add_surface_from_arrays(selection_tile_mesh, RS::PRIMITIVE_TRIANGLES, mesh_array);
+	rs->mesh_surface_set_material(selection_tile_mesh, 0, inner_mat->get_rid());
+
+	// add lines around the cell
+	rs->mesh_add_surface_from_arrays(selection_tile_mesh, RS::PRIMITIVE_LINE_STRIP, lines_array);
+	rs->mesh_surface_set_material(selection_tile_mesh, 1, outer_mat->get_rid());
+
+	// create the multimesh for rendering the tile mesh in multiple locations.
+	selection_multimesh = rs->multimesh_create();
+	rs->multimesh_set_mesh(selection_multimesh, selection_tile_mesh);
 }
 
 void GridMapEditor::_update_theme() {
@@ -1192,43 +1561,30 @@ void GridMapEditor::_notification(int p_what) {
 			const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
 
 			for (int i = 0; i < 3; i++) {
-				grid[i] = RS::get_singleton()->mesh_create();
-				grid_instance[i] = RS::get_singleton()->instance_create2(grid[i], scenario);
+				grid_mesh[i] = RS::get_singleton()->mesh_create();
+				grid_instance[i] = RS::get_singleton()->instance_create2(grid_mesh[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 				RenderingServer::get_singleton()->instance_set_layer_mask(grid_instance[i], 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
-				selection_level_instance[i] = RenderingServer::get_singleton()->instance_create2(selection_level_mesh[i], scenario);
-				RenderingServer::get_singleton()->instance_set_layer_mask(selection_level_instance[i], 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
+				RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], false);
 			}
-
-			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, scenario);
-			RenderingServer::get_singleton()->instance_set_layer_mask(cursor_instance, 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
-			RenderingServer::get_singleton()->instance_set_visible(cursor_instance, false);
-			selection_instance = RenderingServer::get_singleton()->instance_create2(selection_mesh, scenario);
-			RenderingServer::get_singleton()->instance_set_layer_mask(selection_instance, 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
-			paste_instance = RenderingServer::get_singleton()->instance_create2(paste_mesh, scenario);
-			RenderingServer::get_singleton()->instance_set_layer_mask(paste_instance, 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
-
-			_update_selection_transform();
-			_update_paste_indicator();
+			_update_selection();
+			_clear_clipboard_data();
 			_update_theme();
+			_update_options_menu();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {
-				RS::get_singleton()->free_rid(grid_instance[i]);
-				RS::get_singleton()->free_rid(grid[i]);
+				RS::get_singleton()->free(grid_instance[i]);
+				RS::get_singleton()->free(grid_mesh[i]);
 				grid_instance[i] = RID();
-				grid[i] = RID();
-				RenderingServer::get_singleton()->free_rid(selection_level_instance[i]);
+				grid_mesh[i] = RID();
 			}
 
-			RenderingServer::get_singleton()->free_rid(cursor_instance);
-			RenderingServer::get_singleton()->free_rid(selection_instance);
-			RenderingServer::get_singleton()->free_rid(paste_instance);
-			cursor_instance = RID();
-			selection_instance = RID();
-			paste_instance = RID();
+			selection.active = false;
+			_update_selection();
+			_clear_clipboard_data();
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -1236,15 +1592,13 @@ void GridMapEditor::_notification(int p_what) {
 				return;
 			}
 
-			Transform3D xf = node->get_global_transform();
-
-			if (xf != grid_xform) {
-				for (int i = 0; i < 3; i++) {
-					RS::get_singleton()->instance_set_transform(grid_instance[i], xf * edit_grid_xform);
-				}
-				grid_xform = xf;
-				_update_cursor_transform();
-				_update_selection_transform();
+			// if the transform of our GridMap node has been changed, update
+			// the grid.
+			Transform3D transform = node->get_global_transform();
+			if (transform != node_global_transform) {
+				node_global_transform = transform;
+				update_grid();
+				_update_selection();
 			}
 		} break;
 
@@ -1324,14 +1678,19 @@ void GridMapEditor::_item_selected_cbk(int p_idx) {
 }
 
 void GridMapEditor::_floor_changed(float p_value) {
-	if (updating) {
-		return;
-	}
-
+	// update the floor number for the current plane we're editing
 	edit_floor[edit_axis] = p_value;
-	node->set_meta("_editor_floor_", Vector3(edit_floor[0], edit_floor[1], edit_floor[2]));
+
+	// save off editor floor numbers so the user can jump in and out of the
+	// gridmap editor without losing their place.
+	TypedArray<int> floors;
+	for (int i = 0; i < AXIS_MAX; i++) {
+		floors.push_back(edit_floor[i]);
+	}
+	node->set_meta("_editor_floor_", floors);
+
 	update_grid();
-	_update_selection_transform();
+	_update_selection();
 }
 
 void GridMapEditor::_floor_mouse_exited() {
@@ -1343,6 +1702,64 @@ void GridMapEditor::_bind_methods() {
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
 }
 
+void GridMapEditor::_update_options_menu() {
+	PopupMenu *popup = options->get_popup();
+
+	// save off the current settings
+	bool paste_selects = false;
+	if (int index = popup->get_item_index(MENU_OPTION_PASTE_SELECTS) != -1) {
+		popup->is_item_checked(index);
+	}
+
+	// clear the menu
+	popup->clear();
+
+	// rebuild the menu
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/previous_floor"), MENU_OPTION_PREV_LEVEL);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/next_floor"), MENU_OPTION_NEXT_LEVEL);
+	popup->add_separator();
+
+	// shape-specific edit axis options
+	if (node && node->get_cell_shape() == GridMap::CELL_SHAPE_HEXAGON) {
+		// hex cells have five edit axis; we add shortcuts for Y, two more for
+		// rotating a vertical plane clockwise and counter clockwise.
+		popup->add_radio_check_item(TTR("Edit X Axis"), MENU_OPTION_X_AXIS);
+		popup->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_y_axis"), MENU_OPTION_Y_AXIS);
+		popup->add_radio_check_item(TTR("Edit Q Axis"), MENU_OPTION_Q_AXIS);
+		popup->add_radio_check_item(TTR("Edit R Axis (Z Axis)"), MENU_OPTION_R_AXIS);
+		popup->add_radio_check_item(TTR("Edit S Axis"), MENU_OPTION_S_AXIS);
+		popup->add_shortcut(ED_GET_SHORTCUT("grid_map/edit_plane_rotate_cw"), MENU_OPTION_ROTATE_AXIS_CW);
+		popup->add_shortcut(ED_GET_SHORTCUT("grid_map/edit_plane_rotate_ccw"), MENU_OPTION_ROTATE_AXIS_CCW);
+	} else {
+		// square cell shape only uses XYZ with per-plane shortcuts
+		popup->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_x_axis"), MENU_OPTION_X_AXIS);
+		popup->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_y_axis"), MENU_OPTION_Y_AXIS);
+		popup->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_z_axis"), MENU_OPTION_Z_AXIS);
+	}
+	popup->set_item_checked(popup->get_item_index(MENU_OPTION_Y_AXIS), true);
+
+	popup->add_separator();
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_rotate_x"), MENU_OPTION_CURSOR_ROTATE_X);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_rotate_y"), MENU_OPTION_CURSOR_ROTATE_Y);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_rotate_z"), MENU_OPTION_CURSOR_ROTATE_Z);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_back_rotate_x"), MENU_OPTION_CURSOR_BACK_ROTATE_X);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_back_rotate_y"), MENU_OPTION_CURSOR_BACK_ROTATE_Y);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_back_rotate_z"), MENU_OPTION_CURSOR_BACK_ROTATE_Z);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cursor_clear_rotation"), MENU_OPTION_CURSOR_CLEAR_ROTATION);
+	popup->add_separator();
+	// TRANSLATORS: This is a toggle to select after pasting the new content.
+	popup->add_check_shortcut(ED_GET_SHORTCUT("grid_map/paste_selects"), MENU_OPTION_PASTE_SELECTS);
+	popup->set_item_checked(popup->get_item_index(MENU_OPTION_PASTE_SELECTS), paste_selects);
+	popup->add_separator();
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/duplicate_selection"), MENU_OPTION_SELECTION_DUPLICATE);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/cut_selection"), MENU_OPTION_SELECTION_CUT);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/clear_selection"), MENU_OPTION_SELECTION_CLEAR);
+	popup->add_shortcut(ED_GET_SHORTCUT("grid_map/fill_selection"), MENU_OPTION_SELECTION_FILL);
+
+	popup->add_separator();
+	popup->add_item(TTR("Settings..."), MENU_OPTION_GRIDMAP_SETTINGS);
+}
+
 GridMapEditor::GridMapEditor() {
 	ED_SHORTCUT("grid_map/previous_floor", TTRC("Previous Floor"), Key::KEY_1, true);
 	ED_SHORTCUT("grid_map/next_floor", TTRC("Next Floor"), Key::KEY_3, true);
@@ -1352,18 +1769,18 @@ GridMapEditor::GridMapEditor() {
 	ED_SHORTCUT("grid_map/keep_selected", TTRC("Keep Selection"));
 	ED_SHORTCUT("grid_map/clear_rotation", TTRC("Clear Rotation"));
 
+	// TRANSLATORS: These two shortcuts are only used with hex-shaped cells to rotate an edit plane about the Y axis clockwise or counter-clockwise.
+	ED_SHORTCUT("grid_map/edit_plane_rotate_cw", TTR("Rotate Edit Plane Clockwise"), Key::C, true);
+	ED_SHORTCUT("grid_map/edit_plane_rotate_ccw", TTR("Rotate Edit Plane Counter-Clockwise"), Key::Z, true);
+
+
 	options = memnew(MenuButton);
-	options->set_theme_type_variation(SceneStringName(FlatButton));
-	options->get_popup()->add_separator();
-	options->get_popup()->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_x_axis"), MENU_OPTION_X_AXIS);
-	options->get_popup()->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_y_axis"), MENU_OPTION_Y_AXIS);
-	options->get_popup()->add_radio_check_shortcut(ED_GET_SHORTCUT("grid_map/edit_z_axis"), MENU_OPTION_Z_AXIS);
-	options->get_popup()->set_item_checked(options->get_popup()->get_item_index(MENU_OPTION_Y_AXIS), true);
-	options->get_popup()->add_separator();
-	// TRANSLATORS: This is a toggle to select after pasting the new content.
-	options->get_popup()->add_shortcut(ED_GET_SHORTCUT("grid_map/clear_rotation"), MENU_OPTION_CURSOR_CLEAR_ROTATION);
-	options->get_popup()->add_check_shortcut(ED_GET_SHORTCUT("grid_map/keep_selected"), MENU_OPTION_PASTE_SELECTS);
-	options->get_popup()->set_item_checked(options->get_popup()->get_item_index(MENU_OPTION_PASTE_SELECTS), true);
+	spatial_editor_hb->add_child(options);
+	spatial_editor_hb->hide();
+
+	options->set_text(TTR("Grid Map"));
+	_update_options_menu();
+
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Settings..."), MENU_OPTION_GRIDMAP_SETTINGS);
 
@@ -1599,154 +2016,26 @@ GridMapEditor::GridMapEditor() {
 	info_message->set_anchors_and_offsets_preset(PRESET_FULL_RECT, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	mesh_library_palette->add_child(info_message);
 
-	edit_axis = Vector3::AXIS_Y;
 	edit_floor[0] = -1;
 	edit_floor[1] = -1;
 	edit_floor[2] = -1;
 
-	cursor_mesh = RenderingServer::get_singleton()->mesh_create();
-	selection_mesh = RenderingServer::get_singleton()->mesh_create();
-	paste_mesh = RenderingServer::get_singleton()->mesh_create();
+	edit_axis = AXIS_Y;
+	edit_plane = Plane();
 
-	{
-		// Selection mesh create.
+	inner_mat.instantiate();
+	inner_mat->set_albedo(Color(0.7, 0.7, 1.0, 0.2));
+	inner_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	inner_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	inner_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 
-		Vector<Vector3> lines;
-		Vector<Vector3> triangles;
-		Vector<Vector3> square[3];
+	outer_mat.instantiate();
+	outer_mat->set_albedo(Color(0.7, 0.7, 1.0, 0.8));
+	outer_mat->set_on_top_of_alpha();
 
-		for (int i = 0; i < 6; i++) {
-			Vector3 face_points[4];
-
-			for (int j = 0; j < 4; j++) {
-				float v[3];
-				v[0] = 1.0;
-				v[1] = 1 - 2 * ((j >> 1) & 1);
-				v[2] = v[1] * (1 - 2 * (j & 1));
-
-				for (int k = 0; k < 3; k++) {
-					if (i < 3) {
-						face_points[j][(i + k) % 3] = v[k];
-					} else {
-						face_points[3 - j][(i + k) % 3] = -v[k];
-					}
-				}
-			}
-
-			triangles.push_back(face_points[0] * 0.5 + Vector3(0.5, 0.5, 0.5));
-			triangles.push_back(face_points[1] * 0.5 + Vector3(0.5, 0.5, 0.5));
-			triangles.push_back(face_points[2] * 0.5 + Vector3(0.5, 0.5, 0.5));
-
-			triangles.push_back(face_points[2] * 0.5 + Vector3(0.5, 0.5, 0.5));
-			triangles.push_back(face_points[3] * 0.5 + Vector3(0.5, 0.5, 0.5));
-			triangles.push_back(face_points[0] * 0.5 + Vector3(0.5, 0.5, 0.5));
-		}
-
-		for (int i = 0; i < 12; i++) {
-			AABB base(Vector3(0, 0, 0), Vector3(1, 1, 1));
-			Vector3 a, b;
-			base.get_edge(i, a, b);
-			lines.push_back(a);
-			lines.push_back(b);
-		}
-
-		for (int i = 0; i < 3; i++) {
-			Vector3 points[4];
-			for (int j = 0; j < 4; j++) {
-				static const bool orderx[4] = { false, true, true, false };
-				static const bool ordery[4] = { false, false, true, true };
-
-				Vector3 sp;
-				if (orderx[j]) {
-					sp[(i + 1) % 3] = 1.0;
-				}
-				if (ordery[j]) {
-					sp[(i + 2) % 3] = 1.0;
-				}
-
-				points[j] = sp;
-			}
-
-			for (int j = 0; j < 4; j++) {
-				Vector3 ofs;
-				ofs[i] += 0.01;
-				square[i].push_back(points[j] - ofs);
-				square[i].push_back(points[(j + 1) % 4] - ofs);
-				square[i].push_back(points[j] + ofs);
-				square[i].push_back(points[(j + 1) % 4] + ofs);
-			}
-		}
-
-		Array d;
-		d.resize(RS::ARRAY_MAX);
-
-		default_color = Color(0.0, 0.565, 1.0); // blue 0.7, 0.7, 1.0
-		erase_color = Color(1.0, 0.2, 0.2); // red
-		pick_color = Color(1, 0.7, 0); // orange/yellow
-
-		cursor_inner_mat.instantiate();
-		cursor_inner_mat->set_albedo(Color(default_color, 0.2));
-		cursor_inner_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-		cursor_inner_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-		cursor_inner_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-
-		cursor_outer_mat.instantiate();
-		cursor_outer_mat->set_albedo(Color(default_color, 0.8));
-		cursor_outer_mat->set_on_top_of_alpha();
-		cursor_outer_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-		cursor_outer_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-		cursor_outer_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-
-		inner_mat.instantiate();
-		inner_mat->set_albedo(Color(default_color, 0.2));
-		inner_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-		inner_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-		inner_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-
-		outer_mat.instantiate();
-		outer_mat->set_albedo(Color(default_color, 0.8));
-		outer_mat->set_on_top_of_alpha();
-		outer_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-		outer_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-		outer_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-
-		selection_floor_mat.instantiate();
-		selection_floor_mat->set_albedo(Color(0.80, 0.80, 1.0, 1));
-		selection_floor_mat->set_on_top_of_alpha();
-		selection_floor_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-		selection_floor_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-
-		d[RS::ARRAY_VERTEX] = triangles;
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(cursor_mesh, RS::PRIMITIVE_TRIANGLES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(cursor_mesh, 0, cursor_inner_mat->get_rid());
-
-		d[RS::ARRAY_VERTEX] = lines;
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(cursor_mesh, RS::PRIMITIVE_LINES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(cursor_mesh, 1, cursor_outer_mat->get_rid());
-
-		d[RS::ARRAY_VERTEX] = triangles;
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(selection_mesh, RS::PRIMITIVE_TRIANGLES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(selection_mesh, 0, inner_mat->get_rid());
-
-		d[RS::ARRAY_VERTEX] = lines;
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(selection_mesh, RS::PRIMITIVE_LINES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(selection_mesh, 1, outer_mat->get_rid());
-
-		d[RS::ARRAY_VERTEX] = triangles;
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(paste_mesh, RS::PRIMITIVE_TRIANGLES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(paste_mesh, 0, inner_mat->get_rid());
-
-		d[RS::ARRAY_VERTEX] = lines;
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(paste_mesh, RS::PRIMITIVE_LINES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(paste_mesh, 1, outer_mat->get_rid());
-
-		for (int i = 0; i < 3; i++) {
-			d[RS::ARRAY_VERTEX] = square[i];
-			selection_level_mesh[i] = RS::get_singleton()->mesh_create();
-			RenderingServer::get_singleton()->mesh_add_surface_from_arrays(selection_level_mesh[i], RS::PRIMITIVE_LINES, d);
-			RenderingServer::get_singleton()->mesh_surface_set_material(selection_level_mesh[i], 0, selection_floor_mat->get_rid());
-		}
-	}
+	outer_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	outer_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	outer_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 
 	_set_selection(false);
 
@@ -1764,33 +2053,18 @@ GridMapEditor::~GridMapEditor() {
 	_clear_clipboard_data();
 
 	for (int i = 0; i < 3; i++) {
-		if (grid[i].is_valid()) {
-			RenderingServer::get_singleton()->free_rid(grid[i]);
+		if (grid_mesh[i].is_valid()) {
+			RenderingServer::get_singleton()->free(grid_mesh[i]);
 		}
 		if (grid_instance[i].is_valid()) {
 			RenderingServer::get_singleton()->free_rid(grid_instance[i]);
 		}
-		if (selection_level_instance[i].is_valid()) {
-			RenderingServer::get_singleton()->free_rid(selection_level_instance[i]);
-		}
-		if (selection_level_mesh[i].is_valid()) {
-			RenderingServer::get_singleton()->free_rid(selection_level_mesh[i]);
-		}
 	}
-
-	RenderingServer::get_singleton()->free_rid(cursor_mesh);
-	if (cursor_instance.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(cursor_instance);
+	if (selection_multimesh.is_valid()) {
+		RenderingServer::get_singleton()->free(selection_multimesh);
 	}
-
-	RenderingServer::get_singleton()->free_rid(selection_mesh);
-	if (selection_instance.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(selection_instance);
-	}
-
-	RenderingServer::get_singleton()->free_rid(paste_mesh);
-	if (paste_instance.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(paste_instance);
+	if (selection_tile_mesh.is_valid()) {
+		RenderingServer::get_singleton()->free(selection_tile_mesh);
 	}
 }
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -194,7 +194,8 @@ void GridMapEditor::_menu_option(int p_option) {
 
 void GridMapEditor::_update_cursor_transform() {
 	cursor_transform = Transform3D();
-	cursor_transform.origin = cursor_origin;
+	cursor_transform.origin = node->map_to_local(cursor_cell);
+	cursor_transform.basis = node->get_basis_with_orthogonal_index(cursor_rot);
 	cursor_transform.basis *= node->get_cell_scale();
 	cursor_transform = node->get_global_transform() * cursor_transform;
 
@@ -372,24 +373,14 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 		}
 	}
 
+	Vector3 cell = node->local_to_map(inters);
+	cell[edit_axis] = edit_floor[edit_axis];
 	Vector3 cell_size = node->get_cell_size();
-
-	for (int i = 0; i < 3; i++) {
-		if (i == edit_axis) {
-			cursor_gridpos[i] = edit_floor[i];
-		} else {
-			cursor_gridpos[i] = inters[i] / cell_size[i];
-			if (inters[i] < 0) {
-				cursor_gridpos[i] -= 1; // Compensate negative.
-			}
-			grid_ofs[i] = cursor_gridpos[i] * cell_size[i];
-		}
-	}
 
 	RS::get_singleton()->instance_set_transform(grid_instance[edit_axis], node->get_global_transform() * edit_grid_xform);
 
 	if (cursor_instance.is_valid()) {
-		cursor_origin = (Vector3(cursor_gridpos) + Vector3(0.5 * node->get_center_x(), 0.5 * node->get_center_y(), 0.5 * node->get_center_z())) * node->get_cell_size();
+		cursor_cell = cell;
 		cursor_visible = true;
 
 		if (input_action == INPUT_PASTE) {
@@ -1070,7 +1061,98 @@ void GridMapEditor::update_grid() {
 	updating = false;
 }
 
-void GridMapEditor::_draw_grids(const Vector3 &cell_size) {
+void GridMapEditor::_draw_floor_grid(RID p_mesh_id, int p_floor) {
+	Vector<Vector2> shape_points;
+	if (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE) {
+		shape_points.append(Vector2(-0.5, -0.5));
+		shape_points.append(Vector2(0.5, -0.5));
+		shape_points.append(Vector2(0.5, 0.5));
+		shape_points.append(Vector2(-0.5, 0.5));
+	} else {
+		float overlap = 0.25;
+		shape_points.append(Vector2(0.0, -0.5));
+		shape_points.append(Vector2(-0.5, overlap - 0.5));
+		shape_points.append(Vector2(-0.5, 0.5 - overlap));
+		shape_points.append(Vector2(0.0, 0.5));
+		shape_points.append(Vector2(0.5, 0.5 - overlap));
+		shape_points.append(Vector2(0.5, overlap - 0.5));
+
+		if (node->get_cell_offset_axis() == GridMap::CELL_OFFSET_AXIS_VERTICAL) {
+			for (int i = 0; i < shape_points.size(); i++) {
+				shape_points.write[i] = Vector2(shape_points[i].y, shape_points[i].x);
+			}
+		}
+	}
+
+	Vector3 cell_size = node->get_cell_size();
+
+	Vector<Vector3> grid_points;
+	Vector<Color> grid_colors;
+
+	for (int x = -GRID_CURSOR_SIZE; x <= GRID_CURSOR_SIZE; x++) {
+		for (int z = -GRID_CURSOR_SIZE; z <= GRID_CURSOR_SIZE; z++) {
+			Vector3 center = node->map_to_local(Vector3(x, p_floor, z));
+
+			for (int i = 1; i < shape_points.size(); i++) {
+				grid_points.append(center + Vector3(shape_points[i - 1].x * cell_size.x, 0, shape_points[i - 1].y * cell_size.z));
+				grid_points.append(center + Vector3(shape_points[i].x * cell_size.x, 0, shape_points[i].y * cell_size.z));
+
+				float a1 = Math::pow(MAX(0, 1.0 - (Vector2(x + 1, z).length() / GRID_CURSOR_SIZE)), 2);
+				float a2 = Math::pow(MAX(0, 1.0 - (Vector2(x, z + 1).length() / GRID_CURSOR_SIZE)), 2);
+				grid_colors.append(Color(1, 1, 1, a1));
+				grid_colors.append(Color(1, 1, 1, a2));
+			}
+		}
+	}
+
+	Array d;
+	d.resize(RS::ARRAY_MAX);
+	d[RS::ARRAY_VERTEX] = grid_points;
+	d[RS::ARRAY_COLOR] = grid_colors;
+	RenderingServer::get_singleton()->mesh_add_surface_from_arrays(p_mesh_id, RenderingServer::PRIMITIVE_LINES, d);
+	RenderingServer::get_singleton()->mesh_surface_set_material(p_mesh_id, 0, indicator_mat->get_rid());
+}
+
+void GridMapEditor::_draw_plane_grid(RID p_mesh_id, const Vector3 &p_axis_n1, const Vector3 &p_axis_n2) {
+	Vector<Vector3> grid_points;
+	Vector<Color> grid_colors;
+
+	Vector3 cell_size = node->get_cell_size();
+	Vector3 axis_n1 = p_axis_n1 * cell_size;
+	Vector3 axis_n2 = p_axis_n2 * cell_size;
+
+	for (int j = -GRID_CURSOR_SIZE; j <= GRID_CURSOR_SIZE; j++) {
+		for (int k = -GRID_CURSOR_SIZE; k <= GRID_CURSOR_SIZE; k++) {
+			Vector3 p = axis_n1 * j + axis_n2 * k;
+			float trans = Math::pow(MAX(0, 1.0 - (Vector2(j, k).length() / GRID_CURSOR_SIZE)), 2);
+
+			Vector3 pj = axis_n1 * (j + 1) + axis_n2 * k;
+			float transj = Math::pow(MAX(0, 1.0 - (Vector2(j + 1, k).length() / GRID_CURSOR_SIZE)), 2);
+
+			Vector3 pk = axis_n1 * j + axis_n2 * (k + 1);
+			float transk = Math::pow(MAX(0, 1.0 - (Vector2(j, k + 1).length() / GRID_CURSOR_SIZE)), 2);
+
+			grid_points.push_back(p);
+			grid_points.push_back(pk);
+			grid_colors.push_back(Color(1, 1, 1, trans));
+			grid_colors.push_back(Color(1, 1, 1, transk));
+
+			grid_points.push_back(p);
+			grid_points.push_back(pj);
+			grid_colors.push_back(Color(1, 1, 1, trans));
+			grid_colors.push_back(Color(1, 1, 1, transj));
+		}
+	}
+
+	Array d;
+	d.resize(RS::ARRAY_MAX);
+	d[RS::ARRAY_VERTEX] = grid_points;
+	d[RS::ARRAY_COLOR] = grid_colors;
+	RenderingServer::get_singleton()->mesh_add_surface_from_arrays(p_mesh_id, RenderingServer::PRIMITIVE_LINES, d);
+	RenderingServer::get_singleton()->mesh_surface_set_material(p_mesh_id, 0, indicator_mat->get_rid());
+}
+
+void GridMapEditor::_draw_grids(const Vector3 &p_cell_size) {
 	Vector3 edited_floor = node->get_meta("_editor_floor_", Vector3());
 
 	for (int i = 0; i < 3; i++) {
@@ -1078,47 +1160,9 @@ void GridMapEditor::_draw_grids(const Vector3 &cell_size) {
 		edit_floor[i] = edited_floor[i];
 	}
 
-	Vector<Vector3> grid_points[3];
-	Vector<Color> grid_colors[3];
-
-	for (int i = 0; i < 3; i++) {
-		Vector3 axis;
-		axis[i] = 1;
-		Vector3 axis_n1;
-		axis_n1[(i + 1) % 3] = cell_size[(i + 1) % 3];
-		Vector3 axis_n2;
-		axis_n2[(i + 2) % 3] = cell_size[(i + 2) % 3];
-
-		for (int j = -GRID_CURSOR_SIZE; j <= GRID_CURSOR_SIZE; j++) {
-			for (int k = -GRID_CURSOR_SIZE; k <= GRID_CURSOR_SIZE; k++) {
-				Vector3 p = axis_n1 * j + axis_n2 * k;
-				float trans = Math::pow(MAX(0, 1.0 - (Vector2(j, k).length() / GRID_CURSOR_SIZE)), 2);
-
-				Vector3 pj = axis_n1 * (j + 1) + axis_n2 * k;
-				float transj = Math::pow(MAX(0, 1.0 - (Vector2(j + 1, k).length() / GRID_CURSOR_SIZE)), 2);
-
-				Vector3 pk = axis_n1 * j + axis_n2 * (k + 1);
-				float transk = Math::pow(MAX(0, 1.0 - (Vector2(j, k + 1).length() / GRID_CURSOR_SIZE)), 2);
-
-				grid_points[i].push_back(p);
-				grid_points[i].push_back(pk);
-				grid_colors[i].push_back(Color(1, 1, 1, trans));
-				grid_colors[i].push_back(Color(1, 1, 1, transk));
-
-				grid_points[i].push_back(p);
-				grid_points[i].push_back(pj);
-				grid_colors[i].push_back(Color(1, 1, 1, trans));
-				grid_colors[i].push_back(Color(1, 1, 1, transj));
-			}
-		}
-
-		Array d;
-		d.resize(RS::ARRAY_MAX);
-		d[RS::ARRAY_VERTEX] = grid_points[i];
-		d[RS::ARRAY_COLOR] = grid_colors[i];
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(grid[i], RenderingServer::PRIMITIVE_LINES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(grid[i], 0, indicator_mat->get_rid());
-	}
+	_draw_plane_grid(grid[0], Vector3(0, 1, 0), Vector3(0, 0, 1));
+	_draw_floor_grid(grid[1], edit_floor[1]);
+	_draw_plane_grid(grid[2], Vector3(1, 0, 0), Vector3(0, 1, 0));
 }
 
 void GridMapEditor::_update_theme() {
@@ -1273,8 +1317,8 @@ void GridMapEditor::_on_tool_mode_changed() {
 	_update_cursor_instance();
 }
 
-void GridMapEditor::_item_selected_cbk(int idx) {
-	selected_palette = mesh_library_palette->get_item_metadata(idx);
+void GridMapEditor::_item_selected_cbk(int p_idx) {
+	selected_palette = mesh_library_palette->get_item_metadata(p_idx);
 
 	_update_cursor_instance();
 }

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "grid_map_editor_plugin.h"
 
+#include "core/math/basis.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
@@ -136,7 +137,7 @@ void GridMapEditor::_menu_option(int p_option) {
 
 		case MENU_OPTION_CURSOR_ROTATE_Y: {
 			Basis r;
-			real_t rotation = Math_PI / (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? 2.0 : 3.0);
+			real_t rotation = Math::PI / (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? 2.0 : 3.0);
 
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_orientation);
@@ -153,7 +154,7 @@ void GridMapEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_CURSOR_ROTATE_X: {
 			Basis r;
-			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math::PI / 2.0) : Math::PI;
 
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_orientation);
@@ -170,7 +171,7 @@ void GridMapEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_CURSOR_ROTATE_Z: {
 			Basis r;
-			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math::PI / 2.0) : Math::PI;
 
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_orientation);
@@ -186,7 +187,7 @@ void GridMapEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_CURSOR_BACK_ROTATE_Y: {
 			Basis r;
-			real_t rotation = Math_PI / (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? 2.0 : 3.0);
+			real_t rotation = Math::PI / (node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? 2.0 : 3.0);
 
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_orientation);
@@ -198,12 +199,12 @@ void GridMapEditor::_menu_option(int p_option) {
 				for (int i = 0; i < cells.size(); i++) {
 					Vector3i cell = cells[i];
 					r = node->get_basis_with_orthogonal_index(node->get_cell_item_orientation(cell));
-					r.rotate(rotation_axis, rotation_angle);
+					r.rotate(Vector3(0, 1, 0), rotation);
 					node->set_cell_item(cell, node->get_cell_item(cell), node->get_orthogonal_index_from_basis(r));
 				}
 			} else {
 				r = node->get_basis_with_orthogonal_index(cursor_rot);
-				r.rotate(rotation_axis, rotation_angle);
+				r.rotate(Vector3(0, 1, 0), rotation);
 				cursor_rot = node->get_orthogonal_index_from_basis(r);
 				_update_cursor_transform();
 			}
@@ -215,8 +216,9 @@ void GridMapEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_CURSOR_BACK_ROTATE_X: {
 			Basis r;
-			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math::PI / 2.0) : Math::PI;
 
+			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_orientation);
 				r.rotate(Vector3(1, 0, 0), rotation);
 				paste_orientation = node->get_orthogonal_index_from_basis(r);
@@ -231,7 +233,7 @@ void GridMapEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_CURSOR_BACK_ROTATE_Z: {
 			Basis r;
-			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math_PI / 2.0) : Math_PI;
+			real_t rotation = node->get_cell_shape() == GridMap::CELL_SHAPE_SQUARE ? (Math::PI / 2.0) : Math::PI;
 
 			if (input_action == INPUT_PASTE) {
 				r = node->get_basis_with_orthogonal_index(paste_orientation);
@@ -895,8 +897,6 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 		return EditorPlugin::AFTER_GUI_INPUT_PASS;
 	}
 
-	Ref<InputEventKey> k = p_event;
-
 	if (k.is_valid()) {
 		if (k->is_pressed()) {
 			if (k->get_keycode() == Key::ESCAPE) {
@@ -1219,7 +1219,7 @@ void GridMapEditor::update_grid() {
 			active_grid_instance = grid_instance[2];
 			edit_plane.normal = Vector3(SQRT3_2, 0, -0.5).normalized();
 			cell_depth = 1.5 * cell_size.x;
-			grid_transform.rotate(Vector3(0, 1, 0), -Math_PI / 3.0);
+			grid_transform.rotate(Vector3(0, 1, 0), -Math::PI / 3.0);
 			// offset the edit grid on even numbered floors by half a cell
 			grid_transform.translate_local(Vector3(is_even_floor * SQRT3_2 * cell_size.x, 0, 0));
 			menu_axis = MENU_OPTION_Q_AXIS;
@@ -1235,7 +1235,7 @@ void GridMapEditor::update_grid() {
 			active_grid_instance = grid_instance[2];
 			edit_plane.normal = Vector3(SQRT3_2, 0, 0.5).normalized();
 			cell_depth = 1.5 * cell_size.x;
-			grid_transform.rotate(Vector3(0, 1, 0), Math_PI / 3.0);
+			grid_transform.rotate(Vector3(0, 1, 0), Math::PI / 3.0);
 			grid_transform.translate_local(Vector3(is_even_floor * SQRT3_2 * cell_size.x, 0, 0));
 			menu_axis = MENU_OPTION_S_AXIS;
 			break;
@@ -1291,10 +1291,10 @@ void GridMapEditor::_draw_hex_grid(RID p_mesh_id, const Vector3 &p_cell_size) {
 
 	Vector<Vector3> grid_points;
 	TypedArray<Vector3i> cells = node->local_region_to_map(
-			Vector3i(-GRID_CURSOR_SIZE * Math_SQRT3 * p_cell_size.x,
+			Vector3i(-GRID_CURSOR_SIZE * Math::SQRT3 * p_cell_size.x,
 					0,
 					-GRID_CURSOR_SIZE * 1.625 * p_cell_size.x),
-			Vector3i(GRID_CURSOR_SIZE * Math_SQRT3 * p_cell_size.x,
+			Vector3i(GRID_CURSOR_SIZE * Math::SQRT3 * p_cell_size.x,
 					0,
 					GRID_CURSOR_SIZE * 1.625 * p_cell_size.x));
 	for (const Vector3i cell : cells) {
@@ -1400,7 +1400,7 @@ void GridMapEditor::_draw_grids(const Vector3 &p_cell_size) {
 			break;
 		case GridMap::CELL_SHAPE_HEXAGON: {
 			real_t radius = p_cell_size.x;
-			Vector3 cell_size = Vector3(Math_SQRT3 * radius, p_cell_size.y, Math_SQRT3 * radius);
+			Vector3 cell_size = Vector3(Math::SQRT3 * radius, p_cell_size.y, Math::SQRT3 * radius);
 			_draw_hex_r_axis_grid(grid_mesh[0], p_cell_size);
 			_draw_hex_grid(grid_mesh[1], p_cell_size);
 			_draw_plane_grid(grid_mesh[2], Vector3(1, 0, 0), Vector3(0, 1, 0), cell_size);
@@ -1775,9 +1775,6 @@ GridMapEditor::GridMapEditor() {
 
 
 	options = memnew(MenuButton);
-	spatial_editor_hb->add_child(options);
-	spatial_editor_hb->hide();
-
 	options->set_text(TTR("Grid Map"));
 	_update_options_menu();
 
@@ -2022,6 +2019,19 @@ GridMapEditor::GridMapEditor() {
 
 	edit_axis = AXIS_Y;
 	edit_plane = Plane();
+
+	cursor_inner_mat.instantiate();
+	cursor_inner_mat->set_albedo(Color(default_color, 0.2));
+	cursor_inner_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	cursor_inner_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	cursor_inner_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+
+	cursor_outer_mat.instantiate();
+	cursor_outer_mat->set_albedo(Color(default_color, 0.8));
+	cursor_outer_mat->set_on_top_of_alpha();
+	cursor_outer_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	cursor_outer_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	cursor_outer_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 
 	inner_mat.instantiate();
 	inner_mat->set_albedo(Color(0.7, 0.7, 1.0, 0.2));

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -246,6 +246,7 @@ class GridMapEditor : public VBoxContainer {
 	void _set_clipboard_data();
 	void _update_paste_indicator();
 	void _do_paste();
+	void _show_viewports_transform_gizmo(bool p_value);
 	void _update_selection();
 	void _set_selection(bool p_active, const Vector3 &p_begin = Vector3(), const Vector3 &p_end = Vector3());
 	AABB _get_selection() const;

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -173,6 +173,7 @@ class GridMapEditor : public VBoxContainer {
 	bool cursor_visible = false;
 	Transform3D cursor_transform;
 
+	Vector3 cursor_cell;
 	Vector3 cursor_origin;
 	Vector3i cursor_gridpos;
 
@@ -214,13 +215,15 @@ class GridMapEditor : public VBoxContainer {
 	Label *info_message = nullptr;
 
 	void update_grid(); // Change which and where the grid is displayed
-	void _draw_grids(const Vector3 &cell_size);
+	void _draw_floor_grid(RID p_grid, int p_floor);
+	void _draw_plane_grid(RID p_grid, const Vector3 &p_axis_n1, const Vector3 &p_axis_n2);
+	void _draw_grids(const Vector3 &p_cell_size);
 	void _configure();
 	void _menu_option(int);
 	void update_palette();
 	void _update_mesh_library();
 	void _set_display_mode(int p_mode);
-	void _item_selected_cbk(int idx);
+	void _item_selected_cbk(int p_idx);
 	void _update_cursor_transform();
 	void _update_cursor_instance();
 	void _on_tool_mode_changed();

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -160,9 +160,9 @@ void GridMap::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void GridMap::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "cell_layout" && cell_shape == CELL_SHAPE_SQUARE) {
-		p_property.usage ^= PROPERTY_USAGE_READ_ONLY;
+		p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 	} else if (p_property.name == "cell_offset_axis" && cell_shape == CELL_SHAPE_SQUARE) {
-		p_property.usage ^= PROPERTY_USAGE_READ_ONLY;
+		p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 	}
 }
 
@@ -605,7 +605,7 @@ Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
 	Vector3 map_position = p_local_position - _get_offset();
 	map_position /= cell_size;
 
-	// Divide by the overlapping ratio
+	// Divide by the overlapping ratio.
 	double overlapping_ratio = 1.0;
 	if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
 		if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
@@ -622,17 +622,17 @@ Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
 	// For each half-offset shape, we check if we are in the corner of the tile, and thus should correct the world position accordingly.
 	if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
 		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels or overlap.
-		// square = no overlap, hexagon = 0.25 overlap, isometric = 0.5 overlap
+		// square = no overlap, hexagon = 0.25 overlap, isometric = 0.5 overlap.
 		if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
-			// Smart floor of the position
+			// Smart floor of the position.
 			Vector3 raw_pos = map_position;
-			if (Math::posmod(Math::floor(map_position.z), 2) ^ (cell_layout == GridMap::CELL_LAYOUT_STACKED_OFFSET)) {
+			if ((Math::posmod(Math::floor(map_position.z), 2) != 0.0) ^ (cell_layout == GridMap::CELL_LAYOUT_STACKED_OFFSET)) {
 				map_position = Vector3(Math::floor(map_position.x + 0.5) - 0.5, map_position.y, Math::floor(map_position.z));
 			} else {
 				map_position = map_position.floor();
 			}
 
-			// Compute the tile offset, and if we might the output for a neighbour top tile
+			// Compute the tile offset, and if we might the output for a neighbor top tile.
 			Vector2 in_cell_pos = Vector2(raw_pos.x - map_position.x, raw_pos.z - map_position.z);
 			bool in_top_left_triangle = (in_cell_pos - Vector2(0.5, 0.0)).cross(Vector2(-0.5, 1.0 / overlapping_ratio - 1)) <= 0;
 			bool in_top_right_triangle = (in_cell_pos - Vector2(0.5, 0.0)).cross(Vector2(0.5, 1.0 / overlapping_ratio - 1)) > 0;
@@ -641,9 +641,9 @@ Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
 				case GridMap::CELL_LAYOUT_STACKED:
 					map_position = map_position.floor();
 					if (in_top_left_triangle) {
-						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) ? 0 : -1, 0, -1);
+						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) != 0.0 ? 0 : -1, 0, -1);
 					} else if (in_top_right_triangle) {
-						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) ? 1 : 0, 0, -1);
+						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) != 0.0 ? 1 : 0, 0, -1);
 					}
 					break;
 				case GridMap::CELL_LAYOUT_STACKED_OFFSET:
@@ -690,15 +690,15 @@ Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
 					break;
 			}
 		} else { // CELL_OFFSET_AXIS_VERTICAL
-			// Smart floor of the position
+			// Smart floor of the position.
 			Vector3 raw_pos = map_position;
-			if (Math::posmod(Math::floor(map_position.x), 2) ^ (cell_layout == GridMap::CELL_LAYOUT_STACKED_OFFSET)) {
+			if ((Math::posmod(Math::floor(map_position.x), 2) != 0.0) ^ (cell_layout == GridMap::CELL_LAYOUT_STACKED_OFFSET)) {
 				map_position = Vector3(Math::floor(map_position.x), Math::floor(map_position.y), Math::floor(map_position.z + 0.5) - 0.5);
 			} else {
 				map_position = map_position.floor();
 			}
 
-			// Compute the tile offset, and if we might the output for a neighbour top tile
+			// Compute the tile offset, and if we might the output for a neighbor top tile.
 			Vector2 in_cell_pos = Vector2(raw_pos.x - map_position.x, raw_pos.z - map_position.z);
 			bool in_top_left_triangle = (in_cell_pos - Vector2(0.0, 0.5)).cross(Vector2(1.0 / overlapping_ratio - 1, -0.5)) > 0;
 			bool in_bottom_left_triangle = (in_cell_pos - Vector2(0.0, 0.5)).cross(Vector2(1.0 / overlapping_ratio - 1, 0.5)) <= 0;
@@ -707,17 +707,17 @@ Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
 				case GridMap::CELL_LAYOUT_STACKED:
 					map_position = map_position.floor();
 					if (in_top_left_triangle) {
-						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? 0 : -1);
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) != 0.0 ? 0 : -1);
 					} else if (in_bottom_left_triangle) {
-						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? 1 : 0);
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) != 0.0 ? 1 : 0);
 					}
 					break;
 				case GridMap::CELL_LAYOUT_STACKED_OFFSET:
 					map_position = map_position.floor();
 					if (in_top_left_triangle) {
-						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? -1 : 0);
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) != 0.0 ? -1 : 0);
 					} else if (in_bottom_left_triangle) {
-						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? 0 : 1);
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) != 0.0 ? 0 : 1);
 					}
 					break;
 				case GridMap::CELL_LAYOUT_STAIRS_RIGHT:
@@ -817,7 +817,7 @@ Vector3 GridMap::map_to_local(const Vector3i &p_map_position) const {
 		}
 	}
 
-	// Multiply by the overlapping ratio
+	// Multiply by the overlapping ratio.
 	if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
 		if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
 			map_position.z *= 0.75;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -158,6 +158,14 @@ void GridMap::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 }
 
+void GridMap::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "cell_layout" && cell_shape == CELL_SHAPE_SQUARE) {
+		p_property.usage ^= PROPERTY_USAGE_READ_ONLY;
+	} else if (p_property.name == "cell_offset_axis" && cell_shape == CELL_SHAPE_SQUARE) {
+		p_property.usage ^= PROPERTY_USAGE_READ_ONLY;
+	}
+}
+
 #ifndef PHYSICS_3D_DISABLED
 void GridMap::set_collision_layer(uint32_t p_layer) {
 	collision_layer = p_layer;
@@ -297,6 +305,46 @@ void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {
 
 Ref<MeshLibrary> GridMap::get_mesh_library() const {
 	return mesh_library;
+}
+
+void GridMap::set_cell_shape(CellShape p_shape) {
+	ERR_FAIL_INDEX(p_shape, CELL_SHAPE_MAX);
+	if (cell_shape == p_shape) {
+		return;
+	}
+	cell_shape = p_shape;
+	notify_property_list_changed();
+	_recreate_octant_data();
+}
+
+GridMap::CellShape GridMap::get_cell_shape() const {
+	return cell_shape;
+}
+
+void GridMap::set_cell_layout(CellLayout p_layout) {
+	ERR_FAIL_INDEX(p_layout, CELL_LAYOUT_MAX);
+	if (cell_layout == p_layout) {
+		return;
+	}
+	cell_layout = p_layout;
+	_recreate_octant_data();
+}
+
+GridMap::CellLayout GridMap::get_cell_layout() const {
+	return cell_layout;
+}
+
+void GridMap::set_cell_offset_axis(CellOffsetAxis p_offset_axis) {
+	ERR_FAIL_INDEX(p_offset_axis, CELL_OFFSET_AXIS_MAX);
+	if (cell_offset_axis == p_offset_axis) {
+		return;
+	}
+	cell_offset_axis = p_offset_axis;
+	_recreate_octant_data();
+}
+
+GridMap::CellOffsetAxis GridMap::get_cell_offset_axis() const {
+	return cell_offset_axis;
 }
 
 void GridMap::set_cell_size(const Vector3 &p_size) {
@@ -554,16 +602,235 @@ GridMap::OctantKey GridMap::get_octant_key_from_cell_coords(const Vector3i &p_ce
 }
 
 Vector3i GridMap::local_to_map(const Vector3 &p_world_position) const {
-	Vector3 map_position = (p_world_position / cell_size).floor();
+	Vector3 map_position = (p_world_position / cell_size);
+
+	// Divide by the overlapping ratio
+	double overlapping_ratio = 1.0;
+	if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
+		if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
+			overlapping_ratio = 0.75;
+		}
+		map_position.z /= overlapping_ratio;
+	} else { // CELL_OFFSET_AXIS_VERTICAL
+		if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
+			overlapping_ratio = 0.75;
+		}
+		map_position.x /= overlapping_ratio;
+	}
+
+	// For each half-offset shape, we check if we are in the corner of the tile, and thus should correct the world position accordingly.
+	if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
+		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels or overlap.
+		// square = no overlap, hexagon = 0.25 overlap, isometric = 0.5 overlap
+		if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
+			// Smart floor of the position
+			Vector3 raw_pos = map_position;
+			if (Math::posmod(Math::floor(map_position.z), 2) ^ (cell_layout == GridMap::CELL_LAYOUT_STACKED_OFFSET)) {
+				map_position = Vector3(Math::floor(map_position.x + 0.5) - 0.5, map_position.y, Math::floor(map_position.z));
+			} else {
+				map_position = map_position.floor();
+			}
+
+			// Compute the tile offset, and if we might the output for a neighbour top tile
+			Vector2 in_cell_pos = Vector2(raw_pos.x - map_position.x, raw_pos.z - map_position.z);
+			bool in_top_left_triangle = (in_cell_pos - Vector2(0.5, 0.0)).cross(Vector2(-0.5, 1.0 / overlapping_ratio - 1)) <= 0;
+			bool in_top_right_triangle = (in_cell_pos - Vector2(0.5, 0.0)).cross(Vector2(0.5, 1.0 / overlapping_ratio - 1)) > 0;
+
+			switch (cell_layout) {
+				case GridMap::CELL_LAYOUT_STACKED:
+					map_position = map_position.floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) ? 0 : -1, 0, -1);
+					} else if (in_top_right_triangle) {
+						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) ? 1 : 0, 0, -1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_STACKED_OFFSET:
+					map_position = map_position.floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) ? -1 : 0, 0, -1);
+					} else if (in_top_right_triangle) {
+						map_position += Vector3i(Math::posmod(Math::floor(map_position.z), 2) ? 0 : 1, 0, -1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_RIGHT:
+					map_position = Vector3(map_position.x - map_position.z / 2, map_position.y, map_position.z).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(0, 0, -1);
+					} else if (in_top_right_triangle) {
+						map_position += Vector3i(1, 0, -1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_DOWN:
+					map_position = Vector3(map_position.x * 2, map_position.y, map_position.z / 2 - map_position.x).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(-1, 0, 0);
+					} else if (in_top_right_triangle) {
+						map_position += Vector3i(1, 0, -1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_RIGHT:
+					map_position = Vector3(map_position.x - map_position.z / 2, map_position.y, map_position.z / 2 + map_position.x).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(0, 0, -1);
+					} else if (in_top_right_triangle) {
+						map_position += Vector3i(1, 0, 0);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_DOWN:
+					map_position = Vector3(map_position.x + map_position.z / 2, map_position.y, map_position.z / 2 - map_position.x).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(-1, 0, 0);
+					} else if (in_top_right_triangle) {
+						map_position += Vector3i(0, 0, -1);
+					}
+					break;
+				default:
+					break;
+			}
+		} else { // CELL_OFFSET_AXIS_VERTICAL
+			// Smart floor of the position
+			Vector3 raw_pos = map_position;
+			if (Math::posmod(Math::floor(map_position.x), 2) ^ (cell_layout == GridMap::CELL_LAYOUT_STACKED_OFFSET)) {
+				map_position = Vector3(Math::floor(map_position.x), Math::floor(map_position.y), Math::floor(map_position.z + 0.5) - 0.5);
+			} else {
+				map_position = map_position.floor();
+			}
+
+			// Compute the tile offset, and if we might the output for a neighbour top tile
+			Vector2 in_cell_pos = Vector2(raw_pos.x - map_position.x, raw_pos.z - map_position.z);
+			bool in_top_left_triangle = (in_cell_pos - Vector2(0.0, 0.5)).cross(Vector2(1.0 / overlapping_ratio - 1, -0.5)) > 0;
+			bool in_bottom_left_triangle = (in_cell_pos - Vector2(0.0, 0.5)).cross(Vector2(1.0 / overlapping_ratio - 1, 0.5)) <= 0;
+
+			switch (cell_layout) {
+				case GridMap::CELL_LAYOUT_STACKED:
+					map_position = map_position.floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? 0 : -1);
+					} else if (in_bottom_left_triangle) {
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? 1 : 0);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_STACKED_OFFSET:
+					map_position = map_position.floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? -1 : 0);
+					} else if (in_bottom_left_triangle) {
+						map_position += Vector3i(-1, 0, Math::posmod(Math::floor(map_position.x), 2) ? 0 : 1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_RIGHT:
+					map_position = Vector3(map_position.x / 2 - map_position.z, map_position.y, map_position.z * 2).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(0, 0, -1);
+					} else if (in_bottom_left_triangle) {
+						map_position += Vector3i(-1, 0, 1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_DOWN:
+					map_position = Vector3(map_position.x, map_position.y, map_position.z - map_position.x / 2).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(-1, 0, 0);
+					} else if (in_bottom_left_triangle) {
+						map_position += Vector3i(-1, 0, 1);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_RIGHT:
+					map_position = Vector3(map_position.x / 2 - map_position.z, map_position.y, map_position.z + map_position.x / 2).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(0, 0, -1);
+					} else if (in_bottom_left_triangle) {
+						map_position += Vector3i(-1, 0, 0);
+					}
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_DOWN:
+					map_position = Vector3(map_position.x / 2 + map_position.z, map_position.y, map_position.z - map_position.x / 2).floor();
+					if (in_top_left_triangle) {
+						map_position += Vector3i(-1, 0, 0);
+					} else if (in_bottom_left_triangle) {
+						map_position += Vector3i(0, 0, 1);
+					}
+					break;
+				default:
+					break;
+			}
+		}
+	} else {
+		map_position = (map_position + Vector3(0.00005, 0.00005, 0.00005)).floor();
+	}
+
 	return Vector3i(map_position);
 }
 
 Vector3 GridMap::map_to_local(const Vector3i &p_map_position) const {
+	Vector3 map_position = p_map_position;
+	if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
+		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels or overlap.
+		// square = no overlap, hexagon = 0.25 overlap, isometric = 0.5 overlap
+		if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
+			switch (cell_layout) {
+				case GridMap::CELL_LAYOUT_STACKED:
+					map_position = Vector3(map_position.x + (Math::posmod(map_position.z, 2) == 0 ? 0.0 : 0.5), map_position.y, map_position.z);
+					break;
+				case GridMap::CELL_LAYOUT_STACKED_OFFSET:
+					map_position = Vector3(map_position.x + (Math::posmod(map_position.z, 2) == 1 ? 0.0 : 0.5), map_position.y, map_position.z);
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_RIGHT:
+					map_position = Vector3(map_position.x + map_position.z / 2, map_position.y, map_position.z);
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_DOWN:
+					map_position = Vector3(map_position.x / 2, map_position.y, map_position.z * 2 + map_position.x);
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_RIGHT:
+					map_position = Vector3((map_position.x + map_position.z) / 2, map_position.y, map_position.z - map_position.x);
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_DOWN:
+					map_position = Vector3((map_position.x - map_position.z) / 2, map_position.y, map_position.z + map_position.x);
+					break;
+				default:
+					break;
+			}
+		} else { // CELL_OFFSET_AXIS_VERTICAL
+			switch (cell_layout) {
+				case GridMap::CELL_LAYOUT_STACKED:
+					map_position = Vector3(map_position.x, map_position.y, map_position.z + (Math::posmod(map_position.x, 2) == 0 ? 0.0 : 0.5));
+					break;
+				case GridMap::CELL_LAYOUT_STACKED_OFFSET:
+					map_position = Vector3(map_position.x, map_position.y, map_position.z + (Math::posmod(map_position.x, 2) == 1 ? 0.0 : 0.5));
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_RIGHT:
+					map_position = Vector3(map_position.x * 2 + map_position.z, map_position.y, map_position.z / 2);
+					break;
+				case GridMap::CELL_LAYOUT_STAIRS_DOWN:
+					map_position = Vector3(map_position.x, map_position.y, map_position.z + map_position.x / 2);
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_RIGHT:
+					map_position = Vector3(map_position.x + map_position.z, map_position.y, (map_position.z - map_position.x) / 2);
+					break;
+				case GridMap::CELL_LAYOUT_DIAMOND_DOWN:
+					map_position = Vector3(map_position.x - map_position.z, map_position.y, (map_position.z + map_position.x) / 2);
+					break;
+				default:
+					break;
+			}
+		}
+	}
+
+	// Multiply by the overlapping ratio
+	if (cell_shape == GridMap::CELL_SHAPE_HEXAGON) {
+		if (cell_offset_axis == GridMap::CELL_OFFSET_AXIS_HORIZONTAL) {
+			map_position.z *= 0.75;
+		} else { // CELL_OFFSET_AXIS_VERTICAL
+			map_position.x *= 0.75;
+		}
+	}
+
 	Vector3 offset = _get_offset();
 	Vector3 local_position(
-			p_map_position.x * cell_size.x + offset.x,
-			p_map_position.y * cell_size.y + offset.y,
-			p_map_position.z * cell_size.z + offset.z);
+			(map_position.x + offset.x) * cell_size.x,
+			(map_position.y + offset.y) * cell_size.y,
+			(map_position.z + offset.z) * cell_size.z);
+
 	return local_position;
 }
 
@@ -677,13 +944,11 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			continue;
 		}
 
-		Vector3 cellpos = Vector3(E.x, E.y, E.z);
-		Vector3 ofs = _get_offset();
-
+		Vector3 map_pos = Vector3(E.x, E.y, E.z);
 		Transform3D xform;
 
 		xform.basis = _ortho_bases[c.rot];
-		xform.set_origin(cellpos * cell_size + ofs);
+		xform.set_origin(map_to_local(map_pos));
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
 		if (baked_meshes.is_empty()) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
@@ -1202,6 +1467,15 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh_library", "mesh_library"), &GridMap::set_mesh_library);
 	ClassDB::bind_method(D_METHOD("get_mesh_library"), &GridMap::get_mesh_library);
 
+	ClassDB::bind_method(D_METHOD("set_cell_shape", "shape"), &GridMap::set_cell_shape);
+	ClassDB::bind_method(D_METHOD("get_cell_shape"), &GridMap::get_cell_shape);
+
+	ClassDB::bind_method(D_METHOD("set_cell_layout", "layout"), &GridMap::set_cell_layout);
+	ClassDB::bind_method(D_METHOD("get_cell_layout"), &GridMap::get_cell_layout);
+
+	ClassDB::bind_method(D_METHOD("set_cell_offset_axis", "offset_axis"), &GridMap::set_cell_offset_axis);
+	ClassDB::bind_method(D_METHOD("get_cell_offset_axis"), &GridMap::get_cell_offset_axis);
+
 	ClassDB::bind_method(D_METHOD("set_cell_size", "size"), &GridMap::set_cell_size);
 	ClassDB::bind_method(D_METHOD("get_cell_size"), &GridMap::get_cell_size);
 
@@ -1249,6 +1523,9 @@ void GridMap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material", "get_physics_material");
 #endif // PHYSICS_3D_DISABLED
 	ADD_GROUP("Cell", "cell_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_shape", PROPERTY_HINT_ENUM, "Square,Hexagon"), "set_cell_shape", "get_cell_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_layout", PROPERTY_HINT_ENUM, "Stacked,Stacked Offset,Stairs Right,Stairs Down,Diamond Right,Diamond Down"), "set_cell_layout", "get_cell_layout");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_offset_axis", PROPERTY_HINT_ENUM, "Horizontal Offset,Vertical Offset"), "set_cell_offset_axis", "get_cell_offset_axis");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "cell_size", PROPERTY_HINT_NONE, "suffix:m"), "set_cell_size", "get_cell_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_octant_size", PROPERTY_HINT_RANGE, "1,1024,1"), "set_octant_size", "get_octant_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cell_center_x"), "set_center_x", "get_center_x");
@@ -1263,6 +1540,22 @@ void GridMap::_bind_methods() {
 #endif // PHYSICS_3D_DISABLED
 	ADD_GROUP("Navigation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_navigation"), "set_bake_navigation", "is_baking_navigation");
+
+	BIND_ENUM_CONSTANT(CELL_SHAPE_SQUARE);
+	BIND_ENUM_CONSTANT(CELL_SHAPE_HEXAGON);
+	BIND_ENUM_CONSTANT(CELL_SHAPE_MAX);
+
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_STACKED);
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_STACKED_OFFSET);
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_STAIRS_RIGHT);
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_STAIRS_DOWN);
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_DIAMOND_RIGHT);
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_DIAMOND_DOWN);
+	BIND_ENUM_CONSTANT(CELL_LAYOUT_MAX);
+
+	BIND_ENUM_CONSTANT(CELL_OFFSET_AXIS_HORIZONTAL);
+	BIND_ENUM_CONSTANT(CELL_OFFSET_AXIS_VERTICAL);
+	BIND_ENUM_CONSTANT(CELL_OFFSET_AXIS_MAX);
 
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -33,6 +33,7 @@
 #include "core/io/marshalls.h"
 #include "core/templates/a_hash_map.h"
 #include "scene/resources/3d/mesh_library.h"
+#include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/surface_tool.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -730,7 +731,7 @@ Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
 
 	// convert x/z point into axial hex coordinates
 	// https://www.redblobgames.com/grids/hexagons/#pixel-to-hex
-	real_t q = (Math_SQRT3 / 3 * p_local_position.x - 1.0 / 3 * p_local_position.z) / cell_size.x;
+	real_t q = (Math::SQRT3 / 3 * p_local_position.x - 1.0 / 3 * p_local_position.z) / cell_size.x;
 	real_t r = (2.0 / 3 * p_local_position.z) / cell_size.x;
 	Vector2i hex = axial_round(q, r);
 
@@ -753,7 +754,7 @@ Vector3 GridMap::map_to_local(const Vector3i &p_map_position) const {
 	// convert axial hex coordinates to a point
 	// https://www.redblobgames.com/grids/hexagons/#hex-to-pixel
 	Vector3 local;
-	local.x = cell_size.x * (Math_SQRT3 * p_map_position.x + SQRT3_2 * p_map_position.z);
+	local.x = cell_size.x * (Math::SQRT3 * p_map_position.x + SQRT3_2 * p_map_position.z);
 	local.y = p_map_position.y * cell_size.y + offset.y;
 	local.z = cell_size.x * (3.0 / 2 * p_map_position.z);
 	return local;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -601,8 +601,9 @@ GridMap::OctantKey GridMap::get_octant_key_from_cell_coords(const Vector3i &p_ce
 	return ok;
 }
 
-Vector3i GridMap::local_to_map(const Vector3 &p_world_position) const {
-	Vector3 map_position = (p_world_position / cell_size);
+Vector3i GridMap::local_to_map(const Vector3 &p_local_position) const {
+	Vector3 map_position = p_local_position - _get_offset();
+	map_position /= cell_size;
 
 	// Divide by the overlapping ratio
 	double overlapping_ratio = 1.0;

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -32,7 +32,10 @@
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/mesh_library.h"
-#include "scene/resources/multimesh.h"
+
+// SQRT(3)/2; used both in the editor and the GridMap.  Due to the division, it
+// didn't fit the pattern of other Math_SQRTN defines, so I'm putting it here.
+#define SQRT3_2 0.8660254037844386
 
 class NavigationMesh;
 class NavigationMeshSourceGeometryData3D;
@@ -48,22 +51,6 @@ public:
 		CELL_SHAPE_SQUARE,
 		CELL_SHAPE_HEXAGON,
 		CELL_SHAPE_MAX,
-	};
-
-	enum CellLayout {
-		CELL_LAYOUT_STACKED,
-		CELL_LAYOUT_STACKED_OFFSET,
-		CELL_LAYOUT_STAIRS_RIGHT,
-		CELL_LAYOUT_STAIRS_DOWN,
-		CELL_LAYOUT_DIAMOND_RIGHT,
-		CELL_LAYOUT_DIAMOND_DOWN,
-		CELL_LAYOUT_MAX,
-	};
-
-	enum CellOffsetAxis {
-		CELL_OFFSET_AXIS_HORIZONTAL,
-		CELL_OFFSET_AXIS_VERTICAL,
-		CELL_OFFSET_AXIS_MAX,
 	};
 
 private:
@@ -191,8 +178,7 @@ private:
 
 	bool _in_tree = false;
 	CellShape cell_shape = CELL_SHAPE_SQUARE;
-	CellLayout cell_layout = CELL_LAYOUT_STACKED;
-	CellOffsetAxis cell_offset_axis = CELL_OFFSET_AXIS_HORIZONTAL;
+	TypedArray<Basis> cell_orientations;
 	Vector3 cell_size = Vector3(2, 2, 2);
 	int octant_size = 8;
 	bool center_x = true;
@@ -258,7 +244,6 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
 	void _update_visibility();
@@ -305,12 +290,6 @@ public:
 	void set_cell_shape(CellShape p_shape);
 	CellShape get_cell_shape() const;
 
-	void set_cell_layout(CellLayout p_layout);
-	CellLayout get_cell_layout() const;
-
-	void set_cell_offset_axis(CellOffsetAxis p_offset_axis);
-	CellOffsetAxis get_cell_offset_axis() const;
-
 	void set_cell_size(const Vector3 &p_size);
 	Vector3 get_cell_size() const;
 
@@ -330,9 +309,12 @@ public:
 	Basis get_cell_item_basis(const Vector3i &p_position) const;
 	Basis get_basis_with_orthogonal_index(int p_index) const;
 	int get_orthogonal_index_from_basis(const Basis &p_basis) const;
+	TypedArray<Vector3i> get_cell_neighbors(const Vector3i p_cell) const;
 
 	Vector3i local_to_map(const Vector3 &p_local_position) const;
 	Vector3 map_to_local(const Vector3i &p_map_position) const;
+
+	TypedArray<Vector3i> local_region_to_map(Vector3 p_local_point_a, Vector3 p_local_point_b) const;
 
 	void set_cell_scale(float p_scale);
 	float get_cell_scale() const;
@@ -366,7 +348,5 @@ public:
 	~GridMap();
 };
 VARIANT_ENUM_CAST(GridMap::CellShape);
-VARIANT_ENUM_CAST(GridMap::CellLayout);
-VARIANT_ENUM_CAST(GridMap::CellOffsetAxis);
 
 #endif // GRID_MAP_H

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -34,7 +34,7 @@
 #include "scene/resources/3d/mesh_library.h"
 
 // SQRT(3)/2; used both in the editor and the GridMap.  Due to the division, it
-// didn't fit the pattern of other Math_SQRTN defines, so I'm putting it here.
+// didn't fit the pattern of other Math::SQRTN defines, so I'm putting it here.
 #define SQRT3_2 0.8660254037844386
 
 class NavigationMesh;
@@ -349,4 +349,3 @@ public:
 };
 VARIANT_ENUM_CAST(GridMap::CellShape);
 
-#endif // GRID_MAP_H

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -43,6 +43,30 @@ class PhysicsMaterial;
 class GridMap : public Node3D {
 	GDCLASS(GridMap, Node3D);
 
+public:
+	enum CellShape {
+		CELL_SHAPE_SQUARE,
+		CELL_SHAPE_HEXAGON,
+		CELL_SHAPE_MAX,
+	};
+
+	enum CellLayout {
+		CELL_LAYOUT_STACKED,
+		CELL_LAYOUT_STACKED_OFFSET,
+		CELL_LAYOUT_STAIRS_RIGHT,
+		CELL_LAYOUT_STAIRS_DOWN,
+		CELL_LAYOUT_DIAMOND_RIGHT,
+		CELL_LAYOUT_DIAMOND_DOWN,
+		CELL_LAYOUT_MAX,
+	};
+
+	enum CellOffsetAxis {
+		CELL_OFFSET_AXIS_HORIZONTAL,
+		CELL_OFFSET_AXIS_VERTICAL,
+		CELL_OFFSET_AXIS_MAX,
+	};
+
+private:
 	enum {
 		MAP_DIRTY_TRANSFORMS = 1,
 		MAP_DIRTY_INSTANCES = 2,
@@ -166,6 +190,9 @@ class GridMap : public Node3D {
 	Transform3D last_transform;
 
 	bool _in_tree = false;
+	CellShape cell_shape = CELL_SHAPE_SQUARE;
+	CellLayout cell_layout = CELL_LAYOUT_STACKED;
+	CellOffsetAxis cell_offset_axis = CELL_OFFSET_AXIS_HORIZONTAL;
 	Vector3 cell_size = Vector3(2, 2, 2);
 	int octant_size = 8;
 	bool center_x = true;
@@ -231,6 +258,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
 	void _update_visibility();
@@ -273,6 +301,15 @@ public:
 
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);
 	Ref<MeshLibrary> get_mesh_library() const;
+
+	void set_cell_shape(CellShape p_shape);
+	CellShape get_cell_shape() const;
+
+	void set_cell_layout(CellLayout p_layout);
+	CellLayout get_cell_layout() const;
+
+	void set_cell_offset_axis(CellOffsetAxis p_offset_axis);
+	CellOffsetAxis get_cell_offset_axis() const;
 
 	void set_cell_size(const Vector3 &p_size);
 	Vector3 get_cell_size() const;
@@ -328,3 +365,8 @@ public:
 	GridMap();
 	~GridMap();
 };
+VARIANT_ENUM_CAST(GridMap::CellShape);
+VARIANT_ENUM_CAST(GridMap::CellLayout);
+VARIANT_ENUM_CAST(GridMap::CellOffsetAxis);
+
+#endif // GRID_MAP_H

--- a/modules/gridmap/tests/test_grid_map.h
+++ b/modules/gridmap/tests/test_grid_map.h
@@ -1,0 +1,320 @@
+/**************************************************************************/
+/*  test_grid_map.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_GRID_MAP_H
+#define TEST_GRID_MAP_H
+
+#include "../grid_map.h"
+#include "core/math/math_defs.h"
+#include "core/math/vector3i.h"
+#include "core/string/print_string.h"
+#include "tests/core/math/test_vector4.h"
+#include "tests/test_macros.h"
+
+namespace TestGridMap {
+
+TEST_CASE("[SceneTree][GridMap] hex cell set_cell_size()") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_HEXAGON);
+	map.set_cell_size(Vector3(1.0, 3.0, 200.0));
+	CHECK(map.get_cell_size().x == 1.0);
+	CHECK(map.get_cell_size().y == 3.0);
+	CHECK_MESSAGE(map.get_cell_size().z == 1.0,
+			"set_cell_size() hex cell, z value should be overwritten with x");
+}
+
+#define CHECK_HEX_BOUNDARIES(p, c)                                                     \
+	{                                                                                  \
+		Vector3i index = map.local_to_map((p));                                        \
+		CHECK_MESSAGE(index == (c), #p " center not in expected cell");                \
+		index = map.local_to_map((p) + Vector3(0, 0, 0.499));                          \
+		CHECK_MESSAGE(index == (c), #p " east edge not in expected cell");             \
+		index = map.local_to_map((p) + Vector3(Math_SQRT3 / 2.0 - 0.001, 0, 0.499));   \
+		CHECK_MESSAGE(index == (c), #p " northeast vertex not in expected cell");      \
+		index = map.local_to_map((p) + Vector3(0, 0, 0.999));                          \
+		CHECK_MESSAGE(index == (c), #p " north vertex not in expected cell");          \
+		index = map.local_to_map((p) + Vector3(-Math_SQRT3 / 2.0 + 0.001, 0, 0.499));  \
+		CHECK_MESSAGE(index == (c), #p " northwest vertex not in expected cell");      \
+		index = map.local_to_map((p) + Vector3(0, 0, -0.499));                         \
+		CHECK_MESSAGE(index == (c), #p " west edge not in expected cell");             \
+		index = map.local_to_map((p) + Vector3(-Math_SQRT3 / 2.0 + 0.001, 0, -0.499)); \
+		CHECK_MESSAGE(index == (c), #p " southwest vertex not in expected cell");      \
+		index = map.local_to_map((p) + Vector3(0, 0, -0.99));                          \
+		CHECK_MESSAGE(index == (c), #p " south vertex not in expected cell");          \
+		index = map.local_to_map((p) + Vector3(Math_SQRT3 / 2.0 - 0.001, 0, -0.49));   \
+		CHECK_MESSAGE(index == (c), #p " southeast vertex not in expected cell");      \
+	}
+
+TEST_CASE("[SceneTree][GridMap] local_to_map() for hex cells") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_HEXAGON);
+	map.set_cell_size(Vector3(1.0, 1.0, 1.0));
+
+	// verify origin
+	CHECK_HEX_BOUNDARIES(Vector3(0, 0, 0), Vector3i(0, 0, 0));
+	// north two rows
+	CHECK_HEX_BOUNDARIES(Vector3(0, 0, 3), Vector3i(-1, 0, 2));
+	// south two rows
+	CHECK_HEX_BOUNDARIES(Vector3(0, 0, -3), Vector3i(1, 0, -2));
+	// east one cell
+	CHECK_HEX_BOUNDARIES(Vector3(Math_SQRT3, 0, 0), Vector3i(1, 0, 0));
+	// west one cell
+	CHECK_HEX_BOUNDARIES(Vector3(-Math_SQRT3, 0, 0), Vector3i(-1, 0, 0));
+	// northeast one cell
+	CHECK_HEX_BOUNDARIES(Vector3(Math_SQRT3 / 2, 0, 1.5), Vector3i(0, 0, 1));
+	// northwest one cell
+	CHECK_HEX_BOUNDARIES(Vector3(-Math_SQRT3 / 2, 0, 1.5), Vector3i(-1, 0, 1));
+	// southwest one cell
+	CHECK_HEX_BOUNDARIES(Vector3(-Math_SQRT3 / 2, 0, -1.5), Vector3i(0, 0, -1));
+}
+
+TEST_CASE("[SceneTree][GridMap] map_to_local() for hex cells") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_HEXAGON);
+	map.set_cell_size(Vector3(1.0, 1.0, 1.0));
+
+	CHECK(map.map_to_local(Vector3i(0, 0, 0)) == Vector3(0, 0.5, 0));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 2)) == Vector3(0, 0.5, 3));
+	CHECK(map.map_to_local(Vector3i(1, 0, -2)) == Vector3(0, 0.5, -3));
+	CHECK(map.map_to_local(Vector3i(1, 0, 0)) == Vector3(Math_SQRT3, 0.5, 0));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 0)) == Vector3(-Math_SQRT3, 0.5, 0));
+	CHECK(map.map_to_local(Vector3i(0, 0, 1)) == Vector3(Math_SQRT3 / 2, 0.5, 1.5));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 1)) == Vector3(-Math_SQRT3 / 2, 0.5, 1.5));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 1)) == Vector3(-Math_SQRT3 / 2, 0.5, 1.5));
+	CHECK(map.map_to_local(Vector3i(0, 0, -1)) == Vector3(-Math_SQRT3 / 2, 0.5, -1.5));
+
+	CHECK(map.map_to_local(Vector3i(0, 1, 0)) == Vector3(0, 1.5, 0));
+	CHECK(map.map_to_local(Vector3i(0, -1, 0)) == Vector3(0, -0.5, 0));
+}
+
+TEST_CASE("[SceneTree][GridMap] map_to_local() with square cells") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_SQUARE);
+	map.set_cell_size(Vector3(1.0, 1.0, 1.0));
+
+	// even with zero volume, we'll include the single cell we are within.
+	TypedArray<Vector3i> cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(0, 0, 0));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.size() == 1);
+
+	// three cells along the x-axis
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(2, 0, 0));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(1, 0, 0)));
+	CHECK(cells.has(Vector3i(2, 0, 0)));
+	CHECK(cells.size() == 3);
+
+	// three cells along the y-axis
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(0, 2, 0));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(0, 1, 0)));
+	CHECK(cells.has(Vector3i(0, 2, 0)));
+	CHECK(cells.size() == 3);
+
+	// three cells along the z-axis
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(0, 0, 2));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(0, 0, 1)));
+	CHECK(cells.has(Vector3i(0, 0, 2)));
+	CHECK(cells.size() == 3);
+
+	// three by three by three region starting at origin
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(2, 2, 2));
+	CHECK(cells.size() == 3 * 3 * 3);
+	for (int z = 0; z <= 2; z++) {
+		for (int y = 0; y <= 2; y++) {
+			for (int x = 0; x <= 2; x++) {
+				CHECK_MESSAGE(cells.has(Vector3i(x, y, z)),
+						"cells should contain (", x, ", ", y, ", ", z, ")");
+			}
+		}
+	}
+
+	// two by three by four region starting at (-10, -100, -1000)
+	cells = map.local_region_to_map(Vector3(-10, -100, -1000), Vector3(-11, -102, -1003));
+	CHECK(cells.size() == 2 * 3 * 4);
+	for (int z = -1003; z <= -1000; z++) {
+		for (int y = -102; y <= -100; y++) {
+			for (int x = -11; x <= -10; x++) {
+				CHECK_MESSAGE(cells.has(Vector3i(x, y, z)),
+						"cells should contain (", x, ", ", y, ", ", z, ")");
+			}
+		}
+	}
+
+	// 5x2x1 passing through the origin
+	cells = map.local_region_to_map(Vector3(-2, -1, 0), Vector3(2, 0, 0));
+	CHECK(cells.size() == 5 * 2 * 1);
+	for (int z = 0; z <= 0; z++) {
+		for (int y = -1; y <= 0; y++) {
+			for (int x = -2; x <= -2; x++) {
+				CHECK_MESSAGE(cells.has(Vector3i(x, y, z)),
+						"cells should contain (", x, ", ", y, ", ", z, ")");
+			}
+		}
+	}
+
+	SUBCASE("2x2x2 cube tiles") {
+		GridMap test_map;
+		test_map.set_cell_shape(GridMap::CELL_SHAPE_SQUARE);
+		test_map.set_cell_size(Vector3(2.0, 2.0, 2.0));
+
+		cells = test_map.local_region_to_map(Vector3(0, 0, 0), Vector3(3.9, 0, 3.9));
+		CHECK(cells.has(Vector3i(0, 0, 0)));
+		CHECK(cells.has(Vector3i(0, 0, 1)));
+		CHECK(cells.has(Vector3i(1, 0, 0)));
+		CHECK(cells.has(Vector3i(1, 0, 1)));
+		CHECK(cells.size() == 4);
+	}
+}
+
+TEST_CASE("[SceneTree][GridMap] map_to_local() with hex cells") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_HEXAGON);
+	map.set_cell_size(Vector3(1.0, 1.0, 1.0));
+
+	// even with zero volume, we'll include the single cell we are within.
+	TypedArray<Vector3i> cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(0, 0, 0));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.size() == 1);
+
+	// three cells along the x-axis
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(Math_SQRT3 * 2, 0, 0));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(1, 0, 0)));
+	CHECK(cells.has(Vector3i(2, 0, 0)));
+	CHECK(cells.size() == 3);
+
+	// three cells along the y-axis
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(0, 2, 0));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(0, 1, 0)));
+	CHECK(cells.has(Vector3i(0, 2, 0)));
+	CHECK(cells.size() == 3);
+
+	// cells along the z-axis, slightly to the left of center to ensure we add
+	// the southwest zigzag cells
+	cells = map.local_region_to_map(Vector3(-0.1, 0, 0), Vector3(-0.1, 0, 3));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(-1, 0, 1)));
+	CHECK(cells.has(Vector3i(-1, 0, 2)));
+	CHECK(cells.size() == 3);
+
+	// Same as above, but go southeast instead
+	cells = map.local_region_to_map(Vector3(0.1, 0, 0), Vector3(0.1, 0, 3));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(0, 0, 1)));
+	CHECK(cells.has(Vector3i(-1, 0, 2)));
+	CHECK(cells.size() == 3);
+
+	// square region around the origin
+	cells = map.local_region_to_map(Vector3(-Math_SQRT3, 0, -1), Vector3(Math_SQRT3, 0, 1));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(0, 0, 1)));
+	CHECK(cells.has(Vector3i(0, 0, -1)));
+	CHECK(cells.has(Vector3i(1, 0, -1)));
+	CHECK(cells.has(Vector3i(1, 0, 0)));
+	CHECK(cells.has(Vector3i(-1, 0, 0)));
+	CHECK(cells.has(Vector3i(-1, 0, 1)));
+	CHECK(cells.size() == 7);
+
+	// similar to above, but bring in the X coordinates to exclude east & west
+	// cells
+	cells = map.local_region_to_map(Vector3(-SQRT3_2 + 0.1, 0, -1), Vector3(SQRT3_2 - 0.1, 0, 1));
+	CHECK(cells.has(Vector3i(0, 0, 0)));
+	CHECK(cells.has(Vector3i(0, 0, 1)));
+	CHECK(cells.has(Vector3i(0, 0, -1)));
+	CHECK(cells.has(Vector3i(1, 0, -1)));
+	CHECK(cells.has(Vector3i(-1, 0, 1)));
+	CHECK(cells.size() == 5);
+}
+
+TEST_CASE("[SceneTree][GridMap] get_cell_neighbors() square cells") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_SQUARE);
+
+	SUBCASE("cell (0,0,0)") {
+		TypedArray<Vector3i> cells = map.get_cell_neighbors(Vector3i(0, 0, 0));
+		CHECK(cells.size() == 6);
+		CHECK(cells.has(Vector3i(1, 0, 0)));
+		CHECK(cells.has(Vector3i(0, 1, 0)));
+		CHECK(cells.has(Vector3i(0, 0, 1)));
+		CHECK(cells.has(Vector3i(-1, 0, 0)));
+		CHECK(cells.has(Vector3i(0, -1, 0)));
+		CHECK(cells.has(Vector3i(0, 0, -1)));
+	}
+
+	SUBCASE("cell (-12,10,100)") {
+		Vector3i cell = Vector3i(-12, 10, 100);
+		TypedArray<Vector3i> cells = map.get_cell_neighbors(cell);
+		CHECK(cells.size() == 6);
+		CHECK(cells.has(cell + Vector3i(1, 0, 0)));
+		CHECK(cells.has(cell + Vector3i(0, 1, 0)));
+		CHECK(cells.has(cell + Vector3i(0, 0, 1)));
+		CHECK(cells.has(cell + Vector3i(-1, 0, 0)));
+		CHECK(cells.has(cell + Vector3i(0, -1, 0)));
+		CHECK(cells.has(cell + Vector3i(0, 0, -1)));
+	}
+}
+
+TEST_CASE("[SceneTree][GridMap] get_cell_neighbors() hex cells") {
+	GridMap map;
+	map.set_cell_shape(GridMap::CELL_SHAPE_HEXAGON);
+
+	SUBCASE("cell (0,0,0)") {
+		TypedArray<Vector3i> cells = map.get_cell_neighbors(Vector3i(0, 0, 0));
+		CHECK(cells.size() == 8);
+		CHECK(cells.has(Vector3i(1, 0, 0)));
+		CHECK(cells.has(Vector3i(1, 0, -1)));
+		CHECK(cells.has(Vector3i(0, 0, -1)));
+		CHECK(cells.has(Vector3i(-1, 0, 0)));
+		CHECK(cells.has(Vector3i(-1, 0, 1)));
+		CHECK(cells.has(Vector3i(0, 0, 1)));
+		CHECK(cells.has(Vector3i(0, -1, 0)));
+		CHECK(cells.has(Vector3i(0, 1, 0)));
+	}
+
+	SUBCASE("cell (-12,10,100)") {
+		Vector3i cell = Vector3i(-12, 10, 100);
+		TypedArray<Vector3i> cells = map.get_cell_neighbors(cell);
+		CHECK(cells.size() == 8);
+		CHECK(cells.has(cell + Vector3i(1, 0, 0)));
+		CHECK(cells.has(cell + Vector3i(1, 0, -1)));
+		CHECK(cells.has(cell + Vector3i(0, 0, -1)));
+		CHECK(cells.has(cell + Vector3i(-1, 0, 0)));
+		CHECK(cells.has(cell + Vector3i(-1, 0, 1)));
+		CHECK(cells.has(cell + Vector3i(0, 0, 1)));
+		CHECK(cells.has(cell + Vector3i(0, -1, 0)));
+		CHECK(cells.has(cell + Vector3i(0, 1, 0)));
+	}
+}
+} // namespace TestGridMap
+
+#endif // TEST_GRID_MAP_H

--- a/modules/gridmap/tests/test_grid_map.h
+++ b/modules/gridmap/tests/test_grid_map.h
@@ -56,19 +56,19 @@ TEST_CASE("[SceneTree][GridMap] hex cell set_cell_size()") {
 		CHECK_MESSAGE(index == (c), #p " center not in expected cell");                \
 		index = map.local_to_map((p) + Vector3(0, 0, 0.499));                          \
 		CHECK_MESSAGE(index == (c), #p " east edge not in expected cell");             \
-		index = map.local_to_map((p) + Vector3(Math_SQRT3 / 2.0 - 0.001, 0, 0.499));   \
+		index = map.local_to_map((p) + Vector3(Math::SQRT3 / 2.0 - 0.001, 0, 0.499));   \
 		CHECK_MESSAGE(index == (c), #p " northeast vertex not in expected cell");      \
 		index = map.local_to_map((p) + Vector3(0, 0, 0.999));                          \
 		CHECK_MESSAGE(index == (c), #p " north vertex not in expected cell");          \
-		index = map.local_to_map((p) + Vector3(-Math_SQRT3 / 2.0 + 0.001, 0, 0.499));  \
+		index = map.local_to_map((p) + Vector3(-Math::SQRT3 / 2.0 + 0.001, 0, 0.499));  \
 		CHECK_MESSAGE(index == (c), #p " northwest vertex not in expected cell");      \
 		index = map.local_to_map((p) + Vector3(0, 0, -0.499));                         \
 		CHECK_MESSAGE(index == (c), #p " west edge not in expected cell");             \
-		index = map.local_to_map((p) + Vector3(-Math_SQRT3 / 2.0 + 0.001, 0, -0.499)); \
+		index = map.local_to_map((p) + Vector3(-Math::SQRT3 / 2.0 + 0.001, 0, -0.499)); \
 		CHECK_MESSAGE(index == (c), #p " southwest vertex not in expected cell");      \
 		index = map.local_to_map((p) + Vector3(0, 0, -0.99));                          \
 		CHECK_MESSAGE(index == (c), #p " south vertex not in expected cell");          \
-		index = map.local_to_map((p) + Vector3(Math_SQRT3 / 2.0 - 0.001, 0, -0.49));   \
+		index = map.local_to_map((p) + Vector3(Math::SQRT3 / 2.0 - 0.001, 0, -0.49));   \
 		CHECK_MESSAGE(index == (c), #p " southeast vertex not in expected cell");      \
 	}
 
@@ -84,15 +84,15 @@ TEST_CASE("[SceneTree][GridMap] local_to_map() for hex cells") {
 	// south two rows
 	CHECK_HEX_BOUNDARIES(Vector3(0, 0, -3), Vector3i(1, 0, -2));
 	// east one cell
-	CHECK_HEX_BOUNDARIES(Vector3(Math_SQRT3, 0, 0), Vector3i(1, 0, 0));
+	CHECK_HEX_BOUNDARIES(Vector3(Math::SQRT3, 0, 0), Vector3i(1, 0, 0));
 	// west one cell
-	CHECK_HEX_BOUNDARIES(Vector3(-Math_SQRT3, 0, 0), Vector3i(-1, 0, 0));
+	CHECK_HEX_BOUNDARIES(Vector3(-Math::SQRT3, 0, 0), Vector3i(-1, 0, 0));
 	// northeast one cell
-	CHECK_HEX_BOUNDARIES(Vector3(Math_SQRT3 / 2, 0, 1.5), Vector3i(0, 0, 1));
+	CHECK_HEX_BOUNDARIES(Vector3(Math::SQRT3 / 2, 0, 1.5), Vector3i(0, 0, 1));
 	// northwest one cell
-	CHECK_HEX_BOUNDARIES(Vector3(-Math_SQRT3 / 2, 0, 1.5), Vector3i(-1, 0, 1));
+	CHECK_HEX_BOUNDARIES(Vector3(-Math::SQRT3 / 2, 0, 1.5), Vector3i(-1, 0, 1));
 	// southwest one cell
-	CHECK_HEX_BOUNDARIES(Vector3(-Math_SQRT3 / 2, 0, -1.5), Vector3i(0, 0, -1));
+	CHECK_HEX_BOUNDARIES(Vector3(-Math::SQRT3 / 2, 0, -1.5), Vector3i(0, 0, -1));
 }
 
 TEST_CASE("[SceneTree][GridMap] map_to_local() for hex cells") {
@@ -103,12 +103,12 @@ TEST_CASE("[SceneTree][GridMap] map_to_local() for hex cells") {
 	CHECK(map.map_to_local(Vector3i(0, 0, 0)) == Vector3(0, 0.5, 0));
 	CHECK(map.map_to_local(Vector3i(-1, 0, 2)) == Vector3(0, 0.5, 3));
 	CHECK(map.map_to_local(Vector3i(1, 0, -2)) == Vector3(0, 0.5, -3));
-	CHECK(map.map_to_local(Vector3i(1, 0, 0)) == Vector3(Math_SQRT3, 0.5, 0));
-	CHECK(map.map_to_local(Vector3i(-1, 0, 0)) == Vector3(-Math_SQRT3, 0.5, 0));
-	CHECK(map.map_to_local(Vector3i(0, 0, 1)) == Vector3(Math_SQRT3 / 2, 0.5, 1.5));
-	CHECK(map.map_to_local(Vector3i(-1, 0, 1)) == Vector3(-Math_SQRT3 / 2, 0.5, 1.5));
-	CHECK(map.map_to_local(Vector3i(-1, 0, 1)) == Vector3(-Math_SQRT3 / 2, 0.5, 1.5));
-	CHECK(map.map_to_local(Vector3i(0, 0, -1)) == Vector3(-Math_SQRT3 / 2, 0.5, -1.5));
+	CHECK(map.map_to_local(Vector3i(1, 0, 0)) == Vector3(Math::SQRT3, 0.5, 0));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 0)) == Vector3(-Math::SQRT3, 0.5, 0));
+	CHECK(map.map_to_local(Vector3i(0, 0, 1)) == Vector3(Math::SQRT3 / 2, 0.5, 1.5));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 1)) == Vector3(-Math::SQRT3 / 2, 0.5, 1.5));
+	CHECK(map.map_to_local(Vector3i(-1, 0, 1)) == Vector3(-Math::SQRT3 / 2, 0.5, 1.5));
+	CHECK(map.map_to_local(Vector3i(0, 0, -1)) == Vector3(-Math::SQRT3 / 2, 0.5, -1.5));
 
 	CHECK(map.map_to_local(Vector3i(0, 1, 0)) == Vector3(0, 1.5, 0));
 	CHECK(map.map_to_local(Vector3i(0, -1, 0)) == Vector3(0, -0.5, 0));
@@ -206,7 +206,7 @@ TEST_CASE("[SceneTree][GridMap] map_to_local() with hex cells") {
 	CHECK(cells.size() == 1);
 
 	// three cells along the x-axis
-	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(Math_SQRT3 * 2, 0, 0));
+	cells = map.local_region_to_map(Vector3(0, 0, 0), Vector3(Math::SQRT3 * 2, 0, 0));
 	CHECK(cells.has(Vector3i(0, 0, 0)));
 	CHECK(cells.has(Vector3i(1, 0, 0)));
 	CHECK(cells.has(Vector3i(2, 0, 0)));
@@ -235,7 +235,7 @@ TEST_CASE("[SceneTree][GridMap] map_to_local() with hex cells") {
 	CHECK(cells.size() == 3);
 
 	// square region around the origin
-	cells = map.local_region_to_map(Vector3(-Math_SQRT3, 0, -1), Vector3(Math_SQRT3, 0, 1));
+	cells = map.local_region_to_map(Vector3(-Math::SQRT3, 0, -1), Vector3(Math::SQRT3, 0, 1));
 	CHECK(cells.has(Vector3i(0, 0, 0)));
 	CHECK(cells.has(Vector3i(0, 0, 1)));
 	CHECK(cells.has(Vector3i(0, 0, -1)));


### PR DESCRIPTION
This adds support for hexagonal grids in the `GridMap` node with the same offset and layout semantics as `TileMap`.

This is a rebase of the latest master for https://github.com/godotengine/godot/pull/59842. There was minimal editing outside of updating to the proper 4.2+ API, and using the new naming convention introduced in master. (IE: `world_to_map` and `map_to_world` to `local_to_map` and `map_to_local`).

Performed functional testing with a hex MeshLibrary.

Closes https://github.com/godotengine/godot-proposals/issues/4337. Based on discussion, it wouldn't be too hard to remove the Layout and Offset Axis options, though they seem to work just fine.
