### PR TITLE
Add input action name to window title in input map editor

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -168,7 +168,7 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 			current_action_name = item->get_meta("__name");
 			current_action_event_index = -1;
 
-			event_config_dialog->popup_and_configure();
+			event_config_dialog->popup_and_configure(Ref<InputEvent>(), current_action_name);
 		} break;
 		case ActionMapEditor::BUTTON_EDIT_EVENT: {
 			// Action and Action name is located on the parent of the event.
@@ -179,7 +179,7 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 
 			Ref<InputEvent> ie = item->get_meta("__event");
 			if (ie.is_valid()) {
-				event_config_dialog->popup_and_configure(ie);
+				event_config_dialog->popup_and_configure(ie, current_action_name);
 			}
 		} break;
 		case ActionMapEditor::BUTTON_REMOVE_ACTION: {

--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -572,7 +572,7 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 	}
 }
 
-void InputEventConfigurationDialog::popup_and_configure(const Ref<InputEvent> &p_event) {
+void InputEventConfigurationDialog::popup_and_configure(const Ref<InputEvent> &p_event, const String &p_current_action_name) {
 	if (p_event.is_valid()) {
 		_set_event(p_event->duplicate(), p_event);
 	} else {
@@ -596,6 +596,12 @@ void InputEventConfigurationDialog::popup_and_configure(const Ref<InputEvent> &p
 		device_id_option->select(0);
 	}
 
+	if (!p_current_action_name.is_empty()) {
+		set_title(vformat(TTR("Event Configuration for \"%s\""), p_current_action_name));
+	} else {
+		set_title(TTR("Event Configuration"));
+	}
+
 	popup_centered(Size2(0, 400) * EDSCALE);
 }
 
@@ -611,7 +617,6 @@ void InputEventConfigurationDialog::set_allowed_input_types(int p_type_masks) {
 InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	allowed_input_types = INPUT_KEY | INPUT_MOUSE_BUTTON | INPUT_JOY_BUTTON | INPUT_JOY_MOTION;
 
-	set_title(TTR("Event Configuration"));
 	set_min_size(Size2i(550, 0) * EDSCALE);
 
 	VBoxContainer *main_vbox = memnew(VBoxContainer);

--- a/editor/input_event_configuration_dialog.h
+++ b/editor/input_event_configuration_dialog.h
@@ -120,7 +120,8 @@ protected:
 
 public:
 	// Pass an existing event to configure it. Alternatively, pass no event to start with a blank configuration.
-	void popup_and_configure(const Ref<InputEvent> &p_event = Ref<InputEvent>());
+	// An action name can be passed for descriptive purposes.
+	void popup_and_configure(const Ref<InputEvent> &p_event = Ref<InputEvent>(), const String &p_current_action_name = "");
 	Ref<InputEvent> get_event() const;
 
 	void set_allowed_input_types(int p_type_masks);


### PR DESCRIPTION
Thanks to @nrichards for helping me debug the code :slightly_smiling_face:

- This closes https://github.com/godotengine/godot-proposals/discussions/8682.

## Preview

### Adding new event

![Screenshot_20231218_014323](https://github.com/godotengine/godot/assets/180032/0605f53a-92fc-4ee4-878b-cd620c76f628)

### Modifying an existing event

![Screenshot_20231218_014330](https://github.com/godotengine/godot/assets/180032/c229439c-0c80-4c65-9990-a77d00b519cf)
