### PR TITLE
Fix BasisUniversal ETC RA as RG transcoding

### DIFF
--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -221,7 +221,7 @@ static Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size
 				imgfmt = Image::FORMAT_DXT5_RA_AS_RG;
 			} else if (RS::get_singleton()->has_os_feature("etc2")) {
 				format = basist::transcoder_texture_format::cTFETC2; // get this from renderer
-				imgfmt = Image::FORMAT_ETC2_RGBA8;
+				imgfmt = Image::FORMAT_ETC2_RA_AS_RG;
 			} else {
 				//opengl most likely, bad for normal maps, nothing to do about this.
 				format = basist::transcoder_texture_format::cTFRGBA32;


### PR DESCRIPTION
The BasisUniversal module was incorrectly set to interpret `RA_AS_RG` textures as `ETC2_RGBA8`, which caused the following error on mobile devices:

| VRAM Compressed | BasisUniversal |
|---------------------|----------------|
| ![IMG_20240107_115719](https://github.com/godotengine/godot/assets/53150244/05e84efd-6d89-44ed-aad9-a12dbd727d07) | ![IMG_20240107_115648](https://github.com/godotengine/godot/assets/53150244/ac234983-5a27-463d-bffd-3f9b8c6a1c13) |

This PR should fix that issue, though I haven't been able to test it yet.

MRP for testing the changes: [basisu_transcode.zip](https://github.com/godotengine/godot/files/13853352/basisu_transcode.zip)
