### PR TITLE
Improve pathfinding performance by using a heap to store traversable polygons

### DIFF
--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -31,6 +31,7 @@
 #ifndef TEST_NAVIGATION_SERVER_3D_H
 #define TEST_NAVIGATION_SERVER_3D_H
 
+#include "modules/navigation/nav_utils.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "servers/navigation_server_3d.h"
@@ -60,6 +61,32 @@ static inline Array build_array(Variant item, Targs... Fargs) {
 	a.push_front(item);
 	return a;
 }
+
+struct GreaterThan {
+	bool operator()(int p_a, int p_b) const { return p_a > p_b; }
+};
+
+struct CompareArrayValues {
+	const int *array;
+
+	CompareArrayValues(const int *p_array) :
+			array(p_array) {}
+
+	bool operator()(uint32_t p_index_a, uint32_t p_index_b) const {
+		return array[p_index_a] < array[p_index_b];
+	}
+};
+
+struct RegisterHeapIndexes {
+	uint32_t *indexes;
+
+	RegisterHeapIndexes(uint32_t *p_indexes) :
+			indexes(p_indexes) {}
+
+	void operator()(uint32_t p_vector_index, uint32_t p_heap_index) {
+		indexes[p_vector_index] = p_heap_index;
+	}
+};
 
 TEST_SUITE("[Navigation]") {
 	TEST_CASE("[NavigationServer3D] Server should be empty when initialized") {
@@ -788,6 +815,139 @@ TEST_SUITE("[Navigation]") {
 		CHECK_EQ(navigation_mesh->get_vertices().size(), 0);
 	}
 	*/
+
+	TEST_CASE("[Heap] size") {
+		gd::Heap<int> heap;
+
+		CHECK(heap.size() == 0);
+
+		heap.push(0);
+		CHECK(heap.size() == 1);
+
+		heap.push(1);
+		CHECK(heap.size() == 2);
+
+		heap.pop();
+		CHECK(heap.size() == 1);
+
+		heap.pop();
+		CHECK(heap.size() == 0);
+	}
+
+	TEST_CASE("[Heap] is_empty") {
+		gd::Heap<int> heap;
+
+		CHECK(heap.is_empty() == true);
+
+		heap.push(0);
+		CHECK(heap.is_empty() == false);
+
+		heap.pop();
+		CHECK(heap.is_empty() == true);
+	}
+
+	TEST_CASE("[Heap] push/pop") {
+		SUBCASE("Default comparator") {
+			gd::Heap<int> heap;
+
+			heap.push(2);
+			heap.push(7);
+			heap.push(5);
+			heap.push(3);
+			heap.push(4);
+
+			CHECK(heap.pop() == 7);
+			CHECK(heap.pop() == 5);
+			CHECK(heap.pop() == 4);
+			CHECK(heap.pop() == 3);
+			CHECK(heap.pop() == 2);
+		}
+
+		SUBCASE("Custom comparator") {
+			GreaterThan greaterThan;
+			gd::Heap<int, GreaterThan> heap(greaterThan);
+
+			heap.push(2);
+			heap.push(7);
+			heap.push(5);
+			heap.push(3);
+			heap.push(4);
+
+			CHECK(heap.pop() == 2);
+			CHECK(heap.pop() == 3);
+			CHECK(heap.pop() == 4);
+			CHECK(heap.pop() == 5);
+			CHECK(heap.pop() == 7);
+		}
+
+		SUBCASE("Intermediate pops") {
+			gd::Heap<int> heap;
+
+			heap.push(0);
+			heap.push(3);
+			heap.pop();
+			heap.push(1);
+			heap.push(2);
+
+			CHECK(heap.pop() == 2);
+			CHECK(heap.pop() == 1);
+			CHECK(heap.pop() == 0);
+		}
+	}
+
+	TEST_CASE("[Heap] shift") {
+		int values[] = { 5, 3, 6, 7, 1 };
+		uint32_t heap_indexes[] = { 0, 0, 0, 0, 0 };
+		CompareArrayValues comparator(values);
+		RegisterHeapIndexes indexer(heap_indexes);
+		gd::Heap<uint32_t, CompareArrayValues, RegisterHeapIndexes> heap(comparator, indexer);
+
+		heap.push(0);
+		heap.push(1);
+		heap.push(2);
+		heap.push(3);
+		heap.push(4);
+
+		// Shift down: 6 -> 2
+		values[2] = 2;
+		heap.shift(heap_indexes[2]);
+
+		// Shift up: 5 -> 8
+		values[0] = 8;
+		heap.shift(heap_indexes[0]);
+
+		CHECK(heap.pop() == 0);
+		CHECK(heap.pop() == 3);
+		CHECK(heap.pop() == 1);
+		CHECK(heap.pop() == 2);
+		CHECK(heap.pop() == 4);
+
+		CHECK(heap_indexes[0] == UINT32_MAX);
+		CHECK(heap_indexes[1] == UINT32_MAX);
+		CHECK(heap_indexes[2] == UINT32_MAX);
+		CHECK(heap_indexes[3] == UINT32_MAX);
+		CHECK(heap_indexes[4] == UINT32_MAX);
+	}
+
+	TEST_CASE("[Heap] clear") {
+		uint32_t heap_indexes[] = { 0, 0, 0, 0 };
+		RegisterHeapIndexes indexer(heap_indexes);
+		gd::Heap<uint32_t, Comparator<uint32_t>, RegisterHeapIndexes> heap(indexer);
+
+		heap.push(0);
+		heap.push(2);
+		heap.push(1);
+		heap.push(3);
+
+		heap.clear();
+
+		CHECK(heap.size() == 0);
+
+		CHECK(heap_indexes[0] == UINT32_MAX);
+		CHECK(heap_indexes[1] == UINT32_MAX);
+		CHECK(heap_indexes[2] == UINT32_MAX);
+		CHECK(heap_indexes[3] == UINT32_MAX);
+	}
 }
 } //namespace TestNavigationServer3D
 


### PR DESCRIPTION
## Description

Improves pathfinding performance by doing 2 things.
- Makes retrieval of already visited polygons constant time instead of linear time
- Uses a heap to store the polygons to visit instead of a linked list
  - To implement this, introduces a generic heap structure that notifies of element index changes and also allows to update an arbitrary element's position (the existing functions in `SortArray` don't allow for that)

Closes https://github.com/godotengine/godot-proposals/issues/8496.

### Changes in time complexity

`n`: number of polygons visited until now (`navigation_polys`)
`m`: number of polygons marked for later visiting (`traversable_polys`)

In every scenario, `m` increases at a much slower rate than `n`.

- An individual neighbor polygon check/registration/update goes from `O(n)` to `O(log2(m))` (or `O(1)` if the polygon has already been visited and no update is needed)
- Retrieving the next polygon to visit goes from `O(m)` to `O(log2(m))`

These changes should result in a big performance improvement on big maps.

## Test project

[Navigation path finding tests.zip](https://github.com/godotengine/godot/files/13800063/Navigation.path.finding.tests.zip)

## Benchmark numbers

Below are execution times for `NavigationServer*D.map_get_path` before and after this PR on different map sizes.

Map size | Iteration count | Average time - master | Average time - PR | Speed-up
--- | --- | --- | --- | ---
15x10 cells (small) | 1000 | 0.047ms | 0.026ms | x1.80 faster
90x50 cells (normal) | 500 | 5.976ms | 0.688ms | x8.68 faster
240x160 cells (big) | 10 | 465.4ms | 11.3ms | x41.1 faster

As you can see, the bigger the map, the bigger the speed-up.

- The measurements were done on a build made with `scons platform=windows` (no debug info)
- Done on Windows 10.0.19045 with an AMD Ryzen 7 2700X (4.3 GHz max, 8 core, 16 threads)
- You can find the maps in the test project linked above

## Further improvements

There is room for further improvement here.
- Right now memory is allocated on the heap on each path request. It's rather wasteful but doesn't need to. We could keep a pool of arrays that would be reused each request.
- Finding the start and end polygon before the actual pathfinding is currently an `O(n)` operation. We will invariably loop over every polygon each request. We could use a specialized data structure to improve performance here.
- With the current API, even if we're interested only in paths that actually reach the target, a path to the closest reachable polygon will always be calculated if the target is unreachable. That's two pathfinding requests even if we only want one. We could add a new option/method to cover this use case. That one requires a proposal though.

I intend to work on these if there is no problem with this PR.