### PR TITLE
Add type when converting a PackedArray to Array with constructor

### DIFF
--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -202,15 +202,15 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructNoArgs<Array>>(sarray());
 	add_constructor<VariantConstructor<Array, Array>>(sarray("from"));
 	add_constructor<VariantConstructorTypedArray>(sarray("base", "type", "class_name", "script"));
-	add_constructor<VariantConstructorToArray<PackedByteArray>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedInt32Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedInt64Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedFloat32Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedFloat64Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedStringArray>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedVector2Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedVector3Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedColorArray>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedByteArray, Variant::INT>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedInt32Array, Variant::INT>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedInt64Array, Variant::INT>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedFloat32Array, Variant::FLOAT>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedFloat64Array, Variant::FLOAT>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedStringArray, Variant::STRING>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedVector2Array, Variant::VECTOR2>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedVector3Array, Variant::VECTOR3>>(sarray("from"));
+	add_constructor<VariantConstructorToTypedArray<PackedColorArray, Variant::COLOR>>(sarray("from"));
 
 	add_constructor<VariantConstructNoArgs<PackedByteArray>>(sarray());
 	add_constructor<VariantConstructor<PackedByteArray, PackedByteArray>>(sarray("from"));

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -470,8 +470,8 @@ public:
 	}
 };
 
-template <class T>
-class VariantConstructorToArray {
+template <class T, Variant::Type ValueType>
+class VariantConstructorToTypedArray {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
 		if (p_args[0]->get_type() != GetTypeInfo<T>::VARIANT_TYPE) {
@@ -483,9 +483,10 @@ public:
 
 		r_ret = Array();
 		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(&r_ret);
+		dst_arr.set_typed(ValueType, StringName(), Variant());
 		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
 
-		int size = src_arr.size();
+		const int size = src_arr.size();
 		dst_arr.resize(size);
 		for (int i = 0; i < size; i++) {
 			dst_arr[i] = src_arr[i];
@@ -495,9 +496,10 @@ public:
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
 		*r_ret = Array();
 		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(r_ret);
+		dst_arr.set_typed(ValueType, StringName(), Variant());
 		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
 
-		int size = src_arr.size();
+		const int size = src_arr.size();
 		dst_arr.resize(size);
 		for (int i = 0; i < size; i++) {
 			dst_arr[i] = src_arr[i];
@@ -505,9 +507,10 @@ public:
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		Array dst_arr;
-		T src_arr = PtrToArg<T>::convert(p_args[0]);
+		dst_arr.set_typed(ValueType, StringName(), Variant());
+		const T src_arr = PtrToArg<T>::convert(p_args[0]);
 
-		int size = src_arr.size();
+		const int size = src_arr.size();
 		dst_arr.resize(size);
 		for (int i = 0; i < size; i++) {
 			dst_arr[i] = src_arr[i];

--- a/modules/gdscript/tests/scripts/runtime/features/packed_to_typed_array.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/packed_to_typed_array.gd
@@ -1,0 +1,25 @@
+func test():
+	test_typed_array()
+	test_array()
+
+func test_typed_array():
+	var _bytes : Array[int] = Array(PackedByteArray())
+	var _i32s : Array[int] = Array(PackedInt32Array())
+	var _i64s : Array[int] = Array(PackedInt64Array())
+	var _f32s : Array[float] = Array(PackedFloat32Array())
+	var _f64s : Array[float] = Array(PackedFloat64Array())
+	var _strings : Array[String] = Array(PackedStringArray())
+	var _vec2s : Array[Vector2] = Array(PackedVector2Array())
+	var _vec3s : Array[Vector3] = Array(PackedVector3Array())
+	var _colors : Array[Color] = Array(PackedColorArray())
+
+func test_array():
+	var _bytes : Array = Array(PackedByteArray())
+	var _i32s : Array = Array(PackedInt32Array())
+	var _i64s : Array = Array(PackedInt64Array())
+	var _f32s : Array = Array(PackedFloat32Array())
+	var _f64s : Array = Array(PackedFloat64Array())
+	var _strings : Array = Array(PackedStringArray())
+	var _vec2s : Array = Array(PackedVector2Array())
+	var _vec3s : Array = Array(PackedVector3Array())
+	var _colors : Array = Array(PackedColorArray())

--- a/modules/gdscript/tests/scripts/runtime/features/packed_to_typed_array.out
+++ b/modules/gdscript/tests/scripts/runtime/features/packed_to_typed_array.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Converting `PackedArray` to `Array` doesn't have any type information. This PR enhances the `Array` constructor to call `set_typed` depending on the `PackedArray` that is supplied.

This is useful because some API will return `PackedArray` such a `String::split()` but it is useful to convert to an `Array` to do further processing with `map`, `reduce`, `filter`.