### PR TITLE
Fix missing autocompletion for inheriting classes

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -198,6 +198,7 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 			r_options->push_back(name.quote());
 		}
 	}
+	Object::get_argument_options(p_function, p_idx, r_options);
 }
 
 void Input::VelocityTrack::update(const Vector2 &p_delta_p) {

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -584,7 +584,7 @@ void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_
 			r_options->push_back(String(name).quote());
 		}
 	}
-	Node::get_argument_options(p_function, p_idx, r_options);
+	Node2D::get_argument_options(p_function, p_idx, r_options);
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1446,7 +1446,7 @@ void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_
 			r_options->push_back(String(name).quote());
 		}
 	}
-	Node::get_argument_options(p_function, p_idx, r_options);
+	SpriteBase3D::get_argument_options(p_function, p_idx, r_options);
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -665,7 +665,7 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 			r_options->push_back(String(name).quote());
 		}
 	}
-	Node::get_argument_options(p_function, p_idx, r_options);
+	AnimationMixer::get_argument_options(p_function, p_idx, r_options);
 }
 
 void AnimationPlayer::_animation_removed(const StringName &p_name, const StringName &p_library) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -205,7 +205,7 @@ void Control::set_root_layout_direction(int p_root_dir) {
 
 void Control::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	ERR_READ_THREAD_GUARD;
-	Node::get_argument_options(p_function, p_idx, r_options);
+	CanvasItem::get_argument_options(p_function, p_idx, r_options);
 
 	if (p_idx == 0) {
 		List<StringName> sn;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1728,6 +1728,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 			}
 		}
 	}
+	MainLoop::get_argument_options(p_function, p_idx, r_options);
 }
 
 void SceneTree::set_disable_node_threading(bool p_disable) {

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -468,7 +468,7 @@ void ShaderMaterial::get_argument_options(const StringName &p_function, int p_id
 			}
 		}
 	}
-	Resource::get_argument_options(p_function, p_idx, r_options);
+	Material::get_argument_options(p_function, p_idx, r_options);
 }
 
 bool ShaderMaterial::_can_do_next_pass() const {


### PR DESCRIPTION
This PR ensures we always call the very next inherited class when getting autocompletion results. This is more future-proof. Previously, some classes were "jumping" way ahead, potentially skipping some options. When people add new autocompletion results, they should be reminded of this, perhaps.

This also fixes **Input** and **SceneTree** not having any of **Object**'s autocompletion. You may have never noticed.