### PR TITLE
Fix Clang `-Winconsistent-missing-override` warning

### DIFF
--- a/platform/windows/vulkan_context_win.h
+++ b/platform/windows/vulkan_context_win.h
@@ -39,7 +39,7 @@
 #include <windows.h>
 
 class VulkanContextWindows : public VulkanContext {
-	virtual const char *_get_platform_surface_extension() const;
+	virtual const char *_get_platform_surface_extension() const override final;
 
 public:
 	struct WindowPlatformData {


### PR DESCRIPTION
Adds missing `override` and `final` qualifiers to `VulkanContextWindows::_get_platform_surface_extension()`, similar to other `VulkanContext` implementations. Missing these causes a build error when building with `dev_mode` enabled (warnings as errors):

```
In file included from platform\windows\godot_windows.cpp:31:
In file included from platform\windows/os_windows.h:53:
platform\windows/vulkan_context_win.h:42:22: error: '_get_platform_surface_extension' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual const char *_get_platform_surface_extension() const;
                            ^
./drivers/vulkan/vulkan_context.h:261:22: note: overridden virtual function is here
        virtual const char *_get_platform_surface_extension() const { return nullptr; }
                            ^
1 error generated.
```