### PR TITLE
Fix double `text_changed` signal when overwriting selection in LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -624,7 +624,12 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			int prev_len = text.length();
 			insert_text_at_caret(ucodestr);
 			if (text.length() != prev_len) {
-				_text_changed();
+				if (!text_changed_dirty) {
+					if (is_inside_tree()) {
+						callable_mp(this, &LineEdit::_text_changed).call_deferred();
+					}
+					text_changed_dirty = true;
+				}
 			}
 			accept_event();
 			return;


### PR DESCRIPTION
The part of gui_input that handles unicode wasn't checking text_changed_dirty before emitting the signal, unlike the rest of the text editing functions in LineEdit.

This brings it in line with the other code in the same file and fixes #86451
