### PR TITLE
Disable mesh compression if vertex `position.z` is always 0

### DIFF
--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -996,7 +996,16 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				surftool->generate_tangents();
 			}
 
-			if (p_mesh->get_blend_shape_count() != 0 || p_skin_controller) {
+			// Disable compression if all z equals 0 (the mesh is 2D).
+			bool is_mesh_2d = true;
+			for (int k = 0; k < vertex_array.size(); k++) {
+				if (!Math::is_zero_approx(vertex_array[k].vertex.z)) {
+					is_mesh_2d = false;
+					break;
+				}
+			};
+
+			if (p_mesh->get_blend_shape_count() != 0 || p_skin_controller || is_mesh_2d) {
 				// Can't compress if attributes missing or if using vertex weights.
 				mesh_flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
 			}

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -384,7 +384,22 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 			if (p_disable_compression) {
 				mesh_flags = 0;
+			} else {
+				bool is_mesh_2d = true;
+
+				// Disable compression if all z equals 0 (the mesh is 2D).
+				for (int i = 0; i < vertices.size(); i++) {
+					if (!Math::is_zero_approx(vertices[i].z)) {
+						is_mesh_2d = false;
+						break;
+					}
+				}
+
+				if (is_mesh_2d) {
+					mesh_flags = 0;
+				}
 			}
+
 			//groups are too annoying
 			if (surf_tool->get_vertex_array().size()) {
 				//another group going on, commit it

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3059,7 +3059,17 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				array[Mesh::ARRAY_TANGENT] = tangents;
 			}
 
-			if (p_state->force_disable_compression || !a.has("POSITION") || !a.has("NORMAL") || p.has("targets") || (a.has("JOINTS_0") || a.has("JOINTS_1"))) {
+			// Disable compression if all z equals 0 (the mesh is 2D).
+			const Vector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
+			bool is_mesh_2d = true;
+			for (int k = 0; k < vertices.size(); k++) {
+				if (!Math::is_zero_approx(vertices[k].z)) {
+					is_mesh_2d = false;
+					break;
+				}
+			}
+
+			if (p_state->force_disable_compression || is_mesh_2d || !a.has("POSITION") || !a.has("NORMAL") || p.has("targets") || (a.has("JOINTS_0") || a.has("JOINTS_1"))) {
 				flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
 			}
 


### PR DESCRIPTION
Fixes #85963

As https://github.com/godotengine/godot/issues/85963#issuecomment-1848615844 mentioned, "We could detect if the z channel is used in the vertex positions, if z is always 0, we could assume the mesh is 2D and disable compression" , this pr is a brute-force way of implementing it. I'm not sure if it's the right place to insert this check, but it seems the suitable place. 

Feel free to correct me!


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
