### PR TITLE
Improve 3D Asset Import Dialog material editing

### DIFF
--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -107,12 +107,12 @@ void TriangleMesh::get_indices(Vector<int> *r_triangles_indices) const {
 void TriangleMesh::create(const Vector<Vector3> &p_faces, const Vector<int32_t> &p_surface_indices) {
 	valid = false;
 
-	ERR_FAIL_COND(p_surface_indices.size() && p_surface_indices.size() != p_faces.size());
-
 	int fc = p_faces.size();
 	ERR_FAIL_COND(!fc || ((fc % 3) != 0));
 	fc /= 3;
 	triangles.resize(fc);
+
+	ERR_FAIL_COND(p_surface_indices.size() && p_surface_indices.size() != triangles.size());
 
 	bvh.resize(fc * 3); //will never be larger than this (todo make better)
 	BVH *bw = bvh.ptrw();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1284,7 +1284,7 @@ void EditorNode::save_resource(const Ref<Resource> &p_resource) {
 	if (path.is_resource_file() && !FileAccess::exists(path + ".import")) {
 		save_resource_in_path(p_resource, p_resource->get_path());
 	} else {
-		save_resource_as(p_resource);
+		save_resource_as(p_resource, "");
 	}
 }
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -398,6 +398,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			if (edited_resource.is_null()) {
 				return;
 			}
+
 			EditorNode::get_singleton()->save_resource(edited_resource);
 		} break;
 
@@ -405,6 +406,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			if (edited_resource.is_null()) {
 				return;
 			}
+
 			EditorNode::get_singleton()->save_resource_as(edited_resource);
 		} break;
 

--- a/editor/icons/MaterialSelect.svg
+++ b/editor/icons/MaterialSelect.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="svg29" width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path id="path27" d="m8 2 6 3v6l-6 3-6-3V5zm0 12V8l6-3M8 8 2 5" fill="none" stroke="#e0e0e0" stroke-linejoin="round" stroke-width="2"/>
+</svg>

--- a/editor/icons/MaterialSelectDisabled.svg
+++ b/editor/icons/MaterialSelectDisabled.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg29"
+   width="16"
+   height="16"
+   version="1.1"
+   viewBox="0 0 16 16"
+   sodipodi:docname="MaterialSelectDisabled.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="54.5625"
+     inkscape:cx="4.325315"
+     inkscape:cy="8"
+     inkscape:window-width="2490"
+     inkscape:window-height="1376"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg29" />
+  <path
+     id="path27"
+     d="m8 2 6 3v6l-6 3-6-3V5zm0 12V8l6-3M8 8 2 5"
+     fill="none"
+     stroke="#e0e0e0"
+     stroke-linejoin="round"
+     stroke-width="2"
+     style="stroke:#808080;stroke-opacity:1" />
+</svg>

--- a/editor/icons/MeshSelect.svg
+++ b/editor/icons/MeshSelect.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   viewBox="0 0 16 16"
+   width="16"
+   version="1.1"
+   id="svg827"
+   sodipodi:docname="MeshSelect.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs831" />
+  <sodipodi:namedview
+     id="namedview829"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="54.5625"
+     inkscape:cx="7.9908362"
+     inkscape:cy="8"
+     inkscape:window-width="2490"
+     inkscape:window-height="1376"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg827" />
+  <path
+     d="M4.73 2A2 2 0 1 0 2 4.73v6.541A2 2 0 1 0 4.73 14h6.541A2 2 0 1 0 14 11.27V4.729A2 2 0 1 0 11.27 2Zm.683 2h5.857a2 2 0 0 0 .729.73v5.856L5.412 4zM3.999 5.414 10.584 12H4.727a2 2 0 0 0-.729-.73V5.414z"
+     fill="#808080"
+     id="path825"
+     style="fill:#e0e0e0;fill-opacity:1" />
+</svg>

--- a/editor/icons/NodeSelect.svg
+++ b/editor/icons/NodeSelect.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   viewBox="0 0 16 16"
+   width="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="NodeSelect.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="54.5625"
+     inkscape:cx="4.325315"
+     inkscape:cy="8"
+     inkscape:window-width="2490"
+     inkscape:window-height="1376"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <circle
+     cx="8"
+     cy="8"
+     r="5"
+     fill="none"
+     stroke-width="2"
+     stroke="#e0e0e0"
+     id="circle2" />
+</svg>

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1192,9 +1192,17 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								post_importer_plugins.write[j]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MATERIAL, p_root, p_node, mat, matdata);
 							}
 
+							// Old style material, keep for compatibility.
 							if (matdata.has("use_external/enabled") && bool(matdata["use_external/enabled"]) && matdata.has("use_external/path")) {
 								String path = matdata["use_external/path"];
 								Ref<Material> external_mat = ResourceLoader::load(path);
+								if (external_mat.is_valid()) {
+									m->set_surface_material(i, external_mat);
+								}
+							}
+							// New style custom material
+							if (matdata.has("custom")) {
+								Ref<Material> external_mat = matdata["custom"];
 								if (external_mat.is_valid()) {
 									m->set_surface_material(i, external_mat);
 								}
@@ -1708,8 +1716,11 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "lods/normal_merge_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), 60.0f));
 		} break;
 		case INTERNAL_IMPORT_CATEGORY_MATERIAL: {
-			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "use_external/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
-			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "use_external/path", PROPERTY_HINT_FILE, "*.material,*.res,*.tres"), ""));
+			// Compatibility (hidden) settings.
+			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "use_external/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), false));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "use_external/path", PROPERTY_HINT_FILE, "*.material,*.res,*.tres", PROPERTY_USAGE_NONE), ""));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::OBJECT, "custom", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), Ref<Material>()));
+
 		} break;
 		case INTERNAL_IMPORT_CATEGORY_ANIMATION: {
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "settings/loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Pingpong"), 0));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1367,7 +1367,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				}
 
 				EditorNode::get_singleton()->push_item(resource.ptr());
-				EditorNode::get_singleton()->save_resource_as(resource);
+				EditorNode::get_singleton()->save_resource_as(resource, "");
 
 				if (scr.is_valid()) {
 					update_docs_from_script(scr);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/filesystem_dock.h"
+#include "editor/gui/editor_file_dialog.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/text_shader_editor.h"
 #include "editor/plugins/visual_shader_editor_plugin.h"

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -41,6 +41,7 @@ class TabContainer;
 class TextShaderEditor;
 class VisualShaderEditor;
 class WindowWrapper;
+class EditorFileDialog;
 
 #ifdef MINGW_ENABLED
 #undef FILE_OPEN

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3535,7 +3535,7 @@ void ThemeEditor::_theme_save_button_cbk(bool p_save_as) {
 	ERR_FAIL_COND_MSG(theme.is_null(), "Invalid state of the Theme Editor; the Theme resource is missing.");
 
 	if (p_save_as) {
-		EditorNode::get_singleton()->save_resource_as(theme);
+		EditorNode::get_singleton()->save_resource_as(theme, "");
 	} else {
 		EditorNode::get_singleton()->save_resource(theme);
 	}

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -384,7 +384,7 @@ Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 	}
 
 	triangle_mesh = Ref<TriangleMesh>(memnew(TriangleMesh));
-	triangle_mesh->create(faces);
+	triangle_mesh->create(faces, surface_indices);
 
 	return triangle_mesh;
 }


### PR DESCRIPTION
Implements [7238](https://github.com/godotengine/godot-proposals/issues/7238) (for the most part).

* Ability to select nodes, meshes or materials by clicking.
* Moved mesh/material previews to the inspector area.
* Ability to override materials and edit them directly in the inspector.
* By default, shows overridden materials in the imported scene, with a button to disable them and show original materials.
* Keeps compatibility with the old override format.

**Note:** Adding preview sun/env will be left for another PR.

How it looks:

![asset_import_usability](https://github.com/godotengine/godot/assets/6265307/e4af5ae9-925e-4b31-8d1c-2bbd1d11a235)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
