### PR TITLE
Fix bug in AudioStreamPlaybackPolyphonic where stream IDs returned from `play_stream` may not work (MSVC)

### DIFF
--- a/scene/resources/audio_stream_polyphonic.h
+++ b/scene/resources/audio_stream_polyphonic.h
@@ -60,7 +60,7 @@ public:
 class AudioStreamPlaybackPolyphonic : public AudioStreamPlayback {
 	GDCLASS(AudioStreamPlaybackPolyphonic, AudioStreamPlayback)
 
-	enum {
+	enum : uint32_t {
 		INTERNAL_BUFFER_LEN = 128,
 		ID_MASK = 0xFFFFFFFF,
 		INDEX_SHIFT = 32


### PR DESCRIPTION
Intended to fix this bug: https://github.com/godotengine/godot/issues/86053

The docs state that invoking `play_stream` on an instance of `AudioStreamPlaybackPolyphonic` returns an integer ID that can be used to control the volume or stop playback of a given stream, but in GDScript none of these IDs work.

While debugging I noticed that the _find_stream method seems to have platform-dependent behavior because an implicitly typed enum value is used as a bitmask. This line here appears to be the problem:

https://github.com/godotengine/godot/blob/6882e5042d1ebada62f07130a44a85b032944c31/scene/resources/audio_stream_polyphonic.cpp#L228

The usage here seems to be casting ID_MASK undesirably on my system; the result of `p_id & ID_MASK` is always exactly equal to p_id. My guess is that MSVC is reading 0xFFFFFFFF as -1 and then casting that up to an int64_t also with the value of -1. Added an explicit type to the enum that should remove this ambiguity.

My compiler version is: Microsoft (R) C/C++ Optimizing Compiler Version 19.34.31937 for x64

*Bugsquad edit:*
- Fixes #86053.