### PR TITLE
Fix SoftBody Race Condition on multi-threaded physics

### DIFF
--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -274,7 +274,7 @@ public:
 
 	FUNCRID(soft_body)
 
-	FUNC2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
+	FUNC2S(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
 
 	FUNC2(soft_body_set_space, RID, RID)
 	FUNC1RC(RID, soft_body_get_space, RID)


### PR DESCRIPTION
Fixes #86790.

This PR sets `PhysicsServer3DWrapMT::soft_body_update_rendering_server()` as sync. to prevent the race condition mentioned [here](https://github.com/godotengine/godot/issues/86790#issuecomment-1877797680).

The following code is called to draw a softbody: 

https://github.com/godotengine/godot/blob/179dfdc8d78b5bd5377dd115af026df58308bdaf/scene/3d/soft_body_3d.cpp#L425-L429

First, line 425 opens a buffer so that `soft_body_update_rendering_server() ` will write data about the softbody's vertices and normals on it. After, on line 427, this buffer is closed, and finally, it is passed to the Rendering Server on line 429.

Since `soft_body_update_rendering_server()` needs to write all the data on the buffer and it is called only within this snippet, it must be sync.