### PR TITLE
CanvasItem: Expose get_effective_z_index to GDScript.

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -417,6 +417,13 @@
 				Returns the transform from the coordinate system of the canvas, this item is in, to the [Viewport]s coordinate system.
 			</description>
 		</method>
+		<method name="get_effective_z_index" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total Z index, accounting for [member z_as_relative].
+				This does not account for other effects such as [member top_level], [member y_sort_enabled], or sorting by hierarchy (see [method Node.get_index]).
+			</description>
+		</method>
 		<method name="get_global_mouse_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1119,6 +1119,7 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_z_index", "z_index"), &CanvasItem::set_z_index);
 	ClassDB::bind_method(D_METHOD("get_z_index"), &CanvasItem::get_z_index);
+	ClassDB::bind_method(D_METHOD("get_effective_z_index"), &CanvasItem::get_effective_z_index);
 
 	ClassDB::bind_method(D_METHOD("set_z_as_relative", "enable"), &CanvasItem::set_z_as_relative);
 	ClassDB::bind_method(D_METHOD("is_z_relative"), &CanvasItem::is_z_relative);


### PR DESCRIPTION
Recently had a fellow developer run into a need for this function (as it is, it was reimplemented in GDScript) due to picking logic being rather unusual (see attached test project). While it would be nice for this logic to be more consistent, being able to sort items properly is important anyway.

In addition this sort of thing seems to be wanted generally, i.e. https://forum.godotengine.org/t/getting-the-absolute-z-index-of-a-node/23709/2

With this in mind, I decided it would be good to simply expose this function and point out what it doesn't handle in the documentation. This allows GDScript-side code to collate and sort the objects. Again, even if picking behaviour changes to be more consistent, this should still have usecases.

Attached test project shows how the function works. It also shows how picking logic appears to act, in case that helps explain the rationale.

[godot-dev-test-effectivez.zip](https://github.com/godotengine/godot/files/13613488/godot-dev-test-effectivez.zip)

An alternative might be a "does this CanvasItem draw above this other CanvasItem" function. While this would be useful and more versatile, to get it to really work *right* would be difficult, particularly given Y-sorting became integrated into RenderingServer. It's the sort of thing that would probably need some kind of unit test that could introspect the RenderingServer's draw order to compare.