### PR TITLE
Fix `OggPacketSequencePlayback::next_ogg_packet()` never returning false

### DIFF
--- a/modules/ogg/ogg_packet_sequence.cpp
+++ b/modules/ogg/ogg_packet_sequence.cpp
@@ -159,9 +159,7 @@ bool OggPacketSequencePlayback::next_ogg_packet(ogg_packet **p_packet) const {
 
 	*p_packet = packet;
 
-	if (!packet->e_o_s) { // Added this so it doesn't try to go to the next packet if it's the last packet of the file.
-		packet_cursor++;
-	}
+	packet_cursor++;
 
 	return true;
 }


### PR DESCRIPTION
This fixes a bug introduced in #80452 (see https://github.com/godotengine/godot/pull/80452#pullrequestreview-1773999033). The check that was here caused this function to never return false.

I've tested this with the example projects provided in the issues that the PR purported to fix, and it causes no issues.