### PR TITLE
Fix texture artifacts around Sprite3D with linear filtering

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2406,6 +2406,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_
 	material->set_flag(FLAG_ALBEDO_TEXTURE_MSDF, p_msdf);
 	material->set_flag(FLAG_DISABLE_DEPTH_TEST, p_no_depth);
 	material->set_flag(FLAG_FIXED_SIZE, p_fixed_size);
+	material->set_flag(FLAG_USE_TEXTURE_REPEAT, false); // Undesired.
 	material->set_alpha_antialiasing(p_alpha_antialiasing_mode);
 	material->set_texture_filter(p_filter);
 	if (p_billboard || p_billboard_y) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/73739
Closes https://github.com/godotengine/godot-proposals/issues/13044

This PR fully fixes the original issue described, by disabling the texture repeat on the material generated by **Sprite3D**, preventing the color to leak around the edges outright.

| Before | After
| --- | --- |
| ![image](https://github.com/godotengine/godot/assets/66727710/2c0ab608-260e-4b76-b55c-46888d9f3bbe)| ![image](https://github.com/godotengine/godot/assets/66727710/b509ea67-36a8-4386-83d2-a799052f4c95)


This issue also exists in **Label3D**, but you'd never ever see it in practice, as it resizes with a bit of padding around the edges to compensate.

_Bugsquad edit: Fixes https://github.com/godotengine/godot/issues/82044_