### PR TITLE
Add Extensible Clipboard Data Loading

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -17,14 +17,6 @@
 				[b]Note:[/b] This method is implemented on macOS, Linux (X11/Wayland), and Windows.
 			</description>
 		</method>
-		<method name="clipboard_add_type_handler" qualifiers="const">
-			<return type="int" enum="Error" />
-			<param index="0" name="type" type="String" />
-			<param index="1" name="handler" type="Callable" />
-			<description>
-				Adds a handler to parse raw data from the clipboard into a Godot type for data with the MIME type [param type]. Type handlers must be registered for a MIME type before that type can be loaded using [method clipboard_get_type].
-			</description>
-		</method>
 		<method name="clipboard_get" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -46,10 +38,10 @@
 			</description>
 		</method>
 		<method name="clipboard_get_type" qualifiers="const">
-			<return type="Variant" />
+			<return type="PackedByteArray" />
 			<param index="0" name="type" type="String" />
 			<description>
-				Returns the user's clipboard data parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
+				Returns the contents of the user's clipboard as the MIME type [param type].
 			</description>
 		</method>
 		<method name="clipboard_has" qualifiers="const">
@@ -68,21 +60,7 @@
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
-				Returns [code]true[/code] if the user's clipboard data can be parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
-			</description>
-		</method>
-		<method name="clipboard_has_type_handler" qualifiers="const">
-			<return type="bool" />
-			<param index="0" name="type" type="String" />
-			<description>
-				Returns [code]true[/code] if there is a type handler registered to load data from the clipboard with the MIME type [param type].
-			</description>
-		</method>
-		<method name="clipboard_remove_type_handler" qualifiers="const">
-			<return type="int" enum="Error" />
-			<param index="0" name="type" type="String" />
-			<description>
-				Removes a type handler from the clipboard. That MIME type will no longer be loadable from the clipboard unless a new handler is added with [method clipboard_add_type_handler].
+				Returns [code]true[/code] if the user's clipboard data can be retrieved as the MIME type [param type].
 			</description>
 		</method>
 		<method name="clipboard_set">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -22,7 +22,7 @@
 			<param index="0" name="type" type="String" />
 			<param index="1" name="handler" type="Callable" />
 			<description>
-			Adds a handler to parse raw data from the clipboard into a Godot type for data with the MIME type [code]type[/code]. Type handlers must be registered for a MIME type before that type can be loaded using [code]clipboard_get/has_type[/code].
+			Adds a handler to parse raw data from the clipboard into a Godot type for data with the MIME type [param type]. Type handlers must be registered for a MIME type before that type can be loaded using [method clipboard_get_type].
 			</description>
 		</method>
 		<method name="clipboard_get" qualifiers="const">
@@ -49,7 +49,7 @@
 			<return type="Variant" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Returns the user's clipboard data parsed as the MIME type [code]type[/code]. Requires a type handler to have been registered to handle that type with [code]clipboard_add_type_handler[/code].
+			Returns the user's clipboard data parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
 			</description>
 		</method>
 		<method name="clipboard_has" qualifiers="const">
@@ -68,21 +68,21 @@
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Returns [code]true[/code] if the user's clipboard data can be parsed as the MIME type [code]type[/code]. Requires a type handler to have been registered to handle that type with [code]clipboard_add_type_handler[/code].
+			Returns [code]true[/code] if the user's clipboard data can be parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
 			</description>
 		</method>
 		<method name="clipboard_has_type_handler" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Returns [code]true[/code] if there is a type handler registered to load data from the clipboard with the MIME type [code]type[/code].
+			Returns [code]true[/code] if there is a type handler registered to load data from the clipboard with the MIME type [param type].
 			</description>
 		</method>
 		<method name="clipboard_remove_type_handler" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Removes a type handler from the clipboard. That MIME type will no longer be loadable from the clipboard unless a new handler is added with [code]clipboard_add_type_handler[/code].
+			Removes a type handler from the clipboard. That MIME type will no longer be loadable from the clipboard unless a new handler is added with [method clipboard_add_type_handler].
 			</description>
 		</method>
 		<method name="clipboard_set">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -22,7 +22,7 @@
 			<param index="0" name="type" type="String" />
 			<param index="1" name="handler" type="Callable" />
 			<description>
-			Adds a handler to parse raw data from the clipboard into a Godot type for data with the MIME type [param type]. Type handlers must be registered for a MIME type before that type can be loaded using [method clipboard_get_type].
+				Adds a handler to parse raw data from the clipboard into a Godot type for data with the MIME type [param type]. Type handlers must be registered for a MIME type before that type can be loaded using [method clipboard_get_type].
 			</description>
 		</method>
 		<method name="clipboard_get" qualifiers="const">
@@ -49,7 +49,7 @@
 			<return type="Variant" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Returns the user's clipboard data parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
+				Returns the user's clipboard data parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
 			</description>
 		</method>
 		<method name="clipboard_has" qualifiers="const">
@@ -68,21 +68,21 @@
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Returns [code]true[/code] if the user's clipboard data can be parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
+				Returns [code]true[/code] if the user's clipboard data can be parsed as the MIME type [param type]. Requires a type handler to have been registered to handle that type with [method clipboard_add_type_handler].
 			</description>
 		</method>
 		<method name="clipboard_has_type_handler" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Returns [code]true[/code] if there is a type handler registered to load data from the clipboard with the MIME type [param type].
+				Returns [code]true[/code] if there is a type handler registered to load data from the clipboard with the MIME type [param type].
 			</description>
 		</method>
 		<method name="clipboard_remove_type_handler" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="type" type="String" />
 			<description>
-			Removes a type handler from the clipboard. That MIME type will no longer be loadable from the clipboard unless a new handler is added with [method clipboard_add_type_handler].
+				Removes a type handler from the clipboard. That MIME type will no longer be loadable from the clipboard unless a new handler is added with [method clipboard_add_type_handler].
 			</description>
 		</method>
 		<method name="clipboard_set">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -17,6 +17,14 @@
 				[b]Note:[/b] This method is implemented on macOS, Linux (X11/Wayland), and Windows.
 			</description>
 		</method>
+		<method name="clipboard_add_type_handler" qualifiers="const">
+			<return type="int" enum="Error" />
+			<param index="0" name="type" type="String" />
+			<param index="1" name="handler" type="Callable" />
+			<description>
+			Adds a handler to parse raw data from the clipboard into a Godot type for data with the MIME type [code]type[/code]. Type handlers must be registered for a MIME type before that type can be loaded using [code]clipboard_get/has_type[/code].
+			</description>
+		</method>
 		<method name="clipboard_get" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -37,6 +45,13 @@
 				[b]Note:[/b] This method is only implemented on Linux (X11/Wayland).
 			</description>
 		</method>
+		<method name="clipboard_get_type" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="type" type="String" />
+			<description>
+			Returns the user's clipboard data parsed as the MIME type [code]type[/code]. Requires a type handler to have been registered to handle that type with [code]clipboard_add_type_handler[/code].
+			</description>
+		</method>
 		<method name="clipboard_has" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -47,6 +62,27 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if there is an image content on the user's clipboard.
+			</description>
+		</method>
+		<method name="clipboard_has_type" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="type" type="String" />
+			<description>
+			Returns [code]true[/code] if the user's clipboard data can be parsed as the MIME type [code]type[/code]. Requires a type handler to have been registered to handle that type with [code]clipboard_add_type_handler[/code].
+			</description>
+		</method>
+		<method name="clipboard_has_type_handler" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="type" type="String" />
+			<description>
+			Returns [code]true[/code] if there is a type handler registered to load data from the clipboard with the MIME type [code]type[/code].
+			</description>
+		</method>
+		<method name="clipboard_remove_type_handler" qualifiers="const">
+			<return type="int" enum="Error" />
+			<param index="0" name="type" type="String" />
+			<description>
+			Removes a type handler from the clipboard. That MIME type will no longer be loadable from the clipboard unless a new handler is added with [code]clipboard_add_type_handler[/code].
 			</description>
 		</method>
 		<method name="clipboard_set">

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -719,9 +719,9 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 	return ret;
 }
 
-Atom DisplayServerX11::_clipboard_get_image_target(Atom p_source, Window x11_window) const {
-	Atom target = XInternAtom(x11_display, "TARGETS", 0);
-	Atom png = XInternAtom(x11_display, "image/png", 0);
+Atom DisplayServerX11::_clipboard_get_type_target(Atom p_source, Window x11_window, const String &p_type) const {
+	Atom targets_atom = XInternAtom(x11_display, "TARGETS", 0);
+	Atom target = XInternAtom(x11_display, p_type.ascii().get_data(), 0);
 	Atom *valid_targets = nullptr;
 	unsigned long atom_count = 0;
 
@@ -731,7 +731,7 @@ Atom DisplayServerX11::_clipboard_get_image_target(Atom p_source, Window x11_win
 		MutexLock mutex_lock(events_mutex);
 
 		Atom selection = XA_PRIMARY;
-		XConvertSelection(x11_display, p_source, target, selection, x11_window, CurrentTime);
+		XConvertSelection(x11_display, p_source, targets_atom, selection, x11_window, CurrentTime);
 
 		XFlush(x11_display);
 
@@ -777,9 +777,9 @@ Atom DisplayServerX11::_clipboard_get_image_target(Atom p_source, Window x11_win
 	}
 	for (unsigned long i = 0; i < atom_count; i++) {
 		Atom atom = valid_targets[i];
-		if (atom == png) {
+		if (atom == target) {
 			XFree(valid_targets);
-			return png;
+			return target;
 		}
 	}
 
@@ -830,7 +830,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 	Atom clipboard = XInternAtom(x11_display, "CLIPBOARD", 0);
 	Window x11_window = windows[MAIN_WINDOW_ID].x11_window;
 	Ref<Image> ret;
-	Atom target = _clipboard_get_image_target(clipboard, x11_window);
+	Atom target = _clipboard_get_type_target(clipboard, x11_window, String("image/png"));
 	if (target == None) {
 		return ret;
 	}
@@ -971,10 +971,164 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 }
 
 bool DisplayServerX11::clipboard_has_image() const {
-	Atom target = _clipboard_get_image_target(
+	Atom target = _clipboard_get_type_target(
 			XInternAtom(x11_display, "CLIPBOARD", 0),
-			windows[MAIN_WINDOW_ID].x11_window);
+			windows[MAIN_WINDOW_ID].x11_window,
+			String("image/png"));
 	return target != None;
+}
+
+bool DisplayServerX11::clipboard_has_type(const String &p_type) const {
+	Atom target = _clipboard_get_type_target(
+			XInternAtom(x11_display, "CLIPBOARD", 0),
+			windows[MAIN_WINDOW_ID].x11_window,
+			p_type);
+	return target != None;
+}
+
+Vector<uint8_t> DisplayServerX11::clipboard_get_raw_type(const String &p_type) const {
+	_THREAD_SAFE_METHOD_
+	Atom clipboard = XInternAtom(x11_display, "CLIPBOARD", 0);
+	Window x11_window = windows[MAIN_WINDOW_ID].x11_window;
+	Vector<uint8_t> ret;
+	Atom target = _clipboard_get_type_target(clipboard, x11_window, p_type);
+	if (target == None) {
+		return ret;
+	}
+
+	Window selection_owner = XGetSelectionOwner(x11_display, clipboard);
+
+	if (selection_owner != None && selection_owner != x11_window) {
+		// Block events polling while processing selection events.
+		MutexLock mutex_lock(events_mutex);
+
+		// Identifier for the property the other window
+		// will send the converted data to.
+		Atom transfer_prop = XA_PRIMARY;
+		XConvertSelection(x11_display,
+				clipboard, // source selection
+				target, // format to convert to
+				transfer_prop, // output property
+				x11_window, CurrentTime);
+
+		XFlush(x11_display);
+
+		// Blocking wait for predicate to be True and remove the event from the queue.
+		XEvent event;
+		XIfEvent(x11_display, &event, _predicate_clipboard_selection, (XPointer)&x11_window);
+
+		// Do not get any data, see how much data is there.
+		Atom type;
+		int format, result;
+		unsigned long len, bytes_left, dummy;
+		unsigned char *data;
+		XGetWindowProperty(x11_display, x11_window,
+				transfer_prop, // Property data is transferred through
+				0, 1, // offset, len (4 so we can get the size if INCR is used)
+				0, // Delete 0==FALSE
+				AnyPropertyType, // flag
+				&type, // return type
+				&format, // return format
+				&len, &bytes_left, // data length
+				&data);
+
+		if (type == XInternAtom(x11_display, "INCR", 0)) {
+			ERR_FAIL_COND_V_MSG(len != 1, ret, "Incremental transfer initial value was not length.");
+
+			// Data is going to be received incrementally.
+			DEBUG_LOG_X11("INCR selection started.\n");
+
+			LocalVector<uint8_t> incr_data;
+			uint32_t data_size = 0;
+			bool success = false;
+
+			// Initial response is the lower bound of the length of the transferred data.
+			incr_data.resize(*(unsigned long *)data);
+			XFree(data);
+			data = nullptr;
+
+			// Delete INCR property to notify the owner.
+			XDeleteProperty(x11_display, x11_window, transfer_prop);
+
+			// Process events from the queue.
+			bool done = false;
+			while (!done) {
+				if (!_wait_for_events()) {
+					// Error or timeout, abort.
+					break;
+				}
+				// Non-blocking wait for next event and remove it from the queue.
+				XEvent ev;
+				while (XCheckIfEvent(x11_display, &ev, _predicate_clipboard_incr, (XPointer)&transfer_prop)) {
+					result = XGetWindowProperty(x11_display, x11_window,
+							transfer_prop, // output property
+							0, LONG_MAX, // offset - len
+							True, // delete property to notify the owner
+							AnyPropertyType, // flag
+							&type, // return type
+							&format, // return format
+							&len, &bytes_left, // data length
+							&data);
+
+					DEBUG_LOG_X11("PropertyNotify: len=%lu, format=%i\n", len, format);
+
+					if (result == Success) {
+						if (data && (len > 0)) {
+							uint32_t prev_size = incr_data.size();
+							// New chunk, resize to be safe and append data.
+							incr_data.resize(MAX(data_size + len, prev_size));
+							memcpy(incr_data.ptr() + data_size, data, len);
+							data_size += len;
+						} else if (!(format == 0 && len == 0)) {
+							// For unclear reasons the first GetWindowProperty always returns a length and format of 0.
+							// Otherwise, last chunk, process finished.
+							done = true;
+							success = true;
+						}
+					} else {
+						print_verbose("Failed to get selection data chunk.");
+						done = true;
+					}
+
+					if (data) {
+						XFree(data);
+						data = nullptr;
+					}
+
+					if (done) {
+						break;
+					}
+				}
+			}
+
+			if (success && (data_size > 0)) {
+				ret.resize(incr_data.size());
+				memcpy(ret.ptrw(), incr_data.ptr(), incr_data.size());
+			}
+		} else if (bytes_left > 0) {
+			if (data) {
+				XFree(data);
+				data = nullptr;
+			}
+			// Data is ready and can be processed all at once.
+			result = XGetWindowProperty(x11_display, x11_window,
+					transfer_prop, 0, bytes_left + 4, 0,
+					AnyPropertyType, &type, &format,
+					&len, &dummy, &data);
+			if (result == Success) {
+				ret.resize(bytes_left);
+				memcpy(ret.ptrw(), data, bytes_left);
+			} else {
+				print_verbose("Failed to get selection data.");
+			}
+
+			if (data) {
+				XFree(data);
+			}
+		}
+	}
+
+	return ret;
 }
 
 Bool DisplayServerX11::_predicate_clipboard_save_targets(Display *display, XEvent *event, XPointer arg) {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -979,7 +979,6 @@ bool DisplayServerX11::clipboard_has_image() const {
 }
 
 bool DisplayServerX11::clipboard_has_type(const String &p_type) const {
-	ERR_FAIL_COND_V_MSG(!clipboard_has_type_handler(p_type), false, "No handler registered for '" + p_type + "'");
 	Atom target = _clipboard_get_type_target(
 			XInternAtom(x11_display, "CLIPBOARD", 0),
 			windows[MAIN_WINDOW_ID].x11_window,
@@ -987,7 +986,7 @@ bool DisplayServerX11::clipboard_has_type(const String &p_type) const {
 	return target != None;
 }
 
-Vector<uint8_t> DisplayServerX11::clipboard_get_raw_type(const String &p_type) const {
+Vector<uint8_t> DisplayServerX11::clipboard_get_type(const String &p_type) const {
 	_THREAD_SAFE_METHOD_
 	Atom clipboard = XInternAtom(x11_display, "CLIPBOARD", 0);
 	Window x11_window = windows[MAIN_WINDOW_ID].x11_window;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -979,6 +979,7 @@ bool DisplayServerX11::clipboard_has_image() const {
 }
 
 bool DisplayServerX11::clipboard_has_type(const String &p_type) const {
+	ERR_FAIL_COND_V_MSG(!clipboard_has_type_handler(p_type), false, "No handler registered for '" + p_type + "'");
 	Atom target = _clipboard_get_type_target(
 			XInternAtom(x11_display, "CLIPBOARD", 0),
 			windows[MAIN_WINDOW_ID].x11_window,

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -305,7 +305,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	String _clipboard_get_impl(Atom p_source, Window x11_window, Atom target) const;
 	String _clipboard_get(Atom p_source, Window x11_window) const;
-	Atom _clipboard_get_image_target(Atom p_source, Window x11_window) const;
+	Atom _clipboard_get_type_target(Atom p_source, Window x11_window, const String &p_type) const;
 	void _clipboard_transfer_ownership(Atom p_source, Window x11_window) const;
 
 	bool do_mouse_warp = false;
@@ -421,6 +421,9 @@ public:
 	virtual bool clipboard_has_image() const override;
 	virtual void clipboard_set_primary(const String &p_text) override;
 	virtual String clipboard_get_primary() const override;
+
+	virtual bool clipboard_has_type(const String &p_type) const override;
+	virtual Vector<uint8_t> clipboard_get_raw_type(const String &p_type) const override;
 
 	virtual int get_screen_count() const override;
 	virtual int get_primary_screen() const override;

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -423,7 +423,7 @@ public:
 	virtual String clipboard_get_primary() const override;
 
 	virtual bool clipboard_has_type(const String &p_type) const override;
-	virtual Vector<uint8_t> clipboard_get_raw_type(const String &p_type) const override;
+	virtual Vector<uint8_t> clipboard_get_type(const String &p_type) const override;
 
 	virtual int get_screen_count() const override;
 	virtual int get_primary_screen() const override;

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -50,7 +50,6 @@ class DisplayServer : public Object {
 
 	static DisplayServer *singleton;
 	static bool hidpi_allowed;
-	static HashMap<StringName, Callable> clipboard_handler_map;
 
 #ifndef DISABLE_DEPRECATED
 	mutable HashMap<String, RID> menu_names;
@@ -272,7 +271,6 @@ private:
 protected:
 	static bool _get_window_early_clear_override(Color &r_color);
 
-	virtual Vector<uint8_t> clipboard_get_raw_type(const String &p_type) const;
 
 public:
 	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
@@ -300,11 +298,8 @@ public:
 	virtual void clipboard_set_primary(const String &p_text);
 	virtual String clipboard_get_primary() const;
 
-	Error clipboard_add_type_handler(const String &p_type, const Callable &p_handler) const;
-	Error clipboard_remove_type_handler(const String &p_type) const;
-	bool clipboard_has_type_handler(const String &p_type) const;
 	virtual bool clipboard_has_type(const String &p_type) const;
-	Variant clipboard_get_type(const String &p_type) const;
+	virtual PackedByteArray clipboard_get_type(const String &p_type) const;
 
 	virtual TypedArray<Rect2> get_display_cutouts() const { return TypedArray<Rect2>(); }
 	virtual Rect2i get_display_safe_area() const { return screen_get_usable_rect(); }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -35,7 +35,11 @@
 #include "core/io/image.h"
 #include "core/io/resource.h"
 #include "core/os/os.h"
+#include "core/string/string_name.h"
+#include "core/templates/hash_map.h"
 #include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
 
 #include "display/native_menu.h"
 
@@ -46,6 +50,7 @@ class DisplayServer : public Object {
 
 	static DisplayServer *singleton;
 	static bool hidpi_allowed;
+	static HashMap<StringName, Callable> clipboard_map;
 
 #ifndef DISABLE_DEPRECATED
 	mutable HashMap<String, RID> menu_names;
@@ -267,6 +272,8 @@ private:
 protected:
 	static bool _get_window_early_clear_override(Color &r_color);
 
+	virtual Vector<uint8_t> clipboard_get_raw_type(const String &p_type) const;
+
 public:
 	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
 
@@ -292,6 +299,11 @@ public:
 	virtual bool clipboard_has_image() const;
 	virtual void clipboard_set_primary(const String &p_text);
 	virtual String clipboard_get_primary() const;
+
+	Error clipboard_add_type_handler(const String &p_type, const Callable &p_handler) const;
+	Error clipboard_remove_type_handler(const String &p_type) const;
+	virtual bool clipboard_has_type(const String &p_type) const;
+	Variant clipboard_get_type(const String &p_type) const;
 
 	virtual TypedArray<Rect2> get_display_cutouts() const { return TypedArray<Rect2>(); }
 	virtual Rect2i get_display_safe_area() const { return screen_get_usable_rect(); }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -50,7 +50,7 @@ class DisplayServer : public Object {
 
 	static DisplayServer *singleton;
 	static bool hidpi_allowed;
-	static HashMap<StringName, Callable> clipboard_map;
+	static HashMap<StringName, Callable> clipboard_handler_map;
 
 #ifndef DISABLE_DEPRECATED
 	mutable HashMap<String, RID> menu_names;
@@ -302,6 +302,7 @@ public:
 
 	Error clipboard_add_type_handler(const String &p_type, const Callable &p_handler) const;
 	Error clipboard_remove_type_handler(const String &p_type) const;
+	bool clipboard_has_type_handler(const String &p_type) const;
 	virtual bool clipboard_has_type(const String &p_type) const;
 	Variant clipboard_get_type(const String &p_type) const;
 


### PR DESCRIPTION
(Note: This is very freshly written, so I haven't even implemented it on Windows yet.)

This mostly addresses godotengine/godot-proposals#7899 by adding several functions to DisplayServer:

- `clipboard_has_type`, implemented per-platform, to test if a given type is available on the clipboard.
- `clipboard_add_type_handler` and `clipboard_remove_type_handler`, for adding and removing type handlers (`Callable`s which map the raw data to the correct type) from the internal list.
- `clipboard_get_raw_type`, implemented per-platform, which is not exposed outside the engine and simply produces the raw bytes of a type from the clipboard in a PackedByteArray.
- `clipboard_get_type`, implemented for all platforms, which takes the raw data from `clipboard_get_raw_type` and converts it using the appropriate Callable from the handler map to produce the correct type.

Something not explicit in the code is that `p_type`, the type name being requested by the user, is a MIME type, which should be directly supported on Linux and (as far as I can tell) Windows, and which should be convertable to the correct representation on Mac.

I still want to implement this for windows, and I don't know if the API is really what we'd want to expose for this, but I'm making this draft PR to let anyone who'd like to leave feedback on it.