### PR TITLE
Improve error message in text resource format parser

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -281,7 +281,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 					if (error == ERR_FILE_MISSING_DEPENDENCIES) {
 						// Resource loading error, just skip it.
 					} else if (error != ERR_FILE_EOF) {
-						_printerr();
+						ERR_PRINT(vformat("Parse Error: %s. [Resource file %s:%d]", error_names[error], res_path, lines));
 						return Ref<PackedScene>();
 					} else {
 						error = OK;


### PR DESCRIPTION
Related to my debugging of #77007 and should help users identify potential recursion points in order to circumvent or fix these issues with a work around while we continue to find a fix on an engine level.  

This improves the error message in our text resource parsing code to help the user potentially fix parsing issues in case of failure. It also helps with the debugging process of finding out which sub_resource is causing the parser to fail with line messages and resource paths. 

Old error message:
```
ERROR: res://scenes/objects/some_entity.tscn:203 - Parse Error: 
   at: _parse_node_tag (scene/resources/resource_format_text.cpp:284)
```

New error message:
```
ERROR: Parse Error: Busy. [Resource file res://Character.tscn:10]
   at: _parse_node_tag (scene/resources/resource_format_text.cpp:285)
```

This notably:
1 - Gives us the error code, which can help identify which conditional down the code path is flagging an error. It can also potentially help us determine whether or not the error is valid (In this example, the error code is `Busy`).
2 - Tells the user which file is problematic and which line the parser failed on. The line of failure is important as it empowers the user to find a work around in the worst case scenario, but also helps them find potential mistakes that they may have made during a git conflict resolution. 

I'll continue to look into causes for the bug but I think we should consider making our error message here more verbose to help with the debugging process of future tscn parsing bugs. :)
