### PR TITLE
Fix Instance float uniform doesn't work if assigned an integer

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1488,6 +1488,8 @@ void RendererSceneCull::instance_geometry_set_shader_parameter(RID p_instance, c
 
 	ERR_FAIL_COND(p_value.get_type() == Variant::OBJECT);
 
+	_update_dirty_instance(instance);
+
 	HashMap<StringName, Instance::InstanceShaderParameter>::Iterator E = instance->instance_shader_uniforms.find(p_parameter);
 
 	if (!E) {
@@ -1497,7 +1499,15 @@ void RendererSceneCull::instance_geometry_set_shader_parameter(RID p_instance, c
 		isp.value = p_value;
 		instance->instance_shader_uniforms[p_parameter] = isp;
 	} else {
-		E->value.value = p_value;
+		if (p_value.get_type() == E->value.info.type) {
+			E->value.value = p_value;
+		} else if (Variant::can_convert(p_value.get_type(), E->value.info.type)) {
+			Callable::CallError error;
+			const Variant *args[] = { &p_value };
+			Variant::construct(E->value.info.type, E->value.value, args, 1, error);
+		} else {
+			ERR_FAIL_MSG("Unsupported variant type for instance parameter: " + Variant::get_type_name(p_value.get_type()));
+		}
 		if (E->value.index >= 0 && instance->instance_allocated_shader_uniforms) {
 			int flags_count = 0;
 			if (E->value.info.hint == PROPERTY_HINT_FLAGS) {
@@ -1515,7 +1525,7 @@ void RendererSceneCull::instance_geometry_set_shader_parameter(RID p_instance, c
 				}
 			}
 			//update directly
-			RSG::material_storage->global_shader_parameters_instance_update(p_instance, E->value.index, p_value, flags_count);
+			RSG::material_storage->global_shader_parameters_instance_update(p_instance, E->value.index, E->value.value, flags_count);
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86130

In a nutshell, the problem lies in the fact that `global_shader_parameters_instance_update` (when set instance uniform) does not take in a type parameter, it just uses the type of the value passed in, while in `MaterialData::update_uniform_buffer` (when set uniform) it passes the correct type to `_fill_std140_variant_ubo_value`.

So in one hand we cound add an additional parameter to `global_shader_parameters_instance_update` and give it the correct type, but that requires a bigger change. 

So what I try to do in this pr is that in `instance_geometry_set_shader_parameter`, do some check about whether the type conversion is valid and do the conversion early (keep the variant's value but use the instance's type). Your suggestions are welcomed as I'm not familiar to the variant system... 



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
