### PR TITLE
Use `PER_MONITOR_DPI_AWARE` option if it's supported by OS

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -626,6 +626,20 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 			set_setting("application/boot_splash/fullsize", Variant());
 		}
 	}
+
+	if (p_from_version == 5) {
+		const RBMap<StringName, ProjectSettings::VariantContainer>::Element *old_hidpi = props.find("display/window/dpi/allow_hidpi");
+		if (old_hidpi) {
+			OS::HidpiAwareness new_hidpi;
+			if (old_hidpi->value().variant.booleanize()) {
+				new_hidpi = OS::HidpiAwareness::SYSTEM_WIDE_AWARENESS;
+			} else {
+				new_hidpi = OS::HidpiAwareness::NO_AWARENESS;
+			}
+			set_setting("display/window/dpi/hidpi_awareness", int(new_hidpi));
+			props.erase("display/window/dpi/allow_hidpi");
+		}
+	}
 #endif // DISABLE_DEPRECATED
 }
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -47,7 +47,7 @@ public:
 	enum HidpiAwareness {
 		NO_AWARENESS,
 		SYSTEM_WIDE_AWARENESS,
-		PER_MONITOR_AWARENESS
+		PER_MONITOR_AWARENESS,
 	};
 
 private:

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -43,6 +43,14 @@
 class MainLoop;
 
 class OS {
+public:
+	enum HidpiAwareness {
+		NO_AWARENESS,
+		SYSTEM_WIDE_AWARENESS,
+		PER_MONITOR_AWARENESS
+	};
+
+private:
 	static OS *singleton;
 	static uint64_t target_ticks;
 	String _execpath;
@@ -57,7 +65,7 @@ class OS {
 	String _local_clipboard;
 	// Assume success by default, all failure cases need to set EXIT_FAILURE explicitly.
 	int _exit_code = EXIT_SUCCESS;
-	bool _allow_hidpi = false;
+	HidpiAwareness _hidpi_awareness = HidpiAwareness::NO_AWARENESS;
 	bool _allow_layered = false;
 	bool _stdout_enabled = true;
 	bool _stderr_enabled = true;
@@ -223,7 +231,7 @@ public:
 	virtual String get_model_name() const;
 
 	bool is_layered_allowed() const { return _allow_layered; }
-	bool is_hidpi_allowed() const { return _allow_hidpi; }
+	HidpiAwareness get_hidpi_awareness() const { return _hidpi_awareness; }
 
 	void ensure_user_data_dir();
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -949,10 +949,10 @@
 		</member>
 		<member name="display/window/dpi/hidpi_awareness" type="int" setter="" getter="" default="1">
 			This option controls how the application handles high-resolution displays.
-			[code]No[/code] - application not ready for high-resolution displays.
-			[code]System wide[/code] - application can work with high-resolution displays, but is not ready for different dpi on different monitors.
-			[code]Per monitor[/code] - application can work with high-resolution displays, also can handle situations when different displays use their own DPI value.
-			If "No" used, the platform's low-DPI fallback will be used on HiDPI displays, which causes the window to be displayed in a blurry or pixelated manner (and can cause various window management bugs). Therefore, it is recommended to make your project scale to [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] instead of disabling this setting.
+			[code]No[/code] - the application is not ready for high-resolution displays.
+			[code]System wide[/code] - the application can work with high-resolution displays, but is not ready for different DPI values on different monitors.
+			[code]Per monitor[/code] - the application can work with high-resolution displays, it can also handle situations when different displays use their own DPI value.
+			If [b]No[/b] is used, the platform's low-DPI fallback will be used on HiDPI displays, which causes the window to be displayed in a blurry or pixelated manner (and can cause various window management bugs). Therefore, it is recommended to make your project scale to [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] instead of disabling this setting.
 			[b]Note:[/b] This setting has no effect on Linux as DPI-awareness fallbacks are not supported there.
 		</member>
 		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="true">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -947,8 +947,12 @@
 		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="" default="Vector2(10, 10)">
 			Position offset for tooltips, relative to the mouse cursor's hotspot.
 		</member>
-		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], allows HiDPI display on Windows, macOS, Android, iOS and Web. If [code]false[/code], the platform's low-DPI fallback will be used on HiDPI displays, which causes the window to be displayed in a blurry or pixelated manner (and can cause various window management bugs). Therefore, it is recommended to make your project scale to [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] instead of disabling this setting.
+		<member name="display/window/dpi/hidpi_awareness" type="int" setter="" getter="" default="1">
+			This option controls how the application handles high-resolution displays.
+			[code]No[/code] - application not ready for high-resolution displays.
+			[code]System wide[/code] - application can work with high-resolution displays, but is not ready for different dpi on different monitors.
+			[code]Per monitor[/code] - application can work with high-resolution displays, also can handle situations when different displays use their own DPI value.
+			If "No" used, the platform's low-DPI fallback will be used on HiDPI displays, which causes the window to be displayed in a blurry or pixelated manner (and can cause various window management bugs). Therefore, it is recommended to make your project scale to [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] instead of disabling this setting.
 			[b]Note:[/b] This setting has no effect on Linux as DPI-awareness fallbacks are not supported there.
 		</member>
 		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="true">

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -286,17 +286,24 @@ EditorRun::WindowPlacement EditorRun::get_window_placement() {
 	int window_placement = EDITOR_GET("run/window_placement/rect");
 	if (screen_rect != Rect2()) {
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HIDPI)) {
-			bool hidpi_proj = GET_CONFIG_WITH_OVERRIDE("display", "window/dpi/allow_hidpi");
+			OS::HidpiAwareness hidpi_proj = GET_CONFIG_WITH_OVERRIDE("display", "window/dpi/hidpi_awareness");
+			OS::HidpiAwareness hidpi_editor = OS::get_singleton()->get_hidpi_awareness();
 			int display_scale = 1;
+			// There are some problems
+			// - display_scale is int, but in one case it's assigned a float value.
+			// - Is it necessary to somehow handle the situation when the project uses OS::HidpiAwareness::PER_MONITOR_AWARENESS ?
+			//   Looks like project is more aware of that 'dpi' than editor and should be able handle it on it's own.
+			//
+			// Should we assume that the editor always runs in SYSTEM_WIDE_AWARENESS mode?
 
-			if (OS::get_singleton()->is_hidpi_allowed()) {
-				if (hidpi_proj) {
+			if (hidpi_editor == OS::HidpiAwareness::NO_AWARENESS) {
+				if (hidpi_proj == OS::HidpiAwareness::NO_AWARENESS) {
 					display_scale = 1; // Both editor and project runs in hiDPI mode, do not scale.
 				} else {
 					display_scale = DisplayServer::get_singleton()->screen_get_max_scale(); // Editor is in hiDPI mode, project is not, scale down.
 				}
 			} else {
-				if (hidpi_proj) {
+				if (hidpi_proj == OS::HidpiAwareness::NO_AWARENESS) {
 					display_scale = (1.f / DisplayServer::get_singleton()->screen_get_max_scale()); // Editor is not in hiDPI mode, project is, scale up.
 				} else {
 					display_scale = 1; // Both editor and project runs in lowDPI mode, do not scale.

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -291,8 +291,8 @@ EditorRun::WindowPlacement EditorRun::get_window_placement() {
 			int display_scale = 1;
 			// There are some problems
 			// - display_scale is int, but in one case it's assigned a float value.
-			// - Is it necessary to somehow handle the situation when the project uses OS::HidpiAwareness::PER_MONITOR_AWARENESS ?
-			//   Looks like project is more aware of that 'dpi' than editor and should be able handle it on it's own.
+			// - Is it necessary to somehow handle the situation when the project uses OS::HidpiAwareness::PER_MONITOR_AWARENESS?
+			//   Looks like project is more aware of that 'dpi' than editor and should be able handle it on its own.
 			//
 			// Should we assume that the editor always runs in SYSTEM_WIDE_AWARENESS mode?
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2640,7 +2640,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 	}
 
-	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
+	OS::get_singleton()->_hidpi_awareness = OS::HidpiAwareness(int(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/dpi/hidpi_awareness", PROPERTY_HINT_ENUM, "No,System wide,Per monitor"), int(OS::HidpiAwareness::SYSTEM_WIDE_AWARENESS))));
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF_RST("display/window/per_pixel_transparency/allowed", false);
 
 	load_shell_env = GLOBAL_DEF("application/run/load_shell_environment", false);
@@ -2648,7 +2648,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager) {
 		// The editor and project manager always detect and use hiDPI if needed.
-		OS::get_singleton()->_allow_hidpi = true;
+		OS::get_singleton()->_hidpi_awareness = OS::HidpiAwareness::SYSTEM_WIDE_AWARENESS;
 		load_shell_env = true;
 	}
 #endif

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1609,7 +1609,7 @@ float DisplayServerMacOS::screen_get_scale(int p_screen) const {
 	int screen_count = get_screen_count();
 	ERR_FAIL_INDEX_V(p_screen, screen_count, 1.0f);
 
-	if (OS::get_singleton()->is_hidpi_allowed()) {
+	if (OS::get_singleton()->get_hidpi_awareness() != OS::HidpiAwareness::NO_AWARENESS) {
 		NSArray<NSScreen *> *screens = NSScreen.screens;
 		NSUInteger index = (NSUInteger)p_screen;
 		if (index < screens.count) {

--- a/platform/macos/gl_manager_macos_legacy.mm
+++ b/platform/macos/gl_manager_macos_legacy.mm
@@ -90,7 +90,7 @@ void GLManagerLegacy_MacOS::window_resize(DisplayServer::WindowID p_window_id, i
 	dim[1] = p_height;
 	CGLSetParameter((CGLContextObj)[win.context CGLContextObj], kCGLCPSurfaceBackingSize, &dim[0]);
 	CGLEnable((CGLContextObj)[win.context CGLContextObj], kCGLCESurfaceBackingSize);
-	if (OS::get_singleton()->is_hidpi_allowed()) {
+	if (OS::get_singleton()->get_hidpi_awareness() != OS::HidpiAwareness::NO_AWARENESS) {
 		[win.window_view setWantsBestResolutionOpenGLSurface:YES];
 	} else {
 		[win.window_view setWantsBestResolutionOpenGLSurface:NO];

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1116,7 +1116,7 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, WindowMode 
 	godot_js_config_canvas_id_get(canvas_id, 256);
 
 	// Handle contextmenu, webglcontextlost
-	godot_js_display_setup_canvas(p_resolution.x, p_resolution.y, (p_window_mode == WINDOW_MODE_FULLSCREEN || p_window_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN), OS::get_singleton()->is_hidpi_allowed() ? 1 : 0);
+	godot_js_display_setup_canvas(p_resolution.x, p_resolution.y, (p_window_mode == WINDOW_MODE_FULLSCREEN || p_window_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN), OS::get_singleton()->get_hidpi_awareness() != OS::HidpiAwareness::NO_AWARENESS ? 1 : 0);
 
 	// Check if it's windows.
 	swap_cancel_ok = godot_js_display_is_swap_ok_cancel() == 1;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7055,8 +7055,13 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 	}
 
-	if (OS::get_singleton()->is_hidpi_allowed()) {
-		SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+	OS::HidpiAwareness awareness_setting = OS::get_singleton()->get_hidpi_awareness();
+	if (awareness_setting != OS::HidpiAwareness::NO_AWARENESS) {
+		if (awareness_setting == OS::HidpiAwareness::PER_MONITOR_AWARENESS) {
+			SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+		} else {
+			SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+		}
 	}
 
 	HMODULE comctl32 = LoadLibraryW(L"comctl32.dll");


### PR DESCRIPTION
Fixes some problems described in #56341.
It is not an implementation of automatic scaling when a window moves from one monitor to another, but at least the PER_MONITOR_DPI_AWARE option can fix problems with unnecessary scaling for secondary monitors.

A new project setting "display/window/dpi/hidpi_awareness" has been introduced, which replaces "display/window/dpi/allow_hidpi". New setting has 3 options:
    "No" - application not ready for high-resolution displays.
    "System wide" - application can work with high-resolution displays, but is not ready for different dpi on different monitors.
    "Per monitor" - application can work with high-resolution displays, also can handle situations when different displays use their own dpi value.
