### PR TITLE
`OS_Windows::execute` - Expand variables in arguments

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -729,7 +729,14 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	String path = p_path.replace("/", "\\");
 	String command = _quote_command_line_argument(path);
 	for (const String &E : p_arguments) {
-		command += " " + _quote_command_line_argument(E);
+		String argument = E;
+		DWORD bufferSize = ExpandEnvironmentStringsW((LPWSTR)argument.utf16().ptrw(), NULL, 0);
+		if (bufferSize > 0) {
+			std::wstring expanded(bufferSize, L'\0');
+			ExpandEnvironmentStringsW((LPWSTR)argument.utf16().ptrw(), &expanded[0], bufferSize);
+			argument = String(expanded.c_str());
+		}
+		command += " " + _quote_command_line_argument(argument);
 	}
 
 	ProcessInfo pi;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -730,11 +730,12 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	String command = _quote_command_line_argument(path);
 	for (const String &E : p_arguments) {
 		String argument = E;
-		DWORD bufferSize = ExpandEnvironmentStringsW((LPWSTR)argument.utf16().ptrw(), NULL, 0);
-		if (bufferSize > 0) {
-			std::wstring expanded(bufferSize, L'\0');
-			ExpandEnvironmentStringsW((LPWSTR)argument.utf16().ptrw(), &expanded[0], bufferSize);
-			argument = String(expanded.c_str());
+		DWORD buffer_size = ExpandEnvironmentStringsW((LPCWSTR)argument.utf16().ptr(), NULL, 0);
+		if (buffer_size > 0) {
+			Char16String expanded;
+			expanded.resize(buffer_size + 1);
+			ExpandEnvironmentStringsW((LPCWSTR)argument.utf16().ptr(), (LPWSTR)expanded.ptrw(), buffer_size);
+			argument = String::utf16(expanded.get_data());
 		}
 		command += " " + _quote_command_line_argument(argument);
 	}

--- a/tests/core/os/test_os.h
+++ b/tests/core/os/test_os.h
@@ -131,13 +131,24 @@ TEST_CASE("[OS] Execute") {
 	arguments.push_back("/C");
 	arguments.push_back("dir > NUL");
 	int exit_code;
-	const Error err = OS::get_singleton()->execute("cmd", arguments, nullptr, &exit_code);
+	Error err = OS::get_singleton()->execute("cmd", arguments, nullptr, &exit_code);
 	CHECK_MESSAGE(
 			err == OK,
 			"(Running the command `cmd /C \"dir > NUL\"` returns the expected Godot error code (OK).");
 	CHECK_MESSAGE(
 			exit_code == 0,
 			"Running the command `cmd /C \"dir > NUL\"` returns a zero (successful) exit code.");
+	arguments.clear();
+	arguments.push_back("-Command");
+	arguments.push_back("if ('%LOCALAPPDATA%' -eq $env:LOCALAPPDATA) { exit 0 } else { exit 1 }");
+	err = OS::get_singleton()->execute("powershell", arguments, nullptr, &exit_code);
+	CHECK_MESSAGE(
+			err == OK,
+			"(Running the command that checks if the variable is expanded returns the expected Godot error code (OK).");
+	CHECK_MESSAGE(
+			exit_code == 0,
+			"Running the command that checks if the variable is expanded returns a zero (successful) exit code.");
+
 #else
 	List<String> arguments;
 	arguments.push_back("-c");


### PR DESCRIPTION
When attempting to Export to a Linux target from a Windows host, I tried to use `%LOCALAPPDATA%` from "Extra Args SSH", so I could specify some paths in a shorter way.

This didn't work, since `ssh` and its arguments are passed to `OS_Windows::execute` and used for [`CreateProcessW` ](https://github.com/godotengine/godot/blob/5d924373effbca5a96b458c737ec39358ffe481f/platform/windows/os_windows.cpp#L774), so it's run directly, without `Cmd.exe` being involved. Because of this, the variables are not expanded.

I think it can be useful to expand variables in arguments as it would also make it easier to eg. reuse the same extra args for multiple machines.