### PR TITLE
Clarify doc: `Node.get_child` returns null for invalid index

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -267,7 +267,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="include_internal" type="bool" default="false" />
 			<description>
-				Fetches a child node by its index. Each child node has an index relative its siblings (see [method get_index]). The first child is at index 0. Negative values can also be used to start from the end of the list. This method can be used in combination with [method get_child_count] to iterate over this node's children.
+				Fetches a child node by its index. Each child node has an index relative its siblings (see [method get_index]). The first child is at index 0. Negative values can also be used to start from the end of the list. This method can be used in combination with [method get_child_count] to iterate over this node's children. If no child exists at the given index, this method returns [code]null[/code] and an error is generated.
 				If [param include_internal] is [code]false[/code], internal children are ignored (see [method add_child]'s [code]internal[/code] parameter).
 				[codeblock]
 				# Assuming the following are children of this node, in order:


### PR DESCRIPTION
This adds a line to `Node.get_child`'s doc explaining that if no child exists at the specified index, `null` will be returned.

I found myself repeatedly writing code that checks for `get_child_count() >= (n + 1)` before calling `get_child(n)`. I had a wrong assumption that calling `get_child` with an out-of-bounds index would raise an error rather than returning null, as many collections do in other languages/frameworks. I think this would be helpful and relevant to mention in the doc.