### PR TITLE
Update Curve3D.xml

### DIFF
--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -137,6 +137,7 @@
 			<param index="2" name="apply_tilt" type="bool" default="false" />
 			<description>
 				Returns a [Transform3D] with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes. See also [method sample_baked].
+				Note that in the GDScript implementation, offset is expected to be normalized, that is, between zero and one. This diverges slightly from the C++ implementation, which expects an unnormalized offset.
 			</description>
 		</method>
 		<method name="samplef" qualifiers="const">


### PR DESCRIPTION
Added clarification on discrepancy in implementation of `sample_baked_with_rotation`. GDScript expects the offset to be normalized, while C++ apparently does not.

This is worthy of discussion before accepting the change. Is it a bug? Is it possible to fix without breaking projects further? The C++ code clearly clamps offset to [0, length), but in GDScript the value only behaves as expected when something like `PathFollow3D.progress_ratio` is used (normalized) instead of `PathFollow3D.progress` (unnormalized).

Moreover, if the difference is accepted and intentional, is there a better place to document the GDScript version? It feels essential, yet out-of-place, in the C++ docs.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
