### PR TITLE
Move MIDI's global constants into InputEventMIDI

### DIFF
--- a/core/input/input_event.compat.inc
+++ b/core/input/input_event.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  input_event.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void InputEventMIDI::_set_message_bind_compat_86716(const MIDIMessage p_message) {
+	set_message(Message(p_message));
+}
+
+MIDIMessage InputEventMIDI::_get_message_bind_compat_86716() const {
+	return MIDIMessage(get_message());
+}
+
+void InputEventMIDI::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_message", "message"), &InputEventMIDI::_set_message_bind_compat_86716);
+	ClassDB::bind_compatibility_method(D_METHOD("get_message"), &InputEventMIDI::_get_message_bind_compat_86716);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "input_event.h"
+#include "input_event.compat.inc"
 
 #include "core/input/input_map.h"
 #include "core/input/shortcut.h"
@@ -1785,11 +1786,11 @@ int InputEventMIDI::get_channel() const {
 	return channel;
 }
 
-void InputEventMIDI::set_message(const MIDIMessage p_message) {
+void InputEventMIDI::set_message(const Message p_message) {
 	message = p_message;
 }
 
-MIDIMessage InputEventMIDI::get_message() const {
+InputEventMIDI::Message InputEventMIDI::get_message() const {
 	return message;
 }
 
@@ -1848,19 +1849,19 @@ String InputEventMIDI::as_text() const {
 String InputEventMIDI::to_string() {
 	String ret;
 	switch (message) {
-		case MIDIMessage::NOTE_ON:
+		case Message::MESSAGE_NOTE_ON:
 			ret = vformat("Note On: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
 			break;
-		case MIDIMessage::NOTE_OFF:
+		case Message::MESSAGE_NOTE_OFF:
 			ret = vformat("Note Off: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
 			break;
-		case MIDIMessage::PITCH_BEND:
+		case Message::MESSAGE_PITCH_BEND:
 			ret = vformat("Pitch Bend: channel=%d, pitch=%d", channel, pitch);
 			break;
-		case MIDIMessage::CHANNEL_PRESSURE:
+		case Message::MESSAGE_CHANNEL_PRESSURE:
 			ret = vformat("Channel Pressure: channel=%d, pressure=%d", channel, pressure);
 			break;
-		case MIDIMessage::CONTROL_CHANGE:
+		case Message::MESSAGE_CONTROL_CHANGE:
 			ret = vformat("Control Change: channel=%d, controller_number=%d, controller_value=%d", channel, controller_number, controller_value);
 			break;
 		default:
@@ -1886,6 +1887,26 @@ void InputEventMIDI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_controller_number"), &InputEventMIDI::get_controller_number);
 	ClassDB::bind_method(D_METHOD("set_controller_value", "controller_value"), &InputEventMIDI::set_controller_value);
 	ClassDB::bind_method(D_METHOD("get_controller_value"), &InputEventMIDI::get_controller_value);
+
+	BIND_ENUM_CONSTANT(MESSAGE_NONE);
+	BIND_ENUM_CONSTANT(MESSAGE_NOTE_OFF);
+	BIND_ENUM_CONSTANT(MESSAGE_NOTE_ON);
+	BIND_ENUM_CONSTANT(MESSAGE_AFTERTOUCH);
+	BIND_ENUM_CONSTANT(MESSAGE_CONTROL_CHANGE);
+	BIND_ENUM_CONSTANT(MESSAGE_PROGRAM_CHANGE);
+	BIND_ENUM_CONSTANT(MESSAGE_CHANNEL_PRESSURE);
+	BIND_ENUM_CONSTANT(MESSAGE_PITCH_BEND);
+	BIND_ENUM_CONSTANT(MESSAGE_SYSTEM_EXCLUSIVE);
+	BIND_ENUM_CONSTANT(MESSAGE_QUARTER_FRAME);
+	BIND_ENUM_CONSTANT(MESSAGE_SONG_POSITION_POINTER);
+	BIND_ENUM_CONSTANT(MESSAGE_SONG_SELECT);
+	BIND_ENUM_CONSTANT(MESSAGE_TUNE_REQUEST);
+	BIND_ENUM_CONSTANT(MESSAGE_TIMING_CLOCK);
+	BIND_ENUM_CONSTANT(MESSAGE_START);
+	BIND_ENUM_CONSTANT(MESSAGE_CONTINUE);
+	BIND_ENUM_CONSTANT(MESSAGE_STOP);
+	BIND_ENUM_CONSTANT(MESSAGE_ACTIVE_SENSING);
+	BIND_ENUM_CONSTANT(MESSAGE_SYSTEM_RESET);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "channel"), "set_channel", "get_channel");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "message"), "set_message", "get_message");

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -532,10 +532,35 @@ public:
 };
 
 class InputEventMIDI : public InputEvent {
+private:
 	GDCLASS(InputEventMIDI, InputEvent);
 
+public:
+	enum Message {
+		MESSAGE_NONE = (int)MIDIMessage::NONE,
+		MESSAGE_NOTE_OFF = (int)MIDIMessage::NOTE_OFF,
+		MESSAGE_NOTE_ON = (int)MIDIMessage::NOTE_ON,
+		MESSAGE_AFTERTOUCH = (int)MIDIMessage::AFTERTOUCH,
+		MESSAGE_CONTROL_CHANGE = (int)MIDIMessage::CONTROL_CHANGE,
+		MESSAGE_PROGRAM_CHANGE = (int)MIDIMessage::PROGRAM_CHANGE,
+		MESSAGE_CHANNEL_PRESSURE = (int)MIDIMessage::CHANNEL_PRESSURE,
+		MESSAGE_PITCH_BEND = (int)MIDIMessage::PITCH_BEND,
+		MESSAGE_SYSTEM_EXCLUSIVE = (int)MIDIMessage::SYSTEM_EXCLUSIVE,
+		MESSAGE_QUARTER_FRAME = (int)MIDIMessage::QUARTER_FRAME,
+		MESSAGE_SONG_POSITION_POINTER = (int)MIDIMessage::SONG_POSITION_POINTER,
+		MESSAGE_SONG_SELECT = (int)MIDIMessage::SONG_SELECT,
+		MESSAGE_TUNE_REQUEST = (int)MIDIMessage::TUNE_REQUEST,
+		MESSAGE_TIMING_CLOCK = (int)MIDIMessage::TIMING_CLOCK,
+		MESSAGE_START = (int)MIDIMessage::START,
+		MESSAGE_CONTINUE = (int)MIDIMessage::CONTINUE,
+		MESSAGE_STOP = (int)MIDIMessage::STOP,
+		MESSAGE_ACTIVE_SENSING = (int)MIDIMessage::ACTIVE_SENSING,
+		MESSAGE_SYSTEM_RESET = (int)MIDIMessage::SYSTEM_RESET,
+	};
+
+private:
 	int channel = 0;
-	MIDIMessage message = MIDIMessage::NONE;
+	Message message = Message::MESSAGE_NONE;
 	int pitch = 0;
 	int velocity = 0;
 	int instrument = 0;
@@ -546,12 +571,18 @@ class InputEventMIDI : public InputEvent {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void _set_message_bind_compat_86716(const MIDIMessage p_message);
+	MIDIMessage _get_message_bind_compat_86716() const;
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	void set_channel(const int p_channel);
 	int get_channel() const;
 
-	void set_message(const MIDIMessage p_message);
-	MIDIMessage get_message() const;
+	void set_message(const Message p_message);
+	Message get_message() const;
 
 	void set_pitch(const int p_pitch);
 	int get_pitch() const;
@@ -576,6 +607,7 @@ public:
 
 	InputEventMIDI() {}
 };
+VARIANT_ENUM_CAST(InputEventMIDI::Message);
 
 class InputEventShortcut : public InputEvent {
 	GDCLASS(InputEventShortcut, InputEvent);

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -111,7 +111,7 @@ void MIDIDriver::send_event(int p_device_index, uint8_t p_status,
 	event.instantiate();
 	event->set_device(p_device_index);
 	event->set_channel(Parser::channel(p_status));
-	event->set_message(msg);
+	event->set_message(InputEventMIDI::Message(msg));
 	switch (msg) {
 		case MIDIMessage::NOTE_OFF:
 		case MIDIMessage::NOTE_ON:

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2546,66 +2546,66 @@
 		<constant name="JOY_AXIS_MAX" value="10" enum="JoyAxis">
 			The maximum number of game controller axes: OpenVR supports up to 5 Joysticks making a total of 10 axes.
 		</constant>
-		<constant name="MIDI_MESSAGE_NONE" value="0" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_NONE" value="0" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_NONE] instead.">
 			Does not correspond to any MIDI message. This is the default value of [member InputEventMIDI.message].
 		</constant>
-		<constant name="MIDI_MESSAGE_NOTE_OFF" value="8" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_NOTE_OFF" value="8" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_NOTE_OFF] instead.">
 			MIDI message sent when a note is released.
 			[b]Note:[/b] Not all MIDI devices send this message; some may send [constant MIDI_MESSAGE_NOTE_ON] with [member InputEventMIDI.velocity] set to [code]0[/code].
 		</constant>
-		<constant name="MIDI_MESSAGE_NOTE_ON" value="9" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_NOTE_ON" value="9" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_NOTE_ON] instead.">
 			MIDI message sent when a note is pressed.
 		</constant>
-		<constant name="MIDI_MESSAGE_AFTERTOUCH" value="10" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_AFTERTOUCH" value="10" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_AFTERTOUCH] instead.">
 			MIDI message sent to indicate a change in pressure while a note is being pressed down, also called aftertouch.
 		</constant>
-		<constant name="MIDI_MESSAGE_CONTROL_CHANGE" value="11" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_CONTROL_CHANGE" value="11" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_CONTROL_CHANGE] instead.">
 			MIDI message sent when a controller value changes. In a MIDI device, a controller is any input that doesn't play notes. These may include sliders for volume, balance, and panning, as well as switches and pedals. See the [url=https://en.wikipedia.org/wiki/General_MIDI#Controller_events]General MIDI specification[/url] for a small list.
 		</constant>
-		<constant name="MIDI_MESSAGE_PROGRAM_CHANGE" value="12" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_PROGRAM_CHANGE" value="12" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_PROGRAM_CHANGE] instead.">
 			MIDI message sent when the MIDI device changes its current instrument (also called [i]program[/i] or [i]preset[/i]).
 		</constant>
-		<constant name="MIDI_MESSAGE_CHANNEL_PRESSURE" value="13" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_CHANNEL_PRESSURE" value="13" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_CHANNEL_PRESSURE] instead.">
 			MIDI message sent to indicate a change in pressure for the whole channel. Some MIDI devices may send this instead of [constant MIDI_MESSAGE_AFTERTOUCH].
 		</constant>
-		<constant name="MIDI_MESSAGE_PITCH_BEND" value="14" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_PITCH_BEND" value="14" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_PITCH_BEND] instead.">
 			MIDI message sent when the value of the pitch bender changes, usually a wheel on the MIDI device.
 		</constant>
-		<constant name="MIDI_MESSAGE_SYSTEM_EXCLUSIVE" value="240" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SYSTEM_EXCLUSIVE" value="240" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_SYSTEM_EXCLUSIVE] instead.">
 			MIDI system exclusive (SysEx) message. This type of message is not standardized and it's highly dependent on the MIDI device sending it.
 			[b]Note:[/b] Getting this message's data from [InputEventMIDI] is not implemented.
 		</constant>
-		<constant name="MIDI_MESSAGE_QUARTER_FRAME" value="241" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_QUARTER_FRAME" value="241" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_QUARTER_FRAME] instead.">
 			MIDI message sent every quarter frame to keep connected MIDI devices synchronized. Related to [constant MIDI_MESSAGE_TIMING_CLOCK].
 			[b]Note:[/b] Getting this message's data from [InputEventMIDI] is not implemented.
 		</constant>
-		<constant name="MIDI_MESSAGE_SONG_POSITION_POINTER" value="242" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SONG_POSITION_POINTER" value="242" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_SONG_POSITION_POINTER] instead.">
 			MIDI message sent to jump onto a new position in the current sequence or song.
 			[b]Note:[/b] Getting this message's data from [InputEventMIDI] is not implemented.
 		</constant>
-		<constant name="MIDI_MESSAGE_SONG_SELECT" value="243" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SONG_SELECT" value="243" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_SONG_SELECT] instead.">
 			MIDI message sent to select a sequence or song to play.
 			[b]Note:[/b] Getting this message's data from [InputEventMIDI] is not implemented.
 		</constant>
-		<constant name="MIDI_MESSAGE_TUNE_REQUEST" value="246" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_TUNE_REQUEST" value="246" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_TUNE_REQUEST] instead.">
 			MIDI message sent to request a tuning calibration. Used on analog synthesizers. Most modern MIDI devices do not need this message.
 		</constant>
-		<constant name="MIDI_MESSAGE_TIMING_CLOCK" value="248" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_TIMING_CLOCK" value="248" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_TIMING_CLOCK] instead.">
 			MIDI message sent 24 times after [constant MIDI_MESSAGE_QUARTER_FRAME], to keep connected MIDI devices synchronized.
 		</constant>
-		<constant name="MIDI_MESSAGE_START" value="250" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_START" value="250" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_START] instead.">
 			MIDI message sent to start the current sequence or song from the beginning.
 		</constant>
-		<constant name="MIDI_MESSAGE_CONTINUE" value="251" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_CONTINUE" value="251" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_CONTINUE] instead.">
 			MIDI message sent to resume from the point the current sequence or song was paused.
 		</constant>
-		<constant name="MIDI_MESSAGE_STOP" value="252" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_STOP" value="252" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_STOP] instead.">
 			MIDI message sent to pause the current sequence or song.
 		</constant>
-		<constant name="MIDI_MESSAGE_ACTIVE_SENSING" value="254" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_ACTIVE_SENSING" value="254" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_ACTIVE_SENSING] instead.">
 			MIDI message sent repeatedly while the MIDI device is idle, to tell the receiver that the connection is alive. Most MIDI devices do not send this message.
 		</constant>
-		<constant name="MIDI_MESSAGE_SYSTEM_RESET" value="255" enum="MIDIMessage">
+		<constant name="MIDI_MESSAGE_SYSTEM_RESET" value="255" enum="MIDIMessage" deprecated="Use [constant InputEventMIDI.MESSAGE_SYSTEM_RESET] instead.">
 			MIDI message sent to reset a MIDI device to its default state, as if it was just turned on. It should not be sent when the MIDI device is being turned on.
 		</constant>
 		<constant name="OK" value="0" enum="Error">

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -70,16 +70,16 @@
 			The MIDI channel of this message, ranging from [code]0[/code] to [code]15[/code]. MIDI channel [code]9[/code] is reserved for percussion instruments.
 		</member>
 		<member name="controller_number" type="int" setter="set_controller_number" getter="get_controller_number" default="0">
-			The unique number of the controller, if [member message] is [constant MIDI_MESSAGE_CONTROL_CHANGE], otherwise this is [code]0[/code]. This value can be used to identify sliders for volume, balance, and panning, as well as switches and pedals on the MIDI device. See the [url=https://en.wikipedia.org/wiki/General_MIDI#Controller_events]General MIDI specification[/url] for a small list.
+			The unique number of the controller, if [member message] is [constant MESSAGE_CONTROL_CHANGE], otherwise this is [code]0[/code]. This value can be used to identify sliders for volume, balance, and panning, as well as switches and pedals on the MIDI device. See the [url=https://en.wikipedia.org/wiki/General_MIDI#Controller_events]General MIDI specification[/url] for a small list.
 		</member>
 		<member name="controller_value" type="int" setter="set_controller_value" getter="get_controller_value" default="0">
-			The value applied to the controller. If [member message] is [constant MIDI_MESSAGE_CONTROL_CHANGE], this value ranges from [code]0[/code] to [code]127[/code], otherwise it is [code]0[/code]. See also [member controller_value].
+			The value applied to the controller. If [member message] is [constant MESSAGE_CONTROL_CHANGE], this value ranges from [code]0[/code] to [code]127[/code], otherwise it is [code]0[/code]. See also [member controller_value].
 		</member>
 		<member name="instrument" type="int" setter="set_instrument" getter="get_instrument" default="0">
 			The instrument (also called [i]program[/i] or [i]preset[/i]) used on this MIDI message. This value ranges from [code]0[/code] to [code]127[/code].
 			To see what each value means, refer to the [url=https://en.wikipedia.org/wiki/General_MIDI#Program_change_events]General MIDI's instrument list[/url]. Keep in mind that the list is off by 1 because it does not begin from 0. A value of [code]0[/code] corresponds to the acoustic grand piano.
 		</member>
-		<member name="message" type="int" setter="set_message" getter="get_message" enum="MIDIMessage" default="0">
+		<member name="message" type="int" setter="set_message" getter="get_message" enum="InputEventMIDI.Message" default="0">
 			Represents the type of MIDI message (see the [enum MIDIMessage] enum).
 			For more information, see the [url=https://www.midi.org/specifications-old/item/table-2-expanded-messages-list-status-bytes]MIDI message status byte list chart[/url].
 		</member>
@@ -93,7 +93,7 @@
 		</member>
 		<member name="velocity" type="int" setter="set_velocity" getter="get_velocity" default="0">
 			The velocity of the MIDI message. This value ranges from [code]0[/code] to [code]127[/code]. For a musical keyboard, this corresponds to how quickly the key was pressed, and is rarely above [code]110[/code] in practice.
-			[b]Note:[/b] Some MIDI devices may send a [constant MIDI_MESSAGE_NOTE_ON] message with [code]0[/code] velocity and expect it to be treated the same as a [constant MIDI_MESSAGE_NOTE_OFF] message. If necessary, this can be handled with a few lines of code:
+			[b]Note:[/b] Some MIDI devices may send a [constant MESSAGE_NOTE_ON] message with [code]0[/code] velocity and expect it to be treated the same as a [constant MESSAGE_NOTE_OFF] message. If necessary, this can be handled with a few lines of code:
 			[codeblock]
 			func _input(event):
 			    if event is InputEventMIDI:
@@ -102,4 +102,63 @@
 			[/codeblock]
 		</member>
 	</members>
+	<constants>
+		<constant name="MESSAGE_NONE" value="0" enum="Message">
+			Enum value which doesn't correspond to any MIDI message. This is used to initialize [enum MIDIMessage] properties with a generic state.
+		</constant>
+		<constant name="MESSAGE_NOTE_OFF" value="8" enum="Message">
+			MIDI note OFF message. Not all MIDI devices send this event; some send [constant MESSAGE_NOTE_ON] with zero velocity instead. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+		</constant>
+		<constant name="MESSAGE_NOTE_ON" value="9" enum="Message">
+			MIDI note ON message. Some MIDI devices send this event with velocity zero instead of [constant MESSAGE_NOTE_OFF], but implementations vary. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+		</constant>
+		<constant name="MESSAGE_AFTERTOUCH" value="10" enum="Message">
+			MIDI aftertouch message. This message is most often sent by pressing down on the key after it "bottoms out".
+		</constant>
+		<constant name="MESSAGE_CONTROL_CHANGE" value="11" enum="Message">
+			MIDI control change message. This message is sent when a controller value changes. Controllers include devices such as pedals and levers.
+		</constant>
+		<constant name="MESSAGE_PROGRAM_CHANGE" value="12" enum="Message">
+			MIDI program change message. This message sent when the program patch number changes.
+		</constant>
+		<constant name="MESSAGE_CHANNEL_PRESSURE" value="13" enum="Message">
+			MIDI channel pressure message. This message is most often sent by pressing down on the key after it "bottoms out". This message is different from polyphonic after-touch as it indicates the highest pressure across all keys.
+		</constant>
+		<constant name="MESSAGE_PITCH_BEND" value="14" enum="Message">
+			MIDI pitch bend message. This message is sent to indicate a change in the pitch bender (wheel or lever, typically).
+		</constant>
+		<constant name="MESSAGE_SYSTEM_EXCLUSIVE" value="240" enum="Message">
+			MIDI system exclusive message. This has behavior exclusive to the device you're receiving input from. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_QUARTER_FRAME" value="241" enum="Message">
+			MIDI quarter frame message. Contains timing information that is used to synchronize MIDI devices. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_SONG_POSITION_POINTER" value="242" enum="Message">
+			MIDI song position pointer message. Gives the number of 16th notes since the start of the song. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_SONG_SELECT" value="243" enum="Message">
+			MIDI song select message. Specifies which sequence or song is to be played. Getting this data is not implemented in Godot.
+		</constant>
+		<constant name="MESSAGE_TUNE_REQUEST" value="246" enum="Message">
+			MIDI tune request message. Upon receiving a tune request, all analog synthesizers should tune their oscillators.
+		</constant>
+		<constant name="MESSAGE_TIMING_CLOCK" value="248" enum="Message">
+			MIDI timing clock message. Sent 24 times per quarter note when synchronization is required.
+		</constant>
+		<constant name="MESSAGE_START" value="250" enum="Message">
+			MIDI start message. Start the current sequence playing. This message will be followed with Timing Clocks.
+		</constant>
+		<constant name="MESSAGE_CONTINUE" value="251" enum="Message">
+			MIDI continue message. Continue at the point the sequence was stopped.
+		</constant>
+		<constant name="MESSAGE_STOP" value="252" enum="Message">
+			MIDI stop message. Stop the current sequence.
+		</constant>
+		<constant name="MESSAGE_ACTIVE_SENSING" value="254" enum="Message">
+			MIDI active sensing message. This message is intended to be sent repeatedly to tell the receiver that a connection is alive.
+		</constant>
+		<constant name="MESSAGE_SYSTEM_RESET" value="255" enum="Message">
+			MIDI system reset message. Reset all receivers in the system to power-up status. It should not be sent on power-up itself.
+		</constant>
+	</constants>
 </class>

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -24,3 +24,12 @@ Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/regist
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/unregister_projection_views_extension/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 
 Switched from `OpenXRExtensionWrapperExtension` to parent `OpenXRExtensionWrapper`. Compatibility methods registered.
+
+
+GH-86716
+---------
+Validate extension JSON: Error: Field 'classes/InputEventMIDI/properties/message': type changed value in new API, from "enum::MIDIMessage" to "enum::InputEventMIDI.Message".
+Validate extension JSON: Error: Field 'classes/InputEventMIDI/methods/get_message/return_value': type changed value in new API, from "enum::MIDIMessage" to "enum::InputEventMIDI.Message".
+Validate extension JSON: Error: Field 'classes/InputEventMIDI/methods/set_message/arguments/0': type changed value in new API, from "enum::MIDIMessage" to "enum::InputEventMIDI.Message".
+
+Moved MIDI message constants from the global scope to InputEventMIDI. `InputEventMIDI.message`'s type changed accordingly.


### PR DESCRIPTION
Partially addresses https://github.com/godotengine/godot-proposals/issues/8761.
Related to https://github.com/godotengine/godot/pull/86713 and https://github.com/godotengine/godot/pull/86693.

This PR moves the **MIDIMessage**'s global constants into the **InputEventMIDI**, under the new **Message** enum (prefixing MIDI would be very redudant).
The previous constants still exist, but are marked as **deprecated**.

This means the following:

| Currently| This PR |
| --- | --- |
| MIDI_MESSAGE_NONE | InputEventMIDI.**MESSAGE_NONE** |
| MIDI_MESSAGE_NOTE_ON | InputEventMIDI.**MESSAGE_NOTE_ON** |
| MIDI_MESSAGE_NOTE_OFF | InputEventMIDI.**MESSAGE_NOTE_OFF** |
| MIDI_MESSAGE_AFTERTOUCH | InputEventMIDI.**MESSAGE_AFTERTOUCH** |
| MIDI_MESSAGE_CONTROL_CHANGE | InputEventMIDI.**MESSAGE_CONTROL_CHANGE** |
| MIDI_MESSAGE_PROGRAM_CHANGE | InputEventMIDI.**MESSAGE_PROGRAM_CHANGE** |
| MIDI_MESSAGE_CHANNEL_PRESSURE | InputEventMIDI.**MESSAGE_CHANNEL_PRESSURE** |
| MIDI_MESSAGE_PITCH_BEND | InputEventMIDI.**MESSAGE_PITCH_BEND** |
| MIDI_MESSAGE_SYSTEM_EXCLUSIVE | InputEventMIDI.**MESSAGE_SYSTEM_EXCLUSIVE** |
| MIDI_MESSAGE_QUARTER_FRAME | InputEventMIDI.**MESSAGE_QUARTER_FRAME** |
| MIDI_MESSAGE_SONG_POSITION_POINTER | InputEventMIDI.**MESSAGE_SONG_POSITION_POINTER** |
| MIDI_MESSAGE_SONG_SELECT | InputEventMIDI.**MESSAGE_SONG_SELECT** |
| MIDI_MESSAGE_TUNE_REQUEST | InputEventMIDI.**MESSAGE_TUNE_REQUEST** |
| MIDI_MESSAGE_TIMING_CLOCK | InputEventMIDI.**MESSAGE_TIMING_CLOCK** |
| MIDI_MESSAGE_START | InputEventMIDI.**MESSAGE_START** |
| MIDI_MESSAGE_CONTINUE | InputEventMIDI.**MESSAGE_CONTINUE** |
| MIDI_MESSAGE_STOP | InputEventMIDI.**MESSAGE_STOP** |
| MIDI_MESSAGE_ACTIVE_SENSING | InputEventMIDI.**MESSAGE_ACTIVE_SENSING** |
| MIDI_MESSAGE_SYSTEM_RESET | InputEventMIDI.**MESSAGE_SYSTEM_RESET** |

----

This would also be a great opportunity to discuss the usefulness of these constants, and the names associated with them (see also the sources https://github.com/godotengine/godot/pull/86693):
- Godot does **not** support MIDI output. Only input. A lot of these assume that messages can be sent to other MIDI devices as well, which they can't.
- The **General MIDI** standard is never-changing. It has been established a long while ago and there is little need to keep a majority of what each message corresponds to in mind.
- Most users make games with Godot, they don't need any of these advanced use-case messages.
     - If the user needs a specific message constant for their music game... Hmm... It's complicated.
     The problem is that the **Message** enum may limit our choice. There could be 256 MIDI messages in total...
     Is a value outside of the **Message** enum accepted and returned from `InputEventMIDI.message` just fine? I am not sure right now.


With all of that said:
- **MESSAGE_TUNE_REQUEST** is basically useless. It was only ever used by [analog synthesizers](https://en.wikipedia.org/wiki/Analog_synthesizer), which are rare nowadays.
- **MIDI_MESSAGE_ACTIVE_SENSING** is rarely if ever sent by modern MIDI devices, especially through USB.
- You cannot get **MESSAGE_SONG_POSITION_POINTER**'s data, and is thus basically useless.
- You cannot get **MIDI_MESSAGE_SONG_SELECT**'s data, and is thus basically useless.
- None of the synchronization-related messages can easily be used, because of reasons stated above.
- It is impossible to send **MIDI_MESSAGE_SYSTEM_RESET** to connected MIDI Devices, only receive it for reasons stated above.