### PR TITLE
Stops Scene Save Dialog from closing entire project

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1393,6 +1393,10 @@ void EditorNode::_menu_confirm_current() {
 	_menu_option_confirm(current_menu_option, true);
 }
 
+void EditorNode::_cancel_save_dialog() {
+	tab_closing_menu_option = -1;
+}
+
 void EditorNode::trigger_menu_option(int p_option, bool p_confirmed) {
 	_menu_option_confirm(p_option, p_confirmed);
 }
@@ -7718,6 +7722,7 @@ EditorNode::EditorNode() {
 	gui_base->add_child(save_confirmation);
 	save_confirmation->set_min_size(Vector2(450.0 * EDSCALE, 0));
 	save_confirmation->connect("confirmed", callable_mp(this, &EditorNode::_menu_confirm_current));
+	save_confirmation->connect("canceled", callable_mp(this, &EditorNode::_cancel_save_dialog));
 	save_confirmation->connect("custom_action", callable_mp(this, &EditorNode::_discard_changes));
 
 	gradle_build_manage_templates = memnew(ConfirmationDialog);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -547,6 +547,7 @@ private:
 	void _menu_option(int p_option);
 	void _menu_confirm_current();
 	void _menu_option_confirm(int p_option, bool p_confirmed);
+	void _cancel_save_dialog();
 
 	void _android_build_source_selected(const String &p_file);
 


### PR DESCRIPTION
Fixes  #80053

Going to close the entire project with unsaved changes would save a value to `tab_closing_menu_option` to show what record what sort of operation was happening for managing tabs. However, this wouldn't get cleared if the Save Dialog was cancelled. Therefore, if you then went to close an unsaved Tab from the dialog, it would still think the operation from `tab_closing_menu_option` was still in action and close the entire project.

I considered resetting the `tab_closing_menu_option` from inside `_menu_option_confirm` (Save and Close) and `_discard_changes` for all the options it needs to be reset for (it's already done for three options). However, I decided that the most consistent and straightforward fix would be to reset the variable whenever "Cancel" was pressed on the Save Dialog.