### PR TITLE
Store horizontal and vertical split offsets separately in FileSystem dock

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5047,7 +5047,8 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p
 
 	// Save FileSystemDock state.
 
-	p_layout->set_value(p_section, "dock_filesystem_split", FileSystemDock::get_singleton()->get_split_offset());
+	p_layout->set_value(p_section, "dock_filesystem_h_split_offset", FileSystemDock::get_singleton()->get_h_split_offset());
+	p_layout->set_value(p_section, "dock_filesystem_v_split_offset", FileSystemDock::get_singleton()->get_v_split_offset());
 	p_layout->set_value(p_section, "dock_filesystem_display_mode", FileSystemDock::get_singleton()->get_display_mode());
 	p_layout->set_value(p_section, "dock_filesystem_file_sort", FileSystemDock::get_singleton()->get_file_sort());
 	p_layout->set_value(p_section, "dock_filesystem_file_list_display_mode", FileSystemDock::get_singleton()->get_file_list_display_mode());
@@ -5272,9 +5273,14 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 
 	// FileSystemDock.
 
-	if (p_layout->has_section_key(p_section, "dock_filesystem_split")) {
-		int fs_split_ofs = p_layout->get_value(p_section, "dock_filesystem_split");
-		FileSystemDock::get_singleton()->set_split_offset(fs_split_ofs);
+	if (p_layout->has_section_key(p_section, "dock_filesystem_h_split_offset")) {
+		int fs_h_split_ofs = p_layout->get_value(p_section, "dock_filesystem_h_split_offset");
+		FileSystemDock::get_singleton()->set_h_split_offset(fs_h_split_ofs);
+	}
+
+	if (p_layout->has_section_key(p_section, "dock_filesystem_v_split_offset")) {
+		int fs_v_split_ofs = p_layout->get_value(p_section, "dock_filesystem_v_split_offset");
+		FileSystemDock::get_singleton()->set_v_split_offset(fs_v_split_ofs);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_display_mode")) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -470,8 +470,6 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 			case DISPLAY_MODE_HSPLIT:
 			case DISPLAY_MODE_VSPLIT:
 				const bool is_vertical = display_mode == DISPLAY_MODE_VSPLIT;
-				const int split_offset = split_box->get_split_offset();
-				is_vertical ? split_box_offset_h = split_offset : split_box_offset_v = split_offset;
 				split_box->set_vertical(is_vertical);
 
 				const int actual_offset = is_vertical ? split_box_offset_v : split_box_offset_h;
@@ -2588,6 +2586,14 @@ void FileSystemDock::_change_split_mode() {
 	emit_signal(SNAME("display_mode_changed"));
 }
 
+void FileSystemDock::_split_dragged(int p_offset) {
+	if (split_box->is_vertical()) {
+		split_box_offset_v = p_offset;
+	} else {
+		split_box_offset_h = p_offset;
+	}
+}
+
 void FileSystemDock::fix_dependencies(const String &p_for_file) {
 	deps_editor->edit(p_for_file);
 }
@@ -3767,6 +3773,8 @@ FileSystemDock::FileSystemDock() {
 
 	split_box = memnew(SplitContainer);
 	split_box->set_v_size_flags(SIZE_EXPAND_FILL);
+	split_box->connect("dragged", callable_mp(this, &FileSystemDock::_split_dragged));
+	split_box_offset_h = 240 * EDSCALE;
 	add_child(split_box);
 
 	tree = memnew(FileSystemTree);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -306,6 +306,7 @@ private:
 	void _rescan();
 
 	void _change_split_mode();
+	void _split_dragged(int p_offset);
 
 	void _search_changed(const String &p_text, const Control *p_from);
 
@@ -387,8 +388,10 @@ public:
 
 	void fix_dependencies(const String &p_for_file);
 
-	int get_split_offset() { return split_box->get_split_offset(); }
-	void set_split_offset(int p_offset) { split_box->set_split_offset(p_offset); }
+	int get_h_split_offset() const { return split_box_offset_h; }
+	void set_h_split_offset(int p_offset) { split_box_offset_h = p_offset; }
+	int get_v_split_offset() const { return split_box_offset_v; }
+	void set_v_split_offset(int p_offset) { split_box_offset_v = p_offset; }
 	void select_file(const String &p_file);
 
 	void set_display_mode(DisplayMode p_display_mode);


### PR DESCRIPTION
Fixes #83333