### PR TITLE
Fix `MenuBar` and `MenuButton` hover position scaling properly with the scale factor multiplier

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -181,24 +181,7 @@ void MenuBar::_popup_visibility_changed(bool p_visible) {
 	}
 
 	if (switch_on_hover) {
-		Window *wnd = Object::cast_to<Window>(get_viewport());
-		if (wnd) {
-			mouse_pos_adjusted = wnd->get_position();
-
-			if (wnd->is_embedded()) {
-				Window *wnd_parent = Object::cast_to<Window>(wnd->get_parent()->get_viewport());
-				while (wnd_parent) {
-					if (!wnd_parent->is_embedded()) {
-						mouse_pos_adjusted += wnd_parent->get_position();
-						break;
-					}
-
-					wnd_parent = Object::cast_to<Window>(wnd_parent->get_parent()->get_viewport());
-				}
-			}
-
-			set_process_internal(true);
-		}
+		set_process_internal(true);
 	}
 }
 
@@ -334,8 +317,7 @@ void MenuBar::_notification(int p_what) {
 				// Handled by OS.
 				return;
 			}
-
-			Vector2 pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted - get_global_position();
+			Vector2 pos = get_local_mouse_position();
 			if (pos == old_mouse_pos) {
 				return;
 			}

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -71,7 +71,6 @@ class MenuBar : public Control {
 	int selected_menu = -1;
 	int active_menu = -1;
 
-	Vector2i mouse_pos_adjusted;
 	Vector2i old_mouse_pos;
 	ObjectID shortcut_context;
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -57,24 +57,7 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 	}
 
 	if (switch_on_hover) {
-		Window *wnd = Object::cast_to<Window>(get_viewport());
-		if (wnd) {
-			mouse_pos_adjusted = wnd->get_position();
-
-			if (wnd->is_embedded()) {
-				Window *wnd_parent = Object::cast_to<Window>(wnd->get_parent()->get_viewport());
-				while (wnd_parent) {
-					if (!wnd_parent->is_embedded()) {
-						mouse_pos_adjusted += wnd_parent->get_position();
-						break;
-					}
-
-					wnd_parent = Object::cast_to<Window>(wnd_parent->get_parent()->get_viewport());
-				}
-			}
-
-			set_process_internal(true);
-		}
+		set_process_internal(true);
 	}
 }
 
@@ -155,8 +138,7 @@ void MenuButton::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			Vector2i mouse_pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted;
-			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_find_control(mouse_pos));
+			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_find_control(get_viewport()->get_mouse_position()));
 
 			if (menu_btn_other && menu_btn_other != this && menu_btn_other->is_switch_on_hover() && !menu_btn_other->is_disabled() &&
 					(get_parent()->is_ancestor_of(menu_btn_other) || menu_btn_other->get_parent()->is_ancestor_of(popup))) {

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -42,8 +42,6 @@ class MenuButton : public Button {
 	bool disable_shortcuts = false;
 	PopupMenu *popup = nullptr;
 
-	Vector2i mouse_pos_adjusted;
-
 	void _popup_visibility_changed(bool p_visible);
 
 protected:


### PR DESCRIPTION
Fixes #86240. The solution was basically to just remove `mouse_pos_adjusted` and the code related to it, and simply get the position from `get_local_mouse_position()`, and it now works properly. I don't think this breaks anything, but feel free to correct me if I'm wrong. From what I see, the code is there since the beginning of `MenuBar` (#63950) and it seems to be copy-pasted from the `MenuButton` code, introduced in #50619.

~~`MenuButton` seems to be a bit more difficult to fix. Simply using `get_local_mouse_position()` is not working properly, but getting the local mouse position from the parent is working properly. Problem is, this function is only implemented in `CanvasItem` nodes. If the `MenuButtons` have a 3D node as a parent, this solution is not going to work. Which is why, I am assuming, the `mouse_pos_adjusted` code is in `MenuButton` in the first place. Any ideas on how to handle this would be appreciated!~~
EDIT: `MenuButton` has also been fixed, thanks to #78472.

If this PR gets accepted, I would greatly appreciate it if also got cherry-picked to 4.2.x.