### PR TITLE
Restrict shader compilation error lines range and remove unnecessary files output

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1497,29 +1497,31 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 
 		// Print the files.
 		for (const KeyValue<String, Vector<String>> &E : includes) {
-			if (E.key.is_empty()) {
-				if (p_path == "") {
-					print_line("--Main Shader--");
-				} else {
-					print_line("--" + p_path + "--");
-				}
-			} else {
-				print_line("--" + E.key + "--");
-			}
 			int err_line = -1;
 			for (int i = 0; i < include_positions.size(); i++) {
 				if (include_positions[i].file == E.key) {
 					err_line = include_positions[i].line;
 				}
 			}
-			const Vector<String> &V = E.value;
-			for (int i = 0; i < V.size(); i++) {
-				if (i == err_line - 1) {
-					// Mark the error line to be visible without having to look at
-					// the trace at the end.
-					print_line(vformat("E%4d-> %s", i + 1, V[i]));
+			if (err_line > 0) {
+				if (E.key.is_empty()) {
+					if (p_path.is_empty()) {
+						print_line("--Main Shader--");
+					} else {
+						print_line("--" + p_path + " at Line" + itos(err_line) + "--");
+					}
 				} else {
-					print_line(vformat("%5d | %s", i + 1, V[i]));
+					print_line("--" + E.key + " at Line" + itos(err_line) + "--");
+				}
+				const Vector<String> &V = E.value;
+				for (int i = MAX(0, err_line - 8); i < MIN(V.size(), err_line + 8); i++) {
+					if (i == err_line - 1) {
+						// Mark the error line to be visible without having to look at
+						// the trace at the end.
+						print_line(vformat("E%4d-> %s", i + 1, V[i]));
+					} else {
+						print_line(vformat("%5d | %s", i + 1, V[i]));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes [#85419 ](https://github.com/godotengine/godot/issues/85419)

This PR restricts shader compilation error lines to limited amount of lines and remove unnecessary files output(usually `.gdshaderinc` files which not related to the error line) instead of just throw all of the lines in shader files, which is annoying when writing shaders with several large `.gdshaderinc` files included.

↓↓↓↓↓↓↓↓↓ [Before] 29k+ log output just because of a single simple redefinition of function name
<img width="433" alt="image" src="https://github.com/godotengine/godot/assets/33864304/0af29b87-ec35-40b4-8482-bd5bba8a616b">

↓↓↓↓↓↓↓↓↓ [After] limited range to only lines near the error line, and removed unrelated included files output
<img width="433" alt="image" src="https://github.com/godotengine/godot/assets/33864304/50cbd3e5-0be2-452b-8926-2475b538682f">

