### PR TITLE
Blend the animation playback track when timestamp value is manually changed

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1569,7 +1569,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					}
 				} break;
 				case Animation::TYPE_ANIMATION: {
-					if (p_update_only || Math::is_zero_approx(blend)) {
+					if (Math::is_zero_approx(blend)) {
 						continue;
 					}
 					TrackCacheAnimation *t = static_cast<TrackCacheAnimation *>(track);
@@ -1603,7 +1603,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							default:
 								break;
 						}
-						if (player2->is_playing() || seeked) {
+						if (!p_update_only && (player2->is_playing() || seeked)) {
 							player2->seek(at_anim_pos);
 							player2->play(anim_name);
 							t->playing = true;


### PR DESCRIPTION
* This closes #86217

Before, the tracks of type Animation Playback weren't recalculated when the timeline was changed manually, it was only updated when the track's animation was played. Now, we can manually set a time value and see how the animation will look at that instant, allowing to more easily sync multiple animations.

## Preview 
I created a simple AnimationPlayer that makes a blinking sprite and connected it as a track in another AnimationPlayer.

![Screenshot from 2023-12-18 14-03-49](https://github.com/godotengine/godot/assets/52176659/f019a50d-c31d-4246-bb60-1dc75abd77bc)
![Screenshot from 2023-12-18 14-04-12](https://github.com/godotengine/godot/assets/52176659/c5342450-d71b-4849-b8f0-c944801bf62e)
![Screenshot from 2023-12-18 14-04-33](https://github.com/godotengine/godot/assets/52176659/c956bffc-fc72-4a0f-8367-c933ec4bcad1)

