### PR TITLE
[macOS] Fix updating editor tab titles in the dock menu.

### DIFF
--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -191,12 +191,14 @@ void EditorSceneTabs::_disable_menu_option_if(int p_option, bool p_condition) {
 }
 
 void EditorSceneTabs::update_scene_tabs() {
+	static bool menu_initialized = false;
 	tab_preview_panel->hide();
 
-	if (scene_tabs->get_tab_count() == EditorNode::get_editor_data().get_edited_scene_count()) {
+	if (menu_initialized && scene_tabs->get_tab_count() == EditorNode::get_editor_data().get_edited_scene_count()) {
 		_update_tab_titles();
 		return;
 	}
+	menu_initialized = true;
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
 		DisplayServer::get_singleton()->global_menu_clear("_dock");


### PR DESCRIPTION
Fixes errors cause by `update_tab_titles` trying to update non-existing global menu items.
