### PR TITLE
[3.x] Remove unused struct in GradientTexture1D

### DIFF
--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -608,15 +608,6 @@ public:
 class GradientTexture : public Texture {
 	GDCLASS(GradientTexture, Texture);
 
-public:
-	struct Point {
-		float offset;
-		Color color;
-		bool operator<(const Point &p_ponit) const {
-			return offset < p_ponit.offset;
-		}
-	};
-
 private:
 	Ref<Gradient> gradient;
 	bool update_pending;


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/66222

I was skimming through my branches, and found this hot & ready. Looks like I forgot create a PR. 