### PR TITLE
Replace `GDVIRTUAL_CALL` with `GDVIRTUAL_REQUIRED_CALL` where applicable

### DIFF
--- a/editor/editor_script.cpp
+++ b/editor/editor_script.cpp
@@ -62,9 +62,7 @@ EditorInterface *EditorScript::get_editor_interface() const {
 }
 
 void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
+	GDVIRTUAL_REQUIRED_CALL(_run);
 }
 
 void EditorScript::_bind_methods() {

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -32,8 +32,6 @@
 
 #include "editor_node.h"
 
-#define UNIMPLEMENTED() ERR_PRINT(vformat("Unimplemented virtual function in EditorVCSInterface based plugin: %s", __func__))
-
 EditorVCSInterface *EditorVCSInterface::singleton = nullptr;
 
 void EditorVCSInterface::popup_error(String p_msg) {
@@ -43,23 +41,17 @@ void EditorVCSInterface::popup_error(String p_msg) {
 
 bool EditorVCSInterface::initialize(String p_project_path) {
 	bool result = false;
-	if (!GDVIRTUAL_CALL(_initialize, p_project_path, result)) {
-		UNIMPLEMENTED();
-		return false;
-	}
+	GDVIRTUAL_REQUIRED_CALL(_initialize, p_project_path, result);
 	return result;
 }
 
 void EditorVCSInterface::set_credentials(String p_username, String p_password, String p_ssh_public_key, String p_ssh_private_key, String p_ssh_passphrase) {
-	if (!GDVIRTUAL_CALL(_set_credentials, p_username, p_password, p_ssh_public_key, p_ssh_private_key, p_ssh_passphrase)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_set_credentials, p_username, p_password, p_ssh_public_key, p_ssh_private_key, p_ssh_passphrase);
 }
 
 List<String> EditorVCSInterface::get_remotes() {
 	TypedArray<String> result;
-	if (!GDVIRTUAL_CALL(_get_remotes, result)) {
-		UNIMPLEMENTED();
+	if (!GDVIRTUAL_REQUIRED_CALL(_get_remotes, result)) {
 		return {};
 	}
 
@@ -72,8 +64,7 @@ List<String> EditorVCSInterface::get_remotes() {
 
 List<EditorVCSInterface::StatusFile> EditorVCSInterface::get_modified_files_data() {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_CALL(_get_modified_files_data, result)) {
-		UNIMPLEMENTED();
+	if (!GDVIRTUAL_REQUIRED_CALL(_get_modified_files_data, result)) {
 		return {};
 	}
 
@@ -85,33 +76,24 @@ List<EditorVCSInterface::StatusFile> EditorVCSInterface::get_modified_files_data
 }
 
 void EditorVCSInterface::stage_file(String p_file_path) {
-	if (!GDVIRTUAL_CALL(_stage_file, p_file_path)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_stage_file, p_file_path);
 }
 
 void EditorVCSInterface::unstage_file(String p_file_path) {
-	if (!GDVIRTUAL_CALL(_unstage_file, p_file_path)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_unstage_file, p_file_path);
 }
 
 void EditorVCSInterface::discard_file(String p_file_path) {
-	if (!GDVIRTUAL_CALL(_discard_file, p_file_path)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_discard_file, p_file_path);
 }
 
 void EditorVCSInterface::commit(String p_msg) {
-	if (!GDVIRTUAL_CALL(_commit, p_msg)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_commit, p_msg);
 }
 
 List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(String p_identifier, TreeArea p_area) {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_CALL(_get_diff, p_identifier, int(p_area), result)) {
-		UNIMPLEMENTED();
+	if (!GDVIRTUAL_REQUIRED_CALL(_get_diff, p_identifier, int(p_area), result)) {
 		return {};
 	}
 
@@ -124,8 +106,7 @@ List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(String p_identif
 
 List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_max_commits) {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_CALL(_get_previous_commits, p_max_commits, result)) {
-		UNIMPLEMENTED();
+	if (!GDVIRTUAL_REQUIRED_CALL(_get_previous_commits, p_max_commits, result)) {
 		return {};
 	}
 
@@ -138,8 +119,7 @@ List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_
 
 List<String> EditorVCSInterface::get_branch_list() {
 	TypedArray<String> result;
-	if (!GDVIRTUAL_CALL(_get_branch_list, result)) {
-		UNIMPLEMENTED();
+	if (!GDVIRTUAL_REQUIRED_CALL(_get_branch_list, result)) {
 		return {};
 	}
 
@@ -151,68 +131,48 @@ List<String> EditorVCSInterface::get_branch_list() {
 }
 
 void EditorVCSInterface::create_branch(String p_branch_name) {
-	if (!GDVIRTUAL_CALL(_create_branch, p_branch_name)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_create_branch, p_branch_name);
 }
 
 void EditorVCSInterface::create_remote(String p_remote_name, String p_remote_url) {
-	if (!GDVIRTUAL_CALL(_create_remote, p_remote_name, p_remote_url)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_create_remote, p_remote_name, p_remote_url);
 }
 
 void EditorVCSInterface::remove_branch(String p_branch_name) {
-	if (!GDVIRTUAL_CALL(_remove_branch, p_branch_name)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_remove_branch, p_branch_name);
 }
 
 void EditorVCSInterface::remove_remote(String p_remote_name) {
-	if (!GDVIRTUAL_CALL(_remove_remote, p_remote_name)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_remove_remote, p_remote_name);
 }
 
 String EditorVCSInterface::get_current_branch_name() {
 	String result;
-	if (!GDVIRTUAL_CALL(_get_current_branch_name, result)) {
-		UNIMPLEMENTED();
-		return "";
-	}
+	GDVIRTUAL_REQUIRED_CALL(_get_current_branch_name, result);
 	return result;
 }
 
 bool EditorVCSInterface::checkout_branch(String p_branch_name) {
 	bool result = false;
-	if (!GDVIRTUAL_CALL(_checkout_branch, p_branch_name, result)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_checkout_branch, p_branch_name, result);
 	return result;
 }
 
 void EditorVCSInterface::pull(String p_remote) {
-	if (!GDVIRTUAL_CALL(_pull, p_remote)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_pull, p_remote);
 }
 
 void EditorVCSInterface::push(String p_remote, bool p_force) {
-	if (!GDVIRTUAL_CALL(_push, p_remote, p_force)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_push, p_remote, p_force);
 }
 
 void EditorVCSInterface::fetch(String p_remote) {
-	if (!GDVIRTUAL_CALL(_fetch, p_remote)) {
-		UNIMPLEMENTED();
-	}
+	GDVIRTUAL_REQUIRED_CALL(_fetch, p_remote);
 }
 
 List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(String p_file_path, String p_text) {
 	TypedArray<Dictionary> result;
-	if (!GDVIRTUAL_CALL(_get_line_diff, p_file_path, p_text, result)) {
-		UNIMPLEMENTED();
+	if (!GDVIRTUAL_REQUIRED_CALL(_get_line_diff, p_file_path, p_text, result)) {
 		return {};
 	}
 
@@ -225,19 +185,13 @@ List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(String p_fi
 
 bool EditorVCSInterface::shut_down() {
 	bool result = false;
-	if (!GDVIRTUAL_CALL(_shut_down, result)) {
-		UNIMPLEMENTED();
-		return false;
-	}
+	GDVIRTUAL_REQUIRED_CALL(_shut_down, result);
 	return result;
 }
 
 String EditorVCSInterface::get_vcs_name() {
 	String result;
-	if (!GDVIRTUAL_CALL(_get_vcs_name, result)) {
-		UNIMPLEMENTED();
-		return {};
-	}
+	GDVIRTUAL_REQUIRED_CALL(_get_vcs_name, result);
 	return result;
 }
 

--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -119,9 +119,7 @@ Ref<Texture2D> VideoStreamPlayback::get_texture() const {
 }
 
 void VideoStreamPlayback::update(double p_delta) {
-	if (!GDVIRTUAL_CALL(_update, p_delta)) {
-		ERR_FAIL_MSG("VideoStreamPlayback::update unimplemented");
-	}
+	GDVIRTUAL_REQUIRED_CALL(_update, p_delta);
 }
 
 void VideoStreamPlayback::set_mix_callback(AudioMixCallback p_callback, void *p_userdata) {


### PR DESCRIPTION
A handful of `GDVIRTUAL_CALL` implementations were used as booleans for a check exclusively to see if they're implemented, throwing an error if they weren't. This functionality is already present in `GDVIRTUAL_REQUIRED_CALL`, though it was added later on compared to the bulk of these implementations, so this PR updates them accordingly.