### PR TITLE
Update `get_image` doc to mention that it will return an empty image with invalid texture

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -123,6 +123,7 @@
 			<return type="Image" />
 			<description>
 				Returns an [Image] that is a copy of data from this [Texture2D] (a new [Image] is created each time). [Image]s can be accessed and manipulated directly.
+				[b]Note:[/b] This will return [code]null[/code] if this [Texture2D] is invalid.
 				[b]Note:[/b] This will fetch the texture data from the GPU, which might cause performance problems when overused.
 			</description>
 		</method>


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/86489

Unfortunately I can't reproduce that issue with a similiar gdscript version of that MRP, but I think it's better to mention this behaviour. 

I checked all the virtual `get_image` implementation, looks like it's appropriate to add this note (`NoiseTexture2D`'s `get_image` will directly return the image stored in member, but I think it's fine).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
