### PR TITLE
Fix `blend_node` crash with invalid AnimationNode reference

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1403,6 +1403,7 @@ String AnimationNodeBlendTree::get_caption() const {
 double AnimationNodeBlendTree::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
 	Ref<AnimationNodeOutput> output = nodes[SceneStringNames::get_singleton()->output].node;
 	node_state.connections = nodes[SceneStringNames::get_singleton()->output].connections;
+	ERR_FAIL_COND_V(output.is_null(), 0);
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -140,6 +140,7 @@ double AnimationNode::blend_input(int p_input, AnimationMixer::PlaybackInfo p_pl
 	}
 
 	Ref<AnimationNode> node = blend_tree->get_node(node_name);
+	ERR_FAIL_COND_V(node.is_null(), 0);
 
 	real_t activity = 0.0;
 	Vector<AnimationTree::Activity> *activity_ptr = process_state->tree->input_activity_map.getptr(node_state.base_path);
@@ -153,12 +154,13 @@ double AnimationNode::blend_input(int p_input, AnimationMixer::PlaybackInfo p_pl
 }
 
 double AnimationNode::blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only) {
+	ERR_FAIL_COND_V(p_node.is_null(), 0);
+
 	p_node->node_state.connections.clear();
 	return _blend_node(p_node, p_subpath, this, p_playback_info, p_filter, p_sync, p_test_only, nullptr);
 }
 
 double AnimationNode::_blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationNode *p_new_parent, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only, real_t *r_activity) {
-	ERR_FAIL_COND_V(!p_node.is_valid(), 0);
 	ERR_FAIL_NULL_V(process_state, 0);
 
 	int blend_count = node_state.track_weights.size();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86070

It's a regression because https://github.com/godotengine/godot/commit/5acf6b4ca6360bb53a4f67bde207a730170d00b2  changed  `node_state.connections.clear()` to `p_node->node_state.connections.clear()` , previously the crash can be prevented by null check in `_blend_node` .

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
