### PR TITLE
Add some options to Project Settings to silence warnings in AnimationMixer caching

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1416,6 +1416,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on.editor", false);
 
+	GLOBAL_DEF("animation/warnings/check_invalid_track_paths", true);
+	GLOBAL_DEF("animation/warnings/check_angle_interpolation_type_conflicting", true);
+
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres"), "res://default_bus_layout.tres");
 	GLOBAL_DEF_RST("audio/general/text_to_speech", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/2d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -238,6 +238,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="animation/warnings/check_angle_interpolation_type_conflicting" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [AnimationMixer] prints the warning of interpolation being forced to choose the shortest rotation path due to multiple angle interpolation types being mixed in the [AnimationMixer] cache.
+		</member>
+		<member name="animation/warnings/check_invalid_track_paths" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [AnimationMixer] prints the warning of no matching object of the track path in the scene.
+		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>


### PR DESCRIPTION
- Closes #85316

This PR is a salvaged version of #69480 with corrected error handling for finding path as pointed out in #85368. Also, as discussed several times in the past, invalid paths will be changed to a warning instead of an error since it is not a critical.

However, since cases where animations do not play due to path mismatches may occur to a certain extent in beginners, so the default is true; There are cases where the destination of add_child scenes is wrong, the name of the Skeleton is changed due to the use of retargeting and etc. It means, flag have been inverted from the original PR (#69480).

And finally, I added a statement in the warning that it is possible to turn off that warning in project settings.

- Supersedes/closes #69480
- Supersedes/closes #85368
- Fixes #83418 (maybe)