### PR TITLE
Fixes a crash in the TileSet editor

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -628,6 +628,9 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 					int closest_point;
 					_grab_polygon_point(mb->get_position(), xform, closest_polygon, closest_point);
 					if (closest_polygon >= 0) {
+						// Prevents crash from dragging and deleting a point at the same time.
+						drag_type = DRAG_TYPE_NONE;
+
 						PackedVector2Array old_polygon = polygons[closest_polygon];
 						polygons[closest_polygon].remove_at(closest_point);
 						undo_redo->create_action(TTR("Edit Polygons"));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86562.

Right clicking while dragging an occlusion polygon point in the TileSet editor would crash Godot 100% of the time (edit: when there are exactly 3 points). This one line of code forces the editor out of drag mode and deletes the polygon with no issues.