### PR TITLE
Improve error message for `String.format` when using nested Arrays

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3536,7 +3536,7 @@ String String::format(const Variant &values, String placeholder) const {
 
 					new_string = new_string.replace(placeholder.replace("_", key), val);
 				} else {
-					ERR_PRINT(String("STRING.format Inner Array size != 2 ").ascii().get_data());
+					ERR_PRINT(vformat("Invalid format: the inner Array at index %d needs to contain only 2 elements, as a key-value pair.", i).ascii().get_data());
 				}
 			} else { //Array structure ["RobotGuy","Logis","rookie"]
 				Variant v_val = values_arr[i];


### PR DESCRIPTION
Mitigates the confusion in https://github.com/godotengine/godot/issues/69253.

This PR changes the error message to be more helpful.