### PR TITLE
Android: Update the logic used to start / stop the render thread

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -484,6 +484,14 @@ class Godot(private val context: Context) : SensorEventListener {
 		return containerLayout
 	}
 
+	fun onStart(host: GodotHost) {
+		if (host != primaryHost) {
+			return
+		}
+
+		renderView!!.onActivityStarted()
+	}
+
 	fun onResume(host: GodotHost) {
 		if (host != primaryHost) {
 			return
@@ -526,6 +534,14 @@ class Godot(private val context: Context) : SensorEventListener {
 		for (plugin in pluginRegistry.allPlugins) {
 			plugin.onMainPause()
 		}
+	}
+
+	fun onStop(host: GodotHost) {
+		if (host != primaryHost) {
+			return
+		}
+
+		renderView!!.onActivityStopped()
 	}
 
 	fun onDestroy(primaryHost: GodotHost) {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -271,6 +271,32 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 	}
 
 	@Override
+	public void onStop() {
+		super.onStop();
+		if (!godot.isInitialized()) {
+			if (null != mDownloaderClientStub) {
+				mDownloaderClientStub.disconnect(getActivity());
+			}
+			return;
+		}
+
+		godot.onStop(this);
+	}
+
+	@Override
+	public void onStart() {
+		super.onStart();
+		if (!godot.isInitialized()) {
+			if (null != mDownloaderClientStub) {
+				mDownloaderClientStub.connect(getActivity());
+			}
+			return;
+		}
+
+		godot.onStart(this);
+	}
+
+	@Override
 	public void onResume() {
 		super.onResume();
 		if (!godot.isInitialized()) {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
@@ -114,12 +114,30 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 
 	@Override
 	public void onActivityPaused() {
-		onPause();
+		queueEvent(() -> {
+			GodotLib.focusout();
+			// Pause the renderer
+			godotRenderer.onActivityPaused();
+		});
+	}
+
+	@Override
+	public void onActivityStopped() {
+		pauseGLThread();
 	}
 
 	@Override
 	public void onActivityResumed() {
-		onResume();
+		queueEvent(() -> {
+			// Resume the renderer
+			godotRenderer.onActivityResumed();
+			GodotLib.focusin();
+		});
+	}
+
+	@Override
+	public void onActivityStarted() {
+		resumeGLThread();
 	}
 
 	@Override
@@ -282,27 +300,5 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 	public void startRenderer() {
 		/* Set the renderer responsible for frame rendering */
 		setRenderer(godotRenderer);
-	}
-
-	@Override
-	public void onResume() {
-		super.onResume();
-
-		queueEvent(() -> {
-			// Resume the renderer
-			godotRenderer.onActivityResumed();
-			GodotLib.focusin();
-		});
-	}
-
-	@Override
-	public void onPause() {
-		super.onPause();
-
-		queueEvent(() -> {
-			GodotLib.focusout();
-			// Pause the renderer
-			godotRenderer.onActivityPaused();
-		});
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotRenderView.java
@@ -47,7 +47,12 @@ public interface GodotRenderView {
 	void queueOnRenderThread(Runnable event);
 
 	void onActivityPaused();
+
+	void onActivityStopped();
+
 	void onActivityResumed();
+
+	void onActivityStarted();
 
 	void onBackPressed();
 

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotVulkanRenderView.java
@@ -92,12 +92,30 @@ public class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderV
 
 	@Override
 	public void onActivityPaused() {
-		onPause();
+		queueOnVkThread(() -> {
+			GodotLib.focusout();
+			// Pause the renderer
+			mRenderer.onVkPause();
+		});
+	}
+
+	@Override
+	public void onActivityStopped() {
+		pauseRenderThread();
+	}
+
+	@Override
+	public void onActivityStarted() {
+		resumeRenderThread();
 	}
 
 	@Override
 	public void onActivityResumed() {
-		onResume();
+		queueOnVkThread(() -> {
+			// Resume the renderer
+			mRenderer.onVkResume();
+			GodotLib.focusin();
+		});
 	}
 
 	@Override
@@ -210,27 +228,5 @@ public class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderV
 			return getPointerIcon();
 		}
 		return super.onResolvePointerIcon(me, pointerIndex);
-	}
-
-	@Override
-	public void onResume() {
-		super.onResume();
-
-		queueOnVkThread(() -> {
-			// Resume the renderer
-			mRenderer.onVkResume();
-			GodotLib.focusin();
-		});
-	}
-
-	@Override
-	public void onPause() {
-		super.onPause();
-
-		queueOnVkThread(() -> {
-			GodotLib.focusout();
-			// Pause the renderer
-			mRenderer.onVkPause();
-		});
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
@@ -122,8 +122,8 @@ import javax.microedition.khronos.opengles.GL10;
  * <p>
  * <h3>Activity Life-cycle</h3>
  * A GLSurfaceView must be notified when to pause and resume rendering. GLSurfaceView clients
- * are required to call {@link #onPause()} when the activity stops and
- * {@link #onResume()} when the activity starts. These calls allow GLSurfaceView to
+ * are required to call {@link #pauseGLThread()} when the activity stops and
+ * {@link #resumeGLThread()} when the activity starts. These calls allow GLSurfaceView to
  * pause and resume the rendering thread, and also allow GLSurfaceView to release and recreate
  * the OpenGL display.
  * <p>
@@ -339,8 +339,8 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	 * setRenderer is called:
 	 * <ul>
 	 * <li>{@link #getRenderMode()}
-	 * <li>{@link #onPause()}
-	 * <li>{@link #onResume()}
+	 * <li>{@link #pauseGLThread()}
+	 * <li>{@link #resumeGLThread()}
 	 * <li>{@link #queueEvent(Runnable)}
 	 * <li>{@link #requestRender()}
 	 * <li>{@link #setRenderMode(int)}
@@ -568,6 +568,7 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	}
 
 
+	// -- GODOT start --
 	/**
 	 * Pause the rendering thread, optionally tearing down the EGL context
 	 * depending upon the value of {@link #setPreserveEGLContextOnPause(boolean)}.
@@ -578,22 +579,23 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	 *
 	 * Must not be called before a renderer has been set.
 	 */
-	public void onPause() {
+	protected final void pauseGLThread() {
 		mGLThread.onPause();
 	}
 
 	/**
 	 * Resumes the rendering thread, re-creating the OpenGL context if necessary. It
-	 * is the counterpart to {@link #onPause()}.
+	 * is the counterpart to {@link #pauseGLThread()}.
 	 *
 	 * This method should typically be called in
 	 * {@link android.app.Activity#onStart Activity.onStart}.
 	 *
 	 * Must not be called before a renderer has been set.
 	 */
-	public void onResume() {
+	protected final void resumeGLThread() {
 		mGLThread.onResume();
 	}
+	// -- GODOT end --
 
 	/**
 	 * Queue a runnable to be run on the GL rendering thread. This can be used

--- a/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkSurfaceView.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkSurfaceView.kt
@@ -99,7 +99,7 @@ open internal class VkSurfaceView(context: Context) : SurfaceView(context), Surf
 	 *
 	 * Must not be called before a [VkRenderer] has been set.
 	 */
-	open fun onResume() {
+	protected fun resumeRenderThread() {
 		vkThread.onResume()
 	}
 
@@ -108,7 +108,7 @@ open internal class VkSurfaceView(context: Context) : SurfaceView(context), Surf
 	 *
 	 * Must not be called before a [VkRenderer] has been set.
 	 */
-	open fun onPause() {
+	protected fun pauseRenderThread() {
 		vkThread.onPause()
 	}
 


### PR DESCRIPTION
Currently the render thread is started / stopped when the activity is respectively resumed / paused. However, according to the `GLSurfaceView` documentation, this should be done instead when the activity is started / stopped, so this change updates the start / stop logic for the render thread to match the documentation.

[3.x version](https://github.com/godotengine/godot/pull/86380)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
