### PR TITLE
Display functions that were previously forgotten in Profiler

### DIFF
--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -342,10 +342,12 @@ public:
 		}
 		ServerInfo &srv = server_data[name];
 
-		ServerFunctionInfo fi;
-		fi.name = p_data[1];
-		fi.time = p_data[2];
-		srv.functions.push_back(fi);
+		for (int idx = 1; idx < p_data.size() - 1; idx += 2) {
+			ServerFunctionInfo fi;
+			fi.name = p_data[idx];
+			fi.time = p_data[idx + 1];
+			srv.functions.push_back(fi);
+		}
 	}
 
 	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {


### PR DESCRIPTION
The array data in `add()` contains these data, but some data may have been forgotten to be converted into `ServerFunctionInfo`.

This results in some information not being displayed in the Profiler.

| Before | This PR |
| :-------: | :---------: |
| ![0](https://github.com/godotengine/godot/assets/30386067/e9e62d16-56c2-44ae-8804-03995eb14203) | ![1](https://github.com/godotengine/godot/assets/30386067/eacc1447-b7bd-47ad-a65f-198cf40048d7) |

Should the display of these functions be reordered? According to the order in the same frame. :thinking: 


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
