### PR TITLE
 Update compiler flags to make dx12 compatible with llvm-mingw

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -788,7 +788,10 @@ if selected_platform in platform_list:
             common_warnings += ["-Wno-ordered-compare-function-pointers"]
 
         if env["warnings"] == "extra":
-            env.Append(CCFLAGS=["-Wall", "-Wextra", "-Wwrite-strings", "-Wno-unused-parameter"] + common_warnings)
+            env.Append(
+                CCFLAGS=["-Wall", "-Wextra", "-Wwrite-strings", "-Wno-unused-parameter", "-Wno-unknown-pragmas"]
+                + common_warnings
+            )
             env.Append(CXXFLAGS=["-Wctor-dtor-privacy", "-Wnon-virtual-dtor"])
             if methods.using_gcc(env):
                 env.Append(

--- a/drivers/d3d12/d3d12_context.cpp
+++ b/drivers/d3d12/d3d12_context.cpp
@@ -830,7 +830,7 @@ void D3D12Context::_wait_for_idle_queue(ID3D12CommandQueue *p_queue) {
 #endif
 }
 
-void D3D12Context::flush(bool p_flush_setup, bool p_flush_pending) {
+void D3D12Context::flush(bool p_flush_setup, bool p_flush_pending, bool p_sync) {
 	if (p_flush_setup && command_list_queue[0]) {
 		md.queue->ExecuteCommandLists(1, command_list_queue.ptr());
 		command_list_queue.write[0] = nullptr;
@@ -841,7 +841,7 @@ void D3D12Context::flush(bool p_flush_setup, bool p_flush_pending) {
 		command_list_count = 1;
 	}
 
-	if (p_flush_setup || p_flush_pending) {
+	if ((p_flush_setup || p_flush_pending) && p_sync) {
 		_wait_for_idle_queue(md.queue.Get());
 	}
 }

--- a/platform/windows/vulkan_context_win.h
+++ b/platform/windows/vulkan_context_win.h
@@ -39,7 +39,7 @@
 #include <windows.h>
 
 class VulkanContextWindows : public VulkanContext {
-	virtual const char *_get_platform_surface_extension() const;
+	virtual const char *_get_platform_surface_extension() const override final;
 
 public:
 	Error window_create(DisplayServer::WindowID p_window_id, DisplayServer::VSyncMode p_vsync_mode, HWND p_window, HINSTANCE p_instance, int p_width, int p_height);


### PR DESCRIPTION
Fixes llvm-build error.

<details>
  <summary>Click me</summary>
  
```
x86_64-w64-mingw32-g++ -o platform\windows\key_mapping_windows.windows.editor.x86_64.o -c -std=gnu++17 -fno-exceptions -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -mwindows -O2 -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow -Wno-misleading-indentation -Wno-return-type -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wattribute-alias=2 -Wlogical-op -Werror -isystem thirdparty\glad -DTOOLS_ENABLED -DDEBUG_ENABLED -DEIGEN_MPL2_ONLY -DNDEBUG -DNO_EDITOR_SPLASH -DWINDOWS_SUBSYSTEM_CONSOLE -DWINDOWS_ENABLED -DWASAPI_ENABLED -DWINMIDI_ENABLED -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DVULKAN_ENABLED -DD3D12_ENABLED -DGLES3_ENABLED -DMINGW_ENABLED -DMINGW_HAS_SECURE_API=1 -DMINIZIP_ENABLED -DBROTLI_ENABLED -DCLIPPER2_ENABLED -DZSTD_STATIC_LINKING_ONLY -DRD_ENABLED -DUSE_VOLK -DVK_USE_PLATFORM_WIN32_KHR -DRD_ENABLED -DGLAD_ENABLED -DEGL_ENABLED -DSQLITE_ENABLE_RBU=1 -DSQLITE_USE_URI=1 -DSQLITE_ENABLE_JSON1 -Ithirdparty\freetype\include -Ithirdparty\libpng -Ithirdparty\directx_headers\include\directx -Ithirdparty\volk -Ithirdparty\vulkan -Ithirdparty\vulkan\include -Ithirdparty\zstd -Ithirdparty\zlib -Ithirdparty\clipper2\include -Ithirdparty\brotli\include -Ithirdparty\angle\include -Iplatform\windows -I. -Ithirdparty\d3d12ma platform\windows\key_mapping_windows.cpp
scons: *** [platform\windows\godot_windows.windows.editor.x86_64.o] Error 1
=====
In file included from thirdparty\directx_headers\include\directx/d3dx12.h:11,
                 from ./drivers/d3d12/rendering_device_driver_d3d12.h:47,
                 from ./drivers/d3d12/d3d12_context.h:38,
                 from platform\windows\os_windows.h:56,
                 from platform\windows\godot_windows.cpp:31:
thirdparty\directx_headers\include\directx/d3d12.h:547: error: ignoring '#pragma region App' [-Werror=unknown-pragmas]
  547 | #pragma region App Family
      | 
In file included from thirdparty\directx_headers\include\directx/d3d12.h:26817:
thirdparty\directx_headers\include\directx/d3d12sdklayers.h:209: error: ignoring '#pragma region App' [-Werror=unknown-pragmas]
  209 | #pragma region App Family
      | 
thirdparty\directx_headers\include\directx/d3d12sdklayers.h:4193: error: ignoring '#pragma endregion ' [-Werror=unknown-pragmas]
 4193 | #pragma endregion
      | 
thirdparty\directx_headers\include\directx/d3d12.h:31818: error: ignoring '#pragma endregion ' [-Werror=unknown-pragmas]
31818 | #pragma endregion
      | 
./drivers/d3d12/d3d12_context.h:235:22: error: 'virtual void D3D12Context::flush(bool, bool)' marked 'override', but does not override
  235 |         virtual void flush(bool p_flush_setup = false, bool p_flush_pending = false) override final;
      |                      ^~~~~
cc1plus.exe: all warnings being treated as errors

=====
=====
In file included from thirdparty\directx_headers\include\directx/d3dx12.h:11,
scons: *** [platform\windows\os_windows.windows.editor.x86_64.o] Error 1
                 from ./drivers/d3d12/rendering_device_driver_d3d12.h:47,
                 from ./drivers/d3d12/d3d12_context.h:38,
                 from platform\windows\os_windows.h:56,
                 from platform\windows\os_windows.cpp:31:
thirdparty\directx_headers\include\directx/d3d12.h:547: error: ignoring '#pragma region App' [-Werror=unknown-pragmas]
  547 | #pragma region App Family
      | 
In file included from thirdparty\directx_headers\include\directx/d3d12.h:26817:
thirdparty\directx_headers\include\directx/d3d12sdklayers.h:209: error: ignoring '#pragma region App' [-Werror=unknown-pragmas]
  209 | #pragma region App Family
      | 
thirdparty\directx_headers\include\directx/d3d12sdklayers.h:4193: error: ignoring '#pragma endregion ' [-Werror=unknown-pragmas]
 4193 | #pragma endregion
      | 
thirdparty\directx_headers\include\directx/d3d12.h:31818: error: ignoring '#pragma endregion ' [-Werror=unknown-pragmas]
31818 | #pragma endregion
      | 
./drivers/d3d12/d3d12_context.h:235:22: error: 'virtual void D3D12Context::flush(bool, bool)' marked 'override', but does not override
  235 |         virtual void flush(bool p_flush_setup = false, bool p_flush_pending = false) override final;
      |                      ^~~~~
cc1plus.exe: all warnings being treated as errors

=====
=====
In file included from thirdparty\directx_headers\include\directx/d3dx12.h:11,
                 from ./drivers/d3d12/rendering_device_driver_d3d12.h:47,
                 from ./drivers/d3d12/d3d12_context.h:38,
                 from platform\windows\os_windows.h:56,
                 from platform\windows\joypad_windows.h:34,
                 from platform\windows\display_server_windows.h:35,
                 from platform\windows\display_server_windows.cpp:31:
thirdparty\directx_headers\include\directx/d3d12.h:547: error: ignoring '#pragma region App' [-Werror=unknown-pragmas]
  547 | #pragma region App Family
      | 
In file included from thirdparty\directx_headers\include\directx/d3d12.h:26817:
thirdparty\directx_headers\include\directx/d3d12sdklayers.h:209: error: ignoring '#pragma region App' [-Werror=unknown-pragmas]
  209 | #pragma region App Family
      | 
thirdparty\directx_headers\include\directx/d3d12sdklayers.h:4193: error: ignoring '#pragma endregion ' [-Werror=unknown-pragmas]
 4193 | #pragma endregion
      | 
thirdparty\directx_headers\include\directx/d3d12.h:31818: error: ignoring '#pragma endregion ' [-Werror=unknown-pragmas]
31818 | #pragma endregion
      | 
./drivers/d3d12/d3d12_context.h:235:22: error: 'virtual void D3D12Context::flush(bool, bool)' marked 'override', but does not override
  235 |         virtual void flush(bool p_flush_setup = false, bool p_flush_pending = false) override final;
      |                      ^~~~~
In file included from ./core/templates/cowdata.h:35,
                 from ./core/string/ustring.h:37,
                 from ./core/os/keyboard.h:34,
                 from platform\windows\key_mapping_windows.h:34,
                 from platform\windows\os_windows.h:35:
platform\windows\display_server_windows.cpp: In constructor 'DisplayServerWindows::DisplayServerWindows(const String&, DisplayServer::WindowMode, DisplayServer::VSyncMode, uint32_t, const Vector2i*, const Vector2i&, int, Error&)':
platform\windows\display_server_windows.cpp:4663: error: invalid new-expression of abstract class type 'D3D12Context'
 4663 |                 context_rd = memnew(D3D12Context);
      | 
./core/os/memory.h:94:51: note: in definition of macro 'memnew'
   94 | #define memnew(m_class) _post_initialize(new ("") m_class)
      |                                                   ^~~~~~~
./drivers/d3d12/d3d12_context.h:68:7: note:   because the following virtual functions are pure within 'D3D12Context':
   68 | class D3D12Context : public ApiContextRD {
      |       ^~~~~~~~~~~~
In file included from ./drivers/vulkan/vulkan_context.h:42,
                 from platform\windows\vulkan_context_win.h:36,
                 from platform\windows\os_windows.h:53:
./servers/rendering/renderer_rd/api_context_rd.h:61:22: note:     'virtual void ApiContextRD::flush(bool, bool, bool)'
   61 |         virtual void flush(bool p_flush_setup = false, bool p_flush_pending = false, bool p_sync = true) = 0;
      |                      ^~~~~
cc1plus.exe: all warnings being treated as errors
```
</details>

https://github.com/V-Sekai/godot/actions/runs/7352075692/job/20016489784 (custom fork)