### PR TITLE
[X11] Partial fix for Editor and Project Manager stealing focus on some window managers

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4718,19 +4718,6 @@ void DisplayServerX11::process_events() {
 					break;
 				}
 
-				const WindowData &wd = windows[window_id];
-
-				XWindowAttributes xwa;
-				XSync(x11_display, False);
-				XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
-
-				// Set focus when menu window is re-used.
-				// RevertToPointerRoot is used to make sure we don't lose all focus in case
-				// a subwindow and its parent are both destroyed.
-				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup && _window_focus_check()) {
-					_set_input_focus(wd.x11_window, RevertToPointerRoot);
-				}
-
 				_window_changed(&event);
 			} break;
 


### PR DESCRIPTION
This is a workaround for the most critical portion of the WM focus bug described in #68305. On some specific X11 WM configurations, the editor's main window and any popups it creates will fight for focus, which causes a total system lockup due to mouse and keyboard input being stolen as well. Getting out of this infinite loop requires force restarting the system.

It can be tested with the following shell script:

```bash
!#/bin/sh

godot4 &
sleep 30
pkill -x godot4
```

Here is a gif of the bug in action on my machine:

![68305-bug](https://github.com/godotengine/godot/assets/35282898/3735a684-e970-442c-be13-0a7be72f36bc)

The gif above actually doesn't show the exact behavior. The constant focus swap is actually too fast for my screen recorder's framerate to pick up, so what you are seeing is about 24 out of 60 focus swaps. :)

Here is the same with this patch applied:

![68305-fixed](https://github.com/godotengine/godot/assets/35282898/4106bad9-2e8c-4844-92a9-abee50e47406)

My system information:
- Linux version: 6.6.6-arch1-1 (linux@archlinux) (gcc (GCC) 13.2.1 20230801, GNU ld (GNU Binutils) 2.41.0)
- WM: Fluxbox-only launched via Xinit.

The workaround identified by @nargacu83 in #68305 is to remove the call to XSetInputFocus in the ConfigureNotify event handler, so I have removed the conditional block that calls this as well as the setup code above it since there is no need to allocate the memory for the variables if they won't be used in that call anymore.

This is just a hack and is not a complete fix for #68305. Multiple developers are collaborating on a proper fix in the discussion in that issue, but time is a valuable resource that no one has enough of, so I am submitting this workaround as a stop-gap to prevent the most critical problem while we work on a full solution for the underlying cause.

This bug affects a very small number of users, and the general consensus in the related issue is that we don't want to submit a PR for a hack if we can get a proper fix. Particularly since we aren't completely sure why this workaround fixes the problem, and I agree with this as well, but personally, I am concerned that with this being a platform bug, it could affect exported games and not just developers, and in that case, it probably wouldn't show up on the developer's machine, but a player with the affected configuration could encounter the bug when running an exported Godot game, and although the number of people playing games on custom WM-only Linux machines is probably very low, it only takes one very vocal gamer on Twitter to ruin an indie studio, so I wanted to submit this workaround now instead of sitting on it since no one in the related issue has reported any regressions with this workaround, and we don't know when a proper fix will be ready.

Please feel free to close this PR if you feel that we should wait until we have a better idea of the problem and exactly *why* this workaround works. Thanks!