### PR TITLE
Add support for selecting multiple properties with `PropertySelector`

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4970,11 +4970,13 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 
 	switch (adding_track_type) {
 		case Animation::TYPE_VALUE: {
+			prop_selector->set_multiselect(true);
 			adding_track_path = path_to;
 			prop_selector->set_type_filter(Vector<Variant::Type>());
 			prop_selector->select_property_from_instance(node);
 		} break;
 		case Animation::TYPE_BLEND_SHAPE: {
+			prop_selector->set_multiselect(true);
 			adding_track_path = path_to;
 			Vector<Variant::Type> filter;
 			filter.push_back(Variant::FLOAT);
@@ -4994,6 +4996,7 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 
 		} break;
 		case Animation::TYPE_BEZIER: {
+			prop_selector->set_multiselect(true);
 			Vector<Variant::Type> filter;
 			filter.push_back(Variant::INT);
 			filter.push_back(Variant::FLOAT);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5059,7 +5059,7 @@ void AnimationTrackEditor::_add_track(int p_type) {
 	pick_track->get_filter_line_edit()->grab_focus();
 }
 
-void AnimationTrackEditor::_handle_multiple_properties_selected(Array p_multiple_properties) {
+void AnimationTrackEditor::_add_multiple_tracks(Array p_multiple_properties) {
 	for (int i = 0; i < p_multiple_properties.size(); i++) {
 		_new_track_property_selected(p_multiple_properties[i]);
 	}
@@ -7388,7 +7388,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);
 	prop_selector->connect("selected", callable_mp(this, &AnimationTrackEditor::_new_track_property_selected));
-	prop_selector->connect("multiple_properties_selected", callable_mp(this, &AnimationTrackEditor::_handle_multiple_properties_selected));
+	prop_selector->connect("multiple_properties_selected", callable_mp(this, &AnimationTrackEditor::_add_multiple_tracks));
 	prop_selector->set_multiselect(true);
 
 	method_selector = memnew(PropertySelector);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4970,13 +4970,11 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 
 	switch (adding_track_type) {
 		case Animation::TYPE_VALUE: {
-			prop_selector->set_multiselect(true);
 			adding_track_path = path_to;
 			prop_selector->set_type_filter(Vector<Variant::Type>());
 			prop_selector->select_property_from_instance(node);
 		} break;
 		case Animation::TYPE_BLEND_SHAPE: {
-			prop_selector->set_multiselect(true);
 			adding_track_path = path_to;
 			Vector<Variant::Type> filter;
 			filter.push_back(Variant::FLOAT);
@@ -4996,7 +4994,6 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 
 		} break;
 		case Animation::TYPE_BEZIER: {
-			prop_selector->set_multiselect(true);
 			Vector<Variant::Type> filter;
 			filter.push_back(Variant::INT);
 			filter.push_back(Variant::FLOAT);
@@ -5060,6 +5057,12 @@ void AnimationTrackEditor::_add_track(int p_type) {
 	pick_track->popup_scenetree_dialog(nullptr, root_node);
 	pick_track->get_filter_line_edit()->clear();
 	pick_track->get_filter_line_edit()->grab_focus();
+}
+
+void AnimationTrackEditor::_handle_multiple_properties_selected(Array p_multiple_properties) {
+	for (int i = 0; i < p_multiple_properties.size(); i++) {
+		_new_track_property_selected(p_multiple_properties[i]);
+	}
 }
 
 void AnimationTrackEditor::_fetch_value_track_options(const NodePath &p_path, Animation::UpdateMode *r_update_mode, Animation::InterpolationType *r_interpolation_type, bool *r_loop_wrap) {
@@ -7385,6 +7388,8 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);
 	prop_selector->connect("selected", callable_mp(this, &AnimationTrackEditor::_new_track_property_selected));
+	prop_selector->connect("multiple_properties_selected", callable_mp(this, &AnimationTrackEditor::_handle_multiple_properties_selected));
+	prop_selector->set_multiselect(true);
 
 	method_selector = memnew(PropertySelector);
 	add_child(method_selector);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -449,6 +449,8 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _add_track(int p_type);
 	void _new_track_node_selected(NodePath p_path);
 	void _new_track_property_selected(const String &p_name);
+	void _new_track_property_selected(String p_name);
+	void _handle_multiple_properties_selected(Array p_multiple_properties);
 
 	void _update_step_spinbox();
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -450,7 +450,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _new_track_node_selected(NodePath p_path);
 	void _new_track_property_selected(const String &p_name);
 	void _new_track_property_selected(String p_name);
-	void _handle_multiple_properties_selected(Array p_multiple_properties);
+	void _add_multiple_tracks(Array p_multiple_properties);
 
 	void _update_step_spinbox();
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -449,7 +449,6 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _add_track(int p_type);
 	void _new_track_node_selected(NodePath p_path);
 	void _new_track_property_selected(const String &p_name);
-	void _new_track_property_selected(String p_name);
 	void _add_multiple_tracks(Array p_multiple_properties);
 
 	void _update_step_spinbox();

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -425,10 +425,12 @@ void PropertySelector::_hide_requested() {
 
 void PropertySelector::_notification(int p_what) {
 	switch (p_what) {
+		case 30: {
+			selected_properties.clear();
+		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			connect(SceneStringName(confirmed), callable_mp(this, &PropertySelector::_confirmed));
 		} break;
-
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect(SceneStringName(confirmed), callable_mp(this, &PropertySelector::_confirmed));
 		} break;
@@ -590,9 +592,9 @@ PropertySelector::PropertySelector() {
 	search_box->connect(SceneStringName(gui_input), callable_mp(this, &PropertySelector::_sbox_input));
 	search_options = memnew(Tree);
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	search_options->set_select_mode(search_options->SELECT_MULTI);
+	search_options->set_select_mode(search_options->SELECT_SINGLE);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
-	set_ok_button_text(TTR("Open"));
+	set_ok_button_text(TTR("Select"));
 	get_ok_button()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -358,15 +358,20 @@ void PropertySelector::_update_search() {
 }
 
 void PropertySelector::_confirmed() {
-	Array keys = selected_properties.keys();
 	TreeItem *ti = search_options->get_selected();
 	if (!ti) {
 		return;
 	}
-	for (int i = 0; i < keys.size(); i++){
-		emit_signal(SNAME("selected"), keys[i]);
+	if (search_options->get_select_mode() == search_options->SELECT_SINGLE) {
+		emit_signal(SNAME("selected"), ti->get_metadata(0));
 	}
-	selected_properties.clear();
+	if (search_options->get_select_mode() == search_options->SELECT_MULTI) {
+		Array keys = selected_properties.keys();
+		for (int i = 0; i < keys.size(); i++) {
+			emit_signal(SNAME("selected"), keys[i]);
+		}
+		selected_properties.clear();
+	}
 	hide();
 }
 
@@ -374,7 +379,7 @@ void PropertySelector::_multi_item_selected(Object *p_item, int p_column, bool p
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	if (p_is_item_selected) {
 		selected_properties[item->get_metadata(0)];
-	}	else {
+	} else {
 		selected_properties.erase(item->get_metadata(0));
 	}
 }
@@ -567,6 +572,10 @@ void PropertySelector::set_type_filter(const Vector<Variant::Type> &p_type_filte
 	type_filter = p_type_filter;
 }
 
+void PropertySelector::set_multiselect(bool p_is_multiselect) {
+	search_options->set_select_mode(p_is_multiselect ? search_options->SELECT_MULTI : search_options->SELECT_SINGLE);
+}
+
 void PropertySelector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name")));
 }
@@ -588,8 +597,8 @@ PropertySelector::PropertySelector() {
 	get_ok_button()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect("multi_selected", callable_mp(this, &PropertySelector::_multi_item_selected));
 	search_options->connect("cell_selected", callable_mp(this, &PropertySelector::_item_selected));
+	search_options->connect("multi_selected", callable_mp(this, &PropertySelector::_multi_item_selected));
 	search_options->connect("item_activated", callable_mp(this, &PropertySelector::_confirmed));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -366,10 +366,8 @@ void PropertySelector::_confirmed() {
 		emit_signal(SNAME("selected"), ti->get_metadata(0));
 	}
 	if (search_options->get_select_mode() == search_options->SELECT_MULTI) {
-		Array keys = selected_properties.keys();
-		for (int i = 0; i < keys.size(); i++) {
-			emit_signal(SNAME("selected"), keys[i]);
-		}
+		Array selected_properties_keys = selected_properties.keys();
+		emit_signal(SNAME("multiple_properties_selected"), selected_properties_keys);
 		selected_properties.clear();
 	}
 	hide();
@@ -578,6 +576,7 @@ void PropertySelector::set_multiselect(bool p_is_multiselect) {
 
 void PropertySelector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("multiple_properties_selected", PropertyInfo(Variant::ARRAY, "name")));
 }
 
 PropertySelector::PropertySelector() {

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -357,7 +357,6 @@ void PropertySelector::_update_search() {
 	get_ok_button()->set_disabled(root->get_first_child() == nullptr);
 }
 
-Dictionary selected_properties;
 void PropertySelector::_confirmed() {
 	Array keys = selected_properties.keys();
 	TreeItem *ti = search_options->get_selected();
@@ -371,9 +370,9 @@ void PropertySelector::_confirmed() {
 	hide();
 }
 
-void PropertySelector::_multi_item_selected(Object *p_item, int column,bool is_item_selected) {
+void PropertySelector::_multi_item_selected(Object *p_item, int p_column, bool p_is_item_selected) {
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
-	if (is_item_selected) {
+	if (p_is_item_selected) {
 		selected_properties[item->get_metadata(0)];
 	}	else {
 		selected_properties.erase(item->get_metadata(0));

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -48,7 +48,7 @@ class PropertySelector : public ConfirmationDialog {
 	void _update_search();
 	void _confirmed();
 	void _item_selected();
-	void _multi_item_selected(Object *p_item, int column,bool is_item_selected);
+	void _multi_item_selected(Object *p_item, int p_column, bool p_is_item_selected);
 	void _hide_requested();
 
 	EditorHelpBit *help_bit = nullptr;
@@ -61,6 +61,7 @@ class PropertySelector : public ConfirmationDialog {
 	Object *instance = nullptr;
 	bool virtuals_only = false;
 
+	Dictionary selected_properties;
 	Vector<Variant::Type> type_filter;
 
 protected:

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -81,6 +81,7 @@ public:
 
 	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
 
+	void set_multiselect(bool p_is_multiselect);
 	PropertySelector();
 };
 

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -48,6 +48,7 @@ class PropertySelector : public ConfirmationDialog {
 	void _update_search();
 	void _confirmed();
 	void _item_selected();
+	void _multi_item_selected(Object *p_item, int column,bool is_item_selected);
 	void _hide_requested();
 
 	EditorHelpBit *help_bit = nullptr;


### PR DESCRIPTION
Proposal: https://github.com/godotengine/godot-proposals/issues/8713

PR allows selecting and adding multiple property tracks in animation player with either shift + click (range), or ctrl + click for (single) . I would like this feature as I spend too much time adding hframes, vframes, frames and texture properties individually for each spritesheet.


I don't know if there is an issue for this, or someone was working on it.

![image](https://github.com/godotengine/godot/assets/49783296/57e61d85-7bbd-4c2b-83a6-39787f5e1699)

Keep in mind I don't know C++ :sweat_smile: ; so I'm probably committing some sins . There is a bug when pressing arrow keys that I think I introduced (and maybe other ones);  but the multiple selecting seems to work and adds the tracks to the animation. This is a first draft; I'll add more details and clean it up tomorrow/ investigate; I'm tired  right now though : /

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/8713_