### PR TITLE
Properly select the newly duplicated file

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1296,6 +1296,13 @@ void FileSystemDock::_fs_changed() {
 		_update_file_list(true);
 	}
 
+	if (!select_after_scan.is_empty()) {
+		_navigate_to_path(select_after_scan);
+		select_after_scan.clear();
+		import_dock_needs_update = true;
+		_update_import_dock();
+	}
+
 	set_process(false);
 }
 
@@ -1475,8 +1482,6 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.") + "\n" + old_path + "\n");
 		return;
 	}
-	const_cast<FileSystemDock *>(this)->current_path = new_path;
-
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 
 	if (p_item.is_file) {
@@ -1916,6 +1921,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 		for (int i = 0; i < to_move.size(); i++) {
 			if (to_move[i].path != new_paths[i]) {
 				_try_duplicate_item(to_move[i], new_paths[i]);
+				select_after_scan = new_paths[i];
 				is_copied = true;
 			}
 		}

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -225,6 +225,7 @@ private:
 	int history_max_size;
 
 	String current_path;
+	String select_after_scan;
 
 	bool initialized = false;
 


### PR DESCRIPTION
Follow-up to #74626

The previous selecting method wasn't reliable enough. The worst part was that Import dock was not updated to the new file, which caused me to change import type of a wrong file a couple of times. This PR ensures that the path is selected properly.