### PR TITLE
Workaround on GodotSharp duplicate key exception when adding generic entries to ScriptTypeBiMap

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
@@ -9,6 +9,7 @@ internal class ReflectionUtils
 {
     public static Type? FindTypeInLoadedAssemblies(string assemblyName, string typeFullName)
     {
-        return Type.GetType($"{assemblyName}.{typeFullName}");
+        // TODO: Validate the side effects of this workaround
+        return null;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
@@ -9,8 +9,6 @@ internal class ReflectionUtils
 {
     public static Type? FindTypeInLoadedAssemblies(string assemblyName, string typeFullName)
     {
-        return AppDomain.CurrentDomain.GetAssemblies()
-            .FirstOrDefault(a => a.GetName().Name == assemblyName)?
-            .GetType(typeFullName);
+        return Type.GetType($"{assemblyName}.{typeFullName}");
     }
 }


### PR DESCRIPTION
A workaround for #79519, this issue is a blocking issue for most .Net users.
Which is one of the causes of the Mega #78513
<s>While #83204 resolved this issue by simply rejecting the duplicating addition, it still left the issue on the Native end and caused error message prints. </s>
<s>We believe this PR(86305) solves the core issue of this whole chain.</s>
Found by @Smallantsa

Validated using [This Repo](https://github.com/taylorhadden/godot-csharp-generic-assembly-reload-error)

**_It turns out that this PR is yet another workaround on the issue, while it somehow resolves the symptoms, further investigation on `Generic Derivatives holding empty Script Path` is required to fully resolve this issue._**

By returning null on `ReflectionUtils.FindTypeInLoadedAssemblies`, this PR is a workaround for issues related to the `System.ArgumentException: An item with the same key has already been added.` in `ScriptTypeBiMap`.
**While side effects are still to be validated.**

<s>It looks like the old way of obtaining a generic type will return a different instance for the type, resulting in a duplicate key exception in `ScriptTypeBiMap.Add(IntPtr scriptPtr, Type scriptType)`
```csharp
AppDomain.CurrentDomain.GetAssemblies()
            .FirstOrDefault(a => a.GetName().Name == assemblyName)?
            .GetType(typeFullName)
```

This new approach appears to return the same instance, so it should fix all issues related to:
```
modules/mono/glue/runtime_interop.cpp:1324 - System.ArgumentException: An item with the same key has already been added. Key: GenericScript`1[System.Single]
     at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
     at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
     at Godot.Bridge.ScriptManagerBridge.ScriptTypeBiMap.Add(IntPtr scriptPtr, Type scriptType) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs:line 23
     whatever  other calls
```
</s>