### PR TITLE
Fix quitting search bar in doc causes "Parameter "p_node" is null"

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2925,6 +2925,7 @@ FindBar::FindBar() {
 	search_text->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_text->connect("text_changed", callable_mp(this, &FindBar::_search_text_changed));
 	search_text->connect("text_submitted", callable_mp(this, &FindBar::_search_text_submitted));
+	search_text->connect("focus_exited", callable_mp(this, &FindBar::_focus_lost));
 
 	matches_label = memnew(Label);
 	add_child(matches_label);
@@ -3066,7 +3067,8 @@ void FindBar::unhandled_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_action_pressed(SNAME("ui_cancel"), false, true)) {
-		if (rich_text_label->has_focus() || is_ancestor_of(get_viewport()->gui_get_focus_owner())) {
+		Control *focus_owner = get_viewport()->gui_get_focus_owner();
+		if (rich_text_label->has_focus() || (focus_owner && is_ancestor_of(focus_owner))) {
 			_hide_bar();
 			accept_event();
 		}
@@ -3082,5 +3084,11 @@ void FindBar::_search_text_submitted(const String &p_text) {
 		search_prev();
 	} else {
 		search_next();
+	}
+}
+
+void FindBar::_focus_lost() {
+	if (Input::get_singleton()->is_action_pressed(SNAME("ui_cancel"))) {
+		_hide_bar();
 	}
 }

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -69,6 +69,7 @@ class FindBar : public HBoxContainer {
 protected:
 	void _notification(int p_what);
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
+	void _focus_lost();
 
 	bool _search(bool p_search_previous = false);
 


### PR DESCRIPTION
Fixes #85847
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
