### PR TITLE
Fix `SoftBody3D` pinned points breaking when reloading scene

### DIFF
--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -215,7 +215,13 @@ bool SoftBody3D::_set_property_pinned_points_attachment(int p_item, const String
 
 	if ("spatial_attachment_path" == p_what) {
 		PinnedPoint *w = pinned_points.ptrw();
-		callable_mp(this, &SoftBody3D::_pin_point_deferred).call_deferred(Variant(w[p_item].point_index), true, p_value);
+
+		if (is_inside_tree()) {
+			callable_mp(this, &SoftBody3D::_pin_point_deferred).call_deferred(Variant(w[p_item].point_index), true, p_value);
+		} else {
+			pin_point(w[p_item].point_index, true, p_value);
+			_make_cache_dirty();
+		}
 	} else if ("offset" == p_what) {
 		PinnedPoint *w = pinned_points.ptrw();
 		w[p_item].offset = p_value;


### PR DESCRIPTION
Fixes #86308.

The issue is that `SoftBody3D::_add_pinned_point()` uses `pinned_point->spatial_attachment->get_global_transform()` to calculate the offset of the pinned point, but getting the global transform of the spatial attachment fails when it's not inside the tree. When calling `get_tree().reload_current_scene()`, the spatial attachment was not inside the tree when `_add_pinned_point()` was called, causing the bug described in #86308, as the offset calculation failed and the pinned points became displaced as a result.

I found that disabling the deferred call to `SoftBody3D::pin_point()` implemented in #71824 and instead calling `pin_point()` immediately in `SoftBody3D::_set_property_pinned_points_attachment()` got rid of this issue, but that broke the reparenting issue that motivated the deferred call in the first place.

By adding an `is_inside_tree()` condition and using the deferred call to `pin_point()` when inside the tree and calling `pin_point()` directly when outside of the tree, I managed to get it into a state where both the offset calculation issue (#86308) and the reparenting issue (#71785) are prevented.

*Physics squad edit*:

- Fixes https://github.com/godotengine/godot/issues/82434