### PR TITLE
Add autocompletion for RenderingServer's global shader methods & `has_os_feature`

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2204,6 +2204,25 @@ void RenderingServer::fix_surface_compatibility(SurfaceData &p_surface, const St
 }
 #endif
 
+#ifdef TOOLS_ENABLED
+void RenderingServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0) {
+		if (pf == "global_shader_parameter_set" || pf == "global_shader_parameter_set_override" ||
+				pf == "global_shader_parameter_get" || pf == "global_shader_parameter_get_type" || pf == "global_shader_parameter_remove") {
+			for (StringName E : global_shader_parameter_get_list()) {
+				r_options->push_back(E.operator String().quote());
+			}
+		} else if (pf == "has_os_feature") {
+			for (String E : { "\"rgtc\"", "\"s3tc\"", "\"bptc\"", "\"etc\"", "\"etc2\"", "\"astc\"" }) {
+				r_options->push_back(E);
+			}
+		}
+	}
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void RenderingServer::_bind_methods() {
 	BIND_CONSTANT(NO_INDEX_ARRAY);
 	BIND_CONSTANT(ARRAY_WEIGHTS_SIZE);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1639,6 +1639,10 @@ public:
 
 	virtual void call_on_render_thread(const Callable &p_callable) = 0;
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	RenderingServer();
 	virtual ~RenderingServer();
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86753, https://github.com/godotengine/godot/pull/86747, https://github.com/godotengine/godot/pull/86758,  https://github.com/godotengine/godot/pull/86764, and https://github.com/godotengine/godot/pull/86777

This PR adds autocompletion to all of **RenderingServer**'s methods that are about global shaders, allowing you to see the available ones right away, instead of having to check the Project Settings every time.

![image](https://github.com/godotengine/godot/assets/66727710/84a674e3-4dd7-441b-94c9-a0f7420fba3d)

It also features... `has_os_feature()` because it's really nice to have a general clue as to what to put in there.

![image](https://github.com/godotengine/godot/assets/66727710/e072489d-023f-4219-b08f-25a7b73bf5ea)
