### PR TITLE
fix GDScript style guide violation in ConfigFile documentation

### DIFF
--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -51,7 +51,7 @@
 		var err = config.load("user://scores.cfg")
 
 		# If the file didn't load, ignore it.
-		if err != OK:
+		if err == not OK:
 		    return
 
 		# Iterate over all sections.


### PR DESCRIPTION
the third script example in the
[documentation for ConfigFile](https://docs.godotengine.org/en/4.2/classes/class_configfile.html) had a spot that violates the
[GDScript style guide](https://docs.godotengine.org/en/4.2/tutorials/scripting/gdscript/gdscript_styleguide.html) , section
[Boolean Operators](https://docs.godotengine.org/en/4.2/tutorials/scripting/gdscript/gdscript_styleguide.html#boolean-operators) :

> Prefer the plain English versions of boolean operators, as they are
> the most accessible:
> - use ``not`` instead of ``!``

```GDScript
if err != OK:
	return
```

after this commit, this spot no longer violates the GDScript style guide:

```GDScript
if err == not OK:
	return
```

— sosasees <https://github.com/sosasees>

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
