### PR TITLE
Turn off distraction free mode when selecting default layout

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5566,6 +5566,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 			layout_dialog->popup_centered();
 		} break;
 		case SETTINGS_LAYOUT_DEFAULT: {
+			set_distraction_free_mode(false);
 			_load_docks_from_config(default_layout, "docks");
 			_save_editor_layout();
 		} break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Currently the behavior when selecting the default layout while distraction free mode is enabled is a bit odd:

![image](https://github.com/godotengine/godot/assets/105675984/acf29435-f19d-4af4-a204-7ff89b53e78a)

The panels are restored; however, they are blank, and distraction free is still enabled according to its respective button. 

This is resolved by turning off distraction free mode, which I believe is the desired behavior when expecting the layout to return to a true default. 