### PR TITLE
Improve `EditorDirDialog`

### DIFF
--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -110,7 +110,7 @@ void DirectoryCreateDialog::ok_pressed() {
 	err = da->make_dir_recursive(path);
 
 	if (err == OK) {
-		emit_signal(SNAME("dir_created"));
+		emit_signal(SNAME("dir_created"), base_dir.path_join(path));
 	} else {
 		EditorNode::get_singleton()->show_warning(TTR("Could not create folder."));
 	}
@@ -131,7 +131,7 @@ void DirectoryCreateDialog::config(const String &p_base_dir) {
 }
 
 void DirectoryCreateDialog::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("dir_created"));
+	ADD_SIGNAL(MethodInfo("dir_created", PropertyInfo(Variant::STRING, "path")));
 }
 
 DirectoryCreateDialog::DirectoryCreateDialog() {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1883,10 +1883,6 @@ Vector<String> FileSystemDock::_check_existing() {
 	return conflicting_items;
 }
 
-void FileSystemDock::_move_dialog_confirm(const String &p_path) {
-	_move_operation_confirm(p_path, move_dialog->is_copy_pressed());
-}
-
 void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_copy, Overwrite p_overwrite) {
 	if (p_overwrite == OVERWRITE_UNDECIDED) {
 		to_move_path = p_to_path;
@@ -2363,6 +2359,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				}
 			}
 			if (to_move.size() > 0) {
+				move_dialog->config(p_selected);
 				move_dialog->popup_centered_ratio(0.4);
 			}
 		} break;
@@ -3847,7 +3844,8 @@ FileSystemDock::FileSystemDock() {
 
 	move_dialog = memnew(EditorDirDialog);
 	add_child(move_dialog);
-	move_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_dialog_confirm));
+	move_dialog->connect("move_pressed", callable_mp(this, &FileSystemDock::_move_operation_confirm).bind(false, OVERWRITE_UNDECIDED));
+	move_dialog->connect("copy_pressed", callable_mp(this, &FileSystemDock::_move_operation_confirm).bind(true, OVERWRITE_UNDECIDED));
 
 	overwrite_dialog = memnew(ConfirmationDialog);
 	add_child(overwrite_dialog);
@@ -3884,7 +3882,7 @@ FileSystemDock::FileSystemDock() {
 
 	make_dir_dialog = memnew(DirectoryCreateDialog);
 	add_child(make_dir_dialog);
-	make_dir_dialog->connect("dir_created", callable_mp(this, &FileSystemDock::_rescan));
+	make_dir_dialog->connect("dir_created", callable_mp(this, &FileSystemDock::_rescan).unbind(1));
 
 	make_scene_dialog = memnew(SceneCreateDialog);
 	add_child(make_scene_dialog);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -102,6 +102,12 @@ public:
 		FILE_SORT_MAX,
 	};
 
+	enum Overwrite {
+		OVERWRITE_UNDECIDED,
+		OVERWRITE_REPLACE,
+		OVERWRITE_RENAME,
+	};
+
 private:
 	enum FileMenu {
 		FILE_OPEN,
@@ -131,12 +137,6 @@ private:
 		FILE_NEW_FOLDER,
 		FILE_NEW_SCRIPT,
 		FILE_NEW_SCENE,
-	};
-
-	enum Overwrite {
-		OVERWRITE_UNDECIDED,
-		OVERWRITE_REPLACE,
-		OVERWRITE_RENAME,
 	};
 
 	HashMap<String, Color> folder_colors;
@@ -290,7 +290,6 @@ private:
 	void _duplicate_operation_confirm();
 	void _overwrite_dialog_action(bool p_overwrite);
 	Vector<String> _check_existing();
-	void _move_dialog_confirm(const String &p_path);
 	void _move_operation_confirm(const String &p_to_path, bool p_copy = false, Overwrite p_overwrite = OVERWRITE_UNDECIDED);
 
 	void _tree_rmb_option(int p_option);
@@ -409,5 +408,7 @@ public:
 	FileSystemDock();
 	~FileSystemDock();
 };
+
+VARIANT_ENUM_CAST(FileSystemDock::Overwrite);
 
 #endif // FILESYSTEM_DOCK_H

--- a/editor/gui/editor_dir_dialog.h
+++ b/editor/gui/editor_dir_dialog.h
@@ -33,7 +33,7 @@
 
 #include "scene/gui/dialogs.h"
 
-class CheckBox;
+class DirectoryCreateDialog;
 class EditorFileSystemDirectory;
 class Tree;
 class TreeItem;
@@ -41,25 +41,24 @@ class TreeItem;
 class EditorDirDialog : public ConfirmationDialog {
 	GDCLASS(EditorDirDialog, ConfirmationDialog);
 
-	ConfirmationDialog *makedialog = nullptr;
-	LineEdit *makedirname = nullptr;
-	AcceptDialog *mkdirerr = nullptr;
+	DirectoryCreateDialog *makedialog = nullptr;
 
 	Button *makedir = nullptr;
+	Button *copy = nullptr;
 	HashSet<String> opened_paths;
+	String new_dir_path;
 
 	Tree *tree = nullptr;
 	bool updating = false;
-	CheckBox *copy = nullptr;
 
-	void _copy_toggled(bool p_pressed);
 	void _item_collapsed(Object *p_item);
 	void _item_activated();
 	void _update_dir(TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path = String());
 
 	void _make_dir();
-	void _make_dir_confirm();
+	void _make_dir_confirm(const String &p_path);
 
+	void _copy_pressed();
 	void ok_pressed() override;
 
 	bool must_reload = false;
@@ -69,8 +68,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	void config(const Vector<String> &p_paths);
 	void reload(const String &p_path = "");
-	bool is_copy_pressed() const;
 
 	EditorDirDialog();
 };


### PR DESCRIPTION
* Automatically selects the newly created directory
* Automatically selects "res://" when nothing is selected
* Fixes an error when overwrite/replace dialog appears
* Changes "copy checkbox + action button" to "copy button + move button"
* Double clicking a directory (un)collapses it instead of copy/move
* Moves "Create Folder" to top row for better UX
* Uses DirectoryCreateDialog for "Create Folder"

| Before | After |
|---|---|
| ![ksnip_20231224-140532](https://github.com/godotengine/godot/assets/372476/3a7d559c-cb73-4cf6-85e1-6bda236e5303) | ![image](https://github.com/godotengine/godot/assets/372476/42e0509a-0dbb-4594-9878-37d607cdbeaa) |

