### PR TITLE
Improve Path2D editing

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -80,6 +80,7 @@ class Path2DEditor : public HBoxContainer {
 	enum Action {
 		ACTION_NONE,
 		ACTION_MOVING_POINT,
+		ACTION_MOVING_NEW_POINT,
 		ACTION_MOVING_IN,
 		ACTION_MOVING_OUT,
 	};


### PR DESCRIPTION
When adding or splitting a point in Path2D, it was creating 2 undo actions: for creating the point and moving it. This PR merges it into one undo action.

https://github.com/godotengine/godot/assets/2223172/4282d88c-173b-4166-9b62-4275d9f4873d

