### PR TITLE
[3.x] Fix various GCC 13 warnings

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1460,7 +1460,11 @@ bool String::parse_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
 		int skip = 0;
 		while (ptrtmp != ptrtmp_limit && *ptrtmp) {
 			if (skip == 0) {
+#if CHAR_MIN == 0
+				uint8_t c = *ptrtmp;
+#else
 				uint8_t c = *ptrtmp >= 0 ? *ptrtmp : uint8_t(256 + *ptrtmp);
+#endif
 
 				if (p_skip_cr && c == '\r') {
 					ptrtmp++;

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1214,10 +1214,10 @@ public:
 
 		struct MipMaps {
 			struct Size {
-				GLuint fbo;
-				GLuint color;
-				int width;
-				int height;
+				GLuint fbo = 0;
+				GLuint color = 0;
+				int width = 0;
+				int height = 0;
 			};
 
 			Vector<Size> sizes;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1349,9 +1349,9 @@ public:
 		struct Effects {
 			struct MipMaps {
 				struct Size {
-					GLuint fbo;
-					int width;
-					int height;
+					GLuint fbo = 0;
+					int width = 0;
+					int height = 0;
 				};
 
 				Vector<Size> sizes;

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -160,7 +160,7 @@ struct CSGBrushOperation {
 		};
 
 		struct Face2D {
-			int vertex_idx[3];
+			int vertex_idx[3] = {};
 		};
 
 		Vector<Vertex2D> vertices;
@@ -168,7 +168,7 @@ struct CSGBrushOperation {
 		Plane plane;
 		Transform to_2D;
 		Transform to_3D;
-		float vertex_snap2;
+		float vertex_snap2 = 0.0;
 
 		inline int _get_point_idx(const Vector2 &p_point);
 		inline int _add_vertex(const Vertex2D &p_vertex);

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1696,11 +1696,7 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 			}
 
 			next = node->sequence_outputs[output];
-			if (next) {
-				VSDEBUG("GOT NEXT NODE - " + itos(next->get_id()));
-			} else {
-				VSDEBUG("GOT NEXT NODE - NULL");
-			}
+			VSDEBUG("GOT NEXT NODE - " + (next ? itos(next->get_id()) : "NULL"));
 		}
 
 		if (flow_stack) {

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -115,8 +115,8 @@ bool PhysicsDirectSpaceStateSW::intersect_ray(const Vector3 &p_from, const Vecto
 
 	bool collided = false;
 	Vector3 res_point, res_normal;
-	int res_shape;
-	const CollisionObjectSW *res_obj;
+	int res_shape = 0;
+	const CollisionObjectSW *res_obj = nullptr;
 	real_t min_d = 1e10;
 
 	for (int i = 0; i < amount; i++) {

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -137,8 +137,8 @@ bool Physics2DDirectSpaceStateSW::intersect_ray(const Vector2 &p_from, const Vec
 
 	bool collided = false;
 	Vector2 res_point, res_normal;
-	int res_shape;
-	const CollisionObject2DSW *res_obj;
+	int res_shape = 0;
+	const CollisionObject2DSW *res_obj = nullptr;
 	real_t min_d = 1e10;
 
 	for (int i = 0; i < amount; i++) {


### PR DESCRIPTION
Fixes occurrences of `-Wtype-limits`, `-Wmaybe-uninitialized`, `-Wduplicated-branches`.

Includes `3.x` version of #85500.