### PR TITLE
Don't warn of shadowing non-static variables in static contexts

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -6014,7 +6014,26 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 
 		if (base_class != nullptr) {
 			if (base_class->has_member(name)) {
-				parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()));
+				bool can_access_member = true;
+				if (static_context) {
+					const GDScriptParser::ClassNode::Member member = base_class->get_member(name);
+					switch (member.type) {
+						case GDScriptParser::ClassNode::Member::CONSTANT:
+							can_access_member = true;
+							break;
+						case GDScriptParser::ClassNode::Member::FUNCTION:
+							can_access_member = member.function->is_static;
+							break;
+						case GDScriptParser::ClassNode::Member::VARIABLE:
+							can_access_member = member.variable->is_static;
+							break;
+						default:
+							can_access_member = false;
+					}
+				}
+				if (can_access_member) {
+					parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, p_identifier->name, base_class->get_member(name).get_type_name(), itos(base_class->get_member(name).get_line()));
+				}
 				return;
 			}
 			base_class = base_class->base_type.class_type;


### PR DESCRIPTION
I got a warning that a variable in a static function is shadowing a variable that's a member of the class. I wouldn't expect this to give a warning, as code inside the static function can't access the non-static variable.

This changes that warning to only show in a static context if the member being shadowed is also static. 

| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/godotengine/godot/assets/1078569/881f30f9-4c42-4197-9068-78f4a0d466d3) | ![after](https://github.com/godotengine/godot/assets/1078569/46dec464-1848-4a12-8d99-6833500c5ebd) |

Note: I'm using a lambda, which I see are [discouraged in the guidelines](https://docs.godotengine.org/en/latest/contributing/development/cpp_usage_guidelines.html#lambdas). I'm using it to avoid eagerly fetching `member`. If there's a more preferred way to structure this, happy to change it.