### PR TITLE
Remember last `color_mode` and `picker_shape` in `ColorPicker`s in the editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3701,8 +3701,9 @@ void EditorNode::_set_current_scene_nocheck(int p_idx) {
 
 void EditorNode::setup_color_picker(ColorPicker *p_picker) {
 	p_picker->set_editor_settings(EditorSettings::get_singleton());
-	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
-	int picker_shape = EDITOR_GET("interface/inspector/default_color_picker_shape");
+	int default_color_mode = EditorSettings::get_singleton()->get_project_metadata("color_picker", "color_mode", EDITOR_GET("interface/inspector/default_color_picker_mode"));
+	int picker_shape = EditorSettings::get_singleton()->get_project_metadata("color_picker", "picker_shape", EDITOR_GET("interface/inspector/default_color_picker_shape"));
+
 	p_picker->set_color_mode((ColorPicker::ColorModeType)default_color_mode);
 	p_picker->set_picker_shape((ColorPicker::PickerShapeType)picker_shape);
 }

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -693,6 +693,12 @@ void ColorPicker::set_picker_shape(PickerShapeType p_shape) {
 
 	current_shape = p_shape;
 
+#ifdef TOOLS_ENABLED
+	if (editor_settings) {
+		editor_settings->call(SNAME("set_project_metadata"), "color_picker", "picker_shape", current_shape);
+	}
+#endif
+
 	_copy_color_to_hsv();
 
 	_update_controls();
@@ -926,6 +932,12 @@ void ColorPicker::set_color_mode(ColorModeType p_mode) {
 	}
 
 	current_mode = p_mode;
+
+#ifdef TOOLS_ENABLED
+	if (editor_settings) {
+		editor_settings->call(SNAME("set_project_metadata"), "color_picker", "color_mode", current_mode);
+	}
+#endif
 
 	if (!is_inside_tree()) {
 		return;


### PR DESCRIPTION
Fixes #86063 

Now when using `ColorPicker` in the Editor, it will always use the last `color_mode` (RGB/HSV/etc) and `picker_shape` (Rectangle/Wheel/Circle/etc.) that the user chose in ANY `ColorPicker`. (eg. If you chose HSV while in the Picker for a Sprite's modulate colour, then HSV will be chosen if you then open the Picker for the Color of a ColorRect)

This is a Project specific setting. The first time the Project is started, it will use EditorSettings for the default of these two values. Any changes will persist across all Pickers in the project and across closing and opening the project again (values saved to hard drive). It will NOT affect Pickers in exported running projects, this is Editor only. 