### PR TITLE
Move OS' MIDI methods into InputEventMIDI

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1841,6 +1841,18 @@ int InputEventMIDI::get_controller_value() const {
 	return controller_value;
 }
 
+void InputEventMIDI::open_inputs() {
+	OS::get_singleton()->open_midi_inputs();
+}
+
+void InputEventMIDI::close_inputs() {
+	OS::get_singleton()->close_midi_inputs();
+}
+
+PackedStringArray InputEventMIDI::get_connected_inputs() {
+	return OS::get_singleton()->get_connected_midi_inputs();
+}
+
 String InputEventMIDI::as_text() const {
 	return vformat(RTR("MIDI Input on Channel=%s Message=%s"), itos(channel), itos((int64_t)message));
 }
@@ -1886,6 +1898,10 @@ void InputEventMIDI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_controller_number"), &InputEventMIDI::get_controller_number);
 	ClassDB::bind_method(D_METHOD("set_controller_value", "controller_value"), &InputEventMIDI::set_controller_value);
 	ClassDB::bind_method(D_METHOD("get_controller_value"), &InputEventMIDI::get_controller_value);
+
+	ClassDB::bind_static_method("InputEventMIDI", D_METHOD("open_inputs"), &InputEventMIDI::open_inputs);
+	ClassDB::bind_static_method("InputEventMIDI", D_METHOD("close_inputs"), &InputEventMIDI::close_inputs);
+	ClassDB::bind_static_method("InputEventMIDI", D_METHOD("get_connected_inputs"), &InputEventMIDI::get_connected_inputs);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "channel"), "set_channel", "get_channel");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "message"), "set_message", "get_message");

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -571,6 +571,10 @@ public:
 	void set_controller_value(const int p_controller_value);
 	int get_controller_value() const;
 
+	static void open_inputs();
+	static void close_inputs();
+	static PackedStringArray get_connected_inputs();
+
 	virtual String as_text() const override;
 	virtual String to_string() override;
 

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -6,12 +6,12 @@
 	<description>
 		InputEventMIDI stores information about messages from [url=https://en.wikipedia.org/wiki/MIDI]MIDI[/url] (Musical Instrument Digital Interface) devices. These may include musical keyboards, synthesizers, and drum machines.
 		MIDI messages can be received over a 5-pin MIDI connector or over USB. If your device supports both be sure to check the settings in the device to see which output it is using.
-		By default, Godot does not detect MIDI devices. You need to call [method OS.open_midi_inputs], first. You can check which devices are detected with [method OS.get_connected_midi_inputs], and close the connection with [method OS.close_midi_inputs].
+		By default, Godot does not detect MIDI devices. You need to call [method open_inputs], first. You can check which devices are detected with [method get_connected_inputs], and close the connection with [method close_inputs].
 		[codeblocks]
 		[gdscript]
 		func _ready():
-		    OS.open_midi_inputs()
-		    print(OS.get_connected_midi_inputs())
+		    InputEventMIDI.open_inputs()
+		    print(InputEventMIDI.get_connected_inputs())
 
 		func _input(input_event):
 		    if input_event is InputEventMIDI:
@@ -31,8 +31,8 @@
 		[csharp]
 		public override void _Ready()
 		{
-		    OS.OpenMidiInputs();
-		    GD.Print(OS.GetConnectedMidiInputs());
+		    InputEventMIDI.OpenInputs();
+		    GD.Print(InputEventMIDI.GetConnectedInputs());
 		}
 
 		public override void _Input(InputEvent inputEvent)
@@ -58,13 +58,40 @@
 		[/csharp]
 		[/codeblocks]
 		[b]Note:[/b] Godot does not support MIDI output, so there is no way to emit MIDI messages from Godot. Only MIDI input is supported.
-		[b]Note:[/b] On the Web platform, using MIDI input requires a browser permission to be granted first. This permission request is performed when calling [method OS.open_midi_inputs]. MIDI input will not work until the user accepts the permission request.
+		[b]Note:[/b] On the Web platform, using MIDI input requires a browser permission to be granted first. This permission request is performed when calling [method open_inputs]. MIDI input will not work until the user accepts the permission request.
 	</description>
 	<tutorials>
 		<link title="MIDI Message Status Byte List">https://www.midi.org/specifications-old/item/table-2-expanded-messages-list-status-bytes</link>
 		<link title="Wikipedia General MIDI Instrument List">https://en.wikipedia.org/wiki/General_MIDI#Program_change_events</link>
 		<link title="Wikipedia Piano Key Frequencies List">https://en.wikipedia.org/wiki/Piano_key_frequencies#List</link>
 	</tutorials>
+	<methods>
+		<method name="close_inputs" qualifiers="static">
+			<return type="void" />
+			<description>
+				Shuts down the system MIDI driver. Godot will no longer receive [InputEventMIDI]. See also [method open_inputs] and [method get_connected_inputs].
+				[b]Note:[/b] This method is implemented on Linux, macOS, Windows, and Web.
+			</description>
+		</method>
+		<method name="get_connected_inputs" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of connected MIDI device names, if they exist. Returns an empty array if the system MIDI driver has not previously been initialized with [method open_inputs]. See also [method close_inputs].
+				[b]Note:[/b] This method is implemented on Linux, macOS, Windows, and Web.
+				[b]Note:[/b] On the Web platform, Web MIDI needs to be supported by the browser. [url=https://caniuse.com/midi]For the time being[/url], it is currently supported by all major browsers, except Safari.
+				[b]Note:[/b] On the Web platform, using MIDI input requires a browser permission to be granted first. This permission request is performed when calling [method open_inputs]. The browser will refrain from processing MIDI input until the user accepts the permission request.
+			</description>
+		</method>
+		<method name="open_inputs" qualifiers="static">
+			<return type="void" />
+			<description>
+				Initializes the singleton for the system MIDI driver, allowing Godot to receive [InputEventMIDI]. See also [method get_connected_inputs] and [method close_inputs].
+				[b]Note:[/b] This method is implemented on Linux, macOS, Windows, and Web.
+				[b]Note:[/b] On the Web platform, Web MIDI needs to be supported by the browser. [url=https://caniuse.com/midi]For the time being[/url], it is currently supported by all major browsers, except Safari.
+				[b]Note:[/b] On the Web platform, using MIDI input requires a browser permission to be granted first. This permission request is performed when calling [method open_inputs]. The browser will refrain from processing MIDI input until the user accepts the permission request.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="channel" type="int" setter="set_channel" getter="get_channel" default="0">
 			The MIDI channel of this message, ranging from [code]0[/code] to [code]15[/code]. MIDI channel [code]9[/code] is reserved for percussion instruments.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -19,7 +19,7 @@
 				Displays a modal dialog box using the host platform's implementation. The engine execution is blocked until the dialog is closed.
 			</description>
 		</method>
-		<method name="close_midi_inputs">
+		<method name="close_midi_inputs" deprecated="Use [method InputEventMIDI.close_inputs] instead.">
 			<return type="void" />
 			<description>
 				Shuts down the system MIDI driver. Godot will no longer receive [InputEventMIDI]. See also [method open_midi_inputs] and [method get_connected_midi_inputs].
@@ -240,7 +240,7 @@
 				Not to be confused with [method get_user_data_dir], which returns the [i]project-specific[/i] user data path.
 			</description>
 		</method>
-		<method name="get_connected_midi_inputs">
+		<method name="get_connected_midi_inputs" deprecated="Use [method InputEventMIDI.get_connected_inputs] instead.">
 			<return type="PackedStringArray" />
 			<description>
 				Returns an array of connected MIDI device names, if they exist. Returns an empty array if the system MIDI driver has not previously been initialized with [method open_midi_inputs]. See also [method close_midi_inputs].
@@ -713,7 +713,7 @@
 				[b]Note:[/b] If the user has disabled the recycle bin on their system, the file will be permanently deleted instead.
 			</description>
 		</method>
-		<method name="open_midi_inputs">
+		<method name="open_midi_inputs" deprecated="Use [method InputEventMIDI.open_inputs] instead.">
 			<return type="void" />
 			<description>
 				Initializes the singleton for the system MIDI driver, allowing Godot to receive [InputEventMIDI]. See also [method get_connected_midi_inputs] and [method close_midi_inputs].


### PR DESCRIPTION
Partially addresses https://github.com/godotengine/godot-proposals/issues/8761.
Related to https://github.com/godotengine/godot/pull/86716 and https://github.com/godotengine/godot/pull/86693.

This PR moves the **OS**' methods related to MIDI into the **InputEventMIDI**, as static methods.
The previous methods are still available, but are marked as **deprecated**.

This means the following:
| Currently| This PR |
| --- | --- |
| `OS.open_midi_inputs()` | `InputEventMIDI.open_inputs()` |
| `OS.get_connected_midi_inputs()` | `InputEventMIDI.get_connected_inputs()` |
| `OS.close_midi_inputs()` | `InputEventMIDI.close_inputs()` |

-----------

The original intention was to [move the global constants as well](https://github.com/godotengine/godot/pull/86708), but that fell through for the time being, and will be done in a separate PR for further discussion.

On the other hand, the methods are comparatively safer to implement and do not break existing compatibility. See the proposal for reasoning.
