### PR TITLE
Deprecate usage of nested Arrays as key-value pairs in `String.format()`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3552,9 +3552,11 @@ String String::format(const Variant &p_values, const String &p_placeholder) cons
 		Array values_arr = p_values;
 
 		for (int i = 0; i < values_arr.size(); i++) {
-			if (values_arr[i].get_type() == Variant::ARRAY) { //Array in Array structure [["name","RobotGuy"],[0,"godot"],["strength",9000.91]]
+#ifndef DISABLE_DEPRECATED
+			if (values_arr[i].get_type() == Variant::ARRAY) { // Array in Array structure [["name","RobotGuy"], [0,"godot"], ["strength",9000.91]].
 				Array value_arr = values_arr[i];
 
+				WARN_DEPRECATED_MSG("In String.format(), Arrays inside another Array are treated as key-value pairs. This behavior is deprecated. Consider using a Dictionary instead.");
 				if (value_arr.size() == 2) {
 					String key = value_arr[0];
 					String val = value_arr[1];
@@ -3563,14 +3565,17 @@ String String::format(const Variant &p_values, const String &p_placeholder) cons
 				} else {
 					ERR_PRINT(vformat("Invalid format: the inner Array at index %d needs to contain only 2 elements, as a key-value pair.", i).ascii().get_data());
 				}
-			} else { //Array structure ["RobotGuy","Logis","rookie"]
-				String val = values_arr[i];
+				continue;
+			}
+#endif // DISABLE_DEPRECATED
 
-				if (p_placeholder.contains_char('_')) {
-					new_string = new_string.replace(p_placeholder.replace("_", String::num_int64(i)), val);
-				} else {
-					new_string = new_string.replace_first(p_placeholder, val);
-				}
+			// Array structure ["RobotGuy", "Logis", "rookie"].
+			String val = values_arr[i];
+
+			if (p_placeholder.contains_char('_')) {
+				new_string = new_string.replace(p_placeholder.replace("_", String::num_int64(i)), val);
+			} else {
+				new_string = new_string.replace_first(p_placeholder, val);
 			}
 		}
 	} else if (p_values.get_type() == Variant::DICTIONARY) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8753.

For **String**'s `format()`, This PR deprecates using nested arrays in an **Array** as key-value pairs, recommending dictionaries for that purpose, instead. The functionality still exists, but is discouraged with a warning. The existing behavior with Arrays is left unchanged.

This is an obscure behavior that is barely worth documenting. See the proposal for further reasoning.