### PR TITLE
Fix SpotLight and OmniLight cull masks not working in mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1646,6 +1646,10 @@ void main() {
 				break;
 			}
 
+			if (!bool(omni_lights.data[light_index].mask & instances.data[draw_call.instance_index].layer_mask)) {
+				continue; //not masked
+			}
+
 			float shadow = light_process_omni_shadow(light_index, vertex, normal);
 
 			shadow = blur_shadow(shadow);
@@ -1689,6 +1693,10 @@ void main() {
 
 			if (light_index == 0xFF) {
 				break;
+			}
+
+			if (!bool(spot_lights.data[light_index].mask & instances.data[draw_call.instance_index].layer_mask)) {
+				continue; //not masked
 			}
 
 			float shadow = light_process_spot_shadow(light_index, vertex, normal);


### PR DESCRIPTION
Fixes #82263

I'm not sure whether there's any unexpected impacts that prevents us from adding it at the first place, feel free to correct me.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
