### PR TITLE
Tiny fix for lightmapper DDA

### DIFF
--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -105,7 +105,7 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 				EditorNode::get_singleton()->show_warning(TTR("Lightmap data is not local to the scene."));
 			} break;
 			case LightmapGI::BAKE_ERROR_TEXTURE_SIZE_TOO_SMALL: {
-				EditorNode::get_singleton()->show_warning(TTR("Maximum texture size is too small for the lightmap images."));
+				EditorNode::get_singleton()->show_warning(TTR("Maximum texture size is too small for the lightmap images.\nWhile this can be fixed by increasing the maximum texture size, it is recommended you split the scene into more objects instead."));
 			} break;
 			default: {
 			} break;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -264,7 +264,16 @@ uint trace_ray(vec3 p_from, vec3 p_to, bool p_any_hit, out float r_distance, out
 			break;
 		}
 
-		bvec3 mask = lessThanEqual(side.xyz, min(side.yzx, side.zxy));
+		// There should be only one axis updated at a time for DDA to work properly.
+		bvec3 mask = bvec3(true, false, false);
+		float m = side.x;
+		if (side.y < m) {
+			m = side.y;
+			mask = bvec3(false, true, false);
+		}
+		if (side.z < m) {
+			mask = bvec3(false, false, true);
+		}
 		side += vec3(mask) * delta;
 		icell += ivec3(vec3(mask)) * step;
 		iters++;


### PR DESCRIPTION
- Ensures only one axis advances at a time
- This fixes extremely corner cases where the DDA may skip over geometry
- As a bonus, clarify to the user that splitting into more meshes may improve the texture size limit.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
