### PR TITLE
Add descriptions to remaining properties of RDSamplerState

### DIFF
--- a/doc/classes/RDSamplerState.xml
+++ b/doc/classes/RDSamplerState.xml
@@ -26,12 +26,13 @@
 			The mipmap LOD bias to use. Positive values will make the sampler blurrier at a given distance, while negative values will make the sampler sharper at a given distance (at the risk of looking grainy). Recommended values are between [code]-0.5[/code] and [code]0.0[/code]. Only effective if the sampler has mipmaps available.
 		</member>
 		<member name="mag_filter" type="int" setter="set_mag_filter" getter="get_mag_filter" enum="RenderingDevice.SamplerFilter" default="0">
-			The sampler's magnification filter.
+			The sampler's magnification filter. It is the filtering method used when sampling texels that appear bigger than on-screen pixels.
 		</member>
 		<member name="max_lod" type="float" setter="set_max_lod" getter="get_max_lod" default="1e+20">
 			The maximum mipmap LOD bias to display (lowest resolution). Only effective if the sampler has mipmaps available.
 		</member>
 		<member name="min_filter" type="int" setter="set_min_filter" getter="get_min_filter" enum="RenderingDevice.SamplerFilter" default="0">
+			The sampler's minification filter. It is the filtering method used when sampling texels that appear smaller than on-screen pixels.
 		</member>
 		<member name="min_lod" type="float" setter="set_min_lod" getter="get_min_lod" default="0.0">
 			The minimum mipmap LOD bias to display (highest resolution). Only effective if the sampler has mipmaps available.
@@ -49,6 +50,7 @@
 			The repeat mode to use along the W axis of UV coordinates. This affects the returned values if sampling outside the UV bounds. Only effective for 3D samplers.
 		</member>
 		<member name="unnormalized_uvw" type="bool" setter="set_unnormalized_uvw" getter="get_unnormalized_uvw" default="false">
+			If [code]true[/code], the texture will be sampled with coordinates ranging from 0 to the texture's resolution. Otherwise, the coordinates will be normalized and range from 0 to 1.
 		</member>
 		<member name="use_anisotropy" type="bool" setter="set_use_anisotropy" getter="get_use_anisotropy" default="false">
 			If [code]true[/code], perform anisotropic sampling. See [member anisotropy_max].


### PR DESCRIPTION
I added descriptions to the min_filter and unnormalized_uvw properties of RDSamplerState. I also updated the mag_filter description to be a little more helpful and consistent with the new min_filter description.