### PR TITLE
Emit slider's `drag_started` signal before the first value change

### DIFF
--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -33,7 +33,7 @@
 		</signal>
 		<signal name="drag_started">
 			<description>
-				Emitted when dragging is started.
+				Emitted when dragging is started. This is emitted before the corresponding [signal Range.value_changed] signal.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -64,6 +64,8 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				grab.pos = orientation == VERTICAL ? mb->get_position().y : mb->get_position().x;
+				grab.value_before_dragging = get_as_ratio();
+				emit_signal(SNAME("drag_started"));
 
 				double grab_width = (double)grabber->get_width();
 				double grab_height = (double)grabber->get_height();
@@ -78,12 +80,11 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				grab.active = true;
 				grab.uvalue = get_as_ratio();
 
-				emit_signal(SNAME("drag_started"));
 				_notify_shared_value_changed();
 			} else {
 				grab.active = false;
 
-				const bool value_changed = !Math::is_equal_approx((double)grab.uvalue, get_as_ratio());
+				const bool value_changed = !Math::is_equal_approx((double)grab.value_before_dragging, get_as_ratio());
 				emit_signal(SNAME("drag_ended"), value_changed);
 			}
 		} else if (scrollable) {

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -38,7 +38,8 @@ class Slider : public Range {
 
 	struct Grab {
 		int pos = 0;
-		double uvalue = 0.0;
+		double uvalue = 0.0; // Value at `pos`.
+		double value_before_dragging = 0.0;
 		bool active = false;
 	} grab;
 


### PR DESCRIPTION
Fixes #86370

#80916 made `value_changed` to emit **after** `drag_started` in order to fix ColorPicker's deferred mode. But the actual value change is still **before** `drag_started`.

It was then impossible to safely ignore `value_changed` signal when dragging, because you'll miss the `value_changed` signal when pressing down the mouse button.

This PR:

1. Moves `drag_started` before the initial value change, so users can get the correct start value when handling the signal.
2. Records the value before the initial value change, so that `drag_ended` can correctly tell that the value is changed if the user simply clicks somewhere on the slider other than the grabber.