### PR TITLE
Correctly register editor-only module classes with the API

### DIFF
--- a/modules/minimp3/register_types.cpp
+++ b/modules/minimp3/register_types.cpp
@@ -52,8 +52,13 @@ void initialize_minimp3_module(ModuleInitializationLevel p_level) {
 		ResourceFormatImporter::get_singleton()->add_importer(mp3_import);
 	}
 
+	ClassDB::APIType prev_api = ClassDB::get_current_api();
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
+
 	// Required to document import options in the class reference.
 	GDREGISTER_CLASS(ResourceImporterMP3);
+
+	ClassDB::set_current_api(prev_api);
 #endif
 
 	GDREGISTER_CLASS(AudioStreamMP3);

--- a/modules/vorbis/register_types.cpp
+++ b/modules/vorbis/register_types.cpp
@@ -48,8 +48,13 @@ void initialize_vorbis_module(ModuleInitializationLevel p_level) {
 		ResourceFormatImporter::get_singleton()->add_importer(ogg_vorbis_importer);
 	}
 
+	ClassDB::APIType prev_api = ClassDB::get_current_api();
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
+
 	// Required to document import options in the class reference.
 	GDREGISTER_CLASS(ResourceImporterOggVorbis);
+
+	ClassDB::set_current_api(prev_api);
 #endif
 
 	GDREGISTER_CLASS(AudioStreamOggVorbis);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86206. We can call it a regression from https://github.com/godotengine/godot/pull/49524. Probably worth cherry-picking, though technically this changes the exposed API.

This pattern is used in the GLTF module, btw.