### PR TITLE
Fix OpenSLES cleanup on Android

### DIFF
--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -313,6 +313,15 @@ void AudioDriverOpenSL::unlock() {
 }
 
 void AudioDriverOpenSL::finish() {
+	(*playItf)->SetPlayState(playItf, SL_PLAYSTATE_STOPPED);
+	(*bufferQueueItf)->RegisterCallback(bufferQueueItf, nullptr, nullptr);
+
+	for (int i = 0; i < BUFFER_COUNT; i++) {
+		memdelete_arr(buffers[i]);
+	}
+
+	(*player)->Destroy(player);
+	(*OutputMix)->Destroy(OutputMix);
 	(*sl)->Destroy(sl);
 }
 


### PR DESCRIPTION

Fixes the following error output: 
![Bildschirmfoto 2023-12-08 um 23 19 02](https://github.com/godotengine/godot/assets/41921395/66010b13-e974-411d-a8e1-30f5cea9794f)

I'm not sure if this is critical. This happens when the app is terminated via the "BACK" button. On Android, however, the app is not completely terminated, the app is still in the app list in the background and can be restarted.