### PR TITLE
Handle built-in shaders when closing scene

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -55,6 +55,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 		TextShaderEditor *shader_editor = nullptr;
 		VisualShaderEditor *visual_shader_editor = nullptr;
 		String path;
+		String name;
 	};
 
 	LocalVector<EditedShader> edited_shaders;


### PR DESCRIPTION
Resolves TODO in the shader editor. When closing scene, the editor will warn about unsaved shaders. This is relevant after #75864

Also fixed the unsaved shader list displaying wrong names.