### PR TITLE
Fix playback position label update in Audio Stream Importer

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -277,6 +277,8 @@ void AudioStreamImportSettingsDialog::_draw_indicator() {
 		rect.size.height -= y_ofs;
 	}
 
+	_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
+
 	float ofs_x = (_current - zoom_bar->get_value()) * rect.size.width / zoom_bar->get_page();
 	if (ofs_x < 0 || ofs_x >= rect.size.width) {
 		return;
@@ -310,8 +312,6 @@ void AudioStreamImportSettingsDialog::_draw_indicator() {
 			}
 		}
 	}
-
-	_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
 }
 
 void AudioStreamImportSettingsDialog::_on_indicator_mouse_exited() {


### PR DESCRIPTION
The current playback position label doesn't get updated if the playhead is not visible. This can be visualized in this example:

[audio-stream-importer-1.webm](https://github.com/godotengine/godot/assets/26153311/886c74e7-32ce-4e34-be46-a87eb6920032)

The label is updated in `_draw_indicator()` at the end of the function, but we return early if the calculated offset falls outside the valid range. This fix moves the label updating above this check, ensuring that the label always gets updated regardless of the visibility of the playhead:

[audio-stream-importer-2.webm](https://github.com/godotengine/godot/assets/26153311/6e7460c8-af47-4fc4-946e-9ceca8d49c43)

Fixes #86550.

