### PR TITLE
SCons: Consolidate lists where applicable

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -243,7 +243,7 @@ SConscript("error/SCsub")
 
 # Build it all as a library
 lib = env.add_library("core", env.core_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)
 
 # Needed to force rebuilding the core files when the thirdparty code is updated.
 env.Depends(lib, thirdparty_obj)

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -38,4 +38,4 @@ SConscript("png/SCsub")
 env.add_source_files(env.drivers_sources, "*.cpp")
 
 lib = env.add_library("drivers", env.drivers_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -128,4 +128,4 @@ if env.editor_build:
     SConscript("plugins/SCsub")
 
     lib = env.add_library("editor", env.editor_sources)
-    env.Prepend(LIBS=[lib])
+    env.Prepend(LIBS=lib)

--- a/main/SCsub
+++ b/main/SCsub
@@ -36,4 +36,4 @@ env_main.CommandNoCache(
 )
 
 lib = env_main.add_library("main", env.main_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)

--- a/methods.py
+++ b/methods.py
@@ -597,16 +597,16 @@ def no_verbose(sys, env):
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
     )
 
-    env.Append(CXXCOMSTR=[compile_source_message])
-    env.Append(CCCOMSTR=[compile_source_message])
-    env.Append(SHCCCOMSTR=[compile_shared_source_message])
-    env.Append(SHCXXCOMSTR=[compile_shared_source_message])
-    env.Append(ARCOMSTR=[link_library_message])
-    env.Append(RANLIBCOMSTR=[ranlib_library_message])
-    env.Append(SHLINKCOMSTR=[link_shared_library_message])
-    env.Append(LINKCOMSTR=[link_program_message])
-    env.Append(JARCOMSTR=[java_library_message])
-    env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(CXXCOMSTR=compile_source_message)
+    env.Append(CCCOMSTR=compile_source_message)
+    env.Append(SHCCCOMSTR=compile_shared_source_message)
+    env.Append(SHCXXCOMSTR=compile_shared_source_message)
+    env.Append(ARCOMSTR=link_library_message)
+    env.Append(RANLIBCOMSTR=ranlib_library_message)
+    env.Append(SHLINKCOMSTR=link_shared_library_message)
+    env.Append(LINKCOMSTR=link_program_message)
+    env.Append(JARCOMSTR=java_library_message)
+    env.Append(JAVACCOMSTR=java_compile_source_message)
 
 
 def detect_visual_c_compiler_version(tools_env):

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -34,7 +34,7 @@ for name, path in env.module_list.items():
     SConscript(base_path + "/SCsub")
 
     lib = env_modules.add_library("module_%s" % name, env.modules_sources)
-    env.Prepend(LIBS=[lib])
+    env.Prepend(LIBS=lib)
     if env["vsproj"]:
         vs_sources += env.modules_sources
 
@@ -67,6 +67,6 @@ if env["tests"]:
 env.modules_sources = []
 env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
 lib = env_modules.add_library("modules", env.modules_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)
 if env["vsproj"]:
     env.modules_sources += vs_sources

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -100,7 +100,7 @@ if env["builtin_freetype"]:
             inserted = True
             break
     if not inserted:
-        env.Append(LIBS=[lib])
+        env.Append(LIBS=lib)
 
 
 # Godot source files

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -52,7 +52,7 @@ if env["builtin_msdfgen"]:
             inserted = True
             break
     if not inserted:
-        env.Append(LIBS=[lib])
+        env.Append(LIBS=lib)
 
 
 # Godot source files

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -181,7 +181,7 @@ if env["builtin_harfbuzz"]:
             inserted = True
             break
     if not inserted:
-        env.Append(LIBS=[lib])
+        env.Append(LIBS=lib)
 
 
 if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
@@ -251,7 +251,7 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
             inserted = True
             break
     if not inserted:
-        env.Append(LIBS=[lib])
+        env.Append(LIBS=lib)
 
 
 if env["builtin_icu4c"]:
@@ -521,7 +521,7 @@ if env["builtin_icu4c"]:
             inserted = True
             break
     if not inserted:
-        env.Append(LIBS=[lib])
+        env.Append(LIBS=lib)
 
 
 # Godot source files

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -116,7 +116,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         f'tvg_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_tvg_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 # MSDFGEN
 if env["msdfgen_enabled"] and env["freetype_enabled"]:
@@ -155,7 +155,7 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
         f'msdfgen_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_msdfgen_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 # FreeType
 if env["freetype_enabled"]:
@@ -284,7 +284,7 @@ if env["freetype_enabled"]:
         f'freetype_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_freetype_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 # HarfBuzz
 env_harfbuzz = env.Clone()
@@ -414,7 +414,7 @@ lib = env_harfbuzz.Library(
     f'harfbuzz_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
     thirdparty_harfbuzz_sources,
 )
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)
 
 # Graphite
 if env["graphite_enabled"] and env["freetype_enabled"]:
@@ -474,7 +474,7 @@ if env["graphite_enabled"] and env["freetype_enabled"]:
         f'graphite_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_graphite_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 # ICU
 env_icu = env.Clone()
@@ -732,7 +732,7 @@ if env["platform"] == "windows":
     env.Append(LIBS=["advapi32"])
 
 lib = env_icu.Library(f'icu_builtin{env["suffix"]}{env["LIBSUFFIX"]}', thirdparty_icu_sources)
-env.Append(LIBS=[lib])
+env.Append(LIBS=lib)
 
 env.Append(CPPDEFINES=["GDEXTENSION"])
 env.Append(CPPPATH=["../"])

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -43,16 +43,16 @@ def no_verbose(sys, env):
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
     )
 
-    env.Append(CXXCOMSTR=[compile_source_message])
-    env.Append(CCCOMSTR=[compile_source_message])
-    env.Append(SHCCCOMSTR=[compile_shared_source_message])
-    env.Append(SHCXXCOMSTR=[compile_shared_source_message])
-    env.Append(ARCOMSTR=[link_library_message])
-    env.Append(RANLIBCOMSTR=[ranlib_library_message])
-    env.Append(SHLINKCOMSTR=[link_shared_library_message])
-    env.Append(LINKCOMSTR=[link_program_message])
-    env.Append(JARCOMSTR=[java_library_message])
-    env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(CXXCOMSTR=compile_source_message)
+    env.Append(CCCOMSTR=compile_source_message)
+    env.Append(SHCCCOMSTR=compile_shared_source_message)
+    env.Append(SHCXXCOMSTR=compile_shared_source_message)
+    env.Append(ARCOMSTR=link_library_message)
+    env.Append(RANLIBCOMSTR=ranlib_library_message)
+    env.Append(SHLINKCOMSTR=link_shared_library_message)
+    env.Append(LINKCOMSTR=link_program_message)
+    env.Append(JARCOMSTR=java_library_message)
+    env.Append(JAVACCOMSTR=java_compile_source_message)
 
 
 def disable_warnings(self):

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -111,7 +111,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         f'tvg_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_tvg_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 # MSDFGEN
 if env["msdfgen_enabled"] and env["freetype_enabled"]:
@@ -150,7 +150,7 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
         f'msdfgen_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_msdfgen_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 # FreeType
 if env["freetype_enabled"]:
@@ -279,7 +279,7 @@ if env["freetype_enabled"]:
         f'freetype_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_freetype_sources,
     )
-    env.Append(LIBS=[lib])
+    env.Append(LIBS=lib)
 
 
 env.Append(CPPDEFINES=["GDEXTENSION"])

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -43,16 +43,16 @@ def no_verbose(sys, env):
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
     )
 
-    env.Append(CXXCOMSTR=[compile_source_message])
-    env.Append(CCCOMSTR=[compile_source_message])
-    env.Append(SHCCCOMSTR=[compile_shared_source_message])
-    env.Append(SHCXXCOMSTR=[compile_shared_source_message])
-    env.Append(ARCOMSTR=[link_library_message])
-    env.Append(RANLIBCOMSTR=[ranlib_library_message])
-    env.Append(SHLINKCOMSTR=[link_shared_library_message])
-    env.Append(LINKCOMSTR=[link_program_message])
-    env.Append(JARCOMSTR=[java_library_message])
-    env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(CXXCOMSTR=compile_source_message)
+    env.Append(CCCOMSTR=compile_source_message)
+    env.Append(SHCCCOMSTR=compile_shared_source_message)
+    env.Append(SHCXXCOMSTR=compile_shared_source_message)
+    env.Append(ARCOMSTR=link_library_message)
+    env.Append(RANLIBCOMSTR=ranlib_library_message)
+    env.Append(SHLINKCOMSTR=link_shared_library_message)
+    env.Append(LINKCOMSTR=link_program_message)
+    env.Append(JARCOMSTR=java_library_message)
+    env.Append(JAVACCOMSTR=java_compile_source_message)
 
 
 def disable_warnings(self):

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -27,4 +27,4 @@ with open("register_platform_apis.gen.cpp", "w", encoding="utf-8") as f:
 env.add_source_files(env.platform_sources, "register_platform_apis.gen.cpp")
 
 lib = env.add_library("platform", env.platform_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -21,4 +21,4 @@ SConscript("theme/SCsub")
 
 # Build it all as a library
 lib = env.add_library("scene", env.scene_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -19,4 +19,4 @@ SConscript("navigation/SCsub")
 
 lib = env.add_library("servers", env.servers_sources)
 
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -19,4 +19,4 @@ if env["disable_exceptions"]:
 env_tests.add_source_files(env.tests_sources, "*.cpp")
 
 lib = env_tests.add_library("tests", env.tests_sources)
-env.Prepend(LIBS=[lib])
+env.Prepend(LIBS=lib)


### PR DESCRIPTION
Examining the generated `.scons_env.json` file shows that there's a few instances where something that should be a list of items is erroneously a list of a list of items. This PR fixes that minor issue, and the resulting builds are actually entirely identical. The only difference is the resulting `.scons_env.json` is more condensed & readable.

<details>
  <summary>Before</summary>

```json
    "CXXCOMSTR": [
        "\u001b[0;94mCompiling \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m"
    ],
    "CCCOMSTR": [
        "\u001b[0;94mCompiling \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m"
    ],
    "SHCCCOMSTR": [
        "\u001b[0;94mCompiling shared \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m"
    ],
    "SHCXXCOMSTR": [
        "\u001b[0;94mCompiling shared \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m"
    ],
    "ARCOMSTR": [
        "\u001b[0;94mLinking Static Library \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m"
    ],
    "RANLIBCOMSTR": [
        "\u001b[0;94mRanlib Library \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m"
    ],
    "SHLINKCOMSTR": [
        "\u001b[0;94mLinking Shared Library \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m"
    ],
    "LINKCOMSTR": [
        "\u001b[0;94mLinking Program \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m"
    ],
    "JARCOMSTR": [
        "\u001b[0;94mCreating Java Archive \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m"
    ],
    "JAVACCOMSTR": [
        "\u001b[0;94mCompiling \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m"
    ],
    "LIBS": [
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>",
        "<<non-serializable: NodeList>>"
    ],
```
</details>

<details>
  <summary>After</summary>

```json
    "CXXCOMSTR": "\u001b[0;94mCompiling \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m",
    "CCCOMSTR": "\u001b[0;94mCompiling \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m",
    "SHCCCOMSTR": "\u001b[0;94mCompiling shared \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m",
    "SHCXXCOMSTR": "\u001b[0;94mCompiling shared \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m",
    "ARCOMSTR": "\u001b[0;94mLinking Static Library \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m",
    "RANLIBCOMSTR": "\u001b[0;94mRanlib Library \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m",
    "SHLINKCOMSTR": "\u001b[0;94mLinking Shared Library \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m",
    "LINKCOMSTR": "\u001b[0;94mLinking Program \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m",
    "JARCOMSTR": "\u001b[0;94mCreating Java Archive \u001b[1;94m$TARGET\u001b[0;94m ...\u001b[0m",
    "JAVACCOMSTR": "\u001b[0;94mCompiling \u001b[1;94m$SOURCE\u001b[0;94m ...\u001b[0m",
    "LIBS": "<<non-serializable: NodeList>>",
```
</details>