### PR TITLE
Reset TileMap editor `drag_type` when the toolbar mode is not selected

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -524,6 +524,7 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 	}
 
 	if (CanvasItemEditor::get_singleton()->get_current_tool() != CanvasItemEditor::TOOL_SELECT) {
+		_stop_dragging();
 		return false;
 	}
 


### PR DESCRIPTION
this fixes : https://github.com/godotengine/godot/issues/85077

The problem made it so that the drag_type was kept until the toolbar mode SELECT was once again pressed. This made it so tilemap was drawing automatically without having to press down the left mouse button. By changing drag type to none when select is not used, this is fixed.