### PR TITLE
Fix `UndoRedo history mismatch` when creating a new tile atlas

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -117,11 +117,11 @@ void TileSetEditor::_load_texture_files(const Vector<String> &p_paths) {
 		// Actually create the new source.
 		Ref<TileSetAtlasSource> atlas_source = memnew(TileSetAtlasSource);
 		atlas_source->set_texture(texture);
+		atlas_source->set_texture_region_size(tile_set->get_tile_size());
 
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Add a new atlas source"));
 		undo_redo->add_do_method(*tile_set, "add_source", atlas_source, source_id);
-		undo_redo->add_do_method(*atlas_source, "set_texture_region_size", tile_set->get_tile_size());
 		undo_redo->add_undo_method(*tile_set, "remove_source", source_id);
 		undo_redo->commit_action();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86291

It seems that there's no need to put `set_texture_region_size` in do method as it's a newly created resource and no pairded redo method. 

But I feel the `history mismatch` problem lies in other places, it's only a stopgap measure. Any suggestions ? 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
