### PR TITLE
Allow ZIPPacker and ZIPReader to use passwords

### DIFF
--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -7,3 +7,10 @@ should instead be used to justify these changes and describe how users should wo
 Add new entries at the end of the file.
 
 ## Changes between 4.2-stable and 4.3-stable
+
+GH-85973
+--------
+Validate extension JSON: Error: Field 'classes/ZIPPacker/methods/start_file/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ZIPReader/methods/read_file/arguments': size changed value in new API, from 2 to 3.
+
+Added a new argument to each and provided compatibility methods as compatibility fallback.

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -13,4 +13,4 @@ GH-85973
 Validate extension JSON: Error: Field 'classes/ZIPPacker/methods/start_file/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/ZIPReader/methods/read_file/arguments': size changed value in new API, from 2 to 3.
 
-Added a new argument to each and provided compatibility methods as compatibility fallback.
+Added support for passwords, compatibility methods registered.

--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -47,6 +47,7 @@
 		<method name="start_file">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="password" type="String" default="&quot;&quot;" />
 			<description>
 				Starts writing to a file within the archive. Only one file can be written at the same time.
 				Must be called after [method open].

--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -52,6 +52,7 @@
 			<return type="PackedByteArray" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="case_sensitive" type="bool" default="true" />
+			<param index="2" name="password" type="String" default="&quot;&quot;" />
 			<description>
 				Loads the whole content of a file in the loaded zip archive into memory and returns it.
 				Must be called after [method open].

--- a/modules/zip/zip_packer.compat.inc
+++ b/modules/zip/zip_packer.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  zip_reader.h                                                          */
+/*  zip_packer.compat.inc                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,39 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef ZIP_READER_H
-#define ZIP_READER_H
-
-#include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
-
-#include "thirdparty/minizip/unzip.h"
-
-class ZIPReader : public RefCounted {
-	GDCLASS(ZIPReader, RefCounted)
-
-	Ref<FileAccess> fa;
-	unzFile uzf = nullptr;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	PackedByteArray _read_file_bind_compat_85973(const String &p_path, bool p_case_sensitive);
 
-	static void _bind_compatibility_methods();
+Error ZIPPacker::_start_file_bind_compat_85973(const String &p_path) {
+	return start_file(p_path, "");
+}
+
+void ZIPPacker::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("start_file", "path"), &ZIPPacker::_start_file_bind_compat_85973);
+}
+
 #endif // DISABLE_DEPRECATED
-
-public:
-	Error open(const String &p_path);
-	Error close();
-
-	PackedStringArray get_files();
-	PackedByteArray read_file(const String &p_path, bool p_case_sensitive, const String &p_password);
-	bool file_exists(const String &p_path, bool p_case_sensitive);
-
-	ZIPReader();
-	~ZIPReader();
-};
-
-#endif // ZIP_READER_H

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -105,7 +105,7 @@ Error ZIPPacker::start_file(const String &p_path, const String &p_password) {
 Error ZIPPacker::write_file(const Vector<uint8_t> &p_data) {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
 
-	// If we have a password, write to the buffer instead
+	// If we have a password, write to the buffer instead.
 	if (!current_password.is_empty()) {
 		write_buffer.append_array(p_data);
 		return OK;
@@ -117,7 +117,7 @@ Error ZIPPacker::write_file(const Vector<uint8_t> &p_data) {
 Error ZIPPacker::close_file() {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
 
-	// If we have a password, open and write the file now
+	// If we have a password, open and write the file now.
 	if (!current_password.is_empty()) {
 		zip_fileinfo zipfi;
 

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -41,9 +41,18 @@ class ZIPPacker : public RefCounted {
 
 	Ref<FileAccess> fa;
 	zipFile zf = nullptr;
+	Vector<uint8_t> write_buffer;
+	String current_password;
+	String current_path;
 
 protected:
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	Error _start_file_bind_compat_85973(const String &p_path);
+
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
 
 public:
 	enum ZipAppend {
@@ -55,7 +64,7 @@ public:
 	Error open(const String &p_path, ZipAppend p_append);
 	Error close();
 
-	Error start_file(const String &p_path);
+	Error start_file(const String &p_path, const String &p_password);
 	Error write_file(const Vector<uint8_t> &p_data);
 	Error close_file();
 

--- a/modules/zip/zip_reader.compat.inc
+++ b/modules/zip/zip_reader.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  zip_reader.h                                                          */
+/*  zip_reader.compat.inc                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,39 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef ZIP_READER_H
-#define ZIP_READER_H
-
-#include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
-
-#include "thirdparty/minizip/unzip.h"
-
-class ZIPReader : public RefCounted {
-	GDCLASS(ZIPReader, RefCounted)
-
-	Ref<FileAccess> fa;
-	unzFile uzf = nullptr;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	PackedByteArray _read_file_bind_compat_85973(const String &p_path, bool p_case_sensitive);
 
-	static void _bind_compatibility_methods();
+PackedByteArray ZIPReader::_read_file_bind_compat_85973(const String &p_path, bool p_case_sensitive) {
+	return read_file(p_path, p_case_sensitive, "");
+}
+
+void ZIPReader::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("read_file", "path", "case_sensitive"), &ZIPReader::_read_file_bind_compat_85973, DEFVAL(Variant(true)));
+}
+
 #endif // DISABLE_DEPRECATED
-
-public:
-	Error open(const String &p_path);
-	Error close();
-
-	PackedStringArray get_files();
-	PackedByteArray read_file(const String &p_path, bool p_case_sensitive, const String &p_password);
-	bool file_exists(const String &p_path, bool p_case_sensitive);
-
-	ZIPReader();
-	~ZIPReader();
-};
-
-#endif // ZIP_READER_H

--- a/thirdparty/minizip/patches/godot-uncrypt.patch
+++ b/thirdparty/minizip/patches/godot-uncrypt.patch
@@ -1,0 +1,15 @@
+diff --git a/thirdparty/minizip/unzip.c b/thirdparty/minizip/unzip.c
+index 41a203b164..5dd00365f0 100644
+--- a/thirdparty/minizip/unzip.c
++++ b/thirdparty/minizip/unzip.c
+@@ -68,10 +68,6 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#ifndef NOUNCRYPT
+-        #define NOUNCRYPT
+-#endif
+-
+ #include "zlib.h"
+ #include "unzip.h"
+ 

--- a/thirdparty/minizip/unzip.c
+++ b/thirdparty/minizip/unzip.c
@@ -68,10 +68,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef NOUNCRYPT
-        #define NOUNCRYPT
-#endif
-
 #include "zlib.h"
 #include "unzip.h"
 


### PR DESCRIPTION
These changes allow Godot to both read and write files inside ZIP archives that are password protected.

Randomly stumbled over [this discussion](https://forum.godotengine.org/t/is-there-an-option-to-use-a-zip-with-password/34590) and I think this addition makes sense.

While Godot provides encrypted files for secure file storage/exchange, password protected zip files are way more accessible (e.g. with non-custom tools), while still somewhat preventing trivial access to information.