### PR TITLE
Move MIDI's methods and constants into InputEventMIDI

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input_map.h"
 #include "core/input/shortcut.h"
 #include "core/os/keyboard.h"
+#include "core/os/midi_driver.h"
 #include "core/os/os.h"
 
 const int InputEvent::DEVICE_ID_EMULATION = -1;
@@ -1661,11 +1662,11 @@ int InputEventMIDI::get_channel() const {
 	return channel;
 }
 
-void InputEventMIDI::set_message(const MIDIMessage p_message) {
+void InputEventMIDI::set_message(const Message p_message) {
 	message = p_message;
 }
 
-MIDIMessage InputEventMIDI::get_message() const {
+InputEventMIDI::Message InputEventMIDI::get_message() const {
 	return message;
 }
 
@@ -1717,6 +1718,31 @@ int InputEventMIDI::get_controller_value() const {
 	return controller_value;
 }
 
+void InputEventMIDI::open_inputs() {
+	if (MIDIDriver::get_singleton()) {
+		MIDIDriver::get_singleton()->open();
+	} else {
+		ERR_PRINT(vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
+	}
+}
+
+void InputEventMIDI::close_inputs() {
+	if (MIDIDriver::get_singleton()) {
+		MIDIDriver::get_singleton()->close();
+	} else {
+		ERR_PRINT(vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
+	}
+}
+
+PackedStringArray InputEventMIDI::get_connected_inputs() {
+	if (MIDIDriver::get_singleton()) {
+		return MIDIDriver::get_singleton()->get_connected_inputs();
+	}
+
+	PackedStringArray list;
+	ERR_FAIL_V_MSG(list, vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
+}
+
 String InputEventMIDI::as_text() const {
 	return vformat(RTR("MIDI Input on Channel=%s Message=%s"), itos(channel), itos((int64_t)message));
 }
@@ -1724,19 +1750,19 @@ String InputEventMIDI::as_text() const {
 String InputEventMIDI::to_string() {
 	String ret;
 	switch (message) {
-		case MIDIMessage::NOTE_ON:
+		case Message::MESSAGE_NOTE_ON:
 			ret = vformat("Note On: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
 			break;
-		case MIDIMessage::NOTE_OFF:
+		case Message::MESSAGE_NOTE_OFF:
 			ret = vformat("Note Off: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
 			break;
-		case MIDIMessage::PITCH_BEND:
+		case Message::MESSAGE_PITCH_BEND:
 			ret = vformat("Pitch Bend: channel=%d, pitch=%d", channel, pitch);
 			break;
-		case MIDIMessage::CHANNEL_PRESSURE:
+		case Message::MESSAGE_CHANNEL_PRESSURE:
 			ret = vformat("Channel Pressure: channel=%d, pressure=%d", channel, pressure);
 			break;
-		case MIDIMessage::CONTROL_CHANGE:
+		case Message::MESSAGE_CONTROL_CHANGE:
 			ret = vformat("Control Change: channel=%d, controller_number=%d, controller_value=%d", channel, controller_number, controller_value);
 			break;
 		default:
@@ -1762,6 +1788,30 @@ void InputEventMIDI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_controller_number"), &InputEventMIDI::get_controller_number);
 	ClassDB::bind_method(D_METHOD("set_controller_value", "controller_value"), &InputEventMIDI::set_controller_value);
 	ClassDB::bind_method(D_METHOD("get_controller_value"), &InputEventMIDI::get_controller_value);
+
+	ClassDB::bind_static_method("InputEventMIDI", D_METHOD("open_inputs"), &InputEventMIDI::open_inputs);
+	ClassDB::bind_static_method("InputEventMIDI", D_METHOD("close_inputs"), &InputEventMIDI::close_inputs);
+	ClassDB::bind_static_method("InputEventMIDI", D_METHOD("get_connected_inputs"), &InputEventMIDI::get_connected_inputs);
+
+	BIND_ENUM_CONSTANT(MESSAGE_NONE);
+	BIND_ENUM_CONSTANT(MESSAGE_NOTE_OFF);
+	BIND_ENUM_CONSTANT(MESSAGE_NOTE_ON);
+	BIND_ENUM_CONSTANT(MESSAGE_AFTERTOUCH);
+	BIND_ENUM_CONSTANT(MESSAGE_CONTROL_CHANGE);
+	BIND_ENUM_CONSTANT(MESSAGE_PROGRAM_CHANGE);
+	BIND_ENUM_CONSTANT(MESSAGE_CHANNEL_PRESSURE);
+	BIND_ENUM_CONSTANT(MESSAGE_PITCH_BEND);
+	BIND_ENUM_CONSTANT(MESSAGE_SYSTEM_EXCLUSIVE);
+	BIND_ENUM_CONSTANT(MESSAGE_QUARTER_FRAME);
+	BIND_ENUM_CONSTANT(MESSAGE_SONG_POSITION_POINTER);
+	BIND_ENUM_CONSTANT(MESSAGE_SONG_SELECT);
+	BIND_ENUM_CONSTANT(MESSAGE_TUNE_REQUEST);
+	BIND_ENUM_CONSTANT(MESSAGE_TIMING_CLOCK);
+	BIND_ENUM_CONSTANT(MESSAGE_START);
+	BIND_ENUM_CONSTANT(MESSAGE_CONTINUE);
+	BIND_ENUM_CONSTANT(MESSAGE_STOP);
+	BIND_ENUM_CONSTANT(MESSAGE_ACTIVE_SENSING);
+	BIND_ENUM_CONSTANT(MESSAGE_SYSTEM_RESET);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "channel"), "set_channel", "get_channel");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "message"), "set_message", "get_message");

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -508,10 +508,35 @@ public:
 };
 
 class InputEventMIDI : public InputEvent {
+private:
 	GDCLASS(InputEventMIDI, InputEvent);
 
+public:
+	enum Message {
+		MESSAGE_NONE = MIDIMessage::NONE,
+		MESSAGE_NOTE_OFF = MIDIMessage::NOTE_OFF,
+		MESSAGE_NOTE_ON = MIDIMessage::NOTE_ON,
+		MESSAGE_AFTERTOUCH = MIDIMessage::AFTERTOUCH,
+		MESSAGE_CONTROL_CHANGE = MIDIMessage::CONTROL_CHANGE,
+		MESSAGE_PROGRAM_CHANGE = MIDIMessage::PROGRAM_CHANGE,
+		MESSAGE_CHANNEL_PRESSURE = MIDIMessage::CHANNEL_PRESSURE,
+		MESSAGE_PITCH_BEND = MIDIMessage::PITCH_BEND,
+		MESSAGE_SYSTEM_EXCLUSIVE = MIDIMessage::SYSTEM_EXCLUSIVE,
+		MESSAGE_QUARTER_FRAME = MIDIMessage::QUARTER_FRAME,
+		MESSAGE_SONG_POSITION_POINTER = MIDIMessage::SONG_POSITION_POINTER,
+		MESSAGE_SONG_SELECT = MIDIMessage::SONG_SELECT,
+		MESSAGE_TUNE_REQUEST = MIDIMessage::TUNE_REQUEST,
+		MESSAGE_TIMING_CLOCK = MIDIMessage::TIMING_CLOCK,
+		MESSAGE_START = MIDIMessage::START,
+		MESSAGE_CONTINUE = MIDIMessage::CONTINUE,
+		MESSAGE_STOP = MIDIMessage::STOP,
+		MESSAGE_ACTIVE_SENSING = MIDIMessage::ACTIVE_SENSING,
+		MESSAGE_SYSTEM_RESET = MIDIMessage::SYSTEM_RESET,
+	};
+
+private:
 	int channel = 0;
-	MIDIMessage message = MIDIMessage::NONE;
+	Message message = Message::MESSAGE_NONE;
 	int pitch = 0;
 	int velocity = 0;
 	int instrument = 0;
@@ -526,8 +551,8 @@ public:
 	void set_channel(const int p_channel);
 	int get_channel() const;
 
-	void set_message(const MIDIMessage p_message);
-	MIDIMessage get_message() const;
+	void set_message(const Message p_message);
+	Message get_message() const;
 
 	void set_pitch(const int p_pitch);
 	int get_pitch() const;
@@ -547,11 +572,16 @@ public:
 	void set_controller_value(const int p_controller_value);
 	int get_controller_value() const;
 
+	static void open_inputs();
+	static void close_inputs();
+	static PackedStringArray get_connected_inputs();
+
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
 	InputEventMIDI() {}
 };
+VARIANT_ENUM_CAST(InputEventMIDI::Message);
 
 class InputEventShortcut : public InputEvent {
 	GDCLASS(InputEventShortcut, InputEvent);

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -51,57 +51,57 @@ void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_
 		if (data[0] >= 0xF0) {
 			// channel does not apply to system common messages
 			event->set_channel(0);
-			event->set_message(MIDIMessage(data[0]));
+			event->set_message(InputEventMIDI::Message(data[0]));
 			last_received_message = data[0];
 		} else if ((data[0] & 0x80) == 0x00) {
 			// running status
 			event->set_channel(last_received_message & 0xF);
-			event->set_message(MIDIMessage(last_received_message >> 4));
+			event->set_message(InputEventMIDI::Message(last_received_message >> 4));
 			param_position = 0;
 		} else {
 			event->set_channel(data[0] & 0xF);
-			event->set_message(MIDIMessage(data[0] >> 4));
+			event->set_message(InputEventMIDI::Message(data[0] >> 4));
 			param_position = 1;
 			last_received_message = data[0];
 		}
 	}
 
 	switch (event->get_message()) {
-		case MIDIMessage::AFTERTOUCH:
+		case InputEventMIDI::Message::MESSAGE_AFTERTOUCH:
 			if (length >= 2 + param_position) {
 				event->set_pitch(data[param_position]);
 				event->set_pressure(data[param_position + 1]);
 			}
 			break;
 
-		case MIDIMessage::CONTROL_CHANGE:
+		case InputEventMIDI::Message::MESSAGE_CONTROL_CHANGE:
 			if (length >= 2 + param_position) {
 				event->set_controller_number(data[param_position]);
 				event->set_controller_value(data[param_position + 1]);
 			}
 			break;
 
-		case MIDIMessage::NOTE_ON:
-		case MIDIMessage::NOTE_OFF:
+		case InputEventMIDI::Message::MESSAGE_NOTE_ON:
+		case InputEventMIDI::Message::MESSAGE_NOTE_OFF:
 			if (length >= 2 + param_position) {
 				event->set_pitch(data[param_position]);
 				event->set_velocity(data[param_position + 1]);
 			}
 			break;
 
-		case MIDIMessage::PITCH_BEND:
+		case InputEventMIDI::Message::MESSAGE_PITCH_BEND:
 			if (length >= 2 + param_position) {
 				event->set_pitch((data[param_position + 1] << 7) | data[param_position]);
 			}
 			break;
 
-		case MIDIMessage::PROGRAM_CHANGE:
+		case InputEventMIDI::Message::MESSAGE_PROGRAM_CHANGE:
 			if (length >= 1 + param_position) {
 				event->set_instrument(data[param_position]);
 			}
 			break;
 
-		case MIDIMessage::CHANNEL_PRESSURE:
+		case InputEventMIDI::Message::MESSAGE_CHANNEL_PRESSURE:
 			if (length >= 1 + param_position) {
 				event->set_pressure(data[param_position]);
 			}

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2529,62 +2529,81 @@
 		<constant name="JOY_AXIS_MAX" value="10" enum="JoyAxis">
 			The maximum number of game controller axes: OpenVR supports up to 5 Joysticks making a total of 10 axes.
 		</constant>
-		<constant name="MIDI_MESSAGE_NONE" value="0" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_NONE" value="0" enum="MIDIMessage" is_deprecated="true">
 			Enum value which doesn't correspond to any MIDI message. This is used to initialize [enum MIDIMessage] properties with a generic state.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_NONE].
 		</constant>
-		<constant name="MIDI_MESSAGE_NOTE_OFF" value="8" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_NOTE_OFF" value="8" enum="MIDIMessage" is_deprecated="true">
 			MIDI note OFF message. Not all MIDI devices send this event; some send [constant MIDI_MESSAGE_NOTE_ON] with zero velocity instead. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_NOTE_OFF].
 		</constant>
-		<constant name="MIDI_MESSAGE_NOTE_ON" value="9" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_NOTE_ON" value="9" enum="MIDIMessage" is_deprecated="true">
 			MIDI note ON message. Some MIDI devices send this event with velocity zero instead of [constant MIDI_MESSAGE_NOTE_OFF], but implementations vary. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_NOTE_ON].
 		</constant>
-		<constant name="MIDI_MESSAGE_AFTERTOUCH" value="10" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_AFTERTOUCH" value="10" enum="MIDIMessage" is_deprecated="true">
 			MIDI aftertouch message. This message is most often sent by pressing down on the key after it "bottoms out".
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_AFTERTOUCH].
 		</constant>
-		<constant name="MIDI_MESSAGE_CONTROL_CHANGE" value="11" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_CONTROL_CHANGE" value="11" enum="MIDIMessage" is_deprecated="true">
 			MIDI control change message. This message is sent when a controller value changes. Controllers include devices such as pedals and levers.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_CONTROL_CHANGE].
 		</constant>
-		<constant name="MIDI_MESSAGE_PROGRAM_CHANGE" value="12" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_PROGRAM_CHANGE" value="12" enum="MIDIMessage" is_deprecated="true">
 			MIDI program change message. This message sent when the program patch number changes.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_PROGRAM_CHANGE].
 		</constant>
-		<constant name="MIDI_MESSAGE_CHANNEL_PRESSURE" value="13" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_CHANNEL_PRESSURE" value="13" enum="MIDIMessage" is_deprecated="true">
 			MIDI channel pressure message. This message is most often sent by pressing down on the key after it "bottoms out". This message is different from polyphonic after-touch as it indicates the highest pressure across all keys.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_CHANNEL_PRESSURE].
 		</constant>
-		<constant name="MIDI_MESSAGE_PITCH_BEND" value="14" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_PITCH_BEND" value="14" enum="MIDIMessage" is_deprecated="true">
 			MIDI pitch bend message. This message is sent to indicate a change in the pitch bender (wheel or lever, typically).
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_PITCH_BEND].
 		</constant>
-		<constant name="MIDI_MESSAGE_SYSTEM_EXCLUSIVE" value="240" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SYSTEM_EXCLUSIVE" value="240" enum="MIDIMessage" is_deprecated="true">
 			MIDI system exclusive message. This has behavior exclusive to the device you're receiving input from. Getting this data is not implemented in Godot.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_SYSTEM_EXCLUSIVE].
 		</constant>
-		<constant name="MIDI_MESSAGE_QUARTER_FRAME" value="241" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_QUARTER_FRAME" value="241" enum="MIDIMessage" is_deprecated="true">
 			MIDI quarter frame message. Contains timing information that is used to synchronize MIDI devices. Getting this data is not implemented in Godot.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_QUARTER_FRAME].
 		</constant>
-		<constant name="MIDI_MESSAGE_SONG_POSITION_POINTER" value="242" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SONG_POSITION_POINTER" value="242" enum="MIDIMessage" is_deprecated="true">
 			MIDI song position pointer message. Gives the number of 16th notes since the start of the song. Getting this data is not implemented in Godot.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_SONG_POSITION_POINTER].
 		</constant>
-		<constant name="MIDI_MESSAGE_SONG_SELECT" value="243" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SONG_SELECT" value="243" enum="MIDIMessage" is_deprecated="true">
 			MIDI song select message. Specifies which sequence or song is to be played. Getting this data is not implemented in Godot.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_SONG_SELECT].
 		</constant>
-		<constant name="MIDI_MESSAGE_TUNE_REQUEST" value="246" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_TUNE_REQUEST" value="246" enum="MIDIMessage" is_deprecated="true">
 			MIDI tune request message. Upon receiving a tune request, all analog synthesizers should tune their oscillators.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_TUNE_REQUEST].
 		</constant>
-		<constant name="MIDI_MESSAGE_TIMING_CLOCK" value="248" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_TIMING_CLOCK" value="248" enum="MIDIMessage" is_deprecated="true">
 			MIDI timing clock message. Sent 24 times per quarter note when synchronization is required.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_TIMING_CLOCK].
 		</constant>
-		<constant name="MIDI_MESSAGE_START" value="250" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_START" value="250" enum="MIDIMessage" is_deprecated="true">
 			MIDI start message. Start the current sequence playing. This message will be followed with Timing Clocks.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_START].
 		</constant>
-		<constant name="MIDI_MESSAGE_CONTINUE" value="251" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_CONTINUE" value="251" enum="MIDIMessage" is_deprecated="true">
 			MIDI continue message. Continue at the point the sequence was stopped.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_CONTINUE].
 		</constant>
-		<constant name="MIDI_MESSAGE_STOP" value="252" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_STOP" value="252" enum="MIDIMessage" is_deprecated="true">
 			MIDI stop message. Stop the current sequence.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_STOP].
 		</constant>
-		<constant name="MIDI_MESSAGE_ACTIVE_SENSING" value="254" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_ACTIVE_SENSING" value="254" enum="MIDIMessage" is_deprecated="true">
 			MIDI active sensing message. This message is intended to be sent repeatedly to tell the receiver that a connection is alive.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_ACTIVE_SENSING].
 		</constant>
-		<constant name="MIDI_MESSAGE_SYSTEM_RESET" value="255" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SYSTEM_RESET" value="255" enum="MIDIMessage" is_deprecated="true">
 			MIDI system reset message. Reset all receivers in the system to power-up status. It should not be sent on power-up itself.
+			[i]Deprecated.[/i] Use [constant InputEventMIDI.MESSAGE_SYSTEM_RESET].
 		</constant>
 		<constant name="OK" value="0" enum="Error">
 			Methods that return [enum Error] return [constant OK] when no error occurred.

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -6,12 +6,12 @@
 	<description>
 		InputEventMIDI allows receiving input events from MIDI (Musical Instrument Digital Interface) devices such as a piano.
 		MIDI signals can be sent over a 5-pin MIDI connector or over USB, if your device supports both be sure to check the settings in the device to see which output it's using.
-		To receive input events from MIDI devices, you need to call [method OS.open_midi_inputs]. You can check which devices are detected using [method OS.get_connected_midi_inputs].
+		To receive input events from MIDI devices, you need to call [method open_inputs]. You can check which devices are detected using [method get_connected_inputs].
 		[codeblocks]
 		[gdscript]
 		func _ready():
-		    OS.open_midi_inputs()
-		    print(OS.get_connected_midi_inputs())
+		    InputEventMIDI.open_inputs()
+		    print(InputEventMIDI.get_connected_inputs())
 
 		func _input(input_event):
 		    if input_event is InputEventMIDI:
@@ -31,8 +31,8 @@
 		[csharp]
 		public override void _Ready()
 		{
-		    OS.OpenMidiInputs();
-		    GD.Print(OS.GetConnectedMidiInputs());
+		    InputEventMIDI.OpenInputs();
+		    GD.Print(InputEventMIDI.GetConnectedInputs());
 		}
 
 		public override void _Input(InputEvent @event)
@@ -64,24 +64,48 @@
 		<link title="Wikipedia General MIDI Instrument List">https://en.wikipedia.org/wiki/General_MIDI#Program_change_events</link>
 		<link title="Wikipedia Piano Key Frequencies List">https://en.wikipedia.org/wiki/Piano_key_frequencies#List</link>
 	</tutorials>
+	<methods>
+		<method name="close_inputs" qualifiers="static">
+			<return type="void" />
+			<description>
+				Shuts down system MIDI driver.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="get_connected_inputs" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of MIDI device names.
+				The returned array will be empty if the system MIDI driver has not previously been initialized with [method open_inputs].
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="open_inputs" qualifiers="static">
+			<return type="void" />
+			<description>
+				Initializes the singleton for the system MIDI driver.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="channel" type="int" setter="set_channel" getter="get_channel" default="0">
 			The MIDI channel of this input event. There are 16 channels, so this value ranges from 0 to 15. MIDI channel 9 is reserved for the use with percussion instruments, the rest of the channels are for non-percussion instruments.
 		</member>
 		<member name="controller_number" type="int" setter="set_controller_number" getter="get_controller_number" default="0">
-			If the message is [constant MIDI_MESSAGE_CONTROL_CHANGE], this indicates the controller number, otherwise this is zero. Controllers include devices such as pedals and levers.
+			If the message is [constant MESSAGE_CONTROL_CHANGE], this indicates the controller number, otherwise this is zero. Controllers include devices such as pedals and levers.
 		</member>
 		<member name="controller_value" type="int" setter="set_controller_value" getter="get_controller_value" default="0">
-			If the message is [constant MIDI_MESSAGE_CONTROL_CHANGE], this indicates the controller value, otherwise this is zero. Controllers include devices such as pedals and levers.
+			If the message is [constant MESSAGE_CONTROL_CHANGE], this indicates the controller value, otherwise this is zero. Controllers include devices such as pedals and levers.
 		</member>
 		<member name="instrument" type="int" setter="set_instrument" getter="get_instrument" default="0">
 			The instrument of this input event. This value ranges from 0 to 127. Refer to the instrument list on the General MIDI wikipedia article to see a list of instruments, except that this value is 0-index, so subtract one from every number on that chart. A standard piano will have an instrument number of 0.
 		</member>
-		<member name="message" type="int" setter="set_message" getter="get_message" enum="MIDIMessage" default="0">
-			Returns a value indicating the type of message for this MIDI signal. This is a member of the [enum MIDIMessage] enum.
+		<member name="message" type="int" setter="set_message" getter="get_message" enum="Message" default="0">
+			Returns a value indicating the type of message for this MIDI signal. This is a member of the [enum Message] enum.
 			For MIDI messages between 0x80 and 0xEF, only the left half of the bits are returned as this value, as the other part is the channel (ex: 0x94 becomes 0x9). For MIDI messages from 0xF0 to 0xFF, the value is returned as-is.
-			Notes will return [constant MIDI_MESSAGE_NOTE_ON] when activated, but they might not always return [constant MIDI_MESSAGE_NOTE_OFF] when deactivated, therefore your code should treat the input as stopped if some period of time has passed.
-			Some MIDI devices may send [constant MIDI_MESSAGE_NOTE_ON] with zero velocity instead of [constant MIDI_MESSAGE_NOTE_OFF].
+			Notes will return [constant MESSAGE_NOTE_ON] when activated, but they might not always return [constant MESSAGE_NOTE_OFF] when deactivated, therefore your code should treat the input as stopped if some period of time has passed.
+			Some MIDI devices may send [constant MESSAGE_NOTE_ON] with zero velocity instead of [constant MESSAGE_NOTE_OFF].
 			For more information, see the note in [member velocity] and the MIDI message status byte list chart linked above.
 		</member>
 		<member name="pitch" type="int" setter="set_pitch" getter="get_pitch" default="0">
@@ -92,7 +116,66 @@
 		</member>
 		<member name="velocity" type="int" setter="set_velocity" getter="get_velocity" default="0">
 			The velocity of the MIDI signal. This value ranges from 0 to 127. For a piano, this corresponds to how quickly the key was pressed, and is rarely above about 110 in practice.
-			[b]Note:[/b] Some MIDI devices may send a [constant MIDI_MESSAGE_NOTE_ON] message with zero velocity and expect this to be treated the same as a [constant MIDI_MESSAGE_NOTE_OFF] message, but device implementations vary so Godot reports event data exactly as received. Depending on the hardware and the needs of the game/app, this MIDI quirk can be handled robustly with a couple lines of script (check for [constant MIDI_MESSAGE_NOTE_ON] with velocity zero).
+			[b]Note:[/b] Some MIDI devices may send a [constant MESSAGE_NOTE_ON] message with zero velocity and expect this to be treated the same as a [constant MESSAGE_NOTE_OFF] message, but device implementations vary so Godot reports event data exactly as received. Depending on the hardware and the needs of the game/app, this MIDI quirk can be handled robustly with a couple lines of script (check for [constant MESSAGE_NOTE_ON] with velocity zero).
 		</member>
 	</members>
+	<constants>
+		<constant name="MESSAGE_NONE" value="0" enum="Message">
+			Enum value which doesn't correspond to any MIDI message. This is used to initialize [enum MIDIMessage] properties with a generic state.
+		</constant>
+		<constant name="MESSAGE_NOTE_OFF" value="8" enum="Message">
+			MIDI note OFF message. Not all MIDI devices send this event; some send [constant MESSAGE_NOTE_ON] with zero velocity instead. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+		</constant>
+		<constant name="MESSAGE_NOTE_ON" value="9" enum="Message">
+			MIDI note ON message. Some MIDI devices send this event with velocity zero instead of [constant MESSAGE_NOTE_OFF], but implementations vary. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+		</constant>
+		<constant name="MESSAGE_AFTERTOUCH" value="10" enum="Message">
+			MIDI aftertouch message. This message is most often sent by pressing down on the key after it "bottoms out".
+		</constant>
+		<constant name="MESSAGE_CONTROL_CHANGE" value="11" enum="Message">
+			MIDI control change message. This message is sent when a controller value changes. Controllers include devices such as pedals and levers.
+		</constant>
+		<constant name="MESSAGE_PROGRAM_CHANGE" value="12" enum="Message">
+			MIDI program change message. This message sent when the program patch number changes.
+		</constant>
+		<constant name="MESSAGE_CHANNEL_PRESSURE" value="13" enum="Message">
+			MIDI channel pressure message. This message is most often sent by pressing down on the key after it "bottoms out". This message is different from polyphonic after-touch as it indicates the highest pressure across all keys.
+		</constant>
+		<constant name="MESSAGE_PITCH_BEND" value="14" enum="Message">
+			MIDI pitch bend message. This message is sent to indicate a change in the pitch bender (wheel or lever, typically).
+		</constant>
+		<constant name="MESSAGE_SYSTEM_EXCLUSIVE" value="240" enum="Message">
+			MIDI system exclusive message. This has behavior exclusive to the device you're receiving input from. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_QUARTER_FRAME" value="241" enum="Message">
+			MIDI quarter frame message. Contains timing information that is used to synchronize MIDI devices. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_SONG_POSITION_POINTER" value="242" enum="Message">
+			MIDI song position pointer message. Gives the number of 16th notes since the start of the song. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_SONG_SELECT" value="243" enum="Message">
+			MIDI song select message. Specifies which sequence or song is to be played. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_TUNE_REQUEST" value="246" enum="Message">
+			MIDI tune request message. Upon receiving a tune request, all analog synthesizers should tune their oscillators.
+		</constant>
+		<constant name="MESSAGE_TIMING_CLOCK" value="248" enum="Message">
+			MIDI timing clock message. Sent 24 times per quarter note when synchronization is required.
+		</constant>
+		<constant name="MESSAGE_START" value="250" enum="Message">
+			MIDI start message. Start the current sequence playing. This message will be followed with Timing Clocks.
+		</constant>
+		<constant name="MESSAGE_CONTINUE" value="251" enum="Message">
+			MIDI continue message. Continue at the point the sequence was stopped.
+		</constant>
+		<constant name="MESSAGE_STOP" value="252" enum="Message">
+			MIDI stop message. Stop the current sequence.
+		</constant>
+		<constant name="MESSAGE_ACTIVE_SENSING" value="254" enum="Message">
+			MIDI active sensing message. This message is intended to be sent repeatedly to tell the receiver that a connection is alive.
+		</constant>
+		<constant name="MESSAGE_SYSTEM_RESET" value="255" enum="Message">
+			MIDI system reset message. Reset all receivers in the system to power-up status. It should not be sent on power-up itself.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -19,11 +19,12 @@
 				Displays a modal dialog box using the host OS' facilities. Execution is blocked until the dialog is closed.
 			</description>
 		</method>
-		<method name="close_midi_inputs">
+		<method name="close_midi_inputs" is_deprecated="true">
 			<return type="void" />
 			<description>
 				Shuts down system MIDI driver.
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+				[i]Deprecated.[/i] Use [method InputEventMIDI.close_inputs].
 			</description>
 		</method>
 		<method name="crash">
@@ -198,12 +199,13 @@
 				Not to be confused with [method get_user_data_dir], which returns the [i]project-specific[/i] user data path.
 			</description>
 		</method>
-		<method name="get_connected_midi_inputs">
+		<method name="get_connected_midi_inputs" is_deprecated="true">
 			<return type="PackedStringArray" />
 			<description>
 				Returns an array of MIDI device names.
 				The returned array will be empty if the system MIDI driver has not previously been initialized with [method open_midi_inputs].
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+				[i]Deprecated.[/i] Use [method InputEventMIDI.get_connected_inputs].
 			</description>
 		</method>
 		<method name="get_data_dir" qualifiers="const">
@@ -580,11 +582,12 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="open_midi_inputs">
+		<method name="open_midi_inputs" is_deprecated="true">
 			<return type="void" />
 			<description>
 				Initializes the singleton for the system MIDI driver.
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+				[i]Deprecated.[/i] Use [method InputEventMIDI.open_inputs].
 			</description>
 		</method>
 		<method name="read_string_from_stdin">


### PR DESCRIPTION
Superseded by https://github.com/godotengine/godot/pull/86713 and https://github.com/godotengine/godot/pull/86716.

This PR moves OS' methods about MIDI, and the global constants into the **InputEventMIDI**. The new methods are static.
The previous methods and constants still exist, but are marked as **deprecated**.
This means the following:

----
Edit: These methods are currently commented out, because they refuse to compile. Will ask for help later.

| Currently| This PR |
| --- | --- |
| `OS.open_midi_inputs()` | `InputEventMIDI.open_inputs()` |
| `OS.get_connected_midi_inputs()` | `InputEventMIDI.get_connected_inputs()` |
| `OS.close_midi_inputs()` | `InputEventMIDI.close_inputs()` |

| Currently| This PR |
| --- | --- |
| MIDI_MESSAGE_NONE | InputEventMIDI.**MESSAGE_NONE** |
| MIDI_MESSAGE_NOTE_ON | InputEventMIDI.**MESSAGE_NOTE_ON** |
| MIDI_MESSAGE_NOTE_OFF | InputEventMIDI.**MESSAGE_NOTE_OFF** |
| MIDI_MESSAGE_AFTERTOUCH | InputEventMIDI.**MESSAGE_AFTERTOUCH** |
| MIDI_MESSAGE_CONTROL_CHANGE | InputEventMIDI.**MESSAGE_CONTROL_CHANGE** |
| MIDI_MESSAGE_PROGRAM_CHANGE | InputEventMIDI.**MESSAGE_PROGRAM_CHANGE** |
| MIDI_MESSAGE_CHANNEL_PRESSURE | InputEventMIDI.**MESSAGE_CHANNEL_PRESSURE** |
| MIDI_MESSAGE_PITCH_BEND | InputEventMIDI.**MESSAGE_PITCH_BEND** |
| MIDI_MESSAGE_SYSTEM_EXCLUSIVE | InputEventMIDI.**MESSAGE_SYSTEM_EXCLUSIVE** |
| MIDI_MESSAGE_QUARTER_FRAME | InputEventMIDI.**MESSAGE_QUARTER_FRAME** |
| MIDI_MESSAGE_SONG_POSITION_POINTER | InputEventMIDI.**MESSAGE_SONG_POSITION_POINTER** |
| MIDI_MESSAGE_SONG_SELECT | InputEventMIDI.**MESSAGE_SONG_SELECT** |
| MIDI_MESSAGE_TUNE_REQUEST | InputEventMIDI.**MESSAGE_TUNE_REQUEST** |
| MIDI_MESSAGE_TIMING_CLOCK | InputEventMIDI.**MESSAGE_TIMING_CLOCK** |
| MIDI_MESSAGE_START | InputEventMIDI.**MESSAGE_START** |
| MIDI_MESSAGE_CONTINUE | InputEventMIDI.**MESSAGE_CONTINUE** |
| MIDI_MESSAGE_STOP | InputEventMIDI.**MESSAGE_STOP** |
| MIDI_MESSAGE_ACTIVE_SENSING | InputEventMIDI.**MESSAGE_ACTIVE_SENSING** |
| MIDI_MESSAGE_SYSTEM_RESET | InputEventMIDI.**MESSAGE_SYSTEM_RESET** |
