### PR TITLE
Make `LineEdit` scrolling show as much text as possible

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1713,6 +1713,12 @@ void LineEdit::set_caret_column(int p_column) {
 	} else if (MAX(primary_caret_offset.x, primary_caret_offset.y) >= ofs_max) {
 		scroll_offset += ofs_max - MAX(primary_caret_offset.x, primary_caret_offset.y);
 	}
+
+	// Scroll to show as much text as possible
+	if (text_width + scroll_offset + x_ofs < ofs_max) {
+		scroll_offset = ofs_max - x_ofs - text_width;
+	}
+
 	scroll_offset = MIN(0, scroll_offset);
 
 	queue_redraw();


### PR DESCRIPTION
Fixes #27420
*Bugsquad edit:* Fixes #27421

This PR makes sure the scrolling in `LineEdit` shows as much text as possible, such as when you delete text after entering more than the textbox can fit. Previously, it wouldn't update the scrolling on deleting text, now it does. See linked issue for video examples.