### PR TITLE
Made tooltip on `TileSet` Paint Button give more information when disabled

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1046,6 +1046,13 @@ void TileSetAtlasSourceEditor::_update_toolbar() {
 	}
 }
 
+void TileSetAtlasSourceEditor::_update_buttons() {
+	tool_paint_button->set_disabled(read_only);
+	tool_paint_button->set_tooltip_text(read_only ? TTR("TileSet is in read-only mode. Make the resource unique to edit TileSet properties.") : TTR("Paint properties."));
+	tools_settings_erase_button->set_disabled(read_only);
+	tool_advanced_menu_button->set_disabled(read_only);
+}
+
 void TileSetAtlasSourceEditor::_tile_atlas_control_mouse_exited() {
 	hovered_base_tile_coords = TileSetSource::INVALID_ATLAS_COORDS;
 	tile_atlas_control->queue_redraw();
@@ -2212,10 +2219,7 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 		tool_setup_atlas_source_button->set_pressed(true);
 	}
 
-	// Disable buttons in read-only mode.
-	tool_paint_button->set_disabled(read_only);
-	tools_settings_erase_button->set_disabled(read_only);
-	tool_advanced_menu_button->set_disabled(read_only);
+	_update_buttons();
 
 	// Update everything.
 	_update_source_inspector();
@@ -2429,10 +2433,7 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 					read_only = EditorNode::get_singleton()->is_resource_read_only(tile_set);
 				}
 
-				// Disable buttons in read-only mode.
-				tool_paint_button->set_disabled(read_only);
-				tools_settings_erase_button->set_disabled(read_only);
-				tool_advanced_menu_button->set_disabled(read_only);
+				_update_buttons();
 
 				// Update everything.
 				_update_source_inspector();
@@ -2516,7 +2517,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tool_paint_button->set_theme_type_variation("FlatButton");
 	tool_paint_button->set_toggle_mode(true);
 	tool_paint_button->set_button_group(tools_button_group);
-	tool_paint_button->set_tooltip_text(TTR("Paint properties."));
 	toolbox->add_child(tool_paint_button);
 
 	// Tile inspector.
@@ -2618,6 +2618,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tool_settings->add_child(outside_tiles_warning);
 
 	_update_toolbar();
+	_update_buttons();
 
 	// Right side of toolbar.
 	Control *middle_space = memnew(Control);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -269,6 +269,7 @@ private:
 	void _update_manage_tile_properties_button();
 	void _update_atlas_view();
 	void _update_toolbar();
+	void _update_buttons();
 
 	// -- Misc --
 	void _auto_create_tiles();


### PR DESCRIPTION
Fixes #78162

When `TileSet` becomes read only (such as multiple scenes using it at the same time), the Paint Button becomes disabled. Apparently this behaviour is not properly communicated to users. This PR changes the tooltip of the Paint Button when enabled/disabled to communicate this behaviour better to the user. When enabled the tooltip is the normal "Paint properties.", however now when disabled the tooltip is "TileSet is in read-only mode. Make the resource unique to edit TileSet properties."