### PR TITLE
Include time delta in `SceneTree` signals `process_frame` and `physics_frame`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -297,11 +297,13 @@
 			</description>
 		</signal>
 		<signal name="physics_frame">
+			<param index="0" name="delta" type="float" />
 			<description>
 				Emitted immediately before [method Node._physics_process] is called on every node in the [SceneTree].
 			</description>
 		</signal>
 		<signal name="process_frame">
+			<param index="0" name="delta" type="float" />
 			<description>
 				Emitted immediately before [method Node._process] is called on every node in the [SceneTree].
 			</description>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -461,7 +461,7 @@ bool SceneTree::physics_process(double p_time) {
 	}
 	physics_process_time = p_time;
 
-	emit_signal(SNAME("physics_frame"));
+	emit_signal(SNAME("physics_frame"), p_time);
 
 	call_group(SNAME("_picking_viewports"), SNAME("_process_picking"));
 
@@ -499,7 +499,7 @@ bool SceneTree::process(double p_time) {
 		}
 	}
 
-	emit_signal(SNAME("process_frame"));
+	emit_signal(SNAME("process_frame"), p_time);
 
 	MessageQueue::get_singleton()->flush(); //small little hack
 
@@ -1661,8 +1661,8 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("node_renamed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_configuration_warning_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 
-	ADD_SIGNAL(MethodInfo("process_frame"));
-	ADD_SIGNAL(MethodInfo("physics_frame"));
+	ADD_SIGNAL(MethodInfo("process_frame", PropertyInfo(Variant::FLOAT, "delta")));
+	ADD_SIGNAL(MethodInfo("physics_frame", PropertyInfo(Variant::FLOAT, "delta")));
 
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);


### PR DESCRIPTION
Unsure if this is wanted upstream but I find this patch particularly useful with non-`Node` objects.

In particular I've implemented a `RefCounted` ringbuffer that keeps a series of screenshots of the last five seconds just so that I can save those in case something interesting happens. With this patch I can avoid implementing leaky abstraction to get the delta through `Node.get_process_delta_time()` or `Node.get_physics_process_delta_time()` or passing the ringbuffer to a `Node` and have it pass the delta within its `_process` or `_physics_process` call. I'm aware the ringbuffer could be turned into a `Node` but it doesn't need all that functionality.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
