### PR TITLE
Fix `OS.get_system_font_path` and `OS.get_system_font_path_for_text` to return correct slashes

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1183,7 +1183,7 @@ Vector<String> OS_Windows::get_system_font_path_for_text(const String &p_font_na
 		if (FAILED(hr)) {
 			continue;
 		}
-		String fpath = String::utf16((const char16_t *)&file_path[0]);
+		String fpath = String::utf16((const char16_t *)&file_path[0]).replace("\\", "/");
 
 		WIN32_FIND_DATAW d;
 		HANDLE fnd = FindFirstFileW((LPCWSTR)&file_path[0], &d);
@@ -1262,7 +1262,7 @@ String OS_Windows::get_system_font_path(const String &p_font_name, int p_weight,
 		if (FAILED(hr)) {
 			continue;
 		}
-		String fpath = String::utf16((const char16_t *)&file_path[0]);
+		String fpath = String::utf16((const char16_t *)&file_path[0]).replace("\\", "/");
 
 		WIN32_FIND_DATAW d;
 		HANDLE fnd = FindFirstFileW((LPCWSTR)&file_path[0], &d);


### PR DESCRIPTION
Fix #86544 

The bug also occurs in `OS.get_system_font_path_for_text` so I've fixed that as well. 

Snippet used:
```gdscript
func _ready() -> void:
	print(OS.get_system_font_path("sans-serif"))
	print(OS.get_system_font_path("serif"))
	print(OS.get_system_font_path("monospace"))
	print(OS.get_system_font_path("cursive"))
	print(OS.get_system_font_path("fantasy"))
```

Print result:
![image](https://github.com/godotengine/godot/assets/13846022/9a2987c0-889d-462e-ac6d-eeeb679ce8bc)

