### PR TITLE
Fix CSGShape3D's `_mesh_changed` to be thread safe

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -934,7 +934,8 @@ CSGBrush *CSGMesh3D::_build_brush() {
 
 void CSGMesh3D::_mesh_changed() {
 	_make_dirty();
-	update_gizmos();
+
+	callable_mp((Node3D *)this, &Node3D::update_gizmos).call_deferred();
 }
 
 void CSGMesh3D::set_material(const Ref<Material> &p_material) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86381

If in a node safe thread, just call `update_gizmos` dierctly, otherwise use `call_deferred`

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
