### PR TITLE
Add warning for using concave shape on CharacterBody3D

### DIFF
--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -35,6 +35,7 @@
 #include "scene/resources/concave_polygon_shape_3d.h"
 #include "scene/resources/convex_polygon_shape_3d.h"
 #include "scene/resources/world_boundary_shape_3d.h"
+#include "vehicle_body_3d.h"
 
 void CollisionShape3D::make_convex_from_siblings() {
 	Node *p = get_parent();
@@ -130,10 +131,21 @@ PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 	}
 
 	if (shape.is_valid() && Object::cast_to<RigidBody3D>(col_object)) {
+		String body_type = "RigidBody3D";
+		if (Object::cast_to<VehicleBody3D>(col_object)) {
+			body_type = "VehicleBody3D";
+		}
+
 		if (Object::cast_to<ConcavePolygonShape3D>(*shape)) {
-			warnings.push_back(RTR("ConcavePolygonShape3D doesn't support RigidBody3D in another mode than static."));
+			warnings.push_back(vformat(RTR("When used for collision, ConcavePolygonShape3D is intended to work with static CollisionObject3D nodes like StaticBody3D.\nIt will likely not behave well for %ss (except when frozen and freeze_mode set to FREEZE_MODE_STATIC)."), body_type));
 		} else if (Object::cast_to<WorldBoundaryShape3D>(*shape)) {
 			warnings.push_back(RTR("WorldBoundaryShape3D doesn't support RigidBody3D in another mode than static."));
+		}
+	}
+
+	if (shape.is_valid() && Object::cast_to<CharacterBody3D>(col_object)) {
+		if (Object::cast_to<ConcavePolygonShape3D>(*shape)) {
+			warnings.push_back(RTR("When used for collision, ConcavePolygonShape3D is intended to work with static CollisionObject3D nodes like StaticBody3D.\nIt will likely not behave well for CharacterBody3Ds."));
 		}
 	}
 


### PR DESCRIPTION
As per #86574 

Tested a simple scene to confirm that ConcaveShapes do not work for collisions on CharacterBody3D (same as RigidBody3D).

Added the following node config warning:
![image](https://github.com/godotengine/godot/assets/23486102/7688733d-c514-4ef8-a718-39b3dd4014cc)

I didn't update the language documentation as I assume that's handled separately

*Bugsquad edit:*
- Fixes #86574 