### PR TITLE
Fix `ScriptLanguageExtension::_find_function` argument names

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -107,7 +107,7 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_supports_builtin_mode);
 	GDVIRTUAL_BIND(_supports_documentation);
 	GDVIRTUAL_BIND(_can_inherit_from_file);
-	GDVIRTUAL_BIND(_find_function, "class_name", "function_name");
+	GDVIRTUAL_BIND(_find_function, "function", "code");
 	GDVIRTUAL_BIND(_make_function, "class_name", "function_name", "function_args");
 	GDVIRTUAL_BIND(_open_in_external_editor, "script", "line", "column");
 	GDVIRTUAL_BIND(_overrides_external_editor);

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -114,9 +114,10 @@
 		</method>
 		<method name="_find_function" qualifiers="virtual const">
 			<return type="int" />
-			<param index="0" name="class_name" type="String" />
-			<param index="1" name="function_name" type="String" />
+			<param index="0" name="function" type="String" />
+			<param index="1" name="code" type="String" />
 			<description>
+				Returns the line where the function is defined in the code, or [code]-1[/code] if the function is not present.
 			</description>
 		</method>
 		<method name="_finish" qualifiers="virtual">


### PR DESCRIPTION
`ScriptLanguageExtension::_find_function` documentation is currently wrong when compared to it GDScript implementation: 
https://github.com/godotengine/godot/blob/13a0d6e9b253654f5cc2a44f3d0b3cae10440443/modules/gdscript/gdscript_editor.cpp#L212