### PR TITLE
Set what were default values for Web platform linker flags `-sSTACK_SIZE` and `-sDEFAULT_PTHREAD_STACK_SIZE`

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -186,8 +186,17 @@ def configure(env: "Environment"):
     env["LIBPREFIXES"] = ["$LIBPREFIX"]
     env["LIBSUFFIXES"] = ["$LIBSUFFIX"]
 
+    # Get version info for checks below.
+    cc_version = get_compiler_version(env)
+    cc_semver = (cc_version["major"], cc_version["minor"], cc_version["patch"])
+
     env.Prepend(CPPPATH=["#platform/web"])
     env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])
+
+    if cc_semver >= (3, 1, 25):
+        env.Append(LINKFLAGS=["-s", "STACK_SIZE=5MB"])
+    else:
+        env.Append(LINKFLAGS=["-s", "TOTAL_STACK=5MB"])
 
     if env["opengl3"]:
         env.AppendUnique(CPPDEFINES=["GLES3_ENABLED"])
@@ -203,12 +212,9 @@ def configure(env: "Environment"):
     env.Append(CPPDEFINES=["PTHREAD_NO_RENAME"])
     env.Append(CCFLAGS=["-s", "USE_PTHREADS=1"])
     env.Append(LINKFLAGS=["-s", "USE_PTHREADS=1"])
+    env.Append(LINKFLAGS=["-s", "DEFAULT_PTHREAD_STACK_SIZE=2MB"])
     env.Append(LINKFLAGS=["-s", "PTHREAD_POOL_SIZE=8"])
     env.Append(LINKFLAGS=["-s", "WASM_MEM_MAX=2048MB"])
-
-    # Get version info for checks below.
-    cc_version = get_compiler_version(env)
-    cc_semver = (cc_version["major"], cc_version["minor"], cc_version["patch"])
 
     if env["lto"] != "none":
         # Workaround https://github.com/emscripten-core/emscripten/issues/19781.


### PR DESCRIPTION
Emscripten did some changes regarding some linkerflags.
- they updated `-sSTACK_SIZE` from 5MB to 64KB and `-sDEFAULT_PTHREAD_STACK_SIZE` from 2MB to 64KB on [3.1.27](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3127---112922).
- they updated `-sDEFAULT_PTHREAD_STACK_SIZE` to match `-sSTACK_SIZE` on [3.1.30](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3130---011123).

This PR sets back both linkerflags to their original value for now on.

Fixes #85564