### PR TITLE
[D3D12] Dynamically load Agility SDK.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1484,6 +1484,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST("rendering/rendering_device/d3d12/max_misc_descriptors_per_frame", 512);
 	custom_prop_info["rendering/rendering_device/d3d12/max_misc_descriptors_per_frame"] = PropertyInfo(Variant::INT, "rendering/rendering_device/d3d12/max_misc_descriptors_per_frame", PROPERTY_HINT_RANGE, "32,4096");
 
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/rendering_device/d3d12/agility_sdk_version"), 610);
+
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap"), 1);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM, "Disable,Enable,Mirror"), 0);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2616,6 +2616,9 @@
 		<member name="rendering/renderer/rendering_method.web" type="String" setter="" getter="" default="&quot;gl_compatibility&quot;">
 			Override for [member rendering/renderer/rendering_method] on web.
 		</member>
+		<member name="rendering/rendering_device/d3d12/agility_sdk_version" type="int" setter="" getter="" default="610">
+			Version code of the Direct3D 12 Agility SDK to use ([code]D3D12SDKVersion[/code]).
+		</member>
 		<member name="rendering/rendering_device/d3d12/max_misc_descriptors_per_frame" type="int" setter="" getter="" default="512">
 			The number of entries in the miscellaneous descriptors heap the Direct3D 12 rendering driver uses each frame, used for various operations like clearing a texture.
 			Depending on the complexity of scenes, this value may be lowered or may need to be raised.

--- a/drivers/d3d12/d3d12_context.h
+++ b/drivers/d3d12/d3d12_context.h
@@ -110,6 +110,7 @@ private:
 		IMAGE_COUNT = FRAME_LAG + 1,
 	};
 
+	ComPtr<ID3D12DeviceFactory> device_factory;
 	ComPtr<IDXGIFactory2> dxgi_factory;
 	ComPtr<IDXGIAdapter> gpu;
 	DeviceLimits gpu_limits = {};
@@ -181,6 +182,7 @@ private:
 			void *p_context);
 
 	Error _initialize_debug_layers();
+	void _init_device_factory();
 
 	Error _select_adapter(int &r_index);
 	void _dump_adapter_info(int p_index);


### PR DESCRIPTION
Instead of relaying on exported symbols and D3D12 loader, load SDK directly via device factory. This should allow using user specified Agility SDK version instead of hard-coded one, and fallback to the system D3D driver if it's not found (so we can make official builds with Agility support, but avoid shipping proprietary DLL that require uses to accept EULA).

Adds `rendering/rendering_device/d3d12/agility_sdk_version` property to control used SDK version.

Based on Mesa Agility loading code - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/18305/diffs#b974333948460f1be995f150bf4db414b591b1b1

- *Production edit: This partially addresses https://github.com/godotengine/godot/issues/86490.*