### PR TITLE
[3.x] GDNative: Fix Linux arm64 warning about ignored `sysv_abi` attribute

### DIFF
--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -37,20 +37,24 @@ extern "C" {
 
 #if defined(_WIN32) || defined(__ANDROID__)
 #define GDCALLINGCONV
-#define GDAPI GDCALLINGCONV
+
 #elif defined(__APPLE__)
 #include "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #define GDCALLINGCONV __attribute__((visibility("default")))
-#define GDAPI GDCALLINGCONV
 #elif TARGET_OS_MAC
 #define GDCALLINGCONV __attribute__((sysv_abi))
-#define GDAPI GDCALLINGCONV
 #endif
-#else // !_WIN32 && !__APPLE__
+
+#else // Linux/BSD/Web
+#if defined(__aarch64__)
+#define GDCALLINGCONV
+#else
 #define GDCALLINGCONV __attribute__((sysv_abi))
-#define GDAPI GDCALLINGCONV
 #endif
+#endif
+
+#define GDAPI GDCALLINGCONV
 
 // This is for libraries *using* the header, NOT GODOT EXPOSING STUFF!!
 #if !defined(GDN_EXPORT)


### PR DESCRIPTION
Fixes #41160.