### PR TITLE
Add autocompletion for a few EditorInterface methods

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -400,6 +400,21 @@ bool EditorInterface::is_movie_maker_enabled() const {
 }
 
 // Base.
+void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	String pf = p_function;
+	if (p_idx == 0) {
+		if (pf == "set_main_screen_editor") {
+			for (String E : { "\"2D\"", "\"3D\"", "\"Script\"", "\"AssetLib\"" }) {
+				r_options->push_back(E);
+			}
+		} else if (pf == "get_editor_viewport_3d") {
+			for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
+				r_options->push_back(String::num_int64(i));
+			}
+		}
+	}
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
 
 void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart_editor", "save"), &EditorInterface::restart_editor, DEFVAL(true));

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -152,6 +152,8 @@ public:
 
 	// Base.
 
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+
 	static void create();
 	static void free();
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86753, https://github.com/godotengine/godot/pull/86747, https://github.com/godotengine/godot/pull/86758,  https://github.com/godotengine/godot/pull/86764, https://github.com/godotengine/godot/pull/86777, and https://github.com/godotengine/godot/pull/86798

This PR adds autocompletion for `get_editor_viewport_3d` and `set_main_screen_editor`.

This originally started with the intention of adding autocompleted results to way more of these, but I had to ditch the idea for now. A lot of the remaining ones require file paths, and it would be nice to find good method to use everywhere, without iterating over entire folders every time.

I originally copied and pasted the implementation in SceneTree for `change_scene_to_file`, but the way this is is done is EXTREMELY inefficient and would lead to plenty of duplicated code.

https://github.com/godotengine/godot/blob/89cc635c0554cb2e518c830969ca4c5eedda0f4e/scene/main/scene_tree.cpp#L1689-L1716