### PR TITLE
Stop using `RTR()` inside the "editor" folder

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -84,7 +84,7 @@ String EditorPerformanceProfiler::_create_label(float p_value, Performance::Moni
 			return String::humanize_size(p_value);
 		}
 		case Performance::MONITOR_TYPE_TIME: {
-			return TS->format_number(rtos(p_value * 1000).pad_decimals(2)) + " " + RTR("ms");
+			return TS->format_number(rtos(p_value * 1000).pad_decimals(2)) + " " + TTR("ms");
 		}
 		default: {
 			return TS->format_number(rtos(p_value));

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -125,12 +125,12 @@ String EditorProfiler::_get_time_as_text(const Metric &m, float p_time, int p_ca
 	const int dmode = display_mode->get_selected();
 
 	if (dmode == DISPLAY_FRAME_TIME) {
-		return TS->format_number(rtos(p_time * 1000).pad_decimals(2)) + " " + RTR("ms");
+		return TS->format_number(rtos(p_time * 1000).pad_decimals(2)) + " " + TTR("ms");
 	} else if (dmode == DISPLAY_AVERAGE_TIME) {
 		if (p_calls == 0) {
-			return TS->format_number("0.00") + " " + RTR("ms");
+			return TS->format_number("0.00") + " " + TTR("ms");
 		} else {
-			return TS->format_number(rtos((p_time / p_calls) * 1000).pad_decimals(2)) + " " + RTR("ms");
+			return TS->format_number(rtos((p_time / p_calls) * 1000).pad_decimals(2)) + " " + TTR("ms");
 		}
 	} else if (dmode == DISPLAY_FRAME_PERCENT) {
 		return _get_percent_txt(p_time, m.frame_time);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -116,7 +116,7 @@ String EditorVisualProfiler::_get_time_as_text(float p_time) {
 	int dmode = display_mode->get_selected();
 
 	if (dmode == DISPLAY_FRAME_TIME) {
-		return TS->format_number(String::num(p_time, 2)) + " " + RTR("ms");
+		return TS->format_number(String::num(p_time, 2)) + " " + TTR("ms");
 	} else if (dmode == DISPLAY_FRAME_PERCENT) {
 		return TS->format_number(String::num(p_time * 100 / graph_limit, 2)) + " " + TS->percent_sign();
 	}

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -724,7 +724,7 @@ void EditorPropertyOTFeatures::update_property() {
 		}
 		for (int i = 0; i < FGRP_MAX; i++) {
 			if (have_sub[i]) {
-				menu->add_submenu_node_item(RTR(group_names[i]), menu_sub[i]);
+				menu->add_submenu_node_item(TTRGET(group_names[i]), menu_sub[i]);
 			}
 		}
 
@@ -856,15 +856,15 @@ EditorPropertyOTFeatures::EditorPropertyOTFeatures() {
 		menu_sub[i]->connect("id_pressed", callable_mp(this, &EditorPropertyOTFeatures::_add_feature));
 	}
 
-	group_names[FGRP_STYLISTIC_SET] = "Stylistic Sets";
-	group_names[FGRP_CHARACTER_VARIANT] = "Character Variants";
-	group_names[FGRP_CAPITLS] = "Capitals";
-	group_names[FGRP_LIGATURES] = "Ligatures";
-	group_names[FGRP_ALTERNATES] = "Alternates";
-	group_names[FGRP_EAL] = "East Asian Language";
-	group_names[FGRP_EAW] = "East Asian Widths";
-	group_names[FGRP_NUMAL] = "Numeral Alignment";
-	group_names[FGRP_CUSTOM] = "Custom";
+	group_names[FGRP_STYLISTIC_SET] = TTRC("Stylistic Sets");
+	group_names[FGRP_CHARACTER_VARIANT] = TTRC("Character Variants");
+	group_names[FGRP_CAPITLS] = TTRC("Capitals");
+	group_names[FGRP_LIGATURES] = TTRC("Ligatures");
+	group_names[FGRP_ALTERNATES] = TTRC("Alternates");
+	group_names[FGRP_EAL] = TTRC("East Asian Language");
+	group_names[FGRP_EAW] = TTRC("East Asian Widths");
+	group_names[FGRP_NUMAL] = TTRC("Numeral Alignment");
+	group_names[FGRP_CUSTOM] = TTRC("Custom");
 }
 
 /*************************************************************************/


### PR DESCRIPTION
~`RTR()` is supposed to be only used in strings that are translatable in user projects, so strings that didn't follow this rule now use `TTR()` instead.~

~This PR is necessary for my work to add built-in strings in the POT generation.~

Alright, unless we want to have loads of `#ifdef`s, this is not a good idea. The PR has now been repurposed to just switch cases of `RTR()` to `TTR()` inside the "editor" folder.