### PR TITLE
Fix file disappearing when renaming dependencies

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1454,8 +1454,10 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	fw.unref();
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	da->remove(p_path);
-	da->rename(p_path + ".depren", p_path);
+	if (da->exists(p_path + ".depren")) {
+		da->remove(p_path);
+		da->rename(p_path + ".depren", p_path);
+	}
 	return OK;
 }
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1790,8 +1790,8 @@ Error ResourceFormatLoaderText::rename_dependencies(const String &p_path, const 
 		err = loader.rename_dependencies(f, p_path, p_map);
 	}
 
-	if (err == OK) {
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	if (err == OK && da->file_exists(p_path + ".depren")) {
 		da->remove(p_path);
 		da->rename(p_path + ".depren", p_path);
 	}


### PR DESCRIPTION
Fixes #86174

When renaming a file, the editor will try to fix dependencies, but it will save affected scenes before that. However as a result of saving, the dependency might get removed thus a rename is performed on a dependency that no longer exists.

Then there is rename method that creates a `.depren` file after renaming dependency. However it treats "no rename" as success
https://github.com/godotengine/godot/blob/f8a2a9193662b2e8c1d04d65e647399dee94f31e/scene/resources/resource_format_text.cpp#L921-L924
meaning the file is not created, but the code continues normally. This results in a disaster.

The fix checks whether `.depren` file actually exists before removing the old file. Another option would be making the rename method return an error if the dependency can't be found, but I'm not sure if it's always expected to exist (in case of the fixed issue it didn't, but maybe it's expected to fail, idk).
I modified the binary format too, but I didn't test if the same bug occurs. Better to be safe anyway.

This was probably regression from #81725 or #81657