### PR TITLE
Add autocompletion for InputMap's methods

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -85,6 +85,35 @@ String InputMap::suggest_actions(const StringName &p_action) const {
 	return error_message;
 }
 
+#ifdef TOOLS_ENABLED
+void InputMap::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	bool first_argument_is_action = false;
+	if (p_idx == 0) {
+		first_argument_is_action = (pf == "has_action" || pf == "erase_action" ||
+				pf == "action_set_deadzone" || pf == "action_get_deadzone" ||
+				pf == "action_has_event" || pf == "action_add_event" || pf == "action_get_events" ||
+				pf == "action_erase_event" || pf == "action_erase_events");
+	}
+	if (first_argument_is_action || (p_idx == 1 && pf == "event_is_action")) {
+		// Cannot rely on `get_actions()`, otherwise the actions would be in the context of the Editor (no user-defined actions).
+		List<PropertyInfo> pinfo;
+		ProjectSettings::get_singleton()->get_property_list(&pinfo);
+
+		for (const PropertyInfo &pi : pinfo) {
+			if (!pi.name.begins_with("input/")) {
+				continue;
+			}
+
+			String name = pi.name.substr(pi.name.find("/") + 1, pi.name.length());
+			r_options->push_back(name.quote());
+		}
+	}
+
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void InputMap::add_action(const StringName &p_action, float p_deadzone) {
 	ERR_FAIL_COND_MSG(input_map.has(p_action), "InputMap already has action \"" + String(p_action) + "\".");
 	input_map[p_action] = Action();

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -95,6 +95,10 @@ public:
 
 	String suggest_actions(const StringName &p_action) const;
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	String get_builtin_display_name(const String &p_name) const;
 	// Use an Ordered Map so insertion order is preserved. We want the elements to be 'grouped' somewhat.
 	const HashMap<String, List<Ref<InputEvent>>> &get_builtins();


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86747, https://github.com/godotengine/godot/pull/86753 and https://github.com/godotengine/godot/pull/86758.

![image](https://github.com/godotengine/godot/assets/66727710/b6ccd0ff-db21-4635-aa9d-8e1bf814f023)


**Input** already autocompleted actions, but **InputMap**, which only contains actions, never did.
... The code is copied straight from **Input** itself.

