### PR TITLE
SCons: Fix pytest asserts on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,9 @@ gmon.out
 # Mypy
 .mypy_cache
 
+# Pytest
+.pytest_cache
+
 # Qt Creator
 *.config
 *.creator

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -97,11 +97,11 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
 
             included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
             if not included_file in header_data.vertex_included_files and header_data.reading == "vertex":
-                header_data.vertex_included_files += [included_file]
+                header_data.vertex_included_files += [included_file.replace("\\", "/")]
                 if include_file_in_gles3_header(included_file, header_data, depth + 1) is None:
                     print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
             elif not included_file in header_data.fragment_included_files and header_data.reading == "fragment":
-                header_data.fragment_included_files += [included_file]
+                header_data.fragment_included_files += [included_file.replace("\\", "/")]
                 if include_file_in_gles3_header(included_file, header_data, depth + 1) is None:
                     print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
 

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -82,15 +82,15 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
                 included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
 
             if not included_file in header_data.vertex_included_files and header_data.reading == "vertex":
-                header_data.vertex_included_files += [included_file]
+                header_data.vertex_included_files += [included_file.replace("\\", "/")]
                 if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
                     print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
             elif not included_file in header_data.fragment_included_files and header_data.reading == "fragment":
-                header_data.fragment_included_files += [included_file]
+                header_data.fragment_included_files += [included_file.replace("\\", "/")]
                 if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
                     print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
             elif not included_file in header_data.compute_included_files and header_data.reading == "compute":
-                header_data.compute_included_files += [included_file]
+                header_data.compute_included_files += [included_file.replace("\\", "/")]
                 if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
                     print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
 


### PR DESCRIPTION
Despite the script normally only running in the static checks on Ubuntu 22.04, it should still be possible to run the script on Windows if desired. Previously, this would always fail the assertion checks, as it tries to compare against different path separators. This PR fixes that by changing the parsed path separators to a Unix format. Additionally, this adds a new ignore for `.pytest_cache`, to exclude the cached data folder explicitly