### PR TITLE
Expose some AudioStreamPlayback methods (namely `mix_audio()`).

### DIFF
--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -113,6 +113,13 @@
 				[b]Note:[/b] Can return fewer frames than requested, make sure to use the size of the return value.
 			</description>
 		</method>
+		<method name="seek">
+			<return type="void" />
+			<param index="0" name="time" type="float" default="0.0" />
+			<description>
+				Seeks the stream at the given [param time], in seconds.
+			</description>
+		</method>
 		<method name="set_sample_playback" experimental="">
 			<return type="void" />
 			<param index="0" name="playback_sample" type="AudioSamplePlayback" />

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -79,10 +79,38 @@
 				Overridable method. Called whenever the audio stream is mixed if the playback is active and [method AudioServer.set_enable_tagging_used_audio_streams] has been set to [code]true[/code]. Editor plugins may use this method to "tag" the current position along the audio stream and display it in a preview.
 			</description>
 		</method>
+		<method name="get_loop_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of times the stream has looped.
+			</description>
+		</method>
+		<method name="get_playback_position" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current position in the stream, in seconds.
+			</description>
+		</method>
 		<method name="get_sample_playback" qualifiers="const" experimental="">
 			<return type="AudioSamplePlayback" />
 			<description>
 				Returns the [AudioSamplePlayback] associated with this [AudioStreamPlayback] for playing back the audio sample of this stream.
+			</description>
+		</method>
+		<method name="is_playing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the stream is playing.
+			</description>
+		</method>
+		<method name="mix_audio">
+			<return type="PackedVector2Array" />
+			<param index="0" name="rate_scale" type="float" />
+			<param index="1" name="frames" type="int" />
+			<description>
+				Mixes up to [param frames] of audio from the stream from the current position, at a rate of [param rate_scale], advancing the stream.
+				Returns a [PackedVector2Array] where each element holds the left and right channel volume levels of each frame.
+				[b]Note:[/b] Can return fewer frames than requested, make sure to use the size of the return value.
 			</description>
 		</method>
 		<method name="set_sample_playback" experimental="">
@@ -90,6 +118,19 @@
 			<param index="0" name="playback_sample" type="AudioSamplePlayback" />
 			<description>
 				Associates [AudioSamplePlayback] to this [AudioStreamPlayback] for playing back the audio sample of this stream.
+			</description>
+		</method>
+		<method name="start">
+			<return type="void" />
+			<param index="0" name="from_pos" type="float" default="0.0" />
+			<description>
+				Starts the stream from the given [param from_pos], in seconds.
+			</description>
+		</method>
+		<method name="stop">
+			<return type="void" />
+			<description>
+				Stops the stream.
 			</description>
 		</method>
 	</methods>

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -76,29 +76,40 @@ int AudioStreamPlayback::mix(AudioFrame *p_buffer, float p_rate_scale, int p_fra
 	return ret;
 }
 
-PackedVector2Array AudioStreamPlayback::mix_audio(float p_rate_scale, int p_frames) {
-	Vector<AudioFrame> frames_in;
-	frames_in.resize(p_frames);
-
-	int frames = mix(frames_in.ptrw(), p_rate_scale, p_frames);
+PackedVector2Array AudioStreamPlayback::_mix_audio_bind(float p_rate_scale, int p_frames) {
+	Vector<AudioFrame> frames = mix_audio(p_rate_scale, p_frames);
 
 	PackedVector2Array res;
-	res.resize(frames);
+	res.resize(frames.size());
 
 	Vector2 *res_ptrw = res.ptrw();
-	for (int i = 0; i < frames; i++) {
-		res_ptrw[i] = Vector2(frames_in[i].left, frames_in[i].right);
+	for (int i = 0; i < frames.size(); i++) {
+		res_ptrw[i] = Vector2(frames[i].left, frames[i].right);
 	}
 
 	return res;
 }
 
+Vector<AudioFrame> AudioStreamPlayback::mix_audio(float p_rate_scale, int p_frames) {
+	Vector<AudioFrame> res;
+	res.resize(p_frames);
+
+	int frames = mix(res.ptrw(), p_rate_scale, p_frames);
+	res.resize(frames);
+
+	return res;
+}
+
 void AudioStreamPlayback::start_playback(double p_from_pos) {
-	start();
+	start(p_from_pos);
 }
 
 void AudioStreamPlayback::stop_playback() {
 	stop();
+}
+
+void AudioStreamPlayback::seek_playback(double p_time) {
+	seek(p_time);
 }
 
 void AudioStreamPlayback::tag_used_streams() {
@@ -133,8 +144,9 @@ void AudioStreamPlayback::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_sample_playback", "playback_sample"), &AudioStreamPlayback::set_sample_playback);
 	ClassDB::bind_method(D_METHOD("get_sample_playback"), &AudioStreamPlayback::get_sample_playback);
-	ClassDB::bind_method(D_METHOD("mix_audio", "rate_scale", "frames"), &AudioStreamPlayback::mix_audio);
+	ClassDB::bind_method(D_METHOD("mix_audio", "rate_scale", "frames"), &AudioStreamPlayback::_mix_audio_bind);
 	ClassDB::bind_method(D_METHOD("start", "from_pos"), &AudioStreamPlayback::start_playback, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("seek", "time"), &AudioStreamPlayback::seek_playback, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayback::stop_playback);
 	ClassDB::bind_method(D_METHOD("get_loop_count"), &AudioStreamPlayback::get_loop_count);
 	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayback::get_playback_position);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -76,6 +76,31 @@ int AudioStreamPlayback::mix(AudioFrame *p_buffer, float p_rate_scale, int p_fra
 	return ret;
 }
 
+PackedVector2Array AudioStreamPlayback::mix_audio(float p_rate_scale, int p_frames) {
+	Vector<AudioFrame> frames_in;
+	frames_in.resize(p_frames);
+
+	int frames = mix(frames_in.ptrw(), p_rate_scale, p_frames);
+
+	PackedVector2Array res;
+	res.resize(frames);
+
+	Vector2 *res_ptrw = res.ptrw();
+	for (int i = 0; i < frames; i++) {
+		res_ptrw[i] = Vector2(frames_in[i].left, frames_in[i].right);
+	}
+
+	return res;
+}
+
+void AudioStreamPlayback::start_playback(double p_from_pos) {
+	start();
+}
+
+void AudioStreamPlayback::stop_playback() {
+	stop();
+}
+
 void AudioStreamPlayback::tag_used_streams() {
 	GDVIRTUAL_CALL(_tag_used_streams);
 }
@@ -108,6 +133,12 @@ void AudioStreamPlayback::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_sample_playback", "playback_sample"), &AudioStreamPlayback::set_sample_playback);
 	ClassDB::bind_method(D_METHOD("get_sample_playback"), &AudioStreamPlayback::get_sample_playback);
+	ClassDB::bind_method(D_METHOD("mix_audio", "rate_scale", "frames"), &AudioStreamPlayback::mix_audio);
+	ClassDB::bind_method(D_METHOD("start", "from_pos"), &AudioStreamPlayback::start_playback, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayback::stop_playback);
+	ClassDB::bind_method(D_METHOD("get_loop_count"), &AudioStreamPlayback::get_loop_count);
+	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayback::get_playback_position);
+	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayback::is_playing);
 }
 
 AudioStreamPlayback::AudioStreamPlayback() {}

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -116,6 +116,10 @@ public:
 
 	AudioStreamPlayback();
 	~AudioStreamPlayback();
+
+	PackedVector2Array mix_audio(float p_rate_scale, int p_frames);
+	void start_playback(double p_from_pos = 0.0);
+	void stop_playback();
 };
 
 class AudioStreamPlaybackResampled : public AudioStreamPlayback {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -81,6 +81,7 @@ class AudioStreamPlayback : public RefCounted {
 
 protected:
 	static void _bind_methods();
+	PackedVector2Array _mix_audio_bind(float p_rate_scale, int p_frames);
 	GDVIRTUAL1(_start, double)
 	GDVIRTUAL0(_stop)
 	GDVIRTUAL0RC(bool, _is_playing)
@@ -117,9 +118,10 @@ public:
 	AudioStreamPlayback();
 	~AudioStreamPlayback();
 
-	PackedVector2Array mix_audio(float p_rate_scale, int p_frames);
+	Vector<AudioFrame> mix_audio(float p_rate_scale, int p_frames);
 	void start_playback(double p_from_pos = 0.0);
 	void stop_playback();
+	void seek_playback(double p_time);
 };
 
 class AudioStreamPlaybackResampled : public AudioStreamPlayback {


### PR DESCRIPTION
Pretty much the same as: 
 - https://github.com/godotengine/godot/pull/75065/
 - https://github.com/godotengine/godot/pull/81324

The former is archived, and the latter seems to go against the maintainers' wishes that `start`, `stop`, and `mix` should not be exposed outward. I added some shim functions to get around this, not sure if that's fine. There are several proposals with different use cases for this:
 - https://github.com/godotengine/godot-proposals/issues/127
 - https://github.com/godotengine/godot-proposals/issues/6466
 - https://github.com/godotengine/godot-proposals/issues/7601
 -  https://github.com/godotengine/godot-proposals/issues/8609

My usecase is embedding [steam-audio](https://valvesoftware.github.io/steam-audio/) as a GDExtension, which requires me to have these functions available as bound methods.