### PR TITLE
GDScript: Allow utility functions to be used as `Callable`

### DIFF
--- a/modules/gdscript/gdscript_utility_callable.cpp
+++ b/modules/gdscript/gdscript_utility_callable.cpp
@@ -1,0 +1,108 @@
+/**************************************************************************/
+/*  gdscript_utility_callable.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_utility_callable.h"
+
+#include "core/templates/hashfuncs.h"
+
+bool GDScriptUtilityCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
+	return p_a->hash() == p_b->hash();
+}
+
+bool GDScriptUtilityCallable::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {
+	return p_a->hash() < p_b->hash();
+}
+
+uint32_t GDScriptUtilityCallable::hash() const {
+	return h;
+}
+
+String GDScriptUtilityCallable::get_as_text() const {
+	String scope;
+	switch (type) {
+		case TYPE_INVALID:
+			scope = "<invalid scope>";
+			break;
+		case TYPE_GLOBAL:
+			scope = "@GlobalScope";
+			break;
+		case TYPE_GDSCRIPT:
+			scope = "@GDScript";
+			break;
+	}
+	return vformat("%s::%s (Callable)", scope, function_name);
+}
+
+CallableCustom::CompareEqualFunc GDScriptUtilityCallable::get_compare_equal_func() const {
+	return compare_equal;
+}
+
+CallableCustom::CompareLessFunc GDScriptUtilityCallable::get_compare_less_func() const {
+	return compare_less;
+}
+
+bool GDScriptUtilityCallable::is_valid() const {
+	return type != TYPE_INVALID;
+}
+
+StringName GDScriptUtilityCallable::get_method() const {
+	return function_name;
+}
+
+ObjectID GDScriptUtilityCallable::get_object() const {
+	return ObjectID();
+}
+
+void GDScriptUtilityCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	switch (type) {
+		case TYPE_INVALID:
+			ERR_PRINT(vformat(R"(Trying to call invalid utility function "%s".)", function_name));
+			break;
+		case TYPE_GLOBAL:
+			Variant::call_utility_function(function_name, &r_return_value, p_arguments, p_argcount, r_call_error);
+			break;
+		case TYPE_GDSCRIPT:
+			gdscript_function(&r_return_value, p_arguments, p_argcount, r_call_error);
+			break;
+	}
+}
+
+GDScriptUtilityCallable::GDScriptUtilityCallable(const StringName &p_function_name) {
+	function_name = p_function_name;
+	if (GDScriptUtilityFunctions::function_exists(p_function_name)) {
+		type = TYPE_GDSCRIPT;
+		gdscript_function = GDScriptUtilityFunctions::get_function(p_function_name);
+	} else if (Variant::has_utility_function(p_function_name)) {
+		type = TYPE_GLOBAL;
+	} else {
+		ERR_PRINT(vformat(R"(Unknown utility function "%s".)", p_function_name));
+	}
+	h = p_function_name.hash();
+}

--- a/modules/gdscript/gdscript_utility_callable.h
+++ b/modules/gdscript/gdscript_utility_callable.h
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  gdscript_utility_callable.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_UTILITY_CALLABLE_H
+#define GDSCRIPT_UTILITY_CALLABLE_H
+
+#include "gdscript_utility_functions.h"
+
+#include "core/variant/callable.h"
+
+class GDScriptUtilityCallable : public CallableCustom {
+	StringName function_name;
+	enum Type {
+		TYPE_INVALID,
+		TYPE_GLOBAL,
+		TYPE_GDSCRIPT,
+	};
+	Type type = TYPE_INVALID;
+	GDScriptUtilityFunctions::FunctionPtr gdscript_function = nullptr;
+	uint32_t h = 0;
+
+	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
+	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
+
+public:
+	uint32_t hash() const override;
+	String get_as_text() const override;
+	CompareEqualFunc get_compare_equal_func() const override;
+	CompareLessFunc get_compare_less_func() const override;
+	bool is_valid() const override;
+	StringName get_method() const override;
+	ObjectID get_object() const override;
+	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
+
+	GDScriptUtilityCallable(const StringName &p_function_name);
+};
+
+#endif // GDSCRIPT_UTILITY_CALLABLE_H

--- a/modules/gdscript/tests/scripts/runtime/features/utility_func_as_callable.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/utility_func_as_callable.gd
@@ -1,0 +1,10 @@
+func test():
+	print(print)
+	print(len)
+
+	prints.callv([1, 2, 3])
+	print(mini.call(1, 2))
+	print(len.bind("abc").call())
+
+	const ABSF = absf
+	print(ABSF.call(-1.2))

--- a/modules/gdscript/tests/scripts/runtime/features/utility_func_as_callable.out
+++ b/modules/gdscript/tests/scripts/runtime/features/utility_func_as_callable.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+@GlobalScope::print (Callable)
+@GDScript::len (Callable)
+1 2 3
+1
+3
+1.2


### PR DESCRIPTION
* This PR aims to improve GDScript consistency. After #82264, it makes sense to allow utility functions to be used as `Callable`s too.

```gdscript
prints.callv([1, 2, 3])
print(mini.call(1, 2))
timer.timeout.connect(print.bind("Completed!"))
```

Also, this makes it possible to call vararg utility functions (such as `print()`) with `Callable.callv()` without boilerplate.

![](https://github.com/godotengine/godot/assets/47700418/c2fb3948-1bc8-436c-91ec-388c5087d02a)