### PR TITLE
Fix data format storage method for PortableCompressedTexture2D

### DIFF
--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -40,7 +40,6 @@ class CompressedTexture2D : public Texture2D {
 
 public:
 	enum DataFormat {
-		DATA_FORMAT_UNDEFINED,
 		DATA_FORMAT_IMAGE,
 		DATA_FORMAT_PNG,
 		DATA_FORMAT_WEBP,

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -39,6 +39,14 @@ class PortableCompressedTexture2D : public Texture2D {
 	GDCLASS(PortableCompressedTexture2D, Texture2D);
 
 public:
+	enum DataFormat {
+		DATA_FORMAT_UNDEFINED,
+		DATA_FORMAT_IMAGE,
+		DATA_FORMAT_PNG,
+		DATA_FORMAT_WEBP,
+		DATA_FORMAT_BASIS_UNIVERSAL,
+	};
+
 	enum CompressionMode {
 		COMPRESSION_MODE_LOSSLESS,
 		COMPRESSION_MODE_LOSSY,


### PR DESCRIPTION
This is a fix after previous merged PR: https://github.com/godotengine/godot/pull/77712

It fixes backwards compatibility after this PR:
The main idea is:
- Remove the problem enum value
- Encode data format as `data_format + 1` to distinguish it from files, generated by previous versions of Godot.
- Subtract 1 while `data_format` decoding if `data_format_code` is greater than 0

Why i cannot just place the `DATA_FORMAT_UNDEFINED` in back of the enum or make it's value so big:
The `DATA_FORMAT_UNDEFINED` is the format that all the old images are in. That's why I can't put it at the end of the enum values list. It must be equal 0. Therefore, it conflicts with the `DATA_FORMAT_IMAGE`. That's why he had to be removed.

Alternative way:
Store the boolean “new data format” sign in a separate byte. And store `data_format` as is (without adding 1)