### PR TITLE
Commit transforms done with editor gizmo on tool mode switch. 

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -7296,6 +7296,12 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 		case MENU_TOOL_ROTATE:
 		case MENU_TOOL_SCALE:
 		case MENU_TOOL_LIST_SELECT: {
+			for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
+				if (viewports[i]->_edit.mode != Node3DEditorViewport::TRANSFORM_NONE) {
+					viewports[i]->commit_transform();
+				}
+			}
+
 			for (int i = 0; i < TOOL_MAX; i++) {
 				tool_button[i]->set_pressed(i == p_option);
 			}

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -4546,6 +4546,10 @@ void CanvasItemEditor::_button_toggle_grid_snap(bool p_status) {
 }
 
 void CanvasItemEditor::_button_tool_select(int p_index) {
+	if (drag_type != DRAG_NONE) {
+		_commit_drag();
+	}
+
 	Button *tb[TOOL_MAX] = { select_button, list_select_button, move_button, scale_button, rotate_button, pivot_button, pan_button, ruler_button };
 	for (int i = 0; i < TOOL_MAX; i++) {
 		tb[i]->set_pressed(i == p_index);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Supplementary but not dependent on: #86805 and #86804

This affects 2D and 3D. 

Currently you can switch gizmo tool modes while an edit is in progress, the tool will switch, but the previous tools action will continue, which is a bit strange. 

https://github.com/user-attachments/assets/d5b3ed52-52be-4d27-b459-0aa04dc2945d

This PR will prevent this, by committing the transform in the editor when switching tool modes which seems like the more expected and less confusing result. 

https://github.com/user-attachments/assets/7ee27b1a-07ab-460c-a75a-2b9da0c4a016


