### PR TITLE
Add `cubic_interpolate_in_time_variant()` to Animation

### DIFF
--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -502,6 +502,7 @@ public:
 	static Variant subtract_variant(const Variant &a, const Variant &b);
 	static Variant blend_variant(const Variant &a, const Variant &b, float c);
 	static Variant interpolate_variant(const Variant &a, const Variant &b, float c, bool p_snap_array_element = false);
+	static Variant cubic_interpolate_in_time_variant(const Variant &pre_a, const Variant &a, const Variant &b, const Variant &post_b, float c, real_t p_pre_a_t, real_t p_b_t, real_t p_post_b_t, bool p_snap_array_element = false);
 
 	Animation();
 	~Animation();


### PR DESCRIPTION
Fixes #85066.

However, about the string interpolation, it fallbacks to linear interpolation because cubic interpolation could not be applied neatly.