### PR TITLE
Add autocompletion for ClassDB & AudioServer

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1512,6 +1512,30 @@ bool ClassDB::is_class_enabled(StringName p_class) const {
 	return ::ClassDB::is_class_enabled(p_class);
 }
 
+#ifdef TOOLS_ENABLED
+void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	bool first_argument_is_class = false;
+	if (p_idx == 0) {
+		first_argument_is_class = (pf == "get_inheriters_from_class" || pf == "get_parent_class" ||
+				pf == "class_exists" || pf == "can_instantiate" || pf == "instantiate" ||
+				pf == "class_has_signal" || pf == "class_get_signal" || pf == "class_get_signal_list" ||
+				pf == "class_get_property_list" || pf == "class_get_property" || pf == "class_set_property" ||
+				pf == "class_has_method" || pf == "class_get_method_list" ||
+				pf == "class_get_integer_constant_list" || pf == "class_has_integer_constant" || pf == "class_get_integer_constant" ||
+				pf == "class_has_enum" || pf == "class_get_enum_list" || pf == "class_get_enum_constants" || pf == "class_get_integer_constant_enum" ||
+				pf == "is_class_enabled");
+	}
+	if (first_argument_is_class || pf == "is_parent_class") {
+		for (const String &E : get_class_list()) {
+			r_options->push_back(E.quote());
+		}
+	}
+
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("get_class_list"), &ClassDB::get_class_list);
 	::ClassDB::bind_method(D_METHOD("get_inheriters_from_class", "class"), &ClassDB::get_inheriters_from_class);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -457,6 +457,10 @@ public:
 
 	bool is_class_enabled(StringName p_class) const;
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	ClassDB() {}
 	~ClassDB() {}
 };

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1678,6 +1678,19 @@ void AudioServer::set_enable_tagging_used_audio_streams(bool p_enable) {
 	tag_used_audio_streams = p_enable;
 }
 
+#ifdef TOOLS_ENABLED
+void AudioServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	if ((p_idx == 0 && pf == "get_bus_index") || (p_idx == 1 && pf == "set_bus_send")) {
+		for (const AudioServer::Bus *E : buses) {
+			r_options->push_back(String(E->name).quote());
+		}
+	}
+
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bus_count", "amount"), &AudioServer::set_bus_count);
 	ClassDB::bind_method(D_METHOD("get_bus_count"), &AudioServer::get_bus_count);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -436,6 +436,10 @@ public:
 
 	void set_enable_tagging_used_audio_streams(bool p_enable);
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	AudioServer();
 	virtual ~AudioServer();
 };


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86753, https://github.com/godotengine/godot/pull/86747, https://github.com/godotengine/godot/pull/86758, and https://github.com/godotengine/godot/pull/86764 

This PR adds autocompletion for almost all of the methods in **ClassDB**.

![image](https://github.com/godotengine/godot/assets/66727710/55599a32-5b37-4e69-aef3-23e923816c42)

This is probably the biggest chain of methods to check for options. These can really come in handy preventing misspells while developing addons and the likes of them, although admittedly it's fairly _niche_.

At first, I was afraid I would have to cache the results for how many there are, but I'm surprised there was no particularly stutter.

... Because it was so small, I also added autocompletion for **AudioServer**'s `get_bus_index()` and `set_bus_send()`, which is just plain nice, I assure you.
