### PR TITLE
Generate complete mipmap chains for compressed DDS images

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -410,17 +410,49 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 			ERR_FAIL_COND_V_MSG(pitch != 0, Ref<Resource>(), "DDS header flags specify that no linear size will given for the top-level image, but a non-zero linear size value is present in the header.");
 		}
 
+		uint32_t last_mip_offset = 0u;
 		for (uint32_t i = 1; i < mipmaps; i++) {
 			w = MAX(1u, w >> 1);
 			h = MAX(1u, h >> 1);
 
 			uint32_t bsize = MAX(info.divisor, w) / info.divisor * MAX(info.divisor, h) / info.divisor * info.block_size;
+			last_mip_offset = size;
 			size += bsize;
 		}
 
 		src_data.resize(size);
 		uint8_t *wb = src_data.ptrw();
 		f->get_buffer(wb, size);
+
+		const uint32_t last_mip_w = w;
+		const uint32_t last_mip_h = h;
+		if ((mipmaps >= 2u) && ((last_mip_w >= 2u) || (last_mip_h >= 2u))) {
+			// The source image's mipmap chain ends above the 1x1 base-case, however the renderer expects textures to have complete mipmap chains.
+			// Thus, we generate (very crude) mipmaps for the missing levels.
+			uint32_t mip_gen_offset = size;
+			while ((w >= 2u) || (h >= 2u)) {
+				w = MAX(1u, w >> 1);
+				h = MAX(1u, h >> 1);
+
+				uint32_t bsize = MAX(info.divisor, w) / info.divisor * MAX(info.divisor, h) / info.divisor * info.block_size;
+				size += bsize;
+			}
+			src_data.resize(size);
+			w = last_mip_w;
+			h = last_mip_h;
+			while ((w >= 2u) || (h >= 2u)) {
+				w = MAX(1u, w >> 1);
+				h = MAX(1u, h >> 1);
+
+				uint32_t blocks_width = MAX(info.divisor, w) / info.divisor;
+				uint32_t blocks_height = MAX(info.divisor, h) / info.divisor;
+				for (uint32_t idx = 0u; idx < (blocks_width * blocks_height); idx++) {
+					// Use copies of the corner of the last mipmap present in the DDS, as data for the smaller mip levels
+					memcpy(&wb[mip_gen_offset], &wb[last_mip_offset], info.block_size);
+					mip_gen_offset += info.block_size;
+				}
+			}
+		}
 
 	} else {
 		// Generic uncompressed.


### PR DESCRIPTION
This PR adjusts the DDS image loader, to ensure that the mipmap chain of compressed images is complete. This aligns with expectations elsewhere throughout the engine, that images with mipmaps will be mipmapped all the way down to 1x1, and will not have partial mipmap chains that terminate at some higher level.

Some DDS exporters create images whose mipmap chains terminate above the 1x1 case (often 4x4 or 8x8). To create the missing mipmap levels, this PR repeatedly copies the first block of compressed data from the last mipmap level that exists in the DDS. This is not mathematically correct, however the hope is that it will create mipmaps with colors that are similar enough to correct, as to not be visually objectionable, given that these low mipmap levels will only be occupying a few pixels on the screen.

The "correct" solution would require decoding the image, resampling it, re-encoding into a compressed form, and copying the result back into the original image data. I felt it was best not to incur that performance & complexity overhead on image loading, unless and until complaints are received about last-level mipmaps of DDS textures looking wrong. The limited color palette available in DXT-compressed pixel blocks means that low-level mipmaps tend not to look much like the original image, anyways.

This PR does not adjust the handling of compressed images which did not have any mipmaps populated in the source file; those images will be left un-mipmapped, as I believe the remainder of the engine is prepared to accept them in that state.

This PR resolves #86330