### PR TITLE
Add SIMD option to compile system and implement SIMD for vector4.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -226,6 +226,14 @@ opts.Add(
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
 opts.Add(BoolVariable("scu_build", "Use single compilation unit build", False))
 opts.Add("scu_limit", "Max includes per SCU file when using scu_build (determines RAM use)", "0")
+opts.Add(
+    EnumVariable(
+        "simd_type",
+        "Explicitly specify SIMD(Single Instruction Multiple Data) type of godot vector math",
+        "none",
+        ("none", "sse", "sse4_1", "sse4_2", "avx", "avx2", "avx512", "neon"),
+    )
+)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_brotli", "Use the built-in Brotli library", True))
@@ -1031,6 +1039,41 @@ if "env" in locals():
     # TODO: replace this with `env.Dump(format="json")`
     # once we start requiring SCons 4.0 as min version.
     methods.dump(env)
+
+# Hands SIMD option.
+simd_type = env["simd_type"]
+x86_x64_simd_types = ["sse", "sse4_1", "sse4_2", "avx", "avx2", "avx512"]
+if not simd_type in (["none", "neon"] + x86_x64_simd_types):
+    print(f"\nInvalid SIMD type: {simd_type}. Please select a valid SIMD type: simd_type=<string>.")
+    Exit(255)
+elif simd_type != "none":
+    error_msg = (
+        '\nSIMD type "{0}" only available on "{1}".  Please select a valid SIMD type or change target architecture.'
+    )
+    if simd_type == "neon":
+        if env["arch"] != "arm64":
+            print(error_msg.format(simd_type, "arm64"))
+            Exit(255)
+        env.Append(CPPDEFINES=["NEON_ENABLED"])
+    if simd_type == "sse":
+        if not env["arch"] in ["x86_32", "x86_64"]:
+            print(error_msg.format(simd_type, 'x86_32", "x86_64'))
+            Exit(255)
+        env.Append(CPPDEFINES=["SSE2_ENABLED"])
+    else:
+        if env["arch"] != "x86_64":
+            print(error_msg.format(simd_type, "x86_64"))
+            Exit(255)
+        for i in range(len(x86_x64_simd_types) - 1, -1, -1):
+            if simd_type == x86_x64_simd_types[i]:
+                for j in range(i + 1):
+                    env.Append(CPPDEFINES=[f"{x86_x64_simd_types[j].upper()}_ENABLED"])
+                if not env.msvc:
+                    if simd_type == "avx512":
+                        env.Append(CCFLAGS=["-mavx512f", "-mavx512vl", "-mavx512dq"])
+                    else:
+                        env.Append(CCFLAGS=["-m" + x86_x64_simd_types[j].lower().replace("_", ".")])
+                break
 
 
 def print_elapsed_time():

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -137,4 +137,63 @@ typedef double real_t;
 typedef float real_t;
 #endif
 
+/**
+ * SIMD
+ *
+ */
+#if (defined(__AVX2__) || defined(AVX512_ENABLED)) && !defined(AVX2_ENABLED)
+#define AVX2_ENABLED
+#endif
+#if (defined(__AVX__) || defined(AVX2_ENABLED)) && !defined(AVX_ENABLED)
+#define AVX_ENABLED
+#endif
+#if (defined(__SSE4_2__) || defined(AVX_ENABLED)) && !defined(SSE4_2_ENABLED)
+#define SSE4_2_ENABLED
+#endif
+#if (defined(__SSE4_1__) || defined(SSE4_2_ENABLED)) && !defined(SSE4_1_ENABLED)
+#define SSE4_1_ENABLED
+#endif
+#if defined(SSE4_1_ENABLED) && !defined(SSE_ENABLED)
+#define SSE_ENABLED
+#endif
+
+#if defined(SSE_ENABLED) || defined(SSE4_1_ENABLED) ||      \
+		defined(SSE4_2_ENABLED) || defined(AVX_ENABLED) ||  \
+		defined(AVX2_ENABLED) || defined(AVX512_ENABLED) || \
+		defined(NEON_ENABLED)
+#define SIMD_ENABLED
+#endif
+
+#ifdef SIMD_ENABLED
+
+#ifdef SSE_ENABLED
+#ifdef REAL_T_IS_DOUBLE
+#define SSE_WITH_DOUBLE_PRECISION
+#else // REAL_T_IS_DOUBLE
+#define SSE_WITH_SINGLE_PRECISION
+#endif // REAL_T_IS_DOUBLE
+#endif // SSE_ENABLED
+
+#ifdef NEON_ENABLED
+#ifdef REAL_T_IS_DOUBLE
+#define NEON_WITH_DOUBLE_PRECISION
+#else // REAL_T_IS_DOUBLE
+#define NEON_WITH_SINGLE_PRECISION
+#endif // REAL_T_IS_DOUBLE
+#endif // NEON_ENABLED
+
+// Include required headers.
+#if defined(SSE_ENABLED)
+#include <immintrin.h>
+#elif defined(NEON_ENABLED)
+#ifdef _MSC_VER
+#include <arm64_neon.h>
+#include <intrin.h>
+#else // _MSC_VER
+#include <arm_neon.h>
+#endif // _MSC_VER
+#endif
+
+#endif // SIMD_ENABLED
+
 #endif // MATH_DEFS_H

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -69,10 +69,66 @@ bool Vector4::is_finite() const {
 }
 
 real_t Vector4::length() const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(SSE4_1_ENABLED)
+	return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(simd_value, simd_value, 0xff)));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	__m256d mul = _mm256_mul_pd(simd_value, simd_value);
+
+	__m128d vlow = _mm256_castpd256_pd128(mul);
+	__m128d vhigh = _mm256_extractf128_pd(mul, 1); // High 128
+	vlow = _mm_add_pd(vlow, vhigh); // Reduce down to 128
+
+	__m128d high64 = _mm_unpackhi_pd(vlow, vlow);
+	return _mm_cvtsd_f64(_mm_sqrt_pd(_mm_add_sd(vlow, high64))); // Reduce to scalar
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	float32x4_t mul = vmulq_f32(simd_value, simd_value);
+	float32x2_t sum = vdup_n_f32(vaddvq_f32(mul));
+	return vget_lane_f32(vsqrt_f32(sum), 0);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	float64x1_t low_sum = vdup_n_f64(vaddvq_f64(vmulq_f64(simd_value.low, simd_value.low)));
+	float64x1_t high_sum = vdup_n_f64(vaddvq_f64(vmulq_f64(simd_value.high, simd_value.high)));
+	float64x1_t sum = vadd_f64(low_sum, high_sum);
+	return vget_lane_f64(vsqrt_f64(sum), 0);
+#else
 	return Math::sqrt(length_squared());
+#endif
 }
 
 void Vector4::normalize() {
+#ifdef SIMD_ENABLED
+	if (*this == Vector4()) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+		simd_value = _mm_setzero_ps();
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+		simd_value = _mm256_setzero_pd();
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+		simd_value.low = _mm_setzero_pd();
+		simd_value.high = _mm_setzero_pd();
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+		simd_value = vdupq_n_f32(0.0);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+		simd_value.low = vdupq_n_f64(0.0);
+		simd_value.high = vdupq_n_f64(0.0);
+#endif
+	} else {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+		simd_value = _mm_div_ps(simd_value, _mm_set1_ps(length()));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+		simd_value = _mm256_div_pd(simd_value, _mm256_set1_pd(length()));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+		simd_component_t len = _mm_set1_pd(length());
+		simd_value.low = _mm_div_pd(simd_value.low, len);
+		simd_value.high = _mm_div_pd(simd_value.high, len);
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+		simd_value = vdivq_f32(simd_value, vdupq_n_f32(length()));
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+		simd_component_t len = vdupq_n_f64(length());
+		simd_value.low = vdivq_f64(simd_value.low, len);
+		simd_value.high = vdivq_f64(simd_value.low, len);
+#endif
+	}
+
+#else // SIMD_ENABLED
 	real_t lengthsq = length_squared();
 	if (lengthsq == 0) {
 		x = y = z = w = 0;
@@ -83,6 +139,7 @@ void Vector4::normalize() {
 		z /= length;
 		w /= length;
 	}
+#endif // SIMD_ENABLED
 }
 
 Vector4 Vector4::normalized() const {
@@ -104,41 +161,121 @@ real_t Vector4::distance_squared_to(const Vector4 &p_to) const {
 }
 
 Vector4 Vector4::direction_to(const Vector4 &p_to) const {
-	Vector4 ret(p_to.x - x, p_to.y - y, p_to.z - z, p_to.w - w);
+	Vector4 ret = p_to - *this;
 	ret.normalize();
 	return ret;
 }
 
 Vector4 Vector4::abs() const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_max_ps(_mm_sub_ps(_mm_setzero_ps(), simd_value), simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_max_pd(_mm256_sub_pd(_mm256_setzero_pd(), simd_value), simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4(_mm_max_pd(_mm_sub_pd(_mm_setzero_pd(), simd_value.low), simd_value.low),
+			_mm_max_pd(_mm_sub_pd(_mm_setzero_pd(), simd_value.high), simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vabsq_f32(simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vabsq_f64(simd_value.low), vabsq_f64(simd_value.high));
+#else
 	return Vector4(Math::abs(x), Math::abs(y), Math::abs(z), Math::abs(w));
+#endif
 }
 
 Vector4 Vector4::sign() const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_t minus_one = _mm_set1_ps(-1.0f);
+	simd_t one = _mm_set1_ps(1.0f);
+	return _mm_or_ps(_mm_and_ps(simd_value, minus_one), one);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_t minus_one = _mm256_set1_pd(-1.0);
+	simd_t one = _mm256_set1_pd(1.0f);
+	return _mm256_or_pd(_mm256_and_pd(simd_value, minus_one), one);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	__m128d minus_one = _mm_set1_pd(-1.0);
+	__m128d one = _mm_set1_pd(1.0);
+	return Vector4(_mm_or_pd(_mm_and_pd(simd_value.low, minus_one), one),
+			_mm_or_pd(_mm_and_pd(simd_value.high, minus_one), one));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_t minus_one = vdupq_n_f32(-1.0f);
+	simd_t one = vdupq_n_f32(1.0f);
+	return vorrq_s32(vandq_s32(simd_value, minus_one), one);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_component_t minus_one = vdupq_n_f64(-1.0f);
+	simd_component_t one = vdupq_n_f64(1.0f);
+	return Vector4(vorrq_s64(vandq_s64(simd_value.low, minus_one), one),
+			vorrq_s64(vandq_s64(simd_value.high, minus_one), one));
+#else
 	return Vector4(SIGN(x), SIGN(y), SIGN(z), SIGN(w));
+#endif
 }
 
 Vector4 Vector4::floor() const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(SSE4_1_ENABLED)
+	return _mm_floor_ps(simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_floor_pd(simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	return Vector4(_mm_floor_pd(simd_value.low), _mm_floor_pd(simd_value.high));
+#else
 	return Vector4(Math::floor(x), Math::floor(y), Math::floor(z), Math::floor(w));
+#endif
 }
 
 Vector4 Vector4::ceil() const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(SSE4_1_ENABLED)
+	return _mm_ceil_ps(simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_ceil_pd(simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	return Vector4(_mm_ceil_pd(simd_value.low), _mm_ceil_pd(simd_value.high));
+#else
 	return Vector4(Math::ceil(x), Math::ceil(y), Math::ceil(z), Math::ceil(w));
+#endif
 }
 
 Vector4 Vector4::round() const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(SSE4_1_ENABLED)
+	return _mm_round_ps(simd_value, _MM_ROUND_NEAREST);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_round_pd(simd_value, _MM_ROUND_NEAREST);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	return Vector4(_mm_round_pd(simd_value.low, _MM_ROUND_NEAREST), _mm_round_pd(simd_value.high, _MM_ROUND_NEAREST));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vrndnq_f32(simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vrndnq_f64(simd_value.low), vrndnq_f64(simd_value.high));
+#else
 	return Vector4(Math::round(x), Math::round(y), Math::round(z), Math::round(w));
+#endif
 }
 
 Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_add_ps(simd_value, _mm_mul_ps(_mm_sub_ps(p_to.simd_value, simd_value), _mm_set1_ps(p_weight)));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_add_pd(simd_value, _mm256_mul_pd(_mm256_sub_pd(p_to.simd_value, simd_value), _mm256_set1_pd(p_weight)));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4{ _mm_add_pd(simd_value.low, _mm_mul_pd(_mm_sub_pd(p_to.simd_value.low, simd_value.low), _mm_set1_pd(p_weight))),
+		_mm_add_pd(simd_value.high, _mm_mul_pd(_mm_sub_pd(p_to.simd_value.high, simd_value.high), _mm_set1_pd(p_weight))) };
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vaddq_f32(simd_value, vmulq_f32(vsubq_f32(p_to.simd_value, simd_value), vdupq_n_f32(p_weight)));
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vaddq_f64(simd_value.low, vmulq_f64(vsubq_f64(p_to.simd_value.low, simd_value.low), vdupq_n_f64(p_weight))),
+			vaddq_f64(simd_value.high, vmulq_f64(vsubq_f64(p_to.simd_value.high, simd_value.high), vdupq_n_f64(p_weight))));
+#else
 	Vector4 res = *this;
 	res.x = Math::lerp(res.x, p_to.x, p_weight);
 	res.y = Math::lerp(res.y, p_to.y, p_weight);
 	res.z = Math::lerp(res.z, p_to.z, p_weight);
 	res.w = Math::lerp(res.w, p_to.w, p_weight);
 	return res;
+#endif
 }
 
 Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const {
+	// TODO SIMD
 	Vector4 res = *this;
 	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
 	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
@@ -148,6 +285,7 @@ Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, c
 }
 
 Vector4 Vector4::cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+	// TODO SIMD
 	Vector4 res = *this;
 	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
@@ -157,18 +295,65 @@ Vector4 Vector4::cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_
 }
 
 Vector4 Vector4::posmod(const real_t p_mod) const {
+	// TODO SIMD
 	return Vector4(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod), Math::fposmod(w, p_mod));
 }
 
 Vector4 Vector4::posmodv(const Vector4 &p_modv) const {
+	// TODO SIMD
 	return Vector4(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y), Math::fposmod(z, p_modv.z), Math::fposmod(w, p_modv.w));
 }
 
 void Vector4::snap(const Vector4 &p_step) {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(AVX_ENABLED)
+	simd_t eq_zero_mask = _mm_cmp_ps(p_step.simd_value, _mm_setzero_ps(), _CMP_EQ_OQ);
+	simd_t snapped = _mm_mul_ps(_mm_floor_ps(_mm_add_ps(_mm_div_ps(simd_value, p_step.simd_value), _mm_set1_ps(0.5))), p_step.simd_value);
+	simd_value = _mm_blendv_ps(snapped, simd_value, eq_zero_mask);
+#elif defined(SSE_WITH_SINGLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	simd_t eq_zero_mask = _mm_cmpeq_ps(p_step.simd_value, _mm_setzero_ps());
+	simd_t snapped = _mm_mul_ps(_mm_floor_ps(_mm_add_ps(_mm_div_ps(simd_value, p_step.simd_value), _mm_set1_ps(0.5))), p_step.simd_value);
+	simd_value = _mm_blendv_ps(snapped, simd_value, eq_zero_mask);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_t eq_zero_mask = _mm256_cmp_pd(p_step.simd_value, _mm256_setzero_pd(), _CMP_EQ_OQ);
+	simd_t snapped = _mm256_mul_pd(_mm256_floor_pd(_mm256_add_pd(_mm256_div_pd(simd_value, p_step.simd_value), _mm256_set1_pd(0.5))), p_step.simd_value);
+	simd_value = _mm256_blendv_pd(snapped, simd_value, eq_zero_mask);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	simd_component_t eq_zero_mask_low = _mm_cmpeq_ps(p_step.simd_value.low, _mm_setzero_pd());
+	simd_component_t snapped_low = _mm_mul_pd(_mm_floor_pd(_mm_add_pd(_mm_div_pd(simd_value.low, p_step.simd_value.low), _mm_set1_pd(0.5))), p_step.simd_value.low);
+	simd_value.low = _mm_blendv_pd(snapped_low, simd_value.low, eq_zero_mask_low);
+
+	simd_component_t eq_zero_mask_high = _mm_cmpeq_ps(p_step.simd_value.high, _mm_setzero_pd());
+	simd_component_t snapped_high = _mm_mul_pd(_mm_floor_pd(_mm_add_pd(_mm_div_pd(simd_value.high, p_step.simd_value.high), _mm_set1_pd(0.5))), p_step.simd_value.high);
+	simd_value.high = _mm_blendv_pd(snapped_high, simd_value.high, eq_zero_mask_high);
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_t eq_zero_mask = vceqq_f32(p_step.simd_value, vdupq_n_f32(0.0f));
+	Vector4 tmp = vaddq_f32(vdivq_f32(simd_value, p_step.simd_value), vdupq_n_f32(0.5));
+	simd_t snapped = vmulq_f32(tmp.floor().simd_value, p_step.simd_value);
+
+	for (int i = 0; i < 4; ++i) {
+		if ((eq_zero_mask.n128_u32[i] & 0xffff) != 0) {
+			simd_value.n128_f32[i] = snapped.n128_f32[i];
+		}
+	}
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	Vector4 tmp(vaddq_f64(vdivq_f64(simd_value.low, p_step.simd_value.low), vdupq_n_f64(0.5)), vaddq_f64(vdivq_f64(simd_value.high, p_step.simd_value.high), vdupq_n_f64(0.5)));
+	Vector4 snapped = tmp.floor() * p_step.simd_value;
+
+	for (int i = 0; i < 2; ++i) {
+		simd_component_t eq_zero_mask = vceqq_f64(p_step.simd_value.components[i], vdupq_n_f64(0.0));
+		for (int j = 0; j < 2; ++i) {
+			if (((eq_zero_mask.n128_u64[j] & 0xffffffff)) != 0) {
+				simd_value.components[i].n128_f64[j] = snapped.simd_value.components[i].n128_f32[j];
+			}
+		}
+	}
+
+#else
 	x = Math::snapped(x, p_step.x);
 	y = Math::snapped(y, p_step.y);
 	z = Math::snapped(z, p_step.z);
 	w = Math::snapped(w, p_step.w);
+#endif
 }
 
 Vector4 Vector4::snapped(const Vector4 &p_step) const {
@@ -178,15 +363,72 @@ Vector4 Vector4::snapped(const Vector4 &p_step) const {
 }
 
 Vector4 Vector4::inverse() const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	constexpr const simd_t identity = simd_t{ 1.0f, 1.0f, 1.0f, 1.0f };
+	return _mm_div_ps(identity, simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	constexpr const simd_t identity = simd_t{ 1.0, 1.0, 1.0, 1.0 };
+	return _mm256_div_pd(identity, simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	constexpr const simd_component_t identity = simd_component_t{ 1.0, 1.0 };
+	return Vector4(_mm_div_pd(identity, simd_value.low), _mm_div_pd(identity, simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vdivq_f32(vdupq_n_f32(1.0f), simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vdivq_f64(vdupq_n_f64(1.0), simd_value.low),
+			vdivq_f64(vdupq_n_f64(1.0), simd_value.high));
+#else
 	return Vector4(1.0f / x, 1.0f / y, 1.0f / z, 1.0f / w);
+#endif
 }
 
 Vector4 Vector4::clamp(const Vector4 &p_min, const Vector4 &p_max) const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(AVX_ENABLED)
+	simd_t less_than_mask = _mm_cmp_ps(p_min.simd_value, p_min.simd_value, _CMP_LT_OQ);
+	simd_t greater_than_mask = _mm_cmp_ps(p_min.simd_value, p_min.simd_value, _CMP_GT_OQ);
+	return _mm_blendv_ps(_mm_blendv_ps(simd_value, p_min.simd_value, less_than_mask), p_max.simd_value, greater_than_mask);
+#elif defined(SSE_WITH_SINGLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	simd_t less_than_mask = _mm_cmplt_ps(p_min.simd_value, p_min.simd_value);
+	simd_t greater_than_mask = _mm_cmpgt_ps(p_min.simd_value, p_min.simd_value);
+	return _mm_blendv_ps(_mm_blendv_ps(simd_value, p_min.simd_value, less_than_mask), p_max.simd_value, greater_than_mask);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_t less_than_mask = _mm256_cmp_pd(p_min.simd_value, p_min.simd_value, _CMP_LT_OQ);
+	simd_t greater_than_mask = _mm256_cmp_pd(p_min.simd_value, p_min.simd_value, _CMP_GT_OQ);
+	return _mm256_blendv_pd(_mm256_blendv_pd(simd_value, p_min.simd_value, less_than_mask), p_max.simd_value, greater_than_mask);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED) && defined(SSE4_1_ENABLED)
+	simd_component_t less_than_mask_low = _mm_cmplt_ps(simd_value.low, p_min.simd_value.low);
+	simd_component_t greater_than_mask_low = _mm_cmpgt_ps(simd_value.low, p_min.simd_value.low);
+	simd_component_t less_than_mask_high = _mm_cmplt_ps(simd_value.high, p_min.simd_value.high);
+	simd_component_t greater_than_mask_high = _mm_cmpgt_ps(simd_value.high, p_min.simd_value.high);
+	return Vector4{
+		_mm_blendv_pd(_mm_blendv_pd(simd_value.low, p_min.simd_value.low, less_than_mask_low), p_max.simd_value.low, greater_than_mask_low),
+		_mm_blendv_pd(_mm_blendv_pd(simd_value.high, p_min.simd_value.high, less_than_mask_high), p_max.simd_value.high, greater_than_mask_high)
+	};
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_t less_than_mask = vcltq_f32(p_min.simd_value, p_min.simd_value);
+	simd_t greater_than_mask = vcgtq_f32(p_min.simd_value, p_min.simd_value);
+	return Vector4(
+			less_than_mask.n128_u32[0] ? p_min.simd_value.n128_f32[0] : (greater_than_mask.n128_u32[0] ? p_max.simd_value.n128_f32[0] : simd_value.n128_f32[0]),
+			less_than_mask.n128_u32[1] ? p_min.simd_value.n128_f32[1] : (greater_than_mask.n128_u32[1] ? p_max.simd_value.n128_f32[1] : simd_value.n128_f32[1]),
+			less_than_mask.n128_u32[2] ? p_min.simd_value.n128_f32[2] : (greater_than_mask.n128_u32[2] ? p_max.simd_value.n128_f32[2] : simd_value.n128_f32[2]),
+			less_than_mask.n128_u32[3] ? p_min.simd_value.n128_f32[3] : (greater_than_mask.n128_u32[3] ? p_max.simd_value.n128_f32[3] : simd_value.n128_f32[3]));
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	uint64x2_t less_than_mask_low = vcltq_f64(p_min.simd_value.low, p_min.simd_value.low);
+	uint64x2_t greater_than_mask_low = vcgtq_f32(p_min.simd_value.low, p_min.simd_value.low);
+	uint64x2_t less_than_mask_high = vcltq_f64(p_min.simd_value.high, p_min.simd_value.high);
+	uint64x2_t greater_than_mask_high = vcgtq_f32(p_min.simd_value.high, p_min.simd_value.high);
+	return Vector4(
+			less_than_mask_low.n128_u64[0] ? p_min.simd_value.low.n128_f64[0] : (greater_than_mask_low.n128_u32[0] ? p_max.simd_value.low.n128_f64[0] : simd_value.low.n128_f64[0]),
+			less_than_mask_low.n128_u64[1] ? p_min.simd_value.low.n128_f64[1] : (greater_than_mask_low.n128_u32[1] ? p_max.simd_value.low.n128_f64[1] : simd_value.low.n128_f64[1]),
+			less_than_mask_high.n128_u64[0] ? p_min.simd_value.high.n128_f64[0] : (greater_than_mask_high.n128_u32[0] ? p_max.simd_value.high.n128_f64[0] : simd_value.high.n128_f64[0]),
+			less_than_mask_high.n128_u64[1] ? p_min.simd_value.high.n128_f64[1] : (greater_than_mask_high.n128_u32[1] ? p_max.simd_value.high.n128_f64[1] : simd_value.high.n128_f64[1]));
+#else
 	return Vector4(
 			CLAMP(x, p_min.x, p_max.x),
 			CLAMP(y, p_min.y, p_max.y),
 			CLAMP(z, p_min.z, p_max.z),
 			CLAMP(w, p_min.w, p_max.w));
+#endif
 }
 
 Vector4::operator String() const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -46,7 +46,57 @@ struct _NO_DISCARD_ Vector4 {
 		AXIS_W,
 	};
 
+// SSE
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	using simd_t = __m128;
+	using simd_t_arg = simd_t;
+#elif defined(SSE_WITH_DOUBLE_PRECISION)
+#ifdef AVX_ENABLED
+	using simd_t = __m256d;
+	using simd_t_arg = __m256d;
+#else //AVX_ENABLED
+	struct simd_t {
+		union {
+			struct {
+				__m128d low, high;
+			};
+			__m128d components[2];
+		};
+
+		simd_t(__m128d p_low, __m128d p_high) :
+				low(p_low), high(p_high) {
+		}
+	};
+	using simd_t_arg = const simd_t &;
+	using simd_component_t = __m128d;
+#endif //AVX_ENABLED
+#endif
+
+// NEON
+#if defined(NEON_WITH_SINGLE_PRECISION)
+	using simd_t = float32x4_t;
+	using simd_t_arg = simd_t;
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	struct simd_t {
+		union {
+			struct {
+				float64x2_t low, high;
+			};
+			float64x2_t components[2];
+		};
+
+		simd_t(const float64x2_t &p_low, const float64x2_t &p_high) :
+				low(p_low), high(p_high) {
+		}
+	};
+	using simd_t_arg = const simd_t &;
+	using simd_component_t = float64x2_t;
+#endif
+
 	union {
+#ifdef SIMD_ENABLED
+		simd_t simd_value;
+#endif // SIMD_ENABLED
 		struct {
 			real_t x;
 			real_t y;
@@ -69,11 +119,39 @@ struct _NO_DISCARD_ Vector4 {
 	Vector4::Axis max_axis_index() const;
 
 	Vector4 min(const Vector4 &p_vector4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+		return _mm_min_ps(simd_value, p_vector4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+		return _mm256_min_pd(simd_value, p_vector4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+		return Vector4(_mm_min_pd(simd_value.low, p_vector4.simd_value.low),
+				_mm_min_pd(simd_value.high, p_vector4.simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+		return vminq_f32(simd_value, p_vector4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+		return Vector4(vminq_f64(simd_value.low, p_vector4.simd_value.low),
+				vminq_f64(simd_value.high, p_vector4.simd_value.high));
+#else
 		return Vector4(MIN(x, p_vector4.x), MIN(y, p_vector4.y), MIN(z, p_vector4.z), MIN(w, p_vector4.w));
+#endif
 	}
 
 	Vector4 max(const Vector4 &p_vector4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+		return _mm_max_ps(simd_value, p_vector4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+		return _mm256_max_pd(simd_value, p_vector4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+		return Vector4(_mm_max_pd(simd_value.low, p_vector4.simd_value.low),
+				_mm_max_pd(simd_value.high, p_vector4.simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+		return vmaxq_f32(simd_value, p_vector4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+		return Vector4(vmaxq_f64(simd_value.low, p_vector4.simd_value.low),
+				vmaxq_f64(simd_value.high, p_vector4.simd_value.high));
+#else
 		return Vector4(MAX(x, p_vector4.x), MAX(y, p_vector4.y), MAX(z, p_vector4.z), MAX(w, p_vector4.w));
+#endif
 	}
 
 	_FORCE_INLINE_ real_t length_squared() const;
@@ -133,29 +211,84 @@ struct _NO_DISCARD_ Vector4 {
 	_FORCE_INLINE_ Vector4() {}
 
 	_FORCE_INLINE_ Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+#if defined(SSE_WITH_SINGLE_PRECISION)
+			simd_value(_mm_set_ps(p_x, p_y, p_z, p_w))
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+			simd_value(_mm256_set_pd(p_x, p_y, p_z, p_w))
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+			simd_value(_mm_set_pd(p_x, p_y), _mm_set_pd(p_z, p_w))
+#else
 			x(p_x),
 			y(p_y),
 			z(p_z),
-			w(p_w) {
+			w(p_w)
+#endif
+	{
 	}
 
 	Vector4(const Vector4 &p_vec4) :
+#ifdef SIMD_ENABLED
+			simd_value(p_vec4.simd_value)
+#else
 			x(p_vec4.x),
 			y(p_vec4.y),
 			z(p_vec4.z),
-			w(p_vec4.w) {
+			w(p_vec4.w)
+#endif
+	{
 	}
 
+#ifdef SIMD_ENABLED
+	_FORCE_INLINE_ Vector4(simd_t_arg p_simd_value) :
+			simd_value(p_simd_value) {
+	}
+
+#if defined(REAL_T_IS_DOUBLE) && (!defined(AVX_ENABLED) || defined(NEON_ENABLED))
+	_FORCE_INLINE_ Vector4(simd_component_t p_simd_value_low, simd_component_t p_simd_value_high) :
+			simd_value(p_simd_value_low, p_simd_value_high) {
+	}
+#endif
+#endif // SIMD_ENABLED
+
 	void operator=(const Vector4 &p_vec4) {
+#ifdef SIMD_ENABLED
+#if (defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)) || defined(NEON_WITH_DOUBLE_PRECISION)
+		simd_value.low = p_vec4.simd_value.low;
+		simd_value.high = p_vec4.simd_value.high;
+#else
+		simd_value = p_vec4.simd_value;
+#endif
+#else //SIMD_ENABLED
 		x = p_vec4.x;
 		y = p_vec4.y;
 		z = p_vec4.z;
 		w = p_vec4.w;
+#endif // SIMD_ENABLED
 	}
 };
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && defined(SSE4_1_ENABLED)
+	return _mm_cvtss_f32(_mm_dp_ps(simd_value, p_vec4.simd_value, 0xff));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	__m256d mul = _mm256_mul_pd(simd_value, p_vec4.simd_value);
+
+	__m128d vlow = _mm256_castpd256_pd128(mul);
+	__m128d vhigh = _mm256_extractf128_pd(mul, 1); // High 128
+	vlow = _mm_add_pd(vlow, vhigh); // Reduce down to 128
+
+	__m128d high64 = _mm_unpackhi_pd(vlow, vlow);
+	return _mm_cvtsd_f64(_mm_add_sd(vlow, high64)); // Reduce to scalar
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vaddvq_f32(vmulq_f32(simd_value, p_vec4.simd_value));
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	float64_t low_sum = vaddvq_f64(vmulq_f64(simd_value.low, p_vec4.simd_value.low));
+	float64_t high_sum = vaddvq_f64(vmulq_f64(simd_value.high, p_vec4.simd_value.high));
+
+	return low_sum + high_sum;
+#else
 	return x * p_vec4.x + y * p_vec4.y + z * p_vec4.z + w * p_vec4.w;
+#endif
 }
 
 real_t Vector4::length_squared() const {
@@ -163,77 +296,324 @@ real_t Vector4::length_squared() const {
 }
 
 void Vector4::operator+=(const Vector4 &p_vec4) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_value = _mm_add_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_value = _mm256_add_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	simd_value.low = _mm_add_pd(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = _mm_add_pd(simd_value.high, p_vec4.simd_value.high);
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_value = vaddq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_value.low = vaddq_f64(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = vaddq_f64(simd_value.high, p_vec4.simd_value.high);
+#else
 	x += p_vec4.x;
 	y += p_vec4.y;
 	z += p_vec4.z;
 	w += p_vec4.w;
+#endif
 }
 
 void Vector4::operator-=(const Vector4 &p_vec4) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_value = _mm_sub_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_value = _mm256_sub_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	simd_value.low = _mm_sub_pd(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = _mm_sub_pd(simd_value.high, p_vec4.simd_value.high);
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_value = vsubq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_value.low = vsubq_f64(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = vsubq_f64(simd_value.high, p_vec4.simd_value.high);
+#else
 	x -= p_vec4.x;
 	y -= p_vec4.y;
 	z -= p_vec4.z;
 	w -= p_vec4.w;
+#endif
 }
 
 void Vector4::operator*=(const Vector4 &p_vec4) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_value = _mm_mul_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_value = _mm256_mul_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	simd_value.low = _mm_mul_pd(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = _mm_mul_pd(simd_value.high, p_vec4.simd_value.high);
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_value = vmulq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_value.low = vmulq_f64(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = vmulq_f64(simd_value.high, p_vec4.simd_value.high);
+#else
 	x *= p_vec4.x;
 	y *= p_vec4.y;
 	z *= p_vec4.z;
 	w *= p_vec4.w;
+#endif
 }
 
 void Vector4::operator/=(const Vector4 &p_vec4) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_value = _mm_div_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_value = _mm256_div_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	simd_value.low = _mm_div_pd(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = _mm_div_pd(simd_value.high, p_vec4.simd_value.high);
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_value = vdivq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_value.low = vdivq_f64(simd_value.low, p_vec4.simd_value.low);
+	simd_value.high = vdivq_f64(simd_value.high, p_vec4.simd_value.high);
+#else
 	x /= p_vec4.x;
 	y /= p_vec4.y;
 	z /= p_vec4.z;
 	w /= p_vec4.w;
+#endif
 }
+
 void Vector4::operator*=(const real_t &s) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_value = _mm_mul_ps(simd_value, _mm_set1_ps(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_value = _mm256_mul_pd(simd_value, _mm256_set1_pd(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	simd_value.low = _mm_mul_pd(simd_value.low, _mm_set1_pd(s));
+	simd_value.high = _mm_mul_pd(simd_value.high, _mm_set1_pd(s));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_value = vmulq_n_f32(simd_value, s);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_value.low = vmulq_n_f64(simd_value.low, s);
+	simd_value.high = vmulq_n_f64(simd_value.high, s);
+#else
 	x *= s;
 	y *= s;
 	z *= s;
 	w *= s;
+#endif
 }
 
 void Vector4::operator/=(const real_t &s) {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	simd_value = _mm_div_ps(simd_value, _mm_set1_ps(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	simd_value = _mm256_div_pd(simd_value, _mm256_set1_pd(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	simd_value.low = _mm_div_pd(simd_value.low, _mm_set1_pd(s));
+	simd_value.high = _mm_div_pd(simd_value.high, _mm_set1_pd(s));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	simd_value = vdivq_f32(simd_value, vdupq_n_f32(s));
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_value.low = vdivq_f64(simd_value.low, vdupq_n_f64(s));
+	simd_value.high = vdivq_f64(simd_value.high, vdupq_n_f64(s));
+#else
 	*this *= 1.0f / s;
+#endif
 }
 
 Vector4 Vector4::operator+(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_add_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_add_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4(_mm_add_pd(simd_value.low, p_vec4.simd_value.low),
+			_mm_add_pd(simd_value.high, p_vec4.simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vaddq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vaddq_f64(simd_value.low, p_vec4.simd_value.low), vaddq_f64(simd_value.high, p_vec4.simd_value.high));
+#else
 	return Vector4(x + p_vec4.x, y + p_vec4.y, z + p_vec4.z, w + p_vec4.w);
+#endif
 }
 
 Vector4 Vector4::operator-(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_sub_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_sub_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4(_mm_sub_pd(simd_value.low, p_vec4.simd_value.low),
+			_mm_sub_pd(simd_value.high, p_vec4.simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vsubq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vsubq_f64(simd_value.low, p_vec4.simd_value.low),
+			vsubq_f64(simd_value.high, p_vec4.simd_value.high));
+#else
 	return Vector4(x - p_vec4.x, y - p_vec4.y, z - p_vec4.z, w - p_vec4.w);
+#endif
 }
 
 Vector4 Vector4::operator*(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_mul_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_mul_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4(_mm_mul_pd(simd_value.low, p_vec4.simd_value.low),
+			_mm_mul_pd(simd_value.high, p_vec4.simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vmulq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vmulq_f64(simd_value.low, p_vec4.simd_value.low),
+			vmulq_f64(simd_value.high, p_vec4.simd_value.high));
+#else
 	return Vector4(x * p_vec4.x, y * p_vec4.y, z * p_vec4.z, w * p_vec4.w);
+#endif
 }
 
 Vector4 Vector4::operator/(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_div_ps(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_div_pd(simd_value, p_vec4.simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4(_mm_div_pd(simd_value.low, p_vec4.simd_value.low),
+			_mm_div_pd(simd_value.high, p_vec4.simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vdivq_f32(simd_value, p_vec4.simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vdivq_f64(simd_value.low, p_vec4.simd_value.low),
+			vdivq_f64(simd_value.high, p_vec4.simd_value.high));
+#else
 	return Vector4(x / p_vec4.x, y / p_vec4.y, z / p_vec4.z, w / p_vec4.w);
+#endif
 }
 
 Vector4 Vector4::operator-() const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_sub_ps(_mm_setzero_ps(), simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_sub_pd(_mm256_setzero_pd(), simd_value);
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4(_mm_sub_pd(_mm_setzero_pd(), simd_value.low),
+			_mm_sub_pd(_mm_setzero_pd(), simd_value.high));
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vnegq_f32(simd_value);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vnegq_f64(simd_value.low),
+			vnegq_f64(simd_value.high));
+#else
 	return Vector4(-x, -y, -z, -w);
+#endif
 }
 
 Vector4 Vector4::operator*(const real_t &s) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_mul_ps(simd_value, _mm_set1_ps(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_mul_pd(simd_value, _mm256_set1_pd(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4{ _mm_mul_pd(simd_value.low, _mm_set1_pd(s)),
+		_mm_mul_pd(simd_value.high, _mm_set1_pd(s)) };
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vmulq_n_f32(simd_value, s);
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vmulq_n_f64(simd_value.low, s), vmulq_n_f64(simd_value.high, s));
+#else
 	return Vector4(x * s, y * s, z * s, w * s);
+#endif
 }
 
 Vector4 Vector4::operator/(const real_t &s) const {
+#if defined(SSE_WITH_SINGLE_PRECISION)
+	return _mm_div_ps(simd_value, _mm_set1_ps(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_div_pd(simd_value, _mm256_set1_pd(s));
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return Vector4{ _mm_div_pd(simd_value.low, _mm_set1_pd(s)),
+		_mm_div_pd(simd_value.high, _mm_set1_pd(s)) };
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	return vdivq_f32(simd_value, vdupq_n_f32(s));
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	return Vector4(vdivq_f64(simd_value.low, vdupq_n_f64(s)),
+			vdivq_f64(simd_value.high, vdupq_n_f64(s)));
+#else
 	return *this * (1.0f / s);
+#endif
 }
 
 bool Vector4::operator==(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && !defined(AVX_ENABLED)
+	return _mm_movemask_ps(_mm_cmpeq_ps(simd_value, p_vec4.simd_value)) == 0b1111;
+#elif defined(SSE_WITH_SINGLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm_movemask_ps(_mm_cmp_ps(simd_value, p_vec4.simd_value, _CMP_EQ_OQ)) == 0b1111;
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_movemask_pd(_mm256_cmp_pd(simd_value, p_vec4.simd_value, _CMP_EQ_OQ)) == 0b1111;
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return _mm_movemask_pd(_mm_cmpeq_pd(simd_value.low, p_vec4.simd_value.low)) == 0b11 &&
+			_mm_movemask_pd(_mm_cmpeq_pd(simd_value.high, p_vec4.simd_value.high)) == 0b11;
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	uint32x4_t cmp = vceqq_f32(simd_value, p_vec4.simd_value);
+	for (uint8_t i = 0; i < 4; ++i) {
+		if (vgetq_lane_u64(cmp, i) == 0) {
+			return false;
+		}
+	}
+	return true;
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	uint64x2_t cmp_low = vceqq_f64(simd_value.low, p_vec4.simd_value.low);
+	uint64x2_t cmp_high = vceqq_f64(simd_value.high, p_vec4.simd_value.high);
+	for (uint8_t i = 0; i < 2; ++i) {
+		if (vgetq_lane_u64(cmp_low, i) == 0) {
+			return false;
+		}
+	}
+	for (uint8_t i = 0; i < 2; ++i) {
+		if (vgetq_lane_u64(cmp_high, i) == 0) {
+			return false;
+		}
+	}
+	return true;
+#else
 	return x == p_vec4.x && y == p_vec4.y && z == p_vec4.z && w == p_vec4.w;
+#endif
 }
 
 bool Vector4::operator!=(const Vector4 &p_vec4) const {
+#if defined(SSE_WITH_SINGLE_PRECISION) && !defined(AVX_ENABLED)
+	return _mm_movemask_ps(_mm_cmpeq_ps(simd_value, p_vec4.simd_value)) != 0b1111;
+#elif defined(SSE_WITH_SINGLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm_movemask_ps(_mm_cmp_ps(simd_value, p_vec4.simd_value, _CMP_EQ_OQ)) != 0b1111;
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && defined(AVX_ENABLED)
+	return _mm256_movemask_pd(_mm256_cmp_pd(simd_value, p_vec4.simd_value, _CMP_EQ_OQ)) != 0b1111;
+#elif defined(SSE_WITH_DOUBLE_PRECISION) && !defined(AVX_ENABLED)
+	return _mm_movemask_pd(_mm_cmpeq_pd(simd_value.low, p_vec4.simd_value.low)) != 0b11 ||
+			_mm_movemask_pd(_mm_cmpeq_pd(simd_value.high, p_vec4.simd_value.high)) != 0b11;
+#elif defined(NEON_WITH_SINGLE_PRECISION)
+	uint32x4_t cmp = vceqq_f32(simd_value, p_vec4.simd_value);
+	for (uint8_t i = 0; i < 4; ++i) {
+		if (vgetq_lane_u64(cmp, i) == 0) {
+			return true;
+		}
+	}
+	return false;
+#elif defined(NEON_WITH_DOUBLE_PRECISION)
+	simd_component_t cmp_low = vceqq_f64(simd_value.low, p_vec4.simd_value.low);
+	simd_component_t cmp_high = vceqq_f64(simd_value.high, p_vec4.simd_value.high);
+	for (uint8_t i = 0; i < 2; ++i) {
+		if (vgetq_lane_u64(cmp_low, i) == 0) {
+			return true;
+		}
+	}
+	for (uint8_t i = 0; i < 2; ++i) {
+		if (vgetq_lane_u64(cmp_high, i) == 0) {
+			return true;
+		}
+	}
+	return false;
+#else
 	return x != p_vec4.x || y != p_vec4.y || z != p_vec4.z || w != p_vec4.w;
+#endif
 }
 
 bool Vector4::operator<(const Vector4 &p_v) const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
To implement SIMD in godot math is a huge work, this is the firt step.

I'm not sure if it's worth, and this change lack of testing.
If this is not worth, I will stop progress and remain in my branch.

---------------------------------------------------------------------------------
CPU: I7-8750H 
Build options: platform=windows arch=x86_x64 target=template_release debug_symbols=no bits=64 tests=yes optimize=speed

**Results:**
[test_results.md](https://github.com/godotengine/godot/files/13741662/test_results.md)

-------------------------------------

As the results show, SIMD does not always bring better speed, I don't know whether there have mistakes in this pr.
I remaind my test in "test_vector4.h", please check it.

And I have arm platform, build with "simd_type=neon" need test by others.