### PR TITLE
Add signals for Area intersections to PhysicsBody nodes

### DIFF
--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -63,4 +63,38 @@
 	<members>
 		<member name="input_pickable" type="bool" setter="set_pickable" getter="is_pickable" overrides="CollisionObject2D" default="false" />
 	</members>
+	<signals>
+		<signal name="entered_area">
+			<param index="0" name="area" type="Area2D" />
+			<description>
+				Emitted when this body enters the received [param area]. Requires [member Area2D.monitoring] to be set to [code]true[/code] on the area in question.
+			</description>
+		</signal>
+		<signal name="entered_area_shape">
+			<param index="0" name="area_rid" type="RID" />
+			<param index="1" name="area" type="Area2D" />
+			<param index="2" name="area_shape_index" type="int" />
+			<param index="3" name="local_shape_index" type="int" />
+			<description>
+				Emitted when a [Shape2D] of this body enters a shape of received [param area]. Requires [member Area2D.monitoring] to be set to [code]true[/code] on the area in question.
+				[param local_shape_index] and [param area_shape_index] contain indices of the interacting shapes from this body and the intersecting area, respectively. [param area_rid] contains the [RID] of the area. These values can be used with the [PhysicsServer3D].
+				See also [signal Area2D.body_shape_entered]
+			</description>
+		</signal>
+		<signal name="exited_area">
+			<param index="0" name="area" type="Area2D" />
+			<description>
+				Emitted when this body exits the received [param area]. Requires [member Area2D.monitoring] to be set to [code]true[/code] on the area in question.
+			</description>
+		</signal>
+		<signal name="exited_area_shape">
+			<param index="0" name="area_rid" type="RID" />
+			<param index="1" name="area" type="Area2D" />
+			<param index="2" name="area_shape_index" type="int" />
+			<param index="3" name="local_shape_index" type="int" />
+			<description>
+				Emitted when a [Shape2D] of this body exits a shape of received [param area]. Requires [member Area2D.monitoring] to be set to [code]true[/code] on the area in question.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -100,4 +100,38 @@
 			Lock the body's linear movement in the Z axis.
 		</member>
 	</members>
+	<signals>
+		<signal name="entered_area">
+			<param index="0" name="area" type="Area3D" />
+			<description>
+				Emitted when this body enters the received [param area]. Requires [member Area3D.monitoring] to be set to [code]true[/code] on the area in question.
+			</description>
+		</signal>
+		<signal name="entered_area_shape">
+			<param index="0" name="area_rid" type="RID" />
+			<param index="1" name="area" type="Area3D" />
+			<param index="2" name="area_shape_index" type="int" />
+			<param index="3" name="local_shape_index" type="int" />
+			<description>
+				Emitted when a [Shape3D] of this body enters a shape of received [param area]. Requires [member Area3D.monitoring] to be set to [code]true[/code] on the area in question.
+				[param local_shape_index] and [param area_shape_index] contain indices of the interacting shapes from this body and the intersecting area, respectively. [param area_rid] contains the [RID] of the area. These values can be used with the [PhysicsServer3D].
+				See also [signal Area3D.body_shape_entered]
+			</description>
+		</signal>
+		<signal name="exited_area">
+			<param index="0" name="area" type="Area3D" />
+			<description>
+				Emitted when this body exits the received [param area]. Requires [member Area3D.monitoring] to be set to [code]true[/code] on the area in question.
+			</description>
+		</signal>
+		<signal name="exited_area_shape">
+			<param index="0" name="area_rid" type="RID" />
+			<param index="1" name="area" type="Area3D" />
+			<param index="2" name="area_shape_index" type="int" />
+			<param index="3" name="local_shape_index" type="int" />
+			<description>
+				Emitted when a [Shape3D] of this body exits a shape of received [param area]. Requires [member Area3D.monitoring] to be set to [code]true[/code] on the area in question.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -143,8 +143,14 @@ void Area2D::_body_enter_tree(ObjectID p_id) {
 
 	E->value.in_tree = true;
 	emit_signal(SceneStringNames::get_singleton()->body_entered, node);
+	if (node->has_signal(SceneStringNames::get_singleton()->entered_area)) {
+		node->emit_signal(SceneStringNames::get_singleton()->entered_area, this);
+	}
 	for (int i = 0; i < E->value.shapes.size(); i++) {
 		emit_signal(SceneStringNames::get_singleton()->body_shape_entered, E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		if (node->has_signal(SceneStringNames::get_singleton()->entered_area_shape)) {
+			node->emit_signal(SceneStringNames::get_singleton()->entered_area_shape, get_rid(), this, E->value.shapes[i].area_shape, E->value.shapes[i].body_shape);
+		}
 	}
 }
 
@@ -157,8 +163,14 @@ void Area2D::_body_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
 	emit_signal(SceneStringNames::get_singleton()->body_exited, node);
+	if (node->has_signal(SceneStringNames::get_singleton()->exited_area)) {
+		node->emit_signal(SceneStringNames::get_singleton()->exited_area, this);
+	}
 	for (int i = 0; i < E->value.shapes.size(); i++) {
 		emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		if (node->has_signal(SceneStringNames::get_singleton()->exited_area_shape)) {
+			node->emit_signal(SceneStringNames::get_singleton()->exited_area_shape, get_rid(), this, E->value.shapes[i].area_shape, E->value.shapes[i].body_shape);
+		}
 	}
 }
 
@@ -204,6 +216,9 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree).bind(objid));
 				if (E->value.in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
+					if (node->has_signal(SceneStringNames::get_singleton()->entered_area)) {
+						node->emit_signal(SceneStringNames::get_singleton()->entered_area, this);
+					}
 				}
 			}
 		}
@@ -214,6 +229,9 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 
 		if (!node || E->value.in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->body_shape_entered, p_body, node, p_body_shape, p_area_shape);
+			if (node && node->has_signal(SceneStringNames::get_singleton()->entered_area_shape)) {
+				node->emit_signal(SceneStringNames::get_singleton()->entered_area_shape, get_rid(), this, p_area_shape, p_body_shape);
+			}
 		}
 
 	} else {
@@ -231,11 +249,17 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree));
 				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
+					if (node->has_signal(SceneStringNames::get_singleton()->exited_area)) {
+						node->emit_signal(SceneStringNames::get_singleton()->exited_area, this);
+					}
 				}
 			}
 		}
 		if (!node || in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->body_shape_exited, p_body, obj, p_body_shape, p_area_shape);
+			if (node && node->has_signal(SceneStringNames::get_singleton()->exited_area_shape)) {
+				node->emit_signal(SceneStringNames::get_singleton()->exited_area_shape, get_rid(), this, p_area_shape, p_body_shape);
+			}
 		}
 	}
 
@@ -379,9 +403,15 @@ void Area2D::_clear_monitoring() {
 
 			for (int i = 0; i < E.value.shapes.size(); i++) {
 				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E.value.rid, node, E.value.shapes[i].body_shape, E.value.shapes[i].area_shape);
+				if (node->has_signal(SceneStringNames::get_singleton()->exited_area_shape)) {
+					node->emit_signal(SceneStringNames::get_singleton()->exited_area_shape, get_rid(), this, E.value.shapes[i].area_shape, E.value.shapes[i].body_shape);
+				}
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
+			if (node->has_signal(SceneStringNames::get_singleton()->exited_area)) {
+				node->emit_signal(SceneStringNames::get_singleton()->exited_area, this);
+			}
 		}
 	}
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -39,6 +39,11 @@ void PhysicsBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_collision_exceptions"), &PhysicsBody2D::get_collision_exceptions);
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &PhysicsBody2D::add_collision_exception_with);
 	ClassDB::bind_method(D_METHOD("remove_collision_exception_with", "body"), &PhysicsBody2D::remove_collision_exception_with);
+
+	ADD_SIGNAL(MethodInfo("entered_area", PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area2D")));
+	ADD_SIGNAL(MethodInfo("exited_area", PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area2D")));
+	ADD_SIGNAL(MethodInfo("entered_area_shape", PropertyInfo(Variant::RID, "area_rid"), PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area2D"), PropertyInfo(Variant::INT, "area_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
+	ADD_SIGNAL(MethodInfo("exited_area_shape", PropertyInfo(Variant::RID, "area_rid"), PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area2D"), PropertyInfo(Variant::INT, "area_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
 }
 
 PhysicsBody2D::PhysicsBody2D(PhysicsServer2D::BodyMode p_mode) :

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -200,8 +200,14 @@ void Area3D::_body_enter_tree(ObjectID p_id) {
 
 	E->value.in_tree = true;
 	emit_signal(SceneStringNames::get_singleton()->body_entered, node);
+	if (node->has_signal(SceneStringNames::get_singleton()->entered_area)) {
+		node->emit_signal(SceneStringNames::get_singleton()->entered_area, this);
+	}
 	for (int i = 0; i < E->value.shapes.size(); i++) {
 		emit_signal(SceneStringNames::get_singleton()->body_shape_entered, E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		if (node->has_signal(SceneStringNames::get_singleton()->entered_area_shape)) {
+			node->emit_signal(SceneStringNames::get_singleton()->entered_area_shape, get_rid(), this, E->value.shapes[i].area_shape, E->value.shapes[i].body_shape);
+		}
 	}
 }
 
@@ -214,8 +220,14 @@ void Area3D::_body_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
 	emit_signal(SceneStringNames::get_singleton()->body_exited, node);
+	if (node->has_signal(SceneStringNames::get_singleton()->exited_area)) {
+		node->emit_signal(SceneStringNames::get_singleton()->exited_area, this);
+	}
 	for (int i = 0; i < E->value.shapes.size(); i++) {
 		emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		if (node->has_signal(SceneStringNames::get_singleton()->exited_area_shape)) {
+			node->emit_signal(SceneStringNames::get_singleton()->exited_area_shape, get_rid(), this, E->value.shapes[i].area_shape, E->value.shapes[i].body_shape);
+		}
 	}
 }
 
@@ -261,6 +273,9 @@ void Area3D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 				node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_body_exit_tree).bind(objid));
 				if (E->value.in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
+					if (node->has_signal(SceneStringNames::get_singleton()->entered_area)) {
+						node->emit_signal(SceneStringNames::get_singleton()->entered_area, this);
+					}
 				}
 			}
 		}
@@ -271,6 +286,10 @@ void Area3D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 
 		if (!node || E->value.in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->body_shape_entered, p_body, node, p_body_shape, p_area_shape);
+
+			if (node && node->has_signal(SceneStringNames::get_singleton()->entered_area_shape)) {
+				node->emit_signal(SceneStringNames::get_singleton()->entered_area_shape, get_rid(), this, p_area_shape, p_body_shape);
+			}
 		}
 
 	} else {
@@ -288,11 +307,17 @@ void Area3D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_body_exit_tree));
 				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
+					if (node->has_signal(SceneStringNames::get_singleton()->exited_area)) {
+						node->emit_signal(SceneStringNames::get_singleton()->exited_area, this);
+					}
 				}
 			}
 		}
 		if (!node || in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->body_shape_exited, p_body, obj, p_body_shape, p_area_shape);
+			if (node && node->has_signal(SceneStringNames::get_singleton()->exited_area_shape)) {
+				node->emit_signal(SceneStringNames::get_singleton()->exited_area_shape, get_rid(), this, p_area_shape, p_body_shape);
+			}
 		}
 	}
 
@@ -326,9 +351,15 @@ void Area3D::_clear_monitoring() {
 
 			for (int i = 0; i < E.value.shapes.size(); i++) {
 				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E.value.rid, node, E.value.shapes[i].body_shape, E.value.shapes[i].area_shape);
+				if (node->has_signal(SceneStringNames::get_singleton()->exited_area_shape)) {
+					node->emit_signal(SceneStringNames::get_singleton()->exited_area_shape, get_rid(), this, E.value.shapes[i].area_shape, E.value.shapes[i].body_shape);
+				}
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, node);
+			if (node->has_signal(SceneStringNames::get_singleton()->exited_area)) {
+				node->emit_signal(SceneStringNames::get_singleton()->exited_area, this);
+			}
 		}
 	}
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -43,6 +43,11 @@ void PhysicsBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &PhysicsBody3D::add_collision_exception_with);
 	ClassDB::bind_method(D_METHOD("remove_collision_exception_with", "body"), &PhysicsBody3D::remove_collision_exception_with);
 
+	ADD_SIGNAL(MethodInfo("entered_area", PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area3D")));
+	ADD_SIGNAL(MethodInfo("exited_area", PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area3D")));
+	ADD_SIGNAL(MethodInfo("entered_area_shape", PropertyInfo(Variant::RID, "area_rid"), PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area3D"), PropertyInfo(Variant::INT, "area_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
+	ADD_SIGNAL(MethodInfo("exited_area_shape", PropertyInfo(Variant::RID, "area_rid"), PropertyInfo(Variant::OBJECT, "area", PROPERTY_HINT_RESOURCE_TYPE, "Area3D"), PropertyInfo(Variant::INT, "area_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
+
 	ADD_GROUP("Axis Lock", "axis_lock_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "axis_lock_linear_x"), "set_axis_lock", "get_axis_lock", PhysicsServer3D::BODY_AXIS_LINEAR_X);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "axis_lock_linear_y"), "set_axis_lock", "get_axis_lock", PhysicsServer3D::BODY_AXIS_LINEAR_Y);

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -85,6 +85,8 @@ SceneStringNames::SceneStringNames() {
 
 	area_shape_entered = StaticCString::create("area_shape_entered");
 	area_shape_exited = StaticCString::create("area_shape_exited");
+	entered_area_shape = StaticCString::create("entered_area_shape");
+	exited_area_shape = StaticCString::create("exited_area_shape");
 
 	_body_inout = StaticCString::create("_body_inout");
 	_area_inout = StaticCString::create("_area_inout");
@@ -158,6 +160,8 @@ SceneStringNames::SceneStringNames() {
 
 	area_entered = StaticCString::create("area_entered");
 	area_exited = StaticCString::create("area_exited");
+	entered_area = StaticCString::create("entered_area");
+	exited_area = StaticCString::create("exited_area");
 
 	_has_point = StaticCString::create("_has_point");
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -110,6 +110,8 @@ public:
 
 	StringName area_shape_entered;
 	StringName area_shape_exited;
+	StringName entered_area_shape;
+	StringName exited_area_shape;
 
 	StringName _body_inout;
 	StringName _area_inout;
@@ -176,6 +178,8 @@ public:
 
 	StringName area_entered;
 	StringName area_exited;
+	StringName entered_area;
+	StringName exited_area;
 
 	StringName _get_minimum_size;
 


### PR DESCRIPTION
- Resolves godotengine/godot-proposals/issues/8784

Adds 4 new signals to all PhysicsBodies:
`entered_area(area)`
`entered_area_shape(area_rid, area, area_shape_id, body_shape_id)`
`exited_area(area)`
`exited_area_shape(area_rid, area, area_shape_id, body_shape_id)`

Signal emission is handled by Areas, when the body enters or exits them.

I need this only in 3D, but also added a 2D version of enhancement in a separate commit.