### PR TITLE
Allow to move FileSystem dock to bottom and drag resources across bottom docks

### DIFF
--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -77,17 +77,20 @@ private:
 	Vector<DockSplitContainer *> hsplits;
 
 	Vector<WindowWrapper *> floating_docks;
+	Vector<Control *> bottom_docks;
 	TabContainer *dock_slot[DOCK_SLOT_MAX];
 	bool docks_visible = true;
 
 	PopupPanel *dock_select_popup = nullptr;
 	Button *dock_float = nullptr;
+	Button *dock_to_bottom = nullptr;
 	Button *dock_tab_move_left = nullptr;
 	Button *dock_tab_move_right = nullptr;
 	Control *dock_select = nullptr;
 	Rect2 dock_select_rect[DOCK_SLOT_MAX];
 	int dock_select_rect_over_idx = -1;
 	int dock_popup_selected_idx = -1;
+	int dock_bottom_selected_idx = -1;
 
 	void _dock_select_popup_theme_changed();
 	void _dock_popup_exit();
@@ -106,6 +109,8 @@ private:
 	void _dock_make_float(Control *p_control, int p_slot_index, bool p_show_window = true);
 	void _restore_floating_dock(const Dictionary &p_dock_dump, Control *p_wrapper, int p_slot_index);
 
+	void _dock_move_selected_to_bottom();
+
 protected:
 	static void _bind_methods();
 
@@ -120,6 +125,8 @@ public:
 	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
 	void load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section);
 	void update_dock_slots_visibility(bool p_keep_selected_tabs = false);
+
+	void bottom_dock_show_placement_popup(const Rect2i &p_position, Control *p_dock);
 
 	void close_all_floating_docks();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -654,6 +654,7 @@ private:
 	void _immediate_dialog_confirmed();
 	void _select_default_main_screen_plugin();
 
+	void _bottom_panel_switch_by_control(bool p_enable, Control *p_control);
 	void _bottom_panel_switch(bool p_enable, int p_idx);
 	void _bottom_panel_raise_toggled(bool);
 
@@ -866,7 +867,7 @@ public:
 
 	bool is_exiting() const { return exiting; }
 
-	Button *add_bottom_panel_item(String p_text, Control *p_item);
+	Button *add_bottom_panel_item(String p_text, Control *p_item, bool p_at_front = false);
 	void make_bottom_panel_item_visible(Control *p_item);
 	void raise_bottom_panel_item(Control *p_item);
 	void hide_bottom_panel();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -39,6 +39,7 @@
 #include "core/templates/list.h"
 #include "editor/create_dialog.h"
 #include "editor/directory_create_dialog.h"
+#include "editor/editor_dock_manager.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
 #include "editor/editor_resource_preview.h"
@@ -494,43 +495,22 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 
 void FileSystemDock::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_TRANSLATION_CHANGED:
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			if (initialized) {
 				return;
 			}
 			initialized = true;
-			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &FileSystemDock::_feature_profile_changed));
 
+			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &FileSystemDock::_feature_profile_changed));
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &FileSystemDock::_fs_changed));
 			EditorResourcePreview::get_singleton()->connect("preview_invalidated", callable_mp(this, &FileSystemDock::_preview_invalidated));
 
-			button_reload->set_icon(get_editor_theme_icon(SNAME("Reload")));
 			button_file_list_display_mode->connect("pressed", callable_mp(this, &FileSystemDock::_toggle_file_display));
-
 			files->connect("item_activated", callable_mp(this, &FileSystemDock::_file_list_activate_file));
 			button_hist_next->connect("pressed", callable_mp(this, &FileSystemDock::_fw_history));
 			button_hist_prev->connect("pressed", callable_mp(this, &FileSystemDock::_bw_history));
-
-			tree_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			tree_search_box->set_clear_button_enabled(true);
-			tree_button_sort->set_icon(get_editor_theme_icon(SNAME("Sort")));
-
-			file_list_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			file_list_search_box->set_clear_button_enabled(true);
-			file_list_button_sort->set_icon(get_editor_theme_icon(SNAME("Sort")));
-
-			if (is_layout_rtl()) {
-				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Back")));
-				button_hist_prev->set_icon(get_editor_theme_icon(SNAME("Forward")));
-			} else {
-				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Forward")));
-				button_hist_prev->set_icon(get_editor_theme_icon(SNAME("Back")));
-			}
 			file_list_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_file_list_rmb_option));
 			tree_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
-
 			current_path_line_edit->connect("text_submitted", callable_mp(this, &FileSystemDock::_navigate_to_path).bind(false));
 
 			always_show_folders = bool(EDITOR_GET("docks/filesystem/always_show_folders"));
@@ -582,16 +562,11 @@ void FileSystemDock::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			overwrite_dialog_scroll->add_theme_style_override("panel", get_theme_stylebox("panel", "Tree"));
+			_update_display_mode(true);
 
-			if (is_visible_in_tree()) {
-				_update_display_mode(true);
-			}
-		} break;
-
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			// Update icons.
 			button_reload->set_icon(get_editor_theme_icon(SNAME("Reload")));
 
 			StringName mode_icon = "Panels1";
@@ -602,13 +577,6 @@ void FileSystemDock::_notification(int p_what) {
 			}
 			button_toggle_display_mode->set_icon(get_editor_theme_icon(mode_icon));
 
-			if (is_layout_rtl()) {
-				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Back")));
-				button_hist_prev->set_icon(get_editor_theme_icon(SNAME("Forward")));
-			} else {
-				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Forward")));
-				button_hist_prev->set_icon(get_editor_theme_icon(SNAME("Back")));
-			}
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
 				button_file_list_display_mode->set_icon(get_editor_theme_icon(SNAME("FileThumbnail")));
 			} else {
@@ -616,13 +584,25 @@ void FileSystemDock::_notification(int p_what) {
 			}
 
 			tree_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			tree_search_box->set_clear_button_enabled(true);
 			tree_button_sort->set_icon(get_editor_theme_icon(SNAME("Sort")));
 
 			file_list_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			file_list_search_box->set_clear_button_enabled(true);
 			file_list_button_sort->set_icon(get_editor_theme_icon(SNAME("Sort")));
 
+			button_dock_placement->set_icon(get_editor_theme_icon(SNAME("GuiTabMenu")));
+
+			if (is_layout_rtl()) {
+				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Back")));
+				button_hist_prev->set_icon(get_editor_theme_icon(SNAME("Forward")));
+			} else {
+				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Forward")));
+				button_hist_prev->set_icon(get_editor_theme_icon(SNAME("Back")));
+			}
+
+			overwrite_dialog_scroll->add_theme_style_override("panel", get_theme_stylebox("panel", "Tree"));
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			// Update editor dark theme & always show folders states from editor settings, redraw if needed.
 			bool do_redraw = false;
 
@@ -2561,6 +2541,10 @@ void FileSystemDock::_rescan() {
 	EditorFileSystem::get_singleton()->scan();
 }
 
+void FileSystemDock::_change_bottom_dock_placement() {
+	EditorDockManager::get_singleton()->bottom_dock_show_placement_popup(button_dock_placement->get_screen_rect(), this);
+}
+
 void FileSystemDock::_change_split_mode() {
 	DisplayMode next_mode = DISPLAY_MODE_TREE_ONLY;
 	if (display_mode == DISPLAY_MODE_VSPLIT) {
@@ -3634,6 +3618,43 @@ MenuButton *FileSystemDock::_create_file_menu_button() {
 	return button;
 }
 
+bool FileSystemDock::_can_dock_horizontal() const {
+	return true;
+}
+
+void FileSystemDock::_set_dock_horizontal(bool p_enable) {
+	if (button_dock_placement->is_visible() == p_enable) {
+		return;
+	}
+
+	if (p_enable) {
+		set_meta("_dock_display_mode", get_display_mode());
+		set_meta("_dock_file_display_mode", get_file_list_display_mode());
+
+		FileSystemDock::DisplayMode new_display_mode = FileSystemDock::DisplayMode(int(get_meta("_bottom_display_mode", int(FileSystemDock::DISPLAY_MODE_HSPLIT))));
+		FileSystemDock::FileListDisplayMode new_file_display_mode = FileSystemDock::FileListDisplayMode(int(get_meta("_bottom_file_display_mode", int(FileSystemDock::FILE_LIST_DISPLAY_THUMBNAILS))));
+
+		set_display_mode(new_display_mode);
+		set_file_list_display_mode(new_file_display_mode);
+		set_custom_minimum_size(Size2(0, 200) * EDSCALE);
+	} else {
+		set_meta("_bottom_display_mode", get_display_mode());
+		set_meta("_bottom_file_display_mode", get_file_list_display_mode());
+
+		FileSystemDock::DisplayMode new_display_mode = FileSystemDock::DISPLAY_MODE_TREE_ONLY;
+		FileSystemDock::FileListDisplayMode new_file_display_mode = FileSystemDock::FILE_LIST_DISPLAY_LIST;
+
+		new_display_mode = FileSystemDock::DisplayMode(int(get_meta("_dock_display_mode", new_display_mode)));
+		new_file_display_mode = FileSystemDock::FileListDisplayMode(int(get_meta("_dock_file_display_mode", new_file_display_mode)));
+
+		set_display_mode(new_display_mode);
+		set_file_list_display_mode(new_file_display_mode);
+		set_custom_minimum_size(Size2(0, 0));
+	}
+
+	button_dock_placement->set_visible(p_enable);
+}
+
 void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_file_list_thumbnail_done"), &FileSystemDock::_file_list_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("_tree_thumbnail_done"), &FileSystemDock::_tree_thumbnail_done);
@@ -3642,6 +3663,9 @@ void FileSystemDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_resource_tooltip_plugin", "plugin"), &FileSystemDock::add_resource_tooltip_plugin);
 	ClassDB::bind_method(D_METHOD("remove_resource_tooltip_plugin", "plugin"), &FileSystemDock::remove_resource_tooltip_plugin);
+
+	ClassDB::bind_method(D_METHOD("_set_dock_horizontal", "enable"), &FileSystemDock::_set_dock_horizontal);
+	ClassDB::bind_method(D_METHOD("_can_dock_horizontal"), &FileSystemDock::_can_dock_horizontal);
 
 	ADD_SIGNAL(MethodInfo("inherit", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("instantiate", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
@@ -3796,6 +3820,12 @@ FileSystemDock::FileSystemDock() {
 	button_toggle_display_mode->set_flat(true);
 	toolbar_hbc->add_child(button_toggle_display_mode);
 
+	button_dock_placement = memnew(Button);
+	button_dock_placement->set_flat(true);
+	button_dock_placement->connect("pressed", callable_mp(this, &FileSystemDock::_change_bottom_dock_placement));
+	button_dock_placement->hide();
+	toolbar_hbc->add_child(button_dock_placement);
+
 	toolbar2_hbc = memnew(HBoxContainer);
 	toolbar2_hbc->add_theme_constant_override("separation", 0);
 	top_vbc->add_child(toolbar2_hbc);
@@ -3803,6 +3833,7 @@ FileSystemDock::FileSystemDock() {
 	tree_search_box = memnew(LineEdit);
 	tree_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	tree_search_box->set_placeholder(TTR("Filter Files"));
+	tree_search_box->set_clear_button_enabled(true);
 	tree_search_box->connect("text_changed", callable_mp(this, &FileSystemDock::_search_changed).bind(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
 
@@ -3852,6 +3883,7 @@ FileSystemDock::FileSystemDock() {
 	file_list_search_box = memnew(LineEdit);
 	file_list_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	file_list_search_box->set_placeholder(TTR("Filter Files"));
+	file_list_search_box->set_clear_button_enabled(true);
 	file_list_search_box->connect("text_changed", callable_mp(this, &FileSystemDock::_search_changed).bind(file_list_search_box));
 	path_hb->add_child(file_list_search_box);
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -154,6 +154,8 @@ private:
 
 	HashSet<String> favorites;
 
+	Button *button_dock_placement = nullptr;
+
 	Button *button_toggle_display_mode = nullptr;
 	Button *button_reload = nullptr;
 	Button *button_file_list_display_mode = nullptr;
@@ -359,6 +361,11 @@ private:
 
 	void _feature_profile_changed();
 	static Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
+
+	void _change_bottom_dock_placement();
+
+	bool _can_dock_horizontal() const;
+	void _set_dock_horizontal(bool p_enable);
 
 private:
 	static FileSystemDock *singleton;


### PR DESCRIPTION
* Allows moving the filesystem dock to the bottom
* Added ability to drag resources across bottom docks

Animation, moving filesystem to the bottom dock:
![move_to_bottom](https://github.com/godotengine/godot/assets/6265307/ca6443f7-b14f-4014-9f9e-4de2db8ac9e1)

Drag and Drop across bottom panels:
![move_to_bottom_dnd](https://github.com/godotengine/godot/assets/6265307/7f47d79a-1160-4146-adbf-7a210f1e2b66)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- *Production edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/1508.*