### PR TITLE
Add persistent folding to Animation Library Editor

### DIFF
--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -31,6 +31,8 @@
 #ifndef ANIMATION_LIBRARY_EDITOR_H
 #define ANIMATION_LIBRARY_EDITOR_H
 
+#include "core/io/config_file.h"
+#include "core/templates/vector.h"
 #include "editor/animation_track_editor.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/animation/animation_mixer.h"
@@ -102,6 +104,11 @@ class AnimationLibraryEditor : public AcceptDialog {
 	void _load_library();
 	void _load_file(const String &p_path);
 	void _load_files(const PackedStringArray &p_paths);
+
+	void _save_mixer_lib_folding(TreeItem *p_item);
+	Vector<uint64_t> _load_mixer_libs_folding();
+	void _load_config_libs_folding(Vector<uint64_t> &p_lib_ids, ConfigFile *p_config, String p_section);
+	String _get_mixer_signature() const;
 
 	void _item_renamed();
 	void _button_pressed(TreeItem *p_item, int p_column, int p_id, MouseButton p_button);

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -33,6 +33,8 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/string/print_string.h"
+#include "core/string/string_name.h"
 #include "scene/2d/audio_stream_player_2d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/audio/audio_stream_player.h"
@@ -265,6 +267,16 @@ bool AnimationMixer::has_animation_library(const StringName &p_name) const {
 	}
 
 	return false;
+}
+
+StringName AnimationMixer::get_animation_library_name(const Ref<AnimationLibrary> &p_animation_library) const {
+	ERR_FAIL_COND_V(p_animation_library.is_null(), StringName());
+	for (const AnimationLibraryData &lib : animation_libraries) {
+		if (lib.library == p_animation_library) {
+			return lib.name;
+		}
+	}
+	return StringName();
 }
 
 StringName AnimationMixer::find_animation_library(const Ref<Animation> &p_animation) const {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -409,6 +409,7 @@ public:
 	void get_animation_library_list(List<StringName> *p_animations) const;
 	Ref<AnimationLibrary> get_animation_library(const StringName &p_name) const;
 	bool has_animation_library(const StringName &p_name) const;
+	StringName get_animation_library_name(const Ref<AnimationLibrary> &p_animation_library) const;
 	StringName find_animation_library(const Ref<Animation> &p_animation) const;
 	Error add_animation_library(const StringName &p_name, const Ref<AnimationLibrary> &p_animation_library);
 	void remove_animation_library(const StringName &p_name);


### PR DESCRIPTION
- Resolves the second part of godotengine/godot-proposals#8226
- Supersedes #84088

Enables folding of the library entries in Animation Library Editor, necessary on big projects with hundreds of animations to prevent excessive scrolling.

For folding to be persistent, the `collapsed` state of TreeItems is saved in a subfolder of .godot/editor/ or wherever get_project_settings_dir() would point. I'd love to do it via editor_folding.ccp, but I couldn't find out how to repurpose existing methods from that class, and didn't want to disrupt anything by accident. Because of that all file manipulations are performed in animation_library_editor.cpp.

Due to the fact that multiple AnimationMixers can be present in a scene and share same libraries, the persistence files are created per mixer node path and not per scene. Filename is formed as (pseudocode):
```"folding-" + (scene_file_path + mixer_node_path).md5()+".cfg"```
Because of this, clutter of outdated files can form when the scene filename or the mixers' nodepaths change.

I would be glad if someone more knowledgeable could suggest how to do persistence in editor more gracefully.^^'