### PR TITLE
Ensure that 2D meshes use a proper input mask

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1388,7 +1388,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 				GLuint vertex_array_gl = 0;
 				GLuint index_array_gl = 0;
 
-				uint64_t input_mask = 0; // 2D meshes always use the same vertex format.
+				uint64_t input_mask = RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_COLOR | RS::ARRAY_FORMAT_TEX_UV; // 2D meshes always use the same vertex format.
 				if (mesh_instance.is_valid()) {
 					mesh_storage->mesh_instance_surface_get_vertex_arrays_and_format(mesh_instance, j, input_mask, vertex_array_gl);
 				} else {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/85945

Regression from https://github.com/godotengine/godot/pull/85092

The input mask was wrongly ignored in earlier versions. Now it is actually used so the input mask variable needs to be a valid number


