### PR TITLE
Cast physics interpolation fraction to real_t

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -116,7 +116,7 @@ public:
 	bool is_in_physics_frame() const { return _in_physics; }
 	uint64_t get_frame_ticks() const { return _frame_ticks; }
 	double get_process_step() const { return _process_step; }
-	double get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
+	real_t get_physics_interpolation_fraction() const { return (real_t)_physics_interpolation_fraction; }
 
 	void set_time_scale(double p_scale);
 	double get_time_scale() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1573,7 +1573,7 @@ double Engine::get_physics_jitter_fix() const {
 	return ::Engine::get_singleton()->get_physics_jitter_fix();
 }
 
-double Engine::get_physics_interpolation_fraction() const {
+real_t Engine::get_physics_interpolation_fraction() const {
 	return ::Engine::get_singleton()->get_physics_interpolation_fraction();
 }
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -479,7 +479,7 @@ public:
 
 	void set_physics_jitter_fix(double p_threshold);
 	double get_physics_jitter_fix() const;
-	double get_physics_interpolation_fraction() const;
+	real_t get_physics_interpolation_fraction() const;
 
 	void set_max_fps(int p_fps);
 	int get_max_fps() const;


### PR DESCRIPTION
`Engine.get_physics_interpolation_fraction()` is a function used in custom physics interpolation solutions that returns a `double`.

In some Godot types that implement a `lerp` or other interpolation functions, the weight is usually a `real_t`. This means that in some languages like C# you have to cast the function return from a double to float.

```cs
// Single precision build
var d = Engine.GetPhysicsInterpolationFraction();
var f = (float)d;

X = Vector3.Lerp(Y, f); // Works fine since the second argument requires float;
X = Vector3.Lerp(Y, d); // Cannot convert double to float error;
```

However, if you are distributing a plugin, and some user is working with a `precision=double` build, they will have to remove the cast, since now the interpolation functions use a double weight.


```cs
// Double precision build
var d = Engine.GetPhysicsInterpolationFraction();
var f = (float)d;

X = Vector3.Lerp(Y, f); // Cannot convert float to double error;
X = Vector3.Lerp(Y, d); // Works;
```

By casting the return value to `real_t`, it should work without manual casting on most cases.

```cs
// Any build precision
var i = Engine.GetPhysicsInterpolationFraction(); // Cast automatically since it uses real_t

X = Vector3.Lerp(Y, i); // Works regardless of version;
```
If this has any kind of compatibility breaking it should be minimal (doesn't affect GDScript projects at all since it considers only one float type, and existing C# projects won't be affected since casting type x to type x doesn't result in errors.