### PR TITLE
Fix global transform being wrong on entering tree

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -315,6 +315,7 @@ void CanvasItem::_notification(int p_what) {
 				}
 			}
 
+			_set_global_invalid(true);
 			_enter_canvas();
 
 			RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, is_visible_in_tree()); // The visibility of the parent may change.


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/85680
- *Bugsquad edit:* Fixes #85705

So, this is a tricky problem to explain. Basically, in the TileMap code, I used to do something like this (it's simplified so you get the idea):
```
case NOTIFICATION_TRANSFORM_CHANGED: {
   ...
    Transform2D gl_transform = tile_map_node->get_global_transform();
	ps->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM, gl_transform * xform);
   ...
}
```

After a long investigation on the TileMap code, I realized that the gl_transform provided there was wrong. Basically, when entering the tree, `get_global_transform` will provide wrong data on the first `NOTIFICATION_TRANSFORM_CHANGED` received (this notification is received on entering the tree, after `ENTER_TREE`).

What this PR does, is making sure that, on entering the tree, the CanvasItem global transform is marked as invalid right away. I am not 100% sure his is the most efficient / correct way to solve the issue, but it works.
~I added it to `NOTIFICATION_PARENTED` as it is the first notification to be triggered (at the CanvasItem level) when adding a CanvasItem to the tree. Also, it calls `_notify_transform` right after, so not marking the global_transform as invalied seemed weird to me. I kind of guessed that when re-parented, the node's global_transform should always we set as invalid anyway.~

~Another solution might be to set the flag in the constructor. As I guess that the fact the `NOTIFICATION_EXIT_TREE` notification sets the state as invalid would probably be enough (basically, the problem seems to be the global_transform not being marked as invalid by default). I decided to add it to `NOTIFICATION_PARENTED` as it seemed to make more sense.~

Edit: after some investigation, it seems like this notification is not always triggered, so I updated the PR to update things in NOTIFICATION_ENTER_TREE instead.


As a side note, something like this worked normally in GDScript:
```
			add_child(tilemaps)
			print(tilemaps.global_transform)
```
I suspect that there's something in the `add_child` chain of events that does trigger the invalidation of the `global_transform` later on, but not sure where. 

