### PR TITLE
Allow detecting when building as an engine module

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -7,6 +7,9 @@ Import("env")
 
 env_modules = env.Clone()
 
+# Allow modules to detect if they are being built as a module.
+env_modules.Append(CPPDEFINES=["GODOT_MODULE"])
+
 Export("env_modules")
 
 # Header with MODULE_*_ENABLED defines.

--- a/modules/text_server_adv/register_types.h
+++ b/modules/text_server_adv/register_types.h
@@ -34,7 +34,7 @@
 #ifdef GDEXTENSION
 #include <godot_cpp/core/class_db.hpp>
 using namespace godot;
-#else
+#elif defined(GODOT_MODULE)
 #include "modules/register_module_types.h"
 #endif
 

--- a/modules/text_server_adv/script_iterator.h
+++ b/modules/text_server_adv/script_iterator.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 
 // Headers for building as built-in module.
 #include "core/string/ustring.h"

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -44,7 +44,7 @@ using namespace godot;
 
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get_setting_with_override(m_var)
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/config/project_settings.h"
@@ -370,7 +370,7 @@ bool TextServerAdvanced::_has_feature(Feature p_feature) const {
 String TextServerAdvanced::_get_name() const {
 #ifdef GDEXTENSION
 	return "ICU / HarfBuzz / Graphite (GDExtension)";
-#else
+#elif defined(GODOT_MODULE)
 	return "ICU / HarfBuzz / Graphite (Built-in)";
 #endif
 }
@@ -4852,7 +4852,7 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 #ifdef GDEXTENSION
 	for (int fb = 0; fb < fallback_font_name.size(); fb++) {
 		const String &E = fallback_font_name[fb];
-#else
+#elif defined(GODOT_MODULE)
 	for (const String &E : fallback_font_name) {
 #endif
 		SystemFontKey key = SystemFontKey(E, font_style & TextServer::FONT_ITALIC, font_weight, font_stretch, p_fdef, this);
@@ -6757,7 +6757,7 @@ String TextServerAdvanced::_strip_diacritics(const String &p_string) const {
 		if (u_getCombiningClass(normalized_string[i]) == 0) {
 #ifdef GDEXTENSION
 			result = result + String::chr(normalized_string[i]);
-#else
+#elif defined(GODOT_MODULE)
 			result = result + normalized_string[i];
 #endif
 		}

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -78,7 +78,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/extension/ext_wrappers.gen.inc"

--- a/modules/text_server_adv/thorvg_bounds_iterator.cpp
+++ b/modules/text_server_adv/thorvg_bounds_iterator.cpp
@@ -35,7 +35,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/typedefs.h"

--- a/modules/text_server_adv/thorvg_bounds_iterator.h
+++ b/modules/text_server_adv/thorvg_bounds_iterator.h
@@ -39,7 +39,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/typedefs.h"

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -38,7 +38,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/error/error_macros.h"

--- a/modules/text_server_adv/thorvg_svg_in_ot.h
+++ b/modules/text_server_adv/thorvg_svg_in_ot.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/os/mutex.h"

--- a/modules/text_server_fb/register_types.h
+++ b/modules/text_server_fb/register_types.h
@@ -34,7 +34,7 @@
 #ifdef GDEXTENSION
 #include <godot_cpp/core/class_db.hpp>
 using namespace godot;
-#else
+#elif defined(GODOT_MODULE)
 #include "modules/register_module_types.h"
 #endif
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -44,7 +44,7 @@ using namespace godot;
 
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get_setting_with_override(m_var)
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/config/project_settings.h"
@@ -95,7 +95,7 @@ bool TextServerFallback::_has_feature(Feature p_feature) const {
 String TextServerFallback::_get_name() const {
 #ifdef GDEXTENSION
 	return "Fallback (GDExtension)";
-#else
+#elif defined(GODOT_MODULE)
 	return "Fallback (Built-in)";
 #endif
 }
@@ -3654,7 +3654,7 @@ RID TextServerFallback::_find_sys_font_for_text(const RID &p_fdef, const String 
 #ifdef GDEXTENSION
 		for (int fb = 0; fb < fallback_font_name.size(); fb++) {
 			const String &E = fallback_font_name[fb];
-#else
+#elif defined(GODOT_MODULE)
 		for (const String &E : fallback_font_name) {
 #endif
 			SystemFontKey key = SystemFontKey(E, font_style & TextServer::FONT_ITALIC, font_weight, font_stretch, p_fdef, this);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -76,7 +76,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/extension/ext_wrappers.gen.inc"

--- a/modules/text_server_fb/thorvg_bounds_iterator.cpp
+++ b/modules/text_server_fb/thorvg_bounds_iterator.cpp
@@ -35,7 +35,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/typedefs.h"

--- a/modules/text_server_fb/thorvg_bounds_iterator.h
+++ b/modules/text_server_fb/thorvg_bounds_iterator.h
@@ -39,7 +39,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/typedefs.h"

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -38,7 +38,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/error/error_macros.h"

--- a/modules/text_server_fb/thorvg_svg_in_ot.h
+++ b/modules/text_server_fb/thorvg_svg_in_ot.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-#else
+#elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
 #include "core/os/mutex.h"


### PR DESCRIPTION
Intended use case: I am working on a project that can be built as either an engine module or a GDExtension. I need to be able to detect whether I am building for an engine module or not in my code.

See also https://github.com/godotengine/godot-cpp/pull/1339 - having at least one of these PRs is highly useful, but having both is even better, because it lets you explicitly error on invalid configurations:

```cpp
#ifdef GDEXTENSION
#include <godot_cpp/classes/engine.hpp>
#elif defined(GODOT_MODULE)
#include "core/config/engine.h"
#else
#error "Must build as Godot GDExtension or Godot module."
#endif
```

Plus single statements can avoid negatives which makes them more readable, such as `#ifdef GODOT_MODULE` instead of `#ifndef GODOT_GDEXTENSION` or vice versa.

Bikeshed: Is module clear enough? We could also do `GODOT_ENGINE_MODULE` if that helps.