### PR TITLE
Specify how CanvasTexture does not work in 3D

### DIFF
--- a/doc/classes/CanvasTexture.xml
+++ b/doc/classes/CanvasTexture.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[CanvasTexture] is an alternative to [ImageTexture] for 2D rendering. It allows using normal maps and specular maps in any node that inherits from [CanvasItem]. [CanvasTexture] also allows overriding the texture's filter and repeat mode independently of the node's properties (or the project settings).
-		[b]Note:[/b] [CanvasTexture] cannot be used in 3D rendering. For physically-based materials in 3D, use [BaseMaterial3D] instead.
+		[b]Note:[/b] [CanvasTexture] cannot be used in 3D. It will not display correctly when applied to any [VisualInstance3D], such as [Sprite3D] or [Decal]. For physically-based materials in 3D, use [BaseMaterial3D] instead.
 	</description>
 	<tutorials>
 		<link title="2D Lights and Shadows">$DOCS_URL/tutorials/2d/2d_lights_and_shadows.html</link>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/75342

I am finding this difficult to solve in the class reference. **CanvasTexture** is the odd one among all `Texture2D`s, because it explicitly does not work outside of CanvasItems, and that is already documented.

The most that can be done is being more explicit.

Can be cherrypicked for prior versions.