### PR TITLE
Tune TAA disocclusion scale to avoid rejecting all samples during motion.

### DIFF
--- a/servers/rendering/renderer_rd/effects/taa.cpp
+++ b/servers/rendering/renderer_rd/effects/taa.cpp
@@ -62,8 +62,8 @@ void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_pr
 	memset(&push_constant, 0, sizeof(TAAResolvePushConstant));
 	push_constant.resolution_width = p_resolution.width;
 	push_constant.resolution_height = p_resolution.height;
-	push_constant.disocclusion_threshold = 0.025f;
-	push_constant.disocclusion_scale = 10.0f;
+	push_constant.disocclusion_threshold = 2.5f; // If velocity changes by less than this amount of texels we can retain the accumulation buffer.
+	push_constant.disocclusion_scale = 0.01f; // Scale the weight of this pixel calculated as (change in velocity - threshold) * scale.
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, pipeline);

--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -307,6 +307,8 @@ float luminance(vec3 color) {
 	return max(dot(color, lumCoeff), 0.0001f);
 }
 
+// This is "velocity disocclusion" as described by https://www.elopezr.com/temporal-aa-and-the-quest-for-the-holy-trail/.
+// We use texel space, so our scale and threshold differ.
 float get_factor_disocclusion(vec2 uv_reprojected, vec2 velocity) {
 	vec2 velocity_previous = imageLoad(last_velocity_buffer, ivec2(uv_reprojected * params.resolution)).xy;
 	vec2 velocity_texels = velocity * params.resolution;
@@ -336,7 +338,7 @@ vec3 temporal_antialiasing(uvec2 pos_group_top_left, uvec2 pos_group, uvec2 pos_
 	// Compute blend factor
 	float blend_factor = RPC_16; // We want to be able to accumulate as many jitter samples as we generated, that is, 16.
 	{
-		// If re-projected UV is out of screen, converge to current color immediatel
+		// If re-projected UV is out of screen, converge to current color immediately.
 		float factor_screen = any(lessThan(uv_reprojected, vec2(0.0))) || any(greaterThan(uv_reprojected, vec2(1.0))) ? 1.0 : 0.0;
 
 		// Increase blend factor when there is disocclusion (fixes a lot of the remaining ghosting).


### PR DESCRIPTION
Noticed while reviewing https://github.com/godotengine/godot/pull/61834

The values we use for the disocclusion scale were a bit problematic. Basically they mean the following:
`disocclusion_threshold`: If the difference in velocity of this pixel between this frame and last frame is less than this amount, we can happily use the reprojected color. If the difference is greater we weight this frame more heavily (basically we assume there is a good chance that this pixel is the result of disocclusion)
`disocclusion_scale`: This scales the disocclusion amount (which is measured in pixels `(difference_in_velocity - disocclusion_threshold)`) to arrive at a final "disocclusion" value.

The final disocclusion value is used to weight towards the current sample. A disocclusion value of 1 means "throw away all previous samples". 0 means, this isn't a disoccluded pixel, blend it as normal. 

As a result of having such high values, we pretty much always had a disocclusion value clamped to 1 if there was any movement at all. 

https://www.elopezr.com/temporal-aa-and-the-quest-for-the-holy-trail/ has a nice breakdown of this type of disocclusion factor. The author uses 0.001 for threshold and 10 for scale. But they measure disocclusion in uv-space and we measure in texel-space. Accordingly, I increased/decreased the values by a factor of 1,000 and the results look a lot better. 

They are most noticable in shadows with https://github.com/godotengine/godot/pull/61834 applied. 

_In this screenshot the camera is moving slowly. On the left is master, on the right is this PR_
![Screenshot from 2024-01-04 12-16-50](https://github.com/godotengine/godot/assets/16521339/cddf7113-891d-4603-9aaf-0e98e1bcda12)

I tested this PR in a couple of scenes, both with and without https://github.com/godotengine/godot/pull/61834 and cannot see any signs of new ghosting or other artifacts that can come from improper disocclusion handling. 