### PR TITLE
Correctly free relevant scripts when closing scene tabs

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3692,7 +3692,7 @@ void EditorNode::_set_current_scene_nocheck(int p_idx) {
 	_edit_current(true);
 
 	_update_title();
-	scene_tabs->update_scene_tabs();
+	callable_mp(scene_tabs, &EditorSceneTabs::update_scene_tabs).call_deferred();
 
 	if (tabs_to_close.is_empty()) {
 		call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // Do after everything else is done setting up.


### PR DESCRIPTION
Fixes #85983 
`EditorNode::_remove_scene` from `editor/editor_node.cpp` calls `editor_data.clear_script_icon_cache()` for cleaning all script icon cache, previously, the implementation inside `_remove_edited_scene(p_change_tab)` loops through all scene tabs including the one we are closing, results in a call to `EditorData::get_script_icon()` on the closing scene tab, and create `Ref<Script>`s to that unloading scene lives inside `_script_icon_cache`.

This issue causes, primarily, the c-sharp scripts not to get freed when closing scene tabs, and might be a cause of #78513.
These wild script references may live inside the `ScriptManagerBridge.ScriptTypeBiMap`, resulting in the duplicate key issue when unloading the assebly.
```
modules/mono/glue/runtime_interop.cpp:1324 - System.ArgumentException: An item with the same key has already been added. Key: Game.WeaponAbilityData
     at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
     at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
     at Godot.Bridge.ScriptManagerBridge.ScriptTypeBiMap.Add(IntPtr scriptPtr, Type scriptType) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs:line 23
     at Godot.Bridge.ScriptManagerBridge.AddScriptBridge(IntPtr scriptPtr, godot_string* scriptPath) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs:line 419
```