### PR TITLE
Improve reliability of folding in node and folder tree

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1524,9 +1524,18 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
 			emit_signal(SNAME("files_moved"), file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
 		}
-		for (int i = 0; i < folder_changed_paths.size(); ++i) {
-			p_folder_renames[folder_changed_paths[i]] = folder_changed_paths[i].replace_first(old_path, new_path);
-			emit_signal(SNAME("folder_moved"), folder_changed_paths[i], p_folder_renames[folder_changed_paths[i]].substr(0, p_folder_renames[folder_changed_paths[i]].length() - 1));
+
+		for (const String &folder : folder_changed_paths) {
+			const String new_folder = folder.replace_first(old_path, new_path);
+			p_folder_renames[folder] = new_folder;
+
+			// Update item path to preserve uncollapsed state.
+			TreeItem **old_folder_item = folder_map.getptr(folder);
+			if (old_folder_item) {
+				(*old_folder_item)->set_metadata(0, new_folder);
+			}
+
+			emit_signal(SNAME("folder_moved"), folder, new_folder.trim_suffix("/"));
 		}
 	} else {
 		EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + "\n");

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2900,6 +2900,7 @@ Node *Node::duplicate_from_editor(HashMap<const Node *, Node *> &r_duplimap, con
 	// if the emitter node comes later in tree order than the receiver
 	_duplicate_signals(this, dupe);
 
+	dupe->set_display_folded(is_displayed_folded());
 	return dupe;
 }
 


### PR DESCRIPTION
Ensures that when duplicating nodes or renaming directories, the folding is preserved (previously it wasn't).