### PR TITLE
Fix default NavigationPolygon source geometry group name

### DIFF
--- a/scene/resources/navigation_polygon.h
+++ b/scene/resources/navigation_polygon.h
@@ -94,7 +94,7 @@ public:
 	uint32_t parsed_collision_mask = 0xFFFFFFFF;
 
 	SourceGeometryMode source_geometry_mode = SOURCE_GEOMETRY_ROOT_NODE_CHILDREN;
-	StringName source_geometry_group_name = "navigation_polygon_source_group";
+	StringName source_geometry_group_name = "navigation_polygon_source_geometry_group";
 
 	void set_vertices(const Vector<Vector2> &p_vertices);
 	Vector<Vector2> get_vertices() const;


### PR DESCRIPTION
Fixes default NavigationPolygon source geometry group name.

Fixes https://github.com/godotengine/godot/issues/86414

The default class group name did not match the bind method defaults and documentation defaults.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
