### PR TITLE
Change the value of DotNetOS.Android to "linux-bionic"

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -54,7 +54,7 @@ namespace GodotTools.Utils
             public const string OSX = "osx";
             public const string Linux = "linux";
             public const string Win10 = "win10";
-            public const string Android = "android";
+            public const string Android = "linux-bionic";
             public const string iOS = "ios";
             public const string iOSSimulator = "iossimulator";
             public const string Browser = "browser";


### PR DESCRIPTION
Currently DotNetOS.Android value is "android" and the platform RID is "android-arm64" when exported, but "android-arm64" does not support NativeAOT yet.
According to https://learn.microsoft.com/en-us/dotnet/core/rid-catalog, "linux-bionic-arm64" is a c library based on Android, it can be used for Android and supports NativeAOT.
I've only tested \<PublishAot\>true\<\/PublishAot\> and \<PublishAot\>false\<\/PublishAot\> under .Net8, and it's not clear if there are any other issues.
(There are a few other steps required to export Android using NativeAOT, but for now this is a necessary step)
