### PR TITLE
Fix wrong fail condition in compressed texture's `_set_data`

### DIFF
--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -75,7 +75,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 				uint32_t mipsize = decode_uint32(data);
 				data += 4;
 				data_size -= 4;
-				ERR_FAIL_COND(mipsize < data_size);
+				ERR_FAIL_COND(mipsize > data_size);
 				Ref<Image> img = loader_func == nullptr
 						? memnew(Image(data, data_size))
 						: Ref<Image>(loader_func(data, data_size));
@@ -89,7 +89,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 				data_size -= mipsize;
 			}
 
-			image = Ref<Image>(memnew(Image(size.width, size.height, mipmap_count > 1, format, image_data)));
+			image = Ref<Image>(memnew(Image(size.width, size.height, mipmaps, format, image_data)));
 
 		} break;
 		case COMPRESSION_MODE_BASIS_UNIVERSAL: {
@@ -100,7 +100,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 		case COMPRESSION_MODE_S3TC:
 		case COMPRESSION_MODE_ETC2:
 		case COMPRESSION_MODE_BPTC: {
-			image = Ref<Image>(memnew(Image(size.width, size.height, mipmap_count > 1, format, p_data.slice(20))));
+			image = Ref<Image>(memnew(Image(size.width, size.height, mipmaps, format, p_data.slice(20))));
 		} break;
 	}
 	ERR_FAIL_COND(image.is_null());


### PR DESCRIPTION
Fixes "Condition "mipsize < data_size" is true." mentioned in https://github.com/godotengine/godot/issues/86784

Along with some clean up.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
