### PR TITLE
Fix crash when renaming input maps in single window mode

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -137,7 +137,7 @@ void ActionMapEditor::_action_edited() {
 			return;
 		}
 
-		emit_signal(SNAME("action_renamed"), old_name, new_name);
+		call_deferred(SNAME("emit_signal"), "action_renamed", old_name, new_name);
 	} else if (action_tree->get_selected_column() == 1) {
 		// Deadzone Edited
 		String name = ti->get_meta("__name");


### PR DESCRIPTION
Fixes #86165

It already uses `call_deferred` in another branch, so IMO it's appropriate to add it here.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
