### PR TITLE
Add `event_index` to InputEventAction

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1244,7 +1244,7 @@ void Input::_update_action_cache(const StringName &p_action_name, ActionState &r
 	r_action_state.cache.strength = 0.0;
 	r_action_state.cache.raw_strength = 0.0;
 
-	int max_event = InputMap::get_singleton()->action_get_events(p_action_name)->size();
+	int max_event = InputMap::get_singleton()->action_get_events(p_action_name)->size() + 1; // +1 comes from InputEventAction.
 	for (const KeyValue<int, ActionState::DeviceState> &kv : r_action_state.device_states) {
 		const ActionState::DeviceState &device_state = kv.value;
 		for (int i = 0; i < max_event; i++) {

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1585,6 +1585,14 @@ float InputEventAction::get_strength() const {
 	return strength;
 }
 
+void InputEventAction::set_event_index(int p_index) {
+	event_index = p_index;
+}
+
+int InputEventAction::get_event_index() const {
+	return event_index;
+}
+
 bool InputEventAction::is_match(const Ref<InputEvent> &p_event, bool p_exact_match) const {
 	if (p_event.is_null()) {
 		return false;
@@ -1649,9 +1657,13 @@ void InputEventAction::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_strength", "strength"), &InputEventAction::set_strength);
 	ClassDB::bind_method(D_METHOD("get_strength"), &InputEventAction::get_strength);
 
+	ClassDB::bind_method(D_METHOD("set_event_index", "index"), &InputEventAction::set_event_index);
+	ClassDB::bind_method(D_METHOD("get_event_index"), &InputEventAction::get_event_index);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action"), "set_action", "get_action");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_strength", "get_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "event_index", PROPERTY_HINT_RANGE, "-1,31,1"), "set_event_index", "get_event_index"); // The max value equals to Input::MAX_EVENT - 1.
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -453,6 +453,7 @@ class InputEventAction : public InputEvent {
 
 	StringName action;
 	float strength = 1.0f;
+	int event_index = -1;
 
 protected:
 	static void _bind_methods();
@@ -465,6 +466,9 @@ public:
 
 	void set_strength(float p_strength);
 	float get_strength() const;
+
+	void set_event_index(int p_index);
+	int get_event_index() const;
 
 	virtual bool is_action(const StringName &p_action) const;
 

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -274,6 +274,13 @@ bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const Str
 		if (r_raw_strength != nullptr) {
 			*r_raw_strength = strength;
 		}
+		if (r_event_index) {
+			if (input_event_action->get_event_index() >= 0) {
+				*r_event_index = input_event_action->get_event_index();
+			} else {
+				*r_event_index = E->value.inputs.size();
+			}
+		}
 		return input_event_action->get_action() == p_action;
 	}
 

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -16,6 +16,9 @@
 		<member name="action" type="StringName" setter="set_action" getter="get_action" default="&amp;&quot;&quot;">
 			The action's name. Actions are accessed via this [String].
 		</member>
+		<member name="event_index" type="int" setter="set_event_index" getter="get_event_index" default="-1">
+			The real event index in action this event corresponds to (from events defined for this action in the [InputMap]). If [code]-1[/code], a unique ID will be used and actions pressed with this ID will need to be released with another [InputEventAction].
+		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the action's state is pressed. If [code]false[/code], the action's state is released.
 		</member>


### PR DESCRIPTION
Fixes #85984

Since #84685 actions rely on event id to press/release action. However InputEventAction does not correspond to any event, so it needed special handling. We could hard-code an event ID, but I thought it would be more useful to allow specifying which device the virtual event corresponds to.