### PR TITLE
Optimize comparisons for Object's `get_argument_options`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1723,8 +1723,9 @@ bool Engine::is_printing_error_messages() const {
 	return ::Engine::get_singleton()->is_printing_error_messages();
 }
 
+#ifdef TOOLS_ENABLED
 void Engine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0 && (pf == "has_singleton" || pf == "get_singleton" || pf == "unregister_singleton")) {
 		for (const String &E : get_singleton_list()) {
 			r_options->push_back(E.quote());
@@ -1732,6 +1733,7 @@ void Engine::get_argument_options(const StringName &p_function, int p_idx, List<
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_ticks_per_second", "physics_ticks_per_second"), &Engine::set_physics_ticks_per_second);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -528,7 +528,9 @@ public:
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	Engine() { singleton = this; }
 };

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -181,8 +181,9 @@ void Input::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("joy_connection_changed", PropertyInfo(Variant::INT, "device"), PropertyInfo(Variant::BOOL, "connected")));
 }
 
+#ifdef TOOLS_ENABLED
 void Input::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 
 	if ((p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released" || pf == "get_action_strength" || pf == "get_action_raw_strength")) ||
 			(p_idx < 2 && pf == "get_axis") ||
@@ -201,6 +202,7 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void Input::VelocityTrack::update(const Vector2 &p_delta_p, const Vector2 &p_screen_delta_p) {
 	uint64_t tick = OS::get_singleton()->get_ticks_usec();

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -270,7 +270,10 @@ protected:
 public:
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
+
+#ifdef TOOLS_ENABLED
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	static Input *get_singleton();
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2086,15 +2086,17 @@ void ObjectDB::debug_objects(DebugFunc p_func) {
 	spin_lock.unlock();
 }
 
+#ifdef TOOLS_ENABLED
 void Object::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
 	if (p_idx == 0) {
-		if (p_function == "connect" || p_function == "is_connected" || p_function == "disconnect" || p_function == "emit_signal" || p_function == "has_signal") {
+		if (pf == "connect" || pf == "is_connected" || pf == "disconnect" || pf == "emit_signal" || pf == "has_signal") {
 			List<MethodInfo> signals;
 			get_signal_list(&signals);
 			for (const MethodInfo &E : signals) {
 				r_options->push_back(E.name.quote());
 			}
-		} else if (p_function == "call" || p_function == "call_deferred" || p_function == "callv" || p_function == "has_method") {
+		} else if (pf == "call" || pf == "call_deferred" || pf == "callv" || pf == "has_method") {
 			List<MethodInfo> methods;
 			get_method_list(&methods);
 			for (const MethodInfo &E : methods) {
@@ -2103,7 +2105,7 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 				}
 				r_options->push_back(E.name.quote());
 			}
-		} else if (p_function == "set" || p_function == "set_deferred" || p_function == "get") {
+		} else if (pf == "set" || pf == "set_deferred" || pf == "get") {
 			List<PropertyInfo> properties;
 			get_property_list(&properties);
 			for (const PropertyInfo &E : properties) {
@@ -2111,13 +2113,13 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 					r_options->push_back(E.name.quote());
 				}
 			}
-		} else if (p_function == "set_meta" || p_function == "get_meta" || p_function == "has_meta" || p_function == "remove_meta") {
+		} else if (pf == "set_meta" || pf == "get_meta" || pf == "has_meta" || pf == "remove_meta") {
 			for (const KeyValue<StringName, Variant> &K : metadata) {
 				r_options->push_back(String(K.key).quote());
 			}
 		}
 	} else if (p_idx == 2) {
-		if (p_function == "connect") {
+		if (pf == "connect") {
 			// Ideally, the constants should be inferred by the parameter.
 			// But a parameter's PropertyInfo does not store the enum they come from, so this will do for now.
 			List<StringName> constants;
@@ -2128,6 +2130,7 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 		}
 	}
 }
+#endif
 
 SpinLock ObjectDB::spin_lock;
 uint32_t ObjectDB::slot_count = 0;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -956,8 +956,6 @@ public:
 	Variant::Type get_static_property_type(const StringName &p_property, bool *r_valid = nullptr) const;
 	Variant::Type get_static_property_type_indexed(const Vector<StringName> &p_path, bool *r_valid = nullptr) const;
 
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
-
 	// Translate message (internationalization).
 	String tr(const StringName &p_message, const StringName &p_context = "") const;
 	String tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
@@ -969,6 +967,7 @@ public:
 	_FORCE_INLINE_ bool can_translate_messages() const { return _can_translate; }
 
 #ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 	void editor_set_section_unfold(const String &p_section, bool p_unfolded);
 	bool editor_is_section_unfolded(const String &p_section);
 	const HashSet<String> &editor_get_section_folding() const { return editor_section_folding; }

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -492,9 +492,9 @@ bool EditorInterface::is_movie_maker_enabled() const {
 	return EditorRunBar::get_singleton()->is_movie_maker_enabled();
 }
 
-// Base.
+#ifdef TOOLS_ENABLED
 void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "set_main_screen_editor") {
 			for (String E : { "\"2D\"", "\"3D\"", "\"Script\"", "\"AssetLib\"" }) {
@@ -508,6 +508,9 @@ void EditorInterface::get_argument_options(const StringName &p_function, int p_i
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
+
+// Base.
 
 void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart_editor", "save"), &EditorInterface::restart_editor, DEFVAL(true));

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -170,10 +170,11 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
-	// Base.
-
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
+	// Base.
 	static void create();
 	static void free();
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -577,9 +577,11 @@ PackedStringArray AnimatedSprite2D::get_configuration_warnings() const {
 	return warnings;
 }
 
+#ifdef TOOLS_ENABLED
 void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
 	if (p_idx == 0 && frames.is_valid()) {
-		if (p_function == "play" || p_function == "play_backwards" || p_function == "set_animation" || p_function == "set_autoplay") {
+		if (pf == "play" || pf == "play_backwards" || pf == "set_animation" || pf == "set_autoplay") {
 			List<StringName> al;
 			frames->get_animation_list(&al);
 			for (const StringName &name : al) {
@@ -589,6 +591,7 @@ void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_
 	}
 	Node2D::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 #ifndef DISABLE_DEPRECATED
 bool AnimatedSprite2D::_set(const StringName &p_name, const Variant &p_value) {

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -126,7 +126,10 @@ public:
 	bool is_flipped_v() const;
 
 	PackedStringArray get_configuration_warnings() const override;
+
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	AnimatedSprite2D();
 };

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1438,9 +1438,11 @@ PackedStringArray AnimatedSprite3D::get_configuration_warnings() const {
 	return warnings;
 }
 
+#ifdef TOOLS_ENABLED
 void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
 	if (p_idx == 0 && frames.is_valid()) {
-		if (p_function == "play" || p_function == "play_backwards" || p_function == "set_animation" || p_function == "set_autoplay") {
+		if (pf == "play" || pf == "play_backwards" || pf == "set_animation" || pf == "set_autoplay") {
 			List<StringName> al;
 			frames->get_animation_list(&al);
 			for (const StringName &name : al) {
@@ -1450,6 +1452,7 @@ void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_
 	}
 	SpriteBase3D::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 #ifndef DISABLE_DEPRECATED
 bool AnimatedSprite3D::_set(const StringName &p_name, const Variant &p_value) {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -286,7 +286,10 @@ public:
 	virtual Rect2 get_item_rect() const override;
 
 	virtual PackedStringArray get_configuration_warnings() const override;
+
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	AnimatedSprite3D();
 };

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1545,8 +1545,9 @@ void AnimationNodeBlendTree::_node_changed(const StringName &p_node) {
 	emit_signal(SNAME("node_changed"), p_node);
 }
 
+#ifdef TOOLS_ENABLED
 void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	bool add_node_options = false;
 	if (p_idx == 0) {
 		add_node_options = (pf == "get_node" || pf == "has_node" || pf == "rename_node" || pf == "remove_node" || pf == "set_node_position" || pf == "get_node_position" || pf == "connect_node" || pf == "disconnect_node");
@@ -1554,12 +1555,13 @@ void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, 
 		add_node_options = (pf == "connect_node" || pf == "disconnect_node");
 	}
 	if (add_node_options) {
-		for (KeyValue<StringName, Node> E : nodes) {
+		for (const KeyValue<StringName, Node> &E : nodes) {
 			r_options->push_back(String(E.key).quote());
 		}
 	}
 	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void AnimationNodeBlendTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeBlendTree::add_node, DEFVAL(Vector2()));

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -454,7 +454,9 @@ public:
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	AnimationNodeBlendTree();
 	~AnimationNodeBlendTree();

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2152,8 +2152,9 @@ void AnimationMixer::_notification(int p_what) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
 void AnimationMixer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "get_animation" || pf == "has_animation") {
 			List<StringName> al;
@@ -2171,6 +2172,7 @@ void AnimationMixer::get_argument_options(const StringName &p_function, int p_id
 	}
 	Node::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void AnimationMixer::_bind_methods() {
 	/* ---- Data lists ---- */

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -326,7 +326,10 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;
+
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	static void _bind_methods();
 	void _node_removed(Node *p_node);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1793,8 +1793,9 @@ void AnimationNodeStateMachine::_animation_node_removed(const ObjectID &p_oid, c
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }
 
+#ifdef TOOLS_ENABLED
 void AnimationNodeStateMachine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	bool add_state_options = false;
 	if (p_idx == 0) {
 		add_state_options = (pf == "get_node" || pf == "has_node" || pf == "rename_node" || pf == "remove_node" || pf == "replace_node" || pf == "set_node_position" || pf == "get_node_position");
@@ -1802,12 +1803,13 @@ void AnimationNodeStateMachine::get_argument_options(const StringName &p_functio
 		add_state_options = (pf == "has_transition" || pf == "add_transition" || pf == "remove_transition");
 	}
 	if (add_state_options) {
-		for (KeyValue<StringName, State> E : states) {
+		for (const KeyValue<StringName, State> &E : states) {
 			r_options->push_back(String(E.key).quote());
 		}
 	}
 	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeStateMachine::add_node, DEFVAL(Vector2()));

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -215,7 +215,9 @@ public:
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	AnimationNodeStateMachine();
 };

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -725,9 +725,10 @@ double AnimationPlayer::get_blend_time(const StringName &p_animation1, const Str
 	}
 }
 
+#ifdef TOOLS_ENABLED
 void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
-	if (p_idx == 0 && (p_function == "play" || p_function == "play_backwards" || p_function == "has_animation" || p_function == "queue")) {
+	const String pf = p_function;
+	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "has_animation" || pf == "queue")) {
 		List<StringName> al;
 		get_animation_list(&al);
 		for (const StringName &name : al) {
@@ -736,6 +737,7 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 	}
 	AnimationMixer::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void AnimationPlayer::_animation_removed(const StringName &p_name, const StringName &p_library) {
 	AnimationMixer::_animation_removed(p_name, p_library);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -188,7 +188,9 @@ public:
 	double get_current_animation_position() const;
 	double get_current_animation_length() const;
 
+#ifdef TOOLS_ENABLED
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	virtual void advance(double p_time) override;
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -203,13 +203,14 @@ void Control::set_root_layout_direction(int p_root_dir) {
 	root_layout_direction = p_root_dir;
 }
 
+#ifdef TOOLS_ENABLED
 void Control::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	ERR_READ_THREAD_GUARD;
 	CanvasItem::get_argument_options(p_function, p_idx, r_options);
 
 	if (p_idx == 0) {
 		List<StringName> sn;
-		String pf = p_function;
+		const String pf = p_function;
 		if (pf == "add_theme_color_override" || pf == "has_theme_color" || pf == "has_theme_color_override" || pf == "get_theme_color") {
 			ThemeDB::get_singleton()->get_default_theme()->get_color_list(get_class(), &sn);
 		} else if (pf == "add_theme_style_override" || pf == "has_theme_style" || pf == "has_theme_style_override" || pf == "get_theme_style") {
@@ -228,6 +229,7 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 		}
 	}
 }
+#endif
 
 PackedStringArray Control::get_configuration_warnings() const {
 	ERR_READ_THREAD_GUARD_V(PackedStringArray());

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -410,8 +410,10 @@ public:
 
 	static void set_root_layout_direction(int p_root_dir);
 
-	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 	PackedStringArray get_configuration_warnings() const override;
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	virtual bool is_text_field() const;
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3167,6 +3167,7 @@ NodePath Node::get_import_path() const {
 #endif
 }
 
+#ifdef TOOLS_ENABLED
 static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<String> *r_options) {
 	if (p_node != p_base && !p_node->get_owner()) {
 		return;
@@ -3183,7 +3184,7 @@ static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<S
 }
 
 void Node::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0 && (pf == "has_node" || pf == "get_node" || pf == "get_node_or_null")) {
 		_add_nodes_to_options(this, this, r_options);
 	} else if (p_idx == 0 && (pf == "add_to_group" || pf == "remove_from_group" || pf == "is_in_group")) {
@@ -3194,6 +3195,7 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void Node::clear_internal_tree_resource_paths() {
 	clear_internal_resource_paths();

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -626,6 +626,7 @@ public:
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);
 	String prevalidate_child_name(Node *p_child, StringName p_name);
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif
 	static String adjust_name_casing(const String &p_name);
 
@@ -640,8 +641,6 @@ public:
 	NodePath get_import_path() const;
 
 	bool is_owned_by_parent() const;
-
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	void clear_internal_tree_resource_paths();
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1690,8 +1690,10 @@ void SceneTree::add_idle_callback(IdleCallback p_callback) {
 	idle_callbacks[idle_callback_count++] = p_callback;
 }
 
+#ifdef TOOLS_ENABLED
 void SceneTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	if (p_function == "change_scene_to_file") {
+	const String pf = p_function;
+	if (pf == "change_scene_to_file") {
 		Ref<DirAccess> dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		List<String> directories;
 		directories.push_back(dir_access->get_current_dir());
@@ -1721,9 +1723,9 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 	} else {
 		bool add_options = false;
 		if (p_idx == 0) {
-			add_options = p_function == "get_nodes_in_group" || p_function == "has_group" || p_function == "get_first_node_in_group" || p_function == "set_group" || p_function == "notify_group" || p_function == "call_group" || p_function == "add_to_group";
+			add_options = pf == "get_nodes_in_group" || pf == "has_group" || pf == "get_first_node_in_group" || pf == "set_group" || pf == "notify_group" || pf == "call_group" || pf == "add_to_group";
 		} else if (p_idx == 1) {
-			add_options = p_function == "set_group_flags" || p_function == "call_group_flags" || p_function == "notify_group_flags";
+			add_options = pf == "set_group_flags" || pf == "call_group_flags" || pf == "notify_group_flags";
 		}
 		if (add_options) {
 			HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
@@ -1734,6 +1736,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 	}
 	MainLoop::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void SceneTree::set_disable_node_threading(bool p_disable) {
 	node_threading_disabled = p_disable;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -409,7 +409,9 @@ public:
 
 	static SceneTree *get_singleton() { return singleton; }
 
+#ifdef TOOLS_ENABLED
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	//network API
 

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -143,8 +143,9 @@ Dictionary AnimationLibrary::_get_data() const {
 	return ret;
 }
 
+#ifdef TOOLS_ENABLED
 void AnimationLibrary::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0 && (pf == "get_animation" || pf == "has_animation" || pf == "rename_animation" || pf == "remove_animation")) {
 		List<StringName> names;
 		get_animation_list(&names);
@@ -154,6 +155,7 @@ void AnimationLibrary::get_argument_options(const StringName &p_function, int p_
 	}
 	Resource::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void AnimationLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "name", "animation"), &AnimationLibrary::add_animation);

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -62,7 +62,9 @@ public:
 	Ref<Animation> get_animation(const StringName &p_name) const;
 	void get_animation_list(List<StringName> *p_animations) const;
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	AnimationLibrary();
 };

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -457,9 +457,10 @@ void ShaderMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shader", PROPERTY_HINT_RESOURCE_TYPE, "Shader"), "set_shader", "get_shader");
 }
 
+#ifdef TOOLS_ENABLED
 void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String f = p_function.operator String();
-	if ((f == "get_shader_parameter" || f == "set_shader_parameter") && p_idx == 0) {
+	const String pf = p_function;
+	if (p_idx == 0 && (pf == "get_shader_parameter" || pf == "set_shader_parameter")) {
 		if (shader.is_valid()) {
 			List<PropertyInfo> pl;
 			shader->get_shader_uniform_list(&pl);
@@ -470,6 +471,7 @@ void ShaderMaterial::get_argument_options(const StringName &p_function, int p_id
 	}
 	Material::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 bool ShaderMaterial::_can_do_next_pass() const {
 	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -106,7 +106,9 @@ protected:
 
 	static void _bind_methods();
 
+#ifdef TOOLS_ENABLED
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	virtual bool _can_do_next_pass() const override;
 	virtual bool _can_use_render_priority() const override;

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -224,8 +224,9 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
 void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "has_animation" || pf == "remove_animation" || pf == "rename_animation" ||
 				pf == "set_animation_speed" || pf == "get_animation_speed" ||
@@ -240,6 +241,7 @@ void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx,
 	}
 	Resource::get_argument_options(p_function, p_idx, r_options);
 }
+#endif
 
 void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "anim"), &SpriteFrames::add_animation);

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -103,7 +103,9 @@ public:
 	void clear(const StringName &p_anim);
 	void clear_all();
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	SpriteFrames();
 };

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2207,15 +2207,15 @@ void RenderingServer::fix_surface_compatibility(SurfaceData &p_surface, const St
 
 #ifdef TOOLS_ENABLED
 void RenderingServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
-	String pf = p_function;
+	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "global_shader_parameter_set" || pf == "global_shader_parameter_set_override" ||
 				pf == "global_shader_parameter_get" || pf == "global_shader_parameter_get_type" || pf == "global_shader_parameter_remove") {
-			for (StringName E : global_shader_parameter_get_list()) {
+			for (const StringName &E : global_shader_parameter_get_list()) {
 				r_options->push_back(E.operator String().quote());
 			}
 		} else if (pf == "has_os_feature") {
-			for (String E : { "\"rgtc\"", "\"s3tc\"", "\"bptc\"", "\"etc\"", "\"etc2\"", "\"astc\"" }) {
+			for (const String E : { "\"rgtc\"", "\"s3tc\"", "\"bptc\"", "\"etc\"", "\"etc2\"", "\"astc\"" }) {
 				r_options->push_back(E);
 			}
 		}


### PR DESCRIPTION

You could say it's a continuation of https://github.com/godotengine/godot/pull/86729 and https://github.com/godotengine/godot/pull/86733

I noticed that some `get_argument_options()` assign their `p_function` **StringName** into a normal `pf` **String** before comparing the method's name. It turns out this is slightly better because it avoids the conversion every time, and sometimes it just... looks more readable.

This PR makes that consistent across the board and gives a purpose to a lonely, unused `pf` in **AnimationPlayer**'s method.
One could question why `get_argument_options()` wants a **StringName** if it's better to just convert it back to **String** every time, but who am I to judge?


I have a feeling this and the other previous PRs can be backported to 3.x, even(?).