### PR TITLE
Strip edges of editor layout names

### DIFF
--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -31,8 +31,6 @@
 #include "editor_layouts_dialog.h"
 
 #include "core/io/config_file.h"
-#include "core/object/class_db.h"
-#include "core/os/keyboard.h"
 #include "editor/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/item_list.h"
@@ -60,7 +58,7 @@ void EditorLayoutsDialog::_update_ok_disable_state() {
 	if (layout_names->is_anything_selected()) {
 		get_ok_button()->set_disabled(false);
 	} else {
-		get_ok_button()->set_disabled(!name->is_visible() || name->get_text().is_empty());
+		get_ok_button()->set_disabled(!name->is_visible() || name->get_text().strip_edges().is_empty());
 	}
 }
 
@@ -80,8 +78,8 @@ void EditorLayoutsDialog::ok_pressed() {
 		for (int i = 0; i < selected_items.size(); ++i) {
 			emit_signal(SNAME("name_confirmed"), layout_names->get_item_text(selected_items[i]));
 		}
-	} else if (name->is_visible() && !name->get_text().is_empty()) {
-		emit_signal(SNAME("name_confirmed"), name->get_text());
+	} else if (name->is_visible() && !name->get_text().strip_edges().is_empty()) {
+		emit_signal(SNAME("name_confirmed"), name->get_text().strip_edges());
 	}
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2135,10 +2135,6 @@ void EditorNode::_dialog_action(String p_file) {
 
 		} break;
 		case SETTINGS_LAYOUT_DELETE: {
-			if (p_file.is_empty()) {
-				return;
-			}
-
 			Ref<ConfigFile> config;
 			config.instantiate();
 			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());


### PR DESCRIPTION
Layout names are saved as `ConfigFile` section names. Leading and trailing spaces in section names are stripped when loaded from disk via `ConfigFile::load()`.

It's currently possible to create a layout named `"    "`. But it's impossible to remove it because it's loaded as `""`. Deleting such item is considered deleting something that does not exist and is skipped.

This PR:

- Makes `EditorLayoutsDialog` always `strip_edges()` for layout names.
    - This only happens for names typed manually. So old layout names that has leading or trailing spaces can still be overwritten/deleted.
- Removes the empty string check when deleting a layout. So existing empty layout name can be deleted.
    - The check was redundant since the dialog already does such check.
- Also removes two unnecessary includes.