### PR TITLE
Fix returned value in Resource Importer when `post_import` fails.

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3255,7 +3255,6 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 			}
 		}
 	}
-	err = OK;
 
 	progress.step(TTR("Running Custom Script..."), 2);
 
@@ -3303,7 +3302,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 			EditorNode::add_io_error(
 					TTR("Error running post-import script:") + " " + post_import_script_path + "\n" +
 					TTR("Did you return a Node-derived object in the `_post_import()` method?"));
-			return err;
+			return ERR_CANT_CREATE;
 		}
 	}
 


### PR DESCRIPTION
err was set to OK and returned on an error path.

This appears to be the correct value to return.
