### PR TITLE
Warn about case mismatch when enabling addons

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -219,6 +219,10 @@ String FileAccess::fix_path(const String &p_path) const {
 	return r_path;
 }
 
+bool FileAccess::is_case_mismatch(bool p_full_check, String *r_physical_path) const {
+	return false;
+}
+
 /* these are all implemented for ease of porting, then can later be optimized */
 
 uint16_t FileAccess::get_16() const {

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -125,6 +125,7 @@ public:
 	static void set_file_close_fail_notify_callback(FileCloseFailNotify p_cbk) { close_fail_notify = p_cbk; }
 
 	virtual bool is_open() const = 0; ///< true when file is open
+	virtual bool is_case_mismatch(bool p_full_check, String *r_physical_path = nullptr) const;
 
 	virtual String get_path() const { return ""; } /// returns the path for the current open file
 	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -122,17 +122,9 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	// a file using the wrong case (which *works* on Windows, but won't on other
 	// platforms).
 	if (p_mode_flags == READ) {
-		WIN32_FIND_DATAW d;
-		HANDLE fnd = FindFirstFileW((LPCWSTR)(path.utf16().get_data()), &d);
-		if (fnd != INVALID_HANDLE_VALUE) {
-			String fname = String::utf16((const char16_t *)(d.cFileName));
-			if (!fname.is_empty()) {
-				String base_file = path.get_file();
-				if (base_file != fname && base_file.findn(fname) == 0) {
-					WARN_PRINT("Case mismatch opening requested file '" + base_file + "', stored as '" + fname + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
-				}
-			}
-			FindClose(fnd);
+		String physical_path;
+		if (is_case_mismatch(false, &physical_path)) {
+			WARN_PRINT("Case mismatch opening requested file '" + path.get_file() + "', stored as '" + physical_path.get_file() + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
 		}
 	}
 #endif
@@ -221,6 +213,46 @@ String FileAccessWindows::get_path_absolute() const {
 
 bool FileAccessWindows::is_open() const {
 	return (f != nullptr);
+}
+
+bool FileAccessWindows::is_case_mismatch(bool p_full_check, String *r_physical_path) const {
+	bool mismatch = false;
+
+	String check_path = path;
+	PackedStringArray splits;
+	if (r_physical_path) {
+		splits = path.split("/");
+	}
+
+	for (int i = splits.size() - 1; i >= 0; i--) {
+		WIN32_FIND_DATAW d;
+		HANDLE fnd = FindFirstFileW((LPCWSTR)(check_path.utf16().get_data()), &d);
+		if (fnd != INVALID_HANDLE_VALUE) {
+			String fname = String::utf16((const char16_t *)(d.cFileName));
+			if (!fname.is_empty()) {
+				String base_file = check_path.get_file();
+				if (base_file != fname && base_file.findn(fname) == 0) {
+					mismatch = true;
+
+					if (r_physical_path) {
+						splits.write[i] = fname;
+					}
+				}
+			}
+			FindClose(fnd);
+		}
+
+		if (!p_full_check) {
+			break;
+		}
+		check_path = check_path.get_base_dir();
+	}
+
+	if (r_physical_path) {
+		*r_physical_path = String("/").join(splits);
+	}
+
+	return mismatch;
 }
 
 void FileAccessWindows::seek(uint64_t p_position) {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -57,6 +57,7 @@ public:
 	virtual String fix_path(const String &p_path) const override;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
+	virtual bool is_case_mismatch(bool p_full_check, String *r_physical_path = nullptr) const override;
 
 	virtual String get_path() const override; /// returns the path for the current open file
 	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3402,8 +3402,18 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 		addon_path = "res://addons/" + addon_path + "/plugin.cfg";
 	}
 
-	ERR_FAIL_COND(p_enabled && addon_name_to_plugin.has(addon_path));
-	ERR_FAIL_COND(!p_enabled && !addon_name_to_plugin.has(addon_path));
+	{
+		Ref<FileAccess> case_checker = FileAccess::open(addon_path, FileAccess::READ);
+		String physical_path;
+
+		if (case_checker.is_valid() && case_checker->is_case_mismatch(true, &physical_path)) {
+			WARN_PRINT(vformat("Path case mismatch when enabling addon: '%s'.", p_addon));
+			addon_path = ProjectSettings::get_singleton()->localize_path(physical_path);
+		}
+	}
+
+	ERR_FAIL_COND_MSG(p_enabled && addon_name_to_plugin.has(addon_path), vformat("Can't enable addon: '%s'. Already enabled.", p_addon));
+	ERR_FAIL_COND_MSG(!p_enabled && !addon_name_to_plugin.has(addon_path), vformat("Can't disable addon: '%s'. Already disabled.", p_addon));
 
 	if (!p_enabled) {
 		EditorPlugin *addon = addon_name_to_plugin[addon_path];
@@ -3421,6 +3431,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 		WARN_PRINT("Addon '" + addon_path + "' failed to load. No directory found. Removing from enabled plugins.");
 		return;
 	}
+
 	Error err = cf->load(addon_path);
 	if (err != OK) {
 		show_warning(vformat(TTR("Unable to enable addon plugin at: '%s' parsing of config failed."), addon_path));


### PR DESCRIPTION
`set_plugin_enabled()` expects a folder name and uses is as a path for enabling a plugin. This can cause problems in case-insensitive filesystems if you provide folder name with case mismatch. The plugin will be enabled, but you won't be able to disable it other than by removing it manually from `project.godot`.

This PR checks whether the folder you provide for `set_plugin_enabled()` has proper casing and if not, it warns and automatically fixes the path. I had to add a new `is_case_mismatch()` function to FileAccess, which checks whether path casing matches filesystem and can return a fixed path.