### PR TITLE
Add autocompletion for SpriteFrames' methods

### DIFF
--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -224,6 +224,23 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 	}
 }
 
+void SpriteFrames::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0) {
+		if (pf == "has_animation" || pf == "remove_animation" || pf == "rename_animation" ||
+				pf == "set_animation_speed" || pf == "get_animation_speed" ||
+				pf == "set_animation_loop" || pf == "get_animation_loop" ||
+				pf == "add_frame" || pf == "set_frame" || pf == "remove_frame" ||
+				pf == "get_frame_count" || pf == "get_frame_texture" || pf == "get_frame_duration" ||
+				pf == "clear") {
+			for (const String &E : get_animation_names()) {
+				r_options->push_back(E.quote());
+			}
+		}
+	}
+	Resource::get_argument_options(p_function, p_idx, r_options);
+}
+
 void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "anim"), &SpriteFrames::add_animation);
 	ClassDB::bind_method(D_METHOD("has_animation", "anim"), &SpriteFrames::has_animation);

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -103,6 +103,8 @@ public:
 	void clear(const StringName &p_anim);
 	void clear_all();
 
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+
 	SpriteFrames();
 };
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86747 and https://github.com/godotengine/godot/pull/86753.

It's also why I wanted to prepare https://github.com/godotengine/godot/pull/86743.

![image](https://github.com/godotengine/godot/assets/66727710/6a2cd1b4-ebea-48f2-9a36-b5d3bc3416dd)

<sub>I wish I could compile a build for a better showcase, but it keeps running out of memory during the compile.</sub>

This PR autocompletes the **SpriteFrames** methods with the names of every existing animation, if they can be detected.

I'm very fond of this. I could have **really** used it in the past.