### PR TITLE
[MP] Fix auth not waiting for confirmation in some cases

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -96,35 +96,29 @@ Error SceneMultiplayer::poll() {
 #endif
 
 		if (pending_peers.has(sender)) {
-			if (pending_peers[sender].local) {
-				// If the auth is over, admit the peer at the first packet.
-				pending_peers.erase(sender);
-				_admit_peer(sender);
+			ERR_CONTINUE(len < 2 || (packet[0] & CMD_MASK) != NETWORK_COMMAND_SYS || packet[1] != SYS_COMMAND_AUTH);
+			// Auth message.
+			PackedByteArray pba;
+			pba.resize(len - 2);
+			if (pba.size()) {
+				memcpy(pba.ptrw(), &packet[2], len - 2);
+				// User callback
+				const Variant sv = sender;
+				const Variant pbav = pba;
+				const Variant *argv[2] = { &sv, &pbav };
+				Variant ret;
+				Callable::CallError ce;
+				auth_callback.callp(argv, 2, ret, ce);
+				ERR_CONTINUE_MSG(ce.error != Callable::CallError::CALL_OK, "Failed to call authentication callback");
 			} else {
-				ERR_CONTINUE(len < 2 || (packet[0] & CMD_MASK) != NETWORK_COMMAND_SYS || packet[1] != SYS_COMMAND_AUTH);
-				// Auth message.
-				PackedByteArray pba;
-				pba.resize(len - 2);
-				if (pba.size()) {
-					memcpy(pba.ptrw(), &packet[2], len - 2);
-					// User callback
-					const Variant sv = sender;
-					const Variant pbav = pba;
-					const Variant *argv[2] = { &sv, &pbav };
-					Variant ret;
-					Callable::CallError ce;
-					auth_callback.callp(argv, 2, ret, ce);
-					ERR_CONTINUE_MSG(ce.error != Callable::CallError::CALL_OK, "Failed to call authentication callback");
-				} else {
-					// Remote complete notification.
-					pending_peers[sender].remote = true;
-					if (pending_peers[sender].local) {
-						pending_peers.erase(sender);
-						_admit_peer(sender);
-					}
+				// Remote complete notification.
+				pending_peers[sender].remote = true;
+				if (pending_peers[sender].local) {
+					pending_peers.erase(sender);
+					_admit_peer(sender);
 				}
-				continue; // Auth in progress.
 			}
+			continue; // Auth in progress.
 		}
 
 		ERR_CONTINUE(!connected_peers.has(sender));


### PR DESCRIPTION
The auth implementation was treating any received packet as a remote confirmation after the peer was confirmed locally.
    
It now correctly awaits for the remote confirmation packet before admitting new peers.