### PR TITLE
Add autocompletion options for AnimatedSprite's other play methods

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -577,11 +577,13 @@ PackedStringArray AnimatedSprite2D::get_configuration_warnings() const {
 }
 
 void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	if (p_idx == 0 && p_function == "play" && frames.is_valid()) {
-		List<StringName> al;
-		frames->get_animation_list(&al);
-		for (const StringName &name : al) {
-			r_options->push_back(String(name).quote());
+	if (p_idx == 0 && frames.is_valid()) {
+		if (p_function == "play" || p_function == "play_backwards" || p_function == "set_animation" || p_function == "set_autoplay") {
+			List<StringName> al;
+			frames->get_animation_list(&al);
+			for (const StringName &name : al) {
+				r_options->push_back(String(name).quote());
+			}
 		}
 	}
 	Node::get_argument_options(p_function, p_idx, r_options);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1439,11 +1439,13 @@ PackedStringArray AnimatedSprite3D::get_configuration_warnings() const {
 }
 
 void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	if (p_idx == 0 && p_function == "play" && frames.is_valid()) {
-		List<StringName> al;
-		frames->get_animation_list(&al);
-		for (const StringName &name : al) {
-			r_options->push_back(String(name).quote());
+	if (p_idx == 0 && frames.is_valid()) {
+		if (p_function == "play" || p_function == "play_backwards" || p_function == "set_animation" || p_function == "set_autoplay") {
+			List<StringName> al;
+			frames->get_animation_list(&al);
+			for (const StringName &name : al) {
+				r_options->push_back(String(name).quote());
+			}
 		}
 	}
 	Node::get_argument_options(p_function, p_idx, r_options);


### PR DESCRIPTION
When **AnimatedSprite2D** & **AnimatedSprite3D**'s `play_backwards()` was added, autocompletion for it was forgotten. This PR fixes that, and also adds it for `set_animation()` and `set_autoplay()` for... completion.