### PR TITLE
Fix CollisionObject2D.xml DISABLE_MODE enums

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -282,11 +282,11 @@
 			Automatically re-added to the physics simulation when the [Node] is processed again.
 		</constant>
 		<constant name="DISABLE_MODE_MAKE_STATIC" value="1" enum="DisableMode">
-			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], make the body static. Doesn't affect [Area2D]. [PhysicsBody2D] can't be affected by forces or other bodies while static.
+			When [member Node.process_mode] is set to [constant Node.DISABLE_MODE_MAKE_STATIC], make the body static. Doesn't affect [Area2D]. [PhysicsBody2D] can't be affected by forces or other bodies while static.
 			Automatically set [PhysicsBody2D] back to its original mode when the [Node] is processed again.
 		</constant>
 		<constant name="DISABLE_MODE_KEEP_ACTIVE" value="2" enum="DisableMode">
-			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], do not affect the physics simulation.
+			When [member Node.process_mode] is set to [constant Node.DISABLE_MODE_KEEP_ACTIVE], do not affect the physics simulation.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
