### PR TITLE
Improved synchronization of Transforms during live debug sessions

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5775,7 +5775,11 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 
 	// there's nothing to be used as source position so snapping will work as absolute if enabled
 	target_position = canvas_item_editor->snap_point(target_position);
-	undo_redo->add_do_method(child, "set_global_position", target_position);
+
+	CanvasItem *parent_ci = Object::cast_to<CanvasItem>(parent);
+	Point2 local_target_pos = parent_ci ? parent_ci->get_global_transform().xform_inv(target_position) : target_position;
+
+	undo_redo->add_do_method(child, "set_position", local_target_pos);
 }
 
 bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, const Point2 &p_point) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3295,8 +3295,10 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					xform.basis.rotate_local(Vector3(1, 0, 0), Math_TAU * 0.25);
 				}
 
-				undo_redo->add_do_method(sp, "set_global_transform", xform);
-				undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
+				Node3D *parent = sp->get_parent_node_3d();
+				Transform3D local_xform = parent ? parent->get_global_transform().inverse_xform(xform) : xform;
+				undo_redo->add_do_method(sp, "set_transform", local_xform);
+				undo_redo->add_undo_method(sp, "set_transform", sp->get_local_gizmo_transform());
 			}
 			undo_redo->commit_action();
 
@@ -4362,16 +4364,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 
 	Node3D *node3d = Object::cast_to<Node3D>(instantiated_scene);
 	if (node3d) {
-		Transform3D gl_transform;
-		Node3D *parent_node3d = Object::cast_to<Node3D>(parent);
-		if (parent_node3d) {
-			gl_transform = parent_node3d->get_global_gizmo_transform();
-		}
-
-		gl_transform.origin = preview_node_pos;
-		gl_transform.basis *= node3d->get_transform().basis;
-
-		undo_redo->add_do_method(instantiated_scene, "set_global_transform", gl_transform);
+		undo_redo->add_do_method(instantiated_scene, "set_transform", node3d->get_transform());
 	}
 
 	return true;
@@ -4607,8 +4600,8 @@ void Node3DEditorViewport::commit_transform() {
 			continue;
 		}
 
-		undo_redo->add_do_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
-		undo_redo->add_undo_method(sp, "set_global_transform", se->original);
+		undo_redo->add_do_method(sp, "set_transform", sp->get_local_gizmo_transform());
+		undo_redo->add_undo_method(sp, "set_transform", se->original_local);
 	}
 	undo_redo->commit_action();
 
@@ -6168,8 +6161,10 @@ void Node3DEditor::_xform_dialog_action() {
 			tr.origin += t.origin;
 		}
 
-		undo_redo->add_do_method(sp, "set_global_transform", tr);
-		undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
+		Node3D *parent = sp->get_parent_node_3d();
+		Transform3D local_tr = parent ? parent->get_global_transform().inverse_xform(tr) : tr;
+		undo_redo->add_do_method(sp, "set_transform", local_tr);
+		undo_redo->add_undo_method(sp, "set_transform", sp->get_transform());
 	}
 	undo_redo->commit_action();
 }
@@ -7518,8 +7513,10 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 					new_transform.origin.y = result.position.y;
 					new_transform.origin = new_transform.origin - position_offset;
 
-					undo_redo->add_do_method(sp, "set_global_transform", new_transform);
-					undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_transform());
+					Node3D *parent = sp->get_parent_node_3d();
+					Transform3D new_local_xform = parent ? parent->get_global_transform().inverse_xform(new_transform) : new_transform;
+					undo_redo->add_do_method(sp, "set_transform", new_local_xform);
+					undo_redo->add_undo_method(sp, "set_transform", sp->get_transform());
 				}
 			}
 


### PR DESCRIPTION
### What problems was this meant to address?
- Some editor transform operations (such as dragging 3D nodes) are committed to the undo/redo system with their _global_ transforms, which are in turn synced to the running game. This means that all the corresponding child nodes in all instances of the scene in the running game are moved to the same location in _world space_, which is not intuitive or useful.
- Furthermore, when you move the _root_ node of a scene (by any means), this operation is synced to the running game. This means that all instances of the edited scene in the running game are moved to the same location, which is also not intuitive or useful.

In the GIF below, you can see the current, undesirable outcome:
![old_3d](https://github.com/godotengine/godot/assets/13228932/175f36a2-d506-4c54-afaa-c52744592675)

### What was changed?
- Transform operations are now committed to undo/redo in local instead of global space.
- Transform edits to the root node of the current edited scene are no longer synced to the running game.

In the GIF below, you can see the new, expected behaviour:
![fixed_3d](https://github.com/godotengine/godot/assets/13228932/e499acde-e189-450e-a32d-1ebfdc54d0c6)

### Are there any caveats or tradeoffs?
- Committing operations in local space will not introduce any new issues, since the undo/redo chronology is maintained, so there is parity with the old behaviour when strictly considering the in-editor workflow. In the niche case of parents being moved around by tool scripts, there will not be parity with the old behaviour. However, it is more intuitive, consistent, and predictable for the operations to be undone/redone in local space in this use case anyway, for the same reasons as in the running game.
- You will no longer be able to move a scene in the running game by moving its scene root in the editor. However, this is arguably something that should never have been possible, as this should be done instead by editing the scene which _contains_ the scene you want to move. This is more consistent with the usual editor workflow for nested scenes anyway, where editing the root transform of a scene does not affect instances of that scene in other scenes.
- Root scale is no longer propagated to the running game. Unlike position and rotation, it is a possibility that the user would expect the root scale to be consistent and propagated across all instances of the scene. However, there is also a possibility that all instances already had individual scales applied (e.g., lots of trees with slight variations in scale). This is a tradeoff, and I think being unable to preview a scale change is less destructive than wiping out existing scales on all instances. Another reason is that many of the synchronized operations are all-inclusive, and teasing out the scale is adding more complexity and overhead.