### PR TITLE
Removed unused code related to command palette

### DIFF
--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -92,8 +92,6 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		}
 	}
 
-	command_keys.clear();
-
 	TreeItem *root = search_options->get_root();
 	root->clear_children();
 

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -77,8 +77,6 @@ class EditorCommandPalette : public ConfirmationDialog {
 	HashMap<String, Command> commands;
 	HashMap<String, Pair<String, Ref<Shortcut>>> unregistered_shortcuts;
 
-	List<String> command_keys;
-
 	void _update_command_search(const String &search_text);
 	float _score_path(const String &p_search, const String &p_path);
 	void _sbox_input(const Ref<InputEvent> &p_ie);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Was skimming the code for the command palette and found this list of strings that is never populated or used for anything. 