### PR TITLE
Add autocompletion for ProjectSettings' methods

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1318,6 +1318,26 @@ const HashMap<StringName, HashSet<StringName>> &ProjectSettings::get_scene_group
 	return scene_groups_cache;
 }
 
+#ifdef TOOLS_ENABLED
+void ProjectSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	if (p_idx == 0) {
+		if (pf == "has_setting" || pf == "set_setting" || pf == "get_setting" || pf == "get_setting_with_override" ||
+				pf == "set_order" || pf == "get_order" || pf == "set_initial_value" || pf == "set_as_basic" ||
+				pf == "set_as_internal" || pf == "set_restart_if_changed" || pf == "clear") {
+			for (const KeyValue<StringName, VariantContainer> &E : props) {
+				if (E.value.hide_from_editor) {
+					continue;
+				}
+
+				r_options->push_back(String(E.key).quote());
+			}
+		}
+	}
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_setting", "name"), &ProjectSettings::has_setting);
 	ClassDB::bind_method(D_METHOD("set_setting", "name", "value"), &ProjectSettings::set_setting);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -222,6 +222,10 @@ public:
 	String get_scene_groups_cache_path() const;
 	void load_scene_groups_cache();
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	ProjectSettings();
 	~ProjectSettings();
 };


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86747 and https://github.com/godotengine/godot/pull/86753.

This PR adds autocompletion options to all of the methods that interact with the settings themselves.

![image](https://github.com/godotengine/godot/assets/66727710/4a60c0fa-903e-4d7e-8bcb-72e98d95266d)

You may think "Didn't they already have autocompletion options?". Well, yeah, you're welcome. Unintentionally, **ProjectSettings** greatly benefitted from https://github.com/godotengine/godot/pull/66427 alone, because `set` and `get` are one good way to check them. This just fills in the rest, which peeved me for a while.