### PR TITLE
Add autocompletion to AnimationNode

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -444,6 +444,34 @@ double AnimationNode::blend_input_ex(int p_input, double p_time, bool p_seek, bo
 	return blend_input(p_input, info, p_filter, p_sync, p_test_only);
 }
 
+#ifdef TOOLS_ENABLED
+void AnimationNode::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	if (p_idx == 0) {
+		if (pf == "find_input") {
+			for (const AnimationNode::Input &E : inputs) {
+				r_options->push_back(E.name.quote());
+			}
+		} else if (pf == "get_parameter" || pf == "set_parameter") {
+			bool is_setter = pf == "set_parameter";
+			List<PropertyInfo> parameters;
+			get_parameter_list(&parameters);
+			for (const PropertyInfo &E : parameters) {
+				if (is_setter && is_parameter_read_only(E.name)) {
+					continue;
+				}
+				r_options->push_back(E.name.quote());
+			}
+		} else if (pf == "set_filter_path" || pf == "is_path_filtered") {
+			for (const KeyValue<NodePath, bool> &E : filter) {
+				r_options->push_back(String(E.key).quote());
+			}
+		}
+	}
+	Resource::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void AnimationNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_input", "name"), &AnimationNode::add_input);
 	ClassDB::bind_method(D_METHOD("remove_input", "index"), &AnimationNode::remove_input);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -151,6 +151,10 @@ public:
 
 	virtual bool has_filter() const;
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const;
 	Ref<AnimationNode> find_node_by_path(const String &p_name) const;
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86799 and https://github.com/godotengine/godot/pull/86884

This PR adds autocompletion to AnimationNode's `find_input`, `get_parameter`, `set_parameter`, `set_filter_path`, and `is_path_filtered`.
This is in the hopes that it makes working with animation nodes in code a little more tolerable, although I have a feeling this is quite niche.