### PR TITLE
Improve BaseMaterial3D refraction quality by using bicubic filtering

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1211,6 +1211,70 @@ uniform vec3 uv2_offset;
 		code += "uniform float fov_override : hint_range(1.0, 179.0, 0.1);\n";
 	}
 
+	if (features[FEATURE_REFRACTION]) {
+		code += R"(
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+float w0(float a) {
+	return (1.0f / 6.0f) * (a * (a * (-a + 3.0f) - 3.0f) + 1.0f);
+}
+
+float w1(float a) {
+	return (1.0f / 6.0f) * (a * a * (3.0f * a - 6.0f) + 4.0f);
+}
+
+float w2(float a) {
+	return (1.0f / 6.0f) * (a * (a * (-3.0f * a + 3.0f) + 3.0f) + 1.0f);
+}
+
+float w3(float a) {
+	return (1.0f / 6.0f) * (a * a * a);
+}
+
+// g0 and g1 are the two amplitude functions
+float g0(float a) {
+	return w0(a) + w1(a);
+}
+
+float g1(float a) {
+	return w2(a) + w3(a);
+}
+
+// h0 and h1 are the two offset functions
+float h0(float a) {
+	return -1.0f + w1(a) / (w0(a) + w1(a));
+}
+
+float h1(float a) {
+	return 1.0f + w3(a) / (w2(a) + w3(a));
+}
+
+vec4 texture2D_bicubic(sampler2D tex, vec2 uv, int p_lod, ivec2 tex_size) {
+	vec2 tex_size_lod = vec2(tex_size >> p_lod);
+	vec2 pixel_size = vec2(1.0f) / tex_size_lod;
+
+	uv = uv * tex_size_lod + vec2(0.5f);
+
+	vec2 iuv = floor(uv);
+	vec2 fuv = fract(uv);
+
+	float g0x = g0(fuv.x);
+	float g1x = g1(fuv.x);
+	float h0x = h0(fuv.x);
+	float h1x = h1(fuv.x);
+	float h0y = h0(fuv.y);
+	float h1y = h1(fuv.y);
+
+	vec2 p0 = (vec2(iuv.x + h0x, iuv.y + h0y) - vec2(0.5f)) * pixel_size;
+	vec2 p1 = (vec2(iuv.x + h1x, iuv.y + h0y) - vec2(0.5f)) * pixel_size;
+	vec2 p2 = (vec2(iuv.x + h0x, iuv.y + h1y) - vec2(0.5f)) * pixel_size;
+	vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - vec2(0.5f)) * pixel_size;
+
+	return (g0(fuv.y) * (g0x * textureLod(tex, p0, float(p_lod)) + g1x * textureLod(tex, p1, float(p_lod)))) +
+		   (g1(fuv.y) * (g0x * textureLod(tex, p2, float(p_lod)) + g1x * textureLod(tex, p3, float(p_lod))));
+}
+)";
+	}
+
 	// Generate vertex shader.
 	code += R"(
 void vertex() {)";
@@ -1819,7 +1883,22 @@ void fragment() {)";
 
 	// If the depth buffer is lower then the model's Z position, use the refracted UV, otherwise use the normal screen UV.
 	// At low depth differences, decrease refraction intensity to avoid sudden discontinuities.
-	EMISSION += textureLod(screen_texture, mix(SCREEN_UV, ref_ofs, smoothstep(0.0, 1.0, VERTEX.z - refraction_view_pos.z)), ROUGHNESS * 8.0).rgb * ref_amount * EXPOSURE;
+	// Also make use of bicubic filtering to reduce aliasing in motion.
+	vec3 lod_lower = texture2D_bicubic(
+			screen_texture,
+			mix(SCREEN_UV, ref_ofs, smoothstep(0.0, 1.0, VERTEX.z - refraction_view_pos.z)),
+			int(ROUGHNESS * 8.0),
+			textureSize(screen_texture, 0)
+	).rgb * ref_amount * EXPOSURE;
+
+	vec3 lod_higher = texture2D_bicubic(
+			screen_texture,
+			mix(SCREEN_UV, ref_ofs, smoothstep(0.0, 1.0, VERTEX.z - refraction_view_pos.z)),
+			int(ROUGHNESS * 8.0) + 1,
+			textureSize(screen_texture, 0)
+	).rgb * ref_amount * EXPOSURE;
+
+	EMISSION += mix(lod_lower, lod_higher, fract(ROUGHNESS * 8.0)) * ref_amount * EXPOSURE;
 	ALBEDO *= 1.0 - ref_amount;
 	// Force transparency on the material (required for refraction).
 	ALPHA = 1.0;


### PR DESCRIPTION
Performance cost varies depending on how much of the viewport is covered by the refractive material. This has a moderate performance impact if the refractive material covers the whole viewport[^1], but the performance cost is low in most other situations.

[^1]: Roughly 0.1 ms of GPU time in 4K on a GeForce RTX 4090.

This intends to support all renderers, but it looks broken in Compatibility (it's too dark and squares appear in the refraction):

![Screenshot_20251117_184819](https://github.com/user-attachments/assets/491a7b17-9b68-4298-9ce6-663906931088)

- This closes https://github.com/godotengine/godot-proposals/issues/3231.

**Testing project:** [test_refraction.zip](https://github.com/godotengine/godot/files/13641567/test_refraction.zip)

## Preview

*Click to view at full size.*

### Forward+

Before | After
-|-
![Screenshot_20231211_225217](https://github.com/godotengine/godot/assets/180032/7399be94-3e5f-46fd-bacd-d106e838790e) | ![Screenshot_20231211_225155](https://github.com/godotengine/godot/assets/180032/e5e68ceb-c9d6-4d39-b4cb-abdf1f826fa3)

### Mobile

*[Mipmap generation or reading is broken in `master`](https://github.com/godotengine/godot/issues/88585), but you can notice the effect working. There's however some darkening that doesn't occur in `master` (I don't know why). It isn't affected by the albedo color.*

Before | After
-|-
![Screenshot_20231211_230824](https://github.com/godotengine/godot/assets/180032/4f80643f-2c2e-4cb7-8694-3088375cff13) | ![Screenshot_20231211_230815](https://github.com/godotengine/godot/assets/180032/1ea7dbdc-775d-4622-a2e7-871175c66dae)

### Forward+ video

*Recorded using Movie Maker mode.
Look at the refractive spheres in the foreground.*

**Left:** before, **Right:** after

https://github.com/godotengine/godot/assets/180032/07194049-f38a-4970-953b-64fd73c8fb76

Something I noticed is that the refraction looks less aliased in Mobile compared to Forward+, but I don't know why:

https://github.com/user-attachments/assets/ab2ab408-50a1-4157-b44b-bc85e0a82d1c

https://github.com/user-attachments/assets/948c3772-f57c-44f7-9cb5-7e3c30dddcf0

## TODO

- [x] Fix Compatibility rendering method having darkened refractive materials and squares in the refraction.
- [ ] Fix Forward+ having squares in the refraction when TAA or FSR2 is enabled. It gets worse when **Scaling 3D Scale** is set below `1.0` when using FSR2, although the issue also occurs in `master` ([refraction isn't visible at all in this case](https://github.com/godotengine/godot/issues/112885)).
- [ ] Figure out why refraction looks better in Mobile compared to Forward+.
- [ ] Fix rendering issues when Texture Mipmap Bias is changed by the user or engine (e.g. when TAA, 3D scaling or FSR2 is enabled).
  - This issue also affects `master` by biasing `SCREEN_TEXTURE` readings, but it doesn't look as bad there.
- [x] Refactor bicubic functions to be generated only when refraction is enabled.
- [ ] Consider skipping bicubic sampling on `roughness < 0.001` to improve performance when used with materials that have smooth parts.
- [ ] Benchmark on various devices to see if it's worth adding an option to disable it.