### PR TITLE
Fix possible crash (use after free) in ScriptTextEditor

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -500,11 +500,14 @@ void ScriptTextEditor::_validate_script() {
 	safe_lines.clear();
 
 	if (!script->get_language()->validate(text, script->get_path(), &fnc, &errors, &warnings, &safe_lines)) {
-		for (List<ScriptLanguage::ScriptError>::Element *E = errors.front(); E; E = E->next()) {
+		List<ScriptLanguage::ScriptError>::Element *E = errors.front();
+		while (E) {
+			List<ScriptLanguage::ScriptError>::Element *next_E = E->next();
 			if ((E->get().path.is_empty() && !script->get_path().is_empty()) || E->get().path != script->get_path()) {
 				depended_errors[E->get().path].push_back(E->get());
 				E->erase();
 			}
+			E = next_E;
 		}
 
 		if (errors.size() > 0) {


### PR DESCRIPTION
while trying to make a PR to fix https://github.com/godotengine/godot/issues/79882, i noticed that https://github.com/godotengine/godot/pull/81156 already fixed it,
and also noticed a use after free bug, this fixes that 
(the crash would have happened when calling `E->next()` after calling `E->erase()` which destructs it)