### PR TITLE
Always call `set_animation` in `set_sprite_frames`

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -299,16 +299,13 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 		List<StringName> al;
 		frames->get_animation_list(&al);
-		if (al.size() == 0) {
-			set_animation(StringName());
+
+		animation = StringName();
+		if (!al.is_empty()) {
+			set_animation(frames->has_animation(animation) ? animation : al[0]);
+		}
+		if (!frames->has_animation(autoplay)) {
 			autoplay = String();
-		} else {
-			if (!frames->has_animation(animation)) {
-				set_animation(al[0]);
-			}
-			if (!frames->has_animation(autoplay)) {
-				autoplay = String();
-			}
 		}
 	}
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1112,16 +1112,13 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 		List<StringName> al;
 		frames->get_animation_list(&al);
-		if (al.size() == 0) {
-			set_animation(StringName());
+
+		animation = StringName();
+		if (!al.is_empty()) {
+			set_animation(frames->has_animation(animation) ? animation : al[0]);
+		}
+		if (!frames->has_animation(autoplay)) {
 			autoplay = String();
-		} else {
-			if (!frames->has_animation(animation)) {
-				set_animation(al[0]);
-			}
-			if (!frames->has_animation(autoplay)) {
-				autoplay = String();
-			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #86058.

Before this patch, say that an `AnimatedSprite2D` called `a` currently has the active animation of `"foo"`. If we update `a`'s sprite frames and the new sprite frames also have an animation called `"foo"`, then `a` will not call `set_animation("foo")` and so will continue to execute the new `"foo"` animation as if it was the original `"foo"` animation. It will continue playing from the same frame with the same speed, even if the new `"foo"` has fewer frames or should last for a different duration.

This manifested in #86058 with the `"default"` animation. The first frame of the `"default"` animation in this case was supposed to last for a duration of `10`, but only lasted for `1` since we never called `set_animation("default")` with the new sprite frames and so the `AnimatedSprite2D` just used its default values until the next frame.

I also think we could get the engine to error by writing some sort of script that swapped between two sets of sprite frames with the same animation name but different frame lengths, but I didn't try it. This change would fix that as well.