### PR TITLE
Ignore internal children when replacing node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2832,7 +2832,7 @@ void Node::replace_by(Node *p_node, bool p_keep_groups) {
 	}
 
 	Node *parent = data.parent;
-	int index_in_parent = get_index();
+	int index_in_parent = get_index(false);
 
 	if (data.parent) {
 		parent->remove_child(this);


### PR DESCRIPTION
Fixes a bug when changing node type under node with internal nodes.

Before:

https://github.com/godotengine/godot/assets/2223172/4ac604fe-14bf-4240-9d2c-d66ec502cc13

After:

https://github.com/godotengine/godot/assets/2223172/857cb5a0-7d1c-4f24-bc25-20e30ecb20bc

