### PR TITLE
Fix MSVC 14.1 complaining about "attempting to reference a deleted function" in RenderPassClearValue

### DIFF
--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -535,6 +535,8 @@ public:
 			float depth;
 			uint32_t stencil;
 		};
+
+		RenderPassClearValue() {}
 	};
 
 	struct AttachmentClear {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86443

We could also add something like `new (&color) Color()` inside the ctor, but it doesn't seems very necessary.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
