### PR TITLE
[3.x] SCons: Fix Linux arm64 build for theora and libvpx

### DIFF
--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -228,7 +228,9 @@ elif env["platform"] != "windows":  # Disable for Windows, yasm SIMD optimizatio
     import platform
 
     is_x11_or_server_arm = (env["platform"] == "x11" or env["platform"] == "server") and (
-        platform.machine().startswith("arm") or platform.machine().startswith("aarch")
+        platform.machine().startswith("arm")
+        or platform.machine().startswith("aarch")
+        or ("arch" in env and env["arch"].startswith("arm"))
     )
     is_macos_x86 = env["platform"] == "osx" and ("arch" in env and (env["arch"] != "arm64"))
     is_ios_x86 = env["platform"] == "iphone" and ("arch" in env and env["arch"].startswith("x86"))

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -312,7 +312,7 @@ def configure(env):
         env.ParseConfig("pkg-config theora theoradec --cflags --libs")
     else:
         list_of_x86 = ["x86_64", "x86", "i386", "i586"]
-        if any(platform.machine() in s for s in list_of_x86):
+        if (env["arch"].startswith("x86") or env["arch"] == "") and any(platform.machine() in s for s in list_of_x86):
             env["x86_libtheora_opt_gcc"] = True
 
     if not env["builtin_libvpx"]:


### PR DESCRIPTION
The architecture handling in 3.x is all over the place, and I'm not going to start a major refactor like I did for 4.0 so late in its life cycle.

So let's add more hacks! ⚔️

This requires manually passing `arch=arm64` when compiling, but this is already the case for other parts of the codebase.

---

Compiled successfully with our Linux arm64 SDK and this command:
```
PATH=~/godot/toolchains/aarch64-godot-linux-gnu_sdk-buildroot/bin:$PATH scons p=x11 verbose=yes arch=arm64
```

Could be cherry-picked for 3.5.x, but there are other PRs made since 3.5 which would be needed to backport to properly fix Linux arm64 builds, and I don't think it's worth the trouble. It's better to get 3.6 released with that support :)