### PR TITLE
GDScript: Fix accessing static function as `Callable` in static context

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -322,9 +322,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								if (member.type == GDScriptParser::ClassNode::Member::FUNCTION || member.type == GDScriptParser::ClassNode::Member::SIGNAL) {
 									// Get like it was a property.
 									GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Get type here.
-									GDScriptCodeGenerator::Address self(GDScriptCodeGenerator::Address::SELF);
 
-									gen->write_get_named(temp, identifier, self);
+									GDScriptCodeGenerator::Address base(GDScriptCodeGenerator::Address::SELF);
+									if (member.type == GDScriptParser::ClassNode::Member::FUNCTION && member.function->is_static) {
+										base = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::CLASS);
+									}
+
+									gen->write_get_named(temp, identifier, base);
 									return temp;
 								}
 							}

--- a/modules/gdscript/tests/scripts/runtime/features/static_method_as_callable.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/static_method_as_callable.gd
@@ -1,12 +1,18 @@
-# GH-79521
+# GH-79521, GH-86032
 
 class_name TestStaticMethodAsCallable
 
 static func static_func() -> String:
 	return "Test"
 
+static func another_static_func():
+	prints("another_static_func:", static_func.call(), static_func.is_valid())
+
 func test():
 	var a: Callable = TestStaticMethodAsCallable.static_func
 	var b: Callable = static_func
 	prints(a.call(), a.is_valid())
 	prints(b.call(), b.is_valid())
+	@warning_ignore("static_called_on_instance")
+	another_static_func()
+	TestStaticMethodAsCallable.another_static_func()

--- a/modules/gdscript/tests/scripts/runtime/features/static_method_as_callable.out
+++ b/modules/gdscript/tests/scripts/runtime/features/static_method_as_callable.out
@@ -1,3 +1,5 @@
 GDTEST_OK
 Test true
 Test true
+another_static_func: Test true
+another_static_func: Test true


### PR DESCRIPTION
* Fixes #86032.