### PR TITLE
Add autocompletion for `Engine.get_singleton` & similar

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1718,6 +1718,16 @@ bool Engine::is_printing_error_messages() const {
 	return ::Engine::get_singleton()->is_printing_error_messages();
 }
 
+void Engine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0 && (pf == "has_singleton" || pf == "get_singleton" || pf == "unregister_singleton")) {
+		for (const String &E : get_singleton_list()) {
+			r_options->push_back(E.quote());
+		}
+	}
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+
 void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_ticks_per_second", "physics_ticks_per_second"), &Engine::set_physics_ticks_per_second);
 	ClassDB::bind_method(D_METHOD("get_physics_ticks_per_second"), &Engine::get_physics_ticks_per_second);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -527,6 +527,8 @@ public:
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
 
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+
 	Engine() { singleton = this; }
 };
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86747.

Unlike the former PR, it's simple as that. If a bunch of methods are interfacing a collection of Strings of some sort, it can be auto-completed. There's a pattern down the line.

Can be backported to prior versions.