### PR TITLE
Add autocompletion for `OS.has_feature()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -41,6 +41,9 @@
 #include "core/os/keyboard.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/typed_array.h"
+#ifdef TOOLS_ENABLED
+#include "editor/export/editor_export.h"
+#endif // TOOLS_ENABLED
 
 namespace core_bind {
 
@@ -556,6 +559,19 @@ void OS::revoke_granted_permissions() {
 String OS::get_unique_id() const {
 	return ::OS::get_singleton()->get_unique_id();
 }
+
+#ifdef TOOLS_ENABLED
+void OS::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0 && pf == "has_feature") {
+		HashSet<String> presets = EditorExport::get_singleton()->get_available_features();
+
+		for (const String &E : presets) {
+			r_options->push_back(E.quote());
+		}
+	}
+}
+#endif // TOOLS_ENABLED
 
 OS *OS::singleton = nullptr;
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -242,6 +242,10 @@ public:
 	Vector<String> get_granted_permissions() const;
 	void revoke_granted_permissions();
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif // TOOLS_ENABLED
+
 	static OS *get_singleton() { return singleton; }
 
 	OS() { singleton = this; }

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -167,6 +167,53 @@ Vector<Ref<EditorExportPlugin>> EditorExport::get_export_plugins() {
 	return export_plugins;
 }
 
+HashSet<String> EditorExport::get_available_features() {
+	HashSet<String> presets;
+
+	presets.insert("bptc");
+	presets.insert("s3tc");
+	presets.insert("etc");
+	presets.insert("etc2");
+	presets.insert("editor");
+	presets.insert("template_debug");
+	presets.insert("template_release");
+	presets.insert("debug");
+	presets.insert("release");
+	presets.insert("template");
+	presets.insert("double");
+	presets.insert("single");
+	presets.insert("32");
+	presets.insert("64");
+	presets.insert("movie");
+
+	for (int i = 0; i < get_export_platform_count(); i++) {
+		List<String> p;
+		get_export_platform(i)->get_platform_features(&p);
+		for (const String &E : p) {
+			presets.insert(E);
+		}
+	}
+
+	for (int i = 0; i < get_export_preset_count(); i++) {
+		List<String> p;
+		get_export_preset(i)->get_platform()->get_preset_features(get_export_preset(i), &p);
+		for (const String &E : p) {
+			presets.insert(E);
+		}
+
+		String custom = get_export_preset(i)->get_custom_features();
+		Vector<String> custom_list = custom.split(",");
+		for (int j = 0; j < custom_list.size(); j++) {
+			String f = custom_list[j].strip_edges();
+			if (!f.is_empty()) {
+				presets.insert(f);
+			}
+		}
+	}
+
+	return presets;
+}
+
 void EditorExport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -74,6 +74,8 @@ public:
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
 	Vector<Ref<EditorExportPlugin>> get_export_plugins();
 
+	HashSet<String> get_available_features();
+
 	void load_config();
 	void update_export_presets();
 	bool poll_export_platforms();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -275,50 +275,7 @@ String ProjectSettingsEditor::_get_setting_name() const {
 }
 
 void ProjectSettingsEditor::_add_feature_overrides() {
-	HashSet<String> presets;
-
-	presets.insert("bptc");
-	presets.insert("s3tc");
-	presets.insert("etc");
-	presets.insert("etc2");
-	presets.insert("editor");
-	presets.insert("template_debug");
-	presets.insert("template_release");
-	presets.insert("debug");
-	presets.insert("release");
-	presets.insert("template");
-	presets.insert("double");
-	presets.insert("single");
-	presets.insert("32");
-	presets.insert("64");
-	presets.insert("movie");
-
-	EditorExport *ee = EditorExport::get_singleton();
-
-	for (int i = 0; i < ee->get_export_platform_count(); i++) {
-		List<String> p;
-		ee->get_export_platform(i)->get_platform_features(&p);
-		for (const String &E : p) {
-			presets.insert(E);
-		}
-	}
-
-	for (int i = 0; i < ee->get_export_preset_count(); i++) {
-		List<String> p;
-		ee->get_export_preset(i)->get_platform()->get_preset_features(ee->get_export_preset(i), &p);
-		for (const String &E : p) {
-			presets.insert(E);
-		}
-
-		String custom = ee->get_export_preset(i)->get_custom_features();
-		Vector<String> custom_list = custom.split(",");
-		for (int j = 0; j < custom_list.size(); j++) {
-			String f = custom_list[j].strip_edges();
-			if (!f.is_empty()) {
-				presets.insert(f);
-			}
-		}
-	}
+	HashSet<String> presets = EditorExport::get_singleton()->get_available_features();
 
 	feature_box->clear();
 	feature_box->add_item(TTR("(All)"), 0); // So it is always on top.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4240.

![image](https://github.com/godotengine/godot/assets/66727710/2581341a-6ef0-492b-b01d-e147ebd8f8d6)

The implementation borrows from **ProjectSettingsEditor**, putting into **EditorExport** for **OS** to access.

But this causes a dependency on the editor class...