### PR TITLE
Docs: Add details on `CanvasItem.clip_children`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -562,7 +562,7 @@
 	</methods>
 	<members>
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">
-			Allows the current node to clip children nodes, essentially acting as a mask.
+			If one of the Clip Children modes is active, any parts of direct child nodes that extend outside this parent's visible region are hidden. The child nodes must be at the same Z Index as the parent in order for the clipping effect to occur.
 		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.


### PR DESCRIPTION
Replaced terms of art with more accessible language to describe 'clip children' feature.

Included the information that only direct children are affected, and mentioned the requirement that child nodes be at the same Z Index as the clipping parent for the effect to occur

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
