### PR TITLE
Implement audio stream playback parameters.

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -28,6 +28,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_parameter_list" qualifiers="virtual const">
+			<return type="Dictionary[]" />
+			<description>
+				Return the controllable parameters of this stream. This array contains dictionaries with a property info description format (see [method Object.get_property_list]). Additionally, the default value for this parameter must be added tho each dictionary in "default_value" field.
+			</description>
+		</method>
 		<method name="_get_stream_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>
@@ -62,4 +68,11 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="parameter_list_changed">
+			<description>
+				Signal to be emitted to notify when the parameter list changed.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -15,6 +15,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_parameter" qualifiers="virtual const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Return the current value of a playback parameter by name (see [method AudioStream._get_parameter_list]).
+			</description>
+		</method>
 		<method name="_get_playback_position" qualifiers="virtual const">
 			<return type="float" />
 			<description>
@@ -37,6 +44,14 @@
 			<return type="void" />
 			<param index="0" name="position" type="float" />
 			<description>
+			</description>
+		</method>
+		<method name="_set_parameter" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Set the current value of a playback parameter by name (see [method AudioStream._get_parameter_list]).
 			</description>
 		</method>
 		<method name="_start" qualifiers="virtual">

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -46,7 +46,9 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int frames_mixed_this_step = p_frames;
 
 	int beat_length_frames = -1;
-	bool beat_loop = mp3_stream->has_loop() && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
+	bool use_loop = looping_override ? looping : mp3_stream->loop;
+
+	bool beat_loop = use_loop && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
 	if (beat_loop) {
 		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
 	}
@@ -82,7 +84,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 
 		else {
 			//EOF
-			if (mp3_stream->loop) {
+			if (use_loop) {
 				seek(mp3_stream->loop_offset);
 				loops++;
 			} else {
@@ -141,6 +143,25 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 
 void AudioStreamPlaybackMP3::tag_used_streams() {
 	mp3_stream->tag_used(get_playback_position());
+}
+
+void AudioStreamPlaybackMP3::set_parameter(const StringName &p_name, const Variant &p_value) {
+	if (p_name == SNAME("looping")) {
+		if (p_value == Variant()) {
+			looping_override = false;
+			looping = false;
+		} else {
+			looping_override = true;
+			looping = p_value;
+		}
+	}
+}
+
+Variant AudioStreamPlaybackMP3::get_parameter(const StringName &p_name) const {
+	if (looping_override && p_name == SNAME("looping")) {
+		return looping;
+	}
+	return Variant();
 }
 
 AudioStreamPlaybackMP3::~AudioStreamPlaybackMP3() {
@@ -230,6 +251,10 @@ double AudioStreamMP3::get_length() const {
 
 bool AudioStreamMP3::is_monophonic() const {
 	return false;
+}
+
+void AudioStreamMP3::get_parameter_list(List<Parameter> *r_parameters) {
+	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }
 
 void AudioStreamMP3::set_bpm(double p_bpm) {

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -47,6 +47,8 @@ class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
 	AudioFrame loop_fade[FADE_SIZE];
 	int loop_fade_remaining = FADE_SIZE;
 
+	bool looping_override = false;
+	bool looping = false;
 	mp3dec_ex_t *mp3d = nullptr;
 	uint32_t frames_mixed = 0;
 	bool active = false;
@@ -71,6 +73,9 @@ public:
 	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
+
+	virtual void set_parameter(const StringName &p_name, const Variant &p_value) override;
+	virtual Variant get_parameter(const StringName &p_name) const override;
 
 	AudioStreamPlaybackMP3() {}
 	~AudioStreamPlaybackMP3();
@@ -125,6 +130,8 @@ public:
 	virtual double get_length() const override;
 
 	virtual bool is_monophonic() const override;
+
+	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
 
 	AudioStreamMP3();
 	virtual ~AudioStreamMP3();

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -46,8 +46,9 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 	int todo = p_frames;
 
 	int beat_length_frames = -1;
-	bool beat_loop = vorbis_stream->has_loop();
-	if (beat_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0) {
+	bool use_loop = looping_override ? looping : vorbis_stream->loop;
+
+	if (use_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0) {
 		beat_length_frames = vorbis_stream->get_beat_count() * vorbis_data->get_sampling_rate() * 60 / vorbis_stream->get_bpm();
 	}
 
@@ -99,7 +100,7 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 			} else
 			**/
 
-			if (beat_loop && beat_length_frames <= (int)frames_mixed) {
+			if (use_loop && beat_length_frames <= (int)frames_mixed) {
 				// End of file when doing beat-based looping. <= used instead of == because importer editing
 				if (!have_packets_left && !have_samples_left) {
 					//Nothing remaining, so do nothing.
@@ -125,7 +126,7 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 		if (!have_packets_left && !have_samples_left) {
 			// Actual end of file!
 			bool is_not_empty = mixed > 0 || vorbis_stream->get_length() > 0;
-			if (vorbis_stream->loop && is_not_empty) {
+			if (use_loop && is_not_empty) {
 				//loop
 
 				seek(vorbis_stream->loop_offset);
@@ -255,6 +256,25 @@ double AudioStreamPlaybackOggVorbis::get_playback_position() const {
 
 void AudioStreamPlaybackOggVorbis::tag_used_streams() {
 	vorbis_stream->tag_used(get_playback_position());
+}
+
+void AudioStreamPlaybackOggVorbis::set_parameter(const StringName &p_name, const Variant &p_value) {
+	if (p_name == SNAME("looping")) {
+		if (p_value == Variant()) {
+			looping_override = false;
+			looping = false;
+		} else {
+			looping_override = true;
+			looping = p_value;
+		}
+	}
+}
+
+Variant AudioStreamPlaybackOggVorbis::get_parameter(const StringName &p_name) const {
+	if (looping_override && p_name == SNAME("looping")) {
+		return looping;
+	}
+	return Variant();
 }
 
 void AudioStreamPlaybackOggVorbis::seek(double p_time) {
@@ -491,6 +511,10 @@ int AudioStreamOggVorbis::get_bar_beats() const {
 
 bool AudioStreamOggVorbis::is_monophonic() const {
 	return false;
+}
+
+void AudioStreamOggVorbis::get_parameter_list(List<Parameter> *r_parameters) {
+	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }
 
 void AudioStreamOggVorbis::_bind_methods() {

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -44,6 +44,8 @@ class AudioStreamPlaybackOggVorbis : public AudioStreamPlaybackResampled {
 
 	uint32_t frames_mixed = 0;
 	bool active = false;
+	bool looping_override = false;
+	bool looping = false;
 	int loops = 0;
 
 	enum {
@@ -94,6 +96,9 @@ public:
 	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
+
+	virtual void set_parameter(const StringName &p_name, const Variant &p_value) override;
+	virtual Variant get_parameter(const StringName &p_name) const override;
 
 	AudioStreamPlaybackOggVorbis() {}
 	~AudioStreamPlaybackOggVorbis();
@@ -151,6 +156,8 @@ public:
 	virtual double get_length() const override; //if supported, otherwise return 0
 
 	virtual bool is_monophonic() const override;
+
+	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
 
 	AudioStreamOggVorbis();
 	virtual ~AudioStreamOggVorbis();

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -89,10 +89,22 @@ private:
 	float panning_strength = 1.0f;
 	float cached_global_panning_strength = 0.5f;
 
+	struct ParameterData {
+		StringName path;
+		Variant value;
+	};
+
+	HashMap<StringName, ParameterData> playback_parameters;
+	void _update_stream_parameters();
+
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
 	void set_stream(Ref<AudioStream> p_stream);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -121,10 +121,22 @@ private:
 	float panning_strength = 1.0f;
 	float cached_global_panning_strength = 0.5f;
 
+	struct ParameterData {
+		StringName path;
+		Variant value;
+	};
+
+	HashMap<StringName, ParameterData> playback_parameters;
+	void _update_stream_parameters();
+
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
 	void set_stream(Ref<AudioStream> p_stream);

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -68,10 +68,22 @@ private:
 
 	Vector<AudioFrame> _get_volume_vector();
 
+	struct ParameterData {
+		StringName path;
+		Variant value;
+	};
+
+	HashMap<StringName, ParameterData> playback_parameters;
+	void _update_stream_parameters();
+
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
 	void set_stream(Ref<AudioStream> p_stream);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -80,6 +80,16 @@ void AudioStreamPlayback::tag_used_streams() {
 	GDVIRTUAL_CALL(_tag_used_streams);
 }
 
+void AudioStreamPlayback::set_parameter(const StringName &p_name, const Variant &p_value) {
+	GDVIRTUAL_CALL(_set_parameter, p_name, p_value);
+}
+
+Variant AudioStreamPlayback::get_parameter(const StringName &p_name) const {
+	Variant ret;
+	GDVIRTUAL_CALL(_get_parameter, p_name, ret);
+	return ret;
+}
+
 void AudioStreamPlayback::_bind_methods() {
 	GDVIRTUAL_BIND(_start, "from_pos")
 	GDVIRTUAL_BIND(_stop)
@@ -89,6 +99,8 @@ void AudioStreamPlayback::_bind_methods() {
 	GDVIRTUAL_BIND(_seek, "position")
 	GDVIRTUAL_BIND(_mix, "buffer", "rate_scale", "frames");
 	GDVIRTUAL_BIND(_tag_used_streams);
+	GDVIRTUAL_BIND(_set_parameter, "name", "value");
+	GDVIRTUAL_BIND(_get_parameter, "name");
 }
 //////////////////////////////
 
@@ -249,6 +261,16 @@ float AudioStream::get_tagged_frame_offset(int p_index) const {
 	return tagged_offsets[p_index];
 }
 
+void AudioStream::get_parameter_list(List<Parameter> *r_parameters) {
+	TypedArray<Dictionary> ret;
+	GDVIRTUAL_CALL(_get_parameter_list, ret);
+	for (int i = 0; i < ret.size(); i++) {
+		Dictionary d = ret[i];
+		ERR_CONTINUE(!d.has("default_value"));
+		r_parameters->push_back(Parameter(PropertyInfo::from_dict(d), d["default_value"]));
+	}
+}
+
 void AudioStream::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_length"), &AudioStream::get_length);
 	ClassDB::bind_method(D_METHOD("is_monophonic"), &AudioStream::is_monophonic);
@@ -259,6 +281,9 @@ void AudioStream::_bind_methods() {
 	GDVIRTUAL_BIND(_is_monophonic);
 	GDVIRTUAL_BIND(_get_bpm)
 	GDVIRTUAL_BIND(_get_beat_count)
+	GDVIRTUAL_BIND(_get_parameter_list)
+
+	ADD_SIGNAL(MethodInfo("parameter_list_changed"));
 }
 
 ////////////////////////////////

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -38,6 +38,7 @@
 
 #include "core/object/gdvirtual.gen.inc"
 #include "core/variant/native_ptr.h"
+#include "core/variant/typed_array.h"
 
 class AudioStream;
 
@@ -54,6 +55,9 @@ protected:
 	GDVIRTUAL1(_seek, double)
 	GDVIRTUAL3R(int, _mix, GDExtensionPtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
+	GDVIRTUAL2(_set_parameter, const StringName &, const Variant &)
+	GDVIRTUAL1RC(Variant, _get_parameter, const StringName &)
+
 public:
 	virtual void start(double p_from_pos = 0.0);
 	virtual void stop();
@@ -65,6 +69,9 @@ public:
 	virtual void seek(double p_time);
 
 	virtual void tag_used_streams();
+
+	virtual void set_parameter(const StringName &p_name, const Variant &p_value);
+	virtual Variant get_parameter(const StringName &p_name) const;
 
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
 };
@@ -124,6 +131,7 @@ protected:
 	GDVIRTUAL0RC(bool, _has_loop)
 	GDVIRTUAL0RC(int, _get_bar_beats)
 	GDVIRTUAL0RC(int, _get_beat_count)
+	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_parameter_list)
 
 public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback();
@@ -141,6 +149,17 @@ public:
 	uint64_t get_tagged_frame() const;
 	uint32_t get_tagged_frame_count() const;
 	float get_tagged_frame_offset(int p_index) const;
+
+	struct Parameter {
+		PropertyInfo property;
+		Variant default_value;
+		Parameter(const PropertyInfo &p_info = PropertyInfo(), const Variant &p_default_value = Variant()) {
+			property = p_info;
+			default_value = p_default_value;
+		}
+	};
+
+	virtual void get_parameter_list(List<Parameter> *r_parameters);
 };
 
 // Microphone


### PR DESCRIPTION
Implements a way for audio stream playback to be configured via parameters directly in the edited AudioStreamPlayer[2D/3D].

Currently, configuring the playback stream is not possible (or is sometimes hacky as the user has to obtain the currently played stream, which is not always immediately available).

All you can do is configure the AudioStream itself, which affects all instances in the game. With this PR, configuring playback parameters per each stream player is possible, giving users far more flexibility and freedom to configure playback or animate parameters.

This PR only implements this new feature to control looping in stream playback instances (a commonly requested feature, which was lost in the transition from Godot 2 to Godot 3). But the idea is that it can do a lot more:

* If effects are bundled to the stream, control per playback instance parameters such as cutoff or resoance, or any other exposed effect parameter per playback instance.
* For the upcoming interactive music PR (#64488), this exposes an easy way to change the active clip, which was not possible before (so this PR is a prerequisite for that one).
* For the upcoming parametrizable audio support (https://github.com/godotengine/godot-proposals/issues/3394) this allows editing and animating audio graph parameters.

Screenshot of how it looks:

![image](https://github.com/godotengine/godot/assets/6265307/abb78fb3-0ca7-4060-995b-b5ac5f8284d4)

Supersedes #65797, implements https://github.com/godotengine/godot-proposals/issues/3120.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
