### PR TITLE
Add `interface/theme/{window_border_margin,top_bar_separation,default_margin_size}` editor settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -665,6 +665,9 @@
 		<member name="interface/theme/custom_theme" type="String" setter="" getter="">
 			The custom theme resource to use for the editor. Must be a Godot theme resource in [code].tres[/code] or [code].res[/code] format.
 		</member>
+		<member name="interface/theme/default_margin_size" type="int" setter="" getter="">
+			Sets the default margin size for components used in the editor.
+		</member>
 		<member name="interface/theme/draw_extra_borders" type="bool" setter="" getter="">
 			If [code]true[/code], draws additional borders around interactive UI elements in the editor. This is automatically enabled when using the [b]Black (OLED)[/b] theme preset, as this theme preset uses a fully black background.
 		</member>
@@ -683,6 +686,12 @@
 		</member>
 		<member name="interface/theme/relationship_line_opacity" type="float" setter="" getter="">
 			The opacity to use when drawing relationship lines in the editor's [Tree]-based GUIs (such as the Scene tree dock).
+		</member>
+		<member name="interface/theme/top_bar_separation" type="int" setter="" getter="">
+			The margin between the top bar and the rest of the editor.
+		</member>
+		<member name="interface/theme/window_border_margin" type="int" setter="" getter="">
+			The margins between the window border and the content of an editor window.
 		</member>
 		<member name="interface/touchscreen/enable_long_press_as_right_click" type="bool" setter="" getter="">
 			If [code]true[/code], long press on touchscreen is treated as right click.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -470,6 +470,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/border_size", 0, "0,2,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 3, "0,6,1")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/additional_spacing", 0.0, "0,5,0.1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/default_margin_size", 4, "0,16,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/window_border_margin", 8, "0,100,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/top_bar_separation", 8, "0,100,1")
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/theme/custom_theme", "", "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// Touchscreen

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -743,14 +743,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	}
 
 	const int thumb_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
+
 	theme->set_constant("scale", EditorStringName(Editor), EDSCALE);
 	theme->set_constant("thumb_size", EditorStringName(Editor), thumb_size);
 	theme->set_constant("class_icon_size", EditorStringName(Editor), 16 * EDSCALE);
 	theme->set_constant("dark_theme", EditorStringName(Editor), dark_theme);
 	theme->set_constant("color_picker_button_height", EditorStringName(Editor), 28 * EDSCALE);
 	theme->set_constant("gizmo_handle_scale", EditorStringName(Editor), gizmo_handle_scale);
-	theme->set_constant("window_border_margin", EditorStringName(Editor), 8);
-	theme->set_constant("top_bar_separation", EditorStringName(Editor), 8 * EDSCALE);
+	theme->set_constant("window_border_margin", EditorStringName(Editor), (int)EDITOR_GET("interface/theme/window_border_margin"));
+	theme->set_constant("top_bar_separation", EditorStringName(Editor), (int)EDITOR_GET("interface/theme/top_bar_separation") * EDSCALE);
 
 	// Register editor icons.
 	// If the settings are comparable to the old theme, then just copy them over.
@@ -800,7 +801,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Ensure borders are visible when using an editor scale below 100%.
 	const int border_width = CLAMP(border_size, 0, 2) * MAX(1, EDSCALE);
 	const int corner_width = CLAMP(corner_radius, 0, 6);
-	const int default_margin_size = 4;
+	int default_margin_size = EDITOR_GET("interface/theme/default_margin_size");
+
 	const int margin_size_extra = default_margin_size + CLAMP(border_size, 0, 2);
 
 	// Styleboxes


### PR DESCRIPTION
This PR adds `interface/theme/window_border_margin`, `interface/theme/top_bar_separation` and `interface/theme/default_margin_size` editor settings in order to easily edit the editor interface margins.

> [!NOTE]
> This PR doesn't directly add a way to change the tree items margin size, only the default margin size used for all sorts of themes initiated during the startup for the editor.

# Preview
![image](https://github.com/godotengine/godot/assets/270928/5b229f3c-1011-4d02-abd7-132d4154390d)

## TreeView (impacted by the change change)
| `default_margin_size` at `4` | `default_margin_size` at `2` |
|--------|------- |
| ![Capture d’écran du 2023-12-20 11-11-40](https://github.com/godotengine/godot/assets/270928/58d44038-5bfd-428b-8425-213e5003b296) | ![Capture d’écran du 2023-12-20 11-12-32](https://github.com/godotengine/godot/assets/270928/4baff4ff-5908-451f-9b9c-e1c66a9dc625) |

# Current issues with the PR
- [ ] Some UI break with the default margins lower than `4` (like the `Tree` arrow placement and lines)

# Fixes
Fixes godotengine/godot-proposals#8505