### PR TITLE
Enable tests for .NET CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -23,13 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor w/ Mono (target=editor)
+          - name: Editor w/ Mono (target=editor, tests=yes)
             cache-name: linux-editor-mono
             target: editor
             sconsflags: module_mono_enabled=yes
             bin: "./bin/godot.linuxbsd.editor.x86_64.mono"
             build-mono: true
-            tests: false # Disabled due freeze caused by mix Mono build and CI
+            tests: true
             doc-test: true
             proj-conv: true
             api-compat: true
@@ -115,7 +115,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         if: ${{ matrix.build-mono }}
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: "6.0.x"
 
       - name: Setup GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master


### PR DESCRIPTION
Based on the discussion in #85178

During some (admittedly not very thorough) tests I couldn't reproduce the CI freeze. @AThousandShips wasn't able to reproduce either. It is possible, that in the two years since it was disabled this was fixed somehow. But further testing is necessary.

Why?
Having .NET during tests would allow to test whether GDScript autocompletion correctly works for scripts in other languages.
