### PR TITLE
Unify tangents in CSGShape

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -31,6 +31,7 @@
 #include "csg_shape.h"
 
 #include "core/math/geometry_2d.h"
+#include "scene/resources/surface_tool.h"
 
 void CSGShape3D::set_use_collision(bool p_enable) {
 	if (use_collision == p_enable) {
@@ -412,38 +413,22 @@ void CSGShape3D::_update_shape() {
 	//create surfaces
 
 	for (int i = 0; i < surfaces.size(); i++) {
-		// calculate tangents for this surface
-		bool have_tangents = calculate_tangents;
-		if (have_tangents) {
-			SMikkTSpaceInterface mkif;
-			mkif.m_getNormal = mikktGetNormal;
-			mkif.m_getNumFaces = mikktGetNumFaces;
-			mkif.m_getNumVerticesOfFace = mikktGetNumVerticesOfFace;
-			mkif.m_getPosition = mikktGetPosition;
-			mkif.m_getTexCoord = mikktGetTexCoord;
-			mkif.m_setTSpace = mikktSetTSpaceDefault;
-			mkif.m_setTSpaceBasic = nullptr;
-
-			SMikkTSpaceContext msc;
-			msc.m_pInterface = &mkif;
-			msc.m_pUserData = &surfaces.write[i];
-			have_tangents = genTangSpaceDefault(&msc);
-		}
-
 		if (surfaces[i].last_added == 0) {
 			continue;
 		}
+		Ref<SurfaceTool> surface_tool;
 
-		// and convert to surface array
-		Array array;
-		array.resize(Mesh::ARRAY_MAX);
+		surface_tool.instantiate();
+		surface_tool->begin(Mesh::PRIMITIVE_TRIANGLES);
 
-		array[Mesh::ARRAY_VERTEX] = surfaces[i].vertices;
-		array[Mesh::ARRAY_NORMAL] = surfaces[i].normals;
-		array[Mesh::ARRAY_TEX_UV] = surfaces[i].uvs;
-		if (have_tangents) {
-			array[Mesh::ARRAY_TANGENT] = surfaces[i].tans;
+		for (int j = 0; j < surfaces[i].last_added; j++) {
+			surface_tool->set_normal(surfaces[i].normalsw[j]);
+			surface_tool->set_uv(surfaces[i].uvsw[j]);
+			surface_tool->add_vertex(surfaces[i].verticesw[j]);
 		}
+		surface_tool->generate_tangents();
+
+		Array array = surface_tool->commit_to_arrays();
 
 		int idx = root_mesh->get_surface_count();
 		root_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, array);


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-proposals/issues/8601.

Part of https://github.com/godotengine/godot/pull/83648.

Ready for review.

----

1. ~~Enforces indexing before generating tangents for efficiency.~~
2. Changes CSGShape to use SurfaceTool::generate_tangents();
3. Needs performance testing and some validation