### PR TITLE
Add export option for the Web to ignore DevTools shortcuts

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -696,6 +696,7 @@ function startEditor(zip) {
 		},
 		'onExecute': Execute,
 		'persistentPaths': persistentPaths,
+		'ignoreDevtoolsInput': false,
 	};
 	editor = new Engine(editorConfig);
 

--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -41,6 +41,10 @@
 			Additional HTML tags to include inside the [code]&lt;head&gt;[/code], such as [code]&lt;meta&gt;[/code] tags.
 			[b]Note:[/b] You do not need to add a [code]&lt;title&gt;[/code] tag, as it is automatically included based on the project's name.
 		</member>
+		<member name="input/ignore_devtools" type="bool" setter="" getter="">
+			Determines if common keyboard shortcuts for browsers' web developer tools should be ignored by Godot.
+			If [code]true[/code], Godot will ignore [code]F12[/code].
+		</member>
 		<member name="progressive_web_app/background_color" type="Color" setter="" getter="">
 			The background color used behind the web application.
 		</member>

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -150,6 +150,7 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 	config["args"] = args;
 	config["fileSizes"] = p_file_sizes;
 	config["ensureCrossOriginIsolationHeaders"] = (bool)p_preset->get("progressive_web_app/ensure_cross_origin_isolation_headers");
+	config["ignoreDevtoolsInput"] = (bool)p_preset->get("input/ignore_devtools");
 
 	String head_include;
 	if (p_preset->get("html/export_icon")) {
@@ -359,6 +360,8 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "variant/thread_support"), false)); // Thread support (i.e. run with or without COEP/COOP headers).
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_desktop"), true)); // S3TC
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "input/ignore_devtools"), true));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/export_icon"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/custom_html_shell", PROPERTY_HINT_FILE, "*.html"), ""));

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -134,6 +134,11 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 */
 		fileSizes: [],
 		/**
+		 * @ignore
+		 * @type {boolean}
+		 */
+		ignoreDevtoolsInput: false,
+		/**
 		 * A callback function for handling Godot's ``OS.execute`` calls.
 		 *
 		 * This is for example used in the Web Editor template to switch between project manager and editor, and for running the game.
@@ -259,6 +264,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.serviceWorker = parse('serviceWorker', this.serviceWorker);
 		this.gdextensionLibs = parse('gdextensionLibs', this.gdextensionLibs);
 		this.fileSizes = parse('fileSizes', this.fileSizes);
+		this.ignoreDevtoolsInput = parse('ignoreDevtoolsInput', this.ignoreDevtoolsInput);
 		this.args = parse('args', this.args);
 		this.onExecute = parse('onExecute', this.onExecute);
 		this.onExit = parse('onExit', this.onExit);
@@ -353,6 +359,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 			'persistentDrops': this.persistentDrops,
 			'virtualKeyboard': this.experimentalVK,
 			'focusCanvas': this.focusCanvas,
+			'ignoreDevtoolsInput': this.ignoreDevtoolsInput,
 			'onExecute': this.onExecute,
 			'onExit': function (p_code) {
 				cleanup(); // We always need to call the cleanup callback to free memory.

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -465,6 +465,15 @@ const GodotInput = {
 			const y = (evt.clientY - rect.y) * rh;
 			return [x, y];
 		},
+		/**
+		 * Tests if the keyboard event passed in parameters is used to call
+		 * the browsers' DevTools.
+		 * @param {KeyboardEvent} evt
+		 */
+		isDevtoolsInput: function (evt) {
+			// Test for the "F12" shortcut.
+			return evt.key === 'F12';
+		},
 	},
 
 	/*
@@ -565,6 +574,9 @@ const GodotInput = {
 	godot_js_input_key_cb: function (callback, code, key) {
 		const func = GodotRuntime.get_func(callback);
 		function key_cb(pressed, evt) {
+			if (GodotConfig.ignore_devtools_input && GodotInput.isDevtoolsInput(evt)) {
+				return;
+			}
 			const modifiers = GodotInput.getModifiers(evt);
 			GodotRuntime.stringToHeap(evt.code, code, 32);
 			GodotRuntime.stringToHeap(evt.key, key, 32);

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -63,6 +63,7 @@ const GodotConfig = {
 		persistent_drops: false,
 		on_execute: null,
 		on_exit: null,
+		ignore_devtools_input: false,
 
 		init_config: function (p_opts) {
 			GodotConfig.canvas_resize_policy = p_opts['canvasResizePolicy'];
@@ -72,6 +73,7 @@ const GodotConfig = {
 			GodotConfig.persistent_drops = !!p_opts['persistentDrops'];
 			GodotConfig.on_execute = p_opts['onExecute'];
 			GodotConfig.on_exit = p_opts['onExit'];
+			GodotConfig.ignore_devtools_input = p_opts['ignoreDevtoolsInput'];
 			if (p_opts['focusCanvas']) {
 				GodotConfig.canvas.focus();
 			}


### PR DESCRIPTION
This PR adds an option for the Web build in order to ignore common shortcuts for summoning web developer tools.

If set to `true`, the Godot Javascript bindings will simply omit to send `F12`, `Ctrl-Shift-I` and `Meta-Shift-I` to Godot.

![Capture d’écran du 2023-12-14 16-26-42](https://github.com/godotengine/godot/assets/270928/82c0c815-9bf3-4f28-a918-d1ead9556bfd)

Fixes #86175