### PR TITLE
Change AudioStreamPlayer autoplay and GLTFBufferView getters to be const

### DIFF
--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -82,3 +82,18 @@ Validate extension JSON: Error: Field 'classes/GPUParticles3D/properties/process
 Validate extension JSON: Error: Field 'classes/Sky/properties/sky_material': type changed value in new API, from "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial" to "PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial,ShaderMaterial".
 
 Property hints reordered to improve editor usability. The types allowed are still the same as before. No adjustments should be necessary.
+
+
+GH-86907
+--------
+
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/methods/is_autoplay_enabled': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/methods/is_autoplay_enabled': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/methods/is_autoplay_enabled': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFBufferView/methods/get_buffer': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFBufferView/methods/get_byte_length': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFBufferView/methods/get_byte_offset': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFBufferView/methods/get_byte_stride': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFBufferView/methods/get_indices': is_const changed value in new API, from false to true.
+
+Change AudioStreamPlayer* is_autoplay_enabled and GLTFBufferView getters to be const.

--- a/modules/gltf/structures/gltf_buffer_view.compat.inc
+++ b/modules/gltf/structures/gltf_buffer_view.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_buffer_view.h                                                    */
+/*  gltf_buffer_view.compat.inc                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,53 +28,34 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GLTF_BUFFER_VIEW_H
-#define GLTF_BUFFER_VIEW_H
-
-#include "../gltf_defines.h"
-
-#include "core/io/resource.h"
-
-class GLTFBufferView : public Resource {
-	GDCLASS(GLTFBufferView, Resource);
-	friend class GLTFDocument;
-
-private:
-	GLTFBufferIndex buffer = -1;
-	int byte_offset = 0;
-	int byte_length = 0;
-	int byte_stride = -1;
-	bool indices = false;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	GLTFBufferIndex _get_buffer_bind_compat_86907();
-	int _get_byte_offset_bind_compat_86907();
-	int _get_byte_length_bind_compat_86907();
-	int _get_byte_stride_bind_compat_86907();
-	bool _get_indices_bind_compat_86907();
-	static void _bind_compatibility_methods();
+
+GLTFBufferIndex GLTFBufferView::_get_buffer_bind_compat_86907() {
+	return get_buffer();
+}
+
+int GLTFBufferView::_get_byte_offset_bind_compat_86907() {
+	return get_byte_offset();
+}
+
+int GLTFBufferView::_get_byte_length_bind_compat_86907() {
+	return get_byte_length();
+}
+
+int GLTFBufferView::_get_byte_stride_bind_compat_86907() {
+	return get_byte_stride();
+}
+
+bool GLTFBufferView::_get_indices_bind_compat_86907() {
+	return get_indices();
+}
+
+void GLTFBufferView::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_buffer"), &GLTFBufferView::_get_buffer_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("get_byte_offset"), &GLTFBufferView::_get_byte_offset_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("get_byte_length"), &GLTFBufferView::_get_byte_length_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("get_byte_stride"), &GLTFBufferView::_get_byte_stride_bind_compat_86907);
+	ClassDB::bind_compatibility_method(D_METHOD("get_indices"), &GLTFBufferView::_get_indices_bind_compat_86907);
+}
+
 #endif // DISABLE_DEPRECATED
-
-public:
-	GLTFBufferIndex get_buffer() const;
-	void set_buffer(GLTFBufferIndex p_buffer);
-
-	int get_byte_offset() const;
-	void set_byte_offset(int p_byte_offset);
-
-	int get_byte_length() const;
-	void set_byte_length(int p_byte_length);
-
-	int get_byte_stride() const;
-	void set_byte_stride(int p_byte_stride);
-
-	bool get_indices() const;
-	void set_indices(bool p_indices);
-
-	Vector<uint8_t> load_buffer_view_data(const Ref<GLTFState> p_state) const;
-};
-
-#endif // GLTF_BUFFER_VIEW_H

--- a/modules/gltf/structures/gltf_buffer_view.cpp
+++ b/modules/gltf/structures/gltf_buffer_view.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "gltf_buffer_view.h"
+#include "gltf_buffer_view.compat.inc"
 
 #include "../gltf_state.h"
 
@@ -53,7 +54,7 @@ void GLTFBufferView::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indices"), "set_indices", "get_indices"); // bool
 }
 
-GLTFBufferIndex GLTFBufferView::get_buffer() {
+GLTFBufferIndex GLTFBufferView::get_buffer() const {
 	return buffer;
 }
 
@@ -61,7 +62,7 @@ void GLTFBufferView::set_buffer(GLTFBufferIndex p_buffer) {
 	buffer = p_buffer;
 }
 
-int GLTFBufferView::get_byte_offset() {
+int GLTFBufferView::get_byte_offset() const {
 	return byte_offset;
 }
 
@@ -69,7 +70,7 @@ void GLTFBufferView::set_byte_offset(int p_byte_offset) {
 	byte_offset = p_byte_offset;
 }
 
-int GLTFBufferView::get_byte_length() {
+int GLTFBufferView::get_byte_length() const {
 	return byte_length;
 }
 
@@ -77,7 +78,7 @@ void GLTFBufferView::set_byte_length(int p_byte_length) {
 	byte_length = p_byte_length;
 }
 
-int GLTFBufferView::get_byte_stride() {
+int GLTFBufferView::get_byte_stride() const {
 	return byte_stride;
 }
 
@@ -85,7 +86,7 @@ void GLTFBufferView::set_byte_stride(int p_byte_stride) {
 	byte_stride = p_byte_stride;
 }
 
-bool GLTFBufferView::get_indices() {
+bool GLTFBufferView::get_indices() const {
 	return indices;
 }
 

--- a/scene/2d/audio_stream_player_2d.compat.inc
+++ b/scene/2d/audio_stream_player_2d.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_buffer_view.h                                                    */
+/*  audio_stream_player_2d.compat.inc                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,53 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GLTF_BUFFER_VIEW_H
-#define GLTF_BUFFER_VIEW_H
-
-#include "../gltf_defines.h"
-
-#include "core/io/resource.h"
-
-class GLTFBufferView : public Resource {
-	GDCLASS(GLTFBufferView, Resource);
-	friend class GLTFDocument;
-
-private:
-	GLTFBufferIndex buffer = -1;
-	int byte_offset = 0;
-	int byte_length = 0;
-	int byte_stride = -1;
-	bool indices = false;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	GLTFBufferIndex _get_buffer_bind_compat_86907();
-	int _get_byte_offset_bind_compat_86907();
-	int _get_byte_length_bind_compat_86907();
-	int _get_byte_stride_bind_compat_86907();
-	bool _get_indices_bind_compat_86907();
-	static void _bind_compatibility_methods();
+
+bool AudioStreamPlayer2D::_is_autoplay_enabled_bind_compat_86907() {
+	return is_autoplay_enabled();
+}
+
+void AudioStreamPlayer2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer2D::_is_autoplay_enabled_bind_compat_86907);
+}
+
 #endif // DISABLE_DEPRECATED
-
-public:
-	GLTFBufferIndex get_buffer() const;
-	void set_buffer(GLTFBufferIndex p_buffer);
-
-	int get_byte_offset() const;
-	void set_byte_offset(int p_byte_offset);
-
-	int get_byte_length() const;
-	void set_byte_length(int p_byte_length);
-
-	int get_byte_stride() const;
-	void set_byte_stride(int p_byte_stride);
-
-	bool get_indices() const;
-	void set_indices(bool p_indices);
-
-	Vector<uint8_t> load_buffer_view_data(const Ref<GLTFState> p_state) const;
-};
-
-#endif // GLTF_BUFFER_VIEW_H

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "audio_stream_player_2d.h"
+#include "audio_stream_player_2d.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "scene/2d/area_2d.h"
@@ -251,7 +252,7 @@ void AudioStreamPlayer2D::set_autoplay(bool p_enable) {
 	internal->autoplay = p_enable;
 }
 
-bool AudioStreamPlayer2D::is_autoplay_enabled() {
+bool AudioStreamPlayer2D::is_autoplay_enabled() const {
 	return internal->autoplay;
 }
 

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -89,6 +89,11 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+#ifndef DISABLE_DEPRECATED
+	bool _is_autoplay_enabled_bind_compat_86907();
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	void set_stream(Ref<AudioStream> p_stream);
 	Ref<AudioStream> get_stream() const;
@@ -109,7 +114,7 @@ public:
 	StringName get_bus() const;
 
 	void set_autoplay(bool p_enable);
-	bool is_autoplay_enabled();
+	bool is_autoplay_enabled() const;
 
 	void set_max_distance(float p_pixels);
 	float get_max_distance() const;

--- a/scene/3d/audio_stream_player_3d.compat.inc
+++ b/scene/3d/audio_stream_player_3d.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_buffer_view.h                                                    */
+/*  audio_stream_player_3d.compat.inc                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,53 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GLTF_BUFFER_VIEW_H
-#define GLTF_BUFFER_VIEW_H
-
-#include "../gltf_defines.h"
-
-#include "core/io/resource.h"
-
-class GLTFBufferView : public Resource {
-	GDCLASS(GLTFBufferView, Resource);
-	friend class GLTFDocument;
-
-private:
-	GLTFBufferIndex buffer = -1;
-	int byte_offset = 0;
-	int byte_length = 0;
-	int byte_stride = -1;
-	bool indices = false;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	GLTFBufferIndex _get_buffer_bind_compat_86907();
-	int _get_byte_offset_bind_compat_86907();
-	int _get_byte_length_bind_compat_86907();
-	int _get_byte_stride_bind_compat_86907();
-	bool _get_indices_bind_compat_86907();
-	static void _bind_compatibility_methods();
+
+bool AudioStreamPlayer3D::_is_autoplay_enabled_bind_compat_86907() {
+	return is_autoplay_enabled();
+}
+
+void AudioStreamPlayer3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer3D::_is_autoplay_enabled_bind_compat_86907);
+}
+
 #endif // DISABLE_DEPRECATED
-
-public:
-	GLTFBufferIndex get_buffer() const;
-	void set_buffer(GLTFBufferIndex p_buffer);
-
-	int get_byte_offset() const;
-	void set_byte_offset(int p_byte_offset);
-
-	int get_byte_length() const;
-	void set_byte_length(int p_byte_length);
-
-	int get_byte_stride() const;
-	void set_byte_stride(int p_byte_stride);
-
-	bool get_indices() const;
-	void set_indices(bool p_indices);
-
-	Vector<uint8_t> load_buffer_view_data(const Ref<GLTFState> p_state) const;
-};
-
-#endif // GLTF_BUFFER_VIEW_H

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "audio_stream_player_3d.h"
+#include "audio_stream_player_3d.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "scene/3d/area_3d.h"
@@ -571,7 +572,7 @@ void AudioStreamPlayer3D::set_autoplay(bool p_enable) {
 	internal->autoplay = p_enable;
 }
 
-bool AudioStreamPlayer3D::is_autoplay_enabled() {
+bool AudioStreamPlayer3D::is_autoplay_enabled() const {
 	return internal->autoplay;
 }
 

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -121,6 +121,11 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+#ifndef DISABLE_DEPRECATED
+	bool _is_autoplay_enabled_bind_compat_86907();
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	void set_stream(Ref<AudioStream> p_stream);
 	Ref<AudioStream> get_stream() const;
@@ -150,7 +155,7 @@ public:
 	int get_max_polyphony() const;
 
 	void set_autoplay(bool p_enable);
-	bool is_autoplay_enabled();
+	bool is_autoplay_enabled() const;
 
 	void set_max_distance(float p_metres);
 	float get_max_distance() const;

--- a/scene/audio/audio_stream_player.compat.inc
+++ b/scene/audio/audio_stream_player.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_buffer_view.h                                                    */
+/*  audio_stream_player.compat.inc                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,53 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GLTF_BUFFER_VIEW_H
-#define GLTF_BUFFER_VIEW_H
-
-#include "../gltf_defines.h"
-
-#include "core/io/resource.h"
-
-class GLTFBufferView : public Resource {
-	GDCLASS(GLTFBufferView, Resource);
-	friend class GLTFDocument;
-
-private:
-	GLTFBufferIndex buffer = -1;
-	int byte_offset = 0;
-	int byte_length = 0;
-	int byte_stride = -1;
-	bool indices = false;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	GLTFBufferIndex _get_buffer_bind_compat_86907();
-	int _get_byte_offset_bind_compat_86907();
-	int _get_byte_length_bind_compat_86907();
-	int _get_byte_stride_bind_compat_86907();
-	bool _get_indices_bind_compat_86907();
-	static void _bind_compatibility_methods();
+
+bool AudioStreamPlayer::_is_autoplay_enabled_bind_compat_86907() {
+	return is_autoplay_enabled();
+}
+
+void AudioStreamPlayer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer::_is_autoplay_enabled_bind_compat_86907);
+}
+
 #endif // DISABLE_DEPRECATED
-
-public:
-	GLTFBufferIndex get_buffer() const;
-	void set_buffer(GLTFBufferIndex p_buffer);
-
-	int get_byte_offset() const;
-	void set_byte_offset(int p_byte_offset);
-
-	int get_byte_length() const;
-	void set_byte_length(int p_byte_length);
-
-	int get_byte_stride() const;
-	void set_byte_stride(int p_byte_stride);
-
-	bool get_indices() const;
-	void set_indices(bool p_indices);
-
-	Vector<uint8_t> load_buffer_view_data(const Ref<GLTFState> p_state) const;
-};
-
-#endif // GLTF_BUFFER_VIEW_H

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "audio_stream_player.h"
+#include "audio_stream_player.compat.inc"
 
 #include "scene/audio/audio_stream_player_internal.h"
 #include "servers/audio/audio_stream.h"
@@ -126,7 +127,7 @@ void AudioStreamPlayer::set_autoplay(bool p_enable) {
 	internal->autoplay = p_enable;
 }
 
-bool AudioStreamPlayer::is_autoplay_enabled() {
+bool AudioStreamPlayer::is_autoplay_enabled() const {
 	return internal->autoplay;
 }
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -67,6 +67,11 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+#ifndef DISABLE_DEPRECATED
+	bool _is_autoplay_enabled_bind_compat_86907();
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	void set_stream(Ref<AudioStream> p_stream);
 	Ref<AudioStream> get_stream() const;
@@ -90,7 +95,7 @@ public:
 	StringName get_bus() const;
 
 	void set_autoplay(bool p_enable);
-	bool is_autoplay_enabled();
+	bool is_autoplay_enabled() const;
 
 	void set_mix_target(MixTarget p_target);
 	MixTarget get_mix_target() const;


### PR DESCRIPTION
I wanted to use these functions with `const AudioStreamPlayer *p_` etc parameters, but I found that these methods were not marked as const, so I could not use them. This PR fixes this and adds compatibility methods.