### PR TITLE
Add VK_EXT_line_rasterization

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2718,7 +2718,7 @@ RDD::PipelineID RenderingDeviceDriverVulkan::render_pipeline_create(
 	rasterization_line_state_create_info_ext.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT;
 	rasterization_line_state_create_info_ext.pNext = nullptr;
 	// this line is ridiculous because the extension mimics the limitations of the original OpenGL line rasterization implementation
-	rasterization_line_state_create_info_ext.lineRasterizationMode = ((Math::is_zero_approx(p_rasterization_state.line_width) || p_rasterization_state.line_width == 1.0f) && !(p_dynamic_state.has_flag(DYNAMIC_STATE_LINE_WIDTH) || p_multisample_state.enable_alpha_to_coverage || p_multisample_state.enable_alpha_to_one || p_multisample_state.enable_sample_shading) ? VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT : VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT);
+	rasterization_line_state_create_info_ext.lineRasterizationMode = ((Math::is_zero_approx(p_rasterization_state.line_width) || p_rasterization_state.line_width == 1.0f) && !p_dynamic_state.has_flag(DYNAMIC_STATE_LINE_WIDTH) && !p_multisample_state.enable_alpha_to_coverage && !p_multisample_state.enable_alpha_to_one && !p_multisample_state.enable_sample_shading) ? VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT : VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT;
 	rasterization_line_state_create_info_ext.stippledLineEnable = false;
 	rasterization_line_state_create_info_ext.lineStippleFactor = 0;
 	rasterization_line_state_create_info_ext.lineStipplePattern = 0;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2713,6 +2713,18 @@ RDD::PipelineID RenderingDeviceDriverVulkan::render_pipeline_create(
 	rasterization_state_create_info.depthBiasSlopeFactor = p_rasterization_state.depth_bias_slope_factor;
 	rasterization_state_create_info.lineWidth = p_rasterization_state.line_width;
 
+	// Hardware bresenham
+	VkPipelineRasterizationLineStateCreateInfoEXT rasterization_line_state_create_info_ext;
+	rasterization_line_state_create_info_ext.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT;
+	rasterization_line_state_create_info_ext.pNext = nullptr;
+	// this line is ridiculous because the extension mimics the limitations of the original OpenGL line rasterization implementation
+	rasterization_line_state_create_info_ext.lineRasterizationMode = ((Math::is_zero_approx(p_rasterization_state.line_width) || p_rasterization_state.line_width == 1.0f) && !(p_dynamic_state.has_flag(DYNAMIC_STATE_LINE_WIDTH) || p_multisample_state.enable_alpha_to_coverage || p_multisample_state.enable_alpha_to_one || p_multisample_state.enable_sample_shading) ? VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT : VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT);
+	rasterization_line_state_create_info_ext.stippledLineEnable = false;
+	rasterization_line_state_create_info_ext.lineStippleFactor = 0;
+	rasterization_line_state_create_info_ext.lineStipplePattern = 0;
+
+	rasterization_state_create_info.pNext = &rasterization_line_state_create_info_ext;
+
 	// Multisample.
 	VkPipelineMultisampleStateCreateInfo multisample_state_create_info = {};
 	multisample_state_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;


### PR DESCRIPTION
Implements #75654 . Not sure if fixes #37016, Potential alternative to #83895 if it does ?
Very basic addition of hardware bresenham support to Vulkan. No device validation checks, and not all valid raster state checks either. Plus, I limited it to only supporting 1px lines for now to make sure nothing weird happened, but with the `wideLines` feature hardware bresenham can actually support >=1px lines.
To me, 1px lines not being pixel perfect is a bug, so I'm not sure if adding a toggle for this is a good idea. 

