### PR TITLE
[3.x] Rewrite most of Resource's documentation

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Resource" inherits="Reference" version="3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for all resources.
+		Base class for serializable objects.
 	</brief_description>
 	<description>
-		Resource is the base class for all Godot-specific resource types, serving primarily as data containers. Since they inherit from [Reference], resources are reference-counted and freed when no longer in use. They are also cached once loaded from disk, so that any further attempts to load a resource from a given path will return the same reference (all this in contrast to a [Node], which is not reference-counted and can be instanced from disk as many times as desired). Resources can be saved externally on disk or bundled into another object, such as a [Node] or another resource.
+		Resource is the base class for all Godot-specific resource types, serving primarily as data containers. Since they inherit from [Reference], resources are reference-counted and freed when no longer in use. They can also be nested within other resources, and saved on disk. [PackedScene], one of the most common [Object]s in a Godot project, is also a resource, uniquely capable of storing and instantiating the [Node]s it contains as many times as desired.
+		In GDScript, resources can loaded from disk by their [member resource_path] using [method @GDScript.load] or [method @GDScript.preload].
+		The engine keeps a global cache of all loaded resources, referenced by paths (see [method ResourceLoader.has_cached]). A resource will be cached when loaded for the first time and removed from cache once all references are released. When a resource is cached, subsequent loads using its path will return the cached reference.
 		[b]Note:[/b] In C#, resources will not be freed instantly after they are no longer in use. Instead, garbage collection will run periodically and will free resources that are no longer in use. This means that unused resources will linger on for a while before being removed.
 	</description>
 	<tutorials>
@@ -15,73 +17,86 @@
 		<method name="_setup_local_to_scene" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Virtual function which can be overridden to customize the behavior value of [method setup_local_to_scene].
+				Override this method to customize the newly duplicated resource created from [method PackedScene.instance], if the original's [member resource_local_to_scene] is set to [code]true[/code].
+				[b]Example:[/b] Set a random [code]damage[/code] value to every local resource from an instantiated scene.
+				[codeblock]
+				extends Resource
+
+				var damage = 0
+
+				func _setup_local_to_scene():
+				    damage = rand_range(10, 40)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="duplicate" qualifiers="const">
 			<return type="Resource" />
 			<argument index="0" name="subresources" type="bool" default="false" />
 			<description>
-				Duplicates the resource, returning a new resource with the exported members copied. [b]Note:[/b] To duplicate the resource the constructor is called without arguments. This method will error when the constructor doesn't have default values.
-				By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [code]subresources[/code] argument which will copy the subresources.
-				[b]Note:[/b] If [code]subresources[/code] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
-				[b]Note:[/b] When duplicating a resource, only [code]export[/code]ed properties are copied. Other properties will be set to their default value in the new resource.
+				Duplicates this resource, returning a new resource with its [code]export[/code]ed or [constant PROPERTY_USAGE_STORAGE] properties copied from the original.
+				If [code]subresources[/code] is [code]false[/code], a shallow copy is returned; nested resources within subresources are not duplicated and are shared from the original resource. If [code]subresources[/code] is [code]true[/code], a deep copy is returned; nested subresources will be duplicated and are not shared.
+				[b]Note:[/b] For custom resources, this method will fail if [method Object._init] has been defined with required parameters.
 			</description>
 		</method>
 		<method name="emit_changed">
 			<return type="void" />
 			<description>
-				Emits the [signal changed] signal.
-				If external objects which depend on this resource should be updated, this method must be called manually whenever the state of this resource has changed (such as modification of properties).
-				The method is equivalent to:
+				Emits the [signal changed] signal. This method is called automatically for some built-in resources.
+				[b]Note:[/b] For custom resources, it's recommended to call this method whenever a meaningful change occurs, such as a modified property. This ensures that custom [Object]s depending on the resource are properly updated.
 				[codeblock]
-				emit_signal("changed")
+				var damage setget set_damage
+
+				func set_damage(new_value):
+				    if damage != new_value:
+				        damage = new_value
+				        emit_changed()
 				[/codeblock]
-				[b]Note:[/b] This method is called automatically for built-in resources.
 			</description>
 		</method>
 		<method name="get_local_scene" qualifiers="const">
 			<return type="Node" />
 			<description>
-				If [member resource_local_to_scene] is enabled and the resource was loaded from a [PackedScene] instantiation, returns the local scene where this resource's unique copy is in use. Otherwise, returns [code]null[/code].
+				If [member resource_local_to_scene] is set to [code]true[/code] and the resource has been loaded from a [PackedScene] instantiation, returns the root [Node] of the scene where this resource is used. Otherwise, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the RID of the resource (or an empty RID). Many resources (such as [Texture], [Mesh], etc) are high-level abstractions of resources stored in a server, so this function will return the original RID.
+				Returns the [RID] of this resource (or an empty RID). Many resources (such as [Texture], [Shape], and so on) are high-level abstractions of resources stored in a specialized server ([VisualServer], [PhysicsServer], etc.), so this function will return the original [RID].
 			</description>
 		</method>
 		<method name="setup_local_to_scene">
 			<return type="void" />
 			<description>
-				This method is called when a resource with [member resource_local_to_scene] enabled is loaded from a [PackedScene] instantiation. Its behavior can be customized by overriding [method _setup_local_to_scene] from script.
-				For most resources, this method performs no base logic. [ViewportTexture] performs custom logic to properly set the proxy texture and flags in the local viewport.
+				Calls [method _setup_local_to_scene]. If [member resource_local_to_scene] is set to [code]true[/code], this method is automatically called from [method PackedScene.instance] by the newly duplicated resource within the scene instance.
 			</description>
 		</method>
 		<method name="take_over_path">
 			<return type="void" />
 			<argument index="0" name="path" type="String" />
 			<description>
-				Sets the path of the resource, potentially overriding an existing cache entry for this path. This differs from setting [member resource_path], as the latter would error out if another resource was already cached for the given path.
+				Sets the [member resource_path] to [code]path[/code], potentially overriding an existing cache entry for this path. Further attempts to load an overridden resource by path will instead return this resource.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" default="false">
-			If [code]true[/code], the resource will be made unique in each instance of its local scene. It can thus be modified in a scene instance without impacting other instances of that same scene.
+			If [code]true[/code], the resource is duplicated for each instance of all scenes using it. At run-time, the resource can be modified in one scene without affecting other instances (see [method PackedScene.instance]).
+			[b]Note:[/b] Changing this property at run-time has no effect on already created duplicate resources.
 		</member>
 		<member name="resource_name" type="String" setter="set_name" getter="get_name" default="&quot;&quot;">
-			The name of the resource. This is an optional identifier. If [member resource_name] is not empty, its value will be displayed to represent the current resource in the editor inspector. For built-in scripts, the [member resource_name] will be displayed as the tab name in the script editor.
+			An optional name for this resource. When defined, its value is displayed to represent the resource in the Inspector dock. For built-in scripts, the name is displayed as part of the tab name in the script editor.
+			[b]Note:[/b] Some resource formats do not support resource names. You can still set the name in the editor or via code, but it will be lost when the resource is reloaded. For example, only built-in scripts can have a resource name, while scripts stored in separate files cannot.
 		</member>
 		<member name="resource_path" type="String" setter="set_path" getter="get_path" default="&quot;&quot;">
-			The path to the resource. In case it has its own file, it will return its filepath. If it's tied to the scene, it will return the scene's path, followed by the resource's index.
+			The unique path to this resource. If it has been saved to disk, the value will be its filepath. If the resource is exclusively contained within a scene, the value will be the [PackedScene]'s filepath, followed by a unique identifier.
+			[b]Note:[/b] Setting this property manually may fail if a resource with the same path has already been previously loaded. If necessary, use [method take_over_path].
 		</member>
 	</members>
 	<signals>
 		<signal name="changed">
 			<description>
-				Emitted whenever the resource changes.
+				Emitted when the resource changes, usually when one of its properties is modified. See also [method emit_changed].
 				[b]Note:[/b] This signal is not emitted automatically for custom resources, which means that you need to create a setter and emit the signal yourself.
 			</description>
 		</signal>


### PR DESCRIPTION


Closes https://github.com/godotengine/godot-docs/issues/6479 (Happy anniversary).

Kind of a 3.x version of https://github.com/godotengine/godot/pull/67072.

This PR brings the Resource's class reference in line with master's, with a few tweaks to suit 3.x:
- **PROPERTY_USAGE_ALWAYS_DUPLICATE** cannot be mentioned because it does not exist.
- The example resources and servers in `get_rid()` are different.

Now, what to do with `setup_local_to_scene`? Should it be deprecated here, too?