### PR TITLE
Fix internal profiling button being visible when disabled in settings

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -647,6 +647,7 @@ EditorProfiler::EditorProfiler() {
 	hb->add_child(display_time);
 
 	display_internal_profiles = memnew(CheckButton(TTR("Display internal functions")));
+	display_internal_profiles->set_visible(EDITOR_GET("debugger/profile_native_calls"));
 	display_internal_profiles->set_pressed(false);
 	display_internal_profiles->connect("pressed", callable_mp(this, &EditorProfiler::_internal_profiles_pressed));
 	hb->add_child(display_internal_profiles);


### PR DESCRIPTION
Fixes issue found in #86394

* *Bugsquad edit, fixes: #86394* 