### PR TITLE
Add the ability to see and unload Resources loaded by ResourceLoader.load_threaded_request()

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -52,6 +52,14 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 	return ::ResourceLoader::load_threaded_request(p_path, p_type_hint, p_use_sub_threads, ResourceFormatLoader::CacheMode(p_cache_mode));
 }
 
+void ResourceLoader::load_threaded_forget(const String &p_path) {
+	return ::ResourceLoader::load_threaded_forget(p_path);
+}
+
+PackedStringArray ResourceLoader::get_requested_paths() {
+	return ::ResourceLoader::get_requested_paths();
+}
+
 ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
 	float progress = 0;
 	::ResourceLoader::ThreadLoadStatus tls = ::ResourceLoader::load_threaded_get_status(p_path, &progress);
@@ -126,6 +134,8 @@ void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode"), &ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE));
 	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &ResourceLoader::load_threaded_get_status, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("load_threaded_get", "path"), &ResourceLoader::load_threaded_get);
+	ClassDB::bind_method(D_METHOD("load_threaded_forget", "path"), &ResourceLoader::load_threaded_forget);
+	ClassDB::bind_method(D_METHOD("get_requested_paths"), &ResourceLoader::get_requested_paths);
 
 	ClassDB::bind_method(D_METHOD("load", "path", "type_hint", "cache_mode"), &ResourceLoader::load, DEFVAL(""), DEFVAL(CACHE_MODE_REUSE));
 	ClassDB::bind_method(D_METHOD("get_recognized_extensions_for_type", "type"), &ResourceLoader::get_recognized_extensions_for_type);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -73,6 +73,8 @@ public:
 	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = Array());
 	Ref<Resource> load_threaded_get(const String &p_path);
+	void load_threaded_forget(const String &p_path);
+	PackedStringArray get_requested_paths();
 
 	Ref<Resource> load(const String &p_path, const String &p_type_hint = "", CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	Vector<String> get_recognized_extensions_for_type(const String &p_type);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -409,6 +409,31 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 	}
 }
 
+void ResourceLoader::load_threaded_forget(const String &p_path) {
+	MutexLock lock(thread_load_mutex);
+
+	if (user_load_tokens.has(p_path)) {
+		String local_path = user_load_tokens[p_path]->local_path;
+		if (thread_load_tasks.has(local_path) && thread_load_tasks[local_path].status == THREAD_LOAD_LOADED) {
+			memdelete(user_load_tokens[p_path]);
+		}
+	}
+}
+
+PackedStringArray ResourceLoader::get_requested_paths() {
+	MutexLock lock(thread_load_mutex);
+
+	PackedStringArray requested_paths;
+	for (KeyValue<String, ResourceLoader::LoadToken *> &kvp : user_load_tokens) {
+		String local_path = kvp.value->local_path;
+		if (thread_load_tasks.has(local_path) && thread_load_tasks[local_path].status == THREAD_LOAD_LOADED) {
+			requested_paths.push_back(kvp.key);
+		}
+	}
+
+	return requested_paths;
+}
+
 Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hint, ResourceFormatLoader::CacheMode p_cache_mode, Error *r_error) {
 	if (r_error) {
 		*r_error = OK;

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -194,6 +194,8 @@ public:
 	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE);
 	static ThreadLoadStatus load_threaded_get_status(const String &p_path, float *r_progress = nullptr);
 	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
+	static void load_threaded_forget(const String &p_path);
+	static PackedStringArray get_requested_paths();
 
 	static bool is_within_load() { return load_nesting > 0; };
 

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -51,6 +51,12 @@
 				Returns the list of recognized extensions for a resource type.
 			</description>
 		</method>
+		<method name="get_requested_paths">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a list of the paths of all currently cached resources loaded by [method load_threaded_request].
+			</description>
+		</method>
 		<method name="get_resource_uid">
 			<return type="int" />
 			<param index="0" name="path" type="String" />
@@ -79,6 +85,13 @@
 				Returns an empty resource if no [ResourceFormatLoader] could handle the file.
 				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
+			</description>
+		</method>
+		<method name="load_threaded_forget">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Unloads the resource previously loaded by [method load_threaded_request].
 			</description>
 		</method>
 		<method name="load_threaded_get">


### PR DESCRIPTION
In response to my own needs and inspired by [this proposal](https://github.com/godotengine/godot-proposals/issues/7866), I've added 2 new methods to ResourceLoader:
- ResourceLoader.load_threaded_cancel() is the direct counterpart to ResourceLoader.load_threaded_request()
- ResourceLoader.get_requested_paths() returns an Array listing all currently requested Resources

Without reiterating the aforementioned thread, I believe those are core features needed to properly manage background loading of Resources in many different contexts. This will let users track and cancel Resources they haven't ended up needing and will work out of the box in existing projects.

Looking forward to your feedback and criticism.