### PR TITLE
Add note that a large value for `Label.outline_size` is not recommended

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -127,6 +127,7 @@
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			Text outline size.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
+			[b]Note:[/b] Using a value that is larger than half the font size is not recommended, as the font outline may fail to be fully closed in this case.
 		</theme_item>
 		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the text's shadow.


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/54214.

Not sure if we want to go into the technical limitations in this note? Perhaps setting a lower maximum value for this property would also be beneficial.