### PR TITLE
Add Separation to Sprite2D

### DIFF
--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -80,6 +80,9 @@
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			The region of the atlas texture to display. [member region_enabled] must be [code]true[/code].
 		</member>
+		<member name="separation" type="Vector2i" setter="set_separation" getter="get_separation" default="Vector2i(0, 0)">
+			The number of pixels separating each frame in the atlas texture.
+		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] object to draw.
 		</member>

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -86,9 +86,23 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 		base_rect = Rect2(0, 0, texture->get_width(), texture->get_height());
 	}
 
+	if (separation.width > 0 || separation.height > 0) {
+		base_rect.size.x -= ((hframes - 1) * separation.width);
+		base_rect.size.y -= ((vframes - 1) * separation.height);
+	}
+
 	Size2 frame_size = base_rect.size / Size2(hframes, vframes);
-	Point2 frame_offset = Point2(frame % hframes, frame / hframes);
+
+	int hposition = frame % hframes;
+	int vposition = frame / hframes;
+
+	Point2 frame_offset = Point2(hposition, vposition);
 	frame_offset *= frame_size;
+
+	if (separation.width > 0 || separation.height > 0) {
+		frame_offset.x += hposition * separation.width;
+		frame_offset.y += vposition * separation.height;
+	}
 
 	r_src_rect.size = frame_size;
 	r_src_rect.position = base_rect.position + frame_offset;
@@ -329,6 +343,21 @@ int Sprite2D::get_hframes() const {
 	return hframes;
 }
 
+void Sprite2D::set_separation(const Vector2i &p_separation) {
+	if (separation == p_separation) {
+		return;
+	}
+
+	separation = Vector2i(0, 0).max(p_separation);
+
+	queue_redraw();
+	item_rect_changed();
+}
+
+Vector2i Sprite2D::get_separation() const {
+	return separation;
+}
+
 bool Sprite2D::is_pixel_opaque(const Point2 &p_point) const {
 	if (texture.is_null()) {
 		return false;
@@ -392,6 +421,11 @@ Rect2 Sprite2D::get_rect() const {
 		s = region_rect.size;
 	} else {
 		s = texture->get_size();
+	}
+
+	if (separation.width > 0 || separation.height > 0) {
+		s.x -= ((hframes - 1) * separation.width);
+		s.y -= ((vframes - 1) * separation.height);
 	}
 
 	s = s / Point2(hframes, vframes);
@@ -475,6 +509,9 @@ void Sprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hframes", "hframes"), &Sprite2D::set_hframes);
 	ClassDB::bind_method(D_METHOD("get_hframes"), &Sprite2D::get_hframes);
 
+	ClassDB::bind_method(D_METHOD("set_separation", "separation"), &Sprite2D::set_separation);
+	ClassDB::bind_method(D_METHOD("get_separation"), &Sprite2D::get_separation);
+
 	ClassDB::bind_method(D_METHOD("get_rect"), &Sprite2D::get_rect);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
@@ -489,6 +526,7 @@ void Sprite2D::_bind_methods() {
 	ADD_GROUP("Animation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hframes", PROPERTY_HINT_RANGE, "1,16384,1"), "set_hframes", "get_hframes");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vframes", PROPERTY_HINT_RANGE, "1,16384,1"), "set_vframes", "get_vframes");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "separation", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_separation", "get_separation");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "frame_coords", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_frame_coords", "get_frame_coords");
 

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -55,6 +55,8 @@ class Sprite2D : public Node2D {
 	int vframes = 1;
 	int hframes = 1;
 
+	Vector2i separation;
+
 	void _get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip_enabled) const;
 
 	void _texture_changed();
@@ -117,6 +119,9 @@ public:
 
 	void set_hframes(int p_amount);
 	int get_hframes() const;
+
+	void set_separation(const Vector2i &p_separation);
+	Vector2i get_separation() const;
 
 	Rect2 get_rect() const;
 	virtual Rect2 get_anchorable_rect() const override;


### PR DESCRIPTION
### What?
This PR adds a new property called Separation to the Sprite2D node. This property allows the user to specify the gap size between each frame in an atlas texture. An atlas texture is a single image that contains multiple frames for animation.

### Why?
This feature is useful for users who want to use the same atlas texture for both AnimatedSprite2D and Sprite2D nodes. Currently, AnimatedSprite2D has a Separation property, but Sprite2D does not. This means that Sprite2D cannot display the correct frame when animated by an AnimationPlayer, unless the user uses a different texture without gaps. This limitation forces the user to use more textures than necessary, which is inefficient and inconvenient.

### How?
The implementation of this feature is similar to how SpriteFrames handle the Separation property. The Sprite2D node calculates the correct texture region based on the Hframes and Vframes properties, as well as the Separation property.

### Testing?
To test this feature, the user can create a Sprite2D node and assign an atlas texture to it. The user can then adjust the Hframes, Vframes, and Separation properties to see the effect on the sprite. When changing the Frame property the correct frame is displayed.

### Additional Benefits
As an aside, this also allows a user to avoid this issue: https://github.com/godotengine/godot/issues/81998 when working with a scaled Sprite2D. With separation between frames the issue no longer presents itself, even if the underlying issue is still present.

### Screenshot
![image](https://github.com/godotengine/godot/assets/454563/4c1b41f2-0ba9-475e-8193-1536a6408b03)

### Proposal
This PR implements the following proposal: https://github.com/godotengine/godot-proposals/issues/8755

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8755*