### PR TITLE
Expose compression block size as parameter of `FileAccess.open_compressed()`

### DIFF
--- a/core/io/file_access.compat.inc
+++ b/core/io/file_access.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  file_access.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Ref<FileAccess> FileAccess::_open_compressed_bind_compat_86395(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode) {
+	return open_compressed(p_path, p_mode_flags, p_compress_mode, 4096);
+}
+
+void FileAccess::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &FileAccess::_open_compressed_bind_compat_86395, DEFVAL(0));
+}
+
+#endif

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "file_access.h"
+#include "file_access.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
@@ -156,10 +157,10 @@ Ref<FileAccess> FileAccess::open_encrypted_pass(const String &p_path, ModeFlags 
 	return fae;
 }
 
-Ref<FileAccess> FileAccess::open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode) {
+Ref<FileAccess> FileAccess::open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode, int p_block_size) {
 	Ref<FileAccessCompressed> fac;
 	fac.instantiate();
-	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
+	fac->configure("GCPF", (Compression::Mode)p_compress_mode, p_block_size);
 	Error err = fac->open_internal(p_path, p_mode_flags);
 	last_file_open_error = err;
 	if (err) {
@@ -856,7 +857,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_static_method("FileAccess", D_METHOD("open", "path", "flags"), &FileAccess::_open);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("open_encrypted", "path", "mode_flags", "key"), &FileAccess::open_encrypted);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("open_encrypted_with_pass", "path", "mode_flags", "pass"), &FileAccess::open_encrypted_pass);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &FileAccess::open_compressed, DEFVAL(0));
+	ClassDB::bind_static_method("FileAccess", D_METHOD("open_compressed", "path", "mode_flags", "compression_mode", "block_size"), &FileAccess::open_compressed, DEFVAL(0), DEFVAL(4096));
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_open_error"), &FileAccess::get_open_error);
 
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_file_as_bytes", "path"), &FileAccess::_get_file_as_bytes);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -108,6 +108,11 @@ protected:
 
 	static FileCloseFailNotify close_fail_notify;
 
+#ifndef DISABLE_DEPRECATED
+	static Ref<FileAccess> _open_compressed_bind_compat_86395(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode = COMPRESSION_FASTLZ);
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	static bool backup_save;
 	thread_local static Error last_file_open_error;
@@ -199,7 +204,7 @@ public:
 
 	static Ref<FileAccess> open_encrypted(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key);
 	static Ref<FileAccess> open_encrypted_pass(const String &p_path, ModeFlags p_mode_flags, const String &p_pass);
-	static Ref<FileAccess> open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode = COMPRESSION_FASTLZ);
+	static Ref<FileAccess> open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode = COMPRESSION_FASTLZ, int p_block_size = 4096);
 	static Error get_open_error();
 
 	static CreateFunc get_create_func(AccessType p_access);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -33,6 +33,11 @@
 #include "core/string/print_string.h"
 
 void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
+	if (p_block_size == 0) {
+		// Treat a block size of 0 as solid compression (compress entire file as a single block).
+		// Solid compression favors compression ratio at the cost of performance and memory usage.
+		p_block_size = -1;
+	}
 	magic = p_magic.ascii().get_data();
 	magic = (magic + "    ").substr(0, 4);
 

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -297,10 +297,13 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="mode_flags" type="int" enum="FileAccess.ModeFlags" />
 			<param index="2" name="compression_mode" type="int" enum="FileAccess.CompressionMode" default="0" />
+			<param index="3" name="block_size" type="int" default="4096" />
 			<description>
-				Creates a new [FileAccess] object and opens a compressed file for reading or writing.
-				[b]Note:[/b] [method open_compressed] can only read files that were saved by Godot, not third-party compression formats. See [url=https://github.com/godotengine/godot/issues/28999]GitHub issue #28999[/url] for a workaround.
+				Creates a new [FileAccess] object and opens a compressed file for reading or writing. The compression mode and block size can be adjusted to tune compression efficiency versus performance and memory usage. A higher block size can lead to significantly better compression ratios, at the cost of increased memory usage and lower performance when seeking in the file (since the entire block needs to be decompressed to even read a single byte from the block). The default value of [code]4096[/code] is optimized for fast seeking; consider increasing it to a value like [code]16384[/code] for files that aren't seeked often. To perform solid compression (where the entire file is compressed as a single block up to 2 GB), use a block size of [code]0[/code]. This will result in the best possible compression ratios, but can require a lot of memory to (de)compress for large files and makes seeking in the file very slow.
 				Returns [code]null[/code] if opening the file failed. You can use [method get_open_error] to check the error that occurred.
+				To tune compression performance and efficiency, adjust the project settings in the [b]Compression &gt; Formats[/b] section.
+				[b]Note:[/b] When opening an existing file, the chosen compression mode must match the existing file, but the chosen block size can differ as it will be read from the existing file. In this case, the new block size will only be effective once the file is saved.
+				[b]Note:[/b] [method open_compressed] can only read files that were saved by Godot, not third-party compression formats. See [url=https://github.com/godotengine/godot/issues/28999]GitHub issue #28999[/url] for a workaround.
 			</description>
 		</method>
 		<method name="open_encrypted" qualifiers="static">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -412,13 +412,13 @@
 			If [code]true[/code], ambient lights will be imported from COLLADA models as [DirectionalLight3D]. If [code]false[/code], ambient lights will be ignored.
 		</member>
 		<member name="compression/formats/gzip/compression_level" type="int" setter="" getter="" default="-1">
-			The default compression level for gzip. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
+			The default compression level for gzip. Affects compressed scenes, resources, and files written by [method FileAccess.open_compressed]. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
 		</member>
 		<member name="compression/formats/zlib/compression_level" type="int" setter="" getter="" default="-1">
-			The default compression level for Zlib. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
+			The default compression level for Zlib. Affects compressed scenes, resources, and files written by [method FileAccess.open_compressed]. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
 		</member>
 		<member name="compression/formats/zstd/compression_level" type="int" setter="" getter="" default="3">
-			The default compression level for Zstandard. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level.
+			The default compression level for Zstandard. Affects compressed scenes, resources, and files written by [method FileAccess.open_compressed]. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level.
 		</member>
 		<member name="compression/formats/zstd/long_distance_matching" type="bool" setter="" getter="" default="false">
 			Enables [url=https://github.com/facebook/zstd/releases/tag/v1.3.2]long-distance matching[/url] in Zstandard.

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -73,3 +73,10 @@ GH-87668
 Validate extension JSON: Error: Field 'classes/Font/methods/find_variation/arguments': size changed value in new API, from 8 to 9.
 
 Added optional "baseline_offset" argument. Compatibility method registered.
+
+
+GH-86395
+--------
+Validate extension JSON: Error: Field 'classes/FileAccess/methods/open_compressed/arguments': size changed value in new API, from 3 to 4.
+
+Added optional argument to open_compressed to specify a compression block size.


### PR DESCRIPTION
This can be used to improve compression ratio significantly for files created by Godot. The default block size remains unchanged to preserve the fast seeking behavior by default.

- This closes https://github.com/godotengine/godot/issues/77820.

## Comparison

*All files are taken from the MRP linked in https://github.com/godotengine/godot/issues/77820.*

### Uncompressed files

012: 256,000 bytes
abc: 270,000 bytes
alice: 174,280 bytes

### Files written by external tools

012 gzip: 2,299 bytes
012 zstd: 295 bytes
abc gzip: 1,645 bytes
abc zstd: 74 bytes
alice gzip: 73,223 bytes
alice zstd: 67,217 bytes

### Block size = 4096 (default)

012 godot gzip: 20,854 bytes
012 godot zstd: 17,660 bytes
abc godot gzip: 5,180 bytes
abc godot zstd: 3,254 bytes
alice godot gzip: 73,223 bytes
alice godot zstd: 67,217 bytes

### Block size = 16384

012 godot gzip: 6,768 bytes
012 godot zstd: 4,500 bytes
abc godot gzip: 1,793 bytes
abc godot zstd: 853 bytes
alice godot gzip: 69,965 bytes
alice godot zstd: 73,105 bytes

### Block size = 65536

012 godot gzip: 2,401 bytes
012 godot zstd: 1,144 bytes
abc godot gzip: 1,001 bytes
abc godot zstd: 265 bytes
alice godot gzip: 63,569 bytes
alice godot zstd: 66,566 bytes

### 0 (solid compression)

012 godot gzip: 1,360 bytes
012 godot zstd: 315 bytes
abc godot gzip: 740 bytes
abc godot zstd: 94 bytes
alice godot gzip: 61,270 bytes
alice godot zstd: 64,255 bytes
