### PR TITLE
Fix `CSGShape3D` debug collision shapes being visible in editor

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -513,7 +513,7 @@ Ref<ConcavePolygonShape3D> CSGShape3D::bake_collision_shape() {
 }
 
 bool CSGShape3D::_is_debug_collision_shape_visible() {
-	return is_inside_tree() && (get_tree()->is_debugging_collisions_hint() || Engine::get_singleton()->is_editor_hint());
+	return !Engine::get_singleton()->is_editor_hint() && is_inside_tree() && get_tree()->is_debugging_collisions_hint();
 }
 
 void CSGShape3D::_update_debug_collision_shape() {
@@ -603,11 +603,6 @@ void CSGShape3D::_notification(int p_what) {
 			if (!is_root_shape() && last_visible != is_visible()) {
 				// Update this node's parent only if its own visibility has changed, not the visibility of parent nodes
 				parent_shape->_make_dirty();
-			}
-			if (is_visible()) {
-				_update_debug_collision_shape();
-			} else {
-				_clear_debug_collision_shape();
 			}
 			last_visible = is_visible();
 		} break;


### PR DESCRIPTION
`CSGShape3D` is improperly co-opting the debug collision visualization system to render editor gizmos. As such, the gizmos do not respect any gizmo visibility settings (see #87919 ).

The only way to control the visibility of the collision gizmos currently is to make the `CSGShape3D` itself invisible (workaround comes from #84174). This is incorrect because an invisible `CSGShape3D` can still have collision, so the gizmo should still be visible. This also affects runtime debug collision visualization (see #96767).

This PR makes the debug collision geometry only visible in the running game, essentially removing their usage as gizmos.
- Fixes #87919 
- Fixes #96767 
- Represents a small step toward a proper gizmo solution by removing broken bandaid solutions and setting a clean slate.