### PR TITLE
C#: Use string literal instead of nameof

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -1142,7 +1142,7 @@ namespace Godot.Collections
         /// </summary>
         /// <param name="from">The typed array to convert.</param>
         /// <returns>A new Godot Array, or <see langword="null"/> if <see paramref="from"/> was null.</returns>
-        [return: NotNullIfNotNull(nameof(from))]
+        [return: NotNullIfNotNull("from")]
         public static explicit operator Array?(Array<T>? from)
         {
             return from?._underlyingArray;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -561,7 +561,7 @@ namespace Godot.Collections
         /// </summary>
         /// <param name="from">The typed dictionary to convert.</param>
         /// <returns>A new Godot Dictionary, or <see langword="null"/> if <see paramref="from"/> was null.</returns>
-        [return: NotNullIfNotNull(nameof(from))]
+        [return: NotNullIfNotNull("from")]
         public static explicit operator Dictionary?(Dictionary<TKey, TValue>? from)
         {
             return from?._underlyingDict;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -241,7 +241,7 @@ namespace Godot.NativeInterop
             return variant->Type.ToString();
         }
 
-        internal static void ThrowIfNullPtr(IntPtr ptr, [CallerArgumentExpression(nameof(ptr))] string? paramName = null)
+        internal static void ThrowIfNullPtr(IntPtr ptr, [CallerArgumentExpression("ptr")] string? paramName = null)
         {
             if (ptr == IntPtr.Zero)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -138,7 +138,7 @@ namespace Godot
         /// Converts this <see cref="NodePath"/> to a string.
         /// </summary>
         /// <param name="from">The <see cref="NodePath"/> to convert.</param>
-        [return: NotNullIfNotNull(nameof(from))]
+        [return: NotNullIfNotNull("from")]
         public static implicit operator string?(NodePath? from) => from?.ToString();
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -84,7 +84,7 @@ namespace Godot
         /// Converts a <see cref="StringName"/> to a string.
         /// </summary>
         /// <param name="from">The <see cref="StringName"/> to convert.</param>
-        [return: NotNullIfNotNull(nameof(from))]
+        [return: NotNullIfNotNull("from")]
         public static implicit operator string?(StringName? from) => from?.ToString();
 
         /// <summary>


### PR DESCRIPTION
Using `nameof` expressions with method parameters requires C# 11 and we're currently on C# 10.
