### PR TITLE
Animation Player no longer calls a method twice when playing the anim…

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1460,7 +1460,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					}
 					TrackCacheMethod *t = static_cast<TrackCacheMethod *>(track);
 					if (seeked) {
-						int idx = a->track_find_key(i, time, is_external_seeking ? Animation::FIND_MODE_NEAREST : Animation::FIND_MODE_EXACT);
+						int idx = a->track_find_key(i, time, is_external_seeking ? Animation::FIND_MODE_NEAREST : Animation::FIND_MODE_EXACT, backward);
 						if (idx < 0) {
 							continue;
 						}

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1451,7 +1451,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 	emit_changed();
 }
 
-int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode) const {
+int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, bool p_backward) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
@@ -1578,7 +1578,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode) 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			int k = _find(mt->methods, p_time);
+			int k = _find(mt->methods, p_time, p_backward);
 			if (k < 0 || k >= mt->methods.size()) {
 				return -1;
 			}

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -401,7 +401,7 @@ public:
 	void track_set_key_transition(int p_track, int p_key_idx, real_t p_transition);
 	void track_set_key_value(int p_track, int p_key_idx, const Variant &p_value);
 	void track_set_key_time(int p_track, int p_key_idx, double p_time);
-	int track_find_key(int p_track, double p_time, FindMode p_find_mode = FIND_MODE_NEAREST) const;
+	int track_find_key(int p_track, double p_time, FindMode p_find_mode = FIND_MODE_NEAREST, bool p_backward = false) const;
 	void track_remove_key(int p_track, int p_idx);
 	void track_remove_key_at_time(int p_track, double p_time);
 	int track_get_key_count(int p_track) const;


### PR DESCRIPTION
**Reasons for the bug**
There are 3 steps to understand the bug:
1) In Animation::track_find_key, in "case TYPE_METHOD", the _find method is being called, however the backwards flag is not being passed to it.
We need to call this function with this flag, so we need to know whether we are playing backwards or not.
2) Currently, there is no way to pass that info to Animation::track_find_key.
3) Even if we could pass that info, AnimationMixer::_blend_process, the "bool backward" variable does not have the correct value at the very beginning. (And Animation::track_find_key is called from that method when the bug happens.)


**Solution**
1) and 2) Animation::track_find_key now has an other parameter called p_backwards (called like this in _find), which defaults to false. In AnimationMixer::_blend_process, in "case Animation::TYPE_METHOD" the Animation::track_find_key is now called with this parameter.
3) The backward variable is incorrect because ai.playback_info.delta is 0.0, and not -0.0. To fix this, in AnimationPlayer::_process_playback_data, there are added checks now to make sure if it's correct. Also, in that function when p_started is true, a constant 0.0 was passed as delta, regardless of playing direction.

**Possible extensions**
In Animation::track_find_key, there are other cases where _find is called without the backwards flag. Might be interesting to check whether they need it as well. This pull request is intended to solve the method call problem only.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/86648*