### PR TITLE
[Editor] Add missing virtual bind to `EditorNode3DGizmo(Plugin)`

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_begin_handle_action" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="secondary" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_commit_handle" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="id" type="int" />

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -11,6 +11,14 @@
 		<link title="Node3D gizmo plugins">$DOCS_URL/tutorials/plugins/editor/3d_gizmos.html</link>
 	</tutorials>
 	<methods>
+		<method name="_begin_handle_action" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="gizmo" type="EditorNode3DGizmo" />
+			<param index="1" name="handle_id" type="int" />
+			<param index="2" name="secondary" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_can_be_hidden" qualifiers="virtual const">
 			<return type="bool" />
 			<description>

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -825,6 +825,7 @@ void EditorNode3DGizmo::_bind_methods() {
 	GDVIRTUAL_BIND(_is_handle_highlighted, "id", "secondary");
 
 	GDVIRTUAL_BIND(_get_handle_value, "id", "secondary");
+	GDVIRTUAL_BIND(_begin_handle_action, "id", "secondary");
 	GDVIRTUAL_BIND(_set_handle, "id", "secondary", "camera", "point");
 	GDVIRTUAL_BIND(_commit_handle, "id", "secondary", "restore", "cancel");
 
@@ -1045,6 +1046,7 @@ void EditorNode3DGizmoPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_is_handle_highlighted, "gizmo", "handle_id", "secondary");
 	GDVIRTUAL_BIND(_get_handle_value, "gizmo", "handle_id", "secondary");
 
+	GDVIRTUAL_BIND(_begin_handle_action, "gizmo", "handle_id", "secondary");
 	GDVIRTUAL_BIND(_set_handle, "gizmo", "handle_id", "secondary", "camera", "screen_pos");
 	GDVIRTUAL_BIND(_commit_handle, "gizmo", "handle_id", "secondary", "restore", "cancel");
 


### PR DESCRIPTION
Method `_begin_handle_action` was not bound

* Fixes: https://github.com/godotengine/godot/issues/86880

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
