### PR TITLE
Fix Android dynamic library loading

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -170,8 +170,6 @@ Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_han
 		so_file_exists = false;
 	}
 
-	ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
-
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
 	if (!p_library_handle && so_file_exists) {
 		// The library may be on the sdcard and thus inaccessible. Try to copy it to the internal


### PR DESCRIPTION
Revert https://github.com/godotengine/godot/pull/86682 for the Android platform as it breaks dynamic library loading

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
