### PR TITLE
Post-merge fixes to Node & OS documentation

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -459,7 +459,7 @@
 			<param index="0" name="node" type="Node" />
 			<param index="1" name="use_unique_path" type="bool" default="false" />
 			<description>
-				Returns the relative [NodePath] from this node to the specified [param node]. Both nodes must be in the same [SceneTree], otherwise this method fails and returns an empty [NodePath].
+				Returns the relative [NodePath] from this node to the specified [param node]. Both nodes must be in the same [SceneTree] or scene hierarchy, otherwise this method fails and returns an empty [NodePath].
 				If [param use_unique_path] is [code]true[/code], returns the shortest path accounting for this node's unique name (see [member unique_name_in_owner]).
 				[b]Note:[/b] If you get a relative path which starts from a unique node, the path may be longer than a normal relative path, due to the addition of the unique node's name.
 			</description>
@@ -839,7 +839,8 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], enables physics (fixed framerate) processing. When a node is being processed, it will receive a [constant NOTIFICATION_PHYSICS_PROCESS] at a fixed (usually 60 FPS, see [member Engine.physics_ticks_per_second] to change) interval (and the [method _physics_process] callback will be called if it exists). Enabled automatically if [method _physics_process] is overridden.
+				If set to [code]true[/code], enables physics (fixed framerate) processing. When a node is being processed, it will receive a [constant NOTIFICATION_PHYSICS_PROCESS] at a fixed (usually 60 FPS, see [member Engine.physics_ticks_per_second] to change) interval (and the [method _physics_process] callback will be called if it exists).
+				[b]Note:[/b] If [method _physics_process] is overridden, this will be automatically enabled before [method _ready] is called.
 			</description>
 		</method>
 		<method name="set_physics_process_internal">
@@ -854,7 +855,8 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], enables processing. When a node is being processed, it will receive a [constant NOTIFICATION_PROCESS] on every drawn frame (and the [method _process] callback will be called if it exists). Enabled automatically if [method _process] is overridden.
+				If set to [code]true[/code], enables processing. When a node is being processed, it will receive a [constant NOTIFICATION_PROCESS] on every drawn frame (and the [method _process] callback will be called if it exists).
+				[b]Note:[/b] If [method _process] is overridden, this will be automatically enabled before [method _ready] is called.
 				[b]Note:[/b] This method only affects the [method _process] callback, i.e. it has no effect on other callbacks like [method _physics_process]. If you want to disable all processing for the node, set [member process_mode] to [constant PROCESS_MODE_DISABLED].
 			</description>
 		</method>
@@ -862,7 +864,8 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], enables input processing. This is not required for GUI controls! Enabled automatically if [method _input] is overridden.
+				If set to [code]true[/code], enables input processing.
+				[b]Note:[/b] If [method _input] is overridden, this will be automatically enabled before [method _ready] is called. Input processing is also already enabled for GUI controls, such as [Button] and [TextEdit].
 			</description>
 		</method>
 		<method name="set_process_internal">
@@ -877,21 +880,24 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], enables shortcut processing for this node. Enabled automatically if [method _shortcut_input] is overridden.
+				If set to [code]true[/code], enables shortcut processing for this node.
+				[b]Note:[/b] If [method _shortcut_input] is overridden, this will be automatically enabled before [method _ready] is called.
 			</description>
 		</method>
 		<method name="set_process_unhandled_input">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], enables unhandled input processing. This is not required for GUI controls! It enables the node to receive all input that was not previously handled (usually by a [Control]). Enabled automatically if [method _unhandled_input] is overridden.
+				If set to [code]true[/code], enables unhandled input processing. It enables the node to receive all input that was not previously handled (usually by a [Control]).
+				[b]Note:[/b] If [method _unhandled_input] is overridden, this will be automatically enabled before [method _ready] is called. Unhandled input processing is also already enabled for GUI controls, such as [Button] and [TextEdit].
 			</description>
 		</method>
 		<method name="set_process_unhandled_key_input">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], enables unhandled key input processing. Enabled automatically if [method _unhandled_key_input] is overridden.
+				If set to [code]true[/code], enables unhandled key input processing.
+				[b]Note:[/b] If [method _unhandled_key_input] is overridden, this will be automatically enabled before [method _ready] is called.
 			</description>
 		</method>
 		<method name="set_scene_instance_load_placeholder">
@@ -926,7 +932,7 @@
 		</member>
 		<member name="name" type="StringName" setter="set_name" getter="get_name">
 			The name of the node. This name must be unique among the siblings (other child nodes from the same parent). When set to an existing sibling's name, the node is automatically renamed.
-			[b]Note:[/b] When changing the name, the following characters will be removed: ([code].[/code] [code]:[/code] [code]@[/code] [code]/[/code] [code]"[/code] [code]%[/code]). In particular, the [code]@[/code] character is reserved for auto-generated names. See also [method String.validate_node_name].
+			[b]Note:[/b] When changing the name, the following characters will be replaced with an underscore: ([code].[/code] [code]:[/code] [code]@[/code] [code]/[/code] [code]"[/code] [code]%[/code]). In particular, the [code]@[/code] character is reserved for auto-generated names. See also [method String.validate_node_name].
 		</member>
 		<member name="owner" type="Node" setter="set_owner" getter="get_owner">
 			The owner of this node. The owner must be an ancestor of this node. When packing the owner node in a [PackedScene], all the nodes it owns are also saved with it. 
@@ -1197,10 +1203,13 @@
 			Process this node (and children nodes set to inherit) on a sub-thread. See [member process_thread_group] for more information.
 		</constant>
 		<constant name="FLAG_PROCESS_THREAD_MESSAGES" value="1" enum="ProcessThreadMessages" is_bitfield="true">
+			Allows this node to process threaded messages created with [method call_deferred_thread_group] right before [method _process] is called.
 		</constant>
 		<constant name="FLAG_PROCESS_THREAD_MESSAGES_PHYSICS" value="2" enum="ProcessThreadMessages" is_bitfield="true">
+			Allows this node to process threaded messages created with [method call_deferred_thread_group] right before [method _physics_process] is called.
 		</constant>
 		<constant name="FLAG_PROCESS_THREAD_MESSAGES_ALL" value="3" enum="ProcessThreadMessages" is_bitfield="true">
+			Allows this node to process threaded messages created with [method call_deferred_thread_group] right before either [method _process] or [method _physics_process] are called.
 		</constant>
 		<constant name="DUPLICATE_SIGNALS" value="1" enum="DuplicateFlags">
 			Duplicate the node's signal connections.
@@ -1209,7 +1218,7 @@
 			Duplicate the node's groups.
 		</constant>
 		<constant name="DUPLICATE_SCRIPTS" value="4" enum="DuplicateFlags">
-			Duplicate the node's script (including the ancestor's script, if combined with [constant DUPLICATE_USE_INSTANTIATION]).
+			Duplicate the node's script (also overriding the duplicated children's scripts, if combined with [constant DUPLICATE_USE_INSTANTIATION]).
 		</constant>
 		<constant name="DUPLICATE_USE_INSTANTIATION" value="8" enum="DuplicateFlags">
 			Duplicate using [method PackedScene.instantiate]. If the node comes from a scene saved on disk, re-uses [method PackedScene.instantiate] as the base for the duplicated node and its children.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -39,7 +39,7 @@
 			<param index="0" name="arguments" type="PackedStringArray" />
 			<description>
 				Creates a new instance of Godot that runs independently. The [param arguments] are used in the given order and separated by a space.
-				If the process is successfully created, the method will return the new process ID, which you can use to monitor the process (and potentially terminate it with [method kill]). If the process cannot be created, the method will return [code]-1[/code].
+				If the process is successfully created, this method returns the new process' ID, which you can use to monitor the process (and potentially terminate it with [method kill]). If the process cannot be created, this method returns [code]-1[/code].
 				See [method create_process] if you wish to run a different process.
 				[b]Note:[/b] This method is implemented on Android, Linux, macOS and Windows.
 			</description>
@@ -342,7 +342,7 @@
 				- On BSD-based operating systems, this is [code]"FreeBSD"[/code], [code]"NetBSD"[/code], [code]"OpenBSD"[/code], or [code]"BSD"[/code] as a fallback.
 				- On Android, this is [code]"Android"[/code].
 				- On iOS, this is [code]"iOS"[/code].
-				- On the web, this is [code]"Web"[/code].
+				- On Web, this is [code]"Web"[/code].
 				[b]Note:[/b] Custom builds of the engine may support additional platforms, such as consoles, possibly returning other names.
 				[codeblocks]
 				[gdscript]
@@ -538,7 +538,7 @@
 			<description>
 				Returns [code]true[/code] if the feature for the given feature tag is supported in the currently running instance, depending on the platform, build, etc. Can be used to check whether you're currently running a debug build, on a certain platform or arch, etc. Refer to the [url=$DOCS_URL/tutorials/export/feature_tags.html]Feature Tags[/url] documentation for more details.
 				[b]Note:[/b] Tag names are case-sensitive.
-				[b]Note:[/b] On the Web platform, one of the following additional tags is defined to indicate host platform: [code]web_android[/code], [code]web_ios[/code], [code]web_linuxbsd[/code], [code]web_macos[/code], or [code]web_windows[/code].
+				[b]Note:[/b] On the Web platform, one of the following additional tags is defined to indicate the host platform: [code]web_android[/code], [code]web_ios[/code], [code]web_linuxbsd[/code], [code]web_macos[/code], or [code]web_windows[/code].
 			</description>
 		</method>
 		<method name="is_debug_build" qualifiers="const">
@@ -645,6 +645,7 @@
 			<description>
 				Reads a user input string from the standard input (usually the terminal). This operation is [i]blocking[/i], which causes the window to freeze if [method read_string_from_stdin] is called on the main thread. The thread calling [method read_string_from_stdin] will block until the program receives a line break in standard input (usually by the user pressing [kbd]Enter[/kbd]).
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+				[b]Note:[/b] On exported Windows builds, run the console wrapper executable to access the terminal. Otherwise, the standard input will not work correctly. If you need a single executable with console support, use a custom build compiled with the [code]windows_subsystem=console[/code] flag.
 			</description>
 		</method>
 		<method name="request_permission">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/86813

This PR picks up from https://github.com/godotengine/godot/pull/68560 and https://github.com/godotengine/godot/pull/80282, adding more details, addressing a few inaccuracies and poor wording.

For Node:
- Adds missing descriptions to the **ProcessThreadMessages** flag constants, finally filling them all.
- Moves a detail of `set_process`, `set_physics_process` etc. into their own note and specifies that they're automatically called before `_ready`.
- Changes an error in `name`'s description:
     - When the original PR was made, invalid characters were removed from a Node name. As time passed, this behavior was changed but the description was not.
- Clarifies DUPLICATE_SCRIPTS' behavior.
     - I have no idea what the original PR's description meant. It's nonsense, in hindsight.

For OS:
- Adds a note to explain that for `OS.read_string_from_stdin()`, a console wrapper is necessary in Windows builds, addressing https://github.com/godotengine/godot/issues/86813.

I wanted to rewrite all of the Node thread-related descriptions here (when the original PR was made they did not exist yet), but I'm leaving that for another time.