### PR TITLE
Support unspecified linear size in DDS files

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -404,8 +404,11 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 		// BC compressed.
 		uint32_t size = MAX(info.divisor, w) / info.divisor * MAX(info.divisor, h) / info.divisor * info.block_size;
 
-		ERR_FAIL_COND_V(size != pitch, Ref<Resource>());
-		ERR_FAIL_COND_V(!(flags & DDSD_LINEARSIZE), Ref<Resource>());
+		if (flags & DDSD_LINEARSIZE) {
+			ERR_FAIL_COND_V_MSG(size != pitch, Ref<Resource>(), "DDS header flags specify that a linear size of the top-level image is present, but the specified size does not match the expected value.");
+		} else {
+			ERR_FAIL_COND_V_MSG(pitch != 0, Ref<Resource>(), "DDS header flags specify that no linear size will given for the top-level image, but a non-zero linear size value is present in the header.");
+		}
 
 		for (uint32_t i = 1; i < mipmaps; i++) {
 			w = MAX(1u, w >> 1);


### PR DESCRIPTION
This PR adjusts the DDS image loader, to properly handle compressed DDS images which were created by tools that elected not to specify the size of the top-level image, in the DDS header.

In cases where the exporter did specify a size, we compare it against our locally-calculated size. In cases where the exporter did not specify, we check that they populated a 0 in the associated header field, to minimize the risk of trying to parse corrupt / malformed files.

This PR fixes a part of #86330. The image supplied in that bug report's reproduction project still does not import successfully, due to the Image subsystem expecting more mipmaps than are actually present in the file, however that appears to be a separate issue, not intrinsically related to the changes being made here (i.e., while that particular image is not fully fixed by this change, there exist other images that are)