### PR TITLE
Android: Ensure cleanup of all subobjects in the OpenSL audio driver

### DIFF
--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -268,6 +268,10 @@ Error AudioDriverOpenSL::init_input_device() {
 }
 
 Error AudioDriverOpenSL::input_start() {
+	if (recordItf || recordBufferQueueItf) {
+		return ERR_ALREADY_IN_USE;
+	}
+
 	if (OS::get_singleton()->request_permission("RECORD_AUDIO")) {
 		return init_input_device();
 	}
@@ -277,6 +281,10 @@ Error AudioDriverOpenSL::input_start() {
 }
 
 Error AudioDriverOpenSL::input_stop() {
+	if (!recordItf || !recordBufferQueueItf) {
+		return ERR_CANT_OPEN;
+	}
+
 	SLuint32 state;
 	SLresult res = (*recordItf)->GetRecordState(recordItf, &state);
 	ERR_FAIL_COND_V(res != SL_RESULT_SUCCESS, ERR_CANT_OPEN);
@@ -313,13 +321,36 @@ void AudioDriverOpenSL::unlock() {
 }
 
 void AudioDriverOpenSL::finish() {
-	(*sl)->Destroy(sl);
+	if (recordItf) {
+		(*recordItf)->SetRecordState(recordItf, SL_RECORDSTATE_STOPPED);
+		recordItf = nullptr;
+	}
+	if (recorder) {
+		(*recorder)->Destroy(recorder);
+		recorder = nullptr;
+	}
+	if (playItf) {
+		(*playItf)->SetPlayState(playItf, SL_PLAYSTATE_STOPPED);
+		playItf = nullptr;
+	}
+	if (player) {
+		(*player)->Destroy(player);
+		player = nullptr;
+	}
+	if (OutputMix) {
+		(*OutputMix)->Destroy(OutputMix);
+		OutputMix = nullptr;
+	}
+	if (sl) {
+		(*sl)->Destroy(sl);
+		sl = nullptr;
+	}
 }
 
 void AudioDriverOpenSL::set_pause(bool p_pause) {
 	pause = p_pause;
 
-	if (active) {
+	if (active && playItf) {
 		if (pause) {
 			(*playItf)->SetPlayState(playItf, SL_PLAYSTATE_PAUSED);
 		} else {

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -54,15 +54,15 @@ class AudioDriverOpenSL : public AudioDriver {
 
 	Vector<int16_t> rec_buffer;
 
-	SLPlayItf playItf;
-	SLRecordItf recordItf;
-	SLObjectItf sl;
-	SLEngineItf EngineItf;
-	SLObjectItf OutputMix;
-	SLObjectItf player;
-	SLObjectItf recorder;
-	SLAndroidSimpleBufferQueueItf bufferQueueItf;
-	SLAndroidSimpleBufferQueueItf recordBufferQueueItf;
+	SLPlayItf playItf = nullptr;
+	SLRecordItf recordItf = nullptr;
+	SLObjectItf sl = nullptr;
+	SLEngineItf EngineItf = nullptr;
+	SLObjectItf OutputMix = nullptr;
+	SLObjectItf player = nullptr;
+	SLObjectItf recorder = nullptr;
+	SLAndroidSimpleBufferQueueItf bufferQueueItf = nullptr;
+	SLAndroidSimpleBufferQueueItf recordBufferQueueItf = nullptr;
 	SLDataSource audioSource;
 	SLDataFormat_PCM pcm;
 	SLDataSink audioSink;


### PR DESCRIPTION
Depending on different Android devices, without these changes, a crash or a hang may occur when the Godot engine instance is being torn down as the OpenSL audio playback subsystem gets closed. The most easily expressible side effect of such an occurrence appears as follows ( taken from ADB LogCat ):
```
12-04 20:08:28.161 11819 11862 E libOpenSLES: Object::Destroy(0xb40000752d630930) for engine ignored; 2 total active objects
12-04 20:08:28.161 11819 11862 E libOpenSLES: Object::Destroy(0xb40000752d630930) for engine ignored; active object ID 2 at 0xb40000752d62fc50
12-04 20:08:28.161 11819 11862 E libOpenSLES: Object::Destroy(0xb40000752d630930) for engine ignored; active object ID 3 at 0xb40000755d61c230
```

*Bugsquad edit:*
- Fixes #85979