### PR TITLE
Fix virtual calls for GDExtension in `CollisionObject2D`

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -523,30 +523,22 @@ void CollisionObject2D::_input_event_call(Viewport *p_viewport, const Ref<InputE
 }
 
 void CollisionObject2D::_mouse_enter() {
-	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_enter);
-	}
+	GDVIRTUAL_CALL(_mouse_enter);
 	emit_signal(SceneStringNames::get_singleton()->mouse_entered);
 }
 
 void CollisionObject2D::_mouse_exit() {
-	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_exit);
-	}
+	GDVIRTUAL_CALL(_mouse_exit);
 	emit_signal(SceneStringNames::get_singleton()->mouse_exited);
 }
 
 void CollisionObject2D::_mouse_shape_enter(int p_shape) {
-	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_shape_enter, p_shape);
-	}
+	GDVIRTUAL_CALL(_mouse_shape_enter, p_shape);
 	emit_signal(SceneStringNames::get_singleton()->mouse_shape_entered, p_shape);
 }
 
 void CollisionObject2D::_mouse_shape_exit(int p_shape) {
-	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_shape_exit, p_shape);
-	}
+	GDVIRTUAL_CALL(_mouse_shape_exit, p_shape);
 	emit_signal(SceneStringNames::get_singleton()->mouse_shape_exited, p_shape);
 }
 


### PR DESCRIPTION
Hello, this is my first PR for Godot engine, 

if I am doing something wrong please kindly point me in the right direction.
This fix is similar in nature to https://github.com/godotengine/godot/pull/85870
Same bug, same fix but 2D instead of 3D respectively. I will comment on the issue of that bug since its so similar and link the PR there.
Hopefully that is in line with the way you usually handle a case like this arround here, if you have a diffferent process with making a separate bug report first, let me know! 

