### PR TITLE
[MP] Fix `complete_auth` notifying the wrong peer

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -483,9 +483,14 @@ Error SceneMultiplayer::complete_auth(int p_peer) {
 	ERR_FAIL_COND_V(!pending_peers.has(p_peer), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V_MSG(pending_peers[p_peer].local, ERR_FILE_CANT_WRITE, "The authentication session was already marked as completed.");
 	pending_peers[p_peer].local = true;
+
 	// Notify the remote peer that the authentication has completed.
 	uint8_t buf[2] = { NETWORK_COMMAND_SYS, SYS_COMMAND_AUTH };
+	multiplayer_peer->set_target_peer(p_peer);
+	multiplayer_peer->set_transfer_channel(0);
+	multiplayer_peer->set_transfer_mode(MultiplayerPeer::TRANSFER_MODE_RELIABLE);
 	Error err = _send(buf, 2);
+
 	// The remote peer already reported the authentication as completed, so admit the peer.
 	// May generate new packets, so it must happen after sending confirmation.
 	if (pending_peers[p_peer].remote) {


### PR DESCRIPTION
The SceneMultiplayer `complete_auth` method was not configuring the multiplayer peer correctly, causing it to potentially send the notification to the wrong peer, on the wrong channel, and/or with an incorrect transfer mode.

The original issue was reported in the contributors chat by @TestSubject06 