### PR TITLE
Fix typo in GD0103 error link

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -146,7 +146,7 @@ namespace Godot.SourceGenerators
                     DiagnosticSeverity.Error,
                     isEnabledByDefault: true,
                     description,
-                    helpLinkUri: string.Format(_helpLinkFormat, "GD1003")),
+                    helpLinkUri: string.Format(_helpLinkFormat, "GD0103")),
                 location,
                 location?.SourceTree?.FilePath));
         }


### PR DESCRIPTION
Fixes a typo in the generated link.