### PR TITLE
[4.2] Fix Audio track crossfade in AnimationPlayer does not work

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -412,7 +412,7 @@ void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, floa
 	}
 
 	if (get_current_animation() != p_name) {
-		_clear_caches();
+		_clear_playing_caches();
 	}
 
 	c.current.from = &animation_set[name];


### PR DESCRIPTION
Cherry-pick from https://github.com/godotengine/godot/pull/86715.

This is an exaggeration. The old AnimationPlayer only deleted the caches for the AudioTrack and AnimationPlaybackTrack.

And now that the AudioTrack is properly managed for blending, there should be no need to delete the cache here so clearing AnimationPlaybackTrack is only needed.