### PR TITLE
[3.x] Prevent shuffling custom shader functions (shader cache requires determinism)

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -229,17 +229,18 @@ void ShaderCompilerGLES2::_dump_function_deps(const SL::ShaderNode *p_node, cons
 
 	ERR_FAIL_COND(fidx == -1);
 
-	for (Set<StringName>::Element *E = p_node->functions[fidx].uses_function.front(); E; E = E->next()) {
-		if (r_added.has(E->get())) {
+	for (int ufidx = 0; ufidx < p_node->functions[fidx].uses_function.size(); ufidx++) {
+		StringName function_name = p_node->functions[fidx].uses_function[ufidx];
+		if (r_added.has(function_name)) {
 			continue;
 		}
 
-		_dump_function_deps(p_node, E->get(), p_func_code, r_to_add, r_added);
+		_dump_function_deps(p_node, function_name, p_func_code, r_to_add, r_added);
 
 		SL::FunctionNode *fnode = nullptr;
 
 		for (int i = 0; i < p_node->functions.size(); i++) {
-			if (p_node->functions[i].name == E->get()) {
+			if (p_node->functions[i].name == function_name) {
 				fnode = p_node->functions[i].function;
 				break;
 			}
@@ -272,9 +273,9 @@ void ShaderCompilerGLES2::_dump_function_deps(const SL::ShaderNode *p_node, cons
 
 		header += ")\n";
 		r_to_add += header.as_string();
-		r_to_add += p_func_code[E->get()];
+		r_to_add += p_func_code[function_name];
 
-		r_added.insert(E->get());
+		r_added.insert(function_name);
 	}
 }
 

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -354,17 +354,18 @@ void ShaderCompilerGLES3::_dump_function_deps(const SL::ShaderNode *p_node, cons
 
 	ERR_FAIL_COND(fidx == -1);
 
-	for (Set<StringName>::Element *E = p_node->functions[fidx].uses_function.front(); E; E = E->next()) {
-		if (added.has(E->get())) {
+	for (int ufidx = 0; ufidx < p_node->functions[fidx].uses_function.size(); ufidx++) {
+		StringName function_name = p_node->functions[fidx].uses_function[ufidx];
+		if (added.has(function_name)) {
 			continue; //was added already
 		}
 
-		_dump_function_deps(p_node, E->get(), p_func_code, r_to_add, added);
+		_dump_function_deps(p_node, function_name, p_func_code, r_to_add, added);
 
 		SL::FunctionNode *fnode = nullptr;
 
 		for (int i = 0; i < p_node->functions.size(); i++) {
-			if (p_node->functions[i].name == E->get()) {
+			if (p_node->functions[i].name == function_name) {
 				fnode = p_node->functions[i].function;
 				break;
 			}
@@ -396,9 +397,9 @@ void ShaderCompilerGLES3::_dump_function_deps(const SL::ShaderNode *p_node, cons
 
 		header += ")\n";
 		r_to_add += header;
-		r_to_add += p_func_code[E->get()];
+		r_to_add += p_func_code[function_name];
 
-		added.insert(E->get());
+		added.insert(function_name);
 	}
 }
 

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3405,7 +3405,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 							//add to current function as dependency
 							for (int j = 0; j < shader->functions.size(); j++) {
 								if (shader->functions[j].name == current_function) {
-									shader->functions.write[j].uses_function.insert(name);
+									shader->functions.write[j].uses_function.push_back(name);
 									break;
 								}
 							}

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -602,7 +602,7 @@ public:
 		struct Function {
 			StringName name;
 			FunctionNode *function;
-			Set<StringName> uses_function;
+			Vector<StringName> uses_function;
 			bool callable;
 		};
 


### PR DESCRIPTION
Custom shader function names are stored as `StringName` so their order in` Set` is determined by pointers comparison which change the order every run (because memory addresses change). This leads to shader compilation even with shader cache enabled and generated previously (shader text changes so it needs to be compiled as new shader in cache).

https://github.com/godotengine/godot/blob/4c4cb12e38dd862c1eedcb8ad17ca39ae9e3474e/servers/visual/shader_language.h#L605

I've replaced `Set` with `Vector` to prevent shuffling.

Related comment, not sure if it helps with the main issue https://github.com/godotengine/godot/issues/82705#issuecomment-1744108670