### PR TITLE
Clear sub-resources list when no sub-resource exists

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -139,8 +139,8 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 					}
 				}
 
+				unique_resources_list_tree->clear();
 				if (resource_propnames.size()) {
-					unique_resources_list_tree->clear();
 					TreeItem *root = unique_resources_list_tree->create_item();
 
 					for (int i = 0; i < resource_propnames.size(); i++) {


### PR DESCRIPTION
This PR makes sure that the sub-resources list in "Make Sub-Resources Unique" dialog is cleared when no resource is available.

Previously, the issue can be reproduced by:

1. Create a Sprite2D node.
2. Open "Make Sub-Resources Unique" dialog from the inspector. Nothing is in the list.
3. Drag `icon.svg` into Texture.
4. Open the dialog again. You can see `texture` is in the list.
5. Clear the Texture property.
6. Open the dialog again. `texture` is still in the list, but the description says "This object has no resources".