### PR TITLE
Promote CowData to 64 bits

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -318,9 +318,9 @@ int PacketPeerStream::get_output_buffer_max_size() const {
 }
 
 PacketPeerStream::PacketPeerStream() {
-	int rbsize = GLOBAL_GET("network/limits/packet_peer_stream/max_buffer_po2");
+	int64_t rbsize = GLOBAL_GET("network/limits/packet_peer_stream/max_buffer_po2");
 
 	ring_buffer.resize(rbsize);
-	input_buffer.resize(1 << rbsize);
-	output_buffer.resize(1 << rbsize);
+	input_buffer.resize(int64_t(1) << rbsize);
+	output_buffer.resize(int64_t(1) << rbsize);
 }

--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -197,7 +197,7 @@ public:
 		int old_size = size();
 		int new_size = 1 << p_power;
 		int mask = new_size - 1;
-		data.resize(1 << p_power);
+		data.resize(int64_t(1) << int64_t(p_power));
 		if (old_size < new_size && read_pos > write_pos) {
 			for (int i = 0; i < write_pos; i++) {
 				data.write[(old_size + i) & mask] = data[i];

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -48,7 +48,7 @@
 template <class T>
 class VectorWriteProxy {
 public:
-	_FORCE_INLINE_ T &operator[](int p_index) {
+	_FORCE_INLINE_ T &operator[](typename CowData<T>::Size p_index) {
 		CRASH_BAD_INDEX(p_index, ((Vector<T> *)(this))->_cowdata.size());
 
 		return ((Vector<T> *)(this))->_cowdata.ptrw()[p_index];
@@ -61,6 +61,7 @@ class Vector {
 
 public:
 	VectorWriteProxy<T> write;
+	typedef typename CowData<T>::Size Size;
 
 private:
 	CowData<T> _cowdata;
@@ -70,9 +71,9 @@ public:
 	_FORCE_INLINE_ bool append(const T &p_elem) { return push_back(p_elem); } //alias
 	void fill(T p_elem);
 
-	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
+	void remove_at(Size p_index) { _cowdata.remove_at(p_index); }
 	_FORCE_INLINE_ bool erase(const T &p_val) {
-		int idx = find(p_val);
+		Size idx = find(p_val);
 		if (idx >= 0) {
 			remove_at(idx);
 			return true;
@@ -87,17 +88,17 @@ public:
 	_FORCE_INLINE_ void clear() { resize(0); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
-	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ const T &get(int p_index) const { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
-	Error resize(int p_size) { return _cowdata.resize(p_size); }
-	Error resize_zeroed(int p_size) { return _cowdata.template resize<true>(p_size); }
-	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
-	Error insert(int p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
-	int find(const T &p_val, int p_from = 0) const { return _cowdata.find(p_val, p_from); }
-	int rfind(const T &p_val, int p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
-	int count(const T &p_val) const { return _cowdata.count(p_val); }
+	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ Size size() const { return _cowdata.size(); }
+	Error resize(Size p_size) { return _cowdata.resize(p_size); }
+	Error resize_zeroed(Size p_size) { return _cowdata.template resize<true>(p_size); }
+	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
+	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
+	Size find(const T &p_val, Size p_from = 0) const { return _cowdata.find(p_val, p_from); }
+	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
+	Size count(const T &p_val) const { return _cowdata.count(p_val); }
 
 	void append_array(Vector<T> p_other);
 
@@ -109,7 +110,7 @@ public:
 
 	template <class Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, class... Args>
 	void sort_custom(Args &&...args) {
-		int len = _cowdata.size();
+		Size len = _cowdata.size();
 		if (len == 0) {
 			return;
 		}
@@ -119,12 +120,12 @@ public:
 		sorter.sort(data, len);
 	}
 
-	int bsearch(const T &p_value, bool p_before) {
+	Size bsearch(const T &p_value, bool p_before) {
 		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
 	}
 
 	template <class Comparator, class Value, class... Args>
-	int bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
+	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
 		SearchArray<T, Comparator> search{ args... };
 		return search.bisect(ptrw(), size(), p_value, p_before);
 	}
@@ -134,7 +135,7 @@ public:
 	}
 
 	void ordered_insert(const T &p_val) {
-		int i;
+		Size i;
 		for (i = 0; i < _cowdata.size(); i++) {
 			if (p_val < operator[](i)) {
 				break;
@@ -157,28 +158,28 @@ public:
 		return ret;
 	}
 
-	Vector<T> slice(int p_begin, int p_end = INT_MAX) const {
+	Vector<T> slice(Size p_begin, Size p_end = CowData<T>::MAX_INT) const {
 		Vector<T> result;
 
-		const int s = size();
+		const Size s = size();
 
-		int begin = CLAMP(p_begin, -s, s);
+		Size begin = CLAMP(p_begin, -s, s);
 		if (begin < 0) {
 			begin += s;
 		}
-		int end = CLAMP(p_end, -s, s);
+		Size end = CLAMP(p_end, -s, s);
 		if (end < 0) {
 			end += s;
 		}
 
 		ERR_FAIL_COND_V(begin > end, result);
 
-		int result_size = end - begin;
+		Size result_size = end - begin;
 		result.resize(result_size);
 
 		const T *const r = ptr();
 		T *const w = result.ptrw();
-		for (int i = 0; i < result_size; ++i) {
+		for (Size i = 0; i < result_size; ++i) {
 			w[i] = r[begin + i];
 		}
 
@@ -186,11 +187,11 @@ public:
 	}
 
 	bool operator==(const Vector<T> &p_arr) const {
-		int s = size();
+		Size s = size();
 		if (s != p_arr.size()) {
 			return false;
 		}
-		for (int i = 0; i < s; i++) {
+		for (Size i = 0; i < s; i++) {
 			if (operator[](i) != p_arr[i]) {
 				return false;
 			}
@@ -199,11 +200,11 @@ public:
 	}
 
 	bool operator!=(const Vector<T> &p_arr) const {
-		int s = size();
+		Size s = size();
 		if (s != p_arr.size()) {
 			return true;
 		}
-		for (int i = 0; i < s; i++) {
+		for (Size i = 0; i < s; i++) {
 			if (operator[](i) != p_arr[i]) {
 				return true;
 			}
@@ -280,7 +281,7 @@ public:
 		Error err = _cowdata.resize(p_init.size());
 		ERR_FAIL_COND(err);
 
-		int i = 0;
+		Size i = 0;
 		for (const T &element : p_init) {
 			_cowdata.set(i++, element);
 		}
@@ -292,7 +293,7 @@ public:
 
 template <class T>
 void Vector<T>::reverse() {
-	for (int i = 0; i < size() / 2; i++) {
+	for (Size i = 0; i < size() / 2; i++) {
 		T *p = ptrw();
 		SWAP(p[i], p[size() - i - 1]);
 	}
@@ -300,13 +301,13 @@ void Vector<T>::reverse() {
 
 template <class T>
 void Vector<T>::append_array(Vector<T> p_other) {
-	const int ds = p_other.size();
+	const Size ds = p_other.size();
 	if (ds == 0) {
 		return;
 	}
-	const int bs = size();
+	const Size bs = size();
 	resize(bs + ds);
-	for (int i = 0; i < ds; ++i) {
+	for (Size i = 0; i < ds; ++i) {
 		ptrw()[bs + i] = p_other[i];
 	}
 }
@@ -323,7 +324,7 @@ bool Vector<T>::push_back(T p_elem) {
 template <class T>
 void Vector<T>::fill(T p_elem) {
 	T *p = ptrw();
-	for (int i = 0; i < size(); i++) {
+	for (Size i = 0; i < size(); i++) {
 		p[i] = p_elem;
 	}
 }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -666,7 +666,7 @@ struct _VariantCall {
 			CharString cs;
 			cs.resize(p_instance->size() + 1);
 			memcpy(cs.ptrw(), r, p_instance->size());
-			cs[p_instance->size()] = 0;
+			cs[(int)p_instance->size()] = 0;
 
 			s = cs.get_data();
 		}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1375,7 +1375,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				return GDScriptCodeGenerator::Address();
 			}
 
-			codegen.script->lambda_info.insert(function, { lambda->captures.size(), lambda->use_self });
+			codegen.script->lambda_info.insert(function, { (int)lambda->captures.size(), lambda->use_self });
 			gen->write_lambda(result, function, captures, lambda->use_self);
 
 			for (int i = 0; i < captures.size(); i++) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -655,7 +655,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	}
 	bool exit_ok = false;
 	bool awaited = false;
-	int variant_address_limits[ADDR_TYPE_MAX] = { _stack_size, _constant_count, p_instance ? p_instance->members.size() : 0 };
+	int variant_address_limits[ADDR_TYPE_MAX] = { _stack_size, _constant_count, p_instance ? (int)p_instance->members.size() : 0 };
 #endif
 
 	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptrw() : nullptr };

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1711,7 +1711,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			push_constant.ray_from = i * max_rays;
 			push_constant.ray_to = MIN((i + 1) * max_rays, int32_t(push_constant.ray_count));
 			rd->compute_list_set_push_constant(compute_list, &push_constant, sizeof(PushConstant));
-			rd->compute_list_dispatch(compute_list, Math::division_round_up(probe_positions.size(), 64), 1, 1);
+			rd->compute_list_dispatch(compute_list, Math::division_round_up((int)probe_positions.size(), 64), 1, 1);
 
 			rd->compute_list_end(); //done
 			rd->submit();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -474,7 +474,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != IntPtr.Zero ? *((int*)_ptr - 1) : 0;
+            get => _ptr != IntPtr.Zero ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -725,7 +725,7 @@ namespace Godot.NativeInterop
             public readonly unsafe int Size
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => _ptr != null ? *((int*)_ptr - 1) : 0;
+                get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
             }
         }
 
@@ -875,7 +875,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -939,7 +939,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -971,7 +971,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -1003,7 +1003,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -1035,7 +1035,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -1067,7 +1067,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -1099,7 +1099,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 
@@ -1131,7 +1131,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1988,7 +1988,7 @@ void LightStorage::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits
 	for (int i = 0; i < 4; i++) {
 		//clear subdivisions
 		shadow_atlas->quadrants[i].shadows.clear();
-		shadow_atlas->quadrants[i].shadows.resize(1 << shadow_atlas->quadrants[i].subdivision);
+		shadow_atlas->quadrants[i].shadows.resize(int64_t(1) << int64_t(shadow_atlas->quadrants[i].subdivision));
 	}
 
 	//erase shadow atlas reference from lights


### PR DESCRIPTION
Fixes a lot of bugs, please help me fill the list.
```
< I welcome the 64 bits overlords >
 ---------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

After this is merged, other areas of the engine can be fixed, such as Image, which also uses 32 bits offsets and causes crashes in some reasonable scenarios (such as baking lightmaps), but it depends on this one. Serialization also may need to be fixed.

*Bugsquad edit:*
- Fixes #62585
- Fixes #77256
- Fixes #80533