### PR TITLE
Update doc to mention that visual comment node is currently not visible

### DIFF
--- a/doc/classes/VisualShaderNodeComment.xml
+++ b/doc/classes/VisualShaderNodeComment.xml
@@ -2,6 +2,7 @@
 <class name="VisualShaderNodeComment" inherits="VisualShaderNodeResizableBase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A comment node to be placed on visual shader graph.
+		[b]Note:[/b] The comment node is going through a rework and thus not visible to the user now.
 	</brief_description>
 	<description>
 		A resizable rectangular area with changeable [member title] and [member description] used for better organizing of other visual shader nodes.


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/86883

It looks like many users are won't aware of the rework and due to the fact that the replacement is not ready yet, IMO we can at least update the doc now as suggested in https://github.com/godotengine/godot/pull/79307#issuecomment-1867647049

The doc itself maybe not needed in 4.3 as the rework might be ready in 4.3, but can be cherry picked for 4.2 at least now.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
