### PR TITLE
Add `PackedRealArray` as an alias for `Vector<real_t>`

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -70,6 +70,7 @@ typedef Vector<int32_t> PackedInt32Array;
 typedef Vector<int64_t> PackedInt64Array;
 typedef Vector<float> PackedFloat32Array;
 typedef Vector<double> PackedFloat64Array;
+typedef Vector<real_t> PackedRealArray;
 typedef Vector<String> PackedStringArray;
 typedef Vector<Vector2> PackedVector2Array;
 typedef Vector<Vector3> PackedVector3Array;


### PR DESCRIPTION
This PR adds PackedRealArray as an alias for `Vector<real_t>` to allow you to specify that you want an array of the float size defined for `real_t`. While it is possible to use `Vector<real_t>` in the engine, this is not possible in GDExtension because PackedFloat(32/64)Array are explicit types and not just `Vector<T>`. We need to provide this alias in both places in order to allow code using it to be compatible with both engine modules and GDExtension.

Corresponding godot-cpp PR: https://github.com/godotengine/godot-cpp/pull/1340