### PR TITLE
[WIP] Implement native DPI scaling.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1539,6 +1539,7 @@ ProjectSettings::ProjectSettings() {
 #endif
 
 	GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);
+	GLOBAL_DEF_BASIC("gui/common/use_dpi_scaling", true);
 	GLOBAL_DEF_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);
 
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/rendering_device/vsync/frame_queue_size", PROPERTY_HINT_RANGE, "2,3,1"), 2);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -858,7 +858,7 @@ void Input::warp_mouse(const Vector2 &p_position) {
 	warp_mouse_func(p_position);
 }
 
-Point2 Input::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) {
+Point2 Input::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect, const Transform2D &p_screen_xfrom) {
 	// The relative distance reported for the next event after a warp is in the boundaries of the
 	// size of the rect on that axis, but it may be greater, in which case there's no problem as fmod()
 	// will warp it, but if the pointer has moved in the opposite direction between the pointer relocation
@@ -877,7 +877,7 @@ Point2 Input::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, cons
 	const Point2 pos_local = p_motion->get_global_position() - p_rect.position;
 	const Point2 pos_warped(Math::fposmod(pos_local.x, p_rect.size.x), Math::fposmod(pos_local.y, p_rect.size.y));
 	if (pos_warped != pos_local) {
-		warp_mouse(pos_warped + p_rect.position);
+		warp_mouse(p_screen_xfrom.basis_xform(pos_warped + p_rect.position));
 	}
 
 	return rel_warped;

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -316,7 +316,7 @@ public:
 	BitField<MouseButtonMask> get_mouse_button_mask() const;
 
 	void warp_mouse(const Vector2 &p_position);
-	Point2 warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect);
+	Point2 warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect, const Transform2D &p_screen_xfrom);
 
 	void parse_input_event(const Ref<InputEvent> &p_event);
 

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -195,14 +195,14 @@
 		<method name="get_display_cutouts" qualifiers="const">
 			<return type="Rect2[]" />
 			<description>
-				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch. These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method get_display_safe_area].
+				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch (in screen coordinates). These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method get_display_safe_area].
 				[b]Note:[/b] Currently only implemented on Android. Other platforms will return an empty array even if they do have display cutouts or notches.
 			</description>
 		</method>
 		<method name="get_display_safe_area" qualifiers="const">
 			<return type="Rect2i" />
 			<description>
-				Returns the unobscured area of the display where interactive controls should be rendered. See also [method get_display_cutouts].
+				Returns the unobscured area (in screen coordinates) of the display where interactive controls should be rendered. See also [method get_display_cutouts].
 			</description>
 		</method>
 		<method name="get_keyboard_focus_screen" qualifiers="const">
@@ -224,6 +224,12 @@
 				Returns index of the primary screen.
 			</description>
 		</method>
+		<method name="get_screen_coordiantes_unit" qualifiers="const">
+			<return type="int" enum="DisplayServer.ScreenCoordinatesUnit" />
+			<description>
+				Returns screen coordinate system unit used by the system.
+			</description>
+		</method>
 		<method name="get_screen_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -234,7 +240,7 @@
 			<return type="int" />
 			<param index="0" name="rect" type="Rect2" />
 			<description>
-				Returns index of the screen which contains specified rectangle.
+				Returns index of the screen which contains specified rectangle (in screen coordinates).
 			</description>
 		</method>
 		<method name="get_swap_cancel_ok">
@@ -248,7 +254,7 @@
 			<return type="int" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Returns the ID of the window at the specified screen [param position] (in pixels). On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
+				Returns the ID of the window at the specified screen [param position] (in screen coordinates). On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
 				[codeblock lang=text]
 				* (0, 0)        +-------+
 				                |       |
@@ -1047,7 +1053,7 @@
 			<description>
 				Returns the greatest scale factor of all screens.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] if there is at least one hiDPI (Retina) screen in the system, and [code]1.0[/code] in all other cases.
-				[b]Note:[/b] This method is implemented only on macOS.
+				[b]Note:[/b] This method is implemented only on macOS and Windows.
 			</description>
 		</method>
 		<method name="screen_get_orientation" qualifiers="const">
@@ -1062,7 +1068,7 @@
 			<return type="Color" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Returns color of the display pixel at the [param position].
+				Returns color of the display pixel at the [param position] (in screen coordinates).
 				[b]Note:[/b] This method is implemented on Linux (X11), macOS, and Windows.
 				[b]Note:[/b] On macOS, this method requires "Screen Recording" permission, if permission is not granted it will return desktop wallpaper color.
 			</description>
@@ -1071,7 +1077,7 @@
 			<return type="Vector2i" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns the screen's top-left corner position in pixels. On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
+				Returns the screen's top-left corner position in screen coordinates. On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
 				[codeblock lang=text]
 				* (0, 0)        +-------+
 				                |       |
@@ -1104,21 +1110,28 @@
 			<description>
 				Returns the scale factor of the specified screen by index.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] for hiDPI (Retina) screen, and [code]1.0[/code] for all other cases.
-				[b]Note:[/b] This method is implemented only on macOS.
+				[b]Note:[/b] This method is implemented only on Android, macOS, Linux/X11 and Windows.
 			</description>
 		</method>
 		<method name="screen_get_size" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns the screen's size in pixels. See also [method screen_get_position] and [method screen_get_usable_rect].
+				Returns the screen's size in screen coordinates. See also [method screen_get_position] and [method screen_get_usable_rect].
+			</description>
+		</method>
+		<method name="screen_get_size_in_pixels" qualifiers="const">
+			<return type="Vector2i" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns the screen's size in pixles.
 			</description>
 		</method>
 		<method name="screen_get_usable_rect" qualifiers="const">
 			<return type="Rect2i" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns the portion of the screen that is not obstructed by a status bar in pixels. See also [method screen_get_size].
+				Returns the portion of the screen that is not obstructed by a status bar in screen coordinates. See also [method screen_get_size].
 			</description>
 		</method>
 		<method name="screen_is_kept_on" qualifiers="const">
@@ -1347,7 +1360,7 @@
 		<method name="virtual_keyboard_get_height" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the on-screen keyboard's height in pixels. Returns 0 if there is no keyboard or if it is currently hidden.
+				Returns the on-screen keyboard's height in screen coordinates. Returns 0 if there is no keyboard or if it is currently hidden.
 			</description>
 		</method>
 		<method name="virtual_keyboard_hide">
@@ -1379,8 +1392,8 @@
 			<return type="void" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Sets the mouse cursor position to the given [param position] relative to an origin at the upper left corner of the currently focused game Window Manager window.
-				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS, and Linux (X11/Wayland). It has no effect on Android, iOS, and Web.
+				Sets the mouse cursor position to the given [param position] relative to an origin at the upper left corner of the currently focused game Window Manager window (in screen coordinates).
+				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux (X11/Wayland). It has no effect on Android, iOS and Web.
 			</description>
 		</method>
 		<method name="window_can_draw" qualifiers="const">
@@ -1422,14 +1435,14 @@
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the window's maximum size (in pixels). See also [method window_set_max_size].
+				Returns the window's maximum size (in screen coordinates). See also [method window_set_max_size].
 			</description>
 		</method>
 		<method name="window_get_min_size" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the window's minimum size (in pixels). See also [method window_set_min_size].
+				Returns the window's minimum size (in screen coordinates). See also [method window_set_min_size].
 			</description>
 		</method>
 		<method name="window_get_mode" qualifiers="const">
@@ -1452,42 +1465,56 @@
 			<return type="Rect2i" />
 			<param index="0" name="window" type="int" />
 			<description>
-				Returns the bounding box of control, or menu item that was used to open the popup window, in the screen coordinate system.
+				Returns the bounding box of control, or menu item that was used to open the popup window (in screen coordinates).
 			</description>
 		</method>
 		<method name="window_get_position" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the position of the client area of the given window on the screen.
+				Returns the position of the client area of the given window on the screen (in screen coordinates).
 			</description>
 		</method>
 		<method name="window_get_position_with_decorations" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the position of the given window on the screen including the borders drawn by the operating system. See also [method window_get_position].
+				Returns the position of the given window on the screen including the borders drawn by the operating system (in screen coordinates). See also [method window_get_position].
 			</description>
 		</method>
 		<method name="window_get_safe_title_margins" qualifiers="const">
 			<return type="Vector3i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns left margins ([code]x[/code]), right margins ([code]y[/code]) and height ([code]z[/code]) of the title that are safe to use (contains no buttons or other elements) when [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set.
+				Returns left margins ([code]x[/code]), right margins ([code]y[/code]) and height ([code]z[/code]) of the title (in screen coordinates) that are safe to use (contains no buttons or other elements) when [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set.
+			</description>
+		</method>
+		<method name="window_get_scale" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns window scaling factor if automatic DPI scaling is supported and enabled.
 			</description>
 		</method>
 		<method name="window_get_size" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the size of the window specified by [param window_id] (in pixels), excluding the borders drawn by the operating system. This is also called the "client area". See also [method window_get_size_with_decorations], [method window_set_size] and [method window_get_position].
+				Returns the size of the window specified by [param window_id] (in screen coordinates), excluding the borders drawn by the operating system. This is also called the "client area". See also [method window_get_size_with_decorations], [method window_set_size] and [method window_get_position].
+			</description>
+		</method>
+		<method name="window_get_size_in_pixels" qualifiers="const">
+			<return type="Vector2i" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns the size of the window specified by [param window_id] (in pixels), excluding the borders drawn by the operating system. This is also called the "client area".
 			</description>
 		</method>
 		<method name="window_get_size_with_decorations" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the size of the window specified by [param window_id] (in pixels), including the borders drawn by the operating system. See also [method window_get_size].
+				Returns the size of the window specified by [param window_id] (in screen coordinates), including the borders drawn by the operating system. See also [method window_get_size].
 			</description>
 		</method>
 		<method name="window_get_title_size" qualifiers="const">
@@ -1495,7 +1522,7 @@
 			<param index="0" name="title" type="String" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Returns the estimated window title bar size (including text and window buttons) for the window specified by [param window_id] (in pixels). This method does not change the window title.
+				Returns the estimated window title bar size (including text and window buttons) for the window specified by [param window_id] (in screen coordinates). This method does not change the window title.
 				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
@@ -1598,7 +1625,7 @@
 			<param index="0" name="position" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the position of the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] popup for the specified [param window_id]. Only effective if [method window_set_ime_active] was set to [code]true[/code] for the specified [param window_id].
+				Sets the position (in screen coordinates) of the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] popup for the specified [param window_id]. Only effective if [method window_set_ime_active] was set to [code]true[/code] for the specified [param window_id].
 			</description>
 		</method>
 		<method name="window_set_input_event_callback">
@@ -1624,7 +1651,7 @@
 			<param index="0" name="max_size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the maximum size of the window specified by [param window_id] in pixels. Normally, the user will not be able to drag the window to make it larger than the specified size. See also [method window_get_max_size].
+				Sets the maximum size of the window specified by [param window_id] in screen coordinates. Normally, the user will not be able to drag the window to make it larger than the specified size. See also [method window_get_max_size].
 				[b]Note:[/b] It's recommended to change this value using [member Window.max_size] instead.
 				[b]Note:[/b] Using third-party tools, it is possible for users to disable window geometry restrictions and therefore bypass this limit.
 			</description>
@@ -1634,7 +1661,7 @@
 			<param index="0" name="min_size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the minimum size for the given window to [param min_size] in pixels. Normally, the user will not be able to drag the window to make it smaller than the specified size. See also [method window_get_min_size].
+				Sets the minimum size for the given window to [param min_size] in screen coordinates. Normally, the user will not be able to drag the window to make it smaller than the specified size. See also [method window_get_min_size].
 				[b]Note:[/b] It's recommended to change this value using [member Window.min_size] instead.
 				[b]Note:[/b] By default, the main window has a minimum size of [code]Vector2i(64, 64)[/code]. This prevents issues that can arise when the window is resized to a near-zero size.
 				[b]Note:[/b] Using third-party tools, it is possible for users to disable window geometry restrictions and therefore bypass this limit.
@@ -1654,7 +1681,7 @@
 			<param index="0" name="region" type="PackedVector2Array" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets a polygonal region of the window which accepts mouse events. Mouse events outside the region will be passed through.
+				Sets a polygonal region (in screen coordinates) of the window which accepts mouse events. Mouse events outside the region will be passed through.
 				Passing an empty array will disable passthrough support (all mouse events will be intercepted by the window, which is the default behavior).
 				[codeblocks]
 				[gdscript]
@@ -1687,7 +1714,7 @@
 			<param index="0" name="window" type="int" />
 			<param index="1" name="rect" type="Rect2i" />
 			<description>
-				Sets the bounding box of control, or menu item that was used to open the popup window, in the screen coordinate system. Clicking this area will not auto-close this popup.
+				Sets the bounding box of control, or menu item that was used to open the popup window (in screen coordinates). Clicking this area will not auto-close this popup.
 			</description>
 		</method>
 		<method name="window_set_position">
@@ -1695,7 +1722,7 @@
 			<param index="0" name="position" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the position of the given window to [param position]. On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
+				Sets the position of the given window to [param position] (in screen coordinates). On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
 				[codeblock lang=text]
 				* (0, 0)        +-------+
 				                |       |
@@ -1723,7 +1750,7 @@
 			<param index="0" name="size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the size of the given window to [param size] (in pixels). See also [method window_get_size] and [method window_get_position].
+				Sets the size of the given window to [param size] (in screen coordinates). See also [method window_get_size] and [method window_get_position].
 				[b]Note:[/b] It's recommended to change this value using [member Window.size] instead.
 			</description>
 		</method>
@@ -1763,7 +1790,7 @@
 			<param index="0" name="offset" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				When [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set, set offset to the center of the first titlebar button.
+				When [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set, set offset (in screen coordinates) to the center of the first titlebar button.
 				[b]Note:[/b] This flag is implemented only on macOS.
 			</description>
 		</method>
@@ -1853,6 +1880,9 @@
 		<constant name="FEATURE_NATIVE_DIALOG_FILE" value="25" enum="Feature">
 			Display server supports spawning dialogs for selecting files or directories using the operating system's native look-and-feel. See [method file_dialog_show] and [method file_dialog_with_options_show]. [b]Windows, macOS, Linux (X11/Wayland)[/b]
 		</constant>
+		<constant name="FEATURE_DPI_SCALING" value="26" enum="Feature">
+			Display server support automatic DPI scaling.
+		</constant>
 		<constant name="MOUSE_MODE_VISIBLE" value="0" enum="MouseMode">
 			Makes the mouse cursor visible if it is hidden.
 		</constant>
@@ -1914,6 +1944,12 @@
 		</constant>
 		<constant name="SCREEN_SENSOR" value="6" enum="ScreenOrientation">
 			Automatic landscape or portrait orientation (default or reverse depending on sensor).
+		</constant>
+		<constant name="SCREEN_COORDS_UNIT_DEVICE_PIXEL" value="0" enum="ScreenCoordinatesUnit">
+			Screen coordinates unit is physical device pixel.
+		</constant>
+		<constant name="SCREEN_COORDS_UNIT_DPI_ADJUSTED_PIXEL" value="1" enum="ScreenCoordinatesUnit">
+			Screen coordinates unit is DPI adjusted pixel (e.g., at [code]2.0[/code] DPI scaling, one DPI adjusted pixel is equal to 2x2 device pixels).
 		</constant>
 		<constant name="KEYBOARD_TYPE_DEFAULT" value="0" enum="VirtualKeyboardType">
 			Default text virtual keyboard.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -708,6 +708,9 @@
 			If [code]true[/code], embed modal windows such as docks inside the main editor window. When single-window mode is enabled, tooltips will also be embedded inside the main editor window, which means they can't be displayed outside of the editor window.
 			[b]Note:[/b] To query whether the editor can use multiple windows in an editor plugin, use [method EditorInterface.is_multi_window_enabled] instead of querying the value of this editor setting.
 		</member>
+		<member name="interface/editor/ui_dpi_scaling" type="bool" setter="" getter="">
+			If [code]true[/code], editor GUI is automatically scaled to match screen DPI.
+		</member>
 		<member name="interface/editor/ui_layout_direction" type="int" setter="" getter="">
 			Editor UI default layout direction.
 		</member>

--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -645,8 +645,8 @@
 		<member name="opentype_feature_overrides" type="Dictionary" setter="set_opentype_feature_overrides" getter="get_opentype_feature_overrides" default="{}">
 			Font OpenType feature set override.
 		</member>
-		<member name="oversampling" type="float" setter="set_oversampling" getter="get_oversampling" default="0.0">
-			Font oversampling factor. If set to [code]0.0[/code], the global oversampling factor is used instead. Used by dynamic fonts only (MSDF fonts ignore oversampling).
+		<member name="oversampling" type="float" setter="set_oversampling" getter="get_oversampling" default="1.0" deprecated="">
+			[i]Deprecated.[/i] This member does nothing. Use [member Viewport.oversampling_factor] instead.
 		</member>
 		<member name="style_name" type="String" setter="set_font_style_name" getter="get_font_style_name" default="&quot;&quot;">
 			Font style name.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1023,6 +1023,9 @@
 		<member name="gui/common/text_edit_undo_stack_max_size" type="int" setter="" getter="" default="1024">
 			Maximum undo/redo history size for [TextEdit] fields.
 		</member>
+		<member name="gui/common/use_dpi_scaling" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], GUI is automatically scaled to match screen DPI.
+		</member>
 		<member name="gui/fonts/dynamic_fonts/use_oversampling" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="gui/theme/custom" type="String" setter="" getter="" default="&quot;&quot;">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -424,6 +424,13 @@
 				[b]Note:[/b] The equivalent node is [CanvasItem].
 			</description>
 		</method>
+		<method name="canvas_item_get_oversampling_factor" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="item" type="RID" />
+			<description>
+				Returns font oversampling factor for the canvas item.
+			</description>
+		</method>
 		<method name="canvas_item_reset_physics_interpolation">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
@@ -542,6 +549,15 @@
 			<param index="1" name="color" type="Color" />
 			<description>
 				Multiplies the color of the canvas item specified by the [param item] RID, while affecting its children. See also [method canvas_item_set_self_modulate]. Equivalent to [member CanvasItem.modulate].
+			</description>
+		</method>
+		<method name="canvas_item_set_oversampling_factor">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="oversampling" type="float" />
+			<description>
+				Sets font oversampling factor for the canvas item.
+				[b]Note:[/b] This value is automatically set by viewport.
 			</description>
 		</method>
 		<method name="canvas_item_set_parent">

--- a/doc/classes/ResourceImporterDynamicFont.xml
+++ b/doc/classes/ResourceImporterDynamicFont.xml
@@ -60,9 +60,6 @@
 		<member name="opentype_features" type="Dictionary" setter="" getter="" default="{}">
 			The OpenType features to enable, disable or set a value for this font. This can be used to enable optional features provided by the font, such as ligatures or alternative glyphs. The list of supported OpenType features varies on a per-font basis.
 		</member>
-		<member name="oversampling" type="float" setter="" getter="" default="0.0">
-			If set to a value greater than [code]0.0[/code], overrides the oversampling factor for the font. This can be used to render the font at a higher or lower resolution than intended without affecting its physical size. In most cases, this should be left at [code]0.0[/code].
-		</member>
 		<member name="preload" type="Array" setter="" getter="" default="[]">
 			The glyph ranges to prerender. This can avoid stuttering during gameplay when new characters need to be rendered, especially if [member subpixel_positioning] is enabled. The downside of using preloading is that initial project load times will increase, as well as memory usage.
 		</member>

--- a/doc/classes/SVGTexture.xml
+++ b/doc/classes/SVGTexture.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SVGTexture" inherits="Texture2D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A scalable [Texture2D] based on an SVG image.
+	</brief_description>
+	<description>
+		A scalable [Texture2D] based on an SVG image. [SVGTexture]s are automatically rescaled to match font oversampling.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_from_string" qualifiers="static">
+			<return type="SVGTexture" />
+			<param index="0" name="source" type="String" />
+			<param index="1" name="scale" type="float" default="1.0" />
+			<param index="2" name="saturation" type="float" default="1.0" />
+			<param index="3" name="color_map" type="Dictionary" default="{}" />
+			<description>
+				Creates a new [SVGTexture] and initializes it by allocating and setting the SVG data from string.
+			</description>
+		</method>
+		<method name="get_scaled_rid" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="scale" type="float" />
+			<description>
+				Returns rescaled texture RID for scale [param scale].
+			</description>
+		</method>
+		<method name="set_size_override">
+			<return type="void" />
+			<param index="0" name="size" type="Vector2i" />
+			<description>
+				Resizes the texture to the specified dimensions.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="base_scale" type="float" setter="set_base_scale" getter="get_base_scale" default="1.0">
+			SVG texture scale.
+		</member>
+		<member name="color_map" type="Dictionary" setter="set_color_map" getter="get_color_map" default="{}">
+			If sets, remaps SVG texture colors according to [Color]-[Color] map.
+		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
+		<member name="saturation" type="float" setter="set_saturation" getter="get_saturation" default="1.0">
+			Overrides texture saturation.
+		</member>
+		<member name="source" type="String" setter="set_source" getter="get_source" default="&quot;&quot;">
+			SVG source code.
+		</member>
+	</members>
+</class>

--- a/doc/classes/SystemFont.xml
+++ b/doc/classes/SystemFont.xml
@@ -52,8 +52,8 @@
 		<member name="multichannel_signed_distance_field" type="bool" setter="set_multichannel_signed_distance_field" getter="is_multichannel_signed_distance_field" default="false">
 			If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
 		</member>
-		<member name="oversampling" type="float" setter="set_oversampling" getter="get_oversampling" default="0.0">
-			Font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead.
+		<member name="oversampling" type="float" setter="set_oversampling" getter="get_oversampling" default="1.0" deprecated="">
+			[i]Deprecated.[/i] This member does nothing. Use [member Viewport.oversampling_factor] instead.
 		</member>
 		<member name="subpixel_positioning" type="int" setter="set_subpixel_positioning" getter="get_subpixel_positioning" enum="TextServer.SubpixelPositioning" default="1">
 			Font glyph subpixel positioning mode. Subpixel positioning provides shaper text and better kerning for smaller font sizes, at the cost of memory usage and font rasterization speed. Use [constant TextServer.SUBPIXEL_POSITIONING_AUTO] to automatically enable it based on the font size.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -193,10 +193,10 @@
 				Returns [code]true[/code] if font texture mipmap generation is enabled.
 			</description>
 		</method>
-		<method name="font_get_global_oversampling" qualifiers="const">
+		<method name="font_get_global_oversampling" qualifiers="const" deprecated="">
 			<return type="float" />
 			<description>
-				Returns the font oversampling factor, shared by all fonts in the TextServer.
+				[i]Deprecated.[/i] This function does nothing. Use [member Viewport.oversampling_factor] instead.
 			</description>
 		</method>
 		<method name="font_get_glyph_advance" qualifiers="const">
@@ -369,11 +369,17 @@
 				Returns [Dictionary] with OpenType font name strings (localized font names, version, description, license information, sample text, etc.).
 			</description>
 		</method>
-		<method name="font_get_oversampling" qualifiers="const">
+		<method name="font_get_oversampling" qualifiers="const" deprecated="">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				Returns font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
+				[i]Deprecated.[/i] This function does nothing. Use [member Viewport.oversampling_factor] instead.
+			</description>
+		</method>
+		<method name="font_get_oversampling_cache_capacity" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns oversampling cache capacity.
 			</description>
 		</method>
 		<method name="font_get_scale" qualifiers="const">
@@ -735,12 +741,11 @@
 				If set to [code]true[/code] font texture mipmap generation is enabled.
 			</description>
 		</method>
-		<method name="font_set_global_oversampling">
+		<method name="font_set_global_oversampling" deprecated="">
 			<return type="void" />
 			<param index="0" name="oversampling" type="float" />
 			<description>
-				Sets oversampling factor, shared by all font in the TextServer.
-				[b]Note:[/b] This value can be automatically changed by display server.
+				[i]Deprecated.[/i] This function does nothing. Use [member Viewport.oversampling_factor] instead.
 			</description>
 		</method>
 		<method name="font_set_glyph_advance">
@@ -862,12 +867,19 @@
 				Sets font OpenType feature set override.
 			</description>
 		</method>
-		<method name="font_set_oversampling">
+		<method name="font_set_oversampling" deprecated="">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="oversampling" type="float" />
 			<description>
-				Sets font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
+				[i]Deprecated.[/i] This function does nothing. Use [member Viewport.oversampling_factor] instead.
+			</description>
+		</method>
+		<method name="font_set_oversampling_cache_capacity">
+			<return type="void" />
+			<param index="0" name="oversampling_capacity" type="int" />
+			<description>
+				Sets oversampling cache capacity.
 			</description>
 		</method>
 		<method name="font_set_scale">

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -413,6 +413,11 @@
 				Returns font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
+		<method name="_font_get_oversampling_cache_capacity" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_font_get_scale" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
@@ -969,6 +974,12 @@
 			<description>
 				[b]Optional.[/b]
 				Sets font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
+			</description>
+		</method>
+		<method name="_font_set_oversampling_cache_capacity" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="oversampling_capacity" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="_font_set_scale" qualifiers="virtual">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -298,6 +298,9 @@
 		<member name="msaa_3d" type="int" setter="set_msaa_3d" getter="get_msaa_3d" enum="Viewport.MSAA" default="0">
 			The multisample anti-aliasing mode for 3D rendering. A higher number results in smoother edges at the cost of significantly worse performance. A value of 2 or 4 is best unless targeting very high-end systems. See also bilinear scaling 3d [member scaling_3d_mode] for supersampling, which provides higher quality but is much more expensive. This has no effect on shader-induced aliasing or texture aliasing.
 		</member>
+		<member name="oversampling_factor" type="float" setter="set_oversampling_factor" getter="get_oversampling_factor" default="1.0">
+			Font oversampling factor.
+		</member>
 		<member name="own_world_3d" type="bool" setter="set_use_own_world_3d" getter="is_using_own_world_3d" default="false">
 			If [code]true[/code], the viewport will use a unique copy of the [World3D] defined in [member world_3d].
 		</member>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -101,6 +101,12 @@
 				The value returned by this method can be overridden with [method _get_contents_minimum_size].
 			</description>
 		</method>
+		<method name="get_dpi_scale" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns window DPI scaling factor.
+			</description>
+		</method>
 		<method name="get_flag" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="Window.Flags" />
@@ -120,10 +126,16 @@
 				Returns the window's position including its border.
 			</description>
 		</method>
+		<method name="get_size_in_pixels" qualifiers="const">
+			<return type="Vector2i" />
+			<description>
+				Return the window's size in pixels.
+			</description>
+		</method>
 		<method name="get_size_with_decorations" qualifiers="const">
 			<return type="Vector2i" />
 			<description>
-				Returns the window's size including its border.
+				Returns the window's size including its border (in screen coordinates).
 			</description>
 		</method>
 		<method name="get_theme_color" qualifiers="const">
@@ -345,10 +357,10 @@
 				Returns [code]true[/code] if the window can be maximized (the maximize button is enabled).
 			</description>
 		</method>
-		<method name="is_using_font_oversampling" qualifiers="const">
+		<method name="is_using_font_oversampling" qualifiers="const" deprecated="">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if font oversampling is enabled. See [method set_use_font_oversampling].
+				[i]Deprecated.[/i] This function does nothing.
 			</description>
 		</method>
 		<method name="move_to_center">
@@ -367,14 +379,14 @@
 			<return type="void" />
 			<param index="0" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />
 			<description>
-				Shows the [Window] and makes it transient (see [member transient]). If [param rect] is provided, it will be set as the [Window]'s size. Fails if called on the main window.
+				Shows the [Window] and makes it transient (see [member transient]). If [param rect] is provided, it will be set as the [Window]'s size and position (in screen coordinates). Fails if called on the main window.
 			</description>
 		</method>
 		<method name="popup_centered">
 			<return type="void" />
 			<param index="0" name="minsize" type="Vector2i" default="Vector2i(0, 0)" />
 			<description>
-				Popups the [Window] at the center of the current screen, with optionally given minimum size. If the [Window] is embedded, it will be centered in the parent [Viewport] instead.
+				Popups the [Window] at the center of the current screen, with optionally given minimum size (in screen coordinates). If the [Window] is embedded, it will be centered in the parent [Viewport] instead.
 				[b]Note:[/b] Calling it with the default value of [param minsize] is equivalent to calling it with [member size].
 			</description>
 		</method>
@@ -445,7 +457,7 @@
 			<return type="void" />
 			<param index="0" name="parent_rect" type="Rect2i" />
 			<description>
-				Popups the [Window] with a position shifted by parent [Window]'s position. If the [Window] is embedded, has the same effect as [method popup].
+				Popups the [Window] with a position shifted by parent [Window]'s position (in screen coordinates). If the [Window] is embedded, has the same effect as [method popup].
 			</description>
 		</method>
 		<method name="remove_theme_color_override">
@@ -521,7 +533,7 @@
 			<return type="void" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Moves IME to the given position.
+				Sets the position (in screen coordinates) of the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] popup for the window. Only effective if [method set_ime_active] was set to [code]true[/code] for the window.
 			</description>
 		</method>
 		<method name="set_layout_direction">
@@ -543,7 +555,7 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				Enables font oversampling. This makes fonts look better when they are scaled up.
+				[i]Deprecated.[/i] This function does nothing.
 			</description>
 		</method>
 		<method name="show">
@@ -600,11 +612,11 @@
 			If [code]true[/code], the [Window] width is expanded to keep the title bar text fully visible.
 		</member>
 		<member name="max_size" type="Vector2i" setter="set_max_size" getter="get_max_size" default="Vector2i(0, 0)">
-			If non-zero, the [Window] can't be resized to be bigger than this size.
+			If non-zero, the [Window] can't be resized to be bigger than this size (in screen coordinates).
 			[b]Note:[/b] This property will be ignored if the value is lower than [member min_size].
 		</member>
 		<member name="min_size" type="Vector2i" setter="set_min_size" getter="get_min_size" default="Vector2i(0, 0)">
-			If non-zero, the [Window] can't be resized to be smaller than this size.
+			If non-zero, the [Window] can't be resized to be smaller than this size (in screen coordinates).
 			[b]Note:[/b] This property will be ignored in favor of [method get_contents_minimum_size] if [member wrap_controls] is enabled and if its size is bigger.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Window.Mode" default="0">
@@ -618,7 +630,7 @@
 			[b]Note:[/b] This property only works with native windows.
 		</member>
 		<member name="mouse_passthrough_polygon" type="PackedVector2Array" setter="set_mouse_passthrough_polygon" getter="get_mouse_passthrough_polygon" default="PackedVector2Array()">
-			Sets a polygonal region of the window which accepts mouse events. Mouse events outside the region will be passed through.
+			Sets a polygonal region (in screen coordinates) of the window which accepts mouse events. Mouse events outside the region will be passed through.
 			Passing an empty array will disable passthrough support (all mouse events will be intercepted by the window, which is the default behavior).
 			[codeblocks]
 			[gdscript]
@@ -650,12 +662,12 @@
 			If [code]true[/code], the [Window] will be considered a popup. Popups are sub-windows that don't show as separate windows in system's window manager's window list and will send close request when anything is clicked outside of them (unless [member exclusive] is enabled).
 		</member>
 		<member name="position" type="Vector2i" setter="set_position" getter="get_position" default="Vector2i(0, 0)">
-			The window's position in pixels.
+			The window's position (in screen or embedder viewport coordinates).
 			If [member ProjectSettings.display/window/subwindows/embed_subwindows] is [code]false[/code], the position is in absolute screen coordinates. This typically applies to editor plugins. If the setting is [code]true[/code], the window's position is in the coordinates of its parent [Viewport].
 			[b]Note:[/b] This property only works if [member initial_position] is set to [constant WINDOW_INITIAL_POSITION_ABSOLUTE].
 		</member>
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(100, 100)">
-			The window's size in pixels.
+			The window's size (in screen or embedder viewport coordinates).
 		</member>
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
 			The [Theme] resource this node and all its [Control] and [Window] children use. If a child node has its own [Theme] resource set, theme items are merged with child's definitions having higher priority.

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -395,7 +395,7 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 
 	if (p_first) {
-		Size2i win_size = DisplayServer::get_singleton()->window_get_size();
+		Size2i win_size = DisplayServer::get_singleton()->window_get_size_in_pixels();
 		if (p_screen_rect.position != Vector2() || p_screen_rect.size != rt->size) {
 			// Viewport doesn't cover entire window so clear window to black before blitting.
 			glViewport(0, 0, win_size.width, win_size.height);
@@ -442,7 +442,7 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 		return;
 	}
 
-	Size2i win_size = DisplayServer::get_singleton()->window_get_size();
+	Size2i win_size = DisplayServer::get_singleton()->window_get_size_in_pixels();
 
 	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 	glViewport(0, 0, win_size.width, win_size.height);

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -215,12 +215,12 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning")) {
-				panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+				panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 			}
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1023,7 +1023,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		menu_insert_key = mb->get_position();
 		if (menu_insert_key.x >= limit && menu_insert_key.x <= get_size().width) {
 			if (!read_only) {
-				Vector2 popup_pos = get_screen_position() + mb->get_position();
+				Vector2 popup_pos = get_final_transform().xform(mb->get_position());
 
 				bool selected = _try_select_at_ui_pos(mb->get_position(), mb->is_shift_pressed(), false);
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1417,7 +1417,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning")) {
-				panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+				panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 			}
 		} break;
 
@@ -2824,7 +2824,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				menu->reset_size();
 
-				Vector2 popup_pos = get_screen_position() + update_mode_rect.position + Vector2(0, update_mode_rect.size.height);
+				Vector2 popup_pos = get_final_transform().xform(update_mode_rect.position + Vector2(0, update_mode_rect.size.height));
 				menu->set_position(popup_pos);
 				menu->popup();
 				accept_event();
@@ -2870,7 +2870,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				menu->reset_size();
 
-				Vector2 popup_pos = get_screen_position() + interp_mode_rect.position + Vector2(0, interp_mode_rect.size.height);
+				Vector2 popup_pos = get_final_transform().xform(interp_mode_rect.position + Vector2(0, interp_mode_rect.size.height));
 				menu->set_position(popup_pos);
 				menu->popup();
 				accept_event();
@@ -2887,7 +2887,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->add_icon_item(get_editor_theme_icon(SNAME("InterpWrapLoop")), TTR("Wrap Loop Interp"), MENU_LOOP_WRAP);
 				menu->reset_size();
 
-				Vector2 popup_pos = get_screen_position() + loop_wrap_rect.position + Vector2(0, loop_wrap_rect.size.height);
+				Vector2 popup_pos = get_final_transform().xform(loop_wrap_rect.position + Vector2(0, loop_wrap_rect.size.height));
 				menu->set_position(popup_pos);
 				menu->popup();
 				accept_event();
@@ -2941,7 +2941,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				menu->reset_size();
 
-				menu->set_position(get_screen_position() + get_local_mouse_position());
+				menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 				menu->popup();
 
 				insert_at_pos = offset + timeline->get_value();
@@ -2963,8 +2963,9 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		path->set_text(animation->track_get_path(track));
 		Vector2 theme_ofs = path->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit"))->get_offset();
-		path_popup->set_position(get_screen_position() + path_rect.position - theme_ofs);
-		path_popup->set_size(path_rect.size);
+		Rect2i popup_rect = get_final_transform().xform(Rect2i(path_rect.position - theme_ofs, path_rect.size));
+		path_popup->set_position(popup_rect.position);
+		path_popup->set_size(popup_rect.size);
 		path_popup->popup();
 		path->grab_focus();
 		path->set_caret_column(path->get_text().length());
@@ -4839,9 +4840,10 @@ void AnimationTrackEditor::_notification(int p_what) {
 		}
 
 		case NOTIFICATION_ENTER_TREE: {
-			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 			[[fallthrough]];
 		}
+
 		case NOTIFICATION_THEME_CHANGED: {
 			zoom_icon->set_texture(get_editor_theme_icon(SNAME("Zoom")));
 			bezier_edit_icon->set_icon(get_editor_theme_icon(SNAME("EditBezier")));
@@ -6200,8 +6202,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				md["path"] = path;
 				it->set_metadata(0, md);
 			}
-
-			track_copy_dialog->popup_centered(Size2(350, 500) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(350 * EDSCALE, 500 * EDSCALE));
+			track_copy_dialog->popup_centered(popup_size);
 		} break;
 		case EDIT_COPY_TRACKS_CONFIRM: {
 			track_clipboard.clear();
@@ -6285,7 +6287,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 		case EDIT_SCALE_SELECTION:
 		case EDIT_SCALE_FROM_CURSOR: {
-			scale_dialog->popup_centered(Size2(200, 100) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(200 * EDSCALE, 100 * EDSCALE));
+			scale_dialog->popup_centered(popup_size);
 		} break;
 		case EDIT_SCALE_CONFIRM: {
 			if (selection.is_empty()) {
@@ -6451,7 +6454,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 
 		case EDIT_EASE_SELECTION: {
-			ease_dialog->popup_centered(Size2(200, 100) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(200 * EDSCALE, 100 * EDSCALE));
+			ease_dialog->popup_centered(popup_size);
 		} break;
 		case EDIT_EASE_CONFIRM: {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -6699,7 +6703,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 
 		case EDIT_BAKE_ANIMATION: {
-			bake_dialog->popup_centered(Size2(200, 100) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(200 * EDSCALE, 100 * EDSCALE));
+			bake_dialog->popup_centered(popup_size);
 		} break;
 		case EDIT_BAKE_ANIMATION_CONFIRM: {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -6816,7 +6821,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 
 		case EDIT_OPTIMIZE_ANIMATION: {
-			optimize_dialog->popup_centered(Size2(250, 180) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 180 * EDSCALE));
+			optimize_dialog->popup_centered(popup_size);
 
 		} break;
 		case EDIT_OPTIMIZE_ANIMATION_CONFIRM: {
@@ -6829,7 +6835,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 		} break;
 		case EDIT_CLEAN_UP_ANIMATION: {
-			cleanup_dialog->popup_centered(Size2(300, 0) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 0));
+			cleanup_dialog->popup_centered(popup_size);
 
 		} break;
 		case EDIT_CLEAN_UP_ANIMATION_CONFIRM: {

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -48,7 +48,8 @@ void GotoLineDialog::popup_find_line(CodeEdit *p_edit) {
 	// Add 1 because text_editor->get_caret_line() starts from 0, but the editor user interface starts from 1.
 	line->set_text(itos(text_editor->get_caret_line() + 1));
 	line->select_all();
-	popup_centered(Size2(180, 80) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(180 * EDSCALE, 80 * EDSCALE));
+	popup_centered(popup_size);
 	line->grab_focus();
 }
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -686,7 +686,8 @@ void ConnectDialog::_advanced_pressed() {
 }
 
 ConnectDialog::ConnectDialog() {
-	set_min_size(Size2(0, 500) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(0, 500 * EDSCALE));
+	set_min_size(popup_size);
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);
 	add_child(main_hb);
@@ -737,7 +738,8 @@ ConnectDialog::ConnectDialog() {
 
 	method_popup = memnew(AcceptDialog);
 	method_popup->set_title(TTR("Select Method"));
-	method_popup->set_min_size(Vector2(400, 600) * EDSCALE);
+	popup_size = get_final_transform().basis_xform(Vector2i(400 * EDSCALE, 600 * EDSCALE));
+	method_popup->set_min_size(popup_size);
 	add_child(method_popup);
 
 	VBoxContainer *method_vbc = memnew(VBoxContainer);
@@ -1292,7 +1294,7 @@ void ConnectionsDock::_tree_gui_input(const Ref<InputEvent> &p_event) {
 			tree->set_selected(item);
 		}
 
-		Vector2 screen_position = tree->get_screen_position() + mb_event->get_position();
+		Vector2 screen_position = tree->get_final_transform().xform(mb_event->get_position());
 
 		switch (_get_item_type(*item)) {
 			case TREE_ITEM_TYPE_ROOT:

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -73,7 +73,8 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
-		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
+		Size2i popup_size = get_final_transform().basis_xform(Vector2i(900 * EDSCALE, 700 * EDSCALE));
+		popup_centered_clamped(popup_size, 0.8);
 	}
 }
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -119,7 +119,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position, Mou
 	item_menu->clear();
 	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), TTR("Save Branch as Scene"), ITEM_MENU_SAVE_REMOTE_NODE);
 	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CopyNodePath")), TTR("Copy Node Path"), ITEM_MENU_COPY_NODE_PATH);
-	item_menu->set_position(get_screen_position() + get_local_mouse_position());
+	item_menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 	item_menu->reset_size();
 	item_menu->popup();
 }

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1613,7 +1613,7 @@ void ScriptEditorDebugger::_breakpoints_item_rmb_selected(const Vector2 &p_pos, 
 	breakpoints_menu->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Delete All Breakpoints in:") + " " + file, ACTION_DELETE_BREAKPOINTS_IN_FILE);
 	breakpoints_menu->add_icon_item(get_editor_theme_icon(SNAME("Remove")), TTR("Delete All Breakpoints"), ACTION_DELETE_ALL_BREAKPOINTS);
 
-	breakpoints_menu->set_position(get_screen_position() + get_local_mouse_position());
+	breakpoints_menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 	breakpoints_menu->popup();
 }
 
@@ -1632,7 +1632,7 @@ void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos, M
 	}
 
 	if (item_menu->get_item_count() > 0) {
-		item_menu->set_position(error_tree->get_screen_position() + p_pos);
+		item_menu->set_position(error_tree->get_final_transform().xform(p_pos));
 		item_menu->popup();
 	}
 }

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -313,7 +313,7 @@ void DependencyEditorOwners::_list_rmb_clicked(int p_item, const Vector2 &p_pos,
 		}
 	}
 
-	file_options->set_position(owners->get_screen_position() + p_pos);
+	file_options->set_position(owners->get_final_transform().xform(p_pos));
 	file_options->reset_size();
 	file_options->popup();
 }
@@ -731,7 +731,8 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	vb->add_margin_child(TTR("Load failed due to missing dependencies:"), files, true);
 	files->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
-	set_min_size(Size2(500, 220) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(500 * EDSCALE, 220 * EDSCALE));
+	set_min_size(popup_size);
 	set_ok_button_text(TTR("Open Anyway"));
 	set_cancel_button_text(TTR("Close"));
 

--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -135,8 +135,9 @@ void DirectoryCreateDialog::_bind_methods() {
 }
 
 DirectoryCreateDialog::DirectoryCreateDialog() {
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(480 * EDSCALE, 0));
 	set_title(TTR("Create Folder"));
-	set_min_size(Size2i(480, 0) * EDSCALE);
+	set_min_size(popup_size);
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	add_child(vb);

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -162,7 +162,8 @@ void EditorAssetInstaller::open_asset(const String &p_path, bool p_autoskip_topl
 	_rebuild_source_tree();
 	_rebuild_destination_tree();
 
-	popup_centered_clamped(Size2(620, 640) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(620 * EDSCALE, 640 * EDSCALE));
+	popup_centered_clamped(popup_size);
 }
 
 void EditorAssetInstaller::_update_file_mappings() {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -521,7 +521,7 @@ void EditorAudioBus::_effect_edited() {
 	if (effect->get_metadata(0) == Variant()) {
 		Rect2 area = effects->get_item_rect(effect);
 
-		effect_options->set_position(effects->get_screen_position() + area.position + Vector2(0, area.size.y));
+		effect_options->set_position(effects->get_final_transform().xform(area.position + Vector2(0, area.size.y)));
 		effect_options->reset_size();
 		effect_options->popup();
 		//add effect
@@ -570,7 +570,7 @@ void EditorAudioBus::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-		bus_popup->set_position(get_screen_position() + mb->get_position());
+		bus_popup->set_position(get_final_transform().xform(mb->get_position()));
 		bus_popup->reset_size();
 		bus_popup->popup();
 	}
@@ -776,7 +776,7 @@ void EditorAudioBus::_effect_rmb(const Vector2 &p_pos, MouseButton p_button) {
 		return;
 	}
 
-	delete_effect_popup->set_position(get_screen_position() + get_local_mouse_position());
+	delete_effect_popup->set_position(get_final_transform().xform(get_local_mouse_position()));
 	delete_effect_popup->reset_size();
 	delete_effect_popup->popup();
 }

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -212,7 +212,8 @@ void EditorCommandPalette::open_popup() {
 	if (was_showed) {
 		popup(prev_rect);
 	} else {
-		popup_centered_clamped(Size2(600, 440) * EDSCALE, 0.8f);
+		Size2i popup_size = get_final_transform().basis_xform(Vector2i(600 * EDSCALE, 440 * EDSCALE));
+		popup_centered_clamped(popup_size, 0.8f);
 	}
 
 	command_search_box->clear();

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -438,7 +438,8 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 			export_profile->set_current_file(_get_selected_profile() + ".profile");
 		} break;
 		case PROFILE_NEW: {
-			new_profile_dialog->popup_centered(Size2(240, 60) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(240 * EDSCALE, 60 * EDSCALE));
+			new_profile_dialog->popup_centered(popup_size);
 			new_profile_name->clear();
 			new_profile_name->grab_focus();
 		} break;
@@ -446,8 +447,9 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 			String selected = _get_selected_profile();
 			ERR_FAIL_COND(selected.is_empty());
 
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(240 * EDSCALE, 60 * EDSCALE));
 			erase_profile_dialog->set_text(vformat(TTR("Remove currently selected profile, '%s'? Cannot be undone."), selected));
-			erase_profile_dialog->popup_centered(Size2(240, 60) * EDSCALE);
+			erase_profile_dialog->popup_centered(popup_size);
 		} break;
 	}
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -781,7 +781,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 	} else if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 		accept_event();
 		_update_popup();
-		menu->set_position(get_screen_position() + get_local_mouse_position());
+		menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 		menu->reset_size();
 		menu->popup();
 		select();
@@ -1269,7 +1269,7 @@ void EditorInspectorCategory::gui_input(const Ref<InputEvent> &p_event) {
 
 	menu->set_item_disabled(menu->get_item_index(MENU_OPEN_DOCS), !EditorHelp::get_doc_data()->class_list.has(doc_class_name));
 
-	menu->set_position(get_screen_position() + mb_event->get_position());
+	menu->set_position(get_final_transform().xform(mb_event->get_position()));
 	menu->reset_size();
 	menu->popup();
 }
@@ -1711,13 +1711,14 @@ void EditorInspectorArray::_rmb_popup_id_pressed(int p_id) {
 		case OPTION_CLEAR_ARRAY:
 			_clear_array();
 			break;
-		case OPTION_RESIZE_ARRAY:
+		case OPTION_RESIZE_ARRAY: {
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 0));
 			new_size_spin_box->set_value(count);
 			resize_dialog->get_ok_button()->set_disabled(true);
-			resize_dialog->popup_centered(Size2(250, 0) * EDSCALE);
+			resize_dialog->popup_centered(popup_size);
 			new_size_spin_box->get_line_edit()->grab_focus();
 			new_size_spin_box->get_line_edit()->select_all();
-			break;
+		} break;
 		default:
 			break;
 	}
@@ -1784,7 +1785,7 @@ void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index
 			popup_array_index_pressed = begin_array_index + p_index;
 			rmb_popup->set_item_disabled(OPTION_MOVE_UP, popup_array_index_pressed == 0);
 			rmb_popup->set_item_disabled(OPTION_MOVE_DOWN, popup_array_index_pressed == count - 1);
-			rmb_popup->set_position(get_screen_position() + mb->get_position());
+			rmb_popup->set_position(get_final_transform().xform(mb->get_position()));
 			rmb_popup->reset_size();
 			rmb_popup->popup();
 		}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -177,7 +177,8 @@ void EditorPropertyMultilineText::_open_big_text() {
 		add_child(big_text_dialog);
 	}
 
-	big_text_dialog->popup_centered_clamped(Size2(1000, 900) * EDSCALE, 0.8);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(1000 * EDSCALE, 900 * EDSCALE));
+	big_text_dialog->popup_centered_clamped(popup_size, 0.8);
 	big_text->set_text(text->get_text());
 	big_text->grab_focus();
 }
@@ -824,7 +825,8 @@ void EditorPropertyLayersGrid::_rename_pressed(int p_menu) {
 	rename_dialog->set_title(vformat(TTR("Renaming layer %d:"), renamed_layer_index + 1));
 	rename_dialog_text->set_text(name);
 	rename_dialog_text->select(0, name.length());
-	rename_dialog->popup_centered(Size2(300, 80) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 80 * EDSCALE));
+	rename_dialog->popup_centered(popup_size);
 	rename_dialog_text->grab_focus();
 }
 
@@ -976,7 +978,7 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
 		if (hovered_index != INT32_MAX) {
 			renamed_layer_index = hovered_index;
-			layer_rename->set_position(get_screen_position() + mb->get_position());
+			layer_rename->set_position(get_final_transform().xform(mb->get_position()));
 			layer_rename->reset_size();
 			layer_rename->popup();
 		}
@@ -1254,10 +1256,9 @@ void EditorPropertyLayers::_button_pressed() {
 	layers->add_separator();
 	layers->add_icon_item(get_editor_theme_icon("Edit"), TTR("Edit Layer Names"), grid->layer_count);
 
-	Rect2 gp = button->get_screen_rect();
+	Vector2 gp = button->get_final_transform().xform(Vector2i(-layers->get_contents_minimum_size().x, 0));
 	layers->reset_size();
-	Vector2 popup_pos = gp.position - Vector2(layers->get_contents_minimum_size().x, 0);
-	layers->set_position(popup_pos);
+	layers->set_position(gp);
 	layers->popup();
 }
 
@@ -1506,7 +1507,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 		}
 
 		if (mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
-			preset->set_position(easing_draw->get_screen_position() + mb->get_position());
+			preset->set_position(easing_draw->get_final_transform().xform(mb->get_position()));
 			preset->reset_size();
 			preset->popup();
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -240,9 +240,9 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 void EditorPropertyArray::_change_type(Object *p_button, int p_slot_index) {
 	Button *button = Object::cast_to<Button>(p_button);
 	changing_type_index = p_slot_index;
-	Rect2 rect = button->get_screen_rect();
+	Point2 position = button->get_final_transform().xform(button->get_size() - Vector2(change_type->get_contents_minimum_size().x, 0));
 	change_type->reset_size();
-	change_type->set_position(rect.get_end() - Vector2(change_type->get_contents_minimum_size().x, 0));
+	change_type->set_position(position);
 	change_type->popup();
 }
 
@@ -866,13 +866,12 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 void EditorPropertyDictionary::_change_type(Object *p_button, int p_slot_index) {
 	Button *button = Object::cast_to<Button>(p_button);
-	int index = slots[p_slot_index].index;
-	Rect2 rect = button->get_screen_rect();
-	change_type->set_item_disabled(change_type->get_item_index(Variant::VARIANT_MAX), index < 0);
+	Point2 position = button->get_final_transform().xform(button->get_size() - Vector2(change_type->get_contents_minimum_size().x, 0));
+	change_type->set_item_disabled(change_type->get_item_index(Variant::VARIANT_MAX), p_slot_index < 0);
 	change_type->reset_size();
-	change_type->set_position(rect.get_end() - Vector2(change_type->get_contents_minimum_size().x, 0));
+	change_type->set_position(position);
 	change_type->popup();
-	changing_type_index = index;
+	changing_type_index = p_slot_index;
 }
 
 void EditorPropertyDictionary::_add_key_value() {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -177,10 +177,9 @@ void EditorResourcePicker::_file_quick_selected() {
 void EditorResourcePicker::_update_menu() {
 	_update_menu_items();
 
-	Rect2 gt = edit_button->get_screen_rect();
-	edit_menu->reset_size();
 	int ms = edit_menu->get_contents_minimum_size().width;
-	Vector2 popup_pos = gt.get_end() - Vector2(ms, 0);
+	Vector2i popup_pos = edit_button->get_final_transform().xform(edit_button->get_size() - Vector2(ms, 0));
+	edit_menu->reset_size();
 	edit_menu->set_position(popup_pos);
 	edit_menu->popup();
 }
@@ -393,7 +392,8 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			_gather_resources_to_duplicate(edited_resource, root);
 
 			duplicate_resources_dialog->reset_size();
-			duplicate_resources_dialog->popup_centered(Vector2(500, 400) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(500 * EDSCALE, 400 * EDSCALE));
+			duplicate_resources_dialog->popup_centered(popup_size);
 		} break;
 
 		case OBJ_MENU_SAVE: {
@@ -536,7 +536,7 @@ void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
 		if (edited_resource.is_valid() || is_editable()) {
 			_update_menu_items();
 
-			Vector2 pos = get_screen_position() + mb->get_position();
+			Vector2 pos = get_final_transform().xform(mb->get_position());
 			edit_menu->reset_size();
 			edit_menu->set_position(pos);
 			edit_menu->popup();

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -124,6 +124,8 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 
 	Rect2 screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(screen);
 
+	//TODO XXXX
+
 	int window_placement = EDITOR_GET("run/window_placement/rect");
 	if (screen_rect != Rect2()) {
 		Size2 window_size;
@@ -140,6 +142,8 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HIDPI)) {
 			bool hidpi_proj = GLOBAL_GET("display/window/dpi/allow_hidpi");
 			int display_scale = 1;
+
+			//TODO XXXX
 
 			if (OS::get_singleton()->is_hidpi_allowed()) {
 				if (hidpi_proj) {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1004,6 +1004,7 @@ void ProjectExportDialog::_tree_popup_edited(bool p_arrow_clicked) {
 	Rect2 bounds = include_files->get_custom_popup_rect();
 	bounds.position += get_global_canvas_transform().get_origin();
 	bounds.size *= get_global_canvas_transform().get_scale();
+	bounds = get_final_transform().xform(bounds);
 	if (!is_embedding_subwindows()) {
 		bounds.position += get_position();
 	}
@@ -1148,8 +1149,9 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 
 void ProjectExportDialog::_export_all_dialog() {
 #ifndef ANDROID_ENABLED
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 0));
 	export_all_dialog->show();
-	export_all_dialog->popup_centered(Size2(300, 80));
+	export_all_dialog->popup_centered(popup_size);
 #endif
 }
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -102,7 +102,7 @@ bool FileSystemList::edit_selected() {
 		case ItemList::ICON_MODE_LEFT:
 			rect = get_item_rect(s, true);
 			ofs = Vector2(0, Math::floor((MAX(line_editor->get_minimum_size().height, rect.size.height) - rect.size.height) / 2));
-			popup_rect.position = get_screen_position() + rect.position - ofs;
+			popup_rect.position = rect.position - ofs;
 			popup_rect.size = rect.size;
 
 			// Adjust for icon position and size.
@@ -111,7 +111,7 @@ bool FileSystemList::edit_selected() {
 			break;
 		case ItemList::ICON_MODE_TOP:
 			rect = get_item_rect(s, false);
-			popup_rect.position = get_screen_position() + rect.position;
+			popup_rect.position = rect.position;
 			popup_rect.size = rect.size;
 
 			// Adjust for icon position and size.
@@ -119,6 +119,8 @@ bool FileSystemList::edit_selected() {
 			popup_rect.position.y += icon_size.y;
 			break;
 	}
+
+	popup_rect = get_final_transform().xform(popup_rect);
 
 	popup_editor->set_position(popup_rect.position);
 	popup_editor->set_size(popup_rect.size);
@@ -2475,7 +2477,8 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 					duplicate_dialog_text->set_text(name);
 					duplicate_dialog_text->select(0, name.length());
 				}
-				duplicate_dialog->popup_centered(Size2(250, 80) * EDSCALE);
+				Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 80 * EDSCALE));
+				duplicate_dialog->popup_centered(popup_size);
 				duplicate_dialog_text->grab_focus();
 			}
 		} break;
@@ -3328,7 +3331,7 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos, MouseButton p_button
 	if (!paths.is_empty()) {
 		tree_popup->reset_size();
 		_file_and_folders_fill_popup(tree_popup, paths);
-		tree_popup->set_position(tree->get_screen_position() + p_pos);
+		tree_popup->set_position(tree->get_final_transform().xform(p_pos));
 		tree_popup->reset_size();
 		tree_popup->popup();
 	}
@@ -3354,7 +3357,7 @@ void FileSystemDock::_tree_empty_click(const Vector2 &p_pos, MouseButton p_butto
 	tree_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Terminal")), ED_GET_SHORTCUT("filesystem_dock/open_in_terminal"), FILE_OPEN_IN_TERMINAL);
 #endif
 
-	tree_popup->set_position(tree->get_screen_position() + p_pos);
+	tree_popup->set_position(tree->get_final_transform().xform(p_pos));
 	tree_popup->reset_size();
 	tree_popup->popup();
 }
@@ -3386,7 +3389,7 @@ void FileSystemDock::_file_list_item_clicked(int p_item, const Vector2 &p_pos, M
 	if (!paths.is_empty()) {
 		file_list_popup->clear();
 		_file_and_folders_fill_popup(file_list_popup, paths, searched_tokens.is_empty());
-		file_list_popup->set_position(files->get_screen_position() + p_pos);
+		file_list_popup->set_position(files->get_final_transform().xform(p_pos));
 		file_list_popup->reset_size();
 		file_list_popup->popup();
 	}
@@ -3416,7 +3419,7 @@ void FileSystemDock::_file_list_empty_clicked(const Vector2 &p_pos, MouseButton 
 	file_list_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Filesystem")), ED_GET_SHORTCUT("filesystem_dock/show_in_explorer"), FILE_SHOW_IN_EXPLORER);
 	file_list_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Terminal")), ED_GET_SHORTCUT("filesystem_dock/open_in_terminal"), FILE_OPEN_IN_TERMINAL);
 
-	file_list_popup->set_position(files->get_screen_position() + p_pos);
+	file_list_popup->set_position(files->get_final_transform().xform(p_pos));
 	file_list_popup->reset_size();
 	file_list_popup->popup();
 }

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -466,7 +466,7 @@ void GroupsEditor::_item_mouse_selected(const Vector2 &p_pos, MouseButton p_mous
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Remove")), ED_GET_SHORTCUT("groups_editor/delete"), DELETE_GROUP);
 		}
 
-		menu->set_position(tree->get_screen_position() + p_pos);
+		menu->set_position(tree->get_final_transform().xform(p_pos));
 		menu->reset_size();
 		menu->popup();
 	}

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -583,11 +583,13 @@ void EditorFileDialog::_action_pressed() {
 			}
 		}
 
+		Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 80 * EDSCALE));
+
 		// First check we're not having an empty name.
 		String file_name = file_text.strip_edges().get_file();
 		if (file_name.is_empty()) {
 			error_dialog->set_text(TTR("Cannot save file with an empty filename."));
-			error_dialog->popup_centered(Size2(250, 80) * EDSCALE);
+			error_dialog->popup_centered(popup_size);
 			return;
 		}
 
@@ -601,13 +603,13 @@ void EditorFileDialog::_action_pressed() {
 
 		if (file_name.begins_with(".")) { // Could still happen if typed manually.
 			error_dialog->set_text(TTR("Cannot save file with a name starting with a dot."));
-			error_dialog->popup_centered(Size2(250, 80) * EDSCALE);
+			error_dialog->popup_centered(popup_size);
 			return;
 		}
 
 		if (dir_access->file_exists(f) && !disable_overwrite_warning) {
 			confirm_save->set_text(vformat(TTR("File \"%s\" already exists.\nDo you want to overwrite it?"), f));
-			confirm_save->popup_centered(Size2(250, 80) * EDSCALE);
+			confirm_save->popup_centered(popup_size);
 		} else {
 			_save_to_recent();
 			hide();
@@ -762,7 +764,7 @@ void EditorFileDialog::_item_list_item_rmb_clicked(int p_item, const Vector2 &p_
 #endif
 
 	if (item_menu->get_item_count() > 0) {
-		item_menu->set_position(item_list->get_screen_position() + p_pos);
+		item_menu->set_position(item_list->get_final_transform().xform(p_pos));
 		item_menu->reset_size();
 		item_menu->popup();
 	}
@@ -795,7 +797,7 @@ void EditorFileDialog::_item_list_empty_clicked(const Vector2 &p_pos, MouseButto
 	item_menu->add_icon_item(theme_cache.filesystem, TTR("Open in File Manager"), ITEM_MENU_SHOW_IN_EXPLORER);
 #endif
 
-	item_menu->set_position(item_list->get_screen_position() + p_pos);
+	item_menu->set_position(item_list->get_final_transform().xform(p_pos));
 	item_menu->reset_size();
 	item_menu->popup();
 }
@@ -1316,10 +1318,11 @@ EditorFileDialog::Access EditorFileDialog::get_access() const {
 
 void EditorFileDialog::_make_dir_confirm() {
 	const String stripped_dirname = makedirname->get_text().strip_edges();
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 50 * EDSCALE));
 
 	if (dir_access->dir_exists(stripped_dirname)) {
 		error_dialog->set_text(TTR("Could not create folder. File with that name already exists."));
-		error_dialog->popup_centered(Size2(250, 50) * EDSCALE);
+		error_dialog->popup_centered(popup_size);
 		makedirname->set_text(""); // Reset label.
 		return;
 	}
@@ -1336,13 +1339,14 @@ void EditorFileDialog::_make_dir_confirm() {
 		}
 	} else {
 		error_dialog->set_text(TTR("Could not create folder."));
-		error_dialog->popup_centered(Size2(250, 50) * EDSCALE);
+		error_dialog->popup_centered(popup_size);
 	}
 	makedirname->set_text(""); // reset label
 }
 
 void EditorFileDialog::_make_dir() {
-	makedialog->popup_centered(Size2(250, 80) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 80 * EDSCALE));
+	makedialog->popup_centered(popup_size);
 	makedirname->grab_focus();
 }
 
@@ -1444,8 +1448,9 @@ void EditorFileDialog::_update_icons() {
 void EditorFileDialog::_favorite_selected(int p_idx) {
 	Error change_dir_result = dir_access->change_dir(favorites->get_item_metadata(p_idx));
 	if (change_dir_result != OK) {
+		Size2i popup_size = get_final_transform().basis_xform(Vector2i(250 * EDSCALE, 50 * EDSCALE));
 		error_dialog->set_text(TTR("Favorited folder does not exist anymore and will be removed."));
-		error_dialog->popup_centered(Size2(250, 50) * EDSCALE);
+		error_dialog->popup_centered(popup_size);
 
 		bool res = (access == ACCESS_RESOURCES);
 

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -97,11 +97,11 @@ void EditorObjectSelector::_show_popup() {
 	sub_objects_menu->clear();
 
 	Size2 size = get_size();
-	Point2 gp = get_screen_position();
-	gp.y += size.y;
+	size.y += size.y;
+	Rect2i gp = get_final_transform().xform(Rect2i(Vector2i(), size));
 
-	sub_objects_menu->set_position(gp);
-	sub_objects_menu->set_size(Size2(size.width, 1));
+	sub_objects_menu->set_position(gp.position);
+	sub_objects_menu->set_size(Size2(gp.size.width, 1));
 
 	sub_objects_menu->take_mouse_focus();
 	sub_objects_menu->popup();

--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -128,7 +128,7 @@ void EditorSceneTabs::_scene_tab_input(const Ref<InputEvent> &p_input) {
 			// Context menu.
 			_update_context_menu();
 
-			scene_tabs_context_menu->set_position(scene_tabs->get_screen_position() + mb->get_position());
+			scene_tabs_context_menu->set_position(scene_tabs->get_final_transform().xform(mb->get_position()));
 			scene_tabs_context_menu->reset_size();
 			scene_tabs_context_menu->popup();
 		}

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -147,7 +147,7 @@ void EditorSpinSlider::_grab_start() {
 	grabbing_spinner_dist_cache = 0;
 	pre_grab_value = get_value();
 	grabbing_spinner = false;
-	grabbing_spinner_mouse_pos = get_global_mouse_position();
+	grabbing_spinner_mouse_pos = get_screen_transform().basis_xform(get_global_mouse_position());
 	emit_signal("grabbed");
 }
 
@@ -418,7 +418,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 			const Rect2 grabber_rect = Rect2(ofs + gofs, svofs, grabber_w, 4 * EDSCALE);
 			draw_rect(grabber_rect, c);
 
-			grabbing_spinner_mouse_pos = get_global_position() + grabber_rect.get_center();
+			grabbing_spinner_mouse_pos = get_screen_transform().basis_xform(get_global_position() + grabber_rect.get_center());
 
 			bool display_grabber = !read_only && (grabbing_grabber || mouse_over_spin || mouse_over_grabber) && !grabbing_spinner && !(value_input_popup && value_input_popup->is_visible());
 			if (grabber->is_visible() != display_grabber) {
@@ -443,7 +443,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 				grabber->set_position(get_global_position() + (grabber_rect.get_center() - grabber->get_size() * 0.5) * scale);
 
 				if (mousewheel_over_grabber) {
-					Input::get_singleton()->warp_mouse(grabber->get_position() + grabber_rect.size);
+					Input::get_singleton()->warp_mouse(get_screen_transform().basis_xform(grabber->get_position() + grabber_rect.size));
 				}
 
 				grabber_range = width;

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1476,7 +1476,7 @@ void SceneTreeEditor::_rmb_select(const Vector2 &p_pos, MouseButton p_button) {
 	if (p_button != MouseButton::RIGHT) {
 		return;
 	}
-	emit_signal(SNAME("rmb_pressed"), tree->get_screen_position() + p_pos);
+	emit_signal(SNAME("rmb_pressed"), p_pos);
 }
 
 void SceneTreeEditor::update_warning() {

--- a/editor/icons/SVGTexture.svg
+++ b/editor/icons/SVGTexture.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path fill="#e0e0e0" d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1Zm1 2h10v8H3Z"/><path fill="#8da5f3" stroke="#8da5f3" stroke-linejoin="round" stroke-width=".75" d="M10.24 9.24H5.76V4.76h4.48L8 7Z"/></svg>

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -69,7 +69,7 @@ bool DynamicFontImportSettingsData::_get(const StringName &p_name, Variant &r_re
 void DynamicFontImportSettingsData::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
 		if (owner && owner->import_settings_data.is_valid()) {
-			if (owner->import_settings_data->get("multichannel_signed_distance_field") && (E->get().option.name == "size" || E->get().option.name == "outline_size" || E->get().option.name == "oversampling")) {
+			if (owner->import_settings_data->get("multichannel_signed_distance_field") && (E->get().option.name == "size" || E->get().option.name == "outline_size")) {
 				continue;
 			}
 			if (!owner->import_settings_data->get("multichannel_signed_distance_field") && (E->get().option.name == "msdf_pixel_range" || E->get().option.name == "msdf_size")) {
@@ -482,8 +482,6 @@ void DynamicFontImportSettingsDialog::_main_prop_changed(const String &p_edited_
 			font_preview->set_hinting((TextServer::Hinting)import_settings_data->get("hinting").operator int());
 		} else if (p_edited_property == "subpixel_positioning") {
 			font_preview->set_subpixel_positioning((TextServer::SubpixelPositioning)import_settings_data->get("subpixel_positioning").operator int());
-		} else if (p_edited_property == "oversampling") {
-			font_preview->set_oversampling(import_settings_data->get("oversampling"));
 		}
 	}
 
@@ -948,7 +946,6 @@ void DynamicFontImportSettingsDialog::_re_import() {
 	main_settings["force_autohinter"] = import_settings_data->get("force_autohinter");
 	main_settings["hinting"] = import_settings_data->get("hinting");
 	main_settings["subpixel_positioning"] = import_settings_data->get("subpixel_positioning");
-	main_settings["oversampling"] = import_settings_data->get("oversampling");
 	main_settings["fallbacks"] = import_settings_data->get("fallbacks");
 	main_settings["compress"] = import_settings_data->get("compress");
 
@@ -1224,7 +1221,6 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 		font_preview->set_force_autohinter(import_settings_data->get("force_autohinter"));
 		font_preview->set_hinting((TextServer::Hinting)import_settings_data->get("hinting").operator int());
 		font_preview->set_subpixel_positioning((TextServer::SubpixelPositioning)import_settings_data->get("subpixel_positioning").operator int());
-		font_preview->set_oversampling(import_settings_data->get("oversampling"));
 	}
 	font_preview_label->add_theme_font_override("font", font_preview);
 	font_preview_label->add_theme_font_size_override("font_size", 200 * EDSCALE);
@@ -1256,7 +1252,6 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "force_autohinter"), false));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), 1));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel"), 1));
-	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));
 
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::NIL, "Metadata Overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::DICTIONARY, "language_support"), Dictionary()));

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -79,9 +79,6 @@ bool ResourceImporterDynamicFont::get_option_visibility(const String &p_path, co
 	if (p_option == "antialiasing" && bool(p_options["multichannel_signed_distance_field"])) {
 		return false;
 	}
-	if (p_option == "oversampling" && bool(p_options["multichannel_signed_distance_field"])) {
-		return false;
-	}
 	if (p_option == "subpixel_positioning" && bool(p_options["multichannel_signed_distance_field"])) {
 		return false;
 	}
@@ -119,7 +116,6 @@ void ResourceImporterDynamicFont::get_import_options(const String &p_path, List<
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "force_autohinter"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), 1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel"), 1));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::NIL, "Fallbacks", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")), Array()));
@@ -156,7 +152,6 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 	bool allow_system_fallback = p_options["allow_system_fallback"];
 	int hinting = p_options["hinting"];
 	int subpixel_positioning = p_options["subpixel_positioning"];
-	real_t oversampling = p_options["oversampling"];
 	Array fallbacks = p_options["fallbacks"];
 
 	// Load base font data.
@@ -178,7 +173,6 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 	font->set_allow_system_fallback(allow_system_fallback);
 	font->set_subpixel_positioning((TextServer::SubpixelPositioning)subpixel_positioning);
 	font->set_hinting((TextServer::Hinting)hinting);
-	font->set_oversampling(oversampling);
 	font->set_fallbacks(fallbacks);
 
 	Dictionary langs = p_options["language_support"];

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -113,7 +113,6 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 	font->set_force_autohinter(false);
 	font->set_allow_system_fallback(false);
 	font->set_hinting(TextServer::HINTING_NONE);
-	font->set_oversampling(1.0f);
 	font->set_fallbacks(fallbacks);
 	font->set_texture_image(0, Vector2i(chr_height, 0), 0, img);
 	font->set_fixed_size_scale_mode(smode);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -109,7 +109,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
-			menu->set_position(blend_space_draw->get_screen_position() + mb->get_position());
+			menu->set_position(blend_space_draw->get_final_transform().xform(mb->get_position()));
 			menu->reset_size();
 			menu->popup();
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -152,7 +152,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
-			menu->set_position(blend_space_draw->get_screen_position() + mb->get_position());
+			menu->set_position(blend_space_draw->get_final_transform().xform(mb->get_position()));
 			menu->reset_size();
 			menu->popup();
 			add_point_pos = (mb->get_position() / blend_space_draw->get_size());

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -391,7 +391,7 @@ void AnimationNodeBlendTreeEditor::_popup(bool p_has_input_ports, const Vector2 
 	_update_options_menu(p_has_input_ports);
 	use_position_from_popup_menu = true;
 	position_from_popup_menu = p_node_position;
-	add_node->get_popup()->set_position(graph->get_screen_position() + graph->get_local_mouse_position());
+	add_node->get_popup()->set_position(graph->get_final_transform().xform(graph->get_local_mouse_position()));
 	add_node->get_popup()->reset_size();
 	add_node->get_popup()->popup();
 }
@@ -921,11 +921,12 @@ void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
 		return;
 	}
 
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(500 * EDSCALE, 500 * EDSCALE));
+	filter_dialog->popup_centered(popup_size);
 }
 
 void AnimationNodeBlendTreeEditor::_update_editor_settings() {
-	graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+	graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 	graph->set_warped_panning(bool(EDITOR_GET("editors/panning/warped_mouse_panning")));
 }
 

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -595,7 +595,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 				file_popup->add_separator();
 				file_popup->add_item(TTR("Open in Inspector"), FILE_MENU_EDIT_LIBRARY);
 				Rect2 pos = tree->get_item_rect(p_item, 1, 0);
-				Vector2 popup_pos = tree->get_screen_transform().xform(pos.position + Vector2(0, pos.size.height));
+				Vector2 popup_pos = tree->get_final_transform().xform(pos.position + Vector2(0, pos.size.height));
 				file_popup->popup(Rect2(popup_pos, Size2()));
 
 				file_dialog_animation = StringName();
@@ -635,7 +635,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 				file_popup->add_separator();
 				file_popup->add_item(TTR("Open in Inspector"), FILE_MENU_EDIT_ANIMATION);
 				Rect2 pos = tree->get_item_rect(p_item, 1, 0);
-				Vector2 popup_pos = tree->get_screen_transform().xform(pos.position + Vector2(0, pos.size.height));
+				Vector2 popup_pos = tree->get_final_transform().xform(pos.position + Vector2(0, pos.size.height));
 				file_popup->popup(Rect2(popup_pos, Size2()));
 
 				file_dialog_animation = anim_name;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -387,7 +387,8 @@ void AnimationPlayerEditor::_animation_new() {
 
 	name_dialog_op = TOOL_NEW_ANIM;
 	name_dialog->set_title(TTR("Create New Animation"));
-	name_dialog->popup_centered(Size2(300, 90));
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 90 * EDSCALE));
+	name_dialog->popup_centered(popup_size);
 	name_title->set_text(TTR("New Animation Name:"));
 	name->set_text(base);
 	name->select_all();
@@ -410,7 +411,8 @@ void AnimationPlayerEditor::_animation_rename() {
 	name_title->set_text(TTR("Change Animation Name:"));
 	name->set_text(selected_name);
 	name_dialog_op = TOOL_RENAME_ANIM;
-	name_dialog->popup_centered(Size2(300, 90));
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 90 * EDSCALE));
+	name_dialog->popup_centered(popup_size);
 	name->select_all();
 	name->grab_focus();
 	library->hide();
@@ -673,7 +675,8 @@ void AnimationPlayerEditor::_edit_animation_blend() {
 		return;
 	}
 
-	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(400 * EDSCALE, 400 * EDSCALE));
+	blend_editor.dialog->popup_centered(popup_size);
 	_update_animation_blend();
 }
 
@@ -1247,7 +1250,8 @@ void AnimationPlayerEditor::_animation_duplicate() {
 	// TRANSLATORS: This is a label for the new name field in the "Duplicate Animation" dialog.
 	name_title->set_text(TTR("Duplicated Animation Name:"));
 	name->set_text(new_name);
-	name_dialog->popup_centered(Size2(300, 90));
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 90 * EDSCALE));
+	name_dialog->popup_centered(popup_size);
 	name->select_all();
 	name->grab_focus();
 }
@@ -1545,7 +1549,7 @@ void AnimationPlayerEditor::_editor_visibility_changed() {
 bool AnimationPlayerEditor::_are_onion_layers_valid() {
 	ERR_FAIL_COND_V(!onion.past && !onion.future, false);
 
-	Size2 capture_size = DisplayServer::get_singleton()->window_get_size(DisplayServer::MAIN_WINDOW_ID);
+	Size2 capture_size = DisplayServer::get_singleton()->window_get_size_in_pixels(DisplayServer::MAIN_WINDOW_ID);
 	return onion.captures.size() == onion.get_capture_count() && onion.capture_size == capture_size;
 }
 
@@ -1553,7 +1557,7 @@ void AnimationPlayerEditor::_allocate_onion_layers() {
 	_free_onion_layers();
 
 	int captures = onion.get_capture_count();
-	Size2 capture_size = DisplayServer::get_singleton()->window_get_size(DisplayServer::MAIN_WINDOW_ID);
+	Size2 capture_size = DisplayServer::get_singleton()->window_get_size_in_pixels(DisplayServer::MAIN_WINDOW_ID);
 
 	onion.captures.resize(captures);
 	onion.captures_valid.resize(captures);
@@ -1664,7 +1668,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 
 	// Tweak the root viewport to ensure it's rendered before our target.
 	RID root_vp = get_tree()->get_root()->get_viewport_rid();
-	onion.temp.screen_rect = Rect2(Vector2(), DisplayServer::get_singleton()->window_get_size(DisplayServer::MAIN_WINDOW_ID));
+	onion.temp.screen_rect = Rect2(Vector2(), DisplayServer::get_singleton()->window_get_size_in_pixels(DisplayServer::MAIN_WINDOW_ID));
 	RS::get_singleton()->viewport_attach_to_screen(root_vp, Rect2(), DisplayServer::INVALID_WINDOW_ID);
 	RS::get_singleton()->viewport_set_update_mode(root_vp, RS::VIEWPORT_UPDATE_ALWAYS);
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -190,8 +190,9 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 					edit_rect.position -= line_sb->get_offset();
 					edit_rect.size += line_sb->get_minimum_size();
 
-					name_edit_popup->set_position(state_machine_draw->get_screen_position() + edit_rect.position);
-					name_edit_popup->set_size(edit_rect.size);
+					Rect2i popup_rect = state_machine_draw->get_final_transform().xform(edit_rect);
+					name_edit_popup->set_position(popup_rect.position);
+					name_edit_popup->set_size(popup_rect.size);
 					name_edit->set_text(node_rects[i].node_name);
 					name_edit_popup->popup();
 					name_edit->grab_focus();
@@ -594,7 +595,7 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	menu->add_separator();
 	menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
-	menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
+	menu->set_position(state_machine_draw->get_final_transform().xform(p_position));
 	menu->popup();
 	add_node_pos = p_position / EDSCALE + state_machine->get_graph_offset();
 }

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -351,7 +351,8 @@ void BoneMapper::update_group_idx() {
 
 void BoneMapper::_pick_bone(const StringName &p_bone_name) {
 	picker_key_name = p_bone_name;
-	picker->popup_bones_tree(Size2(500, 500) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(500 * EDSCALE, 500 * EDSCALE));
+	picker->popup_bones_tree(popup_size);
 }
 
 void BoneMapper::_apply_picker_selection() {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2351,7 +2351,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 				selection_results_menu = selection_results;
 				selection_menu_additive_selection = b->is_shift_pressed();
-				selection_menu->set_position(viewport->get_screen_transform().xform(b->get_position()));
+				selection_menu->set_position(viewport->get_final_transform().xform(b->get_position()));
 				selection_menu->reset_size();
 				selection_menu->popup();
 				return true;
@@ -2376,7 +2376,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			}
 
 			add_node_menu->reset_size();
-			add_node_menu->set_position(viewport->get_screen_transform().xform(b->get_position()));
+			add_node_menu->set_position(viewport->get_final_transform().xform(b->get_position()));
 			add_node_menu->popup();
 			node_create_position = transform.affine_inverse().xform(b->get_position());
 			return true;
@@ -3953,7 +3953,7 @@ void CanvasItemEditor::_update_editor_settings() {
 
 	context_toolbar_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
 
-	panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/2d_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+	panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/2d_editor_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 	panner->set_scroll_speed(EDITOR_GET("editors/panning/2d_editor_pan_speed"));
 	warped_panning = bool(EDITOR_GET("editors/panning/warped_mouse_panning"));
 }
@@ -4442,8 +4442,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			snap_config_menu->get_popup()->set_item_checked(idx, snap_pixel);
 		} break;
 		case SNAP_CONFIGURE: {
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(320 * EDSCALE, 160 * EDSCALE));
 			static_cast<SnapDialog *>(snap_dialog)->set_fields(grid_offset, grid_step, primary_grid_step, snap_rotation_offset, snap_rotation_step, snap_scale_step);
-			snap_dialog->popup_centered(Size2(320, 160) * EDSCALE);
+			snap_dialog->popup_centered(popup_size);
 		} break;
 		case SKELETON_SHOW_BONES: {
 			List<Node *> selection = editor_selection->get_selected_node_list();
@@ -5608,7 +5609,8 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	selection_menu = memnew(PopupMenu);
 	add_child(selection_menu);
-	selection_menu->set_min_size(Vector2(100, 0));
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(100, 0));
+	selection_menu->set_min_size(popup_size);
 	selection_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	selection_menu->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_selection_result_pressed));
 	selection_menu->connect("popup_hide", callable_mp(this, &CanvasItemEditor::_selection_menu_hide), CONNECT_DEFERRED);

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -483,7 +483,7 @@ void ControlEditorPopupButton::toggled(bool p_pressed) {
 		return;
 	}
 
-	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
+	Size2 size = get_final_transform().basis_xform(get_size());
 
 	popup_panel->set_size(Size2(size.width, 0));
 	Point2 gp = get_screen_position();

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -191,7 +191,7 @@ void EditorPropertyFontMetaOverride::_remove(Object *p_button, const String &p_k
 void EditorPropertyFontMetaOverride::_add_menu() {
 	if (script_editor) {
 		Size2 size = get_size();
-		menu->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
+		menu->set_position(get_final_transform().xform(Vector2(0, size.height * get_global_transform().get_scale().y)));
 		menu->reset_size();
 		menu->popup();
 	} else {
@@ -578,7 +578,7 @@ void EditorPropertyOTFeatures::_remove(Object *p_button, int p_key) {
 
 void EditorPropertyOTFeatures::_add_menu() {
 	Size2 size = get_size();
-	menu->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
+	menu->set_position(get_final_transform().xform(Vector2(0, size.height * get_global_transform().get_scale().y)));
 	menu->reset_size();
 	menu->popup();
 }
@@ -979,7 +979,7 @@ bool EditorInspectorPluginFontPreview::parse_property(Object *p_object, const Va
 
 void EditorPropertyFontNamesArray::_add_element() {
 	Size2 size = get_size();
-	menu->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
+	menu->set_position(get_final_transform().xform(Vector2(0, size.height * get_global_transform().get_scale().y)));
 	menu->reset_size();
 	menu->popup();
 }

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -51,7 +51,8 @@ Size2i Camera3DGizmoPlugin::_get_viewport_size(Camera3D *p_camera) {
 
 	Window *window = Object::cast_to<Window>(viewport);
 	if (window) {
-		return window->get_size();
+		Rect2i wrect = window->get_final_transform().affine_inverse().xform(Rect2i(window->get_position(), window->get_size()));
+		return wrect.size;
 	}
 
 	SubViewport *sub_viewport = Object::cast_to<SubViewport>(viewport);

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -194,7 +194,8 @@ void GPUParticles3DEditorBase::_node_selected(const NodePath &p_path) {
 		}
 	}
 
-	emission_dialog->popup_centered(Size2(300, 130));
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 130 * EDSCALE));
+	emission_dialog->popup_centered(popup_size);
 }
 
 void GPUParticles3DEditorBase::_bind_methods() {

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -92,7 +92,7 @@ void GradientEdit::_show_color_picker() {
 	bool show_above = get_global_position().y + get_size().y + minsize.y > viewport_height && get_global_position().y * 2 + get_size().y > viewport_height;
 
 	float v_offset = show_above ? -minsize.y : get_size().y;
-	popup->set_position(get_screen_position() + Vector2(0, v_offset));
+	popup->set_position(get_final_transform().xform(Vector2(0, v_offset)));
 	popup->popup();
 }
 

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -240,7 +240,8 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 		} break;
 
 		case MENU_OPTION_CREATE_OUTLINE_MESH: {
-			outline_dialog->popup_centered(Vector2(200, 90));
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(200 * EDSCALE, 90 * EDSCALE));
+			outline_dialog->popup_centered(popup_size);
 		} break;
 		case MENU_OPTION_CREATE_DEBUG_TANGENTS: {
 			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -222,9 +222,10 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 		case MENU_OPTION_REMOVE_ITEM: {
 			String p = InspectorDock::get_inspector_singleton()->get_selected_path();
 			if (p.begins_with("item") && p.get_slice_count("/") >= 2) {
+				Size2i popup_size = get_final_transform().basis_xform(Vector2i(300 * EDSCALE, 60 * EDSCALE));
 				to_erase = p.get_slice("/", 1).to_int();
 				cd_remove->set_text(vformat(TTR("Remove item %d?"), to_erase));
-				cd_remove->popup_centered(Size2(300, 60));
+				cd_remove->popup_centered(popup_size);
 			}
 		} break;
 		case MENU_OPTION_IMPORT_FROM_SCENE: {
@@ -236,8 +237,9 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			file->popup_file_dialog();
 		} break;
 		case MENU_OPTION_UPDATE_FROM_SCENE: {
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(500 * EDSCALE, 60 * EDSCALE));
 			cd_update->set_text(vformat(TTR("Update from existing scene?:\n%s"), String(mesh_library->get_meta("_editor_source_scene"))));
-			cd_update->popup_centered(Size2(500, 60));
+			cd_update->popup_centered(popup_size);
 		} break;
 	}
 }

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -243,7 +243,8 @@ void MultiMeshEditor::_menu_option(int p_option) {
 
 				_last_pp_node = node;
 			}
-			populate_dialog->popup_centered(Size2(250, 380));
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(250, 380));
+			populate_dialog->popup_centered(popup_size);
 
 		} break;
 	}

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -82,7 +82,7 @@ void Polygon2DEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_ENTER_TREE: {
-			uv_panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+			uv_panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -157,7 +157,8 @@ void EditorPropertyRootMotion::_node_assign() {
 	}
 
 	filters->ensure_cursor_is_visible();
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(500 * EDSCALE, 500 * EDSCALE));
+	filter_dialog->popup_centered(popup_size);
 }
 
 void EditorPropertyRootMotion::_node_clear() {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3269,7 +3269,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_DOWN), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_SORT), tab_container->get_tab_count() <= 1);
 
-	context_menu->set_position(get_screen_position() + get_local_mouse_position());
+	context_menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2000,7 +2000,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 	CodeEdit *tx = code_editor->get_text_editor();
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-		local_pos = mb->get_global_position() - tx->get_global_position();
+		local_pos = tx->get_local_mouse_position();
 		create_menu = true;
 	} else if (k.is_valid() && k->is_action("ui_menu", true)) {
 		tx->adjust_viewport_to_caret(0);
@@ -2124,7 +2124,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					break;
 			}
 			if (has_color) {
-				color_panel->set_position(get_screen_position() + local_pos);
+				color_panel->set_position(tx->get_final_transform().xform(local_pos));
 			}
 		}
 		_make_context_menu(tx->has_selection(), has_color, foldable, open_docs, goto_definition, local_pos);
@@ -2199,7 +2199,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_UNDO), !tx->has_undo());
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_REDO), !tx->has_redo());
 
-	context_menu->set_position(get_screen_position() + p_pos);
+	context_menu->set_position(tx->get_final_transform().xform(p_pos));
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -556,7 +556,7 @@ void Sprite2DEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 		} break;
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -271,7 +271,7 @@ void SpriteFramesEditor::_sheet_scroll_input(const Ref<InputEvent> &p_event) {
 
 	const Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::MIDDLE)) {
-		const Vector2 dragged = Input::get_singleton()->warp_mouse_motion(mm, split_sheet_scroll->get_global_rect());
+		const Vector2 dragged = Input::get_singleton()->warp_mouse_motion(mm, split_sheet_scroll->get_global_rect(), get_screen_transform());
 		split_sheet_scroll->set_h_scroll(split_sheet_scroll->get_h_scroll() - dragged.x);
 		split_sheet_scroll->set_v_scroll(split_sheet_scroll->get_v_scroll() - dragged.y);
 	}

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -529,7 +529,7 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			}
 
 			if (!mb->is_pressed()) {
-				_make_context_menu(tx->has_selection(), can_fold, is_folded, get_local_mouse_position());
+				_make_context_menu(tx->has_selection(), can_fold, is_folded, tx->get_local_mouse_position());
 			}
 		}
 	}
@@ -581,7 +581,7 @@ void TextEditor::_make_context_menu(bool p_selection, bool p_can_fold, bool p_is
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_UNDO), !tx->has_undo());
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_REDO), !tx->has_redo());
 
-	context_menu->set_position(get_screen_position() + p_position);
+	context_menu->set_position(tx->get_final_transform().xform(p_position));
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1016,7 +1016,7 @@ void TextShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					tx->set_caret_column(col);
 				}
 			}
-			_make_context_menu(tx->has_selection(), get_local_mouse_position());
+			_make_context_menu(tx->has_selection(), tx->get_local_mouse_position());
 		}
 	}
 
@@ -1083,7 +1083,8 @@ void TextShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) 
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
 
-	context_menu->set_position(get_screen_position() + p_position);
+	CodeEdit *tx = code_editor->get_text_editor();
+	context_menu->set_position(tx->get_final_transform().xform(p_position));
 	context_menu->reset_size();
 	context_menu->popup();
 }

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -825,7 +825,7 @@ void TextureRegionEditor::_notification(int p_what) {
 		}
 
 		case NOTIFICATION_READY: {
-			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), texture_preview, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1199,8 +1199,9 @@ ThemeItemImportTree::ThemeItemImportTree() {
 
 void ThemeItemEditorDialog::ok_pressed() {
 	if (import_default_theme_items->has_selected_items() || import_editor_theme_items->has_selected_items() || import_other_theme_items->has_selected_items()) {
+		Size2i popup_size = get_final_transform().basis_xform(Vector2i(380 * EDSCALE, 120 * EDSCALE));
 		confirm_closing_dialog->set_text(TTR("Import Items tab has some items selected. Selection will be lost upon closing this window.\nClose anyway?"));
-		confirm_closing_dialog->popup_centered(Size2(380, 120) * EDSCALE);
+		confirm_closing_dialog->popup_centered(popup_size);
 		return;
 	}
 
@@ -1767,9 +1768,10 @@ void ThemeItemEditorDialog::_open_add_theme_item_dialog(int p_data_type) {
 			break; // Can't happen, but silences warning.
 	}
 
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(380 * EDSCALE, 110 * EDSCALE));
 	edit_theme_item_old_vb->hide();
 	theme_item_name->clear();
-	edit_theme_item_dialog->popup_centered(Size2(380, 110) * EDSCALE);
+	edit_theme_item_dialog->popup_centered(popup_size);
 	theme_item_name->grab_focus();
 }
 
@@ -1803,10 +1805,11 @@ void ThemeItemEditorDialog::_open_rename_theme_item_dialog(Theme::DataType p_dat
 			break; // Can't happen, but silences warning.
 	}
 
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(380 * EDSCALE, 140 * EDSCALE));
 	edit_theme_item_old_vb->show();
 	theme_item_old_name->set_text(p_item_name);
 	theme_item_name->set_text(p_item_name);
-	edit_theme_item_dialog->popup_centered(Size2(380, 140) * EDSCALE);
+	edit_theme_item_dialog->popup_centered(popup_size);
 	theme_item_name->grab_focus();
 }
 
@@ -2776,11 +2779,12 @@ void ThemeTypeEditor::_list_type_selected(int p_index) {
 }
 
 void ThemeTypeEditor::_add_type_button_cbk() {
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(560 * EDSCALE, 420 * EDSCALE));
 	add_type_mode = ADD_THEME_TYPE;
 	add_type_dialog->set_title(TTR("Add Item Type"));
 	add_type_dialog->set_ok_button_text(TTR("Add Type"));
 	add_type_dialog->set_include_own_types(false);
-	add_type_dialog->popup_centered(Size2(560, 420) * EDSCALE);
+	add_type_dialog->popup_centered(popup_size);
 }
 
 void ThemeTypeEditor::_add_default_type_items() {
@@ -3323,11 +3327,12 @@ void ThemeTypeEditor::_type_variation_changed(const String p_value) {
 }
 
 void ThemeTypeEditor::_add_type_variation_cbk() {
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(560 * EDSCALE, 420 * EDSCALE));
 	add_type_mode = ADD_VARIATION_BASE;
 	add_type_dialog->set_title(TTR("Set Variation Base Type"));
 	add_type_dialog->set_ok_button_text(TTR("Set Base Type"));
 	add_type_dialog->set_include_own_types(true);
-	add_type_dialog->popup_centered(Size2(560, 420) * EDSCALE);
+	add_type_dialog->popup_centered(popup_size);
 }
 
 void ThemeTypeEditor::_add_type_dialog_selected(const String p_type_name) {
@@ -3554,7 +3559,8 @@ void ThemeEditor::_theme_save_button_cbk(bool p_save_as) {
 }
 
 void ThemeEditor::_theme_edit_button_cbk() {
-	theme_edit_dialog->popup_centered(Size2(850, 700) * EDSCALE);
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(850 * EDSCALE, 700 * EDSCALE));
+	theme_edit_dialog->popup_centered(popup_size);
 }
 
 void ThemeEditor::_theme_close_button_cbk() {

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -581,7 +581,7 @@ void TileAtlasView::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_ENTER_TREE: {
-			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), this, ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -45,7 +45,7 @@ void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_
 
 	ItemList *item_list = Object::cast_to<ItemList>(p_item_list);
 	popup_menu->reset_size();
-	popup_menu->set_position(get_position() + item_list->get_global_mouse_position());
+	popup_menu->set_position(get_final_transform().xform(item_list->get_global_mouse_position()));
 	popup_menu->popup();
 }
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -947,9 +947,9 @@ void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_draw() {
 }
 
 void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_pressed() {
-	Size2 size = tile_data_editor_dropdown_button->get_size();
-	tile_data_editors_popup->set_position(tile_data_editor_dropdown_button->get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
-	tile_data_editors_popup->set_size(Size2(size.width, 0));
+	Rect2i popup_rect = tile_data_editor_dropdown_button->get_final_transform().xform(Rect2i(Vector2i(0, get_size().height * get_global_transform().get_scale().y), tile_data_editor_dropdown_button->get_size()));
+	tile_data_editors_popup->set_position(popup_rect.position);
+	tile_data_editors_popup->set_size(Size2(popup_rect.size.width, 0));
 	tile_data_editors_popup->popup();
 }
 
@@ -1539,12 +1539,12 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 				// We have a tile.
 				menu_option_coords = selected.tile;
 				menu_option_alternative = 0;
-				base_tile_popup_menu->popup(Rect2i(get_screen_transform().xform(get_local_mouse_position()), Size2i()));
+				base_tile_popup_menu->popup(Rect2i(get_final_transform().xform(get_local_mouse_position()), Size2i()));
 			} else if (hovered_base_tile_coords != TileSetSource::INVALID_ATLAS_COORDS) {
 				// We don't have a tile, but can create one.
 				menu_option_coords = hovered_base_tile_coords;
 				menu_option_alternative = TileSetSource::INVALID_TILE_ALTERNATIVE;
-				empty_base_tile_popup_menu->popup(Rect2i(get_screen_transform().xform(get_local_mouse_position()), Size2i()));
+				empty_base_tile_popup_menu->popup(Rect2i(get_final_transform().xform(get_local_mouse_position()), Size2i()));
 			}
 		} break;
 		case DRAG_TYPE_RESIZE_TOP_LEFT:
@@ -1986,7 +1986,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_gui_input(const Ref<In
 						selected = selection.front()->get();
 						menu_option_coords = selected.tile;
 						menu_option_alternative = selected.alternative;
-						alternative_tile_popup_menu->popup(Rect2i(get_screen_transform().xform(get_local_mouse_position()), Size2i()));
+						alternative_tile_popup_menu->popup(Rect2i(get_final_transform().xform(get_local_mouse_position()), Size2i()));
 					}
 				}
 

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -984,7 +984,8 @@ void TileSourceInspectorPlugin::_show_id_edit_dialog(Object *p_for_source) {
 	}
 	edited_source = p_for_source;
 	id_input->set_value(p_for_source->get("id"));
-	id_edit_dialog->popup_centered(Vector2i(400, 0) * EDSCALE);
+	Size2i popup_size = TileSetEditor::get_singleton()->get_final_transform().basis_xform(Vector2i(400 * EDSCALE, 0));
+	id_edit_dialog->popup_centered(popup_size);
 	callable_mp((Control *)id_input->get_line_edit(), &Control::grab_focus).call_deferred();
 }
 

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -97,7 +97,9 @@ void VersionControlEditorPlugin::popup_vcs_set_up_dialog(const Control *p_gui_ba
 
 		_populate_available_vcs_names();
 
-		set_up_dialog->popup_centered_clamped(popup_size * EDSCALE);
+		popup_size = get_window()->get_final_transform().xform(Rect2i(Vector2i(), popup_size * EDSCALE)).size;
+
+		set_up_dialog->popup_centered_clamped(popup_size);
 	} else {
 		// TODO: Give info to user on how to fix this error.
 		EditorNode::get_singleton()->show_warning(TTR("No VCS plugins are available in the project. Install a VCS plugin to use VCS integration features."), TTR("Error"));
@@ -944,7 +946,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	metadata_dialog = memnew(ConfirmationDialog);
 	metadata_dialog->set_title(TTR("Create Version Control Metadata"));
-	metadata_dialog->set_min_size(Size2(200, 40));
+	Size2i popup_size = Vector2i(200, 40);
+	metadata_dialog->set_min_size(popup_size);
 	metadata_dialog->get_ok_button()->connect(SNAME("pressed"), callable_mp(this, &VersionControlEditorPlugin::_create_vcs_metadata_files));
 	EditorInterface::get_singleton()->get_base_control()->add_child(metadata_dialog);
 
@@ -972,7 +975,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	set_up_dialog = memnew(AcceptDialog);
 	set_up_dialog->set_title(TTR("Local Settings"));
-	set_up_dialog->set_min_size(Size2(600, 100));
+	popup_size = Vector2i(600 * EDSCALE, 100 * EDSCALE);
+	set_up_dialog->set_min_size(popup_size);
 	set_up_dialog->add_cancel_button("Cancel");
 	set_up_dialog->set_hide_on_ok(true);
 	EditorInterface::get_singleton()->get_base_control()->add_child(set_up_dialog);
@@ -1172,7 +1176,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	discard_all_confirm = memnew(AcceptDialog);
 	discard_all_confirm->set_title(TTR("Discard all changes"));
-	discard_all_confirm->set_min_size(Size2i(400, 50));
+	popup_size = Vector2i(400, 50);
+	discard_all_confirm->set_min_size(popup_size);
 	discard_all_confirm->set_text(TTR("This operation is IRREVERSIBLE. Your changes will be deleted FOREVER."));
 	discard_all_confirm->set_hide_on_ok(true);
 	discard_all_confirm->set_ok_button_text(TTR("Permanentally delete my changes"));
@@ -1317,7 +1322,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	branch_create_confirm = memnew(AcceptDialog);
 	branch_create_confirm->set_title(TTR("Create New Branch"));
-	branch_create_confirm->set_min_size(Size2(400, 100));
+	popup_size = Vector2i(400, 100);
+	branch_create_confirm->set_min_size(popup_size);
 	branch_create_confirm->set_hide_on_ok(true);
 	version_commit_dock->add_child(branch_create_confirm);
 
@@ -1362,7 +1368,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	remote_create_confirm = memnew(AcceptDialog);
 	remote_create_confirm->set_title(TTR("Create New Remote"));
-	remote_create_confirm->set_min_size(Size2(400, 100));
+	remote_create_confirm->set_min_size(popup_size);
 	remote_create_confirm->set_hide_on_ok(true);
 	version_commit_dock->add_child(remote_create_confirm);
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -155,8 +155,9 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 // Main layout.
 
 void ProjectManager::_update_size_limits() {
+	//TODO XXXX v to s
 	const Size2 minimum_size = Size2(680, 450) * EDSCALE;
-	const Size2 default_size = Size2(1024, 600) * EDSCALE;
+	const Size2 default_size = Size2(1152, 648) * EDSCALE;
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
@@ -1108,6 +1109,9 @@ ProjectManager::ProjectManager() {
 		Control::set_root_layout_direction(pm_root_dir);
 		Window::set_root_layout_direction(pm_root_dir);
 
+		bool pm_dpi_scaling = EDITOR_GET("interface/editor/ui_dpi_scaling");
+		Window::set_use_dpi_scaling(pm_dpi_scaling);
+
 		EditorThemeManager::initialize();
 		theme = EditorThemeManager::generate_theme();
 		DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
@@ -1116,8 +1120,6 @@ ProjectManager::ProjectManager() {
 
 		_build_icon_type_cache(theme);
 	}
-
-	// Project manager layout.
 
 	background_panel = memnew(Panel);
 	add_child(background_panel);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -861,8 +861,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			for (Node *E : nodes) {
 				nodeset.insert(E);
 			}
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(350 * EDSCALE, 700 * EDSCALE));
 			reparent_dialog->set_current(nodeset);
-			reparent_dialog->popup_centered_clamped(Size2(350, 700) * EDSCALE);
+			reparent_dialog->popup_centered_clamped(popup_size);
 		} break;
 		case TOOL_MAKE_ROOT: {
 			if (!profile_allow_editing) {
@@ -3220,7 +3221,7 @@ void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to,
 			}
 
 			menu_properties->reset_size();
-			menu_properties->set_position(get_screen_position() + get_local_mouse_position());
+			menu_properties->set_position(get_final_transform().xform(get_local_mouse_position()));
 			menu_properties->popup();
 		} else if (!valid_properties.is_empty()) {
 			_perform_property_drop(node, valid_properties[0], ResourceLoader::load(res_path));
@@ -3354,7 +3355,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		}
 
 		menu->reset_size();
-		menu->set_position(get_screen_position() + p_menu_pos);
+		menu->set_position(scene_tree->get_final_transform().xform(p_menu_pos));
 		menu->popup();
 		return;
 	}
@@ -3558,7 +3559,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Remove")), ED_SHORTCUT("scene_tree/delete", TTR("Delete Node(s)"), Key::KEY_DELETE), TOOL_ERASE);
 	}
 	menu->reset_size();
-	menu->set_position(p_menu_pos);
+	menu->set_position(scene_tree->get_final_transform().xform(p_menu_pos));
 	menu->popup();
 }
 
@@ -3606,7 +3607,7 @@ void SceneTreeDock::_filter_gui_input(const Ref<InputEvent> &p_event) {
 		filter_quick_menu->clear();
 
 		_append_filter_options_to(filter_quick_menu, false);
-		filter_quick_menu->set_position(get_screen_position() + get_local_mouse_position());
+		filter_quick_menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 		filter_quick_menu->reset_size();
 		filter_quick_menu->popup();
 		filter_quick_menu->grab_focus();

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -35,8 +35,7 @@
 #include "editor/themes/editor_color_map.h"
 #include "editor/themes/editor_icons.gen.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/resources/image_texture.h"
-#include "scene/resources/texture.h"
+#include "scene/resources/svg_texture.h"
 
 #include "modules/modules_enabled.gen.h" // For svg.
 #ifdef MODULE_SVG_ENABLED
@@ -56,26 +55,8 @@ void editor_configure_icons(bool p_dark_theme) {
 }
 
 // See also `generate_icon()` in `scene/theme/default_theme.cpp`.
-Ref<ImageTexture> editor_generate_icon(int p_index, float p_scale, float p_saturation, const HashMap<Color, Color> &p_convert_colors = HashMap<Color, Color>()) {
-	Ref<Image> img = memnew(Image);
-
-#ifdef MODULE_SVG_ENABLED
-	// Upsample icon generation only if the editor scale isn't an integer multiplier.
-	// Generating upsampled icons is slower, and the benefit is hardly visible
-	// with integer editor scales.
-	const bool upsample = !Math::is_equal_approx(Math::round(p_scale), p_scale);
-	Error err = ImageLoaderSVG::create_image_from_string(img, editor_icons_sources[p_index], p_scale, upsample, p_convert_colors);
-	ERR_FAIL_COND_V_MSG(err != OK, Ref<ImageTexture>(), "Failed generating icon, unsupported or invalid SVG data in editor theme.");
-	if (p_saturation != 1.0) {
-		img->adjust_bcs(1.0, 1.0, p_saturation);
-	}
-#else
-	// If the SVG module is disabled, we can't really display the UI well, but at least we won't crash.
-	// 16 pixels is used as it's the most common base size for Godot icons.
-	img = Image::create_empty(16 * p_scale, 16 * p_scale, false, Image::FORMAT_RGBA8);
-#endif
-
-	return ImageTexture::create_from_image(img);
+Ref<SVGTexture> editor_generate_icon(int p_index, float p_scale, float p_saturation, const Dictionary &p_convert_colors = Dictionary()) {
+	return SVGTexture::create_from_string(editor_icons_sources[p_index], p_scale, p_saturation, p_convert_colors);
 }
 
 float get_gizmo_handle_scale(const String &p_gizmo_handle_name, float p_gizmo_handle_scale) {
@@ -109,7 +90,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	// And then some icons are completely excluded from the conversion.
 
 	// Standard color conversion map.
-	HashMap<Color, Color> color_conversion_map;
+	Dictionary color_conversion_map;
 	// Icons by default are set up for the dark theme, so if the theme is light,
 	// we apply the dark-to-light color conversion map.
 	if (!p_dark_theme) {
@@ -137,7 +118,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	// Accent color conversion map.
 	// It is used on some icons (checkbox, radio, toggle, etc.), regardless of the dark
 	// or light mode.
-	HashMap<Color, Color> accent_color_map;
+	Dictionary accent_color_map;
 	HashSet<StringName> accent_color_icons;
 
 	const Color accent_color = p_theme->get_color(SNAME("accent_color"), EditorStringName(Editor));
@@ -156,7 +137,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	// Generate icons.
 	{
 		for (int i = 0; i < editor_icons_count; i++) {
-			Ref<ImageTexture> icon;
+			Ref<SVGTexture> icon;
 
 			const String &editor_icon_name = editor_icons_names[i];
 			if (accent_color_icons.has(editor_icon_name)) {
@@ -184,7 +165,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 		const float scale = (float)p_thumb_size / 64.0 * EDSCALE;
 		for (int i = 0; i < editor_bg_thumbs_count; i++) {
 			const int index = editor_bg_thumbs_indices[i];
-			Ref<ImageTexture> icon;
+			Ref<SVGTexture> icon;
 
 			if (accent_color_icons.has(editor_icons_names[index])) {
 				icon = editor_generate_icon(index, scale, 1.0, accent_color_map);
@@ -207,7 +188,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 		const float scale = (float)p_thumb_size / 32.0 * EDSCALE;
 		for (int i = 0; i < editor_md_thumbs_count; i++) {
 			const int index = editor_md_thumbs_indices[i];
-			Ref<ImageTexture> icon;
+			Ref<SVGTexture> icon;
 
 			if (accent_color_icons.has(editor_icons_names[index])) {
 				icon = editor_generate_icon(index, scale, 1.0, accent_color_map);

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -44,6 +44,7 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
 #include "scene/resources/style_box_texture.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/texture.h"
 
 // Theme configuration.
@@ -1613,7 +1614,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_constant("port_h_offset", "GraphNode", 1);
 			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
 
-			Ref<ImageTexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
+			Ref<SVGTexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
 			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
 			port_icon->set_size_override(Size2(12, 12));
 			p_theme->set_icon("port", "GraphNode", port_icon);

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -394,7 +394,8 @@ void ScreenSelect::_notification(int p_what) {
 			popup_background->add_theme_style_override("panel", get_theme_stylebox("PanelForeground", EditorStringName(EditorStyles)));
 
 			const real_t popup_height = real_t(get_theme_font_size("font_size")) * 2.0;
-			popup->set_min_size(Size2(0, popup_height * 3));
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(0, popup_height * 3));
+			popup->set_min_size(popup_size);
 		} break;
 	}
 }
@@ -415,7 +416,7 @@ void ScreenSelect::_show_popup() {
 		return;
 	}
 
-	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
+	Size2 size = get_final_transform().basis_xform(get_size());
 
 	popup->set_size(Size2(size.width, 0));
 	Point2 gp = get_screen_position();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3733,9 +3733,6 @@ int Main::start() {
 			bool snap_controls = GLOBAL_GET("gui/common/snap_controls_to_pixels");
 			sml->get_root()->set_snap_controls_to_pixels(snap_controls);
 
-			bool font_oversampling = GLOBAL_GET("gui/fonts/dynamic_fonts/use_oversampling");
-			sml->get_root()->set_use_font_oversampling(font_oversampling);
-
 			int texture_filter = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_filter");
 			int texture_repeat = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_repeat");
 			sml->get_root()->set_default_canvas_item_texture_filter(
@@ -3881,7 +3878,7 @@ int Main::start() {
 	}
 
 	if (movie_writer) {
-		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, Engine::get_singleton()->get_write_movie_path());
+		movie_writer->begin(DisplayServer::get_singleton()->window_get_size_in_pixels(), fixed_fps, Engine::get_singleton()->get_write_movie_path());
 	}
 
 	if (minimum_time_msec) {

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -235,7 +235,8 @@ void GridMapEditor::_menu_option(int p_option) {
 
 		} break;
 		case MENU_OPTION_GRIDMAP_SETTINGS: {
-			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + Size2(50, 50) * EDSCALE);
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(settings_vbc->get_combined_minimum_size() + Size2(50, 50) * EDSCALE));
+			settings_dialog->popup_centered(popup_size);
 		} break;
 	}
 }

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -436,7 +436,7 @@ Size2 MobileVRInterface::get_render_target_size() {
 	_THREAD_SAFE_METHOD_
 
 	// we use half our window size
-	Size2 target_size = DisplayServer::get_singleton()->window_get_size();
+	Size2 target_size = DisplayServer::get_singleton()->window_get_size_in_pixels();
 
 	target_size.x *= 0.5 * oversample;
 	target_size.y *= oversample;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -831,7 +831,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 	if (ret.index == -1) {
 		// Could not find texture to fit, create one.
-		int texsize = MAX(p_data->size.x * p_data->oversampling * 8, 256);
+		int texsize = MAX(p_data->size.x * 8, 256);
 
 		texsize = next_power_of_2(texsize);
 		if (p_msdf) {
@@ -1065,7 +1065,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 #ifdef MODULE_FREETYPE_ENABLED
 _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const {
 	FontGlyph chr;
-	chr.advance = p_advance * p_data->scale / p_data->oversampling;
+	chr.advance = p_advance * p_data->scale;
 	chr.found = true;
 
 	int w = p_bitmap.width;
@@ -1178,8 +1178,8 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitma
 	chr.texture_idx = tex_pos.index;
 
 	chr.uv_rect = Rect2(tex_pos.x + p_rect_margin, tex_pos.y + p_rect_margin, w + p_rect_margin * 2, h + p_rect_margin * 2);
-	chr.rect.position = Vector2(p_xofs - p_rect_margin, -p_yofs - p_rect_margin) * p_data->scale / p_data->oversampling;
-	chr.rect.size = chr.uv_rect.size * p_data->scale / p_data->oversampling;
+	chr.rect.position = Vector2(p_xofs - p_rect_margin, -p_yofs - p_rect_margin) * p_data->scale;
+	chr.rect.size = chr.uv_rect.size * p_data->scale;
 	return chr;
 }
 #endif
@@ -1188,8 +1188,8 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitma
 /* Font Cache                                                            */
 /*************************************************************************/
 
-_FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph) const {
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(p_font_data, p_size), false);
+_FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph, bool p_oversampling) const {
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(p_font_data, p_size, p_oversampling), false);
 
 	int32_t glyph_index = p_glyph & 0xffffff; // Remove subpixel shifts.
 
@@ -1250,7 +1250,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data,
 		}
 
 		if (p_font_data->embolden != 0.f) {
-			FT_Pos strength = p_font_data->embolden * p_size.x * fd->oversampling * 4; // 26.6 fractional units (1 / 64).
+			FT_Pos strength = p_font_data->embolden * p_size.x * 4; // 26.6 fractional units (1 / 64).
 			FT_Outline_Embolden(&fd->face->glyph->outline, strength);
 		}
 
@@ -1318,7 +1318,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data,
 				ERR_FAIL_V_MSG(false, "FreeType: Failed to load glyph stroker.");
 			}
 
-			FT_Stroker_Set(stroker, (int)(fd->size.y * fd->oversampling * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
+			FT_Stroker_Set(stroker, (int)(fd->size.y * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 
@@ -1347,9 +1347,20 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data,
 	return false;
 }
 
-_FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size) const {
+_FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size, bool p_oversampling) const {
 	ERR_FAIL_COND_V(p_size.x <= 0, false);
 	if (p_font_data->cache.has(p_size)) {
+		FontForSizeAdvanced *fd = p_font_data->cache[p_size];
+		if (fd->oversampling_lru_element) {
+			if (p_oversampling) {
+				// Update LRU order.
+				p_font_data->oversampling_lru.move_to_front(fd->oversampling_lru_element);
+			} else {
+				// Font size used directly, remove from LRU.
+				p_font_data->oversampling_lru.erase(fd->oversampling_lru_element);
+				fd->oversampling_lru_element = nullptr;
+			}
+		}
 		return true;
 	}
 
@@ -1404,40 +1415,35 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 		}
 
 		if (p_font_data->msdf) {
-			fd->oversampling = 1.0;
 			fd->size.x = p_font_data->msdf_source_size;
-		} else if (p_font_data->oversampling <= 0.0) {
-			fd->oversampling = _font_get_global_oversampling();
-		} else {
-			fd->oversampling = p_font_data->oversampling;
 		}
 
 		if (FT_HAS_COLOR(fd->face) && fd->face->num_fixed_sizes > 0) {
 			int best_match = 0;
 			int diff = ABS(fd->size.x - ((int64_t)fd->face->available_sizes[0].width));
-			fd->scale = double(fd->size.x * fd->oversampling) / fd->face->available_sizes[0].width;
+			fd->scale = double(fd->size.x) / fd->face->available_sizes[0].width;
 			for (int i = 1; i < fd->face->num_fixed_sizes; i++) {
 				int ndiff = ABS(fd->size.x - ((int64_t)fd->face->available_sizes[i].width));
 				if (ndiff < diff) {
 					best_match = i;
 					diff = ndiff;
-					fd->scale = double(fd->size.x * fd->oversampling) / fd->face->available_sizes[i].width;
+					fd->scale = double(fd->size.x) / fd->face->available_sizes[i].width;
 				}
 			}
 			FT_Select_Size(fd->face, best_match);
 		} else {
-			FT_Set_Pixel_Sizes(fd->face, 0, double(fd->size.x * fd->oversampling));
+			FT_Set_Pixel_Sizes(fd->face, 0, double(fd->size.x));
 			if (fd->face->size->metrics.y_ppem != 0) {
-				fd->scale = ((double)fd->size.x * fd->oversampling) / (double)fd->face->size->metrics.y_ppem;
+				fd->scale = double(fd->size.x) / double(fd->face->size->metrics.y_ppem);
 			}
 		}
 
 		fd->hb_handle = hb_ft_font_create(fd->face, nullptr);
 
-		fd->ascent = (fd->face->size->metrics.ascender / 64.0) / fd->oversampling * fd->scale;
-		fd->descent = (-fd->face->size->metrics.descender / 64.0) / fd->oversampling * fd->scale;
-		fd->underline_position = (-FT_MulFix(fd->face->underline_position, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
-		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
+		fd->ascent = (fd->face->size->metrics.ascender / 64.0) * fd->scale;
+		fd->descent = (-fd->face->size->metrics.descender / 64.0) * fd->scale;
+		fd->underline_position = (-FT_MulFix(fd->face->underline_position, fd->face->size->metrics.y_scale) / 64.0) * fd->scale;
+		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) * fd->scale;
 
 #if HB_VERSION_ATLEAST(3, 3, 0)
 		hb_font_set_synthetic_slant(fd->hb_handle, p_font_data->transform[0][1]);
@@ -1841,6 +1847,15 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 		fd->hb_handle = _bmp_font_create(fd, nullptr);
 	}
 	p_font_data->cache[p_size] = fd;
+	if (p_oversampling) {
+		// Insert LRU record, cleanup.
+		fd->oversampling_lru_element = p_font_data->oversampling_lru.push_front(p_size);
+		while (p_font_data->oversampling_lru.size() > oversampling_capacity) {
+			List<Vector2i>::Element *d = p_font_data->oversampling_lru.back();
+			p_font_data->cache.erase(d->get());
+			p_font_data->oversampling_lru.pop_back();
+		}
+	}
 	return true;
 }
 
@@ -1851,6 +1866,7 @@ _FORCE_INLINE_ void TextServerAdvanced::_font_clear_cache(FontAdvanced *p_font_d
 		memdelete(E.value);
 	}
 	p_font_data->cache.clear();
+	p_font_data->oversampling_lru.clear();
 	p_font_data->face_init = false;
 	p_font_data->supported_features.clear();
 	p_font_data->supported_varaitions.clear();
@@ -2537,25 +2553,6 @@ Dictionary TextServerAdvanced::_font_get_variation_coordinates(const RID &p_font
 	return fd->variation_coordinates;
 }
 
-void TextServerAdvanced::_font_set_oversampling(const RID &p_font_rid, double p_oversampling) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
-	ERR_FAIL_NULL(fd);
-
-	MutexLock lock(fd->mutex);
-	if (fd->oversampling != p_oversampling) {
-		_font_clear_cache(fd);
-		fd->oversampling = p_oversampling;
-	}
-}
-
-double TextServerAdvanced::_font_get_oversampling(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
-	ERR_FAIL_NULL_V(fd, 0.0);
-
-	MutexLock lock(fd->mutex);
-	return fd->oversampling;
-}
-
 TypedArray<Vector2i> TextServerAdvanced::_font_get_size_cache_list(const RID &p_font_rid) const {
 	FontAdvanced *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TypedArray<Vector2i>());
@@ -2578,6 +2575,7 @@ void TextServerAdvanced::_font_clear_size_cache(const RID &p_font_rid) {
 		memdelete(E.value);
 	}
 	fd->cache.clear();
+	fd->oversampling_lru.clear();
 }
 
 void TextServerAdvanced::_font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) {
@@ -2757,7 +2755,7 @@ double TextServerAdvanced::_font_get_scale(const RID &p_font_rid, int64_t p_size
 			return fd->cache[size]->scale * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	} else {
-		return fd->cache[size]->scale / fd->cache[size]->oversampling;
+		return fd->cache[size]->scale;
 	}
 }
 
@@ -3296,7 +3294,7 @@ Dictionary TextServerAdvanced::_font_get_glyph_contours(const RID &p_font_rid, i
 		FT_Outline_Transform(&fd->cache[size]->face->glyph->outline, &mat);
 	}
 
-	double scale = (1.0 / 64.0) / fd->cache[size]->oversampling * fd->cache[size]->scale;
+	double scale = (1.0 / 64.0) * fd->cache[size]->scale;
 	if (fd->msdf) {
 		scale = scale * (double)p_size / (double)fd->msdf_source_size;
 	} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size) {
@@ -3602,8 +3600,16 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
-	Vector2i size = _get_size(fd, p_size);
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	Vector2i size;
+	float oversampling = RenderingServer::get_singleton()->canvas_item_get_oversampling_factor(p_canvas);
+	bool skip_oversampling = fd->msdf || fd->fixed_size > 0 || Math::is_equal_approx(oversampling, 1.f);
+	if (skip_oversampling) {
+		size = _get_size(fd, p_size);
+		ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	} else {
+		size = Vector2i(p_size * oversampling, 0);
+		ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, true));
+	}
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 	bool lcd_aa = false;
@@ -3629,7 +3635,7 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	}
 #endif
 
-	if (!_ensure_glyph(fd, size, index)) {
+	if (!_ensure_glyph(fd, size, index, !skip_oversampling)) {
 		return; // Invalid or non-graphical glyph, do not display errors, nothing to draw.
 	}
 
@@ -3666,7 +3672,7 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 					Size2 csize = gl.rect.size * (double)p_size / (double)fd->msdf_source_size;
 					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, 0, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
 				} else {
-					double scale = _font_get_scale(p_font_rid, p_size);
+					double scale = _font_get_scale(p_font_rid, p_size) / oversampling;
 					Point2 cpos = p_pos;
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
 						cpos.x = cpos.x + 0.125;
@@ -3689,6 +3695,9 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 							gpos *= gl_scale;
 							csize *= gl_scale;
 						}
+					} else {
+						gpos /= oversampling;
+						csize /= oversampling;
 					}
 					cpos += gpos;
 					if (lcd_aa) {
@@ -3710,8 +3719,16 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
-	Vector2i size = _get_size_outline(fd, Vector2i(p_size, p_outline_size));
-	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	Vector2i size;
+	float oversampling = RenderingServer::get_singleton()->canvas_item_get_oversampling_factor(p_canvas);
+	bool skip_oversampling = fd->msdf || fd->fixed_size > 0 || Math::is_equal_approx(oversampling, 1.f);
+	if (skip_oversampling) {
+		size = _get_size_outline(fd, Vector2i(p_size, p_outline_size));
+		ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	} else {
+		size = Vector2i(p_size * oversampling, p_outline_size);
+		ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, true));
+	}
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 	bool lcd_aa = false;
@@ -3737,7 +3754,7 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	}
 #endif
 
-	if (!_ensure_glyph(fd, size, index)) {
+	if (!_ensure_glyph(fd, size, index, !skip_oversampling)) {
 		return; // Invalid or non-graphical glyph, do not display errors, nothing to draw.
 	}
 
@@ -3775,7 +3792,7 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, p_outline_size, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
 				} else {
 					Point2 cpos = p_pos;
-					double scale = _font_get_scale(p_font_rid, p_size);
+					double scale = _font_get_scale(p_font_rid, p_size) / oversampling;
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
 						cpos.x = cpos.x + 0.125;
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
@@ -3797,6 +3814,9 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 							gpos *= gl_scale;
 							csize *= gl_scale;
 						}
+					} else {
+						gpos /= oversampling;
+						csize /= oversampling;
 					}
 					cpos += gpos;
 					if (lcd_aa) {
@@ -3946,30 +3966,20 @@ Dictionary TextServerAdvanced::_font_supported_variation_list(const RID &p_font_
 	return fd->supported_varaitions;
 }
 
-double TextServerAdvanced::_font_get_global_oversampling() const {
-	return oversampling;
+int TextServerAdvanced::_font_get_oversampling_cache_capacity() const {
+	return oversampling_capacity;
 }
 
-void TextServerAdvanced::_font_set_global_oversampling(double p_oversampling) {
-	_THREAD_SAFE_METHOD_
-	if (oversampling != p_oversampling) {
-		oversampling = p_oversampling;
-		List<RID> fonts;
-		font_owner.get_owned_list(&fonts);
-		bool font_cleared = false;
-		for (const RID &E : fonts) {
-			if (!_font_is_multichannel_signed_distance_field(E) && _font_get_oversampling(E) <= 0) {
-				_font_clear_size_cache(E);
-				font_cleared = true;
-			}
-		}
-
-		if (font_cleared) {
-			List<RID> text_bufs;
-			shaped_owner.get_owned_list(&text_bufs);
-			for (const RID &E : text_bufs) {
-				invalidate(shaped_owner.get_or_null(E), false);
-			}
+void TextServerAdvanced::_font_set_oversampling_cache_capacity(int p_oversampling_capacity) {
+	oversampling_capacity = p_oversampling_capacity;
+	List<RID> fonts;
+	font_owner.get_owned_list(&fonts);
+	for (const RID &E : fonts) {
+		FontAdvanced *fd = _get_font_data(E);
+		while (fd->oversampling_lru.size() > oversampling_capacity) {
+			List<Vector2i>::Element *d = fd->oversampling_lru.back();
+			fd->cache.erase(d->get());
+			fd->oversampling_lru.pop_back();
 		}
 	}
 }
@@ -5059,7 +5069,6 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 			_font_set_hinting(sysf.rid, key.hinting);
 			_font_set_subpixel_positioning(sysf.rid, key.subpixel_positioning);
 			_font_set_variation_coordinates(sysf.rid, var);
-			_font_set_oversampling(sysf.rid, key.oversampling);
 			_font_set_embolden(sysf.rid, key.embolden);
 			_font_set_transform(sysf.rid, key.transform);
 			_font_set_spacing(sysf.rid, SPACING_TOP, key.extra_spacing[SPACING_TOP]);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -266,7 +266,6 @@ class TextServerAdvanced : public TextServerExtension {
 		double underline_position = 0.0;
 		double underline_thickness = 0.0;
 		double scale = 1.0;
-		double oversampling = 1.0;
 
 		Vector2i size;
 
@@ -280,6 +279,8 @@ class TextServerAdvanced : public TextServerExtension {
 		FT_Face face = nullptr;
 		FT_StreamRec stream;
 #endif
+
+		List<Vector2i>::Element *oversampling_lru_element = nullptr;
 
 		~FontForSizeAdvanced() {
 			if (hb_handle != nullptr) {
@@ -315,7 +316,6 @@ class TextServerAdvanced : public TextServerExtension {
 		TextServer::Hinting hinting = TextServer::HINTING_LIGHT;
 		TextServer::SubpixelPositioning subpixel_positioning = TextServer::SUBPIXEL_POSITIONING_AUTO;
 		Dictionary variation_coordinates;
-		double oversampling = 0.0;
 		double embolden = 0.0;
 		Transform2D transform;
 
@@ -328,6 +328,7 @@ class TextServerAdvanced : public TextServerExtension {
 		float baseline_offset = 0.0;
 
 		HashMap<Vector2i, FontForSizeAdvanced *, VariantHasher, VariantComparator> cache;
+		List<Vector2i> oversampling_lru;
 
 		bool face_init = false;
 		HashSet<uint32_t> supported_scripts;
@@ -349,6 +350,7 @@ class TextServerAdvanced : public TextServerExtension {
 				memdelete(E.value);
 			}
 			cache.clear();
+			oversampling_lru.clear();
 		}
 	};
 
@@ -359,8 +361,8 @@ class TextServerAdvanced : public TextServerExtension {
 #ifdef MODULE_FREETYPE_ENABLED
 	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const;
 #endif
-	_FORCE_INLINE_ bool _ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
-	_FORCE_INLINE_ bool _ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size) const;
+	_FORCE_INLINE_ bool _ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph, bool p_oversampling = false) const;
+	_FORCE_INLINE_ bool _ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size, bool p_oversampling = false) const;
 	_FORCE_INLINE_ void _font_clear_cache(FontAdvanced *p_font_data);
 	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
@@ -543,8 +545,7 @@ class TextServerAdvanced : public TextServerExtension {
 	};
 
 	// Common data.
-
-	double oversampling = 1.0;
+	int oversampling_capacity = 16;
 	mutable RID_PtrOwner<FontAdvancedLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontAdvanced> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
@@ -574,14 +575,13 @@ class TextServerAdvanced : public TextServerExtension {
 		TextServer::Hinting hinting = TextServer::HINTING_LIGHT;
 		TextServer::SubpixelPositioning subpixel_positioning = TextServer::SUBPIXEL_POSITIONING_AUTO;
 		Dictionary variation_coordinates;
-		double oversampling = 0.0;
 		double embolden = 0.0;
 		Transform2D transform;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
 		float baseline_offset = 0.0;
 
 		bool operator==(const SystemFontKey &p_b) const {
-			return (font_name == p_b.font_name) && (antialiasing == p_b.antialiasing) && (italic == p_b.italic) && (disable_embedded_bitmaps == p_b.disable_embedded_bitmaps) && (mipmaps == p_b.mipmaps) && (msdf == p_b.msdf) && (force_autohinter == p_b.force_autohinter) && (weight == p_b.weight) && (stretch == p_b.stretch) && (msdf_range == p_b.msdf_range) && (msdf_source_size == p_b.msdf_source_size) && (fixed_size == p_b.fixed_size) && (hinting == p_b.hinting) && (subpixel_positioning == p_b.subpixel_positioning) && (variation_coordinates == p_b.variation_coordinates) && (oversampling == p_b.oversampling) && (embolden == p_b.embolden) && (transform == p_b.transform) && (extra_spacing[SPACING_TOP] == p_b.extra_spacing[SPACING_TOP]) && (extra_spacing[SPACING_BOTTOM] == p_b.extra_spacing[SPACING_BOTTOM]) && (extra_spacing[SPACING_SPACE] == p_b.extra_spacing[SPACING_SPACE]) && (extra_spacing[SPACING_GLYPH] == p_b.extra_spacing[SPACING_GLYPH]) && (baseline_offset == p_b.baseline_offset);
+			return (font_name == p_b.font_name) && (antialiasing == p_b.antialiasing) && (italic == p_b.italic) && (disable_embedded_bitmaps == p_b.disable_embedded_bitmaps) && (mipmaps == p_b.mipmaps) && (msdf == p_b.msdf) && (force_autohinter == p_b.force_autohinter) && (weight == p_b.weight) && (stretch == p_b.stretch) && (msdf_range == p_b.msdf_range) && (msdf_source_size == p_b.msdf_source_size) && (fixed_size == p_b.fixed_size) && (hinting == p_b.hinting) && (subpixel_positioning == p_b.subpixel_positioning) && (variation_coordinates == p_b.variation_coordinates) && (embolden == p_b.embolden) && (transform == p_b.transform) && (extra_spacing[SPACING_TOP] == p_b.extra_spacing[SPACING_TOP]) && (extra_spacing[SPACING_BOTTOM] == p_b.extra_spacing[SPACING_BOTTOM]) && (extra_spacing[SPACING_SPACE] == p_b.extra_spacing[SPACING_SPACE]) && (extra_spacing[SPACING_GLYPH] == p_b.extra_spacing[SPACING_GLYPH]) && (baseline_offset == p_b.baseline_offset);
 		}
 
 		SystemFontKey(const String &p_font_name, bool p_italic, int p_weight, int p_stretch, RID p_font, const TextServerAdvanced *p_fb) {
@@ -600,7 +600,6 @@ class TextServerAdvanced : public TextServerExtension {
 			hinting = p_fb->_font_get_hinting(p_font);
 			subpixel_positioning = p_fb->_font_get_subpixel_positioning(p_font);
 			variation_coordinates = p_fb->_font_get_variation_coordinates(p_font);
-			oversampling = p_fb->_font_get_oversampling(p_font);
 			embolden = p_fb->_font_get_embolden(p_font);
 			transform = p_fb->_font_get_transform(p_font);
 			extra_spacing[SPACING_TOP] = p_fb->_font_get_spacing(p_font, SPACING_TOP);
@@ -630,7 +629,6 @@ class TextServerAdvanced : public TextServerExtension {
 			hash = hash_murmur3_one_32(p_a.msdf_range, hash);
 			hash = hash_murmur3_one_32(p_a.msdf_source_size, hash);
 			hash = hash_murmur3_one_32(p_a.fixed_size, hash);
-			hash = hash_murmur3_one_double(p_a.oversampling, hash);
 			hash = hash_murmur3_one_double(p_a.embolden, hash);
 			hash = hash_murmur3_one_real(p_a.transform[0].x, hash);
 			hash = hash_murmur3_one_real(p_a.transform[0].y, hash);
@@ -803,9 +801,6 @@ public:
 	MODBIND2(font_set_hinting, const RID &, TextServer::Hinting);
 	MODBIND1RC(TextServer::Hinting, font_get_hinting, const RID &);
 
-	MODBIND2(font_set_oversampling, const RID &, double);
-	MODBIND1RC(double, font_get_oversampling, const RID &);
-
 	MODBIND1RC(TypedArray<Vector2i>, font_get_size_cache_list, const RID &);
 	MODBIND1(font_clear_size_cache, const RID &);
 	MODBIND2(font_remove_size_cache, const RID &, const Vector2i &);
@@ -893,11 +888,11 @@ public:
 	MODBIND2(font_set_opentype_feature_overrides, const RID &, const Dictionary &);
 	MODBIND1RC(Dictionary, font_get_opentype_feature_overrides, const RID &);
 
+	MODBIND0RC(int, font_get_oversampling_cache_capacity);
+	MODBIND1(font_set_oversampling_cache_capacity, int);
+
 	MODBIND1RC(Dictionary, font_supported_feature_list, const RID &);
 	MODBIND1RC(Dictionary, font_supported_variation_list, const RID &);
-
-	MODBIND0RC(double, font_get_global_oversampling);
-	MODBIND1(font_set_global_oversampling, double);
 
 	/* Shaped text buffer interface */
 

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -379,7 +379,7 @@ Size2 WebXRInterfaceJS::get_render_target_size() {
 	if (!initialized || !has_size) {
 		// As a temporary default (until WebXR is fully initialized), use the
 		// window size.
-		return DisplayServer::get_singleton()->window_get_size();
+		return DisplayServer::get_singleton()->window_get_size_in_pixels();
 	}
 
 	render_targetsize.width = (float)js_size[0];

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -429,6 +429,7 @@ public:
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Color screen_get_pixel(const Point2i &p_position) const override;
 	virtual Ref<Image> screen_get_image(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -180,7 +180,6 @@ private:
 	WindowID window_mouseover_id = INVALID_WINDOW_ID;
 	WindowID last_focused_window = INVALID_WINDOW_ID;
 	WindowID window_id_counter = MAIN_WINDOW_ID;
-	float display_max_scale = 1.f;
 	Point2i origin;
 	bool displays_arrangement_dirty = true;
 	bool is_resizing = false;
@@ -311,11 +310,14 @@ public:
 	virtual bool clipboard_has() const override;
 	virtual bool clipboard_has_image() const override;
 
+	virtual ScreenCoordinatesUnit get_screen_coordiantes_unit() const override { return SCREEN_COORDS_UNIT_DPI_ADJUSTED_PIXEL; }
+
 	virtual int get_screen_count() const override;
 	virtual int get_primary_screen() const override;
 	virtual int get_keyboard_focus_screen() const override;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Size2i screen_get_size_in_pixels(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_max_scale() const override;
@@ -364,7 +366,9 @@ public:
 
 	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Size2i window_get_size_in_pixels(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual Size2i window_get_size_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual float window_get_scale(WindowID p_window = MAIN_WINDOW_ID) const override;
 
 	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -67,7 +67,12 @@
 
 DisplayServerMacOS::WindowID DisplayServerMacOS::_create_window(WindowMode p_mode, VSyncMode p_vsync_mode, const Rect2i &p_rect) {
 	WindowID id;
-	const float scale = screen_get_max_scale();
+	int rq_screen = get_screen_from_rect(p_rect);
+	if (rq_screen < 0) {
+		rq_screen = get_primary_screen(); // Requested window rect is outside any screen bounds.
+	}
+
+	const float scale = screen_get_scale(rq_screen);
 	{
 		WindowData wd;
 
@@ -75,25 +80,15 @@ DisplayServerMacOS::WindowID DisplayServerMacOS::_create_window(WindowMode p_mod
 		ERR_FAIL_NULL_V_MSG(wd.window_delegate, INVALID_WINDOW_ID, "Can't create a window delegate");
 		[wd.window_delegate setWindowID:window_id_counter];
 
-		int rq_screen = get_screen_from_rect(p_rect);
-		if (rq_screen < 0) {
-			rq_screen = get_primary_screen(); // Requested window rect is outside any screen bounds.
-		}
-
 		Rect2i srect = screen_get_usable_rect(rq_screen);
 		Point2i wpos = p_rect.position;
 		if (srect != Rect2i()) {
 			wpos = wpos.clamp(srect.position, srect.position + srect.size - p_rect.size / 3);
 		}
-		// macOS native y-coordinate relative to _get_screens_origin() is negative,
-		// Godot passes a positive value.
-		wpos.y *= -1;
-		wpos += _get_screens_origin();
-		wpos /= scale;
 
 		// initWithContentRect uses bottom-left corner of the window’s frame as origin.
 		wd.window_object = [[GodotWindow alloc]
-				initWithContentRect:NSMakeRect(100, 100, MAX(1, p_rect.size.width / scale), MAX(1, p_rect.size.height / scale))
+				initWithContentRect:NSMakeRect(0, 0, 100, 100)
 						  styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable
 							backing:NSBackingStoreBuffered
 							  defer:NO];
@@ -166,39 +161,26 @@ DisplayServerMacOS::WindowID DisplayServerMacOS::_create_window(WindowMode p_mod
 #endif
 		[wd.window_view updateLayerDelegate];
 
-		const NSRect contentRect = [wd.window_view frame];
-		const NSRect windowRect = [wd.window_object frame];
-		const NSRect nsrect = [wd.window_object convertRectToScreen:contentRect];
-		Point2i offset;
-		offset.x = (nsrect.origin.x - windowRect.origin.x);
-		offset.y = (nsrect.origin.y + nsrect.size.height);
-		offset.y -= (windowRect.origin.y + windowRect.size.height);
-		[wd.window_object setFrameTopLeftPoint:NSMakePoint(wpos.x - offset.x, wpos.y - offset.y)];
-
 		id = window_id_counter++;
 		windows[id] = wd;
+
+		window_set_position(wpos, id);
+		window_set_size(p_rect.size, id);
 	}
 
 	WindowData &wd = windows[id];
 	window_set_mode(p_mode, id);
 
 	const NSRect contentRect = [wd.window_view frame];
-	wd.size.width = contentRect.size.width * scale;
-	wd.size.height = contentRect.size.height * scale;
+	wd.size.width = contentRect.size.width;
+	wd.size.height = contentRect.size.height;
 
 	CALayer *layer = [(NSView *)wd.window_view layer];
 	if (layer) {
 		layer.contentsScale = scale;
 	}
 
-#if defined(GLES3_ENABLED)
-	if (gl_manager_legacy) {
-		gl_manager_legacy->window_resize(id, wd.size.width, wd.size.height);
-	}
-	if (gl_manager_angle) {
-		gl_manager_angle->window_resize(id, wd.size.width, wd.size.height);
-	}
-#endif
+	window_resize(id, wd.size.width, wd.size.height);
 
 	return id;
 }
@@ -312,7 +294,7 @@ Point2i DisplayServerMacOS::_get_native_screen_position(int p_screen) const {
 	if ((NSUInteger)p_screen < [screenArray count]) {
 		NSRect nsrect = [[screenArray objectAtIndex:p_screen] frame];
 		// Return the top-left corner of the screen, for macOS the y starts at the bottom.
-		return Point2i(nsrect.origin.x, nsrect.origin.y + nsrect.size.height) * screen_get_max_scale();
+		return Point2i(nsrect.origin.x, nsrect.origin.y + nsrect.size.height);
 	}
 
 	return Point2i();
@@ -669,9 +651,8 @@ void DisplayServerMacOS::get_key_modifier_state(unsigned int p_macos_state, Ref<
 
 void DisplayServerMacOS::update_mouse_pos(DisplayServerMacOS::WindowData &p_wd, NSPoint p_location_in_window) {
 	const NSRect content_rect = [p_wd.window_view frame];
-	const float scale = screen_get_max_scale();
-	p_wd.mouse_pos.x = p_location_in_window.x * scale;
-	p_wd.mouse_pos.y = (content_rect.size.height - p_location_in_window.y) * scale;
+	p_wd.mouse_pos.x = p_location_in_window.x;
+	p_wd.mouse_pos.y = (content_rect.size.height - p_location_in_window.y);
 	Input::get_singleton()->set_mouse_position(p_wd.mouse_pos);
 }
 
@@ -728,17 +709,18 @@ void DisplayServerMacOS::window_destroy(WindowID p_window) {
 }
 
 void DisplayServerMacOS::window_resize(WindowID p_window, int p_width, int p_height) {
+	const float scale = (OS::get_singleton()->is_hidpi_allowed() ? [[windows[p_window].window_object screen] backingScaleFactor] : 1.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
-		rendering_context->window_set_size(p_window, p_width, p_height);
+		rendering_context->window_set_size(p_window, p_width * scale, p_height * scale);
 	}
 #endif
 #if defined(GLES3_ENABLED)
 	if (gl_manager_legacy) {
-		gl_manager_legacy->window_resize(p_window, p_width, p_height);
+		gl_manager_legacy->window_resize(p_window, p_width * scale, p_height * scale);
 	}
 	if (gl_manager_angle) {
-		gl_manager_angle->window_resize(p_window, p_width, p_height);
+		gl_manager_angle->window_resize(p_window, p_width * scale, p_height * scale);
 	}
 #endif
 }
@@ -772,6 +754,7 @@ bool DisplayServerMacOS::has_feature(Feature p_feature) const {
 		case FEATURE_SCREEN_CAPTURE:
 		case FEATURE_STATUS_INDICATOR:
 		case FEATURE_NATIVE_HELP:
+		case FEATURE_DPI_SCALING:
 			return true;
 		default: {
 		}
@@ -1379,8 +1362,7 @@ void DisplayServerMacOS::warp_mouse(const Point2i &p_position) {
 
 		// Local point in window coords.
 		const NSRect contentRect = [wd.window_view frame];
-		const float scale = screen_get_max_scale();
-		NSRect pointInWindowRect = NSMakeRect(p_position.x / scale, contentRect.size.height - (p_position.y / scale), scale, scale);
+		NSRect pointInWindowRect = NSMakeRect(p_position.x, contentRect.size.height - p_position.y, 1, 1);
 		NSPoint pointOnScreen = [[wd.window_view window] convertRectToScreen:pointInWindowRect].origin;
 
 		// Point in screen coords.
@@ -1401,13 +1383,11 @@ Point2i DisplayServerMacOS::mouse_get_position() const {
 	_THREAD_SAFE_METHOD_
 
 	const NSPoint mouse_pos = [NSEvent mouseLocation];
-	const float scale = screen_get_max_scale();
 
 	for (NSScreen *screen in [NSScreen screens]) {
 		NSRect frame = [screen frame];
 		if (NSMouseInRect(mouse_pos, frame, NO)) {
 			Vector2i pos = Vector2i((int)mouse_pos.x, (int)mouse_pos.y);
-			pos *= scale;
 			pos -= _get_screens_origin();
 			pos.y *= -1;
 			return pos;
@@ -1520,9 +1500,23 @@ Size2i DisplayServerMacOS::screen_get_size(int p_screen) const {
 	p_screen = _get_screen_index(p_screen);
 	NSArray *screenArray = [NSScreen screens];
 	if ((NSUInteger)p_screen < [screenArray count]) {
-		// Note: Use frame to get the whole screen size.
-		NSRect nsrect = [[screenArray objectAtIndex:p_screen] frame];
-		return Size2i(nsrect.size.width, nsrect.size.height) * screen_get_max_scale();
+		NSScreen *screen = [screenArray objectAtIndex:p_screen];
+		NSRect nsrect = [screen frame];
+		return Size2i(nsrect.size.width, nsrect.size.height);
+	}
+
+	return Size2i();
+}
+
+Size2i DisplayServerMacOS::screen_get_size_in_pixels(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	p_screen = _get_screen_index(p_screen);
+	NSArray *screenArray = [NSScreen screens];
+	if ((NSUInteger)p_screen < [screenArray count]) {
+		NSScreen *screen = [screenArray objectAtIndex:p_screen];
+		NSRect nsrect = [screen frame];
+		return Size2i(nsrect.size.width, nsrect.size.height) * (OS::get_singleton()->is_hidpi_allowed() ? [screen backingScaleFactor] : 1.0);
 	}
 
 	return Size2i();
@@ -1568,8 +1562,16 @@ float DisplayServerMacOS::screen_get_scale(int p_screen) const {
 float DisplayServerMacOS::screen_get_max_scale() const {
 	_THREAD_SAFE_METHOD_
 
-	// Note: Do not update max display scale on screen configuration change, existing editor windows can't be rescaled on the fly.
-	return display_max_scale;
+	float scale = 1.f;
+	if (OS::get_singleton()->is_hidpi_allowed()) {
+		for (NSScreen *screen in [NSScreen screens]) {
+			if ([screen respondsToSelector:@selector(backingScaleFactor)]) {
+				scale = fmax(scale, [screen backingScaleFactor]);
+			}
+		}
+	}
+
+	return scale;
 }
 
 Rect2i DisplayServerMacOS::screen_get_usable_rect(int p_screen) const {
@@ -1578,12 +1580,12 @@ Rect2i DisplayServerMacOS::screen_get_usable_rect(int p_screen) const {
 	p_screen = _get_screen_index(p_screen);
 	NSArray *screenArray = [NSScreen screens];
 	if ((NSUInteger)p_screen < [screenArray count]) {
-		const float scale = screen_get_max_scale();
-		NSRect nsrect = [[screenArray objectAtIndex:p_screen] visibleFrame];
+		NSScreen *screen = [screenArray objectAtIndex:p_screen];
+		NSRect nsrect = [screen visibleFrame];
 
-		Point2i position = Point2i(nsrect.origin.x, nsrect.origin.y + nsrect.size.height) * scale - _get_screens_origin();
+		Point2i position = Point2i(nsrect.origin.x, nsrect.origin.y + nsrect.size.height) - _get_screens_origin();
 		position.y *= -1;
-		Size2i size = Size2i(nsrect.size.width, nsrect.size.height) * scale;
+		Size2i size = Size2i(nsrect.size.width, nsrect.size.height);
 
 		return Rect2i(position, size);
 	}
@@ -1597,7 +1599,6 @@ Color DisplayServerMacOS::screen_get_pixel(const Point2i &p_position) const {
 	// Godot passes a positive value.
 	position.y *= -1;
 	position += _get_screens_origin();
-	position /= screen_get_max_scale();
 
 	Color color;
 	for (NSScreen *screen in [NSScreen screens]) {
@@ -1816,8 +1817,6 @@ Size2i DisplayServerMacOS::window_get_title_size(const String &p_title, WindowID
 		}
 	}
 
-	float scale = screen_get_max_scale();
-
 	if (wd.window_button_view) {
 		size.x = ([wd.window_button_view getOffset].x + [wd.window_button_view frame].size.width);
 		size.y = ([wd.window_button_view getOffset].y + [wd.window_button_view frame].size.height);
@@ -1838,7 +1837,7 @@ Size2i DisplayServerMacOS::window_get_title_size(const String &p_title, WindowID
 	size.x += text_size.width;
 	size.y = MAX(size.y, text_size.height);
 
-	return size * scale;
+	return size;
 }
 
 void DisplayServerMacOS::window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window) {
@@ -1956,14 +1955,13 @@ Point2i DisplayServerMacOS::window_get_position(WindowID p_window) const {
 	Point2i pos;
 
 	// Return the position of the top-left corner, for macOS the y starts at the bottom.
-	const float scale = screen_get_max_scale();
 	pos.x = nsrect.origin.x;
 	pos.y = (nsrect.origin.y + nsrect.size.height);
-	pos *= scale;
 	pos -= _get_screens_origin();
 	// macOS native y-coordinate relative to _get_screens_origin() is negative,
 	// Godot expects a positive value.
 	pos.y *= -1;
+
 	return pos;
 }
 
@@ -1977,14 +1975,13 @@ Point2i DisplayServerMacOS::window_get_position_with_decorations(WindowID p_wind
 	Point2i pos;
 
 	// Return the position of the top-left corner, for macOS the y starts at the bottom.
-	const float scale = screen_get_max_scale();
 	pos.x = nsrect.origin.x;
 	pos.y = (nsrect.origin.y + nsrect.size.height);
-	pos *= scale;
 	pos -= _get_screens_origin();
 	// macOS native y-coordinate relative to _get_screens_origin() is negative,
 	// Godot expects a positive value.
 	pos.y *= -1;
+
 	return pos;
 }
 
@@ -2003,7 +2000,6 @@ void DisplayServerMacOS::window_set_position(const Point2i &p_position, WindowID
 	// Godot passes a positive value.
 	position.y *= -1;
 	position += _get_screens_origin();
-	position /= screen_get_max_scale();
 
 	// Remove titlebar / window border size.
 	const NSRect contentRect = [wd.window_view frame];
@@ -2067,7 +2063,7 @@ void DisplayServerMacOS::window_set_max_size(const Size2i p_size, WindowID p_win
 	wd.max_size = p_size;
 
 	if ((wd.max_size != Size2i()) && !wd.fullscreen) {
-		Size2i size = wd.max_size / screen_get_max_scale();
+		Size2i size = wd.max_size;
 		[wd.window_object setContentMaxSize:NSMakeSize(size.x, size.y)];
 	} else {
 		[wd.window_object setContentMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
@@ -2113,7 +2109,7 @@ void DisplayServerMacOS::window_set_min_size(const Size2i p_size, WindowID p_win
 	wd.min_size = p_size;
 
 	if ((wd.min_size != Size2i()) && !wd.fullscreen) {
-		Size2i size = wd.min_size / screen_get_max_scale();
+		Size2i size = wd.min_size;
 		[wd.window_object setContentMinSize:NSMakeSize(size.x, size.y)];
 	} else {
 		[wd.window_object setContentMinSize:NSMakeSize(0, 0)];
@@ -2139,7 +2135,7 @@ void DisplayServerMacOS::window_set_size(const Size2i p_size, WindowID p_window)
 		return;
 	}
 
-	Size2i size = p_size / screen_get_max_scale();
+	Size2i size = p_size;
 
 	NSPoint top_left;
 	NSRect old_frame = [wd.window_object frame];
@@ -2165,13 +2161,29 @@ Size2i DisplayServerMacOS::window_get_size(WindowID p_window) const {
 	return wd.size;
 }
 
+Size2i DisplayServerMacOS::window_get_size_in_pixels(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V(!windows.has(p_window), Size2i());
+	const WindowData &wd = windows[p_window];
+	return wd.size * (OS::get_singleton()->is_hidpi_allowed() ? [[wd.window_object screen] backingScaleFactor] : 1.0);
+}
+
 Size2i DisplayServerMacOS::window_get_size_with_decorations(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), Size2i());
 	const WindowData &wd = windows[p_window];
 	NSRect frame = [wd.window_object frame];
-	return Size2i(frame.size.width, frame.size.height) * screen_get_max_scale();
+	return Size2i(frame.size.width, frame.size.height);
+}
+
+float DisplayServerMacOS::window_get_scale(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V(!windows.has(p_window), 1.0);
+	const WindowData &wd = windows[p_window];
+	return (OS::get_singleton()->is_hidpi_allowed() ? [[wd.window_object screen] backingScaleFactor] : 1.0);
 }
 
 void DisplayServerMacOS::window_set_mode(WindowMode p_mode, WindowID p_window) {
@@ -2211,11 +2223,11 @@ void DisplayServerMacOS::window_set_mode(WindowMode p_mode, WindowID p_window) {
 				[wd.window_object setStyleMask:[wd.window_object styleMask] & ~NSWindowStyleMaskResizable];
 			}
 			if (wd.min_size != Size2i()) {
-				Size2i size = wd.min_size / screen_get_max_scale();
+				Size2i size = wd.min_size;
 				[wd.window_object setContentMinSize:NSMakeSize(size.x, size.y)];
 			}
 			if (wd.max_size != Size2i()) {
-				Size2i size = wd.max_size / screen_get_max_scale();
+				Size2i size = wd.max_size;
 				[wd.window_object setContentMaxSize:NSMakeSize(size.x, size.y)];
 			}
 			[wd.window_object toggleFullScreen:nil];
@@ -2319,8 +2331,7 @@ void DisplayServerMacOS::window_set_window_buttons_offset(const Vector2i &p_offs
 
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
-	float scale = screen_get_max_scale();
-	wd.wb_offset = p_offset / scale;
+	wd.wb_offset = p_offset;
 	wd.wb_offset = wd.wb_offset.maxi(12);
 	if (wd.window_button_view) {
 		[wd.window_button_view setOffset:NSMakePoint(wd.wb_offset.x, wd.wb_offset.y)];
@@ -2337,14 +2348,13 @@ Vector3i DisplayServerMacOS::window_get_safe_title_margins(WindowID p_window) co
 		return Vector3i();
 	}
 
-	float scale = screen_get_max_scale();
 	float max_x = [wd.window_button_view getOffset].x + [wd.window_button_view frame].size.width;
 	float max_y = [wd.window_button_view getOffset].y + [wd.window_button_view frame].size.height;
 
 	if ([wd.window_object windowTitlebarLayoutDirection] == NSUserInterfaceLayoutDirectionRightToLeft) {
-		return Vector3i(0, max_x * scale, max_y * scale);
+		return Vector3i(0, max_x, max_y);
 	} else {
-		return Vector3i(max_x * scale, 0, max_y * scale);
+		return Vector3i(max_x, 0, max_y);
 	}
 }
 
@@ -2616,7 +2626,6 @@ DisplayServer::WindowID DisplayServerMacOS::get_window_at_screen_position(const 
 	Point2i position = p_position;
 	position.y *= -1;
 	position += _get_screens_origin();
-	position /= screen_get_max_scale();
 
 	NSInteger wnum = [NSWindow windowNumberAtPoint:NSMakePoint(position.x, position.y) belowWindowWithWindowNumber:0 /*topmost*/];
 	for (const KeyValue<WindowID, WindowData> &E : windows) {
@@ -3030,8 +3039,14 @@ void DisplayServerMacOS::process_events() {
 				[wd.window_object setIgnoresMouseEvents:YES];
 			}
 		} else if (wd.mpath.size() > 0) {
-			update_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream]);
-			if (Geometry2D::is_point_in_polygon(wd.mouse_pos, wd.mpath)) {
+			Vector2 mouse_pos;
+
+			const NSPoint location_in_window = [wd.window_object mouseLocationOutsideOfEventStream];
+			const NSRect content_rect = [wd.window_view frame];
+			mouse_pos.x = location_in_window.x;
+			mouse_pos.y = (content_rect.size.height - location_in_window.y);
+
+			if (Geometry2D::is_point_in_polygon(mouse_pos, wd.mpath)) {
 				if ([wd.window_object ignoresMouseEvents]) {
 					[wd.window_object setIgnoresMouseEvents:NO];
 				}
@@ -3513,11 +3528,6 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 	ERR_FAIL_COND(!event_source);
 
 	CGEventSourceSetLocalEventsSuppressionInterval(event_source, 0.0);
-
-	int screen_count = get_screen_count();
-	for (int i = 0; i < screen_count; i++) {
-		display_max_scale = fmax(display_max_scale, screen_get_scale(i));
-	}
 
 	// Register to be notified on keyboard layout changes.
 	CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenter(),

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -228,8 +228,7 @@
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	const NSRect content_rect = [wd.window_view frame];
-	const float scale = ds->screen_get_max_scale();
-	NSRect point_in_window_rect = NSMakeRect(wd.im_position.x / scale, content_rect.size.height - (wd.im_position.y / scale) - 1, 0, 0);
+	NSRect point_in_window_rect = NSMakeRect(wd.im_position.x, content_rect.size.height - wd.im_position.y - 1, 0, 0);
 	NSPoint point_on_screen = [wd.window_object convertRectToScreen:point_in_window_rect].origin;
 
 	return NSMakeRect(point_on_screen.x, point_on_screen.y, 0, 0);
@@ -453,7 +452,7 @@
 	mm->set_global_position(wd.mouse_pos);
 	mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 	mm->set_screen_velocity(mm->get_velocity());
-	const Vector2i relativeMotion = Vector2i(delta.x, delta.y) * ds->screen_get_max_scale();
+	const Vector2i relativeMotion = Vector2i(delta.x, delta.y);
 	mm->set_relative(relativeMotion);
 	mm->set_relative_screen_position(relativeMotion);
 	ds->get_key_modifier_state([event modifierFlags], mm);

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -173,13 +173,12 @@
 	wd.fs_transition = false;
 
 	// Set window size limits.
-	const float scale = ds->screen_get_max_scale();
 	if (wd.min_size != Size2i()) {
-		Size2i size = wd.min_size / scale;
+		Size2i size = wd.min_size;
 		[wd.window_object setContentMinSize:NSMakeSize(size.x, size.y)];
 	}
 	if (wd.max_size != Size2i()) {
-		Size2i size = wd.max_size / scale;
+		Size2i size = wd.max_size;
 		[wd.window_object setContentMaxSize:NSMakeSize(size.x, size.y)];
 	}
 
@@ -208,6 +207,10 @@
 		return;
 	}
 
+	if (!OS::get_singleton()->is_hidpi_allowed()) {
+		return;
+	}
+
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 
 	CGFloat new_scale_factor = [wd.window_object backingScaleFactor];
@@ -215,17 +218,11 @@
 
 	if (new_scale_factor != old_scale_factor) {
 		// Set new display scale and window size.
-		const float scale = ds->screen_get_max_scale();
-		const NSRect content_rect = [wd.window_view frame];
-
-		wd.size.width = content_rect.size.width * scale;
-		wd.size.height = content_rect.size.height * scale;
-
 		ds->send_window_event(wd, DisplayServerMacOS::WINDOW_EVENT_DPI_CHANGE);
 
 		CALayer *layer = [wd.window_view layer];
 		if (layer) {
-			layer.contentsScale = scale;
+			layer.contentsScale = new_scale_factor;
 		}
 
 		//Force window resize event
@@ -257,9 +254,9 @@
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	const NSRect content_rect = [wd.window_view frame];
-	const float scale = ds->screen_get_max_scale();
-	wd.size.width = content_rect.size.width * scale;
-	wd.size.height = content_rect.size.height * scale;
+	const float scale = (OS::get_singleton()->is_hidpi_allowed() ? [[wd.window_object screen] backingScaleFactor] : 1.0);
+	wd.size.width = content_rect.size.width;
+	wd.size.height = content_rect.size.height;
 
 	CALayer *layer = [wd.window_view layer];
 	if (layer) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -121,6 +121,7 @@ bool DisplayServerWindows::has_feature(Feature p_feature) const {
 		case FEATURE_TEXT_TO_SPEECH:
 		case FEATURE_SCREEN_CAPTURE:
 		case FEATURE_STATUS_INDICATOR:
+		case FEATURE_DPI_SCALING:
 			return true;
 		default:
 			return false;
@@ -1095,10 +1096,43 @@ static BOOL CALLBACK _MonitorEnumProcDpi(HMONITOR hMonitor, HDC hdcMonitor, LPRE
 	EnumDpiData *data = (EnumDpiData *)dwData;
 	if (data->count == data->screen) {
 		data->dpi = QueryDpiForMonitor(hMonitor);
+		return FALSE;
 	}
 
 	data->count++;
 	return TRUE;
+}
+
+static BOOL CALLBACK _MonitorEnumProcDpiMax(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
+	EnumDpiData *data = (EnumDpiData *)dwData;
+	data->dpi = MAX(data->dpi, QueryDpiForMonitor(hMonitor));
+
+	return TRUE;
+}
+
+float DisplayServerWindows::screen_get_scale(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	if (OS::get_singleton()->is_hidpi_allowed()) {
+		p_screen = _get_screen_index(p_screen);
+		EnumDpiData data = { 0, p_screen, 72 };
+		EnumDisplayMonitors(nullptr, nullptr, _MonitorEnumProcDpi, (LPARAM)&data);
+		return (float)data.dpi / 96.0;
+	} else {
+		return 1.0;
+	}
+}
+
+float DisplayServerWindows::screen_get_max_scale() const {
+	_THREAD_SAFE_METHOD_
+
+	if (OS::get_singleton()->is_hidpi_allowed()) {
+		EnumDpiData data = { 0, 0, 72 };
+		EnumDisplayMonitors(nullptr, nullptr, _MonitorEnumProcDpiMax, (LPARAM)&data);
+		return (float)data.dpi / 96.0;
+	} else {
+		return 1.0;
+	}
 }
 
 int DisplayServerWindows::screen_get_dpi(int p_screen) const {
@@ -4797,6 +4831,18 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 
 		} break;
+		case WM_DPICHANGED: {
+			if (OS::get_singleton()->is_hidpi_allowed()) {
+				RECT *const new_window_rect = (RECT *)lParam;
+				SetWindowPos(hWnd, NULL, new_window_rect->left,
+						new_window_rect->top,
+						new_window_rect->right - new_window_rect->left,
+						new_window_rect->bottom - new_window_rect->top,
+						SWP_NOZORDER | SWP_NOACTIVATE);
+
+				_send_window_event(windows[window_id], DisplayServer::WINDOW_EVENT_DPI_CHANGE);
+			}
+		} break;
 		case WM_DEVICECHANGE: {
 			joypad->probe_joypads();
 		} break;
@@ -5618,7 +5664,11 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 			SetProcessDpiAwareness_t SetProcessDpiAwareness = (SetProcessDpiAwareness_t)GetProcAddress(Shcore, "SetProcessDpiAwareness");
 
 			if (SetProcessDpiAwareness) {
-				SetProcessDpiAwareness(SHC_PROCESS_SYSTEM_DPI_AWARE);
+				if ((os_ver.dwMajorVersion > 6) || ((os_ver.dwMajorVersion == 6) && (os_ver.dwMajorVersion >= 3))) {
+					SetProcessDpiAwareness(SHC_PROCESS_PER_MONITOR_DPI_AWARE);
+				} else {
+					SetProcessDpiAwareness(SHC_PROCESS_SYSTEM_DPI_AWARE);
+				}
 			}
 		}
 	}
@@ -5771,6 +5821,11 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	mouse_monitor = SetWindowsHookEx(WH_MOUSE, ::MouseProc, nullptr, GetCurrentThreadId());
 
+	String stretch_mode = GLOBAL_GET("display/window/stretch/mode");
+	Size2i stretch_size = Size2i(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	bool dpi_scaling = GLOBAL_GET("gui/common/use_dpi_scaling");
+
+	float scale = 1.f;
 	Point2i window_position;
 	if (p_position != nullptr) {
 		window_position = *p_position;
@@ -5778,11 +5833,14 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		if (p_screen == SCREEN_OF_MAIN_WINDOW) {
 			p_screen = SCREEN_PRIMARY;
 		}
+		if (dpi_scaling && ((stretch_mode != "canvas_items" && stretch_mode != "viewport") || stretch_size.x == 0 || stretch_size.y == 0)) {
+			scale = screen_get_scale(p_screen);
+		}
 		Rect2i scr_rect = screen_get_usable_rect(p_screen);
-		window_position = scr_rect.position + (scr_rect.size - p_resolution) / 2;
+		window_position = scr_rect.position + (scr_rect.size - p_resolution * scale) / 2;
 	}
 
-	WindowID main_window = _create_window(p_mode, p_vsync_mode, p_flags, Rect2i(window_position, p_resolution));
+	WindowID main_window = _create_window(p_mode, p_vsync_mode, p_flags, Rect2i(window_position, p_resolution * scale));
 	ERR_FAIL_COND_MSG(main_window == INVALID_WINDOW_ID, "Failed to create main window.");
 
 	joypad = new JoypadWindows(&windows[MAIN_WINDOW_ID].hWnd);

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -568,6 +568,8 @@ public:
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_max_scale() const override;
 	virtual Color screen_get_pixel(const Point2i &p_position) const override;
 	virtual Ref<Image> screen_get_image(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2086,7 +2086,7 @@ void ColorPickerButton::pressed() {
 
 	float h_offset = (get_size().x - minsize.x) / 2;
 	float v_offset = show_above ? -minsize.y : get_size().y;
-	popup->set_position(get_screen_position() + Vector2(h_offset, v_offset));
+	popup->set_position(get_final_transform().xform(Vector2(h_offset, v_offset)));
 	popup->popup();
 	picker->set_focus_on_line_edit();
 }

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -202,7 +202,8 @@ void AcceptDialog::register_text_enter(LineEdit *p_line_edit) {
 }
 
 void AcceptDialog::_update_child_rects() {
-	Size2 dlg_size = Vector2(get_size()) / get_content_scale_factor();
+	Size2 dlg_size = get_final_transform().affine_inverse().basis_xform(get_size());
+
 	float h_margins = theme_cache.panel_style->get_margin(SIDE_LEFT) + theme_cache.panel_style->get_margin(SIDE_RIGHT);
 	float v_margins = theme_cache.panel_style->get_margin(SIDE_TOP) + theme_cache.panel_style->get_margin(SIDE_BOTTOM);
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -491,13 +491,15 @@ void FileDialog::_action_pressed() {
 
 		String file_name = file_text.strip_edges().get_file();
 		if (!valid || file_name.is_empty()) {
-			exterr->popup_centered(Size2(250, 80));
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(250, 80));
+			exterr->popup_centered(popup_size);
 			return;
 		}
 
 		if (dir_access->file_exists(f)) {
+			Size2i popup_size = get_final_transform().basis_xform(Vector2i(250, 80));
 			confirm_save->set_text(vformat(atr(ETR("File \"%s\" already exists.\nDo you want to overwrite it?")), f));
-			confirm_save->popup_centered(Size2(250, 80));
+			confirm_save->popup_centered(popup_size);
 		} else {
 			emit_signal(SNAME("file_selected"), f);
 			hide();
@@ -1037,13 +1039,15 @@ void FileDialog::_make_dir_confirm() {
 		update_filters();
 		_push_history();
 	} else {
-		mkdirerr->popup_centered(Size2(250, 50));
+		Size2i popup_size = get_final_transform().basis_xform(Vector2i(250, 50));
+		mkdirerr->popup_centered(popup_size);
 	}
 	makedirname->set_text(""); // reset label
 }
 
 void FileDialog::_make_dir() {
-	makedialog->popup_centered(Size2(250, 80));
+	Size2i popup_size = get_final_transform().basis_xform(Vector2i(250, 80));
+	makedialog->popup_centered(popup_size);
 	makedirname->grab_focus();
 }
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -252,7 +252,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		if (b->is_pressed() && b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_update_context_menu();
-			menu->set_position(get_screen_position() + get_local_mouse_position());
+			menu->set_position(get_final_transform().xform(get_local_mouse_position()));
 			menu->reset_size();
 			menu->popup();
 			grab_focus();
@@ -487,7 +487,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (k->is_action("ui_menu", true)) {
 				_update_context_menu();
 				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2);
-				menu->set_position(get_screen_position() + pos);
+				menu->set_position(get_final_transform().xform(pos));
 				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();
@@ -1090,11 +1090,8 @@ void LineEdit::_notification(int p_what) {
 			if (has_focus()) {
 				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 					DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-					Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2) + get_global_position();
-					if (get_window()->get_embedder()) {
-						pos += get_viewport()->get_popup_base_transform().get_origin();
-					}
-					DisplayServer::get_singleton()->window_set_ime_position(pos, get_viewport()->get_window_id());
+					Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2);
+					DisplayServer::get_singleton()->window_set_ime_position(get_screen_transform().xform(pos), get_viewport()->get_window_id());
 				}
 			}
 		} break;
@@ -1113,11 +1110,8 @@ void LineEdit::_notification(int p_what) {
 
 			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2) + get_global_position();
-				if (get_window()->get_embedder()) {
-					pos += get_viewport()->get_popup_base_transform().get_origin();
-				}
-				DisplayServer::get_singleton()->window_set_ime_position(pos, get_viewport()->get_window_id());
+				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2);
+				DisplayServer::get_singleton()->window_set_ime_position(get_screen_transform().xform(pos), get_viewport()->get_window_id());
 			}
 
 			show_virtual_keyboard();
@@ -1646,9 +1640,9 @@ void LineEdit::clear() {
 void LineEdit::show_virtual_keyboard() {
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 		if (selection.enabled) {
-			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), DisplayServer::VirtualKeyboardType(virtual_keyboard_type), max_length, selection.begin, selection.end);
+			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_screen_rect(), DisplayServer::VirtualKeyboardType(virtual_keyboard_type), max_length, selection.begin, selection.end);
 		} else {
-			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_global_rect(), DisplayServer::VirtualKeyboardType(virtual_keyboard_type), max_length, caret_column);
+			DisplayServer::get_singleton()->virtual_keyboard_show(text, get_screen_rect(), DisplayServer::VirtualKeyboardType(virtual_keyboard_type), max_length, caret_column);
 		}
 	}
 }

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -121,8 +121,8 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 	}
 
 	Rect2 item_rect = _get_menu_item_rect(p_index);
-	Point2 screen_pos = get_screen_position() + item_rect.position * get_viewport()->get_canvas_transform().get_scale();
-	Size2 screen_size = item_rect.size * get_viewport()->get_canvas_transform().get_scale();
+	Point2 screen_pos = get_final_transform().xform(item_rect.position);
+	Size2 screen_size = get_final_transform().basis_xform(item_rect.size);
 
 	active_menu = p_index;
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -85,7 +85,7 @@ void MenuButton::show_popup() {
 	rect.size.height = 0;
 	popup->set_size(rect.size);
 	if (is_layout_rtl()) {
-		rect.position.x += rect.size.width - popup->get_size().width;
+		rect.position.x += (rect.size.width - popup->get_size().width);
 	}
 	popup->set_position(rect.position);
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -229,9 +229,10 @@ Size2 PopupPanel::_get_contents_minimum_size() const {
 }
 
 void PopupPanel::_update_child_rects() {
+	Size2 dlg_size = get_final_transform().affine_inverse().basis_xform(get_size());
+
 	Vector2 cpos(theme_cache.panel_style->get_offset());
-	Vector2 panel_size = Vector2(get_size()) / get_content_scale_factor();
-	Vector2 csize = panel_size - theme_cache.panel_style->get_minimum_size();
+	Vector2 csize(dlg_size - theme_cache.panel_style->get_minimum_size());
 
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
@@ -245,7 +246,7 @@ void PopupPanel::_update_child_rects() {
 
 		if (c == panel) {
 			c->set_position(Vector2());
-			c->set_size(panel_size);
+			c->set_size(dlg_size);
 		} else {
 			c->set_position(cpos);
 			c->set_size(csize);

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -313,17 +313,18 @@ int PopupMenu::_get_items_total_height() const {
 }
 
 int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
-	float win_scale = get_content_scale_factor();
-	if (p_over.x < 0 || p_over.x >= get_size().width * win_scale || p_over.y < theme_cache.panel_style->get_margin(Side::SIDE_TOP) * win_scale) {
+	Size2 dlg_size = get_final_transform().affine_inverse().basis_xform(get_size());
+
+	if (p_over.x < 0 || p_over.x >= dlg_size.width || p_over.y < theme_cache.panel_style->get_margin(Side::SIDE_TOP)) {
 		return -1;
 	}
 
-	Point2 ofs = Point2(0, theme_cache.v_separation * 0.5) * win_scale;
+	Point2 ofs = Point2(0, theme_cache.v_separation * 0.5);
 
 	for (int i = 0; i < items.size(); i++) {
-		ofs.y += i > 0 ? (float)theme_cache.v_separation * win_scale : (float)theme_cache.v_separation * win_scale * 0.5;
-		ofs.y += _get_item_height(i) * win_scale;
-		if (p_over.y - control->get_position().y * win_scale < ofs.y) {
+		ofs.y += i > 0 ? (float)theme_cache.v_separation : (float)theme_cache.v_separation * 0.5;
+		ofs.y += _get_item_height(i);
+		if (p_over.y - control->get_position().y < ofs.y) {
 			return i;
 		}
 	}
@@ -340,18 +341,22 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	Point2 this_pos = get_position();
 	Rect2 this_rect(this_pos, get_size());
 
+	Transform2D xform;
+	Viewport *vp = submenu_popup->get_embedder();
+	if (!vp) {
+		xform = get_final_transform();
+	}
+
 	float scroll_offset = control->get_position().y;
-	float scaled_ofs_cache = items[p_over]._ofs_cache * get_content_scale_factor();
-	float scaled_height_cache = items[p_over]._height_cache * get_content_scale_factor();
 
 	submenu_popup->reset_size(); // Shrink the popup size to its contents.
 	Size2 submenu_size = submenu_popup->get_size();
 
 	Point2 submenu_pos;
 	if (control->is_layout_rtl()) {
-		submenu_pos = this_pos + Point2(-submenu_size.width, scaled_ofs_cache + scroll_offset - theme_cache.v_separation / 2);
+		submenu_pos = this_pos + xform.basis_xform(Point2(0, items[p_over]._ofs_cache + scroll_offset - theme_cache.v_separation / 2)) - Vector2(-submenu_size.width, 0);
 	} else {
-		submenu_pos = this_pos + Point2(this_rect.size.width, scaled_ofs_cache + scroll_offset - theme_cache.v_separation / 2);
+		submenu_pos = this_pos + xform.basis_xform(Point2(0, items[p_over]._ofs_cache + scroll_offset - theme_cache.v_separation / 2)) + Vector2(this_rect.size.width, 0);
 	}
 
 	// Fix pos if going outside parent rect.
@@ -388,9 +393,8 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	// Set autohide areas.
 
 	Rect2 safe_area = this_rect;
-	safe_area.position.y += scaled_ofs_cache + scroll_offset + theme_cache.panel_style->get_offset().height - theme_cache.v_separation / 2;
-	safe_area.size.y = scaled_height_cache + theme_cache.v_separation;
-	Viewport *vp = submenu_popup->get_embedder();
+	safe_area.position.y += xform.basis_xform(Vector2(0, items[p_over]._ofs_cache + scroll_offset + theme_cache.panel_style->get_offset().height - theme_cache.v_separation / 2)).y;
+	safe_area.size.y = xform.basis_xform(Vector2(0, items[p_over]._height_cache + theme_cache.v_separation)).y;
 	if (vp) {
 		vp->subwindow_set_popup_safe_rect(submenu_popup, safe_area);
 	} else {
@@ -400,13 +404,16 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	// Make the position of the parent popup relative to submenu popup.
 	this_rect.position = this_rect.position - submenu_pum->get_position();
 
+	this_rect.position = xform.affine_inverse().basis_xform(this_rect.position); // Convert back to viewport coordinates.
+	this_rect.size = xform.affine_inverse().basis_xform(this_rect.size); // Convert back to viewport coordinates.
+
 	// Autohide area above the submenu item.
 	submenu_pum->clear_autohide_areas();
-	submenu_pum->add_autohide_area(Rect2(this_rect.position.x, this_rect.position.y, this_rect.size.x, scaled_ofs_cache + scroll_offset + theme_cache.panel_style->get_offset().height - theme_cache.v_separation / 2));
+	submenu_pum->add_autohide_area(Rect2(this_rect.position.x, this_rect.position.y, this_rect.size.x, items[p_over]._ofs_cache + scroll_offset + theme_cache.panel_style->get_offset().height - theme_cache.v_separation / 2));
 
 	// If there is an area below the submenu item, add an autohide area there.
-	if (scaled_ofs_cache + scaled_height_cache + scroll_offset <= control->get_size().height) {
-		int from = scaled_ofs_cache + scaled_height_cache + scroll_offset + theme_cache.v_separation / 2 + theme_cache.panel_style->get_offset().height;
+	if (items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset <= control->get_size().height) {
+		int from = items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset + theme_cache.v_separation / 2 + theme_cache.panel_style->get_offset().height;
 		submenu_pum->add_autohide_area(Rect2(this_rect.position.x, this_rect.position.y + from, this_rect.size.x, this_rect.size.y - from));
 	}
 }
@@ -578,7 +585,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 		}
 		item_clickable_area.size.width -= scroll_container->get_v_scroll_bar()->get_size().width;
 	}
-	item_clickable_area.size = item_clickable_area.size * get_content_scale_factor();
+	item_clickable_area.size = item_clickable_area.size;
 
 	Ref<InputEventMouseButton> b = p_event;
 
@@ -1150,11 +1157,10 @@ void PopupMenu::_notification(int p_what) {
 
 			// Only used when using operating system windows.
 			if (!activated_by_keyboard && !is_embedded() && autohide_areas.size()) {
-				Point2 mouse_pos = DisplayServer::get_singleton()->mouse_get_position();
-				mouse_pos -= get_position();
+				Point2 mouse_pos = get_final_transform().affine_inverse().xform(DisplayServer::get_singleton()->mouse_get_position());
 
 				for (const Rect2 &E : autohide_areas) {
-					if (!Rect2(Point2(), get_size()).has_point(mouse_pos) && E.has_point(mouse_pos)) {
+					if (!Rect2(Point2(), get_final_transform().affine_inverse().basis_xform(get_size())).has_point(mouse_pos) && E.has_point(mouse_pos)) {
 						_close_pressed();
 						return;
 					}
@@ -2831,9 +2837,7 @@ void PopupMenu::popup(const Rect2i &p_bounds) {
 		moved = Vector2();
 		popup_time_msec = OS::get_singleton()->get_ticks_msec();
 		if (!is_embedded()) {
-			float win_scale = get_parent_visible_window()->get_content_scale_factor();
-			set_content_scale_factor(win_scale);
-			Size2 minsize = get_contents_minimum_size() * win_scale;
+			Size2 minsize = get_contents_minimum_size();
 			minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
 			set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
 			set_size(Vector2(0, 0)); // Shrinkwraps to min size.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2063,7 +2063,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		if (b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_update_context_menu();
-			menu->set_position(get_screen_position() + b->get_position());
+			menu->set_position(get_final_transform().xform(b->get_position()));
 			menu->reset_size();
 			menu->popup();
 			grab_focus();

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -65,18 +65,20 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 		if (popup) {
 			if (is_layout_rtl() ? pos.x < theme_cache.menu_icon->get_width() : pos.x > size.width - theme_cache.menu_icon->get_width()) {
 				emit_signal(SNAME("pre_popup_pressed"));
+				Size2i scr_size = get_final_transform().basis_xform(Size2i(size.x, content_height));
+				Size2i theme_size = get_final_transform().basis_xform(Size2(0, theme_cache.menu_icon->get_height() / 2.0));
 
 				Vector2 popup_pos = get_screen_position();
 				if (!is_layout_rtl()) {
-					popup_pos.x += size.width - popup->get_size().width;
+					popup_pos.x += scr_size.width - popup->get_size().width;
 				}
 				popup_pos.y += _get_tab_height() / 2.0;
 				if (tabs_position == POSITION_BOTTOM) {
-					popup_pos.y += content_height;
+					popup_pos.y += scr_size.height;
 					popup_pos.y -= popup->get_size().height;
-					popup_pos.y -= theme_cache.menu_icon->get_height() / 2.0;
+					popup_pos.y -= theme_size.y;
 				} else {
-					popup_pos.y += theme_cache.menu_icon->get_height() / 2.0;
+					popup_pos.y += theme_size.y;
 				}
 
 				popup->set_position(popup_pos);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1541,7 +1541,7 @@ void TextEdit::_notification(int p_what) {
 					caret_end = caret_start + post_text.length();
 				}
 
-				DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_global_rect(), DisplayServer::KEYBOARD_TYPE_MULTILINE, -1, caret_start, caret_end);
+				DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_screen_rect(), DisplayServer::KEYBOARD_TYPE_MULTILINE, -1, caret_start, caret_end);
 			}
 		} break;
 
@@ -1866,7 +1866,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				if (context_menu_enabled) {
 					_update_context_menu();
-					menu->set_position(get_screen_position() + mpos);
+					menu->set_position(get_final_transform().xform(mpos));
 					menu->reset_size();
 					menu->popup();
 					grab_focus();
@@ -2169,7 +2169,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (context_menu_enabled) {
 				_update_context_menu();
 				adjust_viewport_to_caret();
-				menu->set_position(get_screen_position() + get_caret_draw_pos());
+				menu->set_position(get_final_transform().xform(get_caret_draw_pos()));
 				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();
@@ -2849,12 +2849,8 @@ void TextEdit::_update_ime_window_position() {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-	Point2 pos = get_global_position() + get_caret_draw_pos();
-	if (get_window()->get_embedder()) {
-		pos += get_viewport()->get_popup_base_transform().get_origin();
-	}
 	// The window will move to the updated position the next time the IME is updated, not immediately.
-	DisplayServer::get_singleton()->window_set_ime_position(pos, get_viewport()->get_window_id());
+	DisplayServer::get_singleton()->window_set_ime_position(get_screen_transform().xform(get_caret_draw_pos()), get_viewport()->get_window_id());
 }
 
 void TextEdit::_update_ime_text() {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3027,9 +3027,9 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 						String s = c.text.get_slicec(',', i);
 						popup_menu->add_item(s.get_slicec(':', 0), s.get_slicec(':', 1).is_empty() ? i : s.get_slicec(':', 1).to_int());
 					}
-
-					popup_menu->set_size(Size2(col_width, 0));
-					popup_menu->set_position(get_screen_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - theme_cache.offset);
+					Rect2i popup_rect = get_final_transform().xform(Rect2i(Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - theme_cache.offset, Size2(col_width, 0)));
+					popup_menu->set_size(popup_rect.size);
+					popup_menu->set_position(popup_rect.position);
 					popup_menu->popup();
 					popup_edited_item = p_item;
 					popup_edited_item_col = col;
@@ -4025,8 +4025,9 @@ bool Tree::edit_selected(bool p_force_edit) {
 			popup_menu->add_item(s2.get_slicec(':', 0), s2.get_slicec(':', 1).is_empty() ? i : s2.get_slicec(':', 1).to_int());
 		}
 
-		popup_menu->set_size(Size2(rect.size.width, 0));
-		popup_menu->set_position(get_screen_position() + rect.position + Point2i(0, rect.size.height));
+		Rect2i popup_rect = get_final_transform().xform(Rect2i(Vector2(rect.position + Point2i(0, rect.size.height)), Size2(rect.size.width, 0)));
+		popup_menu->set_size(popup_rect.size);
+		popup_menu->set_position(popup_rect.position);
 		popup_menu->popup();
 		popup_edited_item = s;
 		popup_edited_item_col = col;
@@ -4039,7 +4040,7 @@ bool Tree::edit_selected(bool p_force_edit) {
 		// "floor()" centers vertically.
 		Vector2 ofs(0, Math::floor((MAX(line_editor->get_minimum_size().height, rect.size.height - value_editor_height) - rect.size.height) / 2));
 
-		popup_rect.position = get_screen_position() + rect.position - ofs;
+		popup_rect.position = (rect.position - ofs);
 		popup_rect.size = rect.size;
 
 		// Account for icon.
@@ -4069,6 +4070,8 @@ bool Tree::edit_selected(bool p_force_edit) {
 			value_editor->hide();
 		}
 
+		popup_rect = get_final_transform().xform(popup_rect);
+
 		popup_editor->set_position(popup_rect.position);
 		popup_editor->set_size(popup_rect.size * popup_scale);
 		if (!popup_editor->is_embedded()) {
@@ -4088,11 +4091,9 @@ bool Tree::edit_selected(bool p_force_edit) {
 		text_editor->select_all();
 		text_editor->show();
 
-		popup_editor->set_position(get_screen_position() + rect.position);
-		popup_editor->set_size(rect.size * popup_scale);
-		if (!popup_editor->is_embedded()) {
-			popup_editor->set_content_scale_factor(popup_scale);
-		}
+		rect = get_final_transform().xform(rect);
+		popup_editor->set_position(rect.position);
+		popup_editor->set_size(rect.size);
 		popup_editor->popup();
 		popup_editor->child_controls_changed();
 
@@ -4377,7 +4378,8 @@ void Tree::_notification(int p_what) {
 			if (popup_edited_item != nullptr) {
 				Rect2 rect = popup_edited_item->get_meta("__focus_rect");
 
-				popup_editor->set_position(get_global_position() + rect.position);
+				rect = get_final_transform().xform(rect);
+				popup_editor->set_position(rect.position);
 				popup_editor->set_size(rect.size);
 				popup_editor->child_controls_changed();
 			}

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input.h"
 #include "core/input/shortcut.h"
 #include "core/os/keyboard.h"
+#include "scene/gui/control.h"
 
 bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) {
 	Ref<InputEventMouseButton> mb = p_event;
@@ -110,7 +111,7 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 	if (mm.is_valid()) {
 		if (is_dragging) {
 			if (p_canvas_rect != Rect2()) {
-				pan_callback.call(Input::get_singleton()->warp_mouse_motion(mm, p_canvas_rect), p_event);
+				pan_callback.call(Input::get_singleton()->warp_mouse_motion(mm, p_canvas_rect, control->get_screen_transform()), p_event);
 			} else {
 				pan_callback.call(mm->get_relative(), p_event);
 			}
@@ -206,10 +207,11 @@ void ViewPanner::set_pan_axis(PanAxis p_pan_axis) {
 	pan_axis = p_pan_axis;
 }
 
-void ViewPanner::setup(ControlScheme p_scheme, Ref<Shortcut> p_shortcut, bool p_simple_panning) {
+void ViewPanner::setup(ControlScheme p_scheme, Control *p_control, Ref<Shortcut> p_shortcut, bool p_simple_panning) {
 	set_control_scheme(p_scheme);
 	set_pan_shortcut(p_shortcut);
 	set_simple_panning_enabled(p_simple_panning);
+	control = p_control;
 }
 
 bool ViewPanner::is_panning() const {

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -35,6 +35,7 @@
 
 class InputEvent;
 class Shortcut;
+class Control;
 
 class ViewPanner : public RefCounted {
 	GDCLASS(ViewPanner, RefCounted);
@@ -69,6 +70,7 @@ private:
 	Callable zoom_callback;
 
 	ControlScheme control_scheme = SCROLL_ZOOMS;
+	Control *control = nullptr;
 
 public:
 	void set_callbacks(Callable p_pan_callback, Callable p_zoom_callback);
@@ -80,7 +82,7 @@ public:
 	void set_scroll_zoom_factor(float p_scroll_zoom_factor);
 	void set_pan_axis(PanAxis p_pan_axis);
 
-	void setup(ControlScheme p_scheme, Ref<Shortcut> p_shortcut, bool p_simple_panning);
+	void setup(ControlScheme p_scheme, Control *p_control, Ref<Shortcut> p_shortcut, bool p_simple_panning);
 
 	bool is_panning() const;
 	void set_force_drag(bool p_force);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -135,9 +135,12 @@ void CanvasItem::_redraw_callback() {
 		return;
 	}
 
-	RenderingServer::get_singleton()->canvas_item_clear(get_canvas_item());
+	RID ci = get_canvas_item();
+	RenderingServer::get_singleton()->canvas_item_clear(ci);
 	//todo updating = true - only allow drawing here
 	if (is_visible_in_tree()) {
+		RenderingServer::get_singleton()->canvas_item_set_oversampling_factor(ci, get_viewport()->get_oversampling_factor());
+
 		drawing = true;
 		current_item_drawn = this;
 		notification(NOTIFICATION_DRAW);
@@ -165,6 +168,12 @@ Transform2D CanvasItem::get_screen_transform() const {
 	ERR_READ_THREAD_GUARD_V(Transform2D());
 	ERR_FAIL_COND_V(!is_inside_tree(), Transform2D());
 	return get_viewport()->get_popup_base_transform() * get_global_transform_with_canvas();
+}
+
+Transform2D CanvasItem::get_final_transform() const {
+	ERR_READ_THREAD_GUARD_V(Transform2D());
+	ERR_FAIL_COND_V(!is_inside_tree(), Transform2D());
+	return get_viewport()->get_final_transform() * get_global_transform_with_canvas();
 }
 
 Transform2D CanvasItem::get_global_transform() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -324,6 +324,7 @@ public:
 	virtual Transform2D get_global_transform() const;
 	virtual Transform2D get_global_transform_with_canvas() const;
 	virtual Transform2D get_screen_transform() const;
+	virtual Transform2D get_final_transform() const;
 
 	CanvasItem *get_top_level() const;
 	_FORCE_INLINE_ RID get_canvas_item() const {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3474,6 +3474,16 @@ Viewport::ScreenSpaceAA Viewport::get_screen_space_aa() const {
 	return screen_space_aa;
 }
 
+void Viewport::set_oversampling_factor(float p_oversampling) {
+	ERR_MAIN_THREAD_GUARD;
+	oversampling_factor = p_oversampling;
+}
+
+float Viewport::get_oversampling_factor() const {
+	ERR_READ_THREAD_GUARD_V(1.f);
+	return oversampling_factor;
+}
+
 void Viewport::set_use_taa(bool p_use_taa) {
 	ERR_MAIN_THREAD_GUARD;
 	if (use_taa == p_use_taa) {
@@ -4662,6 +4672,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_screen_space_aa", "screen_space_aa"), &Viewport::set_screen_space_aa);
 	ClassDB::bind_method(D_METHOD("get_screen_space_aa"), &Viewport::get_screen_space_aa);
 
+	ClassDB::bind_method(D_METHOD("set_oversampling_factor", "oversampling"), &Viewport::set_oversampling_factor);
+	ClassDB::bind_method(D_METHOD("get_oversampling_factor"), &Viewport::get_oversampling_factor);
+
 	ClassDB::bind_method(D_METHOD("set_use_taa", "enable"), &Viewport::set_use_taa);
 	ClassDB::bind_method(D_METHOD("is_using_taa"), &Viewport::is_using_taa);
 
@@ -4823,6 +4836,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mesh_lod_threshold", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_mesh_lod_threshold", "get_mesh_lod_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_draw", PROPERTY_HINT_ENUM, "Disabled,Unshaded,Lighting,Overdraw,Wireframe,Normal Buffer,VoxelGI Albedo,VoxelGI Lighting,VoxelGI Emission,Shadow Atlas,Directional Shadow Map,Scene Luminance,SSAO,SSIL,Directional Shadow Splits,Decal Atlas,SDFGI Cascades,SDFGI Probes,VoxelGI/SDFGI Buffer,Disable Mesh LOD,OmniLight3D Cluster,SpotLight3D Cluster,Decal Cluster,ReflectionProbe Cluster,Occlusion Culling Buffer,Motion Vectors,Internal Buffer"), "set_debug_draw", "get_debug_draw");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hdr_2d"), "set_use_hdr_2d", "is_using_hdr_2d");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "oversampling_factor"), "set_oversampling_factor", "get_oversampling_factor");
 
 #ifndef _3D_DISABLED
 	ADD_GROUP("Scaling 3D", "");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -316,6 +316,8 @@ private:
 
 	uint32_t canvas_cull_mask = 0xffffffff; // by default show everything
 
+	float oversampling_factor = 1.f;
+
 	enum SubWindowDrag {
 		SUB_WINDOW_DRAG_DISABLED,
 		SUB_WINDOW_DRAG_MOVE,
@@ -542,6 +544,9 @@ public:
 
 	void set_screen_space_aa(ScreenSpaceAA p_screen_space_aa);
 	ScreenSpaceAA get_screen_space_aa() const;
+
+	void set_oversampling_factor(float p_oversampling);
+	float get_oversampling_factor() const;
 
 	void set_use_taa(bool p_use_taa);
 	bool is_using_taa() const;

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -124,7 +124,6 @@ private:
 	WindowInitialPosition initial_position = WINDOW_INITIAL_POSITION_ABSOLUTE;
 	bool force_native = false;
 
-	bool use_font_oversampling = false;
 	bool transient = false;
 	bool transient_to_focused = false;
 	bool exclusive = false;
@@ -231,9 +230,12 @@ private:
 	void _update_mouse_over(Vector2 p_pos) override;
 	void _mouse_leave_viewport() override;
 
+	float _get_scale_to_px() const;
+
 	Ref<Shortcut> debugger_stop_shortcut;
 
 	static int root_layout_direction;
+	static bool use_dpi_scaling;
 
 protected:
 	virtual Rect2i _popup_adjust_rect() const { return Rect2i(); }
@@ -267,6 +269,7 @@ public:
 	};
 
 	static void set_root_layout_direction(int p_root_dir);
+	static void set_use_dpi_scaling(bool p_enabled);
 
 	void set_title(const String &p_title);
 	String get_title() const;
@@ -288,8 +291,12 @@ public:
 	Size2i get_size() const;
 	void reset_size();
 
+	Size2i get_size_in_pixels() const;
+
 	Point2i get_position_with_decorations() const;
 	Size2i get_size_with_decorations() const;
+
+	float get_dpi_scale() const;
 
 	void set_max_size(const Size2i &p_max_size);
 	Size2i get_max_size() const;
@@ -360,8 +367,10 @@ public:
 	void set_content_scale_factor(real_t p_factor);
 	real_t get_content_scale_factor() const;
 
-	void set_use_font_oversampling(bool p_oversampling);
-	bool is_using_font_oversampling() const;
+#ifndef DISABLE_DEPRECATED
+	void set_use_font_oversampling(bool p_oversampling){};
+	bool is_using_font_oversampling() const { return true; };
+#endif
 
 	void set_mouse_passthrough_polygon(const Vector<Vector2> &p_region);
 	Vector<Vector2> get_mouse_passthrough_polygon() const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -142,6 +142,7 @@
 #include "scene/resources/style_box_line.h"
 #include "scene/resources/style_box_texture.h"
 #include "scene/resources/surface_tool.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/text_file.h"
 #include "scene/resources/text_line.h"
@@ -492,6 +493,9 @@ void register_scene_types() {
 	int root_dir = GLOBAL_GET("internationalization/rendering/root_node_layout_direction");
 	Control::set_root_layout_direction(root_dir);
 	Window::set_root_layout_direction(root_dir);
+
+	bool dpi_scaling = GLOBAL_GET("gui/common/use_dpi_scaling");
+	Window::set_use_dpi_scaling(dpi_scaling);
 
 	/* REGISTER ANIMATION */
 	GDREGISTER_CLASS(Tween);
@@ -931,6 +935,7 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(Texture3D);
 	GDREGISTER_CLASS(ImageTexture3D);
 	GDREGISTER_CLASS(CompressedTexture3D);
+	GDREGISTER_CLASS(SVGTexture);
 	GDREGISTER_CLASS(Cubemap);
 	GDREGISTER_CLASS(CubemapArray);
 	GDREGISTER_CLASS(Texture2DArray);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -586,7 +586,6 @@ _FORCE_INLINE_ void FontFile::_ensure_rid(int p_cache_index, int p_make_linked_f
 			TS->font_set_allow_system_fallback(cache[p_cache_index], allow_system_fallback);
 			TS->font_set_hinting(cache[p_cache_index], hinting);
 			TS->font_set_subpixel_positioning(cache[p_cache_index], subpixel_positioning);
-			TS->font_set_oversampling(cache[p_cache_index], oversampling);
 		}
 	}
 }
@@ -915,8 +914,10 @@ void FontFile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_subpixel_positioning", "subpixel_positioning"), &FontFile::set_subpixel_positioning);
 	ClassDB::bind_method(D_METHOD("get_subpixel_positioning"), &FontFile::get_subpixel_positioning);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_oversampling", "oversampling"), &FontFile::set_oversampling);
 	ClassDB::bind_method(D_METHOD("get_oversampling"), &FontFile::get_oversampling);
+#endif
 
 	ClassDB::bind_method(D_METHOD("get_cache_count"), &FontFile::get_cache_count);
 	ClassDB::bind_method(D_METHOD("clear_cache"), &FontFile::clear_cache);
@@ -1031,7 +1032,9 @@ void FontFile::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_system_fallback", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_allow_system_fallback", "is_allow_system_fallback");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "force_autohinter", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_force_autohinter", "is_force_autohinter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_STORAGE), "set_hinting", "get_hinting");
+#ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_oversampling", "get_oversampling");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_fixed_size", "get_fixed_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_size_scale_mode", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_fixed_size_scale_mode", "get_fixed_size_scale_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "opentype_feature_overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_opentype_feature_overrides", "get_opentype_feature_overrides");
@@ -1396,7 +1399,6 @@ void FontFile::reset_state() {
 	msdf_size = 128;
 	fixed_size = 0;
 	fixed_size_scale_mode = TextServer::FIXED_SIZE_SCALE_DISABLE;
-	oversampling = 0.f;
 
 	Font::reset_state();
 }
@@ -1430,7 +1432,6 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 	force_autohinter = false;
 	allow_system_fallback = true;
 	hinting = TextServer::HINTING_NONE;
-	oversampling = 1.0f;
 
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_CREATE, vformat("Cannot open font from file: %s.", p_path));
@@ -2274,21 +2275,6 @@ TextServer::SubpixelPositioning FontFile::get_subpixel_positioning() const {
 	return subpixel_positioning;
 }
 
-void FontFile::set_oversampling(real_t p_oversampling) {
-	if (oversampling != p_oversampling) {
-		oversampling = p_oversampling;
-		for (int i = 0; i < cache.size(); i++) {
-			_ensure_rid(i);
-			TS->font_set_oversampling(cache[i], oversampling);
-		}
-		emit_changed();
-	}
-}
-
-real_t FontFile::get_oversampling() const {
-	return oversampling;
-}
-
 RID FontFile::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset) const {
 	// Find existing variation cache.
 	const Dictionary &supported_coords = get_supported_variation_list();
@@ -3072,8 +3058,10 @@ void SystemFont::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_msdf_size", "msdf_size"), &SystemFont::set_msdf_size);
 	ClassDB::bind_method(D_METHOD("get_msdf_size"), &SystemFont::get_msdf_size);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_oversampling", "oversampling"), &SystemFont::set_oversampling);
 	ClassDB::bind_method(D_METHOD("get_oversampling"), &SystemFont::get_oversampling);
+#endif
 
 	ClassDB::bind_method(D_METHOD("get_font_names"), &SystemFont::get_font_names);
 	ClassDB::bind_method(D_METHOD("set_font_names", "names"), &SystemFont::set_font_names);
@@ -3097,7 +3085,9 @@ void SystemFont::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "multichannel_signed_distance_field"), "set_multichannel_signed_distance_field", "is_multichannel_signed_distance_field");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msdf_pixel_range"), "set_msdf_pixel_range", "get_msdf_pixel_range");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msdf_size"), "set_msdf_size", "get_msdf_size");
+#ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), "set_oversampling", "get_oversampling");
+#endif
 }
 
 void SystemFont::_update_rids() const {
@@ -3201,7 +3191,6 @@ void SystemFont::_update_base_font() {
 		file->set_multichannel_signed_distance_field(msdf);
 		file->set_msdf_pixel_range(msdf_pixel_range);
 		file->set_msdf_size(msdf_size);
-		file->set_oversampling(oversampling);
 
 		base_font = file;
 
@@ -3242,7 +3231,6 @@ void SystemFont::reset_state() {
 	allow_system_fallback = true;
 	hinting = TextServer::HINTING_LIGHT;
 	subpixel_positioning = TextServer::SUBPIXEL_POSITIONING_DISABLED;
-	oversampling = 0.f;
 	msdf = false;
 
 	Font::reset_state();
@@ -3435,20 +3423,6 @@ void SystemFont::set_msdf_size(int p_msdf_size) {
 
 int SystemFont::get_msdf_size() const {
 	return msdf_size;
-}
-
-void SystemFont::set_oversampling(real_t p_oversampling) {
-	if (oversampling != p_oversampling) {
-		oversampling = p_oversampling;
-		if (base_font.is_valid()) {
-			base_font->set_oversampling(oversampling);
-		}
-		emit_changed();
-	}
-}
-
-real_t SystemFont::get_oversampling() const {
-	return oversampling;
 }
 
 void SystemFont::set_font_names(const PackedStringArray &p_names) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -197,7 +197,6 @@ class FontFile : public Font {
 	bool allow_system_fallback = true;
 	TextServer::Hinting hinting = TextServer::HINTING_LIGHT;
 	TextServer::SubpixelPositioning subpixel_positioning = TextServer::SUBPIXEL_POSITIONING_AUTO;
-	real_t oversampling = 0.f;
 
 #ifndef DISABLE_DEPRECATED
 	real_t bmp_height = 0.0;
@@ -280,8 +279,10 @@ public:
 	virtual void set_subpixel_positioning(TextServer::SubpixelPositioning p_subpixel);
 	virtual TextServer::SubpixelPositioning get_subpixel_positioning() const;
 
-	virtual void set_oversampling(real_t p_oversampling);
-	virtual real_t get_oversampling() const;
+#ifndef DISABLE_DEPRECATED
+	virtual void set_oversampling(real_t p_oversampling){};
+	virtual real_t get_oversampling() const { return 1.f; };
+#endif
 
 	// Cache.
 	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0) const override;
@@ -480,7 +481,6 @@ class SystemFont : public Font {
 	bool allow_system_fallback = true;
 	TextServer::Hinting hinting = TextServer::HINTING_LIGHT;
 	TextServer::SubpixelPositioning subpixel_positioning = TextServer::SUBPIXEL_POSITIONING_AUTO;
-	real_t oversampling = 0.f;
 	bool msdf = false;
 	int msdf_pixel_range = 16;
 	int msdf_size = 48;
@@ -517,8 +517,10 @@ public:
 	virtual void set_subpixel_positioning(TextServer::SubpixelPositioning p_subpixel);
 	virtual TextServer::SubpixelPositioning get_subpixel_positioning() const;
 
-	virtual void set_oversampling(real_t p_oversampling);
-	virtual real_t get_oversampling() const;
+#ifndef DISABLE_DEPRECATED
+	virtual void set_oversampling(real_t p_oversampling){};
+	virtual real_t get_oversampling() const { return 1.f; };
+#endif
 
 	virtual void set_multichannel_signed_distance_field(bool p_msdf);
 	virtual bool is_multichannel_signed_distance_field() const;

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -44,7 +44,6 @@ class ImageTexture : public Texture2D {
 	bool mipmaps = false;
 	int w = 0;
 	int h = 0;
-	Size2 size_override;
 	mutable Ref<BitMap> alpha_cache;
 	bool image_stored = false;
 

--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -1,0 +1,283 @@
+/**************************************************************************/
+/*  svg_texture.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "svg_texture.h"
+
+#include "core/io/image_loader.h"
+#include "scene/resources/bit_map.h"
+#include "scene/resources/placeholder_textures.h"
+
+#include "modules/modules_enabled.gen.h" // For svg.
+#ifdef MODULE_SVG_ENABLED
+#include "modules/svg/image_loader_svg.h"
+#endif
+
+Ref<SVGTexture> SVGTexture::create_from_string(const String &p_source, float p_scale, float p_saturation, const Dictionary &p_color_map) {
+	Ref<SVGTexture> svg_texture;
+	svg_texture.instantiate();
+	svg_texture->set_source(p_source);
+	svg_texture->set_base_scale(p_scale);
+	svg_texture->set_saturation(p_saturation);
+	svg_texture->set_color_map(p_color_map);
+	return svg_texture;
+}
+
+void SVGTexture::set_source(const String &p_source) {
+	if (source == p_source) {
+		return;
+	}
+	source = p_source;
+	_update_texture();
+}
+
+String SVGTexture::get_source() const {
+	return source;
+}
+
+void SVGTexture::set_base_scale(float p_scale) {
+	if (base_scale == p_scale) {
+		return;
+	}
+	ERR_FAIL_COND(p_scale <= 0.0);
+
+	base_scale = p_scale;
+	_update_texture();
+}
+
+float SVGTexture::get_base_scale() const {
+	return base_scale;
+}
+
+void SVGTexture::set_saturation(float p_saturation) {
+	if (saturation == p_saturation) {
+		return;
+	}
+
+	saturation = p_saturation;
+	_update_texture();
+}
+
+float SVGTexture::get_saturation() const {
+	return saturation;
+}
+
+void SVGTexture::set_color_map(const Dictionary &p_color_map) {
+	if (color_map == p_color_map) {
+		return;
+	}
+	color_map = p_color_map;
+	cmap.clear();
+	for (const Variant *E = color_map.next(); E; E = color_map.next(E)) {
+		cmap[*E] = color_map[*E];
+	}
+	_update_texture();
+}
+
+Dictionary SVGTexture::get_color_map() const {
+	return color_map;
+}
+
+RID SVGTexture::_ensure_scale(float p_scale, bool p_set_size) const {
+	const Ref<TextureCache> *cache_entry = scaled_textures.getptr(p_scale);
+	if (cache_entry && cache_entry->is_valid()) {
+		return (*cache_entry)->scaled_texture;
+	}
+
+	if (source.is_empty()) {
+		return RID();
+	}
+
+	Ref<Image> img = memnew(Image);
+#ifdef MODULE_SVG_ENABLED
+	const bool upsample = !Math::is_equal_approx(Math::round(p_scale), p_scale);
+
+	Error err = ImageLoaderSVG::create_image_from_string(img, source, p_scale, upsample, cmap);
+	ERR_FAIL_COND_V_MSG(err != OK, RID(), "Failed generating icon, unsupported or invalid SVG data in default theme.");
+#else
+	img = Image::create_empty(Math::round(16 * p_scale), Math::round(16 * p_scale), false, Image::FORMAT_RGBA8);
+#endif
+	if (saturation != 1.0) {
+		img->adjust_bcs(1.0, 1.0, saturation);
+	}
+
+	if (p_set_size) {
+		size.x = img->get_width();
+		if (size_override.x != 0) {
+			size.x = size_override.x;
+		}
+		size.y = img->get_height();
+		if (size_override.y != 0) {
+			size.y = size_override.y;
+		}
+	}
+
+	Ref<TextureCache> new_cache_entry;
+	new_cache_entry.instantiate();
+	new_cache_entry->scaled_texture = RenderingServer::get_singleton()->texture_2d_create(img);
+	if (size_override.x != 0 || size_override.y != 0) {
+		RenderingServer::get_singleton()->texture_set_size_override(new_cache_entry->scaled_texture, size.x, size.y);
+	}
+	scaled_textures.insert(p_scale, new_cache_entry);
+
+	return new_cache_entry->scaled_texture;
+}
+
+void SVGTexture::_update_texture() {
+	scaled_textures.clear();
+	alpha_cache.unref();
+	_ensure_scale(base_scale, true);
+
+	emit_changed();
+}
+
+Ref<Image> SVGTexture::get_image() const {
+	RID rid = _ensure_scale(base_scale);
+	if (rid.is_valid()) {
+		return RenderingServer::get_singleton()->texture_2d_get(rid);
+	} else {
+		return Ref<Image>();
+	}
+}
+
+int SVGTexture::get_width() const {
+	return size.x;
+}
+
+int SVGTexture::get_height() const {
+	return size.y;
+}
+
+RID SVGTexture::get_rid() const {
+	return _ensure_scale(base_scale);
+}
+
+RID SVGTexture::get_scaled_rid(float p_scale) const {
+	return _ensure_scale(base_scale * p_scale);
+}
+
+bool SVGTexture::has_alpha() const {
+	return true;
+}
+
+void SVGTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
+	float oversampling = RenderingServer::get_singleton()->canvas_item_get_oversampling_factor(p_canvas_item);
+	RID rid = _ensure_scale(base_scale * oversampling);
+
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, size), rid, false, p_modulate, p_transpose);
+}
+
+void SVGTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {
+	float oversampling = RenderingServer::get_singleton()->canvas_item_get_oversampling_factor(p_canvas_item);
+	RID rid = _ensure_scale(base_scale * oversampling);
+
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, p_rect, rid, p_tile, p_modulate, p_transpose);
+}
+
+void SVGTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) const {
+	float oversampling = RenderingServer::get_singleton()->canvas_item_get_oversampling_factor(p_canvas_item);
+	RID rid = _ensure_scale(base_scale * oversampling);
+
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, rid, Rect2(p_src_rect.position * oversampling, p_src_rect.size * oversampling), p_modulate, p_transpose, p_clip_uv);
+}
+
+bool SVGTexture::is_pixel_opaque(int p_x, int p_y) const {
+	if (!alpha_cache.is_valid()) {
+		Ref<Image> img = get_image();
+		if (img.is_valid()) {
+			alpha_cache.instantiate();
+			alpha_cache->create_from_image_alpha(img);
+		}
+	}
+
+	if (alpha_cache.is_valid()) {
+		int aw = int(alpha_cache->get_size().width);
+		int ah = int(alpha_cache->get_size().height);
+		if (aw == 0 || ah == 0) {
+			return true;
+		}
+
+		int x = p_x * aw / size.x;
+		int y = p_y * ah / size.y;
+
+		x = CLAMP(x, 0, aw);
+		y = CLAMP(y, 0, ah);
+
+		return alpha_cache->get_bit(x, y);
+	}
+
+	return true;
+}
+
+void SVGTexture::set_size_override(const Size2i &p_size) {
+	if (size_override == p_size) {
+		return;
+	}
+	size_override = p_size;
+	if (size_override.x != 0) {
+		size.x = size_override.x;
+	}
+	if (size_override.y != 0) {
+		size.y = size_override.y;
+	}
+	for (LRUCache<float, Ref<TextureCache>>::Iterator E = scaled_textures.begin(); E; ++E) {
+		if (E->second.is_valid()) {
+			RenderingServer::get_singleton()->texture_set_size_override(E->second->scaled_texture, size.x, size.y);
+		}
+	}
+}
+
+void SVGTexture::_bind_methods() {
+	ClassDB::bind_static_method("SVGTexture", D_METHOD("create_from_string", "source", "scale", "saturation", "color_map"), &SVGTexture::create_from_string, DEFVAL(1.0), DEFVAL(1.0), DEFVAL(Dictionary()));
+
+	ClassDB::bind_method(D_METHOD("set_source", "source"), &SVGTexture::set_source);
+	ClassDB::bind_method(D_METHOD("get_source"), &SVGTexture::get_source);
+	ClassDB::bind_method(D_METHOD("set_base_scale", "base_scale"), &SVGTexture::set_base_scale);
+	ClassDB::bind_method(D_METHOD("get_base_scale"), &SVGTexture::get_base_scale);
+	ClassDB::bind_method(D_METHOD("set_saturation", "saturation"), &SVGTexture::set_saturation);
+	ClassDB::bind_method(D_METHOD("get_saturation"), &SVGTexture::get_saturation);
+	ClassDB::bind_method(D_METHOD("set_color_map", "color_map"), &SVGTexture::set_color_map);
+	ClassDB::bind_method(D_METHOD("get_color_map"), &SVGTexture::get_color_map);
+
+	ClassDB::bind_method(D_METHOD("get_scaled_rid", "scale"), &SVGTexture::get_scaled_rid);
+	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &SVGTexture::set_size_override);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source", PROPERTY_HINT_MULTILINE_TEXT), "set_source", "get_source");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.5,10.0,0.01"), "set_base_scale", "get_base_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "saturation", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_saturation", "get_saturation");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "color_map"), "set_color_map", "get_color_map");
+}
+
+SVGTexture::SVGTexture() {
+	scaled_textures.set_capacity(16);
+}
+
+SVGTexture::~SVGTexture() {
+	scaled_textures.clear();
+}

--- a/scene/resources/svg_texture.h
+++ b/scene/resources/svg_texture.h
@@ -1,0 +1,109 @@
+/**************************************************************************/
+/*  svg_texture.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SVG_TEXTURE_H
+#define SVG_TEXTURE_H
+
+#include "core/templates/lru.h"
+#include "scene/resources/texture.h"
+
+class BitMap;
+
+class SVGTexture : public Texture2D {
+	GDCLASS(SVGTexture, Texture2D);
+
+	String source;
+	float base_scale = 1.0;
+	float saturation = 1.0;
+	Dictionary color_map;
+	Size2 size_override;
+
+	class TextureCache : public RefCounted {
+	public:
+		RID scaled_texture;
+
+		TextureCache() {}
+		TextureCache(const RID &p_rid) {
+			scaled_texture = p_rid;
+		}
+		~TextureCache() {
+			if (scaled_texture.is_valid()) {
+				RenderingServer::get_singleton()->free(scaled_texture);
+			}
+		}
+	};
+
+	mutable LRUCache<float, Ref<TextureCache>> scaled_textures;
+	mutable Ref<BitMap> alpha_cache;
+	mutable HashMap<Color, Color> cmap;
+	mutable Size2 size;
+
+	RID _ensure_scale(float p_scale, bool p_set_size = false) const;
+	void _update_texture();
+
+protected:
+	static void _bind_methods();
+
+public:
+	static Ref<SVGTexture> create_from_string(const String &p_source, float p_scale = 1.0, float p_saturation = 1.0, const Dictionary &p_color_map = Dictionary());
+
+	void set_source(const String &p_source);
+	String get_source() const;
+
+	void set_base_scale(float p_scale);
+	float get_base_scale() const;
+
+	void set_color_map(const Dictionary &p_color_map);
+	Dictionary get_color_map() const;
+
+	void set_saturation(float p_saturation);
+	float get_saturation() const;
+
+	Ref<Image> get_image() const override;
+
+	int get_width() const override;
+	int get_height() const override;
+
+	virtual RID get_rid() const override;
+	virtual RID get_scaled_rid(float p_scale) const;
+
+	bool has_alpha() const override;
+	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
+	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
+	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;
+
+	void set_size_override(const Size2i &p_size);
+	bool is_pixel_opaque(int p_x, int p_y) const override;
+
+	SVGTexture();
+	~SVGTexture();
+};
+
+#endif // SVG_TEXTURE_H

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -38,14 +38,12 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 #include "servers/text_server.h"
 
 #include "modules/modules_enabled.gen.h" // For svg.
-#ifdef MODULE_SVG_ENABLED
-#include "modules/svg/image_loader_svg.h"
-#endif
 
 static const int default_font_size = 16;
 
@@ -79,24 +77,12 @@ static Ref<StyleBoxFlat> sb_expand(Ref<StyleBoxFlat> p_sbox, float p_left, float
 }
 
 // See also `editor_generate_icon()` in `editor/themes/editor_icons.cpp`.
-static Ref<ImageTexture> generate_icon(int p_index) {
-	Ref<Image> img = memnew(Image);
-
+static Ref<SVGTexture> generate_icon(int p_index) {
 #ifdef MODULE_SVG_ENABLED
-	// Upsample icon generation only if the scale isn't an integer multiplier.
-	// Generating upsampled icons is slower, and the benefit is hardly visible
-	// with integer scales.
-	const bool upsample = !Math::is_equal_approx(Math::round(scale), scale);
-
-	Error err = ImageLoaderSVG::create_image_from_string(img, default_theme_icons_sources[p_index], scale, upsample, HashMap<Color, Color>());
-	ERR_FAIL_COND_V_MSG(err != OK, Ref<ImageTexture>(), "Failed generating icon, unsupported or invalid SVG data in default theme.");
+	return SVGTexture::create_from_string(default_theme_icons_sources[p_index], scale);
 #else
-	// If the SVG module is disabled, we can't really display the UI well, but at least we won't crash.
-	// 16 pixels is used as it's the most common base size for Godot icons.
-	img = Image::create_empty(Math::round(16 * scale), Math::round(16 * scale), false, Image::FORMAT_RGBA8);
+	return SVGTexture::create_from_string("<svg></svg>", scale);
 #endif
-
-	return ImageTexture::create_from_image(img);
 }
 
 static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -861,12 +861,15 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_display_cutouts"), &DisplayServer::get_display_cutouts);
 	ClassDB::bind_method(D_METHOD("get_display_safe_area"), &DisplayServer::get_display_safe_area);
 
+	ClassDB::bind_method(D_METHOD("get_screen_coordiantes_unit"), &DisplayServer::get_screen_coordiantes_unit);
+
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &DisplayServer::get_screen_count);
 	ClassDB::bind_method(D_METHOD("get_primary_screen"), &DisplayServer::get_primary_screen);
 	ClassDB::bind_method(D_METHOD("get_keyboard_focus_screen"), &DisplayServer::get_keyboard_focus_screen);
 	ClassDB::bind_method(D_METHOD("get_screen_from_rect", "rect"), &DisplayServer::get_screen_from_rect);
 	ClassDB::bind_method(D_METHOD("screen_get_position", "screen"), &DisplayServer::screen_get_position, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_size", "screen"), &DisplayServer::screen_get_size, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_size_in_pixels", "screen"), &DisplayServer::screen_get_size_in_pixels, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_usable_rect", "screen"), &DisplayServer::screen_get_usable_rect, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_dpi", "screen"), &DisplayServer::screen_get_dpi, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_scale", "screen"), &DisplayServer::screen_get_scale, DEFVAL(SCREEN_OF_MAIN_WINDOW));
@@ -902,6 +905,8 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_set_position", "position", "window_id"), &DisplayServer::window_set_position, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_size", "window_id"), &DisplayServer::window_get_size, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_get_scale", "window_id"), &DisplayServer::window_get_scale, DEFVAL(MAIN_WINDOW_ID));
+
 	ClassDB::bind_method(D_METHOD("window_set_size", "size", "window_id"), &DisplayServer::window_set_size, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_rect_changed_callback", "callback", "window_id"), &DisplayServer::window_set_rect_changed_callback, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_window_event_callback", "callback", "window_id"), &DisplayServer::window_set_window_event_callback, DEFVAL(MAIN_WINDOW_ID));
@@ -917,6 +922,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_get_min_size", "window_id"), &DisplayServer::window_get_min_size, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_min_size", "min_size", "window_id"), &DisplayServer::window_set_min_size, DEFVAL(MAIN_WINDOW_ID));
 
+	ClassDB::bind_method(D_METHOD("window_get_size_in_pixels", "window_id"), &DisplayServer::window_get_size_in_pixels, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_size_with_decorations", "window_id"), &DisplayServer::window_get_size_with_decorations, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_mode", "window_id"), &DisplayServer::window_get_mode, DEFVAL(MAIN_WINDOW_ID));
@@ -1023,6 +1029,7 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_HELP);
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_DIALOG_INPUT);
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_DIALOG_FILE);
+	BIND_ENUM_CONSTANT(FEATURE_DPI_SCALING);
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
@@ -1046,6 +1053,9 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(SCREEN_SENSOR_LANDSCAPE);
 	BIND_ENUM_CONSTANT(SCREEN_SENSOR_PORTRAIT);
 	BIND_ENUM_CONSTANT(SCREEN_SENSOR);
+
+	BIND_ENUM_CONSTANT(SCREEN_COORDS_UNIT_DEVICE_PIXEL);
+	BIND_ENUM_CONSTANT(SCREEN_COORDS_UNIT_DPI_ADJUSTED_PIXEL);
 
 	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_DEFAULT);
 	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_MULTILINE);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -142,6 +142,7 @@ public:
 		FEATURE_NATIVE_HELP,
 		FEATURE_NATIVE_DIALOG_INPUT,
 		FEATURE_NATIVE_DIALOG_FILE,
+		FEATURE_DPI_SCALING,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -314,12 +315,19 @@ public:
 		}
 	}
 
+	enum ScreenCoordinatesUnit {
+		SCREEN_COORDS_UNIT_DEVICE_PIXEL,
+		SCREEN_COORDS_UNIT_DPI_ADJUSTED_PIXEL,
+	};
+	virtual ScreenCoordinatesUnit get_screen_coordiantes_unit() const { return SCREEN_COORDS_UNIT_DEVICE_PIXEL; }
+
 	virtual int get_screen_count() const = 0;
 	virtual int get_primary_screen() const = 0;
 	virtual int get_keyboard_focus_screen() const { return get_primary_screen(); }
 	virtual int get_screen_from_rect(const Rect2 &p_rect) const;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
+	virtual Size2i screen_get_size_in_pixels(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return screen_get_size(p_screen); };
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
@@ -444,7 +452,9 @@ public:
 
 	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const = 0;
+	virtual Size2i window_get_size_in_pixels(WindowID p_window = MAIN_WINDOW_ID) const { return window_get_size(p_window); };
 	virtual Size2i window_get_size_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const = 0;
+	virtual float window_get_scale(WindowID p_window = MAIN_WINDOW_ID) const { return screen_get_scale(window_get_current_screen(p_window)); };
 
 	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const = 0;
@@ -594,6 +604,7 @@ VARIANT_ENUM_CAST(DisplayServer::WindowEvent)
 VARIANT_ENUM_CAST(DisplayServer::Feature)
 VARIANT_ENUM_CAST(DisplayServer::MouseMode)
 VARIANT_ENUM_CAST(DisplayServer::ScreenOrientation)
+VARIANT_ENUM_CAST(DisplayServer::ScreenCoordinatesUnit)
 VARIANT_ENUM_CAST(DisplayServer::WindowMode)
 VARIANT_ENUM_CAST(DisplayServer::WindowFlags)
 VARIANT_ENUM_CAST(DisplayServer::HandleType)

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1659,6 +1659,20 @@ void RendererCanvasCull::canvas_item_transform_physics_interpolation(RID p_item,
 	canvas_item->xform_curr = p_transform * canvas_item->xform_curr;
 }
 
+void RendererCanvasCull::canvas_item_set_oversampling_factor(RID p_item, float p_oversampling) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	canvas_item->oversampling_factor = p_oversampling;
+}
+
+float RendererCanvasCull::canvas_item_get_oversampling_factor(RID p_item) const {
+	const Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL_V(canvas_item, 1.f);
+
+	return canvas_item->oversampling_factor;
+}
+
 void RendererCanvasCull::canvas_item_set_canvas_group_mode(RID p_item, RS::CanvasGroupMode p_mode, float p_clear_margin, bool p_fit_empty, float p_fit_margin, bool p_blur_mipmaps) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -55,6 +55,7 @@ public:
 		int ysort_index;
 		int ysort_parent_abs_z_index; // Absolute Z index of parent. Only populated and used when y-sorting.
 		uint32_t visibility_layer = 0xffffffff;
+		float oversampling_factor = 1.f;
 
 		Vector<Item *> child_items;
 
@@ -167,7 +168,7 @@ public:
 	};
 
 	mutable RID_Owner<Canvas, true> canvas_owner;
-	RID_Owner<Item, true> canvas_item_owner;
+	mutable RID_Owner<Item, true> canvas_item_owner;
 	RID_Owner<RendererCanvasRender::Light, true> canvas_light_owner;
 
 	template <typename T>
@@ -274,6 +275,9 @@ public:
 	void canvas_item_set_interpolated(RID p_item, bool p_interpolated);
 	void canvas_item_reset_physics_interpolation(RID p_item);
 	void canvas_item_transform_physics_interpolation(RID p_item, const Transform2D &p_transform);
+
+	void canvas_item_set_oversampling_factor(RID p_item, float p_oversampling);
+	float canvas_item_get_oversampling_factor(RID p_item) const;
 
 	RID canvas_light_allocate();
 	void canvas_light_initialize(RID p_rid);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -921,6 +921,9 @@ public:
 
 	FUNC6(canvas_item_set_canvas_group_mode, RID, CanvasGroupMode, float, bool, float, bool)
 
+	FUNC2(canvas_item_set_oversampling_factor, RID, float)
+	FUNC1RC(float, canvas_item_get_oversampling_factor, RID)
+
 	FUNC1(canvas_item_set_debug_redraw, bool)
 	FUNC0RC(bool, canvas_item_get_debug_redraw)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3261,6 +3261,9 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_rect", "item"), &RenderingServer::debug_canvas_item_get_rect);
 
+	ClassDB::bind_method(D_METHOD("canvas_item_set_oversampling_factor", "item", "oversampling"), &RenderingServer::canvas_item_set_oversampling_factor);
+	ClassDB::bind_method(D_METHOD("canvas_item_get_oversampling_factor", "item"), &RenderingServer::canvas_item_get_oversampling_factor);
+
 	BIND_ENUM_CONSTANT(NINE_PATCH_STRETCH);
 	BIND_ENUM_CONSTANT(NINE_PATCH_TILE);
 	BIND_ENUM_CONSTANT(NINE_PATCH_TILE_FIT);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1515,6 +1515,9 @@ public:
 	virtual void canvas_item_reset_physics_interpolation(RID p_item) = 0;
 	virtual void canvas_item_transform_physics_interpolation(RID p_item, const Transform2D &p_transform) = 0;
 
+	virtual void canvas_item_set_oversampling_factor(RID p_item, float p_oversampling) = 0;
+	virtual float canvas_item_get_oversampling_factor(RID p_item) const = 0;
+
 	/* CANVAS LIGHT */
 	virtual RID canvas_light_create() = 0;
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -128,8 +128,10 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_set_variation_coordinates, "font_rid", "variation_coordinates");
 	GDVIRTUAL_BIND(_font_get_variation_coordinates, "font_rid");
 
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_font_set_oversampling, "font_rid", "oversampling");
 	GDVIRTUAL_BIND(_font_get_oversampling, "font_rid");
+#endif
 
 	GDVIRTUAL_BIND(_font_get_size_cache_list, "font_rid");
 	GDVIRTUAL_BIND(_font_clear_size_cache, "font_rid");
@@ -218,11 +220,16 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_set_opentype_feature_overrides, "font_rid", "overrides");
 	GDVIRTUAL_BIND(_font_get_opentype_feature_overrides, "font_rid");
 
+	GDVIRTUAL_BIND(_font_get_oversampling_cache_capacity);
+	GDVIRTUAL_BIND(_font_set_oversampling_cache_capacity, "oversampling_capacity");
+
 	GDVIRTUAL_BIND(_font_supported_feature_list, "font_rid");
 	GDVIRTUAL_BIND(_font_supported_variation_list, "font_rid");
 
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_font_get_global_oversampling);
 	GDVIRTUAL_BIND(_font_set_global_oversampling, "oversampling");
+#endif
 
 	GDVIRTUAL_BIND(_get_hex_code_box_size, "size", "index");
 	GDVIRTUAL_BIND(_draw_hex_code_box, "canvas", "size", "pos", "index", "color");
@@ -689,15 +696,17 @@ Dictionary TextServerExtension::font_get_variation_coordinates(const RID &p_font
 	return ret;
 }
 
+#ifndef DISABLE_DEPRECATED
 void TextServerExtension::font_set_oversampling(const RID &p_font_rid, double p_oversampling) {
 	GDVIRTUAL_CALL(_font_set_oversampling, p_font_rid, p_oversampling);
 }
 
 double TextServerExtension::font_get_oversampling(const RID &p_font_rid) const {
-	double ret = 0;
+	double ret = 1.f;
 	GDVIRTUAL_CALL(_font_get_oversampling, p_font_rid, ret);
 	return ret;
 }
+#endif
 
 TypedArray<Vector2i> TextServerExtension::font_get_size_cache_list(const RID &p_font_rid) const {
 	TypedArray<Vector2i> ret;
@@ -1005,6 +1014,16 @@ Dictionary TextServerExtension::font_get_opentype_feature_overrides(const RID &p
 	return ret;
 }
 
+int TextServerExtension::font_get_oversampling_cache_capacity() const {
+	int ret = 16;
+	GDVIRTUAL_CALL(_font_get_oversampling_cache_capacity, ret);
+	return ret;
+}
+
+void TextServerExtension::font_set_oversampling_cache_capacity(int p_oversampling_capacity) {
+	GDVIRTUAL_CALL(_font_set_oversampling_cache_capacity, p_oversampling_capacity);
+}
+
 Dictionary TextServerExtension::font_supported_feature_list(const RID &p_font_rid) const {
 	Dictionary ret;
 	GDVIRTUAL_CALL(_font_supported_feature_list, p_font_rid, ret);
@@ -1017,6 +1036,7 @@ Dictionary TextServerExtension::font_supported_variation_list(const RID &p_font_
 	return ret;
 }
 
+#ifndef DISABLE_DEPRECATED
 double TextServerExtension::font_get_global_oversampling() const {
 	double ret = 0;
 	GDVIRTUAL_CALL(_font_get_global_oversampling, ret);
@@ -1026,6 +1046,7 @@ double TextServerExtension::font_get_global_oversampling() const {
 void TextServerExtension::font_set_global_oversampling(double p_oversampling) {
 	GDVIRTUAL_CALL(_font_set_global_oversampling, p_oversampling);
 }
+#endif
 
 Vector2 TextServerExtension::get_hex_code_box_size(int64_t p_size, int64_t p_index) const {
 	Vector2 ret;

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -208,10 +208,12 @@ public:
 	GDVIRTUAL2(_font_set_variation_coordinates, RID, Dictionary);
 	GDVIRTUAL1RC(Dictionary, _font_get_variation_coordinates, RID);
 
+#ifndef DISABLE_DEPRECATED
 	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling) override;
 	virtual double font_get_oversampling(const RID &p_font_rid) const override;
 	GDVIRTUAL2(_font_set_oversampling, RID, double);
 	GDVIRTUAL1RC(double, _font_get_oversampling, RID);
+#endif
 
 	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override;
 	virtual void font_clear_size_cache(const RID &p_font_rid) override;
@@ -363,15 +365,22 @@ public:
 	GDVIRTUAL2(_font_set_opentype_feature_overrides, RID, const Dictionary &);
 	GDVIRTUAL1RC(Dictionary, _font_get_opentype_feature_overrides, RID);
 
+	virtual int font_get_oversampling_cache_capacity() const override;
+	virtual void font_set_oversampling_cache_capacity(int p_oversampling_capacity) override;
+	GDVIRTUAL0RC(int, _font_get_oversampling_cache_capacity);
+	GDVIRTUAL1(_font_set_oversampling_cache_capacity, int);
+
 	virtual Dictionary font_supported_feature_list(const RID &p_font_rid) const override;
 	virtual Dictionary font_supported_variation_list(const RID &p_font_rid) const override;
 	GDVIRTUAL1RC(Dictionary, _font_supported_feature_list, RID);
 	GDVIRTUAL1RC(Dictionary, _font_supported_variation_list, RID);
 
+#ifndef DISABLE_DEPRECATED
 	virtual double font_get_global_oversampling() const override;
 	virtual void font_set_global_oversampling(double p_oversampling) override;
 	GDVIRTUAL0RC(double, _font_get_global_oversampling);
 	GDVIRTUAL1(_font_set_global_oversampling, double);
+#endif
 
 	virtual Vector2 get_hex_code_box_size(int64_t p_size, int64_t p_index) const override;
 	virtual void draw_hex_code_box(const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -284,8 +284,10 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("font_set_variation_coordinates", "font_rid", "variation_coordinates"), &TextServer::font_set_variation_coordinates);
 	ClassDB::bind_method(D_METHOD("font_get_variation_coordinates", "font_rid"), &TextServer::font_get_variation_coordinates);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("font_set_oversampling", "font_rid", "oversampling"), &TextServer::font_set_oversampling);
 	ClassDB::bind_method(D_METHOD("font_get_oversampling", "font_rid"), &TextServer::font_get_oversampling);
+#endif
 
 	ClassDB::bind_method(D_METHOD("font_get_size_cache_list", "font_rid"), &TextServer::font_get_size_cache_list);
 	ClassDB::bind_method(D_METHOD("font_clear_size_cache", "font_rid"), &TextServer::font_clear_size_cache);
@@ -374,11 +376,16 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("font_set_opentype_feature_overrides", "font_rid", "overrides"), &TextServer::font_set_opentype_feature_overrides);
 	ClassDB::bind_method(D_METHOD("font_get_opentype_feature_overrides", "font_rid"), &TextServer::font_get_opentype_feature_overrides);
 
+	ClassDB::bind_method(D_METHOD("font_get_oversampling_cache_capacity"), &TextServer::font_get_oversampling_cache_capacity);
+	ClassDB::bind_method(D_METHOD("font_set_oversampling_cache_capacity", "oversampling_capacity"), &TextServer::font_set_oversampling_cache_capacity);
+
 	ClassDB::bind_method(D_METHOD("font_supported_feature_list", "font_rid"), &TextServer::font_supported_feature_list);
 	ClassDB::bind_method(D_METHOD("font_supported_variation_list", "font_rid"), &TextServer::font_supported_variation_list);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("font_get_global_oversampling"), &TextServer::font_get_global_oversampling);
 	ClassDB::bind_method(D_METHOD("font_set_global_oversampling", "oversampling"), &TextServer::font_set_global_oversampling);
+#endif
 
 	ClassDB::bind_method(D_METHOD("get_hex_code_box_size", "size", "index"), &TextServer::get_hex_code_box_size);
 	ClassDB::bind_method(D_METHOD("draw_hex_code_box", "canvas", "size", "pos", "index", "color"), &TextServer::draw_hex_code_box);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -329,8 +329,10 @@ public:
 	virtual void font_set_variation_coordinates(const RID &p_font_rid, const Dictionary &p_variation_coordinates) = 0;
 	virtual Dictionary font_get_variation_coordinates(const RID &p_font_rid) const = 0;
 
-	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling) = 0;
-	virtual double font_get_oversampling(const RID &p_font_rid) const = 0;
+#ifndef DISABLE_DEPRECATED
+	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling){};
+	virtual double font_get_oversampling(const RID &p_font_rid) const { return 1.f; };
+#endif
 
 	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const = 0;
 	virtual void font_clear_size_cache(const RID &p_font_rid) = 0;
@@ -418,11 +420,16 @@ public:
 	virtual void font_set_opentype_feature_overrides(const RID &p_font_rid, const Dictionary &p_overrides) = 0;
 	virtual Dictionary font_get_opentype_feature_overrides(const RID &p_font_rid) const = 0;
 
+	virtual int font_get_oversampling_cache_capacity() const = 0;
+	virtual void font_set_oversampling_cache_capacity(int p_oversampling_capacity) = 0;
+
 	virtual Dictionary font_supported_feature_list(const RID &p_font_rid) const = 0;
 	virtual Dictionary font_supported_variation_list(const RID &p_font_rid) const = 0;
 
-	virtual double font_get_global_oversampling() const = 0;
-	virtual void font_set_global_oversampling(double p_oversampling) = 0;
+#ifndef DISABLE_DEPRECATED
+	virtual double font_get_global_oversampling() const { return 1.f; };
+	virtual void font_set_global_oversampling(double p_oversampling){};
+#endif
 
 	virtual Vector2 get_hex_code_box_size(int64_t p_size, int64_t p_index) const;
 	virtual void draw_hex_code_box(const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const;


### PR DESCRIPTION
- Removes global oversampling in favor of per-viewport oversampling to allow different windows to use different oversampling factor.
- Implement scalable SVG texture (affected by oversampling factor). Use it for theme element and editor icons.
- Add support for DPI scaling on macOS and Windows (instead of down scaling for the max DPI screen, content is always rendered at native resolution on all screens).

TODO:
- [x] LRU for auto-scaled textures.
- [ ] Fix all window/screen coordinate usage.
- [ ] Match scale for embedded windows.
- [x] Update docs.