### PR TITLE
Do not print error when editor meta was not found as it will be reimported anyway after

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -745,6 +745,10 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path) co
 
 	if (meta.has("has_editor_variant")) {
 		String imported_path = ResourceFormatImporter::get_singleton()->get_internal_resource_path(p_path);
+		if (!FileAccess::exists(imported_path)) {
+			return false;
+		}
+
 		String editor_meta_path = imported_path.replace(".editor.ctex", ".editor.meta");
 		Dictionary editor_meta = _load_editor_meta(editor_meta_path);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/85859

The error is printed when the editor metadata files for a particular image were not found,
which can happen when you check out a new project or clean up your `.godot` folder.

But this is not really necessary, as Godot will reimport the file afterwards anyway, 
because it detects that the metadata are not up to date (in this case it does not even exist).

The following is now changed:
- Deleted all 4 files (`ctex, editor.ctex, editor.meta, md5`) (happens for a newly checked out project)
    - Before: Error
    - Now: Will be recreated, no error
- Deleted `editor.meta`
    - Same as before (see also #75949):
        - Error: Missing required editor-specific import metadata for a texture (please reimport it using the 'Import' tab): 'res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.editor.meta'
- Deleted `editor.ctex`
    - Before: Error
    - After: Will be recreated, no error
- Deleted `ctex`
    - Same as before (recreate)
- Deleted `md5`
    - Same as before (recreate)

cc @YuriSizov I would be interested in your opinion as you have added this error line in https://github.com/godotengine/godot/pull/75949, just in case I miss something here. 🙂