### PR TITLE
Fix operator documentation in GDExtension API dump with docs

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -742,14 +742,19 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 							Dictionary d2;
 							String operator_name = Variant::get_operator_name(Variant::Operator(k));
 							d2["name"] = operator_name;
-							if (k != Variant::OP_NEGATE && k != Variant::OP_POSITIVE && k != Variant::OP_NOT && k != Variant::OP_BIT_NEGATE) {
-								d2["right_type"] = get_builtin_or_variant_type_name(Variant::Type(j));
+
+							String right_type_name = get_builtin_or_variant_type_name(Variant::Type(j));
+							bool is_unary = k == Variant::OP_NEGATE || k == Variant::OP_POSITIVE || k == Variant::OP_NOT || k == Variant::OP_BIT_NEGATE;
+							if (!is_unary) {
+								d2["right_type"] = right_type_name;
 							}
+
 							d2["return_type"] = get_builtin_or_variant_type_name(Variant::get_operator_return_type(Variant::Operator(k), type, Variant::Type(j)));
 
 							if (p_include_docs && builtin_doc != nullptr) {
 								for (const DocData::MethodDoc &operator_doc : builtin_doc->operators) {
-									if (operator_doc.name == "operator " + operator_name) {
+									if (operator_doc.name == "operator " + operator_name &&
+											(is_unary || operator_doc.arguments[0].type == right_type_name)) {
 										d2["description"] = fix_doc_description(operator_doc.description);
 										break;
 									}


### PR DESCRIPTION
This fixes the bug where some binary operators had a `description` which was actually from a different binary operator with the same name but a different right operand type. Now we check the right operand type when searching for the docs of binary operators.

In particular, this also removes the `description` from some (intentionally) undocumented operators like `==` and `!=` where the right operand is a `Variant`, and `%` where the left operand is `String` and the right operand is not a `Variant`.

- Fixes https://github.com/godotengine/godot/issues/86080