### PR TITLE
Include `name` field in MethodInfo operator ==

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -235,7 +235,7 @@ struct MethodInfo {
 		return arguments_metadata.size() > p_arg ? arguments_metadata[p_arg] : 0;
 	}
 
-	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id; }
+	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id && name == p_method.name; }
 	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }
 
 	operator Dictionary() const;


### PR DESCRIPTION
The GDScript analyzer currently does not recognize Methods from other scripting languages as callable. This is caused by this section of the analyzer:

https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/modules/gdscript/gdscript_analyzer.cpp#L5014-L5016

Which uses either `ScriptExtension::get_method_info` which calls [`MethodInfo::from_dict`](https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/core/object/object.cpp#L133) that never sets a `MethodInfo.id`, 

https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/core/object/script_language_extension.h#L105-L109

or `CSharpScript::get_method_info` which doesn't set an ID either.

https://github.com/godotengine/godot/blob/2d0ee20ff30461b6b10f6fdfba87511a0ebc6642/modules/mono/csharp_script.cpp#L2349-L2374


Following the implementation of `operator<` I have therefore extended the equality operator to compare the `name` field as well.

(this fix is also compatible with at least 4.2 and 4.1)
