### PR TITLE
EDITOR: fix spelling mistake on the spanish theme importer

### DIFF
--- a/editor/translations/editor/es.po
+++ b/editor/translations/editor/es.po
@@ -7489,7 +7489,7 @@ msgid "Project theme"
 msgstr "Theme del proyecto"
 
 msgid "Editor theme"
-msgstr "Editor de Theme"
+msgstr "Theme del Editor"
 
 msgid "Default theme"
 msgstr "Theme predeterminado"


### PR DESCRIPTION
Changed line 7942 of the Spanish editor translation, which said "Editor de theme" but it's an incorrect translation as it means "Theme editor" and not "Editor theme", The correct translation is "Theme del Editor"