### PR TITLE
Stop the searching of `find in files` in folders that have `.gdignore`

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -172,9 +172,11 @@ void FindInFiles::_iterate() {
 			_current_dir = _current_dir.path_join(folder_name);
 
 			PackedStringArray sub_dirs;
-			_scan_dir("res://" + _current_dir, sub_dirs);
+			PackedStringArray files_to_scan;
+			_scan_dir("res://" + _current_dir, sub_dirs, files_to_scan);
 
 			_folders_stack.push_back(sub_dirs);
+			_files_to_scan.append_array(files_to_scan);
 
 		} else {
 			// Go back one level.
@@ -211,7 +213,7 @@ float FindInFiles::get_progress() const {
 	return 0;
 }
 
-void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders) {
+void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan) {
 	Ref<DirAccess> dir = DirAccess::open(path);
 	if (dir.is_null()) {
 		print_verbose("Cannot open directory! " + path);
@@ -227,8 +229,11 @@ void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders) {
 			break;
 		}
 
-		// If there is a .gdignore file in the directory, skip searching the directory.
+		// If there is a .gdignore file in the directory, clear all the files/folders
+		// to be searched on this path and skip searching the directory.
 		if (file == ".gdignore") {
+			out_folders.clear();
+			out_files_to_scan.clear();
 			break;
 		}
 
@@ -247,7 +252,7 @@ void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders) {
 		} else {
 			String file_ext = file.get_extension();
 			if (_extension_filter.has(file_ext)) {
-				_files_to_scan.push_back(path.path_join(file));
+				out_files_to_scan.push_back(path.path_join(file));
 			}
 		}
 	}

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -67,7 +67,7 @@ protected:
 private:
 	void _process();
 	void _iterate();
-	void _scan_dir(String path, PackedStringArray &out_folders);
+	void _scan_dir(String path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan);
 	void _scan_file(String fpath);
 
 	// Config


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85935
Fixes https://github.com/godotengine/godot/issues/79375

When a `.gdignore` is detected. It cleans everything that was in the queue to be scanned (in the current dir) and stops the scan.

This is very helpful when you are developing for Android. The `Find in files` enters the res://android/build, and you get many unwanted results.

Test project:
[MinimalSearchInFiles.zip](https://github.com/godotengine/godot/files/13621406/MinimalSearchInFiles.zip)

Tree files of the test project:
![image](https://github.com/godotengine/godot/assets/12563266/44939879-2d37-4f0c-bd9e-cb569e033d74)


Before (with the bug):
![image](https://github.com/godotengine/godot/assets/12563266/82b4a5f8-e8d3-439d-b08a-d48a16b747d0)

After (fixed):
![image](https://github.com/godotengine/godot/assets/12563266/5809180e-6047-44c9-8a09-bce344e08f7e)
