### PR TITLE
Avoid calling `set_scale` instead of avoiding calling `set_rotation`

### DIFF
--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -74,14 +74,13 @@ void RemoteTransform2D::_update_remote() {
 		Transform2D n_trans = n->get_global_transform();
 		Transform2D our_trans = get_global_transform();
 
-		// There are more steps in the operation of set_rotation, so avoid calling it.
-		Transform2D trans = update_remote_rotation ? our_trans : n_trans;
+		Transform2D trans = update_remote_scale ? our_trans : n_trans;
 
-		if (update_remote_rotation ^ update_remote_position) {
+		if (update_remote_scale ^ update_remote_position) {
 			trans.set_origin(update_remote_position ? our_trans.get_origin() : n_trans.get_origin());
 		}
-		if (update_remote_rotation ^ update_remote_scale) {
-			trans.set_scale(update_remote_scale ? our_trans.get_scale() : n_trans.get_scale());
+		if (update_remote_scale ^ update_remote_rotation) {
+			trans.set_rotation(update_remote_rotation ? our_trans.get_rotation() : n_trans.get_rotation());
 		}
 
 		n->set_global_transform(trans);
@@ -94,14 +93,13 @@ void RemoteTransform2D::_update_remote() {
 		Transform2D n_trans = n->get_transform();
 		Transform2D our_trans = get_transform();
 
-		// There are more steps in the operation of set_rotation, so avoid calling it.
-		Transform2D trans = update_remote_rotation ? our_trans : n_trans;
+		Transform2D trans = update_remote_scale ? our_trans : n_trans;
 
-		if (update_remote_rotation ^ update_remote_position) {
+		if (update_remote_scale ^ update_remote_position) {
 			trans.set_origin(update_remote_position ? our_trans.get_origin() : n_trans.get_origin());
 		}
-		if (update_remote_rotation ^ update_remote_scale) {
-			trans.set_scale(update_remote_scale ? our_trans.get_scale() : n_trans.get_scale());
+		if (update_remote_scale ^ update_remote_rotation) {
+			trans.set_rotation(update_remote_rotation ? our_trans.get_rotation() : n_trans.get_rotation());
 		}
 
 		n->set_transform(trans);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Setting the rotation will correct the scale, but not vice versa (And it will cause the cumulative effect of floating point errors to cause offset).

This does not completely eliminate floating point errors in some cases (initial scale is `(1.1, 1.1)`), but performs better in some cases (initial scale is `(1, 1)`). 

Fix #86889.
