### PR TITLE
Update modified shortcuts in command palette

### DIFF
--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -74,7 +74,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		CommandEntry r;
 		r.key_name = E.key;
 		r.display_name = E.value.name;
-		r.shortcut_text = E.value.shortcut;
+		r.shortcut_text = E.value.shortcut_text;
 		r.last_used = E.value.last_used;
 
 		bool is_subsequence_of_key_name = search_text.is_subsequence_ofn(r.key_name);
@@ -168,6 +168,19 @@ void EditorCommandPalette::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			command_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("shortcuts")) {
+				break;
+			}
+
+			for (KeyValue<String, Command> &kv : commands) {
+				Command &c = kv.value;
+				if (c.shortcut.is_valid()) {
+					c.shortcut_text = c.shortcut->get_as_text();
+				}
+			}
+		} break;
 	}
 }
 
@@ -221,7 +234,7 @@ void EditorCommandPalette::remove_command(String p_key_name) {
 	commands.erase(p_key_name);
 }
 
-void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, String p_shortcut_text) {
+void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
 
 	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * arguments.size());
@@ -231,7 +244,12 @@ void EditorCommandPalette::add_command(String p_command_name, String p_key_name,
 	Command command;
 	command.name = p_command_name;
 	command.callable = p_action.bindp(argptrs, arguments.size());
-	command.shortcut = p_shortcut_text;
+	if (p_shortcut.is_null()) {
+		command.shortcut_text = "None";
+	} else {
+		command.shortcut = p_shortcut;
+		command.shortcut_text = p_shortcut->get_as_text();
+	}
 
 	commands[p_key_name] = command;
 }
@@ -242,7 +260,7 @@ void EditorCommandPalette::_add_command(String p_command_name, String p_key_name
 	Command command;
 	command.name = p_command_name;
 	command.callable = p_binded_action;
-	command.shortcut = p_shortcut_text;
+	command.shortcut_text = p_shortcut_text;
 
 	// Commands added from plugins don't exist yet when the history is loaded, so we assign the last use time here if it was recorded.
 	Dictionary command_history = EditorSettings::get_singleton()->get_project_metadata("command_palette", "command_history", Dictionary());
@@ -275,8 +293,7 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 		Ref<InputEventShortcut> ev;
 		ev.instantiate();
 		ev->set_shortcut(shortcut);
-		String shortcut_text = String(shortcut->get_as_text());
-		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), shortcut_text);
+		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), shortcut);
 	}
 	unregistered_shortcuts.clear();
 
@@ -296,8 +313,7 @@ Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command
 		Ref<InputEventShortcut> ev;
 		ev.instantiate();
 		ev->set_shortcut(p_shortcut);
-		String shortcut_text = String(p_shortcut->get_as_text());
-		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), shortcut_text);
+		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), p_shortcut);
 	} else {
 		const String key_name = String(p_key);
 		const String command_name = String(p_command);

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -46,7 +46,8 @@ class EditorCommandPalette : public ConfirmationDialog {
 	struct Command {
 		Callable callable;
 		String name;
-		String shortcut;
+		Ref<Shortcut> shortcut;
+		String shortcut_text;
 		int last_used = 0; // Store time as int, because doubles have problems with text serialization.
 	};
 
@@ -95,7 +96,7 @@ protected:
 public:
 	void open_popup();
 	void get_actions_list(List<String> *p_list) const;
-	void add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, String p_shortcut_text = "None");
+	void add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, const Ref<Shortcut> &p_shortcut);
 	void execute_command(const String &p_command_name);
 	void register_shortcuts_as_command();
 	Ref<Shortcut> add_shortcut_command(const String &p_command, const String &p_key, Ref<Shortcut> p_shortcut);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8778

This only applies to editor shortcuts. User added shortcuts go through a separate method that takes only "shortcut text".