### PR TITLE
Fix `squish` DXT5 RA-As-RG channel swapping

### DIFF
--- a/modules/squish/image_decompress_squish.cpp
+++ b/modules/squish/image_decompress_squish.cpp
@@ -36,7 +36,9 @@ void image_decompress_squish(Image *p_image) {
 	int w = p_image->get_width();
 	int h = p_image->get_height();
 
+	Image::Format source_format = p_image->get_format();
 	Image::Format target_format = Image::FORMAT_RGBA8;
+
 	Vector<uint8_t> data;
 	int target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
 	int mm_count = p_image->get_mipmap_count();
@@ -45,33 +47,49 @@ void image_decompress_squish(Image *p_image) {
 	const uint8_t *rb = p_image->get_data().ptr();
 	uint8_t *wb = data.ptrw();
 
-	int squish_flags = Image::FORMAT_MAX;
-	if (p_image->get_format() == Image::FORMAT_DXT1) {
-		squish_flags = squish::kDxt1;
-	} else if (p_image->get_format() == Image::FORMAT_DXT3) {
-		squish_flags = squish::kDxt3;
-	} else if (p_image->get_format() == Image::FORMAT_DXT5 || p_image->get_format() == Image::FORMAT_DXT5_RA_AS_RG) {
-		squish_flags = squish::kDxt5;
-	} else if (p_image->get_format() == Image::FORMAT_RGTC_R) {
-		squish_flags = squish::kBc4;
-	} else if (p_image->get_format() == Image::FORMAT_RGTC_RG) {
-		squish_flags = squish::kBc5;
-	} else {
-		ERR_FAIL_MSG("Squish: Can't decompress unknown format: " + itos(p_image->get_format()) + ".");
+	int squish_flags = 0;
+
+	switch (source_format) {
+		case Image::FORMAT_DXT1:
+			squish_flags = squish::kDxt1;
+			break;
+
+		case Image::FORMAT_DXT3:
+			squish_flags = squish::kDxt3;
+			break;
+
+		case Image::FORMAT_DXT5:
+		case Image::FORMAT_DXT5_RA_AS_RG:
+			squish_flags = squish::kDxt5;
+			break;
+
+		case Image::FORMAT_RGTC_R:
+			squish_flags = squish::kBc4;
+			break;
+
+		case Image::FORMAT_RGTC_RG:
+			squish_flags = squish::kBc5;
+			break;
+
+		default:
+			ERR_FAIL_MSG("Squish: Can't decompress unknown format: " + itos(p_image->get_format()) + ".");
+			break;
 	}
 
 	for (int i = 0; i <= mm_count; i++) {
 		int src_ofs = 0, mipmap_size = 0, mipmap_w = 0, mipmap_h = 0;
 		p_image->get_mipmap_offset_size_and_dimensions(i, src_ofs, mipmap_size, mipmap_w, mipmap_h);
+
 		int dst_ofs = Image::get_image_mipmap_offset(p_image->get_width(), p_image->get_height(), target_format, i);
 		squish::DecompressImage(&wb[dst_ofs], w, h, &rb[src_ofs], squish_flags);
+
 		w >>= 1;
 		h >>= 1;
 	}
 
 	p_image->set_data(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
 
-	if (p_image->get_format() == Image::FORMAT_DXT5_RA_AS_RG) {
+	if (source_format == Image::FORMAT_DXT5_RA_AS_RG) {
 		p_image->convert_ra_rgba8_to_rg();
 	}
 }


### PR DESCRIPTION
Follow-up to #85863

Fixes DXT5 RA-As-RG images using incorrect color channels after decompression, as well as cleans up some of the code.

Results:
| master  | PR |
| ------------- | ------------- |
| <img width="64" alt="ahah" src="https://github.com/godotengine/godot/assets/53150244/08c4deaa-2b7d-4412-8c92-baeb83a69323"> |  <img width="64" alt="haha" src="https://github.com/godotengine/godot/assets/53150244/3b9b0c5c-623b-4362-ab2c-ce806f53ccac"> |


MRP for testing the changes:
[SquishRA_As_RG.zip](https://github.com/godotengine/godot/files/13625060/SquishRA_As_RG.zip)

Steps to reproduce:
1. Click on `new_standard_material_3d.tres`
2. Look at the Normal Map preview.