### PR TITLE
Cleanup in undo in `TextEdit` and `LineEdit`

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1208,13 +1208,12 @@ void LineEdit::undo() {
 		return;
 	}
 
-	if (undo_stack_pos == nullptr) {
-		if (undo_stack.size() <= 1) {
-			return;
-		}
-		undo_stack_pos = undo_stack.back();
-	} else if (undo_stack_pos == undo_stack.front()) {
+	if (!has_undo()) {
 		return;
+	}
+
+	if (undo_stack_pos == nullptr) {
+		undo_stack_pos = undo_stack.back();
 	}
 
 	deselect();
@@ -1234,10 +1233,7 @@ void LineEdit::redo() {
 		return;
 	}
 
-	if (undo_stack_pos == nullptr) {
-		return;
-	}
-	if (undo_stack_pos == undo_stack.back()) {
+	if (!has_redo()) {
 		return;
 	}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4024,7 +4024,7 @@ void TextEdit::redo() {
 	}
 	_push_current_op();
 
-	if (undo_stack_pos == nullptr) {
+	if (!has_redo()) {
 		return; // Nothing to do.
 	}
 


### PR DESCRIPTION
In both `TextEdit` and `LineEdit`, the Undo and Redo functions seemed to check for themselves whether there was an Undo/Redo available rather than using the existing `has_undo` or `has_redo` functions. I decided to make them use them to remove repetition.

Only exception was the `TextEdit` `Undo` function. I noticed its check for an Undo was slightly different from the `has_undo` function. I decided to leave it alone.