### PR TITLE
Add get_image() function for CurveTexture and CurveXYZTexture

### DIFF
--- a/scene/resources/curve_texture.cpp
+++ b/scene/resources/curve_texture.cpp
@@ -148,6 +148,13 @@ Ref<Curve> CurveTexture::get_curve() const {
 	return _curve;
 }
 
+Ref<Image> CurveTexture::get_image() const {
+	if (!_texture.is_valid()) {
+		return Ref<Image>();
+	}
+	return RenderingServer::get_singleton()->texture_2d_get(_texture);
+}
+
 void CurveTexture::set_texture_mode(TextureMode p_mode) {
 	ERR_FAIL_COND(p_mode < TEXTURE_MODE_RGB || p_mode > TEXTURE_MODE_RED);
 	if (texture_mode == p_mode) {
@@ -364,6 +371,13 @@ RID CurveXYZTexture::get_rid() const {
 		_texture = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 	return _texture;
+}
+
+Ref<Image> CurveXYZTexture::get_image() const {
+	if (!_texture.is_valid()) {
+		return Ref<Image>();
+	}
+	return RenderingServer::get_singleton()->texture_2d_get(_texture);
 }
 
 CurveXYZTexture::CurveXYZTexture() {}

--- a/scene/resources/curve_texture.h
+++ b/scene/resources/curve_texture.h
@@ -72,6 +72,8 @@ public:
 	virtual int get_height() const override { return 1; }
 	virtual bool has_alpha() const override { return false; }
 
+	virtual Ref<Image> get_image() const override;
+
 	CurveTexture();
 	~CurveTexture();
 };
@@ -114,6 +116,8 @@ public:
 
 	virtual int get_height() const override { return 1; }
 	virtual bool has_alpha() const override { return false; }
+
+	virtual Ref<Image> get_image() const override;
 
 	CurveXYZTexture();
 	~CurveXYZTexture();


### PR DESCRIPTION
Fixes #86182

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
