### PR TITLE
Rework `GraphEdit` connections (drawing, API, optimizations)

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -119,6 +119,10 @@ public:
 		}
 	}
 
+	static real_t get_distance_to_segment(const Vector2 &p_point, const Vector2 *p_segment) {
+		return p_point.distance_to(get_closest_point_to_segment(p_point, p_segment));
+	}
+
 	static bool is_point_in_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) {
 		Vector2 an = a - s;
 		Vector2 bn = b - s;
@@ -247,6 +251,28 @@ public:
 			return res2;
 		}
 		return -1;
+	}
+
+	static bool segment_intersects_rect(const Vector2 &p_from, const Vector2 &p_to, const Rect2 &p_rect) {
+		if (p_rect.has_point(p_from) || p_rect.has_point(p_to)) {
+			return true;
+		}
+
+		const Vector2 rect_points[4] = {
+			p_rect.position,
+			p_rect.position + Vector2(p_rect.size.x, 0),
+			p_rect.position + p_rect.size,
+			p_rect.position + Vector2(0, p_rect.size.y)
+		};
+
+		// Check if any of the rect's edges intersect the segment.
+		for (int i = 0; i < 4; i++) {
+			if (segment_intersects_segment(p_from, p_to, rect_points[i], rect_points[(i + 1) % 4], nullptr)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	enum PolyBooleanOperation {

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -143,7 +143,22 @@
 				[b]Note:[/b] This method suppresses any other connection request signals apart from [signal connection_drag_ended].
 			</description>
 		</method>
-		<method name="get_connection_line">
+		<method name="get_closest_connection_at_point" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="point" type="Vector2" />
+			<param index="1" name="max_distance" type="float" default="4.0" />
+			<description>
+				Returns the closest connection to the given point in screen space. If no connection is found within [param max_distance] pixels, an empty [Dictionary] is returned.
+				A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
+				For example, getting a connection at a given mouse position can be achieved like this:
+				[codeblocks]
+				[gdscript]
+				var connection = get_closest_connection_at_point(mouse_event.get_position())
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="get_connection_line" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from_node" type="Vector2" />
 			<param index="1" name="to_node" type="Vector2" />
@@ -154,7 +169,14 @@
 		<method name="get_connection_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
-				Returns an Array containing the list of connections. A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
+				Returns an [Array] containing the list of connections. A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
+			</description>
+		</method>
+		<method name="get_connections_intersecting_with_rect" qualifiers="const">
+			<return type="Dictionary[]" />
+			<param index="0" name="rect" type="Rect2" />
+			<description>
+				Returns an [Array] containing the list of connections that intersect with the given [Rect2]. A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
 			</description>
 		</method>
 		<method name="get_menu_hbox">
@@ -233,7 +255,7 @@
 		<member name="connection_lines_curvature" type="float" setter="set_connection_lines_curvature" getter="get_connection_lines_curvature" default="0.5">
 			The curvature of the lines between the nodes. 0 results in straight lines.
 		</member>
-		<member name="connection_lines_thickness" type="float" setter="set_connection_lines_thickness" getter="get_connection_lines_thickness" default="2.0">
+		<member name="connection_lines_thickness" type="float" setter="set_connection_lines_thickness" getter="get_connection_lines_thickness" default="4.0">
 			The thickness of the lines between the nodes.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
@@ -417,7 +439,16 @@
 	</constants>
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
-			Color of the connection's activity (see [method set_connection_activity]).
+			Color the connection line is interpolated to based on the activity value of a connection (see [method set_connection_activity]).
+		</theme_item>
+		<theme_item name="connection_hover_tint_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.3)">
+			Color which is blended with the connection line when the mouse is hovering over it.
+		</theme_item>
+		<theme_item name="connection_rim_color" data_type="color" type="Color" default="Color(0.1, 0.1, 0.1, 0.6)">
+			Color of the rim around each connection line used for making intersecting lines more distinguishable.
+		</theme_item>
+		<theme_item name="connection_valid_target_tint_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.4)">
+			Color which is blended with the connection line when the currently dragged connection is hovering over a valid target port.
 		</theme_item>
 		<theme_item name="grid_major" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">
 			Color of major grid lines/dots.

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1367,6 +1367,10 @@ void EditorThemeManager::_populate_standard_styles(const Ref<Theme> &p_theme, Th
 		p_theme->set_color("selection_stroke", "GraphEdit", p_theme->get_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)));
 		p_theme->set_color("activity", "GraphEdit", p_config.accent_color);
 
+		p_theme->set_color("connection_hover_tint_color", "GraphEdit", p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3));
+		p_theme->set_color("connection_valid_target_tint_color", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4));
+		p_theme->set_color("connection_rim_color", "GraphEdit", p_config.tree_panel_style->get_bg_color());
+
 		p_theme->set_icon("zoom_out", "GraphEdit", p_theme->get_icon(SNAME("ZoomLess"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("zoom_in", "GraphEdit", p_theme->get_icon(SNAME("ZoomMore"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("zoom_reset", "GraphEdit", p_theme->get_icon(SNAME("ZoomReset"), EditorStringName(EditorIcons)));

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -59,3 +59,10 @@ Validate extension JSON: Error: Field 'classes/TileMap/methods/get_collision_vis
 Validate extension JSON: Error: Field 'classes/TileMap/methods/get_navigation_visibility_mode': is_const changed value in new API, from false to true.
 
 Two TileMap getters were made const. No adjustments should be necessary.
+
+
+GH-86158
+--------
+Validate extension JSON: Error: Field 'classes/GraphEdit/methods/get_connection_line': is_const changed value in new API, from false to true.
+
+get_connection_line was made const.

--- a/scene/gui/graph_edit.compat.inc
+++ b/scene/gui/graph_edit.compat.inc
@@ -38,9 +38,14 @@ void GraphEdit::_set_arrange_nodes_button_hidden_bind_compat_81582(bool p_enable
 	set_show_arrange_button(!p_enable);
 }
 
+PackedVector2Array GraphEdit::_get_connection_line_bind_compat_86158(const Vector2 &p_from, const Vector2 &p_to) {
+	return get_connection_line(p_from, p_to);
+}
+
 void GraphEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("is_arrange_nodes_button_hidden"), &GraphEdit::_is_arrange_nodes_button_hidden_bind_compat_81582);
 	ClassDB::bind_compatibility_method(D_METHOD("set_arrange_nodes_button_hidden", "enable"), &GraphEdit::_set_arrange_nodes_button_hidden_bind_compat_81582);
+	ClassDB::bind_compatibility_method(D_METHOD("get_connection_line", "from_node", "to_node"), &GraphEdit::_get_connection_line_bind_compat_86158);
 }
 
 #endif

--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -65,8 +65,7 @@ void GraphEditArranger::arrange_nodes() {
 	float gap_v = 100.0f;
 	float gap_h = 100.0f;
 
-	List<GraphEdit::Connection> connection_list;
-	graph_edit->get_connection_list(&connection_list);
+	List<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connection_list();
 
 	for (int i = graph_edit->get_child_count() - 1; i >= 0; i--) {
 		GraphNode *graph_element = Object::cast_to<GraphNode>(graph_edit->get_child(i));
@@ -77,15 +76,16 @@ void GraphEditArranger::arrange_nodes() {
 		if (graph_element->is_selected() || arrange_entire_graph) {
 			selected_nodes.insert(graph_element->get_name());
 			HashSet<StringName> s;
-			for (List<GraphEdit::Connection>::Element *E = connection_list.front(); E; E = E->next()) {
-				GraphNode *p_from = Object::cast_to<GraphNode>(node_names[E->get().from_node]);
-				if (E->get().to_node == graph_element->get_name() && (p_from->is_selected() || arrange_entire_graph) && E->get().to_node != E->get().from_node) {
+
+			for (const Ref<GraphEdit::Connection> &connection : connection_list) {
+				GraphNode *p_from = Object::cast_to<GraphNode>(node_names[connection->from_node]);
+				if (connection->to_node == graph_element->get_name() && (p_from->is_selected() || arrange_entire_graph) && connection->to_node != connection->from_node) {
 					if (!s.has(p_from->get_name())) {
 						s.insert(p_from->get_name());
 					}
-					String s_connection = String(p_from->get_name()) + " " + String(E->get().to_node);
+					String s_connection = String(p_from->get_name()) + " " + String(connection->to_node);
 					StringName _connection(s_connection);
-					Pair<int, int> ports(E->get().from_port, E->get().to_port);
+					Pair<int, int> ports(connection->from_port, connection->to_port);
 					port_info.insert(_connection, ports);
 				}
 			}
@@ -437,31 +437,30 @@ float GraphEditArranger::_calculate_threshold(const StringName &p_v, const Strin
 	float threshold = p_current_threshold;
 	if (p_v == p_w) {
 		int min_order = MAX_ORDER;
-		GraphEdit::Connection incoming;
-		List<GraphEdit::Connection> connection_list;
-		graph_edit->get_connection_list(&connection_list);
-		for (List<GraphEdit::Connection>::Element *E = connection_list.front(); E; E = E->next()) {
-			if (E->get().to_node == p_w) {
-				ORDER(E->get().from_node, r_layers);
+		Ref<GraphEdit::Connection> incoming;
+		List<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connection_list();
+		for (const Ref<GraphEdit::Connection> &connection : connection_list) {
+			if (connection->to_node == p_w) {
+				ORDER(connection->from_node, r_layers);
 				if (min_order > order) {
 					min_order = order;
-					incoming = E->get();
+					incoming = connection;
 				}
 			}
 		}
 
-		if (incoming.from_node != StringName()) {
-			GraphNode *gnode_from = Object::cast_to<GraphNode>(r_node_names[incoming.from_node]);
+		if (incoming.is_valid()) {
+			GraphNode *gnode_from = Object::cast_to<GraphNode>(r_node_names[incoming->from_node]);
 			GraphNode *gnode_to = Object::cast_to<GraphNode>(r_node_names[p_w]);
-			Vector2 pos_from = gnode_from->get_output_port_position(incoming.from_port) * graph_edit->get_zoom();
-			Vector2 pos_to = gnode_to->get_input_port_position(incoming.to_port) * graph_edit->get_zoom();
+			Vector2 pos_from = gnode_from->get_output_port_position(incoming->from_port) * graph_edit->get_zoom();
+			Vector2 pos_to = gnode_to->get_input_port_position(incoming->to_port) * graph_edit->get_zoom();
 
 			// If connected block node is selected, calculate thershold or add current block to list.
 			if (gnode_from->is_selected()) {
-				Vector2 connected_block_pos = r_node_positions[r_root[incoming.from_node]];
+				Vector2 connected_block_pos = r_node_positions[r_root[incoming->from_node]];
 				if (connected_block_pos.y != FLT_MAX) {
 					//Connected block is placed, calculate threshold.
-					threshold = connected_block_pos.y + (real_t)r_inner_shift[incoming.from_node] - (real_t)r_inner_shift[p_w] + pos_from.y - pos_to.y;
+					threshold = connected_block_pos.y + (real_t)r_inner_shift[incoming->from_node] - (real_t)r_inner_shift[p_w] + pos_from.y - pos_to.y;
 				}
 			}
 		}
@@ -469,31 +468,30 @@ float GraphEditArranger::_calculate_threshold(const StringName &p_v, const Strin
 	if (threshold == FLT_MIN && (StringName)r_align[p_w] == p_v) {
 		// This time, pick an outgoing edge and repeat as above!
 		int min_order = MAX_ORDER;
-		GraphEdit::Connection outgoing;
-		List<GraphEdit::Connection> connection_list;
-		graph_edit->get_connection_list(&connection_list);
-		for (List<GraphEdit::Connection>::Element *E = connection_list.front(); E; E = E->next()) {
-			if (E->get().from_node == p_w) {
-				ORDER(E->get().to_node, r_layers);
+		Ref<GraphEdit::Connection> outgoing;
+		List<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connection_list();
+		for (const Ref<GraphEdit::Connection> &connection : connection_list) {
+			if (connection->from_node == p_w) {
+				ORDER(connection->to_node, r_layers);
 				if (min_order > order) {
 					min_order = order;
-					outgoing = E->get();
+					outgoing = connection;
 				}
 			}
 		}
 
-		if (outgoing.to_node != StringName()) {
+		if (outgoing.is_valid()) {
 			GraphNode *gnode_from = Object::cast_to<GraphNode>(r_node_names[p_w]);
-			GraphNode *gnode_to = Object::cast_to<GraphNode>(r_node_names[outgoing.to_node]);
-			Vector2 pos_from = gnode_from->get_output_port_position(outgoing.from_port) * graph_edit->get_zoom();
-			Vector2 pos_to = gnode_to->get_input_port_position(outgoing.to_port) * graph_edit->get_zoom();
+			GraphNode *gnode_to = Object::cast_to<GraphNode>(r_node_names[outgoing->to_node]);
+			Vector2 pos_from = gnode_from->get_output_port_position(outgoing->from_port) * graph_edit->get_zoom();
+			Vector2 pos_to = gnode_to->get_input_port_position(outgoing->to_port) * graph_edit->get_zoom();
 
 			// If connected block node is selected, calculate thershold or add current block to list.
 			if (gnode_to->is_selected()) {
-				Vector2 connected_block_pos = r_node_positions[r_root[outgoing.to_node]];
+				Vector2 connected_block_pos = r_node_positions[r_root[outgoing->to_node]];
 				if (connected_block_pos.y != FLT_MAX) {
 					//Connected block is placed. Calculate threshold
-					threshold = connected_block_pos.y + (real_t)r_inner_shift[outgoing.to_node] - (real_t)r_inner_shift[p_w] + pos_from.y - pos_to.y;
+					threshold = connected_block_pos.y + (real_t)r_inner_shift[outgoing->to_node] - (real_t)r_inner_shift[p_w] + pos_from.y - pos_to.y;
 				}
 			}
 		}

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1184,7 +1184,9 @@ void register_scene_types() {
 	}
 
 	if (RenderingServer::get_singleton()) {
-		ColorPicker::init_shaders(); // RenderingServer needs to exist for this to succeed.
+		// RenderingServer needs to exist for this to succeed.
+		ColorPicker::init_shaders();
+		GraphEdit::init_shaders();
 	}
 
 	SceneDebugger::initialize();
@@ -1236,6 +1238,7 @@ void unregister_scene_types() {
 	ParticleProcessMaterial::finish_shaders();
 	CanvasItemMaterial::finish_shaders();
 	ColorPicker::finish_shaders();
+	GraphEdit::finish_shaders();
 	SceneStringNames::free();
 
 	OS::get_singleton()->benchmark_end_measure("Scene", "Unregister Types");

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1161,6 +1161,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("selection_fill", "GraphEdit", Color(1, 1, 1, 0.3));
 	theme->set_color("selection_stroke", "GraphEdit", Color(1, 1, 1, 0.8));
 	theme->set_color("activity", "GraphEdit", Color(1, 1, 1));
+	theme->set_color("connection_hover_tint_color", "GraphEdit", Color(0, 0, 0, 0.3));
+	theme->set_color("connection_valid_target_tint_color", "GraphEdit", Color(1, 1, 1, 0.4));
+	theme->set_color("connection_rim_color", "GraphEdit", style_normal_color);
 
 	// Visual Node Ports
 


### PR DESCRIPTION
Supersedes #83508.

![Peek 2023-12-14 15-45](https://github.com/godotengine/godot/assets/50084500/f1219513-f035-4175-924e-53022b5c4fe1)

# Detailed changes
## API
- Add method `get_closest_connection_at_point` which return the closest connection at a given point in GraphEdit's local screen space (with the given maximum search distance). See the docs for a usage example.
- Add method `get_connections_intersecting_with_rect` 
- Add method `reset_all_connection_activity`

## Visual
- Adjust theming/visual appearance of connection lines
	- Add a tiny rim so that they can be distinguished better when they cross/overlay each other (stripped from #85017)
		- For easy adjustments a `connection_rim_color` theme property is added
	- Hovering a connection now highlights it (theme item `connection_hover_tint_color`)
	- The highlight color when dragging a connection onto a valid port is now a theme item (theme item `connection_valid_target_tint_color`)
- Dragging connection line improvements
	- Show the correct color gradient when hovering over a valid port (it was just a solid color before)
![dragged_connection_demo](https://github.com/godotengine/godot/assets/50084500/08adadca-5f2e-4395-8a91-90aa80d58d87)
	- Fix instability while zooming 
	When zooming/panning fast this could happen before: 
![Pasted image 20231213162506](https://github.com/godotengine/godot/assets/50084500/ce6aac61-e30e-4b0d-9508-2a51724ecb02)

## Optimizations, Fixes & Refactoring
- Optimize connection drawing/handling
	- Introduce connections HashMap (node -> its connections)
		- The old logic iterated over all connections for every GraphNode, now only the relevant connections are checked where possible.
	 - Each connection now caches the line, the start and end positions (in screen space) as well as an AABB. This allows for updating/drawing only those connections visible on the screen (this had a huge performance impact for large graphs). It's also used to accelerate fetching the connection from a screen position/rect intersection which is introduced in this PR.
	 - Further improved performance (especially when panning and moving nodes)
- Connection lines are now drawn using Line2D nodes instead of using `draw_polyline` calls in only one `CanvasItem` 
	- The performance concerns I had turned out to be unfounded, this method even allows for some nice optimizations
	- The reason for this was flexibility: e.g. drawing e.g. type-dependent connection line styles (double/triple/quadruple lines, dashed) with a shader requires passing per-line uniforms to the shaders
- Connection line shader
	- Connection lines use a dedicated canvas item shader now
	- The default shader can be overridden to allow for application specific shaders (e.g. to implement connection type dependent styles)
		- The method is not yet exposed
	- Parameters/uniforms currently set by GraphEdit:
		- int from_type
		- int to_type
		- vec4 rim_color
		- float line_width
	- This allows for type-dependent connection line styles, like you can see here:
	*Keep in mind that the following is just a quick/arbitrary POC using the shader override and not included in this PR*
	![Clipboard - 8  Dezember 2023 21 06](https://github.com/godotengine/godot/assets/50084500/5a56f0b5-7be2-4cf6-8ab8-480299a80039)

- Drawing the lines for the minimap is now completely separate, drawing the lines via a shader is not sensible here (this also paves the way for loosening up the coupling between the minimap and GraphEdit itself and allows for optimizations since the minimap is currently a bottleneck)
- Change signature of `get_connection_list` (now returns the list instead of using a return parameter) [only used internally]

- Fixes #36716.

# TODO
- [ ] Decide what to do with the anti aliased property since AA is basically free now
- [ ] Expose the connection line shader override (maybe in a followup PR?)