### PR TITLE
[iOS] Set provisioning style for both `iPhone Developer` and `iPhone Distribution` to automatic

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -231,8 +231,8 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 	};
 	String dbg_sign_id = p_preset->get("application/code_sign_identity_debug").operator String().is_empty() ? "iPhone Developer" : p_preset->get("application/code_sign_identity_debug");
 	String rel_sign_id = p_preset->get("application/code_sign_identity_release").operator String().is_empty() ? "iPhone Distribution" : p_preset->get("application/code_sign_identity_release");
-	bool dbg_manual = !p_preset->get_or_env("application/provisioning_profile_uuid_debug", ENV_IOS_PROFILE_UUID_DEBUG).operator String().is_empty() || (dbg_sign_id != "iPhone Developer");
-	bool rel_manual = !p_preset->get_or_env("application/provisioning_profile_uuid_release", ENV_IOS_PROFILE_UUID_RELEASE).operator String().is_empty() || (rel_sign_id != "iPhone Distribution");
+	bool dbg_manual = !p_preset->get_or_env("application/provisioning_profile_uuid_debug", ENV_IOS_PROFILE_UUID_DEBUG).operator String().is_empty() || (dbg_sign_id != "iPhone Developer" && dbg_sign_id != "iPhone Distribution");
+	bool rel_manual = !p_preset->get_or_env("application/provisioning_profile_uuid_release", ENV_IOS_PROFILE_UUID_RELEASE).operator String().is_empty() || (rel_sign_id != "iPhone Developer" && rel_sign_id != "iPhone Distribution");
 	String str;
 	String strnew;
 	str.parse_utf8((const char *)pfile.ptr(), pfile.size());


### PR DESCRIPTION
Related: https://github.com/godotengine/godot/issues/57195

I think it should work with development certificate by default (both for debug and release builds)
I do have a distribution certificate and yet I keep getting this error: in `Signing & Capabilities` tab of the target in Xcode:

```... is automatically signed for development, but a conflicting code signing identity iPhone Distribution has been manually specified. Set the code signing identity value to "Apple Development" in the build settings editor, or switch to manual signing in the Signing & Capabilities editor.```

If I replace these two lines in `project.pbxproj` file:
```
				CODE_SIGN_IDENTITY = "iPhone Distribution";
				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
```

to

```
				CODE_SIGN_IDENTITY = "iPhone Developer";
				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
```

things start to work, you may say you can set it in the Godot export wizard for iOS template, but the thing is as soon as I set a value for code sign identity, the `export_plugin.cpp` will set `CODE_SIGN_STYLE` to `MANUAL` instead of `AUTOMATIC` and it also causes an error in Xcode build. The only way things work is when `CODE_SIGN_STYLE` is kept `AUTOMATIC` and the above lines are changed. so there is no way I'm aware of that I (and I guess the people who commented on that issue and probably others) can get a working export out of the box using the export dialog, and the ipa file generation always fails.

If this PR is not accepted, please explain in details what's going on here, what kind of certificates the developer needs to setup on their machine, what configuration is needed to make it work without this PR merged. If it is not officially documented, it needs to at least be mentioned in a GitHub thread somewhere so that a Google Search finds something. The iOS deployment code is helpful if it works smoothly for people other than the one who implemented it, and it needs documentation for this purpose.