### PR TITLE
[3.x] iOS: Support TTS on iOS 16 on real devices on iOS 16+

### DIFF
--- a/platform/iphone/tts_ios.h
+++ b/platform/iphone/tts_ios.h
@@ -31,6 +31,9 @@
 #ifndef TTS_IOS_H
 #define TTS_IOS_H
 
+#if __has_include(<AVFAudio/AVAudioSession.h>)
+#import <AVFAudio/AVAudioSession.h>
+#endif
 #if __has_include(<AVFAudio/AVSpeechSynthesis.h>)
 #import <AVFAudio/AVSpeechSynthesis.h>
 #else

--- a/platform/iphone/tts_ios.mm
+++ b/platform/iphone/tts_ios.mm
@@ -38,6 +38,9 @@
 	self->av_synth = [[AVSpeechSynthesizer alloc] init];
 	[self->av_synth setDelegate:self];
 	print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
+
+	[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+	[[AVAudioSession sharedInstance] setActive:YES error:nil];
 	return self;
 }
 


### PR DESCRIPTION
See e.g. https://stackoverflow.com/questions/76776262/how-to-fix-av-speech-synthesizer-error-unable-to-list-voice-folder-even-after

I haven't tested TTS on 4.x as I am still finishing up my last 3.x project.  So I don't know if this patch needs to be forward-ported to `master`.  

I can say on ios 16.6.1, on a 10th generation iPad (real not simulator), this makes the difference between TTS working (that is, producing audible speech) and not (that is, not producing audible speech).
