### PR TITLE
Fix Android dynamic library loading, while still distinguishing between not found and can't open

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -170,8 +170,6 @@ Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_han
 		so_file_exists = false;
 	}
 
-	ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
-
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
 	if (!p_library_handle && so_file_exists) {
 		// The library may be on the sdcard and thus inaccessible. Try to copy it to the internal
@@ -199,6 +197,7 @@ Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_han
 		}
 	}
 
+	ERR_FAIL_COND_V(!p_library_handle && !so_file_exists, ERR_FILE_NOT_FOUND);
 	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, dlerror()));
 
 	if (r_resolved_path != nullptr) {


### PR DESCRIPTION
Possible alternative to PR https://github.com/godotengine/godot/pull/86792, but which continues to distinguishing between the library not found and being unable to open it.

Currently marked as draft because I haven't had a chance to test it.