### PR TITLE
Add documentation to JavaClass & JavaClassWrapper

### DIFF
--- a/doc/classes/JavaClass.xml
+++ b/doc/classes/JavaClass.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="JavaClass" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Represents an object from the Java Native Interface.
 	</brief_description>
 	<description>
+		Represents an object from the Java Native Interface. It is returned from [method JavaClassWrapper.wrap].
+		[b]Note:[/b] This class only works on Android. For any other build, this class does nothing.
+		[b]Note:[/b] This class is not to be confused with [JavaScriptObject].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/JavaClassWrapper.xml
+++ b/doc/classes/JavaClassWrapper.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="JavaClassWrapper" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Provides access to the Java Native Interface.
 	</brief_description>
 	<description>
+		The JavaClassWrapper singleton provides a way for the Godot application to send and receive data through the [url=https://developer.android.com/training/articles/perf-jni]Java Native Interface[/url] (JNI).
+		[b]Note:[/b] This singleton is only available in Android builds.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,6 +14,8 @@
 			<return type="JavaClass" />
 			<param index="0" name="name" type="String" />
 			<description>
+				Wraps a class defined in Java, and returns it as a [JavaClass] [Object] type that Godot can interact with.
+				[b]Note:[/b] This method only works on Android. On every other platform, this method does nothing and returns an empty [JavaClass].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/22136.

I... seriously don't know. I am struggling to understand the meaning of them. Any mention of these is outstandingly lacking, as if hidden in ancient scrolls. The code is old, uncommented and a bit garbled, and the history on GitHub doesn't tell me anything. Even the Android devs aren't exactly sure what these are for: [JNISingleton](https://docs.godotengine.org/en/stable/classes/class_jnisingleton.html) exists and the tutorial for it is sufficient, at least.

Ever since their introduction they've been left ignored lacking any sort of documentation or proper tutorial. What's the purpose of these? Their obscurity stood out to me like a sore thumb. I had to know, and fill them with _some_ semblance of information. Hence, I have written my... best guesses.