### PR TITLE
Change hashing functions to operate on char32_t data directly

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2884,30 +2884,26 @@ uint64_t String::hash64() const {
 }
 
 String String::md5_text() const {
-	CharString cs = utf8();
 	unsigned char hash[16];
-	CryptoCore::md5((unsigned char *)cs.ptr(), cs.length(), hash);
+	CryptoCore::md5((unsigned char *)ptr(), length() * sizeof(char32_t), hash);
 	return String::hex_encode_buffer(hash, 16);
 }
 
 String String::sha1_text() const {
-	CharString cs = utf8();
 	unsigned char hash[20];
-	CryptoCore::sha1((unsigned char *)cs.ptr(), cs.length(), hash);
+	CryptoCore::sha1((unsigned char *)ptr(), length() * sizeof(char32_t), hash);
 	return String::hex_encode_buffer(hash, 20);
 }
 
 String String::sha256_text() const {
-	CharString cs = utf8();
 	unsigned char hash[32];
-	CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
+	CryptoCore::sha256((unsigned char *)ptr(), length() * sizeof(char32_t), hash);
 	return String::hex_encode_buffer(hash, 32);
 }
 
 Vector<uint8_t> String::md5_buffer() const {
-	CharString cs = utf8();
 	unsigned char hash[16];
-	CryptoCore::md5((unsigned char *)cs.ptr(), cs.length(), hash);
+	CryptoCore::md5((unsigned char *)ptr(), length() * sizeof(char32_t), hash);
 
 	Vector<uint8_t> ret;
 	ret.resize(16);
@@ -2918,9 +2914,8 @@ Vector<uint8_t> String::md5_buffer() const {
 }
 
 Vector<uint8_t> String::sha1_buffer() const {
-	CharString cs = utf8();
 	unsigned char hash[20];
-	CryptoCore::sha1((unsigned char *)cs.ptr(), cs.length(), hash);
+	CryptoCore::sha1((unsigned char *)ptr(), length() * sizeof(char32_t), hash);
 
 	Vector<uint8_t> ret;
 	ret.resize(20);
@@ -2932,9 +2927,8 @@ Vector<uint8_t> String::sha1_buffer() const {
 }
 
 Vector<uint8_t> String::sha256_buffer() const {
-	CharString cs = utf8();
 	unsigned char hash[32];
-	CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
+	CryptoCore::sha256((unsigned char *)ptr(), length() * sizeof(char32_t), hash);
 
 	Vector<uint8_t> ret;
 	ret.resize(32);


### PR DESCRIPTION
This avoids converting character data to utf8, which costs memory and time.

This addresses https://github.com/godotengine/godot/issues/86249.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
