### PR TITLE
Fix some animation state corruptions on activate and reset on save

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -2157,6 +2157,7 @@ void AnimationPlayerEditorPlugin::_update_dummy_player(AnimationMixer *p_mixer) 
 		Node *parent = p_mixer->get_parent();
 		ERR_FAIL_NULL(parent);
 		dummy_player = memnew(AnimationPlayer);
+		dummy_player->set_active(false); // Inactive as default, it will be activated if the AnimationPlayerEditor visibility is changed.
 		parent->add_child(dummy_player);
 	}
 	player = dummy_player;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1974,7 +1974,13 @@ void AnimationMixer::_build_backup_track_cache() {
 				TrackCacheValue *t = static_cast<TrackCacheValue *>(track);
 				Object *t_obj = ObjectDB::get_instance(t->object_id);
 				if (t_obj) {
-					t->value = t_obj->get_indexed(t->subpath);
+					t->value = Animation::cast_to_blendwise(t_obj->get_indexed(t->subpath));
+				}
+				t->use_discrete = false;
+				if (t->init_value.is_array()) {
+					t->element_size = MAX(t->element_size.operator int(), (t->value.operator Array()).size());
+				} else if (t->init_value.is_string()) {
+					t->element_size = (real_t)(t->value.operator Array()).size();
 				}
 			} break;
 			case Animation::TYPE_AUDIO: {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -568,10 +568,11 @@ bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const 
 			pi.seeked = true;
 			root_animation_node->_pre_process(&process_state, pi, false);
 			started = false;
+		} else {
+			pi.seeked = false;
+			pi.time = p_delta;
+			root_animation_node->_pre_process(&process_state, pi, false);
 		}
-		pi.seeked = false;
-		pi.time = p_delta;
-		root_animation_node->_pre_process(&process_state, pi, false);
 	}
 
 	if (!process_state.valid) {


### PR DESCRIPTION
- Follow up #84815
- Follow up #85794

I have commented there on the following:

> BTW, there is a bug with reset on save for arrays, but it exists before this PR, so I will look into it separately.

The main cause of this was that the inactive or duplicated AnimationMixer would do the processing for reset_on_save many times. So this PR adds 2 checks:

1. An inactive AnimationMixer should not affect the scene.
2. AnimationTree that is assigned to a Player that may perform a reset on save will not perform a reset on save.

The conversion of the track cache to blendwise for backup is not necessary in practice, but added for safety.

---

Also, the dummy player is made inactive when it is generated; The dummy player is added to the scene when an AnimationTree is selected, but if it is activated by default, an invisible dummy player would play the animation when an inactive AnimationTree is selected. Fixed.

Moreover, regarding @YuriSizov concern in https://github.com/godotengine/godot/pull/85794#discussion_r1420665375, I have found that the problem occurs at the moment of activating, so I have reverted it so that it is not handled twice. I confirmed that https://github.com/godotengine/godot/issues/85640 works well, so regression will not occur.
