### PR TITLE
[3.x] Workaround GCC warning in `rasterizer_canvas_batcher`

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -682,7 +682,7 @@ public:
 
 			// this should always succeed after growing
 			batch = bdata.batches.request();
-			RAST_DEBUG_ASSERT(batch);
+			CRASH_COND_MSG(!batch, "Out of memory");
 		}
 
 		if (p_blank) {


### PR DESCRIPTION
`-Werror=array-bounds` flags when creating a new batch, possibly due to the possibility of the malloc failing (out of memory).
This PR adds an explicit `CRASHNOW` in the hope the compiler will recognise this case is not intended to be recoverable.

## Notes
* In Godot we don't (by choice) deal with the situation where heap allocations fail. This is notoriously difficult to recover from in any sensible fashion, and most game software doesn't bother.
* Unfortunately some versions of GCC (specifically 13.2) `Werror=array-bounds` seems to flag on some methods we use to deal with allocation failure. I'm not clear on whether it is choking on the possibility of malloc returning NULL, or inability to see inside the `grow` clauses. 
* Installing from source latest versions of GCC is a pain so I'm attempting to guess what is triggering the warning and see if @akien-mga can test. This may or may not fix the warning. :grin: 
* `LocalVector` should be susceptible to the same warning but does not flag, which is interesting. It calls `CRASH_NOW` in the case of allocation failure, so I'm attempting to just do the same here in the hopes the compiler can understand this pattern and prevent the warning. Previously the batcher would assert only in `DEV` builds, release builds would have crashed (without message). This is a hot path, but hopefully the grow branch is less hot so an if check should be okay.
* This is very similar case to #66252 `Werror=array-bounds` again has problems dealing with code 
See specifically https://github.com/godotengine/godot/issues/66252#issuecomment-1255149471 and #66260 .

## Discussion
If this doesn't cure the warning then maybe we need some `if` `else` clauses to guide the compiler warning logic, or alternatively turn off the warning locally. The code looks to be fine (unless I'm missing something obvious), so the problem seems to be the false warning. Google suggests this is one of a few warnings that are notorious for false flags.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
