### PR TITLE
Add autocompletion for AnimationLibrary & AnimationMixer's methods

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2054,6 +2054,26 @@ void AnimationMixer::_notification(int p_what) {
 	}
 }
 
+void AnimationMixer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0) {
+		if (pf == "get_animation" || pf == "has_animation") {
+			List<StringName> al;
+			get_animation_list(&al);
+			for (const StringName &name : al) {
+				r_options->push_back(String(name).quote());
+			}
+		} else if (pf == "get_animation_library" || pf == "has_animation_library" || pf == "remove_animation_library" || pf == "rename_animation_library") {
+			List<StringName> al;
+			get_animation_library_list(&al);
+			for (const StringName &name : al) {
+				r_options->push_back(String(name).quote());
+			}
+		}
+	}
+	Node::get_argument_options(p_function, p_idx, r_options);
+}
+
 void AnimationMixer::_bind_methods() {
 	/* ---- Data lists ---- */
 	ClassDB::bind_method(D_METHOD("add_animation_library", "name", "library"), &AnimationMixer::add_animation_library);

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -340,6 +340,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	static void _bind_methods();
 	void _node_removed(Node *p_node);

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -143,6 +143,18 @@ Dictionary AnimationLibrary::_get_data() const {
 	return ret;
 }
 
+void AnimationLibrary::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0 && (pf == "get_animation" || pf == "has_animation" || pf == "rename_animation" || pf == "remove_animation")) {
+		List<StringName> names;
+		get_animation_list(&names);
+		for (const StringName &E : names) {
+			r_options->push_back(E.operator String().quote());
+		}
+	}
+	Resource::get_argument_options(p_function, p_idx, r_options);
+}
+
 void AnimationLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "name", "animation"), &AnimationLibrary::add_animation);
 	ClassDB::bind_method(D_METHOD("remove_animation", "name"), &AnimationLibrary::remove_animation);

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -62,6 +62,8 @@ public:
 	Ref<Animation> get_animation(const StringName &p_name) const;
 	void get_animation_list(List<StringName> *p_animations) const;
 
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+
 	AnimationLibrary();
 };
 


### PR DESCRIPTION
Complements https://github.com/godotengine/godot/pull/86754

![image](https://github.com/godotengine/godot/assets/66727710/97179d9f-452e-48ef-9b90-4f63e4991caa)


This PR autocompletes the **AnimationLibrary** methods with the names of every existing animation, if they can be detected. Admittedly, this is fairly niche.
But, AnimationMixer's methods are much less so.