### PR TITLE
Correct C# syntax in `_validate_property` example for the Object class

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -314,7 +314,7 @@
 				    {
 				        if (property["name"].AsStringName() == PropertyName.Number &amp;&amp; IsNumberEditable)
 				        {
-				            var usage = property["usage"].As&gt;PropertyUsageFlags&lt;() | PropertyUsageFlags.ReadOnly;
+				            var usage = property["usage"].As&lt;PropertyUsageFlags&gt;() | PropertyUsageFlags.ReadOnly;
 				            property["usage"] = (int)usage;
 				        }
 				    }


### PR DESCRIPTION
The current example for `_validate_property` in C# uses the brackets for casting a variant to `PropertyUsageFlags` in the wrong order.

Current docs:
```cs
property["usage"].As>PropertyUsageFlags<()
```

This PR:
```cs
property["usage"].As<PropertyUsageFlags>()
```