### PR TITLE
Change FileAccessCompressed's default compression to FastLZ

### DIFF
--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -35,7 +35,7 @@
 #include "core/io/file_access.h"
 
 class FileAccessCompressed : public FileAccess {
-	Compression::Mode cmode = Compression::MODE_ZSTD;
+	Compression::Mode cmode = Compression::MODE_FASTLZ;
 	bool writing = false;
 	uint64_t write_pos = 0;
 	uint8_t *write_ptr = nullptr;
@@ -66,7 +66,7 @@ class FileAccessCompressed : public FileAccess {
 	void _close();
 
 public:
-	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
+	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_FASTLZ, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 


### PR DESCRIPTION
Following @AThousandShips 's suggestion to fix https://github.com/godotengine/godot/issues/86338 

But it might have unexpected implications, feel free to correct me.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
