### PR TITLE
Add nullcheck for `editor_plugin_screen` to prevent crash on startup

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2502,12 +2502,14 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 
 			else if (main_plugin != editor_plugin_screen && (!ScriptEditor::get_singleton() || !ScriptEditor::get_singleton()->is_visible_in_tree() || ScriptEditor::get_singleton()->can_take_away_focus())) {
 				// Unedit previous plugin.
-				editor_plugin_screen->edit(nullptr);
-				active_plugins[editor_owner_id].erase(editor_plugin_screen);
+				if (editor_plugin_screen != nullptr) {
+					editor_plugin_screen->edit(nullptr);
+					active_plugins[editor_owner_id].erase(editor_plugin_screen);
+				}
 				// Update screen main_plugin.
 				editor_select(plugin_index);
 				main_plugin->edit(current_obj);
-			} else {
+			} else if (editor_plugin_screen != nullptr) {
 				editor_plugin_screen->edit(current_obj);
 			}
 			is_main_screen_editing = true;


### PR DESCRIPTION
Prevents the crash in https://github.com/godotengine/godot/issues/86869

From the crash call stack, the problem looks like `open_scene_from_path` in `_enter_tree` is called to early, before `editor_plugin_screen` is inited and thus the crash. There maybe other ways of preventing this crash (something like delay any call on the call chain ?),  but I think at least add some null check is harmless.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
