### PR TITLE
Stop escaping `'` on POT generation

### DIFF
--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -141,7 +141,7 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 
 			// Write context.
 			if (!context.is_empty()) {
-				file->store_line("msgctxt " + context.c_escape().quote());
+				file->store_line("msgctxt " + context.json_escape().quote());
 			}
 
 			// Write msgid.
@@ -183,11 +183,11 @@ void POTGenerator::_write_msgid(Ref<FileAccess> r_file, const String &p_id, bool
 	}
 
 	for (int i = 0; i < lines.size() - 1; i++) {
-		r_file->store_line((lines[i] + "\n").c_escape().quote());
+		r_file->store_line((lines[i] + "\n").json_escape().quote());
 	}
 
 	if (!last_line.is_empty()) {
-		r_file->store_line(last_line.c_escape().quote());
+		r_file->store_line(last_line.json_escape().quote());
 	}
 }
 


### PR DESCRIPTION
Escaping the `'` character is unnecessary, and makes the resulting POT incompatible with translations tools such as Weblate.