### PR TITLE
Prevent escape key from closing Editor Settings window when filtering for shortcuts

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -772,6 +772,8 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcut_search_by_event->set_stretch_ratio(0.75);
 	shortcut_search_by_event->set_allowed_input_types(INPUT_KEY);
 	shortcut_search_by_event->connect("event_changed", callable_mp(this, &EditorSettingsDialog::_filter_shortcuts_by_event));
+	shortcut_search_by_event->connect("focus_entered", callable_mp((AcceptDialog *)this, &AcceptDialog::set_close_on_escape).bind(false));
+	shortcut_search_by_event->connect("focus_exited", callable_mp((AcceptDialog *)this, &AcceptDialog::set_close_on_escape).bind(true));
 	top_hbox->add_child(shortcut_search_by_event);
 
 	Button *clear_all_search = memnew(Button);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: #85688

Escape key previously closed the window when listening for a key, and escape is pressed. 

![image](https://github.com/godotengine/godot/assets/105675984/6bc2f113-9e5e-4bc8-bdfb-16dd81b1d47e)

Now it doesn't, matching the behavior of   "Event Configuration" window. 

![image](https://github.com/godotengine/godot/assets/105675984/02278a97-66b2-480f-99e8-a8314c2f58a9)
