### PR TITLE
Import/export GLTF extras to `node->meta` and back

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1023,6 +1023,14 @@ void Object::remove_meta(const StringName &p_name) {
 	set_meta(p_name, Variant());
 }
 
+void Object::merge_meta_from(const Object *p_src) {
+	List<StringName> meta_keys;
+	p_src->get_meta_list(&meta_keys);
+	for (const StringName &key : meta_keys) {
+		set_meta(key, p_src->get_meta(key));
+	}
+}
+
 TypedArray<Dictionary> Object::_get_property_list_bind() const {
 	List<PropertyInfo> lpi;
 	get_property_list(&lpi);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -895,6 +895,7 @@ public:
 	MTVIRTUAL void remove_meta(const StringName &p_name);
 	MTVIRTUAL Variant get_meta(const StringName &p_name, const Variant &p_default = Variant()) const;
 	MTVIRTUAL void get_meta_list(List<StringName> *p_list) const;
+	MTVIRTUAL void merge_meta_from(const Object *p_src);
 
 #ifdef TOOLS_ENABLED
 	void set_edited(bool p_edited);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4949,7 +4949,9 @@ bool EditorNode::is_object_of_custom_type(const Object *p_object, const StringNa
 }
 
 void EditorNode::progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {
-	if (singleton->cmdline_export_mode) {
+	if (!singleton) {
+		return;
+	} else if (singleton->cmdline_export_mode) {
 		print_line(p_task + ": begin: " + p_label + " steps: " + itos(p_steps));
 	} else if (singleton->progress_dialog) {
 		singleton->progress_dialog->add_task(p_task, p_label, p_steps, p_can_cancel);
@@ -4957,7 +4959,9 @@ void EditorNode::progress_add_task(const String &p_task, const String &p_label, 
 }
 
 bool EditorNode::progress_task_step(const String &p_task, const String &p_state, int p_step, bool p_force_refresh) {
-	if (singleton->cmdline_export_mode) {
+	if (!singleton) {
+		return false;
+	} else if (singleton->cmdline_export_mode) {
 		print_line("\t" + p_task + ": step " + itos(p_step) + ": " + p_state);
 		return false;
 	} else if (singleton->progress_dialog) {
@@ -4968,7 +4972,9 @@ bool EditorNode::progress_task_step(const String &p_task, const String &p_state,
 }
 
 void EditorNode::progress_end_task(const String &p_task) {
-	if (singleton->cmdline_export_mode) {
+	if (!singleton) {
+		return;
+	} else if (singleton->cmdline_export_mode) {
 		print_line(p_task + ": end");
 	} else if (singleton->progress_dialog) {
 		singleton->progress_dialog->end_task(p_task);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -649,6 +649,9 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 	String name = p_node->get_name();
 	NodePath original_path = p_root->get_path_to(p_node); // Used to detect renames due to import hints.
 
+	Ref<Resource> original_meta = memnew(Resource); // Create temp resource to hold original meta
+	original_meta->merge_meta_from(p_node);
+
 	bool isroot = p_node == p_root;
 
 	if (!isroot && _teststr(name, "noimp")) {
@@ -1022,6 +1025,8 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			print_verbose(vformat("Fix: Renamed %s to %s", original_path, new_path));
 			r_node_renames.push_back({ original_path, p_node });
 		}
+		// If we created new node instead, merge meta values from the original node.
+		p_node->merge_meta_from(*original_meta);
 	}
 
 	return p_node;
@@ -2452,6 +2457,8 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 		mesh_node->set_transform(src_mesh_node->get_transform());
 		mesh_node->set_skin(src_mesh_node->get_skin());
 		mesh_node->set_skeleton_path(src_mesh_node->get_skeleton_path());
+		mesh_node->merge_meta_from(src_mesh_node);
+
 		if (src_mesh_node->get_mesh().is_valid()) {
 			Ref<ArrayMesh> mesh;
 			if (!src_mesh_node->get_mesh()->has_mesh()) {
@@ -2599,6 +2606,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 				for (int i = 0; i < mesh->get_surface_count(); i++) {
 					mesh_node->set_surface_override_material(i, src_mesh_node->get_surface_material(i));
 				}
+				mesh->merge_meta_from(*src_mesh_node->get_mesh());
 			}
 		}
 
@@ -3114,7 +3122,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	progress.step(TTR("Saving..."), 104);
 
 	int flags = 0;
-	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+	if (EditorSettings::get_singleton() && EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
 		flags |= ResourceSaver::FLAG_COMPRESS;
 	}
 

--- a/modules/gltf/tests/test_gltf_extras.h
+++ b/modules/gltf/tests/test_gltf_extras.h
@@ -1,0 +1,165 @@
+/**************************************************************************/
+/*  test_gltf_extras.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_GLTF_EXTRAS_H
+#define TEST_GLTF_EXTRAS_H
+
+#include "tests/test_macros.h"
+
+#ifdef TOOLS_ENABLED
+
+#include "core/os/os.h"
+#include "editor/import/3d/resource_importer_scene.h"
+#include "modules/gltf/editor/editor_scene_importer_gltf.h"
+#include "modules/gltf/gltf_document.h"
+#include "modules/gltf/gltf_state.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/main/window.h"
+#include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/material.h"
+#include "scene/resources/packed_scene.h"
+
+namespace TestGltfExtras {
+
+static Node *_gltf_export_then_import(Node *p_root, String &p_tempfilebase) {
+	Ref<GLTFDocument> doc;
+	doc.instantiate();
+	Ref<GLTFState> state;
+	state.instantiate();
+	Error err = doc->append_from_scene(p_root, state, EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS);
+	CHECK_MESSAGE(err == OK, "GLTF state generation failed.");
+	err = doc->write_to_filesystem(state, p_tempfilebase + ".gltf");
+	CHECK_MESSAGE(err == OK, "Writing GLTF to cache dir failed.");
+
+	// Setting up importers.
+	Ref<ResourceImporterScene> import_scene = memnew(ResourceImporterScene("PackedScene", true));
+	ResourceFormatImporter::get_singleton()->add_importer(import_scene);
+	Ref<EditorSceneFormatImporterGLTF> import_gltf;
+	import_gltf.instantiate();
+	ResourceImporterScene::add_scene_importer(import_gltf);
+
+	// GTLF importer behaves differently outside of editor, it's too late to modify Engine::get_editor_hint
+	// as the registration of runtime extensions already happened, so remove them. See modules/gltf/register_types.cpp
+	GLTFDocument::unregister_all_gltf_document_extensions();
+
+	HashMap<StringName, Variant> options(20);
+	options["nodes/root_type"] = "";
+	options["nodes/root_name"] = "";
+	options["nodes/apply_root_scale"] = true;
+	options["nodes/root_scale"] = 1.0;
+	options["meshes/ensure_tangents"] = true;
+	options["meshes/generate_lods"] = false;
+	options["meshes/create_shadow_meshes"] = true;
+	options["meshes/light_baking"] = 1;
+	options["meshes/lightmap_texel_size"] = 0.2;
+	options["meshes/force_disable_compression"] = false;
+	options["skins/use_named_skins"] = true;
+	options["animation/import"] = true;
+	options["animation/fps"] = 30;
+	options["animation/trimming"] = false;
+	options["animation/remove_immutable_tracks"] = true;
+	options["import_script/path"] = "";
+	options["_subresources"] = Dictionary();
+	options["gltf/naming_version"] = 1;
+
+	// Process gltf file, note that this generates `.scn` resource from the 2nd argument.
+	err = import_scene->import(p_tempfilebase + ".gltf", p_tempfilebase, options, nullptr, nullptr, nullptr);
+	CHECK_MESSAGE(err == OK, "GLTF import failed.");
+	ResourceImporterScene::remove_scene_importer(import_gltf);
+
+	Ref<PackedScene> packed_scene = ResourceLoader::load(p_tempfilebase + ".scn", "", ResourceFormatLoader::CACHE_MODE_REPLACE, &err);
+	CHECK_MESSAGE(err == OK, "Loading scene failed.");
+	Node *p_scene = packed_scene->instantiate();
+	return p_scene;
+}
+
+TEST_CASE("[SceneTree][Node] GLTF test mesh and material meta export and import") {
+	// Setup scene.
+	Ref<StandardMaterial3D> original_material = memnew(StandardMaterial3D);
+	original_material->set_albedo(Color(1.0, .0, .0));
+	original_material->set_name("material");
+	Dictionary material_dict;
+	material_dict["node_type"] = "material";
+	original_material->set_meta("extras", material_dict);
+
+	Ref<PlaneMesh> original_meshdata = memnew(PlaneMesh);
+	original_meshdata->set_name("planemesh");
+	Dictionary meshdata_dict;
+	meshdata_dict["node_type"] = "planemesh";
+	original_meshdata->set_meta("extras", meshdata_dict);
+	original_meshdata->surface_set_material(0, original_material);
+
+	MeshInstance3D *original_mesh_instance = memnew(MeshInstance3D);
+	original_mesh_instance->set_mesh(original_meshdata);
+	original_mesh_instance->set_name("mesh_instance_3d");
+	Dictionary mesh_instance_dict;
+	mesh_instance_dict["node_type"] = "mesh_instance_3d";
+	original_mesh_instance->set_meta("extras", mesh_instance_dict);
+
+	Node3D *original = memnew(Node3D);
+	SceneTree::get_singleton()->get_root()->add_child(original);
+	original->add_child(original_mesh_instance);
+	original->set_name("node3d");
+	Dictionary node_dict;
+	node_dict["node_type"] = "node3d";
+	original->set_meta("extras", node_dict);
+	original->set_meta("meta_not_nested_under_extras", "should not propagate");
+
+	// Convert to GLFT and back.
+	String tempfile = OS::get_singleton()->get_cache_path().path_join("gltf_extras");
+	Node *loaded = _gltf_export_then_import(original, tempfile);
+
+	// Compare the results.
+	CHECK(loaded->get_name() == "node3d");
+	CHECK(Dictionary(loaded->get_meta("extras")).size() == 1);
+	CHECK(Dictionary(loaded->get_meta("extras"))["node_type"] == "node3d");
+	CHECK_FALSE(loaded->has_meta("meta_not_nested_under_extras"));
+	CHECK_FALSE(Dictionary(loaded->get_meta("extras")).has("meta_not_nested_under_extras"));
+
+	MeshInstance3D *mesh_instance_3d = Object::cast_to<MeshInstance3D>(loaded->find_child("mesh_instance_3d", false, true));
+	CHECK(mesh_instance_3d->get_name() == "mesh_instance_3d");
+	CHECK(Dictionary(mesh_instance_3d->get_meta("extras"))["node_type"] == "mesh_instance_3d");
+
+	Ref<Mesh> mesh = mesh_instance_3d->get_mesh();
+	CHECK(Dictionary(mesh->get_meta("extras"))["node_type"] == "planemesh");
+
+	Ref<Material> material = mesh->surface_get_material(0);
+	CHECK(material->get_name() == "material");
+	CHECK(Dictionary(material->get_meta("extras"))["node_type"] == "material");
+
+	memdelete(original_mesh_instance);
+	memdelete(original);
+	memdelete(loaded);
+}
+} // namespace TestGltfExtras
+
+#endif // TOOLS_ENABLED
+
+#endif // TEST_GLTF_EXTRAS_H

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -174,6 +174,31 @@ TEST_CASE("[Object] Metadata") {
 	CHECK_MESSAGE(
 			meta_list2.size() == 0,
 			"The metadata list should contain 0 items after removing all metadata items.");
+
+	Object other;
+	object.set_meta("conflicting_meta", "string");
+	object.set_meta("not_conflicting_meta", 123);
+	other.set_meta("conflicting_meta", Color(0, 1, 0));
+	other.set_meta("other_meta", "other");
+	object.merge_meta_from(&other);
+
+	CHECK_MESSAGE(
+			Color(object.get_meta("conflicting_meta")).is_equal_approx(Color(0, 1, 0)),
+			"String meta should be overwritten with Color after merging.");
+
+	CHECK_MESSAGE(
+			int(object.get_meta("not_conflicting_meta")) == 123,
+			"Not conflicting meta on destination should be kept intact.");
+
+	CHECK_MESSAGE(
+			object.get_meta("other_meta", String()) == "other",
+			"Not conflicting meta name on source should merged.");
+
+	List<StringName> meta_list3;
+	object.get_meta_list(&meta_list3);
+	CHECK_MESSAGE(
+			meta_list3.size() == 3,
+			"The metadata list should contain 3 items after merging meta from two objects.");
 }
 
 TEST_CASE("[Object] Construction") {


### PR DESCRIPTION
This is useful for custom tagging of objects with properties (for example in Blender) and having this available in the editor for scripting.

- Adds import logic to propagate the parsed GLTF `extras` all the way to the resulting Node->meta where it creates `extras` dictionary
- Adds export logic to save Godot Object `meta`/`extras` dictionary into GLTF `extras`
- Support [`nodes`](https://github.com/godotengine/godot/assets/153469044/aa6105d3-6713-4562-a85c-16420f351cc9), [`meshes`](https://github.com/godotengine/godot/assets/153469044/fae6e311-d627-449d-a69e-f4a945ae157d) and [`materials`](https://github.com/godotengine/godot/assets/153469044/3948dd51-ace7-42cb-be53-fe066ae20618) (in GLTF sense of the words)

![image](https://github.com/godotengine/godot/assets/153469044/aa6105d3-6713-4562-a85c-16420f351cc9)

Closes: https://github.com/godotengine/godot-proposals/issues/8271