### PR TITLE
Add `text_changed` signal to Label and RichTextLabel

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -115,7 +115,7 @@
 		<signal name="text_changed">
 			<param index="0" name="text" type="String" />
 			<description>
-				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.
+				Emitted when the value behind the text property of a Label was changed. The new text is contained in the [param text] argument.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -111,6 +111,14 @@
 			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
 		</member>
 	</members>
+	<signals>
+		<signal name="changed_text">
+			<param index="0" name="text" type="String" />
+			<description>
+				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.
+			</description>
+		</signal>
+	</signals>
 	<theme_items>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [Label].

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -112,7 +112,7 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="changed_text">
+		<signal name="text_changed">
 			<param index="0" name="text" type="String" />
 			<description>
 				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -666,15 +666,15 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="finished">
-			<description>
-				Triggered when the document is fully loaded.
-			</description>
-		</signal>
 		<signal name="changed_text">
 			<param index="0" name="text" type="String" />
 			<description>
 				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.
+			</description>
+		</signal>
+		<signal name="finished">
+			<description>
+				Triggered when the document is fully loaded.
 			</description>
 		</signal>
 		<signal name="meta_clicked">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -669,7 +669,7 @@
 		<signal name="text_changed">
 			<param index="0" name="text" type="String" />
 			<description>
-				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.
+				Emitted when the value behind the text property of a RichTextLabel was changed. The new text is contained in the [param text] argument.
 			</description>
 		</signal>
 		<signal name="finished">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -666,15 +666,15 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="finished">
+			<description>
+				Triggered when the document is fully loaded.
+			</description>
+		</signal>
 		<signal name="text_changed">
 			<param index="0" name="text" type="String" />
 			<description>
 				Emitted when the value behind the text property of a RichTextLabel was changed. The new text is contained in the [param text] argument.
-			</description>
-		</signal>
-		<signal name="finished">
-			<description>
-				Triggered when the document is fully loaded.
 			</description>
 		</signal>
 		<signal name="meta_clicked">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -666,7 +666,7 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="changed_text">
+		<signal name="text_changed">
 			<param index="0" name="text" type="String" />
 			<description>
 				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -671,6 +671,12 @@
 				Triggered when the document is fully loaded.
 			</description>
 		</signal>
+		<signal name="changed_text">
+			<param index="0" name="text" type="String" />
+			<description>
+				Emitted when the text of a label was changed. The new text is contained in the [param text] argument.
+			</description>
+		</signal>
 		<signal name="meta_clicked">
 			<param index="0" name="meta" type="Variant" />
 			<description>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -671,12 +671,6 @@
 				Triggered when the document is fully loaded.
 			</description>
 		</signal>
-		<signal name="text_changed">
-			<param index="0" name="text" type="String" />
-			<description>
-				Emitted when the value behind the text property of a RichTextLabel was changed. The new text is contained in the [param text] argument.
-			</description>
-		</signal>
 		<signal name="meta_clicked">
 			<param index="0" name="meta" type="Variant" />
 			<description>
@@ -693,6 +687,12 @@
 			<param index="0" name="meta" type="Variant" />
 			<description>
 				Triggers when the mouse enters a meta tag.
+			</description>
+		</signal>
+		<signal name="text_changed">
+			<param index="0" name="text" type="String" />
+			<description>
+				Emitted when the value behind the text property of a RichTextLabel was changed. The new text is contained in the [param text] argument.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -894,7 +894,7 @@ void Label::set_text(const String &p_string) {
 	queue_redraw();
 	update_minimum_size();
 	update_configuration_warnings();
-	emit_signal(SNAME("changed_text"), text);
+	emit_signal(SNAME("text_changed"), text);
 }
 
 void Label::_invalidate() {
@@ -1206,7 +1206,7 @@ void Label::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "structured_text_bidi_override", PROPERTY_HINT_ENUM, "Default,URI,File,Email,List,None,Custom"), "set_structured_text_bidi_override", "get_structured_text_bidi_override");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "structured_text_bidi_override_options"), "set_structured_text_bidi_override_options", "get_structured_text_bidi_override_options");
 
-	ADD_SIGNAL(MethodInfo("changed_text", PropertyInfo(Variant::STRING, "text")));
+	ADD_SIGNAL(MethodInfo("text_changed", PropertyInfo(Variant::STRING, "text")));
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, Label, normal_style, "normal");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Label, line_spacing);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -894,6 +894,7 @@ void Label::set_text(const String &p_string) {
 	queue_redraw();
 	update_minimum_size();
 	update_configuration_warnings();
+	emit_signal(SNAME("changed_text"), text);
 }
 
 void Label::_invalidate() {
@@ -1204,6 +1205,8 @@ void Label::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "language", PROPERTY_HINT_LOCALE_ID, ""), "set_language", "get_language");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "structured_text_bidi_override", PROPERTY_HINT_ENUM, "Default,URI,File,Email,List,None,Custom"), "set_structured_text_bidi_override", "get_structured_text_bidi_override");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "structured_text_bidi_override_options"), "set_structured_text_bidi_override_options", "get_structured_text_bidi_override_options");
+
+	ADD_SIGNAL(MethodInfo("changed_text", PropertyInfo(Variant::STRING, "text")));
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, Label, normal_style, "normal");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Label, line_spacing);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5574,7 +5574,7 @@ void RichTextLabel::set_text(const String &p_bbcode) {
 	}
 	text = p_bbcode;
 	_apply_translation();
-	emit_signal(SNAME("changed_text"), text);
+	emit_signal(SNAME("text_changed"), text);
 }
 
 void RichTextLabel::_apply_translation() {
@@ -5991,7 +5991,7 @@ void RichTextLabel::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "structured_text_bidi_override", PROPERTY_HINT_ENUM, "Default,URI,File,Email,List,None,Custom"), "set_structured_text_bidi_override", "get_structured_text_bidi_override");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "structured_text_bidi_override_options"), "set_structured_text_bidi_override_options", "get_structured_text_bidi_override_options");
 
-	ADD_SIGNAL(MethodInfo("changed_text", PropertyInfo(Variant::STRING, "text")));
+	ADD_SIGNAL(MethodInfo("text_changed", PropertyInfo(Variant::STRING, "text")));
 	ADD_SIGNAL(MethodInfo("meta_clicked", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 	ADD_SIGNAL(MethodInfo("meta_hover_started", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 	ADD_SIGNAL(MethodInfo("meta_hover_ended", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5574,6 +5574,7 @@ void RichTextLabel::set_text(const String &p_bbcode) {
 	}
 	text = p_bbcode;
 	_apply_translation();
+	emit_signal(SNAME("changed_text"), text);
 }
 
 void RichTextLabel::_apply_translation() {
@@ -5990,6 +5991,7 @@ void RichTextLabel::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "structured_text_bidi_override", PROPERTY_HINT_ENUM, "Default,URI,File,Email,List,None,Custom"), "set_structured_text_bidi_override", "get_structured_text_bidi_override");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "structured_text_bidi_override_options"), "set_structured_text_bidi_override_options", "get_structured_text_bidi_override_options");
 
+	ADD_SIGNAL(MethodInfo("changed_text", PropertyInfo(Variant::STRING, "text")));
 	ADD_SIGNAL(MethodInfo("meta_clicked", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 	ADD_SIGNAL(MethodInfo("meta_hover_started", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 	ADD_SIGNAL(MethodInfo("meta_hover_ended", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));


### PR DESCRIPTION
- Resolves https://github.com/godotengine/godot-proposals/issues/8790

Added new signal to `Label` and `RichTextLabel`:
`changed_text`, which gets emitted in `set_text()` of each class.
