### PR TITLE
Remove non-existing global class from cache

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -33,6 +33,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_feature_profile.h"
+#include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
@@ -243,7 +244,13 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 	} else {
 		if (ScriptServer::is_global_class(p_type)) {
 			Ref<Script> scr = EditorNode::get_editor_data().script_class_load_script(p_type);
-			ERR_FAIL_COND(scr.is_null());
+			if (scr.is_null()) {
+				// Remove non-existing global class from class cache.
+				ScriptServer::remove_global_class(p_type);
+				ScriptServer::save_global_classes();
+				print_verbose("Removed class " + p_type + " from global classes.");
+				return;
+			}
 
 			Ref<Script> base = scr->get_base_script();
 			if (base.is_null()) {

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -574,52 +574,47 @@ void DependencyRemoveDialog::ok_pressed() {
 			emit_signal(SNAME("resource_removed"), res);
 			res->set_path("");
 		}
-	}
 
-	for (int i = 0; i < files_to_delete.size(); ++i) {
 		// If the file we are deleting for e.g. the main scene, default environment,
 		// or audio bus layout, we must clear its definition in Project Settings.
-		if (files_to_delete[i] == String(GLOBAL_GET("application/config/icon"))) {
+		if (file == String(GLOBAL_GET("application/config/icon"))) {
 			ProjectSettings::get_singleton()->set("application/config/icon", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("application/run/main_scene"))) {
+		if (file == String(GLOBAL_GET("application/run/main_scene"))) {
 			ProjectSettings::get_singleton()->set("application/run/main_scene", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("application/boot_splash/image"))) {
+		if (file == String(GLOBAL_GET("application/boot_splash/image"))) {
 			ProjectSettings::get_singleton()->set("application/boot_splash/image", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("rendering/environment/defaults/default_environment"))) {
+		if (file == String(GLOBAL_GET("rendering/environment/defaults/default_environment"))) {
 			ProjectSettings::get_singleton()->set("rendering/environment/defaults/default_environment", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("display/mouse_cursor/custom_image"))) {
+		if (file == String(GLOBAL_GET("display/mouse_cursor/custom_image"))) {
 			ProjectSettings::get_singleton()->set("display/mouse_cursor/custom_image", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("gui/theme/custom"))) {
+		if (file == String(GLOBAL_GET("gui/theme/custom"))) {
 			ProjectSettings::get_singleton()->set("gui/theme/custom", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("gui/theme/custom_font"))) {
+		if (file == String(GLOBAL_GET("gui/theme/custom_font"))) {
 			ProjectSettings::get_singleton()->set("gui/theme/custom_font", "");
 		}
-		if (files_to_delete[i] == String(GLOBAL_GET("audio/buses/default_bus_layout"))) {
+		if (file == String(GLOBAL_GET("audio/buses/default_bus_layout"))) {
 			ProjectSettings::get_singleton()->set("audio/buses/default_bus_layout", "");
 		}
 
-		String path = OS::get_singleton()->get_resource_dir() + files_to_delete[i].replace_first("res://", "/");
+		String path = OS::get_singleton()->get_resource_dir() + file.replace_first("res://", "/");
 		print_verbose("Moving to trash: " + path);
 		Error err = OS::get_singleton()->move_to_trash(path);
 		if (err != OK) {
-			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + files_to_delete[i] + "\n");
+			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + file + "\n");
 		} else {
-			emit_signal(SNAME("file_removed"), files_to_delete[i]);
+			emit_signal(SNAME("file_removed"), file);
 		}
+
+		EditorFileSystem::get_singleton()->update_file(file);
 	}
 
-	if (dirs_to_delete.size() == 0) {
-		// If we only deleted files we should only need to tell the file system about the files we touched.
-		for (int i = 0; i < files_to_delete.size(); ++i) {
-			EditorFileSystem::get_singleton()->update_file(files_to_delete[i]);
-		}
-	} else {
+	if (dirs_to_delete.size() > 0) {
 		for (int i = 0; i < dirs_to_delete.size(); ++i) {
 			String path = OS::get_singleton()->get_resource_dir() + dirs_to_delete[i].replace_first("res://", "/");
 			print_verbose("Moving to trash: " + path);


### PR DESCRIPTION
Fixes problems with deleting script files containing global classes.
- When a script file containg a global class is externally deleted, Godot editor doesn't handle this gracefully. Editor keeps spamming errors, but doesn't fix the situation.
- When a directory is removed in Godot editor, directory's files are more or less ignored and global classes from those files are not properly removed. Master assumes wrongly that EditorFileSystem's scan will handle the situation, but it doesn't. 
 
Fixes https://github.com/godotengine/godot/issues/81867

## Test cases

Test project contains two new classes, `my_good_sprite_2d.gd` located in root and another in `bad/my_bad_sprite_2d.gd`.

[g42_cache_test.zip](https://github.com/godotengine/godot/files/13646625/g42_cache_test.zip)

1. Open Godot and test project
2. Start adding new node by clicking + button in Scene tree.
--> SUCCESS: MyBadSprite2D is possible node type, no errors 

3. Delete directory "bad"
4. Start adding new node by clicking + button in Scene tree.
--> FAIL: You get errors 

![kuva](https://github.com/godotengine/godot/assets/49998025/f824c609-4736-46a9-b875-7edeb8400bdf)

1. Close Godot and delete `my_good_sprite_2d.gd` from file system
2. Open Godot and test project
3. Start adding new node by clicking + button in Scene tree.
--> FAIL: Now you errors also from MyGoodSprite2D 

![kuva](https://github.com/godotengine/godot/assets/49998025/9e26e160-5b32-4296-bbaf-cb46190a20f7)

The only situation where removing classes from cache file works, is when only files, not directories, are deleted in Godot editor.

## Fixes

The reason for the errors is that the global classes made by the user are not properly removed from `.godot/global_script_class_cache.cfg`. 

- Changes in `create_dialog.cpp` fix the situation when files are deleted externally. When a non-existing global class is detected, it is removed from the cache. This prevents further errors.

![kuva](https://github.com/godotengine/godot/assets/49998025/a0534f31-fc43-4dcc-b3d9-52bce8bb5338)

- Changes in `dependency_editor.cpp` fix the situation when a folder containing a class file is deleted in Godot editor. When directories are deleted, master doesn't process each deleted file the same way as single deleted files are processed. Instead it is assumed that EditorFileSystem's scan will handle this, but it doesn't. Scan doesn't notice deleted directories at all. Now for every deleted file, EditorFileSystem's `update_file` is called and the global class (if file contains one) is deleted from cache file.


