### PR TITLE
Add and expose Basis/Transform2D/3D division by float operator

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -136,6 +136,8 @@ struct _NO_DISCARD_ Basis {
 	_FORCE_INLINE_ Basis operator-(const Basis &p_matrix) const;
 	_FORCE_INLINE_ void operator*=(const real_t p_val);
 	_FORCE_INLINE_ Basis operator*(const real_t p_val) const;
+	_FORCE_INLINE_ void operator/=(const real_t p_val);
+	_FORCE_INLINE_ Basis operator/(const real_t p_val) const;
 
 	bool is_orthogonal() const;
 	bool is_orthonormal() const;
@@ -286,6 +288,18 @@ _FORCE_INLINE_ void Basis::operator*=(const real_t p_val) {
 _FORCE_INLINE_ Basis Basis::operator*(const real_t p_val) const {
 	Basis ret(*this);
 	ret *= p_val;
+	return ret;
+}
+
+_FORCE_INLINE_ void Basis::operator/=(const real_t p_val) {
+	rows[0] /= p_val;
+	rows[1] /= p_val;
+	rows[2] /= p_val;
+}
+
+_FORCE_INLINE_ Basis Basis::operator/(const real_t p_val) const {
+	Basis ret(*this);
+	ret /= p_val;
 	return ret;
 }
 

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -295,6 +295,18 @@ Transform2D Transform2D::operator*(const real_t p_val) const {
 	return ret;
 }
 
+void Transform2D::operator/=(const real_t p_val) {
+	columns[0] /= p_val;
+	columns[1] /= p_val;
+	columns[2] /= p_val;
+}
+
+Transform2D Transform2D::operator/(const real_t p_val) const {
+	Transform2D ret(*this);
+	ret /= p_val;
+	return ret;
+}
+
 Transform2D::operator String() const {
 	return "[X: " + columns[0].operator String() +
 			", Y: " + columns[1].operator String() +

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -109,6 +109,8 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D operator*(const Transform2D &p_transform) const;
 	void operator*=(const real_t p_val);
 	Transform2D operator*(const real_t p_val) const;
+	void operator/=(const real_t p_val);
+	Transform2D operator/(const real_t p_val) const;
 
 	Transform2D interpolate_with(const Transform2D &p_transform, const real_t p_c) const;
 

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -208,6 +208,17 @@ Transform3D Transform3D::operator*(const real_t p_val) const {
 	return ret;
 }
 
+void Transform3D::operator/=(const real_t p_val) {
+	basis /= p_val;
+	origin /= p_val;
+}
+
+Transform3D Transform3D::operator/(const real_t p_val) const {
+	Transform3D ret(*this);
+	ret /= p_val;
+	return ret;
+}
+
 Transform3D::operator String() const {
 	return "[X: " + basis.get_column(0).operator String() +
 			", Y: " + basis.get_column(1).operator String() +

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -104,6 +104,8 @@ struct _NO_DISCARD_ Transform3D {
 	Transform3D operator*(const Transform3D &p_transform) const;
 	void operator*=(const real_t p_val);
 	Transform3D operator*(const real_t p_val) const;
+	void operator/=(const real_t p_val);
+	Transform3D operator/(const real_t p_val) const;
 
 	Transform3D interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -412,6 +412,15 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorDivNZ<Vector4, Vector4i, double>>(Variant::OP_DIVIDE, Variant::VECTOR4I, Variant::FLOAT);
 	register_op<OperatorEvaluatorDivNZ<Vector4i, Vector4i, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR4I, Variant::INT);
 
+	register_op<OperatorEvaluatorDiv<Transform2D, Transform2D, int64_t>>(Variant::OP_DIVIDE, Variant::TRANSFORM2D, Variant::INT);
+	register_op<OperatorEvaluatorDiv<Transform2D, Transform2D, double>>(Variant::OP_DIVIDE, Variant::TRANSFORM2D, Variant::FLOAT);
+
+	register_op<OperatorEvaluatorDiv<Transform3D, Transform3D, int64_t>>(Variant::OP_DIVIDE, Variant::TRANSFORM3D, Variant::INT);
+	register_op<OperatorEvaluatorDiv<Transform3D, Transform3D, double>>(Variant::OP_DIVIDE, Variant::TRANSFORM3D, Variant::FLOAT);
+
+	register_op<OperatorEvaluatorDiv<Basis, Basis, int64_t>>(Variant::OP_DIVIDE, Variant::BASIS, Variant::INT);
+	register_op<OperatorEvaluatorDiv<Basis, Basis, double>>(Variant::OP_DIVIDE, Variant::BASIS, Variant::FLOAT);
+
 	register_op<OperatorEvaluatorDiv<Quaternion, Quaternion, double>>(Variant::OP_DIVIDE, Variant::QUATERNION, Variant::FLOAT);
 	register_op<OperatorEvaluatorDiv<Quaternion, Quaternion, int64_t>>(Variant::OP_DIVIDE, Variant::QUATERNION, Variant::INT);
 

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -256,6 +256,20 @@
 				This operator multiplies all components of the [Basis], which scales it uniformly.
 			</description>
 		</operator>
+		<operator name="operator /">
+			<return type="Basis" />
+			<param index="0" name="right" type="float" />
+			<description>
+				This operator divides all components of the [Basis], which inversely scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Basis" />
+			<param index="0" name="right" type="int" />
+			<description>
+				This operator divides all components of the [Basis], which inversely scales it uniformly.
+			</description>
+		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="Basis" />

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -286,6 +286,20 @@
 				This operator multiplies all components of the [Transform2D], including the [member origin] vector, which scales it uniformly.
 			</description>
 		</operator>
+		<operator name="operator /">
+			<return type="Transform2D" />
+			<param index="0" name="right" type="float" />
+			<description>
+				This operator divides all components of the [Transform2D], including the [member origin] vector, which inversely scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Transform2D" />
+			<param index="0" name="right" type="int" />
+			<description>
+				This operator divides all components of the [Transform2D], including the [member origin] vector, which inversely scales it uniformly.
+			</description>
+		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="Transform2D" />

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -245,6 +245,20 @@
 				This operator multiplies all components of the [Transform3D], including the [member origin] vector, which scales it uniformly.
 			</description>
 		</operator>
+		<operator name="operator /">
+			<return type="Transform3D" />
+			<param index="0" name="right" type="float" />
+			<description>
+				This operator divides all components of the [Transform3D], including the [member origin] vector, which inversely scales it uniformly.
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Transform3D" />
+			<param index="0" name="right" type="int" />
+			<description>
+				This operator divides all components of the [Transform3D], including the [member origin] vector, which inversely scales it uniformly.
+			</description>
+		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="Transform3D" />


### PR DESCRIPTION
I ran into a situation where I needed to use `basis * (1.0 / number)` to inversely scale a basis uniformly, but it would've been nicer to have a division operator. This PR adds that operator. The code is almost identical to the `*` operator.