### PR TITLE
Improve action name for ungroup button in Scene dock

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -121,7 +121,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		}
 
 	} else if (p_id == BUTTON_GROUP) {
-		undo_redo->create_action(TTR("Button Group"));
+		undo_redo->create_action(TTR("Ungroup Children"));
 
 		if (n->is_class("CanvasItem") || n->is_class("Node3D")) {
 			undo_redo->add_do_method(n, "remove_meta", "_edit_group_");


### PR DESCRIPTION
This PR improves the name of the undo action triggered by this button:

![the ungroup button](https://github.com/godotengine/godot/assets/372476/2f3e7bb9-5f06-4142-80d5-df41ae471843)

The undo action name was "Button Group", which is confusing.