### PR TITLE
Add `is_colliding` method to `SpringArm3D`

### DIFF
--- a/doc/classes/SpringArm3D.xml
+++ b/doc/classes/SpringArm3D.xml
@@ -28,6 +28,12 @@
 				Returns the spring arm's current length.
 			</description>
 		</method>
+		<method name="is_colliding" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the SpringArm3D's ray or shape is intersecting with any colliders, and thus, if the spring arm's current length is less than its maximum length.
+			</description>
+		</method>
 		<method name="remove_excluded_object">
 			<return type="bool" />
 			<param index="0" name="RID" type="RID" />

--- a/scene/3d/physics/spring_arm_3d.cpp
+++ b/scene/3d/physics/spring_arm_3d.cpp
@@ -55,6 +55,7 @@ void SpringArm3D::_notification(int p_what) {
 
 void SpringArm3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_hit_length"), &SpringArm3D::get_hit_length);
+	ClassDB::bind_method(D_METHOD("is_colliding"), &SpringArm3D::is_colliding);
 
 	ClassDB::bind_method(D_METHOD("set_length", "length"), &SpringArm3D::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &SpringArm3D::get_length);
@@ -130,6 +131,10 @@ real_t SpringArm3D::get_hit_length() {
 	return current_spring_length;
 }
 
+bool SpringArm3D::is_colliding() const {
+	return collided;
+}
+
 void SpringArm3D::process_spring() {
 	// From
 	real_t motion_delta(1);
@@ -187,6 +192,8 @@ void SpringArm3D::process_spring() {
 
 		get_world_3d()->get_direct_space_state()->cast_motion(shape_params, motion_delta, motion_delta_unsafe);
 	}
+
+	collided = motion_delta < 1.0;
 
 	current_spring_length = spring_length * motion_delta;
 	Transform3D child_transform;

--- a/scene/3d/physics/spring_arm_3d.h
+++ b/scene/3d/physics/spring_arm_3d.h
@@ -36,6 +36,7 @@
 class SpringArm3D : public Node3D {
 	GDCLASS(SpringArm3D, Node3D);
 
+	bool collided = false;
 	Ref<Shape3D> shape;
 	HashSet<RID> excluded_objects;
 	real_t spring_length = 1.0;
@@ -59,6 +60,7 @@ public:
 	bool remove_excluded_object(RID p_rid);
 	void clear_excluded_objects();
 	real_t get_hit_length();
+	bool is_colliding() const;
 	void set_margin(real_t p_margin);
 	real_t get_margin();
 


### PR DESCRIPTION
Adds a method to getect if the arm is currently retracted in parity with Raycast3D and Shapecast3D. 

For me this method was helpful to set up a third person camera which returns smoothly to its intended length after being retracted due to collision.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8691*

Edit: Since first making this little hack I also used it pretty successfully in my character controller, saving me a few extra raycasts. And since Springarm IS in essence a cast, using an additional raycast to detect arm's collision defeats its purpose since you could simply place the object at the contact point using just the raycast. :)