### PR TITLE
Add `RD_ENABLED` when `VULKAN_ENABLED` or `D3D12_ENABLED` is added

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -5,8 +5,6 @@ from pathlib import Path
 
 Import("env")
 
-env.Append(CPPDEFINES=["RD_ENABLED"])
-
 env_d3d12_rdd = env.Clone()
 
 thirdparty_obj = []

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -2,8 +2,6 @@
 
 Import("env")
 
-env.Append(CPPDEFINES=["RD_ENABLED"])
-
 thirdparty_obj = []
 thirdparty_dir = "#thirdparty/vulkan"
 thirdparty_volk_dir = "#thirdparty/volk"

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -200,7 +200,7 @@ def configure(env: "Environment"):
     env.Append(LIBS=["OpenSLES", "EGL", "android", "log", "z", "dl"])
 
     if env["vulkan"]:
-        env.Append(CPPDEFINES=["VULKAN_ENABLED"])
+        env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
         if not env["use_volk"]:
             env.Append(LIBS=["vulkan"])
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -152,7 +152,7 @@ def configure(env: "Environment"):
     env.Append(CPPDEFINES=["IOS_ENABLED", "UNIX_ENABLED", "COREAUDIO_ENABLED"])
 
     if env["vulkan"]:
-        env.Append(CPPDEFINES=["VULKAN_ENABLED"])
+        env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
 
     if env["opengl3"]:
         env.Append(CPPDEFINES=["GLES3_ENABLED", "GLES_SILENCE_DEPRECATION"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -434,7 +434,7 @@ def configure(env: "Environment"):
         env.Append(CPPDEFINES=["X11_ENABLED"])
 
     if env["vulkan"]:
-        env.Append(CPPDEFINES=["VULKAN_ENABLED"])
+        env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
         if not env["use_volk"]:
             env.ParseConfig("pkg-config vulkan --cflags --libs")
         if not env["builtin_glslang"]:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -260,7 +260,7 @@ def configure(env: "Environment"):
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
 
     if env["vulkan"]:
-        env.Append(CPPDEFINES=["VULKAN_ENABLED"])
+        env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
         env.Append(LINKFLAGS=["-framework", "Metal", "-framework", "IOSurface"])
         if not env["use_volk"]:
             env.Append(LINKFLAGS=["-lMoltenVK"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -436,7 +436,7 @@ def configure_msvc(env, vcvars_msvc_config):
         LIBS += ["psapi", "dbghelp"]
 
     if env["vulkan"]:
-        env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED"])
+        env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
         if not env["use_volk"]:
             LIBS += ["vulkan"]
 
@@ -445,7 +445,7 @@ def configure_msvc(env, vcvars_msvc_config):
             print("The Direct3D 12 rendering driver requires dxc_path to be set.")
             sys.exit(255)
 
-        env.AppendUnique(CPPDEFINES=["D3D12_ENABLED"])
+        env.AppendUnique(CPPDEFINES=["D3D12_ENABLED", "RD_ENABLED"])
         LIBS += ["d3d12", "dxgi", "dxguid"]
         LIBS += ["version"]  # Mesa dependency.
 
@@ -657,12 +657,12 @@ def configure_mingw(env):
         env.Append(LIBS=["psapi", "dbghelp"])
 
     if env["vulkan"]:
-        env.Append(CPPDEFINES=["VULKAN_ENABLED"])
+        env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
         if not env["use_volk"]:
             env.Append(LIBS=["vulkan"])
 
     if env["d3d12"]:
-        env.AppendUnique(CPPDEFINES=["D3D12_ENABLED"])
+        env.AppendUnique(CPPDEFINES=["D3D12_ENABLED", "RD_ENABLED"])
         env.Append(LIBS=["d3d12", "dxgi", "dxguid"])
 
         arch_subdir = "arm64" if env["arch"] == "arm64" else "x64"


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86411

In https://github.com/godotengine/godot/pull/83452, @RandomShaper changed the following line to use `RD_ENABLED` instead of `VULKAN_ENABLED` and `D3D12_ENABLED`
https://github.com/godotengine/godot/blob/9d1cbab1c432b6f1d66ec939445bec68b6af519e/core/config/project_settings.cpp#L98-L101

But as far as I can see, `RD_ENABLED` is only defined in driver/vulkan and dx12, I'm not familiar with scon but I guess the definition there only affects the subfolder and so the editor failed to have this macro defined? Feel free to correct me.

Since I dont think revert this line is a good change as godot might support other backend for rd, this pr is a safeguard as I add `RD_ENABLED` when `VULKAN_ENABLED` or `D3D12_ENABLED` is added in detect.py, I might miss some places. Thank you for your help in advance.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
