### PR TITLE
Fix incorrect VehicleWheel3D Roll Influence description

### DIFF
--- a/doc/classes/VehicleWheel3D.xml
+++ b/doc/classes/VehicleWheel3D.xml
@@ -81,7 +81,7 @@
 			This is the distance in meters the wheel is lowered from its origin point. Don't set this to 0.0 and move the wheel into position, instead move the origin point of your wheel (the gizmo in Godot) to the position the wheel will take when bottoming out, then use the rest length to move the wheel down to the position it should be in when the car is in rest.
 		</member>
 		<member name="wheel_roll_influence" type="float" setter="set_roll_influence" getter="get_roll_influence" default="0.1">
-			This value affects the roll of your vehicle. If set to 1.0 for all wheels, your vehicle will be prone to rolling over, while a value of 0.0 will resist body roll.
+			This value affects the roll of your vehicle. If set to 1.0 for all wheels, your vehicle will resist body roll, while a value of 0.0 will be prone to rolling over.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Updated VehicleWheel3D Roll influence description and confirmed the tooltip has been updated in the Editor Inspection window.

I updated the `es.po` translation file, but additional translations need to be corrected. I updated english text for `fr.po`, `zh_CN.po` and `zh_TW.po` in this PR, but I need to find someone to update the alternative text for each of these files.

This PR fixes #85805.
