### PR TITLE
Enable global classes in subfolders of res://addons/

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -160,8 +160,14 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		if (script_path.begins_with("res://addons/")) {
-			if (!EditorNode::get_singleton()->is_addon_plugin_enabled(script_path.get_slicec('/', 3))) {
-				return true; // Plugin is not enabled.
+			String base_path = "res://addons/";
+			Vector<String> folders = script_path.split("/");
+			for (int i = 3; i < folders.size() - 1; i++) {
+				base_path += folders[i] + "/";
+				String plugin = base_path + "plugin.cfg";
+				if (FileAccess::exists(plugin) && !EditorNode::get_singleton()->is_addon_plugin_enabled(plugin)) {
+					return true; // Plugin is not enabled.
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR lets `GlobalClass` classes get added to the "Create New Node" dialog no matter where they are under `addons/` as long as it's not in a disabled plugin (or any subfolder of such as those are assumed to belong to the disabled plugin).

This also then lets you keep non-plugin files under `addons/` and have their `GlobalClass`es work, as seems encouraged by https://docs.godotengine.org/en/stable/tutorials/best_practices/project_organization.html saying "_In general, keep third-party resources in a top-level addons/ folder, even if they aren't editor plugins. This makes it easier to track which files are third-party._"

Fixes https://github.com/godotengine/godot/issues/78400.

The code could presumably be optimised some e.g. by not using `String::split`, but I'm guessing code clarity and brevity takes preference over squeezing out performance here?