### PR TITLE
SCons: Integrate intellisense hinting for `SConstruct`/`SCsub` files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 EnsureSConsVersion(3, 0, 0)
 EnsurePythonVersion(3, 6)
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import core_builders

--- a/core/config/SCsub
+++ b/core/config/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_config = env.Clone()

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_crypto = env.Clone()

--- a/core/debugger/SCsub
+++ b/core/debugger/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/error/SCsub
+++ b/core/error/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_error = env.Clone()

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import make_wrappers

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import input_builders

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_math = env.Clone()

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import make_virtuals

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/string/SCsub
+++ b/core/string/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_string = env.Clone()

--- a/core/templates/SCsub
+++ b/core/templates/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_templates = env.Clone()

--- a/core/variant/SCsub
+++ b/core/variant/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_variant = env.Clone()

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.drivers_sources = []

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "alsa" in env and env["alsa"]:

--- a/drivers/alsamidi/SCsub
+++ b/drivers/alsamidi/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Driver source files

--- a/drivers/coreaudio/SCsub
+++ b/drivers/coreaudio/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Driver source files

--- a/drivers/coremidi/SCsub
+++ b/drivers/coremidi/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Driver source files

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 import os
 from pathlib import Path
 

--- a/drivers/egl/SCsub
+++ b/drivers/egl/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Godot source files

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if env["platform"] in ["macos", "windows", "linuxbsd"]:

--- a/drivers/gles3/SCsub
+++ b/drivers/gles3/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/gles3/effects/SCsub
+++ b/drivers/gles3/effects/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/gles3/environment/SCsub
+++ b/drivers/gles3/environment/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "GLES3_GLSL" in env["BUILDERS"]:

--- a/drivers/gles3/storage/SCsub
+++ b/drivers/gles3/storage/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_png = env.Clone()

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "pulseaudio" in env and env["pulseaudio"]:

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 thirdparty_obj = []

--- a/drivers/wasapi/SCsub
+++ b/drivers/wasapi/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Driver source files

--- a/drivers/windows/SCsub
+++ b/drivers/windows/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/winmidi/SCsub
+++ b/drivers/winmidi/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Driver source files

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.editor_sources = []

--- a/editor/debugger/SCsub
+++ b/editor/debugger/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/debugger/debug_adapter/SCsub
+++ b/editor/debugger/debug_adapter/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/export/SCsub
+++ b/editor/export/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/gui/SCsub
+++ b/editor/gui/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import os

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/plugins/SCsub
+++ b/editor/plugins/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/plugins/gizmos/SCsub
+++ b/editor/plugins/gizmos/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/plugins/tiles/SCsub
+++ b/editor/plugins/tiles/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.editor_sources, "*.cpp")

--- a/main/SCsub
+++ b/main/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import main_builders

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 import modules_builders
 import os
 

--- a/modules/astcenc/SCsub
+++ b/modules/astcenc/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/bmp/SCsub
+++ b/modules/bmp/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/dds/SCsub
+++ b/modules/dds/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/gdscript/editor/script_templates/SCsub
+++ b/modules/gdscript/editor/script_templates/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import editor.template_builders as build_template_gd

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/gltf/extensions/SCsub
+++ b/modules/gltf/extensions/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/hdr/SCsub
+++ b/modules/hdr/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/jsonrpc/SCsub
+++ b/modules/jsonrpc/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/ktx/SCsub
+++ b/modules/ktx/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/meshoptimizer/SCsub
+++ b/modules/meshoptimizer/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/mobile_vr/SCsub
+++ b/modules/mobile_vr/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 import build_scripts.mono_configure as mono_configure
 
 Import("env")

--- a/modules/mono/editor/script_templates/SCsub
+++ b/modules/mono/editor/script_templates/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import editor.template_builders as build_template_cs

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/multiplayer/SCsub
+++ b/modules/multiplayer/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/noise/SCsub
+++ b/modules/noise/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/openxr/editor/SCsub
+++ b/modules/openxr/editor/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/tga/SCsub
+++ b/modules/tga/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/webrtc/SCsub
+++ b/modules/webrtc/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/webxr/SCsub
+++ b/modules/webxr/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/modules/zip/SCsub
+++ b/modules/zip/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 Import("env_modules")
 

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.platform_sources = []

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 import subprocess
 
 Import("env")

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 ios_lib = [

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 from platform_methods import run_in_subprocess

--- a/platform/linuxbsd/x11/SCsub
+++ b/platform/linuxbsd/x11/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 source_files = [

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 from platform_methods import run_in_subprocess

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # The HTTP server "targets". Run with "scons p=web serve", or "scons p=web run"

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import os

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.scene_sources = []

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Thirdparty code

--- a/scene/audio/SCsub
+++ b/scene/audio/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/debugger/SCsub
+++ b/scene/debugger/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.scene_sources, "*.cpp")

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Thirdparty code

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 from platform_methods import run_in_subprocess

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 import default_theme_icons_builders

--- a/scons_hints.py
+++ b/scons_hints.py
@@ -1,0 +1,99 @@
+"""
+Adds intellisense hints for SCons scripts.
+Implemented via `from scons_hints import *`.
+
+This is NOT a 1-1 representation of what the defines will represent in an
+SCons build, as proxies are almost always utilized instead. Rather, this is
+a means of tracing back what those proxies are calling to in the first place.
+"""
+
+# from typing import TYPE_CHECKING
+
+# if TYPE_CHECKING:
+#     from SCons.Action import Action
+#     from SCons.Builder import Builder
+#     from SCons.Defaults import Chmod, Copy, CScan, DefaultEnvironment, Delete, DirScanner, Mkdir, Move, Touch
+#     from SCons.Platform import Platform
+#     from SCons.Platform.virtualenv import Virtualenv
+#     from SCons.Scanner import FindPathDirs, ScannerBase
+#     from SCons.Script import ARGLIST, ARGUMENTS, BUILD_TARGETS, COMMAND_LINE_TARGETS, DEFAULT_TARGETS
+#     from SCons.Subst import SetAllowableExceptions as AllowSubstExceptions
+#     from SCons.Tool import CScanner, DScanner, ProgramScanner, SourceFileScanner, Tool
+#     from SCons.Util import AddMethod, WhereIs
+#     from SCons.Variables import BoolVariable, EnumVariable, ListVariable, PathVariable, PackageVariable, Variables
+#     from SCons.Script.Main import (
+#         AddOption,
+#         BuildTask,
+#         CleanTask,
+#         DebugOptions,
+#         GetBuildFailures,
+#         GetOption,
+#         PrintHelp,
+#         Progress,
+#         QuestionTask,
+#         SetOption,
+#         ValidateOptions,
+#     )
+#     from SCons.Script.SConscript import (
+#         SConsEnvironment,
+#         SConsEnvironment as Environment,  # Hack to have Environment() properly recognized as SConsEnvironment.
+#         Configure,
+#         Return,
+#     )
+#     from SCons.Environment import (
+#         # Environment,  # See above.
+#         Base,
+#     )
+
+#     Default = SConsEnvironment.Default
+#     EnsurePythonVersion = SConsEnvironment.EnsurePythonVersion
+#     EnsureSConsVersion = SConsEnvironment.EnsureSConsVersion
+#     Exit = SConsEnvironment.Exit
+#     Export = SConsEnvironment.Export
+#     GetLaunchDir = SConsEnvironment.GetLaunchDir
+#     Help = SConsEnvironment.Help
+#     Import = SConsEnvironment.Import
+#     SConscript = SConsEnvironment.SConscript
+#     SConscriptChdir = SConsEnvironment.SConscriptChdir
+
+#     AddPostAction = Base.AddPostAction
+#     AddPreAction = Base.AddPreAction
+#     Alias = Base.Alias
+#     AlwaysBuild = Base.AlwaysBuild
+#     CacheDir = Base.CacheDir
+#     Clean = Base.Clean
+#     Command = Base.Command
+#     Decider = Base.Decider
+#     Depends = Base.Depends
+#     Dir = Base.Dir
+#     Entry = Base.Entry
+#     Execute = Base.Execute
+#     File = Base.File
+#     FindFile = Base.FindFile
+#     FindInstalledFiles = Base.FindInstalledFiles
+#     FindSourceFiles = Base.FindSourceFiles
+#     Flatten = Base.Flatten
+#     GetBuildPath = Base.GetBuildPath
+#     Glob = Base.Glob
+#     Ignore = Base.Ignore
+#     Install = Base.Install
+#     InstallAs = Base.InstallAs
+#     InstallVersionedLib = Base.InstallVersionedLib
+#     Literal = Base.Literal
+#     Local = Base.Local
+#     NoCache = Base.NoCache
+#     NoClean = Base.NoClean
+#     ParseDepends = Base.ParseDepends
+#     Precious = Base.Precious
+#     PyPackageDir = Base.PyPackageDir
+#     Repository = Base.Repository
+#     Requires = Base.Requires
+#     SConsignFile = Base.SConsignFile
+#     SideEffect = Base.SideEffect
+#     Split = Base.Split
+#     Tag = Base.Tag
+#     Value = Base.Value
+#     VariantDir = Base.VariantDir
+
+#     env: SConsEnvironment
+#     env_modules: SConsEnvironment

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.servers_sources = []

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/audio/effects/SCsub
+++ b/servers/audio/effects/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/camera/SCsub
+++ b/servers/camera/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/debugger/SCsub
+++ b/servers/debugger/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/extensions/SCsub
+++ b/servers/extensions/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_object = env.Clone()

--- a/servers/movie_writer/SCsub
+++ b/servers/movie_writer/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/navigation/SCsub
+++ b/servers/navigation/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/physics_2d/SCsub
+++ b/servers/physics_2d/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/physics_3d/SCsub
+++ b/servers/physics_3d/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/physics_3d/joints/SCsub
+++ b/servers/physics_3d/joints/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/SCsub
+++ b/servers/rendering/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/dummy/SCsub
+++ b/servers/rendering/dummy/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/dummy/storage/SCsub
+++ b/servers/rendering/dummy/storage/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/SCsub
+++ b/servers/rendering/renderer_rd/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env_effects = env.Clone()

--- a/servers/rendering/renderer_rd/environment/SCsub
+++ b/servers/rendering/renderer_rd/environment/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/forward_clustered/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/forward_mobile/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:

--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:

--- a/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:

--- a/servers/rendering/renderer_rd/spirv-reflect/SCsub
+++ b/servers/rendering/renderer_rd/spirv-reflect/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 # Thirdparty source files

--- a/servers/rendering/renderer_rd/storage_rd/SCsub
+++ b/servers/rendering/renderer_rd/storage_rd/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/rendering/storage/SCsub
+++ b/servers/rendering/storage/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/text/SCsub
+++ b/servers/text/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/xr/SCsub
+++ b/servers/xr/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from scons_hints import *
+
 Import("env")
 
 env.add_source_files(env.servers_sources, "*.cpp")

--- a/typings/__builtins__.pyi
+++ b/typings/__builtins__.pyi
@@ -1,0 +1,133 @@
+import SCons.Action
+import SCons.Builder
+import SCons.Defaults
+import SCons.Environment
+import SCons.Node.FS
+import SCons.Platform
+import SCons.Platform.virtualenv
+import SCons.Scanner
+import SCons.SConf
+import SCons.Script
+import SCons.Script.Main
+import SCons.Script.SConscript as _SConscript
+import SCons.Subst
+import SCons.Tool
+import SCons.Util
+import SCons.Variables
+
+Action = SCons.Action.Action
+
+Builder = SCons.Builder.Builder
+
+Chmod = SCons.Defaults.Chmod
+Copy = SCons.Defaults.Copy
+CScan = SCons.Defaults.CScan
+DefaultEnvironment = SCons.Defaults.DefaultEnvironment
+Delete = SCons.Defaults.Delete
+DirScanner = SCons.Defaults.DirScanner
+Mkdir = SCons.Defaults.Mkdir
+Move = SCons.Defaults.Move
+Touch = SCons.Defaults.Touch
+
+SConsEnvironment = _SConscript.SConsEnvironment
+Environment = _SConscript.SConsEnvironment
+Configure = _SConscript.Configure
+Return = _SConscript.Return
+
+Base = SCons.Environment.Environment
+
+Platform = SCons.Platform.Platform
+
+Virtualenv = SCons.Platform.virtualenv.Virtualenv
+
+FindPathDirs = SCons.Scanner.FindPathDirs
+ScannerBase = SCons.Scanner.ScannerBase
+
+ARGLIST = SCons.Script.ARGLIST
+ARGUMENTS = SCons.Script.ARGUMENTS
+BUILD_TARGETS = SCons.Script.BUILD_TARGETS
+COMMAND_LINE_TARGETS = SCons.Script.COMMAND_LINE_TARGETS
+DEFAULT_TARGETS = SCons.Script.DEFAULT_TARGETS
+
+AddOption = SCons.Script.Main.AddOption
+BuildTask = SCons.Script.Main.BuildTask
+CleanTask = SCons.Script.Main.CleanTask
+DebugOptions = SCons.Script.Main.DebugOptions
+GetBuildFailures = SCons.Script.Main.GetBuildFailures
+GetOption = SCons.Script.Main.GetOption
+PrintHelp = SCons.Script.Main.PrintHelp
+Progress = SCons.Script.Main.Progress
+QuestionTask = SCons.Script.Main.QuestionTask
+SetOption = SCons.Script.Main.SetOption
+ValidateOptions = SCons.Script.Main.ValidateOptions
+
+AllowSubstExceptions = SCons.Subst.SetAllowableExceptions
+
+CScanner = SCons.Tool.CScanner
+DScanner = SCons.Tool.DScanner
+ProgramScanner = SCons.Tool.ProgramScanner
+SourceFileScanner = SCons.Tool.SourceFileScanner
+Tool = SCons.Tool.Tool
+
+AddMethod = SCons.Util.AddMethod
+WhereIs = SCons.Util.WhereIs
+
+BoolVariable = SCons.Variables.BoolVariable
+EnumVariable = SCons.Variables.EnumVariable
+ListVariable = SCons.Variables.ListVariable
+PathVariable = SCons.Variables.PathVariable
+PackageVariable = SCons.Variables.PackageVariable
+Variables = SCons.Variables.Variables
+
+Default = SConsEnvironment.Default
+EnsurePythonVersion = SConsEnvironment.EnsurePythonVersion
+EnsureSConsVersion = SConsEnvironment.EnsureSConsVersion
+Exit = SConsEnvironment.Exit
+Export = SConsEnvironment.Export
+GetLaunchDir = SConsEnvironment.GetLaunchDir
+Help = SConsEnvironment.Help
+Import = SConsEnvironment.Import
+SConscript = SConsEnvironment.SConscript
+SConscriptChdir = SConsEnvironment.SConscriptChdir
+
+AddPostAction = Base.AddPostAction
+AddPreAction = Base.AddPreAction
+Alias = Base.Alias
+AlwaysBuild = Base.AlwaysBuild
+CacheDir = Base.CacheDir
+Clean = Base.Clean
+Command = Base.Command
+Decider = Base.Decider
+Depends = Base.Depends
+Dir = Base.Dir
+Entry = Base.Entry
+Execute = Base.Execute
+File = Base.File
+FindFile = Base.FindFile
+FindInstalledFiles = Base.FindInstalledFiles
+FindSourceFiles = Base.FindSourceFiles
+Flatten = Base.Flatten
+GetBuildPath = Base.GetBuildPath
+Glob = Base.Glob
+Ignore = Base.Ignore
+Install = Base.Install
+InstallAs = Base.InstallAs
+InstallVersionedLib = Base.InstallVersionedLib
+Literal = Base.Literal
+Local = Base.Local
+NoCache = Base.NoCache
+NoClean = Base.NoClean
+ParseDepends = Base.ParseDepends
+Precious = Base.Precious
+PyPackageDir = Base.PyPackageDir
+Repository = Base.Repository
+Requires = Base.Requires
+SConsignFile = Base.SConsignFile
+SideEffect = Base.SideEffect
+Split = Base.Split
+Tag = Base.Tag
+Value = Base.Value
+VariantDir = Base.VariantDir
+
+env: _SConscript.SConsEnvironment
+env_modules: _SConscript.SConsEnvironment


### PR DESCRIPTION
Adds `scons_hints.py` to the repo, which adds intellisense logic to all* SCons files in the repo. No logic was changed across any of the SCons scripts, as this only adds the existing type-checking context for an environment. While it's not a 1-1 representation of what SCons will be calling to behind the scenes (it will frequently utilize proxies for that purpose), it *does* allow users to reliably trace back where the calls are being sent to/from in the first place. In practice, this is a simplified version of the `SCons.Script` initalization—excluding private files, extraneous includes, and workaround linking methods—alongside typing hints for `env` and `env_module` so they're immediately recognized as `SConsEnvironment` for files that open with `Import()` (aka: pretty much every single `SCsub` file)

\* Note: Two SCons files were *not* updated. Those being the standalone `SConstruct` files utilized by the text modules, as they're inherently isolated