### PR TITLE
Fix `get_window_safe_area` on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -178,12 +178,10 @@ public class GodotIO {
 	}
 
 	public int[] getDisplaySafeArea() {
-		DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
-		Display display = activity.getWindowManager().getDefaultDisplay();
-		Point size = new Point();
-		display.getRealSize(size);
+		Rect rect = new Rect();
+		activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
 
-		int[] result = { 0, 0, size.x, size.y };
+		int[] result = { rect.left, rect.top, rect.right, rect.bottom };
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
 			WindowInsets insets = activity.getWindow().getDecorView().getRootWindowInsets();
 			DisplayCutout cutout = insets.getDisplayCutout();


### PR DESCRIPTION
Fixes: #61467

`metrics` removed, was not used in the function.

**Test:** https://github.com/godotengine/godot/issues/61467#issuecomment-1875902228
