### PR TITLE
Remove dead code from `DisplayServerWindows::window_set_size`

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1832,24 +1832,6 @@ void DisplayServerWindows::window_set_size(const Size2i p_size, WindowID p_windo
 
 	int w = p_size.width;
 	int h = p_size.height;
-
-	wd.width = w;
-	wd.height = h;
-
-#if defined(RD_ENABLED)
-	if (rendering_context) {
-		rendering_context->window_set_size(p_window, w, h);
-	}
-#endif
-#if defined(GLES3_ENABLED)
-	if (gl_manager_native) {
-		gl_manager_native->window_resize(p_window, w, h);
-	}
-	if (gl_manager_angle) {
-		gl_manager_angle->window_resize(p_window, w, h);
-	}
-#endif
-
 	RECT rect;
 	GetWindowRect(wd.hWnd, &rect);
 
@@ -4639,6 +4621,14 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				if (rendering_context && window.context_created) {
 					// Note: Trigger resize event to update swapchains when window is minimized/restored, even if size is not changed.
 					rendering_context->window_set_size(window_id, window.width, window.height);
+				}
+#endif
+#if defined(GLES3_ENABLED)
+				if (gl_manager_native) {
+					gl_manager_native->window_resize(window_id, window.width, window.height);
+				}
+				if (gl_manager_angle) {
+					gl_manager_angle->window_resize(window_id, window.width, window.height);
 				}
 #endif
 			}


### PR DESCRIPTION
The removed code will in fact just recreate the swapchain with the same parameters it is already created with. While
`context_vulkan->window_resize(p_window, w, h);` is called with the updated parameters, https://github.com/godotengine/godot/blob/a9f444bbc307004c022e85e1b31fcfbd2e73566d/drivers/vulkan/vulkan_context.cpp#L1981 will reset it to the current window size since the window has not yet been resized.

Also `MoveWindow` is a synchronous call, meaning this line here will be executed before the function returns https://github.com/godotengine/godot/blob/a9f444bbc307004c022e85e1b31fcfbd2e73566d/platform/windows/display_server_windows.cpp#L3773

> MoveWindow sends the [WM_WINDOWPOSCHANGING](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-windowposchanging), [WM_WINDOWPOSCHANGED](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-windowposchanged), [WM_MOVE](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-move), [WM_SIZE](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-size), and [WM_NCCALCSIZE](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-nccalcsize) messages to the window.

So currently calling `window_set_size` will recreate the swapchain twice.