### PR TITLE
Expose viewport `gui_find_control` to scripting

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -120,8 +120,7 @@
 			<return type="Control" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Returns the [Control] that would be under the mouse cursor if the mouse cursor were located at the
-				viewpoint coordinates provided by the point parameter. If no [Control] is at that point, returns null.
+				Returns the [Control] that would be under the mouse cursor if the mouse cursor were located at the viewport coordinates provided by the point parameter. Returns null if there is no [Control] at that point.
 			</description>
 		</method>
 		<method name="gui_get_drag_data" qualifiers="const">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -116,6 +116,14 @@
 				Returns the visible rectangle in global screen coordinates.
 			</description>
 		</method>
+		<method name="gui_find_control">
+			<return type="Control" />
+			<param index="0" name="point" type="Vector2" />
+			<description>
+				Returns the [Control] that would be under the mouse cursor if the mouse cursor were located at the
+				viewpoint coordinates provided by the point parameter. If no [Control] is at that point, returns null.
+			</description>
+		</method>
 		<method name="gui_get_drag_data" qualifiers="const">
 			<return type="Variant" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4564,6 +4564,8 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner);
 	ClassDB::bind_method(D_METHOD("gui_get_hovered_control"), &Viewport::gui_get_hovered_control);
 
+	ClassDB::bind_method(D_METHOD("gui_find_control", "point"), &Viewport::gui_find_control);
+
 	ClassDB::bind_method(D_METHOD("set_disable_input", "disable"), &Viewport::set_disable_input);
 	ClassDB::bind_method(D_METHOD("is_input_disabled"), &Viewport::is_input_disabled);
 


### PR DESCRIPTION
Resubmitting relevant changes from this pull request to expose gui_find_control to GDScript. Another pull request had already been merged in that covered getting the mouse_over control
https://github.com/godotengine/godot/pull/84909

Usage:
```gdscript
var control_under_point = get_viewport().gui_find_control(get_global_mouse_position())
print(control_under_point)
```