### PR TITLE
Add Autocompletion for AnimationNodeStateMachine & AnimationNodeBlendTree

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1544,6 +1544,22 @@ void AnimationNodeBlendTree::_node_changed(const StringName &p_node) {
 	emit_signal(SNAME("node_changed"), p_node);
 }
 
+void AnimationNodeBlendTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	bool add_node_options = false;
+	if (p_idx == 0) {
+		add_node_options = (pf == "get_node" || pf == "has_node" || pf == "rename_node" || pf == "remove_node" || pf == "set_node_position" || pf == "get_node_position" || pf == "connect_node" || pf == "disconnect_node");
+	} else if (p_idx == 2) {
+		add_node_options = (pf == "connect_node" || pf == "disconnect_node");
+	}
+	if (add_node_options) {
+		for (KeyValue<StringName, Node> E : nodes) {
+			r_options->push_back(String(E.key).quote());
+		}
+	}
+	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);
+}
+
 void AnimationNodeBlendTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeBlendTree::add_node, DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("get_node", "name"), &AnimationNodeBlendTree::get_node);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -454,6 +454,8 @@ public:
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+
 	AnimationNodeBlendTree();
 	~AnimationNodeBlendTree();
 };

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1793,6 +1793,22 @@ void AnimationNodeStateMachine::_animation_node_removed(const ObjectID &p_oid, c
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }
 
+void AnimationNodeStateMachine::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	bool add_state_options = false;
+	if (p_idx == 0) {
+		add_state_options = (pf == "get_node" || pf == "has_node" || pf == "rename_node" || pf == "remove_node" || pf == "replace_node" || pf == "set_node_position" || pf == "get_node_position");
+	} else if (p_idx <= 1) {
+		add_state_options = (pf == "has_transition" || pf == "add_transition" || pf == "remove_transition");
+	}
+	if (add_state_options) {
+		for (KeyValue<StringName, State> E : states) {
+			r_options->push_back(String(E.key).quote());
+		}
+	}
+	AnimationRootNode::get_argument_options(p_function, p_idx, r_options);
+}
+
 void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeStateMachine::add_node, DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("replace_node", "name", "node"), &AnimationNodeStateMachine::replace_node);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -215,6 +215,8 @@ public:
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+
 	AnimationNodeStateMachine();
 };
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86799 and https://github.com/godotengine/godot/pull/86754

This PR adds auto completion to **AnimationNodeStateMachine**'s state-related methods, as well as **AnimationNodeBlendTree**'s node-fetching related methods.

![image](https://github.com/godotengine/godot/assets/66727710/3774c7df-fde0-44e7-8b87-ec1d4c846457)
![image](https://github.com/godotengine/godot/assets/66727710/874f0892-4139-4e98-99b8-393940d752b4)


These are not to be confused with **AnimationNodeStateMachinePlayback**'s methods, which unfortunately isn't natively possible to do without further meddling, as it does not have a direct reference to its origin state machine (I tried, I promise).