### PR TITLE
Add logging when macOS export will fail due to disabled texture formats.

### DIFF
--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2051,13 +2051,17 @@ bool EditorExportPlatformMacOS::has_valid_export_configuration(const Ref<EditorE
 	String architecture = p_preset->get("binary_format/architecture");
 	if (architecture == "universal" || architecture == "x86_64") {
 		if (!ResourceImporterTextureSettings::should_import_s3tc_bptc()) {
+			err += TTR("Cannot export for universal or x86_64 if S3TC BPTC texture format is disabled. Enable it in the Project Settings (Rendering > Textures > VRAM Compression > Import S3TC BPTC).") + "\n";
 			valid = false;
 		}
-	} else if (architecture == "arm64") {
+	}
+	if (architecture == "universal" || architecture == "arm64") {
 		if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
+			err += TTR("Cannot export for universal or arm64 if ETC2 ASTC texture format is disabled. Enable it in the Project Settings (Rendering > Textures > VRAM Compression > Import ETC2 ASTC).") + "\n";
 			valid = false;
 		}
-	} else {
+	}
+	if (architecture != "universal" && architecture != "x86_64" && architecture != "arm64") {
 		ERR_PRINT("Invalid architecture");
 	}
 


### PR DESCRIPTION
Currently if a required texture format is disabled during macOS export, the export will fail without logging any information indicating the real source of the problem. This change adds error messaging that will direct the user toward the issue.