### PR TITLE
Properly represent builtin method enum arguments

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -789,7 +789,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					for (int j = 0; j < argcount; j++) {
 						Dictionary d3;
 						d3["name"] = Variant::get_builtin_method_argument_name(type, method_name, j);
-						d3["type"] = get_builtin_or_variant_type_name(Variant::get_builtin_method_argument_type(type, method_name, j));
+						d3["type"] = get_property_info_type_name(Variant::get_builtin_method_argument_type_info(type, method_name, j));
 
 						if (j >= (argcount - default_args.size())) {
 							int dargidx = j - (argcount - default_args.size());

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -573,6 +573,7 @@ public:
 
 	static int get_builtin_method_argument_count(Variant::Type p_type, const StringName &p_method);
 	static Variant::Type get_builtin_method_argument_type(Variant::Type p_type, const StringName &p_method, int p_argument);
+	static PropertyInfo get_builtin_method_argument_type_info(Variant::Type p_type, const StringName &p_method, int p_argument);
 	static String get_builtin_method_argument_name(Variant::Type p_type, const StringName &p_method, int p_argument);
 	static Vector<Variant> get_builtin_method_default_arguments(Variant::Type p_type, const StringName &p_method);
 	static bool has_builtin_method_return_value(Variant::Type p_type, const StringName &p_method);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -274,6 +274,47 @@ static _FORCE_INLINE_ Variant::Type vc_get_argument_type_static(R (*method)(P...
 }
 
 template <class R, class T, class... P>
+static _FORCE_INLINE_ PropertyInfo vc_get_argument_type_info(R (T::*method)(P...), int p_arg) {
+	PropertyInfo pi;
+	call_get_argument_type_info<P...>(p_arg, pi);
+	return pi;
+}
+template <class R, class T, class... P>
+static _FORCE_INLINE_ PropertyInfo vc_get_argument_type_info(R (T::*method)(P...) const, int p_arg) {
+	PropertyInfo pi;
+	call_get_argument_type_info<P...>(p_arg, pi);
+	return pi;
+}
+
+template <class T, class... P>
+static _FORCE_INLINE_ PropertyInfo vc_get_argument_type_info(void (T::*method)(P...), int p_arg) {
+	PropertyInfo pi;
+	call_get_argument_type_info<P...>(p_arg, pi);
+	return pi;
+}
+
+template <class T, class... P>
+static _FORCE_INLINE_ PropertyInfo vc_get_argument_type_info(void (T::*method)(P...) const, int p_arg) {
+	PropertyInfo pi;
+	call_get_argument_type_info<P...>(p_arg, pi);
+	return pi;
+}
+
+template <class R, class T, class... P>
+static _FORCE_INLINE_ PropertyInfo vc_get_argument_type_info(R (*method)(T *, P...), int p_arg) {
+	PropertyInfo pi;
+	call_get_argument_type_info<P...>(p_arg, pi);
+	return pi;
+}
+
+template <class R, class... P>
+static _FORCE_INLINE_ PropertyInfo vc_get_argument_type_info_static(R (*method)(P...), int p_arg) {
+	PropertyInfo pi;
+	call_get_argument_type_info<P...>(p_arg, pi);
+	return pi;
+}
+
+template <class R, class T, class... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(R (T::*method)(P...)) {
 	return GetTypeInfo<R>::VARIANT_TYPE;
 }
@@ -387,6 +428,9 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
 			return vc_get_argument_type(m_method_ptr, p_arg);                                                                                                     \
 		}                                                                                                                                                         \
+		static PropertyInfo get_argument_type_info(int p_arg) {                                                                                                   \
+			return vc_get_argument_type_info(m_method_ptr, p_arg);                                                                                                \
+		}                                                                                                                                                         \
 		static Variant::Type get_return_type() {                                                                                                                  \
 			return vc_get_return_type(m_method_ptr);                                                                                                              \
 		}                                                                                                                                                         \
@@ -426,6 +470,9 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 		}                                                                                                                                                         \
 		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
 			return vc_get_argument_type(m_method_ptr, p_arg);                                                                                                     \
+		}                                                                                                                                                         \
+		static PropertyInfo get_argument_type_info(int p_arg) {                                                                                                   \
+			return vc_get_argument_type_info(m_method_ptr, p_arg);                                                                                                \
 		}                                                                                                                                                         \
 		static Variant::Type get_return_type() {                                                                                                                  \
 			return vc_get_return_type(m_method_ptr);                                                                                                              \
@@ -477,6 +524,9 @@ static _FORCE_INLINE_ void vc_static_ptrcall(void (*method)(P...), const void **
 		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
 			return vc_get_argument_type_static(m_method_ptr, p_arg);                                                                                              \
 		}                                                                                                                                                         \
+		static PropertyInfo get_argument_type_info(int p_arg) {                                                                                                   \
+			return vc_get_argument_type_info_static(m_method_ptr, p_arg);                                                                                         \
+		}                                                                                                                                                         \
 		static Variant::Type get_return_type() {                                                                                                                  \
 			return vc_get_return_type(m_method_ptr);                                                                                                              \
 		}                                                                                                                                                         \
@@ -526,6 +576,9 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 		}                                                                                                                                                         \
 		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
 			return vc_get_argument_type(m_method_ptr, p_arg);                                                                                                     \
+		}                                                                                                                                                         \
+		static PropertyInfo get_argument_type_info(int p_arg) {                                                                                                   \
+			return vc_get_argument_type_info(m_method_ptr, p_arg);                                                                                                \
 		}                                                                                                                                                         \
 		static Variant::Type get_return_type() {                                                                                                                  \
 			return vc_get_return_type(m_method_ptr);                                                                                                              \
@@ -583,6 +636,9 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
 			return Variant::NIL;                                                                                                                                  \
 		}                                                                                                                                                         \
+		static PropertyInfo get_argument_type_info(int p_arg) {                                                                                                   \
+			return PropertyInfo();                                                                                                                                \
+		}                                                                                                                                                         \
 		static Variant::Type get_return_type() {                                                                                                                  \
 			return GetTypeInfo<m_return_type>::VARIANT_TYPE;                                                                                                      \
 		}                                                                                                                                                         \
@@ -634,6 +690,11 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 		}                                                                                                                                                         \
 		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
 			return m_arg_type;                                                                                                                                    \
+		}                                                                                                                                                         \
+		static PropertyInfo get_argument_type_info(int p_arg) {                                                                                                   \
+			PropertyInfo pi;                                                                                                                                      \
+			pi.type = m_arg_type;                                                                                                                                 \
+			return pi; /* TODO: Update define to accept PropertyInfo instead of a generic type if more explicit info is needed. */                                \
 		}                                                                                                                                                         \
 		static Variant::Type get_return_type() {                                                                                                                  \
 			return Variant::NIL;                                                                                                                                  \
@@ -1114,6 +1175,7 @@ struct VariantBuiltInMethodInfo {
 	Variant::Type return_type;
 	int argument_count = 0;
 	Variant::Type (*get_argument_type)(int p_arg) = nullptr;
+	PropertyInfo (*get_argument_type_info)(int p_arg) = nullptr;
 };
 
 typedef OAHashMap<StringName, VariantBuiltInMethodInfo> BuiltinMethodMap;
@@ -1142,6 +1204,7 @@ static void register_builtin_method(const Vector<String> &p_argnames, const Vect
 	imi.return_type = T::get_return_type();
 	imi.argument_count = T::get_argument_count();
 	imi.get_argument_type = T::get_argument_type;
+	imi.get_argument_type_info = T::get_argument_type_info;
 #ifdef DEBUG_METHODS_ENABLED
 	ERR_FAIL_COND(!imi.is_vararg && imi.argument_count != imi.argument_names.size());
 #endif
@@ -1283,6 +1346,14 @@ Variant::Type Variant::get_builtin_method_argument_type(Variant::Type p_type, co
 	return method->get_argument_type(p_argument);
 }
 
+PropertyInfo Variant::get_builtin_method_argument_type_info(Variant::Type p_type, const StringName &p_method, int p_argument) {
+	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, PropertyInfo());
+	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
+	ERR_FAIL_NULL_V(method, PropertyInfo());
+	ERR_FAIL_INDEX_V(p_argument, method->argument_count, PropertyInfo());
+	return method->get_argument_type_info(p_argument);
+}
+
 String Variant::get_builtin_method_argument_name(Variant::Type p_type, const StringName &p_method, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, String());
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
@@ -1400,16 +1471,12 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 				mi.flags |= METHOD_FLAG_STATIC;
 			}
 			for (int i = 0; i < method->argument_count; i++) {
-				PropertyInfo pi;
+				PropertyInfo pi = method->get_argument_type_info(i);
 #ifdef DEBUG_METHODS_ENABLED
 				pi.name = method->argument_names[i];
 #else
 				pi.name = "arg" + itos(i + 1);
 #endif
-				pi.type = method->get_argument_type(i);
-				if (pi.type == Variant::NIL) {
-					pi.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
-				}
 				mi.arguments.push_back(pi);
 			}
 

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -68,7 +68,7 @@
 		<method name="from_euler" qualifiers="static">
 			<return type="Basis" />
 			<param index="0" name="euler" type="Vector3" />
-			<param index="1" name="order" type="int" default="2" />
+			<param index="1" name="order" type="int" enum="EulerOrder" default="2" />
 			<description>
 				Constructs a pure rotation Basis matrix from Euler angles in the specified Euler rotation order. By default, use YXZ order (most common). See the [enum EulerOrder] enum for possible values.
 			</description>
@@ -82,7 +82,7 @@
 		</method>
 		<method name="get_euler" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="order" type="int" default="2" />
+			<param index="0" name="order" type="int" enum="EulerOrder" default="2" />
 			<description>
 				Returns the basis's rotation in the form of Euler angles. The Euler order depends on the [param order] parameter, by default it uses the YXZ convention: when decomposing, first Z, then X, and Y last. The returned vector contains the rotation angles in the format (X angle, Y angle, Z angle).
 				Consider using the [method get_rotation_quaternion] method instead, which returns a [Quaternion] quaternion instead of Euler angles.

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -210,7 +210,7 @@
 		</method>
 		<method name="get_projection_plane" qualifiers="const">
 			<return type="Plane" />
-			<param index="0" name="plane" type="int" />
+			<param index="0" name="plane" type="int" enum="Projection.Planes" />
 			<description>
 				Returns the clipping plane of this [Projection] whose index is given by [param plane].
 				[param plane] should be equal to one of [constant PLANE_NEAR], [constant PLANE_FAR], [constant PLANE_LEFT], [constant PLANE_TOP], [constant PLANE_RIGHT], or [constant PLANE_BOTTOM].

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -100,7 +100,7 @@
 		</method>
 		<method name="get_euler" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="order" type="int" default="2" />
+			<param index="0" name="order" type="int" enum="EulerOrder" default="2" />
 			<description>
 				Returns the quaternion's rotation in the form of Euler angles. The Euler order depends on the [param order] parameter, for example using the YXZ convention: since this method decomposes, first Z, then X, and Y last. See the [enum EulerOrder] enum for possible values. The returned vector contains the rotation angles in the format (X angle, Y angle, Z angle).
 			</description>

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1365,8 +1365,17 @@ def make_enum(t: str, is_bitfield: bool, state: State) -> str:
         else:
             return f":ref:`{e}<enum_{c}_{e}>`"
 
-    # Don't fail for `Vector3.Axis`, as this enum is a special case which is expected not to be resolved.
-    if f"{c}.{e}" != "Vector3.Axis":
+    # Don't fail for these hardcoded enums, as they are special cases which are expected not to be resolved.
+    hardcoded_enums = [
+        "Vector2.Axis",
+        "Vector2i.Axis",
+        "Vector3.Axis",
+        "Vector3i.Axis",
+        "Vector4.Axis",
+        "Vector4i.Axis",
+        "Projection.Planes",
+    ]
+    if f"{c}.{e}" not in hardcoded_enums:
         print_error(f'{state.current_class}.xml: Unresolved enum "{t}".', state)
 
     return t

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -7,3 +7,13 @@ should instead be used to justify these changes and describe how users should wo
 Add new entries at the end of the file.
 
 ## Changes between 4.2-stable and 4.3-stable
+
+
+GH-85942
+--------
+Validate extension JSON: Error: Field 'builtin_classes/Quaternion/methods/get_euler/arguments/0': type changed value in new API, from "int" to "enum::EulerOrder".
+Validate extension JSON: Error: Field 'builtin_classes/Basis/methods/get_euler/arguments/0': type changed value in new API, from "int" to "enum::EulerOrder".
+Validate extension JSON: Error: Field 'builtin_classes/Basis/methods/from_euler/arguments/1': type changed value in new API, from "int" to "enum::EulerOrder".
+Validate extension JSON: Error: Field 'builtin_classes/Projection/methods/get_projection_plane/arguments/0': type changed value in new API, from "int" to "enum::Projection.Planes".
+
+Specifying arguments as enums implemented for builtin methods.

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4082,6 +4082,9 @@ void BindingsGenerator::_populate_global_constants() {
 	hardcoded_enums.push_back("Vector2I.Axis");
 	hardcoded_enums.push_back("Vector3.Axis");
 	hardcoded_enums.push_back("Vector3I.Axis");
+	hardcoded_enums.push_back("Vector4.Axis");
+	hardcoded_enums.push_back("Vector4I.Axis");
+	hardcoded_enums.push_back("Projection.Planes");
 	for (const StringName &enum_cname : hardcoded_enums) {
 		// These enums are not generated and must be written manually (e.g.: Vector3.Axis)
 		// Here, we assume core types do not begin with underscore

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -822,6 +822,9 @@ void add_global_enums(Context &r_context) {
 	hardcoded_enums.push_back("Vector2i.Axis");
 	hardcoded_enums.push_back("Vector3.Axis");
 	hardcoded_enums.push_back("Vector3i.Axis");
+	hardcoded_enums.push_back("Vector4.Axis");
+	hardcoded_enums.push_back("Vector4i.Axis");
+	hardcoded_enums.push_back("Projection.Planes");
 	for (const StringName &E : hardcoded_enums) {
 		// These enums are not generated and must be written manually (e.g.: Vector3.Axis)
 		// Here, we assume core types do not begin with underscore


### PR DESCRIPTION
Fixes a minor issue where enum arguments for the builtin types wouldn't properly register themselves as enums. Now both the extension api & documentation will recognize the arguments as more than generic ints.