### PR TITLE
Added compatibility for Blend Mode in `Light2D`/`PointLight2D` when converting from Godot 3 to 4.

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -425,6 +425,17 @@ real_t PointLight2D::get_texture_scale() const {
 	return _scale;
 }
 
+#ifndef DISABLE_DEPRECATED
+bool PointLight2D::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "mode" && p_value.is_num()) { // Compatibility with Godot 3.x.
+		set_blend_mode((BlendMode)(int)p_value);
+		return true;
+	}
+
+	return false;
+}
+#endif // DISABLE_DEPRECATED
+
 void PointLight2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &PointLight2D::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &PointLight2D::get_texture);

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -146,6 +146,9 @@ private:
 	Vector2 texture_offset;
 
 protected:
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif // DISABLE_DEPRECATED
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Fixes #77887

This ensures that when upgrading your project from Godot 3 to Godot 4, the Blend Mode of any `Light2D` (that becomes `PointLight2D`) will be preserved. 