### PR TITLE
Add static keyword to parent function sig in error

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1728,6 +1728,9 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			if (!valid) {
 				// Compute parent signature as a string to show in the error message.
 				String parent_signature = String(function_name) + "(";
+				if (p_function->is_static) {
+					parent_signature = "static " + parent_signature;
+				}
 				int j = 0;
 				for (const GDScriptParser::DataType &par_type : parameters_types) {
 					if (j > 0) {


### PR DESCRIPTION

If the "static" keyword is omitted on a subclass function, this is (correctly) interpreted as breaking polymorphism but the error message displayed doesn't include it, and so it can be more difficult than necessary to figure out what's going wrong.

This change fixes that.