### PR TITLE
Expose class_has_property on ClassDB

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1395,6 +1395,10 @@ TypedArray<Dictionary> ClassDB::class_get_signal_list(StringName p_class, bool p
 	return ret;
 }
 
+bool ClassDB::class_has_property(StringName p_class, StringName p_property, bool p_no_inheritance) const {
+	return ::ClassDB::has_property(p_class, p_property, p_no_inheritance);
+}
+
 TypedArray<Dictionary> ClassDB::class_get_property_list(StringName p_class, bool p_no_inheritance) const {
 	List<PropertyInfo> plist;
 	::ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
@@ -1525,6 +1529,7 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_get_signal", "class", "signal"), &ClassDB::class_get_signal);
 	::ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &ClassDB::class_get_signal_list, DEFVAL(false));
 
+	::ClassDB::bind_method(D_METHOD("class_has_property", "class", "property", "no_inheritance"), &ClassDB::class_has_property, DEFVAL(false));
 	::ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &ClassDB::class_get_property_list, DEFVAL(false));
 	::ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &ClassDB::class_get_property);
 	::ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &ClassDB::class_set_property);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -438,6 +438,7 @@ public:
 	Dictionary class_get_signal(StringName p_class, StringName p_signal) const;
 	TypedArray<Dictionary> class_get_signal_list(StringName p_class, bool p_no_inheritance = false) const;
 
+	bool class_has_property(StringName p_class, StringName p_property, bool p_no_inheritance = false) const;
 	TypedArray<Dictionary> class_get_property_list(StringName p_class, bool p_no_inheritance = false) const;
 	Variant class_get_property(Object *p_object, const StringName &p_property) const;
 	Error class_set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const;

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -132,6 +132,15 @@
 				Returns whether [param class] (or its ancestry if [param no_inheritance] is [code]false[/code]) has a method called [param method] or not.
 			</description>
 		</method>
+		<method name="class_has_property" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="class" type="StringName" />
+			<param index="1" name="property" type="StringName" />
+			<param index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns whether [param class] (or its ancestry if [param no_inheritance] is [code]false[/code]) has a property called [param property] or not.
+			</description>
+		</method>
 		<method name="class_has_signal" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="class" type="StringName" />


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

I want to be able to check if a class has a property without having to iterate those properties on my own.