### PR TITLE
Add description for rendering/limits/spatial_indexer/threaded_cull_minimum_instances

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2554,6 +2554,7 @@
 			[b]Note:[/b] This setting is only effective when using the Compatibility rendering method, not Forward+ and Mobile.
 		</member>
 		<member name="rendering/limits/spatial_indexer/threaded_cull_minimum_instances" type="int" setter="" getter="" default="1000">
+			The minimum number of instances that must be present in a scene to enable culling computations on multiple threads. If a scene has fewer instances than this number, culling is done on a single thread.
 		</member>
 		<member name="rendering/limits/spatial_indexer/update_iterations_per_frame" type="int" setter="" getter="" default="10">
 		</member>


### PR DESCRIPTION
Adds a description for the property rendering/limits/spatial_indexer/threaded_cull_minimum_instances based on my reading of its use in `renderer_scene_cull.cpp`.

Accessing:

https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/servers/rendering/renderer_scene_cull.cpp#L4164

Using:

https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/servers/rendering/renderer_scene_cull.cpp#L3028-L3033

https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/servers/rendering/renderer_scene_cull.cpp#L3129-L3145