### PR TITLE
Fix red snapping lines persistence after anchor point movement

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1648,6 +1648,8 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 			_commit_canvas_item_state(
 					drag_selection,
 					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection[0]->get_name()));
+			snap_target[0] = SNAP_TARGET_NONE;
+			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
 			return true;
 		}
@@ -1655,6 +1657,8 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		// Cancel a drag
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
+			snap_target[0] = SNAP_TARGET_NONE;
+			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
 			viewport->queue_redraw();
 			return true;


### PR DESCRIPTION
This fix addresses an issue where red snapping lines persist on the canvas after confirming or cancelling an anchor point drag. The solution involves resetting the snap targets to `SNAP_TARGET_NONE` after confirming or cancelling the anchor point movement. Fixes #86726.

Before:

https://github.com/godotengine/godot/assets/26153311/2f5df570-670a-428a-ba75-5012552c7731

After:

https://github.com/godotengine/godot/assets/26153311/986a9e6c-2331-4e15-a53f-13777e90519a

