### PR TITLE
Fix 2D viewport texture drop issue with global history registration

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5842,7 +5842,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 	Vector<String> error_files;
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Create Node"));
+	undo_redo->create_action_for_history(TTR("Create Node"), EditorNode::get_editor_data().get_current_edited_scene_history_id());
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];


### PR DESCRIPTION
This fix addresses an issue where dropping a texture onto the 2D viewport in a scene without a root node incorrectly registers the action in the global history. Subsequently undoing and redoing this action in another scene results in the newly created node replacing the root of the current scene. Fixes #86826.

Fix video:

https://github.com/godotengine/godot/assets/26153311/886dbb96-3017-4702-bf8d-fee70b668b72