### PR TITLE
Bump minimum SCons version to 4.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-EnsureSConsVersion(3, 0, 0)
+EnsureSConsVersion(4, 0)
 EnsurePythonVersion(3, 6)
 
 # System
@@ -950,15 +950,6 @@ if selected_platform in platform_list:
         env.vs_srcs = []
 
     if env["compiledb"]:
-        # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
-        from SCons import __version__ as scons_raw_version
-
-        scons_ver = env._get_major_minor_revision(scons_raw_version)
-
-        if scons_ver < (4, 0, 0):
-            print("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
-            Exit(255)
-
         env.Tool("compilation_db")
         env.Alias("compiledb", env.CompilationDatabase())
 
@@ -1019,9 +1010,9 @@ elif selected_platform != "":
 if "env" in locals():
     # FIXME: This method mixes both cosmetic progress stuff and cache handling...
     methods.show_progress(env)
-    # TODO: replace this with `env.Dump(format="json")`
-    # once we start requiring SCons 4.0 as min version.
-    methods.dump(env)
+
+    with open(".scons_env.json", "w") as f:
+        f.write(env.Dump(format="json"))
 
 
 def print_elapsed_time():

--- a/methods.py
+++ b/methods.py
@@ -1191,14 +1191,3 @@ def show_progress(env):
 
     progress_finish_command = Command("progress_finish", [], progress_finish)
     AlwaysBuild(progress_finish_command)
-
-
-def dump(env):
-    # Dumps latest build information for debugging purposes and external tools.
-    from json import dump
-
-    def non_serializable(obj):
-        return "<<non-serializable: %s>>" % (type(obj).__qualname__)
-
-    with open(".scons_env.json", "w") as f:
-        dump(env.Dictionary(), f, indent=4, default=non_serializable)


### PR DESCRIPTION
Now matches the minimum version used by godot-cpp. In addition, adjusted a handful of sections that needed workarounds for non-4.0 versions; namely: `compile_db` is now just natively available & `methods.dump` is replaced with a built-in alternative. GitHub Actions already have a minimum version of 4.4 specified, so no changes are needed there (unless we wanted to deliberately downgrade).