### PR TITLE
Implement overdraw, lighting, and unshaded debug draw modes for OpenGL

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1485,7 +1485,15 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 	//time global variables
 	scene_state.ubo.time = time;
 
-	if (is_environment(p_render_data->environment)) {
+	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_UNSHADED) {
+		scene_state.ubo.use_ambient_light = true;
+		scene_state.ubo.ambient_light_color_energy[0] = 1;
+		scene_state.ubo.ambient_light_color_energy[1] = 1;
+		scene_state.ubo.ambient_light_color_energy[2] = 1;
+		scene_state.ubo.ambient_light_color_energy[3] = 1.0;
+		scene_state.ubo.use_ambient_cubemap = false;
+		scene_state.ubo.use_reflection_cubemap = false;
+	} else if (is_environment(p_render_data->environment)) {
 		RS::EnvironmentBG env_bg = environment_get_background(p_render_data->environment);
 		RS::EnvironmentAmbientSource ambient_src = environment_get_ambient_source(p_render_data->environment);
 
@@ -2324,7 +2332,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	bool keep_color = false;
 	float sky_energy_multiplier = 1.0;
 
-	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW) {
+	if (unlikely(get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW)) {
 		clear_color = Color(0, 0, 0, 1); //in overdraw mode, BG should always be black
 	} else if (render_data.environment.is_valid()) {
 		RS::EnvironmentBG bg_mode = environment_get_background(render_data.environment);
@@ -2693,6 +2701,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			}
 			glBindTexture(GL_TEXTURE_CUBE_MAP, texture_to_bind);
 		}
+
 	} else if constexpr (p_pass_mode == PASS_MODE_DEPTH || p_pass_mode == PASS_MODE_SHADOW) {
 		shader_variant = SceneShaderGLES3::MODE_DEPTH;
 	}
@@ -2730,8 +2739,16 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			material_data = surf->material_shadow;
 			mesh_surface = surf->surface_shadow;
 		} else {
-			shader = surf->shader;
-			material_data = surf->material;
+			if (unlikely(get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW)) {
+				material_data = overdraw_material_data_ptr;
+				shader = material_data->shader_data;
+			} else if (unlikely(get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_LIGHTING)) {
+				material_data = default_material_data_ptr;
+				shader = material_data->shader_data;
+			} else {
+				shader = surf->shader;
+				material_data = surf->material;
+			}
 			mesh_surface = surf->surface;
 		}
 
@@ -3638,6 +3655,29 @@ void fragment() {
 		scene_globals.default_material = material_storage->material_allocate();
 		material_storage->material_initialize(scene_globals.default_material);
 		material_storage->material_set_shader(scene_globals.default_material, scene_globals.default_shader);
+		default_material_data_ptr = static_cast<GLES3::SceneMaterialData *>(GLES3::MaterialStorage::get_singleton()->material_get_data(scene_globals.default_material, RS::SHADER_SPATIAL));
+	}
+
+	{
+		// Overdraw material and shader.
+		scene_globals.overdraw_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(scene_globals.overdraw_shader);
+		material_storage->shader_set_code(scene_globals.overdraw_shader, R"(
+// 3D editor Overdraw debug draw mode shader.
+
+shader_type spatial;
+
+render_mode blend_add, unshaded;
+
+void fragment() {
+	ALBEDO = vec3(0.4, 0.8, 0.8);
+	ALPHA = 0.2;
+}
+)");
+		scene_globals.overdraw_material = material_storage->material_allocate();
+		material_storage->material_initialize(scene_globals.overdraw_material);
+		material_storage->material_set_shader(scene_globals.overdraw_material, scene_globals.overdraw_shader);
+		overdraw_material_data_ptr = static_cast<GLES3::SceneMaterialData *>(GLES3::MaterialStorage::get_singleton()->material_get_data(scene_globals.overdraw_material, RS::SHADER_SPATIAL));
 	}
 
 	{
@@ -3751,6 +3791,10 @@ RasterizerSceneGLES3::~RasterizerSceneGLES3() {
 	GLES3::MaterialStorage::get_singleton()->shaders.cubemap_filter_shader.version_free(scene_globals.cubemap_filter_shader_version);
 	RSG::material_storage->material_free(scene_globals.default_material);
 	RSG::material_storage->shader_free(scene_globals.default_shader);
+
+	// Overdraw Shader
+	RSG::material_storage->material_free(scene_globals.overdraw_material);
+	RSG::material_storage->shader_free(scene_globals.overdraw_shader);
 
 	// Sky Shader
 	GLES3::MaterialStorage::get_singleton()->shaders.sky_shader.version_free(sky_globals.shader_default_version);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -152,7 +152,12 @@ private:
 		RID default_material;
 		RID default_shader;
 		RID cubemap_filter_shader_version;
+		RID overdraw_material;
+		RID overdraw_shader;
 	} scene_globals;
+
+	GLES3::SceneMaterialData *default_material_data_ptr = nullptr;
+	GLES3::SceneMaterialData *overdraw_material_data_ptr = nullptr;
 
 	/* LIGHT INSTANCE */
 


### PR DESCRIPTION
Debug lighting and unshaded should work as expected. For unshaded specifically it seems like most of the work was already there and just needed to be toggled by setting the right variant.

For overdraw mode, using the same shader as the one used in the forward renderer results in faded colours, probably due to doing blending in srgb vs linear space. one way to compensate for this is to set a higher alpha which is done in this implementation. I attached some pictures of what this looks like, although it doest quite match the forward renderer. I chose to set ALPHA=0.2 instead of ALPHA=0.1 as in forward+ (i wanted to match the colour of forward+, setting ALPHA=0.3 makes the objects look too blue compared to forward+)

![overdraw imgaes](https://github.com/godotengine/godot/assets/33563602/9b7c9417-1fcb-479a-ad70-6848ec05736f)

_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/82485_