### PR TITLE
Separate shadow attenuation from attenuation

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1288,6 +1288,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["LIGHT_IS_DIRECTIONAL"] = "is_directional";
 		actions.renames["LIGHT"] = "light";
 		actions.renames["ATTENUATION"] = "attenuation";
+		actions.renames["SHADOW_ATTENUATION"] = "shadow_attenuation";
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
@@ -1315,6 +1316,7 @@ MaterialStorage::MaterialStorage() {
 		actions.usage_defines["COLOR"] = "#define COLOR_USED\n";
 		actions.usage_defines["INSTANCE_CUSTOM"] = "#define ENABLE_INSTANCE_CUSTOM\n";
 		actions.usage_defines["POSITION"] = "#define OVERRIDE_POSITION\n";
+		actions.usage_defines["SHADOW_ATTENUATION"] = "#define SHADOW_ATTENUATION_USED\n";
 
 		actions.usage_defines["ALPHA_SCISSOR_THRESHOLD"] = "#define ALPHA_SCISSOR_USED\n";
 		actions.usage_defines["ALPHA_HASH_SCALE"] = "#define ALPHA_HASH_USED\n";

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -642,6 +642,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.renames["LIGHT_IS_DIRECTIONAL"] = "is_directional";
 		actions.renames["LIGHT"] = "light";
 		actions.renames["ATTENUATION"] = "attenuation";
+		actions.renames["SHADOW_ATTENUATION"] = "shadow_attenuation";
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
@@ -679,6 +680,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.usage_defines["SSS_TRANSMITTANCE_DEPTH"] = "#define ENABLE_TRANSMITTANCE\n";
 		actions.usage_defines["BACKLIGHT"] = "#define LIGHT_BACKLIGHT_USED\n";
 		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
+		actions.usage_defines["SHADOW_ATTENUATION"] = "#define SHADOW_ATTENUATION_USED\n";
 
 		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -546,6 +546,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.renames["LIGHT_IS_DIRECTIONAL"] = "is_directional";
 		actions.renames["LIGHT"] = "light";
 		actions.renames["ATTENUATION"] = "attenuation";
+		actions.renames["SHADOW_ATTENUATION"] = "shadow_attenuation";
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
@@ -583,6 +584,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.usage_defines["SSS_TRANSMITTANCE_DEPTH"] = "#define ENABLE_TRANSMITTANCE\n";
 		actions.usage_defines["BACKLIGHT"] = "#define LIGHT_BACKLIGHT_USED\n";
 		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
+		actions.usage_defines["SHADOW_ATTENUATION"] = "#define SHADOW_ATTENUATION_USED\n";
 
 		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1999,7 +1999,12 @@ void fragment_shader(in SceneData scene_data) {
 			tint = mix(tint, vec3(1.0), shadow);
 			shadow = 1.0;
 #endif
-
+			float light_attenuation = 1.0;
+#ifdef SHADOW_ATTENUATION_USED
+			float shadow_attenuation = shadow;
+#else
+			light_attenuation = shadow;
+#endif
 			float size_A = sc_use_light_soft_shadows ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), size_A,
@@ -2008,7 +2013,7 @@ void fragment_shader(in SceneData scene_data) {
 #else
 					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
 #endif
-					true, shadow, f0, orms, 1.0, albedo, alpha,
+					true, light_attenuation, f0, orms, 1.0, albedo, alpha,
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
 #endif
@@ -2027,6 +2032,9 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef LIGHT_ANISOTROPY_USED
 					binormal,
 					tangent, anisotropy,
+#endif
+#ifdef SHADOW_ATTENUATION_USED
+					shadow_attenuation,
 #endif
 					diffuse_light,
 					specular_light);

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1596,6 +1596,12 @@ void main() {
 			tint = mix(tint, vec3(1.0), shadow);
 			shadow = 1.0;
 #endif
+			float light_attenuation = 1.0;
+#ifdef SHADOW_ATTENUATION_USED
+			float shadow_attenuation = shadow;
+#else
+			light_attenuation = shadow;
+#endif
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), 0.0,
 #ifndef DEBUG_DRAW_PSSM_SPLITS
@@ -1603,7 +1609,7 @@ void main() {
 #else
 					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
 #endif
-					true, shadow, f0, orms, 1.0, albedo, alpha,
+					true, light_attenuation, f0, orms, 1.0, albedo, alpha,
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
 #endif
@@ -1626,6 +1632,10 @@ void main() {
 #endif
 #ifdef USE_SOFT_SHADOW
 					directional_lights.data[i].size,
+#endif
+
+#ifdef SHADOW_ATTENUATION_USED
+					shadow_attenuation,
 #endif
 					diffuse_light,
 					specular_light);

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -58,7 +58,11 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 #ifdef LIGHT_ANISOTROPY_USED
 		vec3 B, vec3 T, float anisotropy,
 #endif
-		inout vec3 diffuse_light, inout vec3 specular_light) {
+#ifdef SHADOW_ATTENUATION_USED
+		float shadow_attenuation,
+#endif
+		inout vec3 diffuse_light,
+		inout vec3 specular_light) {
 
 	vec4 orms_unpacked = unpackUnorm4x8(orms);
 
@@ -666,8 +670,11 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			color *= proj.rgb * proj.a;
 		}
 	}
-
+#ifdef SHADOW_ATTENUATION_USED
+	float shadow_attenuation = shadow;
+#else
 	light_attenuation *= shadow;
+#endif
 
 	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, light_attenuation, f0, orms, omni_lights.data[idx].specular_amount, albedo, alpha,
 #ifdef LIGHT_BACKLIGHT_USED
@@ -687,6 +694,9 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
+#endif
+#ifdef SHADOW_ATTENUATION_USED
+			shadow_attenuation,
 #endif
 			diffuse_light,
 			specular_light);
@@ -874,7 +884,11 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			color *= proj.rgb * proj.a;
 		}
 	}
+#ifdef SHADOW_ATTENUATION_USED
+	float shadow_attenuation = shadow;
+#else
 	light_attenuation *= shadow;
+#endif
 
 	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, light_attenuation, f0, orms, spot_lights.data[idx].specular_amount, albedo, alpha,
 #ifdef LIGHT_BACKLIGHT_USED
@@ -894,6 +908,9 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
+#endif
+#ifdef SHADOW_ATTENUATION_USED
+			shadow_attenuation,
 #endif
 			diffuse_light, specular_light);
 }

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -192,6 +192,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["LIGHT_COLOR"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["LIGHT_IS_DIRECTIONAL"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["ATTENUATION"] = constt(ShaderLanguage::TYPE_FLOAT);
+	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["SHADOW_ATTENUATION"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["ALBEDO"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["BACKLIGHT"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["METALLIC"] = constt(ShaderLanguage::TYPE_FLOAT);


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/2905

commented
```
#ifdef USE_SOFT_SHADOW
//					directional_lights.data[i].size,
#endif
```

Because it seems unused in the light definition, so i don't think there's any overload of the light compute function that actually uses it.

Tested in all three renderers for omni, spot, and directional light. 
[ShadowAttenuationTest.zip](https://github.com/godotengine/godot/files/13684055/ShadowAttenuationTest.zip)

NOTE: because i removed the .godot folder, editor directional light needs to be disabled for every scene.

