### PR TITLE
SCons: Format generated defines

### DIFF
--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -1,9 +1,9 @@
-proto_mod = """
-#define MODBIND$VER($RETTYPE m_name$ARG) \\
-virtual $RETVAL _##m_name($FUNCARGS) $CONST; \\
-_FORCE_INLINE_ virtual $RETVAL m_name($FUNCARGS) $CONST override { \\
-    $RETX _##m_name($CALLARGS);\\
-}
+proto_mod = """#define MODBIND$VER($RETTYPEm_name$ARG)\\
+	virtual $RETVAL _##m_name($FUNCARGS) $CONST;\\
+	_FORCE_INLINE_ virtual $RETVAL m_name($FUNCARGS) $CONST override {\\
+		$RETX _##m_name($CALLARGS);\\
+	}
+
 """
 
 
@@ -20,13 +20,13 @@ def generate_mod_version(argcount, const=False, returns=False):
     else:
         s = s.replace("$RETTYPE", "")
         s = s.replace("$RETVAL", "void")
-        s = s.replace("$RETX", "")
+        s = s.replace("$RETX ", "")
 
     if const:
         sproto += "C"
         s = s.replace("$CONST", "const")
     else:
-        s = s.replace("$CONST", "")
+        s = s.replace(" $CONST", "")
 
     s = s.replace("$VER", sproto)
     argtext = ""
@@ -54,14 +54,14 @@ def generate_mod_version(argcount, const=False, returns=False):
     return s
 
 
-proto_ex = """
-#define EXBIND$VER($RETTYPE m_name$ARG) \\
-GDVIRTUAL$VER($RETTYPE_##m_name$ARG)\\
-virtual $RETVAL m_name($FUNCARGS) $CONST override { \\
-    $RETPRE\\
-    GDVIRTUAL_REQUIRED_CALL(_##m_name$CALLARGS$RETREF);\\
-    $RETPOST\\
-}
+proto_ex = """#define EXBIND$VER($RETTYPEm_name$ARG)\\
+	GDVIRTUAL$VER($RETTYPE_##m_name$ARG)\\
+	virtual $RETVAL m_name($FUNCARGS) $CONST override {\\
+		$RETPRE\\
+		GDVIRTUAL_REQUIRED_CALL(_##m_name$CALLARGS$RETREF);\\
+		$RETPOST\\
+	}
+
 """
 
 
@@ -73,20 +73,20 @@ def generate_ex_version(argcount, const=False, returns=False):
         sproto += "R"
         s = s.replace("$RETTYPE", "m_ret, ")
         s = s.replace("$RETVAL", "m_ret")
-        s = s.replace("$RETPRE", "m_ret ret; ZeroInitializer<m_ret>::initialize(ret);\\\n")
-        s = s.replace("$RETPOST", "return ret;\\\n")
+        s = s.replace("$RETPRE", "m_ret ret;\\\n\t\tZeroInitializer<m_ret>::initialize(ret);")
+        s = s.replace("$RETPOST", "return ret;")
 
     else:
         s = s.replace("$RETTYPE", "")
         s = s.replace("$RETVAL", "void")
-        s = s.replace("$RETPRE", "")
+        s = s.replace("\t\t$RETPRE\\\n", "")
         s = s.replace("$RETPOST", "return;")
 
     if const:
         sproto += "C"
         s = s.replace("$CONST", "const")
     else:
-        s = s.replace("$CONST", "")
+        s = s.replace("$CONST ", "")
 
     s = s.replace("$VER", sproto)
     argtext = ""
@@ -121,26 +121,27 @@ def generate_ex_version(argcount, const=False, returns=False):
 def run(target, source, env):
     max_versions = 12
 
-    txt = """
+    txt = """/* THIS FILE IS GENERATED DO NOT EDIT */
 #ifndef GDEXTENSION_WRAPPERS_GEN_H
 #define GDEXTENSION_WRAPPERS_GEN_H
+
 """
 
     for i in range(max_versions + 1):
-        txt += "\n/* Extension Wrapper " + str(i) + " Arguments */\n"
+        txt += "/* Extension Wrapper " + str(i) + " Arguments */\n\n"
         txt += generate_ex_version(i, False, False)
         txt += generate_ex_version(i, False, True)
         txt += generate_ex_version(i, True, False)
         txt += generate_ex_version(i, True, True)
 
     for i in range(max_versions + 1):
-        txt += "\n/* Module Wrapper " + str(i) + " Arguments */\n"
+        txt += "/* Module Wrapper " + str(i) + " Arguments */\n\n"
         txt += generate_mod_version(i, False, False)
         txt += generate_mod_version(i, False, True)
         txt += generate_mod_version(i, True, False)
         txt += generate_mod_version(i, True, True)
 
-    txt += "\n#endif\n"
+    txt += "#endif // GDEXTENSION_WRAPPERS_GEN_H\n"
 
     with open(target[0], "w") as f:
         f.write(txt)

--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -119,6 +119,8 @@ def generate_ex_version(argcount, const=False, returns=False):
 
 
 def run(target, source, env):
+    from methods import format_defines
+
     max_versions = 12
 
     txt = """/* THIS FILE IS GENERATED DO NOT EDIT */
@@ -144,7 +146,7 @@ def run(target, source, env):
     txt += "#endif // GDEXTENSION_WRAPPERS_GEN_H\n"
 
     with open(target[0], "w") as f:
-        f.write(txt)
+        f.write(format_defines(txt))
 
 
 if __name__ == "__main__":

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -169,6 +169,8 @@ def generate_version(argcount, const=False, returns=False):
 
 
 def run(target, source, env):
+    from methods import format_defines
+
     max_versions = 12
 
     txt = """/* THIS FILE IS GENERATED DO NOT EDIT */
@@ -202,7 +204,7 @@ def run(target, source, env):
     txt += "#endif // GDVIRTUAL_GEN_H\n"
 
     with open(target[0], "w") as f:
-        f.write(txt)
+        f.write(format_defines(txt))
 
 
 if __name__ == "__main__":

--- a/methods.py
+++ b/methods.py
@@ -1202,3 +1202,34 @@ def dump(env):
 
     with open(".scons_env.json", "w") as f:
         dump(env.Dictionary(), f, indent=4, default=non_serializable)
+
+
+def format_defines(text: str) -> str:
+    lines: list[str] = text.splitlines()
+    defines: list[tuple[int, int]] = []
+
+    start_index = -1
+    index = 0
+    for line in lines:
+        if line.endswith("\\"):
+            if start_index == -1:
+                start_index = index
+        elif start_index != -1:
+            defines.append((start_index, index))
+            start_index = -1
+        index += 1
+
+    for define in defines:
+        lengths: list[int] = []
+        max_length = -1
+        for line in lines[define[0] : define[1]]:
+            length = len(line.expandtabs(4))
+            max_length = max(length, max_length)
+            lengths.append(length)
+        max_length += 2  # one to reach actual line offset, two to append a space
+        index = 0
+        for line in lines[define[0] : define[1]]:
+            lines[index + define[0]] = line.removesuffix("\\") + "\\".rjust(max_length - lengths[index])
+            index += 1
+
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
Adds a way for generated `#define` blocks to be formatted with trailing spaces/backslash in a manner identical to clang-format. Implemented in `make_virtuals.py` and a refactored `make_wrappers.py`.