### PR TITLE
Fix radiance for sky in GLES stereo rendering

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -976,10 +976,10 @@ void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Projection &p_p
 		glDisable(GL_BLEND);
 		glDepthMask(GL_FALSE);
 		glDisable(GL_DEPTH_TEST);
+		scene_state.current_depth_test = GLES3::SceneShaderData::DEPTH_TEST_DISABLED;
 		glDisable(GL_SCISSOR_TEST);
-		glCullFace(GL_BACK);
-		glEnable(GL_CULL_FACE);
-		scene_state.cull_mode = GLES3::SceneShaderData::CULL_BACK;
+		glDisable(GL_CULL_FACE);
+		scene_state.cull_mode = GLES3::SceneShaderData::CULL_DISABLED;
 
 		for (int i = 0; i < 6; i++) {
 			Basis local_view = Basis::looking_at(view_normals[i], view_up[i]);
@@ -1000,6 +1000,14 @@ void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Projection &p_p
 		sky->reflection_dirty = false;
 	} else {
 		if (sky_mode == RS::SKY_MODE_INCREMENTAL && sky->processing_layer < max_processing_layer) {
+			glDisable(GL_BLEND);
+			glDepthMask(GL_FALSE);
+			glDisable(GL_DEPTH_TEST);
+			scene_state.current_depth_test = GLES3::SceneShaderData::DEPTH_TEST_DISABLED;
+			glDisable(GL_SCISSOR_TEST);
+			glDisable(GL_CULL_FACE);
+			scene_state.cull_mode = GLES3::SceneShaderData::CULL_DISABLED;
+
 			_filter_sky_radiance(sky, sky->processing_layer);
 			sky->processing_layer++;
 		}

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -1121,6 +1121,7 @@ void LightStorage::update_directional_shadow_atlas() {
 
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, directional_shadow.depth, 0);
 	}
+	glUseProgram(0);
 	glDepthMask(GL_TRUE);
 	glBindFramebuffer(GL_FRAMEBUFFER, directional_shadow.fbo);
 	RasterizerGLES3::clear_depth(1.0);


### PR DESCRIPTION
This took me waaaaaaaaaaaaaaaaaaaaaaay too long to figure out.

In OpenGL everything is output upside down compared to Vulkan, that means that our culling order is reversed, see 
```
	if (!flip_y) {
		// If we're rendering right-side up, then we need to change the winding order.
		glFrontFace(GL_CW);
	}
```
in `RasterizerSceneGLES3::render_scene`.

However, when we output to OpenXR (or webXR), the compositor expects us to deliver images with the same orientation and thus we change things up and render things "upside down", and only flip the image on output to screen. So we keep to the same culling order.

The problem then is that our sky radiance map update code runs after we do this optional flip. This logic renders a full screen triangle to perform a full screen effect. The order of the vertices of this triangle is defined on the assumption we are doing our flip.

In normal mode, we render our triangle and thus our radiance map is rendered.
In XR mode we cull our triangle and thus our radiance map remains black.

The simple answer is to disable culling as we don't care for culling in this case.

This PR cleans up a few related issues and code that assumes state is retained when it's not.

Fixes #84598