### PR TITLE
Fix LightmapperRD division warning in MSVC

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -357,7 +357,7 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 
 	for (int m_i = 0; m_i < mesh_instances.size(); m_i++) {
 		if (p_step_function) {
-			float p = float(m_i + 1) / mesh_instances.size() * 0.1;
+			float p = float(m_i + 1) / MAX(1, mesh_instances.size()) * 0.1;
 			p_step_function(0.3 + p, vformat(RTR("Plotting mesh into acceleration structure %d/%d"), m_i + 1, mesh_instances.size()), p_bake_userdata, false);
 		}
 


### PR DESCRIPTION
This one (MSVC 14.3):
```
modules\lightmapper_rd\lightmapper_rd.cpp(360) : error C2220: the following warning is treated as an error
modules\lightmapper_rd\lightmapper_rd.cpp(360) : warning C4723: potential divide by 0
```

The value can't be zero with the expected values of the variables involved, though.