### PR TITLE
Optimize Viewport's `_gui_find_control_at_pos` for `Container` nodes

### DIFF
--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -51,6 +51,8 @@ private:
 		int separation = 0;
 	} theme_cache;
 
+	Vector<Control *> cached_children_nodes;
+
 	void _resort();
 
 protected:
@@ -70,6 +72,7 @@ public:
 	bool is_vertical() const;
 
 	virtual Size2 get_minimum_size() const override;
+	virtual Vector<CanvasItem *> get_children_at_pos(const Point2 &p_pos) const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -81,6 +81,17 @@ void Container::remove_child_notify(Node *p_child) {
 	queue_sort();
 }
 
+Vector<CanvasItem *> Container::get_children_at_pos(const Point2 &p_pos) const {
+	Vector<CanvasItem *> children;
+	for (int i = get_child_count() - 1; i >= 0; i--) {
+		CanvasItem *child = Object::cast_to<CanvasItem>(get_child(i));
+		if (child && child->is_visible()) {
+			children.push_back(child);
+		}
+	}
+	return children;
+}
+
 void Container::_sort_children() {
 	if (!is_inside_tree()) {
 		return;

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -59,6 +59,7 @@ public:
 	};
 
 	void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);
+	virtual Vector<CanvasItem *> get_children_at_pos(const Point2 &p_pos) const;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const;
 	virtual Vector<int> get_allowed_size_flags_vertical() const;

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -59,6 +59,8 @@ void FlowContainer::_resort() {
 	int current_container_size = vertical ? get_rect().size.y : get_rect().size.x;
 	int children_in_current_line = 0;
 
+	cached_children_nodes.clear();
+
 	// First pass for line wrapping and minimum size calculation.
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *child = Object::cast_to<Control>(get_child(i));
@@ -140,6 +142,11 @@ void FlowContainer::_resort() {
 		}
 		Size2i child_size = children_minsize_cache[child];
 
+		if (cached_children_nodes.is_empty()) {
+			// Add the first child.
+			cached_children_nodes.push_back(child);
+		}
+
 		_LineData line_data = lines_data[current_line_idx];
 		if (child_idx_in_line >= lines_data[current_line_idx].child_count) {
 			current_line_idx++;
@@ -151,6 +158,7 @@ void FlowContainer::_resort() {
 				ofs.x = 0;
 				ofs.y += line_data.min_line_height + theme_cache.v_separation;
 			}
+			cached_children_nodes.push_back(child);
 			line_data = lines_data[current_line_idx];
 		}
 
@@ -245,6 +253,47 @@ Size2 FlowContainer::get_minimum_size() const {
 	}
 
 	return minimum;
+}
+
+Vector<CanvasItem *> FlowContainer::get_children_at_pos(const Point2 &p_pos) const {
+	if (cached_children_nodes.is_empty()) {
+		return Vector<CanvasItem *>();
+	}
+
+	int coord = vertical ? p_pos.x : p_pos.y;
+	// Custom binary search; we are searching for the closest value to coord, not an exact one.
+	int bin_start = 0;
+	int bin_end = cached_children_nodes.size();
+	while (bin_start < bin_end) {
+		int mid = (bin_start + bin_end) / 2;
+		if (coord < (vertical ? cached_children_nodes[mid]->get_rect().position.x : cached_children_nodes[mid]->get_rect().position.y)) {
+			bin_end = mid;
+		} else {
+			bin_start = mid + 1;
+		}
+	}
+
+	int start_idx = MAX(bin_start - 1, 0);
+	int end_idx = MIN(bin_end, cached_children_nodes.size() - 1);
+	ERR_FAIL_INDEX_V(start_idx, cached_children_nodes.size(), Vector<CanvasItem *>());
+	ERR_FAIL_INDEX_V(end_idx, cached_children_nodes.size(), Vector<CanvasItem *>());
+
+	int start_node_idx = cached_children_nodes[start_idx]->get_index();
+	int end_node_idx = cached_children_nodes[end_idx]->get_index();
+
+	if (start_node_idx == end_node_idx) {
+		// Last row, so include the remaining children.
+		end_node_idx = get_child_count();
+	}
+
+	Vector<CanvasItem *> children;
+	for (end_node_idx--; end_node_idx >= start_node_idx; end_node_idx--) {
+		CanvasItem *child = Object::cast_to<CanvasItem>(get_child(end_node_idx));
+		if (child && child->is_visible()) {
+			children.push_back(child);
+		}
+	}
+	return children;
 }
 
 Vector<int> FlowContainer::get_allowed_size_flags_horizontal() const {

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -57,6 +57,8 @@ private:
 
 	void _resort();
 
+	Vector<Control *> cached_children_nodes;
+
 protected:
 	bool is_fixed = false;
 
@@ -74,6 +76,7 @@ public:
 	bool is_vertical() const;
 
 	virtual Size2 get_minimum_size() const override;
+	virtual Vector<CanvasItem *> get_children_at_pos(const Point2 &p_pos) const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -185,11 +185,18 @@ void GridContainer::_notification(int p_what) {
 			}
 
 			valid_controls_index = 0;
+			cached_children_nodes.clear();
+
 			for (int i = 0; i < get_child_count(); i++) {
 				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c || !c->is_visible_in_tree()) {
 					continue;
 				}
+				if (cached_children_nodes.is_empty()) {
+					// Add the first child.
+					cached_children_nodes.push_back(c);
+				}
+
 				int row = valid_controls_index / columns;
 				int col = valid_controls_index % columns;
 				valid_controls_index++;
@@ -207,6 +214,7 @@ void GridContainer::_notification(int p_what) {
 							// Apply the remaining pixel of the previous row.
 							row_ofs++;
 						}
+						cached_children_nodes.push_back(c);
 					}
 				}
 
@@ -320,6 +328,46 @@ Size2 GridContainer::get_minimum_size() const {
 	ms.width += theme_cache.h_separation * max_col;
 
 	return ms;
+}
+
+Vector<CanvasItem *> GridContainer::get_children_at_pos(const Point2 &p_pos) const {
+	if (cached_children_nodes.is_empty()) {
+		return Vector<CanvasItem *>();
+	}
+
+	// Custom binary search; we are searching for the closest value to coord, not an exact one.
+	int bin_start = 0;
+	int bin_end = cached_children_nodes.size();
+	while (bin_start < bin_end) {
+		int mid = (bin_start + bin_end) / 2;
+		if (p_pos.y < cached_children_nodes[mid]->get_rect().position.y) {
+			bin_end = mid;
+		} else {
+			bin_start = mid + 1;
+		}
+	}
+
+	int start_idx = MAX(bin_start - 1, 0);
+	int end_idx = MIN(bin_end, cached_children_nodes.size() - 1);
+	ERR_FAIL_INDEX_V(start_idx, cached_children_nodes.size(), Vector<CanvasItem *>());
+	ERR_FAIL_INDEX_V(end_idx, cached_children_nodes.size(), Vector<CanvasItem *>());
+
+	int start_node_idx = cached_children_nodes[start_idx]->get_index();
+	int end_node_idx = cached_children_nodes[end_idx]->get_index();
+
+	if (start_node_idx == end_node_idx) {
+		// Last row, so include the remaining children.
+		end_node_idx = get_child_count();
+	}
+
+	Vector<CanvasItem *> children;
+	for (end_node_idx--; end_node_idx >= start_node_idx; end_node_idx--) {
+		CanvasItem *child = Object::cast_to<CanvasItem>(get_child(end_node_idx));
+		if (child && child->is_visible()) {
+			children.push_back(child);
+		}
+	}
+	return children;
 }
 
 GridContainer::GridContainer() {}

--- a/scene/gui/grid_container.h
+++ b/scene/gui/grid_container.h
@@ -43,6 +43,8 @@ class GridContainer : public Container {
 		int v_separation = 0;
 	} theme_cache;
 
+	Vector<Control *> cached_children_nodes;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -51,6 +53,7 @@ public:
 	void set_columns(int p_columns);
 	int get_columns() const;
 	virtual Size2 get_minimum_size() const override;
+	virtual Vector<CanvasItem *> get_children_at_pos(const Point2 &p_pos) const override;
 
 	int get_h_separation() const;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1691,8 +1691,25 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 	}
 
 	Control *c = Object::cast_to<Control>(p_node);
+	Point2 point = matrix.affine_inverse().xform(p_global);
 
-	if (!c || !c->is_clipping_contents() || c->has_point(matrix.affine_inverse().xform(p_global))) {
+	if (!c || !c->is_clipping_contents() || c->has_point(point)) {
+		// If node is a Container, it can optimize the search at the given position.
+		Container *container = Object::cast_to<Container>(p_node);
+		if (container && container->has_point(point)) {
+			Vector<CanvasItem *> children = container->get_children_at_pos(point);
+			for (CanvasItem *ci : children) {
+				if (ci->is_set_as_top_level()) {
+					continue;
+				}
+
+				Control *ret = _gui_find_control_at_pos(ci, p_global, matrix);
+				if (ret) {
+					return ret;
+				}
+			}
+		}
+		// Fallback: Iterate over all children.
 		for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 			CanvasItem *ci = Object::cast_to<CanvasItem>(p_node->get_child(i));
 			if (!ci || ci->is_set_as_top_level()) {


### PR DESCRIPTION
*(I couldn't find a related issue, but if desired, I can open one describing the problem in our project)*

When developing an application for managing the user's gaming library, we've had a few users with thousands of games reporting extremely low performance whenever they interacted with any mouse input, such as picking and scrolling the library. This is easily reproducible by adding 10~20k `Control` nodes to some container, such as `FlowContainer`. When moving the mouse and/or scrolling around, the drop in FPS is extremely noticeable (while in this simple scenario the FPS are still good, on our application performance drops to ~20FPS and has very noticeable stutters) :

https://github.com/godotengine/godot/assets/6501975/24ee74c9-7698-4942-9ce2-76fe8e82c0ba

This slowdown was not visible in any of Godot's profilers, suggesting the issue lied somewhere in engine code. After profilling with external tools, the root cause was on how the viewport tests for valid controls under a given mouse position (`Viewport::_gui_find_control_at_pos`):

https://github.com/godotengine/godot/blob/3ce73e5d419011d1642ed30a3417362b82c41898/scene/main/viewport.cpp#L1695-L1707

This function iterates over every node's children, thus being **O(N)**, which in our scenario is extremely wasteful due to our usage of `Container`s with known positions for children nodes, and since this runs on every frame of input, it quickly becomes a noticeable bottleneck.

By taking advantage of the `Container`'s behavior of automatically repositioning nodes, it was possible to greatly optimize this node lookup process by taking into account the mouse's position, lowering the candidate nodes considerably.

# Optimization

This introduces the `Container::get_children_at_pos` function for all `Container` nodes, which should return the candidate list of nodes likely to be at the given position. The default implementation returns all children, which should keep the current behavior for any containers not overriding this function. When the viewport traverses children, it will call this new function in order to optimize the search, and fallback to the existing behavior if no valid children are found. Thus, in theory, this change should not break or change any existing behavior.

This PR overrides this function for `FlowContainer` (`HFlowContainer`/`VFlowContainer`), `BoxContainer` (`HBoxContainer`/`VBoxContainer`) and `GridContainer`. These seemed the best candidates for this optimization, but if there's more containers that could benefit from this, I can add them as well.

> [!NOTE]
> In the following diagrams, grey numbers/dotted lines represent invisible nodes.

## `FlowContainer`

Since this container can fit an arbitrary number of nodes for each row, information about each row's position and first child index is stored. When searching for children, we find the row that contains the given position through a binary search, and return all the children in that row.

![image](https://github.com/godotengine/godot/assets/6501975/92ed4a67-7e5f-48a6-a037-67905b099707)

## `GridContainer`

Same behavior as `FlowContainer`.

![image](https://github.com/godotengine/godot/assets/6501975/e4657999-0d0f-4bed-92fb-db1ab4963e24)

<image>

## `BoxContainer`

Being a one-dimensional container, only visible children's position and index are stored. When searching for children, we search for it's position with a binary search. This container thus only returns one child.

![image](https://github.com/godotengine/godot/assets/6501975/b706465f-2c5b-4350-864e-2293a3572739)

# Benchmark

[ReproUIPerformance.zip](https://github.com/godotengine/godot/files/13728287/ReproUIPerformance.zip)

This test project allows to test the performance of the viewport's node lookup. It should be opened in the editor, and before running, make one of the existing container's visible in order to let it spawn the children. `Invis` variants spawn some children as invisible. Each child is a button indicating it's index, and global (x, y) position.

![image](https://github.com/godotengine/godot/assets/6501975/8b7a3437-64f3-4476-a43a-d945c3cee3ba)

To test this yourself, enable only one of the container nodes, run the project, click on the `Benchmark` button, and don't move the mouse for the next 500 frames. The test will warp the mouse pointer to the center of the screen, and simulate both mouse motion and wheel scrolling. When done, it shows the average frame time for the test.

> [!WARNING]
> Each enabled container spawns a lot of children nodes (50k), and take significant amounts of RAM to launch (~2GB).

https://github.com/godotengine/godot/assets/6501975/88033a4c-3367-4373-9642-ab33ad1df8ea

Here are the results I obtained from my setup (Ryzen 5 5600G, RX 6500 XT, 8GB RAM):

> [!NOTE]
> Both vanilla and optimized builds were compiled with:
> `$ scons use_llvm=yes linker=mold scu_build=yes use_static_cpp=no optimize=speed`

> [!IMPORTANT]
> Values are updated when requested changes modify speedups significantly. Previous data and comparisons remain available below.

| **Node Type** | **Frame time - Vanilla (ms)** | **Frame time - Optimized (ms)** | **Speedup (relative)** |
|---------------|-------------------------------|---------------------------------|------------------------|
| `HFlowContainer` | 44.296 | 16.540 | x2.678 |
| `HFlowContainerInvis` | 65.306 | 26.398 | x2.474 |
| `VFlowContainer` | 44.084 | 16.160 | x2.728 |
| `VFlowContainerInvis` | 63.886 | 26.120 | x2.446 |
| `HBoxContainer` | 44.974 | 10.532 | x4.270 |
| `HBoxContainerInvis` | 68.046 | 19.448 | x3.499 |
| `VBoxContainer` | 44.542 | 14.746 | x3.021 |
| `VBoxContainerInvis` | 66.014 | 24.556 | x2.688 |
| `GridContainer` | 43.754 | 16.608 | x2.635 |
| `GridContainerInvis` | 65.038 | 26.692 | x2.437 |

<details><summary>Old values</summary>

### Original results
| **Node Type** | **Frame time - Vanilla (ms)** | **Frame time - Optimized (ms)** | **Speedup (relative)** | **Improvement (%)** |
|---------------|-------------------------------|---------------------------------|------------------------|---------------------|
| `HFlowContainer` | 40.690 | 16.256 | x2.503 | **+ 6.99%** |
| `HFlowContainerInvis` | 61.696 | 27.214 | x2.267 | **+ 9.13%** |
| `VFlowContainer` | 40.470 | 16.142 | x2.507 | **+ 8.82%** |
| `VFlowContainerInvis` | 61.688 | 26.044 | x2.369 | **+ 3.25%** |
| `HBoxContainer` | 42.042 | 11.038 | x3.809 | **+ 12.10%** |
| `HBoxContainerInvis` | 65.264 | 18.890 | x3.455 | **+ 1.27%** |
| `VBoxContainer` | 42.838 | 14.172 | x3.023 | *- 0.07%* |
| `VBoxContainerInvis` | 65.764 | 26.184 | x2.512 | **+ 7.01%** |
| `GridContainer` | 41.256 | 16.180 | x2.550 | **+ 3.33%** |
| `GridContainerInvis` | 62.544 | 26.808 | x2.333 | **+ 4.46%** |

> Average improvement: **+5.629%**
</details>


## Remarks

- This optimization does not improve the scenario of switching node focus with keyboard/controllers for nodes without specific focus neighbors, which go through a different function (`Control::_window_find_focus_neighbor`). Something similar is needed to optimize that scenario as well.
- There is potential to optimize further by not falling back to the slow **O(N)** search if no valid children are found on `Container`s, which makes it even faster (for the slowest time at `VBoxContainerInvis`, time becomes **17.812** and speedup **x3.692**). This, however, assumes that `Container`'s children only have content on their "bounding boxes", which is not a guarantee as nodes could be moved beyond this, and thus becoming uninteractable. While the speedup with the fallback is already considerable nevertheless, it would be interesting to find a way to support these scenarios in order to improve even further. 

https://github.com/godotengine/godot/assets/6501975/b14e701f-ee23-4cec-a546-8b07fb3cee13

