### PR TITLE
Use `set_value_no_signal` in editor property code

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1312,17 +1312,12 @@ void EditorPropertyInteger::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyInteger::_value_changed(int64_t val) {
-	if (setting) {
-		return;
-	}
 	emit_changed(get_edited_property(), val);
 }
 
 void EditorPropertyInteger::update_property() {
 	int64_t val = get_edited_property_value();
-	setting = true;
-	spin->set_value(val);
-	setting = false;
+	spin->set_value_no_signal(val);
 #ifdef DEBUG_ENABLED
 	// If spin (currently EditorSplinSlider : Range) is changed so that it can use int64_t, then the below warning wouldn't be a problem.
 	if (val != (int64_t)(double)(val)) {
@@ -1452,10 +1447,6 @@ void EditorPropertyFloat::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyFloat::_value_changed(double val) {
-	if (setting) {
-		return;
-	}
-
 	if (radians_as_degrees) {
 		val = Math::deg_to_rad(val);
 	}
@@ -1467,9 +1458,7 @@ void EditorPropertyFloat::update_property() {
 	if (radians_as_degrees) {
 		val = Math::rad_to_deg(val);
 	}
-	setting = true;
-	spin->set_value(val);
-	setting = false;
+	spin->set_value_no_signal(val);
 }
 
 void EditorPropertyFloat::_bind_methods() {
@@ -1627,18 +1616,12 @@ void EditorPropertyEasing::_set_preset(int p_preset) {
 }
 
 void EditorPropertyEasing::_setup_spin() {
-	setting = true;
 	spin->setup_and_show();
 	spin->get_line_edit()->set_text(TS->format_number(rtos(get_edited_property_value())));
-	setting = false;
 	spin->show();
 }
 
 void EditorPropertyEasing::_spin_value_changed(double p_value) {
-	if (setting) {
-		return;
-	}
-
 	// 0 is a singularity, but both positive and negative values
 	// are otherwise allowed. Enforce 0+ as workaround.
 	if (Math::is_zero_approx(p_value)) {
@@ -1725,10 +1708,6 @@ void EditorPropertyRect2::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyRect2::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Rect2 r2;
 	r2.position.x = spin[0]->get_value();
 	r2.position.y = spin[1]->get_value();
@@ -1739,12 +1718,10 @@ void EditorPropertyRect2::_value_changed(double val, const String &p_name) {
 
 void EditorPropertyRect2::update_property() {
 	Rect2 val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val.position.x);
-	spin[1]->set_value(val.position.y);
-	spin[2]->set_value(val.size.x);
-	spin[3]->set_value(val.size.y);
-	setting = false;
+	spin[0]->set_value_no_signal(val.position.x);
+	spin[1]->set_value_no_signal(val.position.y);
+	spin[2]->set_value_no_signal(val.size.x);
+	spin[3]->set_value_no_signal(val.size.y);
 }
 
 void EditorPropertyRect2::_notification(int p_what) {
@@ -1828,10 +1805,6 @@ void EditorPropertyRect2i::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyRect2i::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Rect2i r2;
 	r2.position.x = spin[0]->get_value();
 	r2.position.y = spin[1]->get_value();
@@ -1842,12 +1815,10 @@ void EditorPropertyRect2i::_value_changed(double val, const String &p_name) {
 
 void EditorPropertyRect2i::update_property() {
 	Rect2i val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val.position.x);
-	spin[1]->set_value(val.position.y);
-	spin[2]->set_value(val.size.x);
-	spin[3]->set_value(val.size.y);
-	setting = false;
+	spin[0]->set_value_no_signal(val.position.x);
+	spin[1]->set_value_no_signal(val.position.y);
+	spin[2]->set_value_no_signal(val.size.x);
+	spin[3]->set_value_no_signal(val.size.y);
 }
 
 void EditorPropertyRect2i::_notification(int p_what) {
@@ -1930,10 +1901,6 @@ void EditorPropertyPlane::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyPlane::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Plane p;
 	p.normal.x = spin[0]->get_value();
 	p.normal.y = spin[1]->get_value();
@@ -1944,12 +1911,10 @@ void EditorPropertyPlane::_value_changed(double val, const String &p_name) {
 
 void EditorPropertyPlane::update_property() {
 	Plane val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val.normal.x);
-	spin[1]->set_value(val.normal.y);
-	spin[2]->set_value(val.normal.z);
-	spin[3]->set_value(val.d);
-	setting = false;
+	spin[0]->set_value_no_signal(val.normal.x);
+	spin[1]->set_value_no_signal(val.normal.y);
+	spin[2]->set_value_no_signal(val.normal.z);
+	spin[3]->set_value_no_signal(val.d);
 }
 
 void EditorPropertyPlane::_notification(int p_what) {
@@ -2041,10 +2006,6 @@ void EditorPropertyQuaternion::_edit_custom_value() {
 }
 
 void EditorPropertyQuaternion::_custom_value_changed(double val) {
-	if (setting) {
-		return;
-	}
-
 	edit_euler.x = euler[0]->get_value();
 	edit_euler.y = euler[1]->get_value();
 	edit_euler.z = euler[2]->get_value();
@@ -2055,17 +2016,13 @@ void EditorPropertyQuaternion::_custom_value_changed(double val) {
 	v.z = Math::deg_to_rad(edit_euler.z);
 
 	Quaternion temp_q = Quaternion::from_euler(v);
-	spin[0]->set_value(temp_q.x);
-	spin[1]->set_value(temp_q.y);
-	spin[2]->set_value(temp_q.z);
-	spin[3]->set_value(temp_q.w);
+	spin[0]->set_value_no_signal(temp_q.x);
+	spin[1]->set_value_no_signal(temp_q.y);
+	spin[2]->set_value_no_signal(temp_q.z);
+	spin[3]->set_value_no_signal(temp_q.w);
 }
 
 void EditorPropertyQuaternion::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Quaternion p;
 	p.x = spin[0]->get_value();
 	p.y = spin[1]->get_value();
@@ -2085,21 +2042,19 @@ bool EditorPropertyQuaternion::is_grabbing_euler() {
 
 void EditorPropertyQuaternion::update_property() {
 	Quaternion val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val.x);
-	spin[1]->set_value(val.y);
-	spin[2]->set_value(val.z);
-	spin[3]->set_value(val.w);
+	spin[0]->set_value_no_signal(val.x);
+	spin[1]->set_value_no_signal(val.y);
+	spin[2]->set_value_no_signal(val.z);
+	spin[3]->set_value_no_signal(val.w);
 	if (!is_grabbing_euler()) {
 		Vector3 v = val.normalized().get_euler();
 		edit_euler.x = Math::rad_to_deg(v.x);
 		edit_euler.y = Math::rad_to_deg(v.y);
 		edit_euler.z = Math::rad_to_deg(v.z);
-		euler[0]->set_value(edit_euler.x);
-		euler[1]->set_value(edit_euler.y);
-		euler[2]->set_value(edit_euler.z);
+		euler[0]->set_value_no_signal(edit_euler.x);
+		euler[1]->set_value_no_signal(edit_euler.y);
+		euler[2]->set_value_no_signal(edit_euler.z);
 	}
-	setting = false;
 }
 
 void EditorPropertyQuaternion::_warning_pressed() {
@@ -2240,10 +2195,6 @@ void EditorPropertyAABB::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyAABB::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	AABB p;
 	p.position.x = spin[0]->get_value();
 	p.position.y = spin[1]->get_value();
@@ -2251,21 +2202,17 @@ void EditorPropertyAABB::_value_changed(double val, const String &p_name) {
 	p.size.x = spin[3]->get_value();
 	p.size.y = spin[4]->get_value();
 	p.size.z = spin[5]->get_value();
-
 	emit_changed(get_edited_property(), p, p_name);
 }
 
 void EditorPropertyAABB::update_property() {
 	AABB val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val.position.x);
-	spin[1]->set_value(val.position.y);
-	spin[2]->set_value(val.position.z);
-	spin[3]->set_value(val.size.x);
-	spin[4]->set_value(val.size.y);
-	spin[5]->set_value(val.size.z);
-
-	setting = false;
+	spin[0]->set_value_no_signal(val.position.x);
+	spin[1]->set_value_no_signal(val.position.y);
+	spin[2]->set_value_no_signal(val.position.z);
+	spin[3]->set_value_no_signal(val.size.x);
+	spin[4]->set_value_no_signal(val.size.y);
+	spin[5]->set_value_no_signal(val.size.z);
 }
 
 void EditorPropertyAABB::_notification(int p_what) {
@@ -2323,10 +2270,6 @@ void EditorPropertyTransform2D::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyTransform2D::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Transform2D p;
 	p[0][0] = spin[0]->get_value();
 	p[1][0] = spin[1]->get_value();
@@ -2340,15 +2283,12 @@ void EditorPropertyTransform2D::_value_changed(double val, const String &p_name)
 
 void EditorPropertyTransform2D::update_property() {
 	Transform2D val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val[0][0]);
-	spin[1]->set_value(val[1][0]);
-	spin[2]->set_value(val[2][0]);
-	spin[3]->set_value(val[0][1]);
-	spin[4]->set_value(val[1][1]);
-	spin[5]->set_value(val[2][1]);
-
-	setting = false;
+	spin[0]->set_value_no_signal(val[0][0]);
+	spin[1]->set_value_no_signal(val[1][0]);
+	spin[2]->set_value_no_signal(val[2][0]);
+	spin[3]->set_value_no_signal(val[0][1]);
+	spin[4]->set_value_no_signal(val[1][1]);
+	spin[5]->set_value_no_signal(val[2][1]);
 }
 
 void EditorPropertyTransform2D::_notification(int p_what) {
@@ -2414,10 +2354,6 @@ void EditorPropertyBasis::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyBasis::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Basis p;
 	p[0][0] = spin[0]->get_value();
 	p[0][1] = spin[1]->get_value();
@@ -2434,18 +2370,15 @@ void EditorPropertyBasis::_value_changed(double val, const String &p_name) {
 
 void EditorPropertyBasis::update_property() {
 	Basis val = get_edited_property_value();
-	setting = true;
-	spin[0]->set_value(val[0][0]);
-	spin[1]->set_value(val[0][1]);
-	spin[2]->set_value(val[0][2]);
-	spin[3]->set_value(val[1][0]);
-	spin[4]->set_value(val[1][1]);
-	spin[5]->set_value(val[1][2]);
-	spin[6]->set_value(val[2][0]);
-	spin[7]->set_value(val[2][1]);
-	spin[8]->set_value(val[2][2]);
-
-	setting = false;
+	spin[0]->set_value_no_signal(val[0][0]);
+	spin[1]->set_value_no_signal(val[0][1]);
+	spin[2]->set_value_no_signal(val[0][2]);
+	spin[3]->set_value_no_signal(val[1][0]);
+	spin[4]->set_value_no_signal(val[1][1]);
+	spin[5]->set_value_no_signal(val[1][2]);
+	spin[6]->set_value_no_signal(val[2][0]);
+	spin[7]->set_value_no_signal(val[2][1]);
+	spin[8]->set_value_no_signal(val[2][2]);
 }
 
 void EditorPropertyBasis::_notification(int p_what) {
@@ -2504,10 +2437,6 @@ void EditorPropertyTransform3D::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyTransform3D::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Transform3D p;
 	p.basis[0][0] = spin[0]->get_value();
 	p.basis[0][1] = spin[1]->get_value();
@@ -2530,20 +2459,18 @@ void EditorPropertyTransform3D::update_property() {
 }
 
 void EditorPropertyTransform3D::update_using_transform(Transform3D p_transform) {
-	setting = true;
-	spin[0]->set_value(p_transform.basis[0][0]);
-	spin[1]->set_value(p_transform.basis[0][1]);
-	spin[2]->set_value(p_transform.basis[0][2]);
-	spin[3]->set_value(p_transform.origin[0]);
-	spin[4]->set_value(p_transform.basis[1][0]);
-	spin[5]->set_value(p_transform.basis[1][1]);
-	spin[6]->set_value(p_transform.basis[1][2]);
-	spin[7]->set_value(p_transform.origin[1]);
-	spin[8]->set_value(p_transform.basis[2][0]);
-	spin[9]->set_value(p_transform.basis[2][1]);
-	spin[10]->set_value(p_transform.basis[2][2]);
-	spin[11]->set_value(p_transform.origin[2]);
-	setting = false;
+	spin[0]->set_value_no_signal(p_transform.basis[0][0]);
+	spin[1]->set_value_no_signal(p_transform.basis[0][1]);
+	spin[2]->set_value_no_signal(p_transform.basis[0][2]);
+	spin[3]->set_value_no_signal(p_transform.origin[0]);
+	spin[4]->set_value_no_signal(p_transform.basis[1][0]);
+	spin[5]->set_value_no_signal(p_transform.basis[1][1]);
+	spin[6]->set_value_no_signal(p_transform.basis[1][2]);
+	spin[7]->set_value_no_signal(p_transform.origin[1]);
+	spin[8]->set_value_no_signal(p_transform.basis[2][0]);
+	spin[9]->set_value_no_signal(p_transform.basis[2][1]);
+	spin[10]->set_value_no_signal(p_transform.basis[2][2]);
+	spin[11]->set_value_no_signal(p_transform.origin[2]);
 }
 
 void EditorPropertyTransform3D::_notification(int p_what) {
@@ -2602,10 +2529,6 @@ void EditorPropertyProjection::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyProjection::_value_changed(double val, const String &p_name) {
-	if (setting) {
-		return;
-	}
-
 	Projection p;
 	p.columns[0][0] = spin[0]->get_value();
 	p.columns[0][1] = spin[1]->get_value();
@@ -2632,24 +2555,22 @@ void EditorPropertyProjection::update_property() {
 }
 
 void EditorPropertyProjection::update_using_transform(Projection p_transform) {
-	setting = true;
-	spin[0]->set_value(p_transform.columns[0][0]);
-	spin[1]->set_value(p_transform.columns[0][1]);
-	spin[2]->set_value(p_transform.columns[0][2]);
-	spin[3]->set_value(p_transform.columns[0][3]);
-	spin[4]->set_value(p_transform.columns[1][0]);
-	spin[5]->set_value(p_transform.columns[1][1]);
-	spin[6]->set_value(p_transform.columns[1][2]);
-	spin[7]->set_value(p_transform.columns[1][3]);
-	spin[8]->set_value(p_transform.columns[2][0]);
-	spin[9]->set_value(p_transform.columns[2][1]);
-	spin[10]->set_value(p_transform.columns[2][2]);
-	spin[11]->set_value(p_transform.columns[2][3]);
-	spin[12]->set_value(p_transform.columns[3][0]);
-	spin[13]->set_value(p_transform.columns[3][1]);
-	spin[14]->set_value(p_transform.columns[3][2]);
-	spin[15]->set_value(p_transform.columns[3][3]);
-	setting = false;
+	spin[0]->set_value_no_signal(p_transform.columns[0][0]);
+	spin[1]->set_value_no_signal(p_transform.columns[0][1]);
+	spin[2]->set_value_no_signal(p_transform.columns[0][2]);
+	spin[3]->set_value_no_signal(p_transform.columns[0][3]);
+	spin[4]->set_value_no_signal(p_transform.columns[1][0]);
+	spin[5]->set_value_no_signal(p_transform.columns[1][1]);
+	spin[6]->set_value_no_signal(p_transform.columns[1][2]);
+	spin[7]->set_value_no_signal(p_transform.columns[1][3]);
+	spin[8]->set_value_no_signal(p_transform.columns[2][0]);
+	spin[9]->set_value_no_signal(p_transform.columns[2][1]);
+	spin[10]->set_value_no_signal(p_transform.columns[2][2]);
+	spin[11]->set_value_no_signal(p_transform.columns[2][3]);
+	spin[12]->set_value_no_signal(p_transform.columns[3][0]);
+	spin[13]->set_value_no_signal(p_transform.columns[3][1]);
+	spin[14]->set_value_no_signal(p_transform.columns[3][2]);
+	spin[15]->set_value_no_signal(p_transform.columns[3][3]);
 }
 
 void EditorPropertyProjection::_notification(int p_what) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -340,7 +340,6 @@ public:
 class EditorPropertyInteger : public EditorProperty {
 	GDCLASS(EditorPropertyInteger, EditorProperty);
 	EditorSpinSlider *spin = nullptr;
-	bool setting = false;
 	void _value_changed(int64_t p_val);
 
 protected:
@@ -399,7 +398,6 @@ public:
 class EditorPropertyFloat : public EditorProperty {
 	GDCLASS(EditorPropertyFloat, EditorProperty);
 	EditorSpinSlider *spin = nullptr;
-	bool setting = false;
 	bool radians_as_degrees = false;
 	void _value_changed(double p_val);
 
@@ -418,7 +416,6 @@ class EditorPropertyEasing : public EditorProperty {
 	Control *easing_draw = nullptr;
 	PopupMenu *preset = nullptr;
 	EditorSpinSlider *spin = nullptr;
-	bool setting = false;
 
 	bool dragging = false;
 	bool full = false;
@@ -459,7 +456,6 @@ public:
 class EditorPropertyRect2 : public EditorProperty {
 	GDCLASS(EditorPropertyRect2, EditorProperty);
 	EditorSpinSlider *spin[4];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -476,7 +472,6 @@ public:
 class EditorPropertyRect2i : public EditorProperty {
 	GDCLASS(EditorPropertyRect2i, EditorProperty);
 	EditorSpinSlider *spin[4];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -493,7 +488,6 @@ public:
 class EditorPropertyPlane : public EditorProperty {
 	GDCLASS(EditorPropertyPlane, EditorProperty);
 	EditorSpinSlider *spin[4];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -511,7 +505,6 @@ class EditorPropertyQuaternion : public EditorProperty {
 	GDCLASS(EditorPropertyQuaternion, EditorProperty);
 	BoxContainer *default_layout = nullptr;
 	EditorSpinSlider *spin[4];
-	bool setting = false;
 
 	Button *warning = nullptr;
 	AcceptDialog *warning_dialog = nullptr;
@@ -544,7 +537,6 @@ public:
 class EditorPropertyAABB : public EditorProperty {
 	GDCLASS(EditorPropertyAABB, EditorProperty);
 	EditorSpinSlider *spin[6];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -561,7 +553,6 @@ public:
 class EditorPropertyTransform2D : public EditorProperty {
 	GDCLASS(EditorPropertyTransform2D, EditorProperty);
 	EditorSpinSlider *spin[6];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -578,7 +569,6 @@ public:
 class EditorPropertyBasis : public EditorProperty {
 	GDCLASS(EditorPropertyBasis, EditorProperty);
 	EditorSpinSlider *spin[9];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -595,7 +585,6 @@ public:
 class EditorPropertyTransform3D : public EditorProperty {
 	GDCLASS(EditorPropertyTransform3D, EditorProperty);
 	EditorSpinSlider *spin[12];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:
@@ -613,7 +602,6 @@ public:
 class EditorPropertyProjection : public EditorProperty {
 	GDCLASS(EditorPropertyProjection, EditorProperty);
 	EditorSpinSlider *spin[16];
-	bool setting = false;
 	void _value_changed(double p_val, const String &p_name);
 
 protected:


### PR DESCRIPTION
In the current master, the editor property code uses a flag `bool setting` to ignore value changed signals. However, this means there were lots of useless signals being emitted. This PR replaces `set_value` with `set_value_no_signal` so there are no longer superfluous signals to guard against.

Note 1: This may slightly change behavior for `EditorPropertyQuaternion::_custom_value_changed`, which previously did not have a `bool setting` guard. However, this was likely a bug before, as you would not want multiple signals to be emitted in the middle of this method (if one is needed, it should be at the end).

~~Note 2: There is one property still using `bool setting`: `EditorPropertyEasing`. This is because it uses a LineEdit instead of a SpinBox, which has a method `set_text` but not `set_text_no_signal`.~~

Note 3: The `EditorPropertyVectorN` code is already using `set_value_no_signal`.

Note 4: I have only tested this PR for a few minutes, I don't think it needs more testing.