### PR TITLE
Mention `etcpak` changes in thirdparty/README.md

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -216,6 +216,8 @@ Files extracted from upstream source:
   ```
 - `AUTHORS.txt` and `LICENSE.txt`
 
+Two files (`ProcessRgtc.{cpp,hpp}`) have been added to provide RGTC compression implementation,
+based on library's `ProcessDxtc.{cpp,hpp}`.
 
 ## fonts
 


### PR DESCRIPTION
Follow-up to #85842

Adds information about the ProcessRgtc files added to `etcpak` to `thirdparty/README.md`.