### PR TITLE
Keep dock slots hidden when default layout is selected and distractio…

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5268,7 +5268,11 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 		hsplits[i]->set_split_offset(ofs);
 	}
 
-	_update_dock_slots_visibility(false);
+	if (is_distraction_free_mode_enabled()) {
+		_update_dock_slots_visibility(true);
+	} else {
+		_update_dock_slots_visibility(false);
+	}
 
 	// FileSystemDock.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Alternative to: #86643

Currently the behavior when selecting the default layout while distraction free mode is enabled is a bit odd:

![image](https://github.com/godotengine/godot/assets/105675984/24044682-f94d-4c8d-be4d-0b147d399b1a)

The panels are restored; however, they are blank, and distraction free is still enabled according to its respective button.

This is resolved by keeping dock slots hidden if distraction free mode is enabled. 