### PR TITLE
Localization: Fix pt_BR strings for Debug/Release User and Password

### DIFF
--- a/editor/translations/properties/pt_BR.po
+++ b/editor/translations/properties/pt_BR.po
@@ -162,6 +162,7 @@
 # Felipe Bertola <eduardodelphinodepaula@gmail.com>, 2023.
 # Vittor Paulo Vieira da Costa <vittorpaulovc@gmail.com>, 2023.
 # Matheus Macedo <mmanganelidemacedo@gmail.com>, 2023.
+# Ricardo Bustamante <ricardo@busta.dev>, 2023.
 msgid ""
 msgstr ""
 "Project-Id-Version: Godot Engine properties\n"
@@ -3371,16 +3372,16 @@ msgid "Keystore"
 msgstr "Keystore"
 
 msgid "Debug User"
-msgstr "Depurar Usuário"
+msgstr "Usuário de Depuração"
 
 msgid "Debug Password"
-msgstr "Depurar Senha"
+msgstr "Senha de Depuração"
 
 msgid "Release User"
-msgstr "Liberar Usuário"
+msgstr "Usuário de Lançamento"
 
 msgid "Release Password"
-msgstr "Liberar Senha"
+msgstr "Senha de Depuração"
 
 msgid "Code"
 msgstr "Código"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The old strings contained
"To Debug User/Password"
and
"Free the User/Password"

![image](https://github.com/godotengine/godot/assets/6434768/ffae09e3-b743-4ee6-a59e-4089f6499fbc)

Replaced them with the strings with the correct meaning in Portuguese from Brazil, based in the regular "Debug" and "Release" strings, so they all match.