### PR TITLE
[3.x] Android: Update the logic used to start / stop the GL thread

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -60,7 +60,6 @@ import android.content.pm.ConfigurationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
-import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
@@ -86,7 +85,6 @@ import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsAnimation;
 import android.view.WindowManager;
-import android.view.animation.AnimationUtils;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
@@ -97,9 +95,6 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.vending.expansion.downloader.DownloadProgressInfo;
@@ -894,7 +889,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			}
 			return;
 		}
-		mView.onPause();
+		mView.onActivityPaused();
 
 		mSensorManager.unregisterListener(this);
 
@@ -904,6 +899,18 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onMainPause();
 		}
+	}
+
+	@Override
+	public void onStop() {
+		super.onStop();
+		if (!godot_initialized) {
+			if (null != mDownloaderClientStub) {
+				mDownloaderClientStub.disconnect(getActivity());
+			}
+			return;
+		}
+		mView.onActivityStopped();
 	}
 
 	public boolean hasClipboard() {
@@ -926,6 +933,19 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	}
 
 	@Override
+	public void onStart() {
+		super.onStart();
+		if (!godot_initialized) {
+			if (null != mDownloaderClientStub) {
+				mDownloaderClientStub.connect(getActivity());
+			}
+			return;
+		}
+
+		mView.onActivityStarted();
+	}
+
+	@Override
 	public void onResume() {
 		super.onResume();
 		activityResumed = true;
@@ -936,7 +956,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			return;
 		}
 
-		mView.onResume();
+		mView.onActivityResumed();
 
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
 		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
@@ -302,10 +302,11 @@ public class GodotView extends GLSurfaceView {
 		return inputHandler;
 	}
 
-	@Override
-	public void onResume() {
-		super.onResume();
+	void onActivityStarted() {
+		resumeGLThread();
+	}
 
+	void onActivityResumed() {
 		queueEvent(() -> {
 			// Resume the renderer
 			godotRenderer.onActivityResumed();
@@ -313,14 +314,15 @@ public class GodotView extends GLSurfaceView {
 		});
 	}
 
-	@Override
-	public void onPause() {
-		super.onPause();
-
+	void onActivityPaused() {
 		queueEvent(() -> {
 			GodotLib.focusout();
 			// Pause the renderer
 			godotRenderer.onActivityPaused();
 		});
+	}
+
+	void onActivityStopped() {
+		pauseGLThread();
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.java
@@ -122,8 +122,8 @@ import javax.microedition.khronos.opengles.GL10;
  * <p>
  * <h3>Activity Life-cycle</h3>
  * A GLSurfaceView must be notified when to pause and resume rendering. GLSurfaceView clients
- * are required to call {@link #onPause()} when the activity stops and
- * {@link #onResume()} when the activity starts. These calls allow GLSurfaceView to
+ * are required to call {@link #pauseGLThread()} when the activity stops and
+ * {@link #resumeGLThread()} when the activity starts. These calls allow GLSurfaceView to
  * pause and resume the rendering thread, and also allow GLSurfaceView to release and recreate
  * the OpenGL display.
  * <p>
@@ -339,8 +339,8 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	 * setRenderer is called:
 	 * <ul>
 	 * <li>{@link #getRenderMode()}
-	 * <li>{@link #onPause()}
-	 * <li>{@link #onResume()}
+	 * <li>{@link #pauseGLThread()}
+	 * <li>{@link #resumeGLThread()}
 	 * <li>{@link #queueEvent(Runnable)}
 	 * <li>{@link #requestRender()}
 	 * <li>{@link #setRenderMode(int)}
@@ -568,6 +568,7 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	}
 
 
+	// -- GODOT start --
 	/**
 	 * Pause the rendering thread, optionally tearing down the EGL context
 	 * depending upon the value of {@link #setPreserveEGLContextOnPause(boolean)}.
@@ -578,22 +579,23 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 	 *
 	 * Must not be called before a renderer has been set.
 	 */
-	public void onPause() {
+	protected final void pauseGLThread() {
 		mGLThread.onPause();
 	}
 
 	/**
 	 * Resumes the rendering thread, re-creating the OpenGL context if necessary. It
-	 * is the counterpart to {@link #onPause()}.
+	 * is the counterpart to {@link #pauseGLThread()}.
 	 *
 	 * This method should typically be called in
 	 * {@link android.app.Activity#onStart Activity.onStart}.
 	 *
 	 * Must not be called before a renderer has been set.
 	 */
-	public void onResume() {
+	protected final void resumeGLThread() {
 		mGLThread.onResume();
 	}
+	// -- GODOT end --
 
 	/**
 	 * Queue a runnable to be run on the GL rendering thread. This can be used


### PR DESCRIPTION
Currently the GL thread is started / stopped when the activity is respectively resumed / paused. However, according to the `GLSurfaceView` documentation, this should be done instead when the activity is started / stopped, so this change updates the start / stop logic for the GL thread to match the documentation.

[4.x version](https://github.com/godotengine/godot/pull/86379)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
