### PR TITLE
Fix Volumetric Fog VoxelGI updates

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -931,9 +931,10 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 			uniforms.push_back(u);
 		}
 
-		if (fog->copy_uniform_set.is_null()) {
-			fog->copy_uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY), 0);
+		if (fog->copy_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(fog->copy_uniform_set)) {
+			RD::get_singleton()->free(fog->copy_uniform_set);
 		}
+		fog->copy_uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY), 0);
 
 		if (!gi_dependent_sets_valid) {
 			fog->gi_dependent_sets.process_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG), 0);

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3725,6 +3725,12 @@ void GI::setup_voxel_gi_instances(RenderDataRD *p_render_data, Ref<RenderSceneBu
 			}
 			rbgi->uniform_set[v] = RID();
 		}
+
+		if (p_render_buffers->has_custom_data(RB_SCOPE_FOG)) {
+			// VoxelGI instances have changed, so we need to update volumetric fog.
+			Ref<RendererRD::Fog::VolumetricFog> fog = p_render_buffers->get_custom_data(RB_SCOPE_FOG);
+			fog->sync_gi_dependent_sets_validity(true);
+		}
 	}
 
 	if (p_voxel_gi_instances.size() > 0) {


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/85765

The problem was that when VoxelGI volumes became visible in the camera or leave it, the active VoxelGI culling results were not updated to volumetric fog uniform sets. The updates only happened when toggling the enviroment off and on or resizing the windows, which forces a full update. More specifically, this volumetric fog uniform update code needs to be re-run every time when VoxelGI culling results change:

https://github.com/godotengine/godot/blob/b94eb58d35b3dd8a9f522bc90df0db73862ef326/servers/rendering/renderer_rd/environment/fog.cpp#L857-L864

There are few similar volumetric fog update issues that I think might be caused by similar missing uniform (or some other) update, for example https://github.com/godotengine/godot/issues/83990 (the same workaround also works there, turning environment off and on or resizing the window).

The Volumetric Fog and VoxelGI interactions and uniform set handling received some work in https://github.com/godotengine/godot/pull/76437, https://github.com/godotengine/godot/pull/76550 and https://github.com/godotengine/godot/pull/77703, so it could be useful to get some feedback from @RandomShaper here. There might be a more elegant or efficient way to implement the update notifying logic, especially if there are other cases like https://github.com/godotengine/godot/issues/83990 that need to be also handled in the future, but this should fix the immediate problem.