### PR TITLE
Add list initialization to Array, Variant, and TypedArray

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -830,6 +830,12 @@ Array::Array(const Array &p_from) {
 	_ref(p_from);
 }
 
+Array::Array(std::initializer_list<Variant> p_init) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init();
+	_p->array = Vector<Variant>(p_init);
+}
+
 Array::Array() {
 	_p = memnew(ArrayPrivate);
 	_p->refcount.init();

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -34,6 +34,7 @@
 #include "core/typedefs.h"
 
 #include <climits>
+#include <initializer_list>
 
 class Variant;
 class ArrayPrivate;
@@ -195,6 +196,7 @@ public:
 
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
+	Array(std::initializer_list<Variant> p_init);
 	Array();
 	~Array();
 };

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -77,6 +77,9 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
 			_ref(p_array);                                                                                       \
 		}                                                                                                        \
+		_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :                                       \
+				Array(Array(p_init), m_variant_type, StringName(), Variant()) {                                  \
+		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
 				Array(Array(p_variant), m_variant_type, StringName(), Variant()) {                               \
 		}                                                                                                        \

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2585,6 +2585,11 @@ Variant::Variant(const Dictionary &p_dictionary) :
 	memnew_placement(_data._mem, Dictionary(p_dictionary));
 }
 
+Variant::Variant(std::initializer_list<Variant> p_init) :
+		type(ARRAY) {
+	memnew_placement(_data._mem, Array(p_init));
+}
+
 Variant::Variant(const Array &p_array) :
 		type(ARRAY) {
 	memnew_placement(_data._mem, Array(p_array));

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -464,6 +464,7 @@ public:
 	Variant(const Signal &p_signal);
 	Variant(const Dictionary &p_dictionary);
 
+	Variant(std::initializer_list<Variant> p_init);
 	Variant(const Array &p_array);
 	Variant(const PackedByteArray &p_byte_array);
 	Variant(const PackedInt32Array &p_int32_array);

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -56,6 +56,26 @@ static inline Dictionary build_dictionary(Variant key, Variant item, Targs... Fa
 	return d;
 }
 
+TEST_CASE("[Array] initializer list") {
+	Array arr = { 0, 1, "test", true, { 0.0, 1.0 } };
+	CHECK(arr.size() == 5);
+	CHECK(arr[0] == Variant(0));
+	CHECK(arr[1] == Variant(1));
+	CHECK(arr[2] == Variant("test"));
+	CHECK(arr[3] == Variant(true));
+	CHECK(arr[4] == Variant({ 0.0, 1.0 }));
+
+	arr = { "reassign" };
+	CHECK(arr.size() == 1);
+	CHECK(arr[0] == Variant("reassign"));
+
+	TypedArray<int> typed_arr = { 0, 1, 2 };
+	CHECK(typed_arr.size() == 3);
+	CHECK(typed_arr[0] == Variant(0));
+	CHECK(typed_arr[1] == Variant(1));
+	CHECK(typed_arr[2] == Variant(2));
+}
+
 TEST_CASE("[Array] size(), clear(), and is_empty()") {
 	Array arr;
 	CHECK(arr.size() == 0);

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -1737,6 +1737,24 @@ TEST_CASE("[Variant] Assignment To Color from Bool,Int,Float,String,Vec2,Vec2i,V
 	CHECK(object_v.get_type() == Variant::COLOR);
 }
 
+TEST_CASE("[Variant] array initializer list") {
+	Variant arr_v = { 0, 1, "test", true, { 0.0, 1.0 } };
+	CHECK(arr_v.get_type() == Variant::ARRAY);
+	Array arr = (Array)arr_v;
+	CHECK(arr.size() == 5);
+	CHECK(arr[0] == Variant(0));
+	CHECK(arr[1] == Variant(1));
+	CHECK(arr[2] == Variant("test"));
+	CHECK(arr[3] == Variant(true));
+	CHECK(arr[4] == Variant({ 0.0, 1.0 }));
+
+	PackedInt32Array packed_arr = { 2, 1, 0 };
+	CHECK(packed_arr.size() == 3);
+	CHECK(packed_arr[0] == 2);
+	CHECK(packed_arr[1] == 1);
+	CHECK(packed_arr[2] == 0);
+}
+
 TEST_CASE("[Variant] Writer and parser array") {
 	Array a = build_array(1, String("hello"), build_array(Variant()));
 	String a_str;


### PR DESCRIPTION
- closes https://github.com/godotengine/godot-proposals/issues/1357 (unless any other types need it)
- salvages #50504
- related #50493

Arrays use Vector list initialization to set its internal Vector.
Variant becomes an array type.
TypedArrays<> must have a type to use the list initialization.

Added initializer list tests for Array, TypedArray<int>, Variant, and PackedInt32Array.
Packed Arrays are typedefs for Vector, so they had this functionality before.

I didn't change any code to use initializer lists in this PR.
In another PR, I think `build_array()` can be replaced with initializer lists in a few test files.
