### PR TITLE
Prevent overriding file info of another file when reimport creates extra files

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2154,6 +2154,9 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 	}
 
+	// Update cpos, newly created files could've changed the index of the reimported p_file.
+	_find_file(p_file, &fs, cpos);
+
 	//update modified times, to avoid reimport
 	fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);
 	fs->files[cpos]->import_modified_time = FileAccess::get_modified_time(p_file + ".import");


### PR DESCRIPTION
Fixes #80132, fixes #75525, fixes #77978, fixes #83154

Special thanks to @MetRiko and @gonzelvis for helping me figure out the exact repro steps. They had issues with `*.glb` files and repro turned out to be exactly the same as in #80132.

`EditorFileSystem::_reimport_file` calls `_find_file(p_file, &fs, cpos)` to get the file index in `filesystem` (`fs`). The problem is - if reimport creates extra fiiles, the `filesystem` gets invalidated and the next usage of `cpos` is incorrect - `_reimport_file` updates wrong file info leading to duplicated uid, dependencies etc. The uid inside created file is still correct at this point, but the data in `fs->files[cpos]` is invalid, so saving the scene after assigning the affected resource causes the resource to save with wrong uid.

Adding `_find_file(p_file, &fs, cpos)` just before the next  line  with `cpos` refreshes the `cpos` index so now it points to a proper file in `fs->files`.