### PR TITLE
Suggest `--headless` CLI argument in DisplayServer not found error message

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2463,7 +2463,7 @@ Error Main::setup2() {
 		}
 
 		if (err != OK || display_server == nullptr) {
-			ERR_PRINT("Unable to create DisplayServer, all display drivers failed.");
+			ERR_PRINT("Unable to create DisplayServer, all display drivers failed.\nUse \"--headless\" command line argument to run the engine in headless mode if this is desired (e.g. for continuous integration).");
 			return err;
 		}
 


### PR DESCRIPTION
This is helpful for newcomers setting up Godot on CI, as this provides automatic guidance as for why it doesn't run out of the box if there's no X11 server available.

- See https://github.com/abarichello/godot-ci/pull/113.

## Preview

```
❯ DISPLAY=:1 bin/godot.linuxbsd.editor.x86_64
Godot Engine v4.3.dev.custom_build.9d1cbab1c - https://godotengine.org
ERROR: X11 Display is not available
   at: DisplayServerX11 (platform/linuxbsd/x11/display_server_x11.cpp:5831)

(zenity:37282): Gtk-WARNING **: 23:42:09.860: Failed to open display
ERROR: Unable to create DisplayServer, all display drivers failed.
Use "--headless" command line argument to run the engine in headless mode if this is desired (e.g. for continuous integration).
   at: setup2 (main/main.cpp:2466)
```
