### PR TITLE
Use ObjectID's instead of node pointers to track scene groups to prevent crash.

### DIFF
--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -78,14 +78,14 @@ class GroupsEditor : public VBoxContainer {
 	Button *add = nullptr;
 	Tree *tree = nullptr;
 
-	HashMap<Node *, HashMap<StringName, bool>> scene_groups_cache;
+	HashMap<ObjectID, HashMap<StringName, bool>> scene_groups_cache;
 	HashMap<StringName, bool> scene_groups_for_caching;
 
 	HashMap<StringName, bool> scene_groups;
 	HashMap<StringName, String> global_groups;
 
-	void _update_scene_groups(Node *p_node);
-	void _cache_scene_groups(Node *p_node);
+	void _update_scene_groups(const ObjectID &p_id);
+	void _cache_scene_groups(const ObjectID &p_id);
 
 	void _show_add_group_dialog();
 	void _show_rename_group_dialog();


### PR DESCRIPTION
Since the node is being cleaned up, queuing this to be called deferred can result in the node already being gone by the time it is called, this results in a crash.

After node_removed is called, the node's destructor gets called and its memory deallocated(verified with breakpoints), this results in the deferred call triggering a crash later.

I'm not 100% sure this is the right fix but it seems to work and is certainly the easy fix.  Just not deferring the call in this case prevents the problem since the node is obviously still valid.  I do wonder if the groupeditor caching is doing something a bit odd though and needs more work.  I'm not familiar enough with it to do that at the moment though.

Fixes #86427
Fixes #86844