### PR TITLE
Update the transform before checking for collisions and start checking from the latest added constraint

### DIFF
--- a/servers/physics_2d/godot_body_2d.h
+++ b/servers/physics_2d/godot_body_2d.h
@@ -202,7 +202,8 @@ public:
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
 
-	_FORCE_INLINE_ void add_constraint(GodotConstraint2D *p_constraint, int p_pos) { constraint_list.push_back({ p_constraint, p_pos }); }
+	// The newest constraint is added to the front to prevent incorrect populating when replacing the old constraint with the new one.
+	_FORCE_INLINE_ void add_constraint(GodotConstraint2D *p_constraint, int p_pos) { constraint_list.push_front({ p_constraint, p_pos }); }
 	_FORCE_INLINE_ void remove_constraint(GodotConstraint2D *p_constraint, int p_pos) { constraint_list.erase({ p_constraint, p_pos }); }
 	const List<Pair<GodotConstraint2D *, int>> &get_constraint_list() const { return constraint_list; }
 	_FORCE_INLINE_ void clear_constraint_list() { constraint_list.clear(); }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
## Place the code that updates the transform before detecting collisions

Previously, after updating the body's transform through a script, the transform used in rendering will be updated immediately in the same frame.

In physics, it is usually necessary to call `GodotBody2D::integrate_velocities()` to update the body's transform. But in `GodotStep2D::step()`, the method is called after the code to detect collision, which will cause the collision to be detected until the next frame. The result is that collisions are "seen" immediately, but reported one frame later.


Fix #86199.


## Add the newest constraint to the front of `constraint_list`
    
Since `constraint_list` adds the newest constraint to the end of the list, and `GodotStep2D::_populate_island()` traverses `constraint_list` from the beginning. That is to say, the collision is judged from the earliest entered shape.

In the case where body `A` enters new shape `1` and exits old shape `0` within the same area/body `B`. The current order is `A` first exits shape `0`, then enters shape `1`. Shape `0` may be the last shape in which `B` collides with `A`, so exiting the last shape will cause `A` to exit from `B`.

Starting with the most recently added constraint can avoid this problem.

Fix #86640.