### PR TITLE
Fix Popup hover and height calculation are off by some pixels

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -237,8 +237,7 @@ int PopupMenu::_get_items_total_height() const {
 		items_total_height += _get_item_height(i) + theme_cache.v_separation;
 	}
 
-	// Subtract a separator which is not needed for the last item.
-	return items_total_height - theme_cache.v_separation;
+	return items_total_height;
 }
 
 int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
@@ -247,14 +246,14 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 	}
 
 	// Accounts for margin in the margin container
-	Point2 ofs = theme_cache.panel_style->get_offset() + Point2(0, theme_cache.v_separation / 2);
+	Point2 ofs = theme_cache.panel_style->get_offset();
 
 	if (ofs.y > p_over.y) {
 		return -1;
 	}
 
 	for (int i = 0; i < items.size(); i++) {
-		ofs.y += i > 0 ? theme_cache.v_separation : (float)theme_cache.v_separation / 2;
+		ofs.y += theme_cache.v_separation;
 
 		ofs.y += _get_item_height(i);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/86140

This was caused by an incorrect calculation of the `v_separation` where it was not needed.

To better understand the issue, this is how the `v_separation` is used:
![image](https://github.com/godotengine/godot/assets/66004280/c859332b-7629-497e-b569-4f70dd571d36)
Every item has a top separation of 5, and a bottom separation of 5 (`v_separation` = 10).
Therefore the following statement is true: 1x item has 1x `v_separation`, which is also the fix for both calculation issues.