### PR TITLE
Cleanup of OpenXR module SCons config

### DIFF
--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -93,37 +93,13 @@ if env["builtin_openxr"]:
 module_obj = []
 
 env_openxr.add_source_files(module_obj, "*.cpp")
-env_openxr.add_source_files(module_obj, "action_map/*.cpp")
-env_openxr.add_source_files(module_obj, "scene/*.cpp")
-
-# We're a little more targeted with our extensions
-if env["platform"] == "android":
-    env_openxr.add_source_files(module_obj, "extensions/openxr_android_extension.cpp")
-if env["vulkan"]:
-    env_openxr.add_source_files(module_obj, "extensions/openxr_vulkan_extension.cpp")
-if env["opengl3"] and env["platform"] != "macos":
-    env_openxr.add_source_files(module_obj, "extensions/openxr_opengl_extension.cpp")
-
-env_openxr.add_source_files(module_obj, "extensions/openxr_local_floor_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_palm_pose_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_composition_layer_depth_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_eye_gaze_interaction.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_htc_controller_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_htc_vive_tracker_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_huawei_controller_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_hand_tracking_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_fb_foveation_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_fb_update_swapchain_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_fb_passthrough_extension_wrapper.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_fb_display_refresh_rate_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_pico_controller_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_wmr_controller_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_ml2_controller_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_extension_wrapper_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_api_extension.cpp")
-env_openxr.add_source_files(module_obj, "extensions/openxr_meta_controller_extension.cpp")
-
 env.modules_sources += module_obj
+
+Export("env_openxr")
+
+SConscript("action_map/SCsub")
+SConscript("extensions/SCsub")
+SConscript("scene/SCsub")
 
 if env.editor_build:
     SConscript("editor/SCsub")

--- a/modules/openxr/action_map/SCsub
+++ b/modules/openxr/action_map/SCsub
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_openxr")
+
+module_obj = []
+
+env_openxr.add_source_files(module_obj, "*.cpp")
+
+env.modules_sources += module_obj

--- a/modules/openxr/extensions/SCsub
+++ b/modules/openxr/extensions/SCsub
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_openxr")
+
+module_obj = []
+
+env_openxr.add_source_files(module_obj, "*.cpp")
+
+# These are platform dependent
+if env["platform"] == "android":
+    env_openxr.add_source_files(module_obj, "platform/openxr_android_extension.cpp")
+if env["vulkan"]:
+    env_openxr.add_source_files(module_obj, "platform/openxr_vulkan_extension.cpp")
+if env["opengl3"] and env["platform"] != "macos":
+    env_openxr.add_source_files(module_obj, "platform/openxr_opengl_extension.cpp")
+
+env.modules_sources += module_obj

--- a/modules/openxr/extensions/platform/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_android_extension.cpp
@@ -30,7 +30,7 @@
 
 #include "openxr_android_extension.h"
 
-#include "../openxr_api.h"
+#include "../../openxr_api.h"
 
 #include "java_godot_wrapper.h"
 #include "os_android.h"

--- a/modules/openxr/extensions/platform/openxr_android_extension.h
+++ b/modules/openxr/extensions/platform/openxr_android_extension.h
@@ -31,8 +31,8 @@
 #ifndef OPENXR_ANDROID_EXTENSION_H
 #define OPENXR_ANDROID_EXTENSION_H
 
-#include "../util.h"
-#include "openxr_extension_wrapper.h"
+#include "../../util.h"
+#include "../openxr_extension_wrapper.h"
 
 class OpenXRAndroidExtension : public OpenXRExtensionWrapper {
 public:

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -32,7 +32,7 @@
 
 #ifdef GLES3_ENABLED
 
-#include "../openxr_util.h"
+#include "../../openxr_util.h"
 
 #include "drivers/gles3/effects/copy_effects.h"
 #include "drivers/gles3/storage/texture_storage.h"

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  openxr_vulkan_extension.h                                             */
+/*  openxr_opengl_extension.h                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,31 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_VULKAN_EXTENSION_H
-#define OPENXR_VULKAN_EXTENSION_H
+#ifndef OPENXR_OPENGL_EXTENSION_H
+#define OPENXR_OPENGL_EXTENSION_H
 
-#include "../openxr_api.h"
-#include "../util.h"
-#include "openxr_extension_wrapper.h"
+#ifdef GLES3_ENABLED
+
+#include "../../openxr_api.h"
+#include "../../util.h"
+#include "../openxr_extension_wrapper.h"
 
 #include "core/templates/vector.h"
 
 // Always include this as late as possible.
-#include "../openxr_platform_inc.h"
+#include "../../openxr_platform_inc.h"
 
-class OpenXRVulkanExtension : public OpenXRGraphicsExtensionWrapper, VulkanHooks {
+class OpenXROpenGLExtension : public OpenXRGraphicsExtensionWrapper {
 public:
-	OpenXRVulkanExtension();
-	virtual ~OpenXRVulkanExtension() override;
-
 	virtual HashMap<String, bool *> get_requested_extensions() override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
 
-	virtual bool create_vulkan_instance(const VkInstanceCreateInfo *p_vulkan_create_info, VkInstance *r_instance) override;
-	virtual bool get_physical_device(VkPhysicalDevice *r_device) override;
-	virtual bool create_vulkan_device(const VkDeviceCreateInfo *p_device_create_info, VkDevice *r_device) override;
+	virtual void on_pre_draw_viewport(RID p_render_target) override;
+	virtual void on_post_draw_viewport(RID p_render_target) override;
 
 	virtual void get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual void get_usable_depth_formats(Vector<int64_t> &p_usable_swap_chains) override;
@@ -63,27 +61,34 @@ public:
 	virtual RID get_texture(void *p_swapchain_graphics_data, int p_image_index) override;
 
 private:
-	static OpenXRVulkanExtension *singleton;
-	static XrGraphicsBindingVulkanKHR graphics_binding_vulkan; // declaring this as static so we don't need to know its size and we only need it once when creating our session
+	static OpenXROpenGLExtension *singleton;
+
+#ifdef WIN32
+	static XrGraphicsBindingOpenGLWin32KHR graphics_binding_gl;
+#elif defined(ANDROID_ENABLED)
+	static XrGraphicsBindingOpenGLESAndroidKHR graphics_binding_gl;
+#else // Linux/X11
+	static XrGraphicsBindingOpenGLXlibKHR graphics_binding_gl;
+#endif
 
 	struct SwapchainGraphicsData {
 		bool is_multiview;
 		Vector<RID> texture_rids;
 	};
 
+	bool srgb_ext_is_available = true;
+	bool hw_linear_to_srgb_is_enabled = false;
+
 	bool check_graphics_api_support(XrVersion p_desired_version);
 
-	VkInstance vulkan_instance = nullptr;
-	VkPhysicalDevice vulkan_physical_device = nullptr;
-	VkDevice vulkan_device = nullptr;
-	uint32_t vulkan_queue_family_index = 0;
-	uint32_t vulkan_queue_index = 0;
-
-	EXT_PROTO_XRRESULT_FUNC3(xrGetVulkanGraphicsRequirements2KHR, (XrInstance), p_instance, (XrSystemId), p_system_id, (XrGraphicsRequirementsVulkanKHR *), p_graphics_requirements)
-	EXT_PROTO_XRRESULT_FUNC4(xrCreateVulkanInstanceKHR, (XrInstance), p_instance, (const XrVulkanInstanceCreateInfoKHR *), p_create_info, (VkInstance *), r_vulkan_instance, (VkResult *), r_vulkan_result)
-	EXT_PROTO_XRRESULT_FUNC3(xrGetVulkanGraphicsDevice2KHR, (XrInstance), p_instance, (const XrVulkanGraphicsDeviceGetInfoKHR *), p_get_info, (VkPhysicalDevice *), r_vulkan_physical_device)
-	EXT_PROTO_XRRESULT_FUNC4(xrCreateVulkanDeviceKHR, (XrInstance), p_instance, (const XrVulkanDeviceCreateInfoKHR *), p_create_info, (VkDevice *), r_device, (VkResult *), r_result)
+#ifdef ANDROID_ENABLED
+	EXT_PROTO_XRRESULT_FUNC3(xrGetOpenGLESGraphicsRequirementsKHR, (XrInstance), p_instance, (XrSystemId), p_system_id, (XrGraphicsRequirementsOpenGLESKHR *), p_graphics_requirements)
+#else
+	EXT_PROTO_XRRESULT_FUNC3(xrGetOpenGLGraphicsRequirementsKHR, (XrInstance), p_instance, (XrSystemId), p_system_id, (XrGraphicsRequirementsOpenGLKHR *), p_graphics_requirements)
+#endif
 	EXT_PROTO_XRRESULT_FUNC4(xrEnumerateSwapchainImages, (XrSwapchain), p_swapchain, (uint32_t), p_image_capacity_input, (uint32_t *), p_image_count_output, (XrSwapchainImageBaseHeader *), p_images)
 };
 
-#endif // OPENXR_VULKAN_EXTENSION_H
+#endif // GLES3_ENABLED
+
+#endif // OPENXR_OPENGL_EXTENSION_H

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -30,7 +30,7 @@
 
 #include "openxr_vulkan_extension.h"
 
-#include "../openxr_util.h"
+#include "../../openxr_util.h"
 
 #include "core/string/print_string.h"
 #include "servers/rendering/renderer_rd/effects/copy_effects.h"

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -46,11 +46,11 @@
 #include "openxr_platform_inc.h"
 
 #ifdef VULKAN_ENABLED
-#include "extensions/openxr_vulkan_extension.h"
+#include "extensions/platform/openxr_vulkan_extension.h"
 #endif
 
 #if defined(GLES3_ENABLED) && !defined(MACOS_ENABLED)
-#include "extensions/openxr_opengl_extension.h"
+#include "extensions/platform/openxr_opengl_extension.h"
 #endif
 
 #include "extensions/openxr_composition_layer_depth_extension.h"

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -61,7 +61,7 @@
 #endif
 
 #ifdef ANDROID_ENABLED
-#include "extensions/openxr_android_extension.h"
+#include "extensions/platform/openxr_android_extension.h"
 #endif
 
 #include "core/config/project_settings.h"

--- a/modules/openxr/scene/SCsub
+++ b/modules/openxr/scene/SCsub
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_openxr")
+
+module_obj = []
+
+env_openxr.add_source_files(module_obj, "*.cpp")
+
+env.modules_sources += module_obj


### PR DESCRIPTION
This PR makes a few changes to the scons setup in the OpenXR modules:
- extensions that are included depending on platform/switches have been moved into the `extensions/platform`
- all `*.cpp` files in the `extensions` folder are now compiled and linked, they no longer need to be individually added
- `action_map`, `extensions` and `scene` now have their own `SCsub` file
