### PR TITLE
Fix the autocomplete function for the `self` keyword.

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1494,11 +1494,8 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 			} break;
 			case GDScriptParser::Node::SELF: {
 				if (p_context.current_class) {
-					if (p_context.type != GDScriptParser::COMPLETION_SUPER_METHOD) {
-						r_type.type = p_context.current_class->get_datatype();
-					} else {
-						r_type.type = p_context.current_class->base_type;
-					}
+					r_type.type = p_context.current_class->get_datatype();
+					r_type.type.is_meta_type = false;
 					found = true;
 				}
 			} break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #85833 

UPD: <del>I will try to fix the bug with singleton in the coming days. While I'm converting the PR into a draft.</del> there is no bug with singleton.