### PR TITLE
Fix `Node` selection when navigating `Tree` with Arrow keys

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3233,8 +3233,8 @@ void Tree::_go_up() {
 		if (!prev) {
 			return;
 		}
-		selected_item = prev;
-		emit_signal(SNAME("cell_selected"));
+
+		select_single_item(prev, get_root(), selected_col);
 		queue_redraw();
 	} else {
 		int col = selected_col < 0 ? 0 : selected_col;
@@ -3266,8 +3266,7 @@ void Tree::_go_down() {
 			return;
 		}
 
-		selected_item = next;
-		emit_signal(SNAME("cell_selected"));
+		select_single_item(next, get_root(), selected_col);
 		queue_redraw();
 	} else {
 		int col = selected_col < 0 ? 0 : selected_col;


### PR DESCRIPTION
Fixes  #12544

Arrow keys change actual selection (not just cursor) when navigating `Tree` and `SceneTreeDock`.