### PR TITLE
Prevent division by 0 when creating vertices of a PrismMesh

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1478,15 +1478,15 @@ void PrismMesh::_create_mesh_array(Array &p_arr) const {
 	thisrow = point;
 	prevrow = 0;
 	for (j = 0; j <= (subdivide_h + 1); j++) {
-		float scale = (y - start_pos.y) / size.y;
+		float scale = j / (subdivide_h + 1.0);
 		float scaled_size_x = size.x * scale;
 		float start_x = start_pos.x + (1.0 - scale) * size.x * left_to_right;
 		float offset_front = (1.0 - scale) * onethird * left_to_right;
 		float offset_back = (1.0 - scale) * onethird * (1.0 - left_to_right);
 
 		float v = j;
-		float v2 = j / (subdivide_h + 1.0);
-		v /= (2.0 * (subdivide_h + 1.0));
+		float v2 = scale;
+		v /= 2.0 * (subdivide_h + 1.0);
 
 		x = 0.0;
 		for (i = 0; i <= (subdivide_w + 1); i++) {
@@ -1568,15 +1568,15 @@ void PrismMesh::_create_mesh_array(Array &p_arr) const {
 	thisrow = point;
 	prevrow = 0;
 	for (j = 0; j <= (subdivide_h + 1); j++) {
-		float v = j;
-		float v2 = j / (subdivide_h + 1.0);
-		v /= (2.0 * (subdivide_h + 1.0));
-
 		float left, right;
-		float scale = (y - start_pos.y) / size.y;
+		float scale = j / (subdivide_h + 1.0);
 
 		left = start_pos.x + (size.x * (1.0 - scale) * left_to_right);
 		right = left + (size.x * scale);
+
+		float v = j;
+		float v2 = scale;
+		v /= 2.0 * (subdivide_h + 1.0);
 
 		z = start_pos.z;
 		for (i = 0; i <= (subdivide_d + 1); i++) {


### PR DESCRIPTION
Fixes #86356

When creating a PrismMesh with a height value of 0, a division by 0 occurs in `PrismMesh::_create_mesh_array`, leading to `nan` values in vertices, and then to undefined behavior when using the resulting mesh array.

First approach was to simply protect the divisions this way:
`float scale = size.y != 0 ? (y - start_pos.y) / size.y : 0`
It fixed the crash by preventing `nan` values to arise, but led to incorrect `x` coordinates for some of the vertices:
![flatprism](https://github.com/godotengine/godot/assets/24794294/3642b772-a984-4d91-b54b-668ce6192e3c)
This is because we are relying on the current ratio of the `y` coordinate to compute `scale`.

Now if we focus on the `y` variable, we see it is initialized before the loop
`y = start_pos.y;`
and incremented at the end of the loop for every iteration
`y += size.y / (subdivide_h + 1.0);`
So we can affirm that at the beginning of the loop, `y == start_pos.y + j * (size.y / (subdivide_h + 1.0))`

Now back to the scale calculation:
`float scale = (y - start_pos.y) / size.y`
Let's replace `y` with the expression we just established and simplify it:
```
scale = (start_pos.y + j * (size.y / (subdivide_h + 1.0)) - start_pos.y) / size.y
scale = j * (size.y / (subdivide_h + 1.0)) / size.y
scale = j / (subdivide_h + 1.0)
```
Notice how we got rid of the division that was causing the issue.
Also notice that the variable `v2` was already assigned with this operation; I kept it as an alias of `scale` to keep naming consistent, not sure it is the best choice.

With this solution we have consistent coordinates even when the prism is flat (size.y == 0) :
![flatprismfixed](https://github.com/godotengine/godot/assets/24794294/ede5f185-7e45-4265-b98c-70dd64ae2630)