### PR TITLE
RenderingDevice: Fix uniform sets wrongly assumed to be bound

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4125,7 +4125,7 @@ void RenderingDevice::draw_list_bind_render_pipeline(DrawListID p_list, RID p_re
 		}
 
 		for (uint32_t i = 0; i < pcount; i++) {
-			dl->state.sets[i].bound = i < first_invalid_set;
+			dl->state.sets[i].bound = dl->state.sets[i].bound && i < first_invalid_set;
 			dl->state.sets[i].pipeline_expected_format = pformats[i];
 		}
 
@@ -4718,7 +4718,7 @@ void RenderingDevice::compute_list_bind_compute_pipeline(ComputeListID p_list, R
 		}
 
 		for (uint32_t i = 0; i < pcount; i++) {
-			cl->state.sets[i].bound = i >= first_invalid_set;
+			cl->state.sets[i].bound = cl->state.sets[i].bound && i < first_invalid_set;
 			cl->state.sets[i].pipeline_expected_format = pformats[i];
 		}
 


### PR DESCRIPTION
With the former logic, the need to re-bind a uniform set at the graphics API level was determined solely on the format and the "survivavility" of the binding according to the relevant binding model. However, it was wrong in failing to realize that a uniform set that has still not been bound at the graphics API level has to be bound regardless any other consideration. **EDIT:** (Not to mention the check was broken whatsoever in the compute case.)

Fixes #86408.
Fixes #86400.
Fixes #86547.
Fixes #86425.