### PR TITLE
Fix virtual keyboard for decimal values on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
@@ -34,10 +34,13 @@ import org.godotengine.godot.*;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.text.InputFilter;
 import android.text.InputType;
+import android.text.TextUtils;
+import android.text.method.DigitsKeyListener;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
@@ -45,6 +48,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import java.lang.ref.WeakReference;
+import java.util.Locale;
 
 public class GodotEditText extends EditText {
 	// ===========================================================
@@ -137,6 +141,7 @@ public class GodotEditText extends EditText {
 					}
 
 					int inputType = InputType.TYPE_CLASS_TEXT;
+					String acceptCharacters = null;
 					switch (edit.getKeyboardType()) {
 						case KEYBOARD_TYPE_DEFAULT:
 							inputType = InputType.TYPE_CLASS_TEXT;
@@ -148,7 +153,8 @@ public class GodotEditText extends EditText {
 							inputType = InputType.TYPE_CLASS_NUMBER;
 							break;
 						case KEYBOARD_TYPE_NUMBER_DECIMAL:
-							inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED;
+							inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL;
+							acceptCharacters = "0123456789,.- ";
 							break;
 						case KEYBOARD_TYPE_PHONE:
 							inputType = InputType.TYPE_CLASS_PHONE;
@@ -164,6 +170,14 @@ public class GodotEditText extends EditText {
 							break;
 					}
 					edit.setInputType(inputType);
+
+					if (!TextUtils.isEmpty(acceptCharacters)) {
+						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+							edit.setKeyListener(DigitsKeyListener.getInstance(Locale.getDefault()));
+						} else {
+							edit.setKeyListener(DigitsKeyListener.getInstance(acceptCharacters));
+						}
+					}
 
 					edit.mInputWrapper.setOriginText(text);
 					edit.addTextChangedListener(edit.mInputWrapper);


### PR DESCRIPTION
Fixes: #84091

In Europe, `comma (,)` is usually used for decimal numbers and not `period (.)`

**Note:** without `accept_characters / KeyListener` the input is validated correctly, i.e. `'-'` is only possible at the beginning and `'.'` only once. The `KeyListener` is there to accept `','`. On a Samsung Android `','` is deactivated (I could not find a solution)

---------------

![Bildschirmfoto 2023-12-29 um 23 18 41](https://github.com/godotengine/godot/assets/41921395/c2a4956f-4a0e-43de-a4b7-d4b5b0c88217)

**Tests** (numbertest.zip from https://github.com/godotengine/godot/issues/84091#issuecomment-1814303735)

Pixel 4a (Android 13)

https://github.com/godotengine/godot/assets/41921395/ccf466eb-3357-4740-b078-671fe515f981

Samsung Tab S7 (Android 13)

https://github.com/godotengine/godot/assets/41921395/514d8f0a-b006-4bfb-a2b2-4f5933b513c3




