### PR TITLE
Add input signals to `SceneTree`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -272,6 +272,12 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="input">
+			<param index="0" name="event" type="InputEvent" />
+			<description>
+				Emitted immediately before [method Node._input] is called on every node in the [SceneTree].
+			</description>
+		</signal>
 		<signal name="node_added">
 			<param index="0" name="node" type="Node" />
 			<description>
@@ -306,6 +312,12 @@
 				Emitted immediately before [method Node._process] is called on every node in the [SceneTree].
 			</description>
 		</signal>
+		<signal name="shortcut_input">
+			<param index="0" name="event" type="InputEvent" />
+			<description>
+				Emitted immediately before [method Node._shortcut_input] is called on every node in the [SceneTree].
+			</description>
+		</signal>
 		<signal name="tree_changed">
 			<description>
 				Emitted whenever the [SceneTree] hierarchy changed (children being moved or renamed, etc.).
@@ -314,6 +326,18 @@
 		<signal name="tree_process_mode_changed">
 			<description>
 				This signal is only emitted in the editor, it allows the editor to update the visibility of disabled nodes. Emitted whenever any node's [member Node.process_mode] is changed.
+			</description>
+		</signal>
+		<signal name="unhandled_input">
+			<param index="0" name="event" type="InputEvent" />
+			<description>
+				Emitted immediately before [method Node._unhandled_input] is called on every node in the [SceneTree].
+			</description>
+		</signal>
+		<signal name="unhandled_key_input">
+			<param index="0" name="event" type="InputEvent" />
+			<description>
+				Emitted immediately before [method Node._unhandled_key_input] is called on every node in the [SceneTree].
 			</description>
 		</signal>
 	</signals>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1179,6 +1179,21 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 
 	Vector<ObjectID> no_context_node_ids; // Nodes may be deleted due to this shortcut input.
 
+	switch (p_call_type) {
+		case CALL_INPUT_TYPE_INPUT:
+			emit_signal(SNAME("input"), p_input);
+			break;
+		case CALL_INPUT_TYPE_SHORTCUT_INPUT:
+			emit_signal(SNAME("shortcut_input"), p_input);
+			break;
+		case CALL_INPUT_TYPE_UNHANDLED_INPUT:
+			emit_signal(SNAME("unhandled_input"), p_input);
+			break;
+		case CALL_INPUT_TYPE_UNHANDLED_KEY_INPUT:
+			emit_signal(SNAME("unhandled_key_input"), p_input);
+			break;
+	}
+
 	for (int i = gr_node_count - 1; i >= 0; i--) {
 		if (p_viewport->is_input_handled()) {
 			break;
@@ -1663,6 +1678,10 @@ void SceneTree::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("process_frame"));
 	ADD_SIGNAL(MethodInfo("physics_frame"));
+	ADD_SIGNAL(MethodInfo("input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	ADD_SIGNAL(MethodInfo("shortcut_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	ADD_SIGNAL(MethodInfo("unhandled_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	ADD_SIGNAL(MethodInfo("unhandled_key_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);


### PR DESCRIPTION
Unsure if this is wanted upstream, but I find it useful with non-`Node` objects.

In particular I wanted to implement a Konami code detector but the input was not propagating to my target node due to calling `Viewport.set_input_as_handled()` somewhere else. Figured it was best to get the `InputEvent` and inspect it before any `Node` input calls were made.

This patch also makes it easier to implement the Konami-code detector as a `RefCounted` object since now it only needs a reference to the SceneTree and there's no need to couple its code with a `Node`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
