### PR TITLE
Attempt parsing environment variables as UTF-8

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -703,10 +703,15 @@ bool OS_Unix::has_environment(const String &p_var) const {
 }
 
 String OS_Unix::get_environment(const String &p_var) const {
-	if (getenv(p_var.utf8().get_data())) {
-		return getenv(p_var.utf8().get_data());
+	const char *val = getenv(p_var.utf8().get_data());
+	if (val == nullptr) { // Not set; return empty string
+		return "";
 	}
-	return "";
+	String s;
+	if (s.parse_utf8(val) == OK) {
+		return s;
+	}
+	return String(val); // Not valid UTF-8, so return as-is
 }
 
 void OS_Unix::set_environment(const String &p_var, const String &p_value) const {

--- a/tests/core/os/test_os.h
+++ b/tests/core/os/test_os.h
@@ -47,11 +47,33 @@ TEST_CASE("[OS] Environment variables") {
 			OS::get_singleton()->has_environment("HOME"),
 			"The HOME environment variable should be present.");
 #endif
+}
 
-	OS::get_singleton()->set_environment("HELLO", "world");
+TEST_CASE("[OS] UTF-8 environment variables") {
+	String value = String::utf8("hell\xc3\xb6"); // "hellö", UTF-8 encoded
+
+	OS::get_singleton()->set_environment("HELLO", value);
+	String val = OS::get_singleton()->get_environment("HELLO");
 	CHECK_MESSAGE(
-			OS::get_singleton()->get_environment("HELLO") == "world",
+			val == value,
 			"The previously-set HELLO environment variable should return the expected value.");
+	CHECK_MESSAGE(
+			val.length() == 5,
+			"The previously-set HELLO environment variable was decoded as UTF-8 and should have a length of 5.");
+	OS::get_singleton()->unset_environment("HELLO");
+}
+
+TEST_CASE("[OS] Non-UTF-8 environment variables") {
+	String value = String("\xff t\xf6rkylempij\xe4vongahdus"); // hex FF and a Finnish pangram, latin-1
+	OS::get_singleton()->set_environment("HELLO", value);
+	String val = OS::get_singleton()->get_environment("HELLO");
+	CHECK_MESSAGE(
+			val == value,
+			"The previously-set HELLO environment variable should return the expected value.");
+	CHECK_MESSAGE(
+			val.length() == 23,
+			"The previously-set HELLO environment variable was not decoded from Latin-1.");
+	OS::get_singleton()->unset_environment("HELLO");
 }
 
 TEST_CASE("[OS] Command line arguments") {


### PR DESCRIPTION
## What?

This PR makes the Unix `get_environment()` implementation attempt to decode values as UTF-8, and if that fails, return the value as-is, as has been the previous behavior. (Since the UNIX specification does not specify an encoding for environment variables, this sounds like the safe bet.)

This matches what the Windows `get_environment()` implementation does in spirit; it uses `GetEnvironmentVariableW()` and `String::utf16`.

## Why?

I have a project which renders texts in short movie sequences based on inputs read from environment variables (as that seemed the easiest way to get values into the Godot process), and there was an audible groan when I saw the all-too-familiar UTF-8 [mojibake](https://en.wikipedia.org/wiki/Mojibake) for `ä` being interpreted as Latin-1:

With vanilla `4.2.1.stable.official.b09f793f5` on macOS:

![pre](https://github.com/godotengine/godot/assets/58669/cbd09d37-2d13-459d-956b-26898b5a073f)

With this PR:

![post](https://github.com/godotengine/godot/assets/58669/51c4b67a-fb10-42d8-912b-20a6fd74a95c)
