### PR TITLE
Redraw SubViewportContainer on SubViewport size change

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5070,6 +5070,7 @@ void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
 
 	if (c) {
 		c->update_minimum_size();
+		c->queue_redraw();
 	}
 }
 


### PR DESCRIPTION
Fixes #86292
When setting the SubViewport's size, the parent SubViewportContainer would not redraw, causing it to display a stretched invalid image.


https://github.com/godotengine/godot/assets/12436824/03012549-d768-408a-9059-ca5fcdeee86d

