### PR TITLE
Prevent `String::num_scientific` from giving different precision levels depending on compiler

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1696,7 +1696,7 @@ String String::num_scientific(double p_num) {
 	// MinGW requires _set_output_format() to conform to C99 output for printf
 	unsigned int old_exponent_format = _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
-	snprintf(buf, 256, "%lg", p_num);
+	snprintf(buf, 256, "%.16lg", p_num);
 
 #if defined(__MINGW32__) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
 	_set_output_format(old_exponent_format);


### PR DESCRIPTION
Fixes  #78204.

`String::num_scientific` has different codepaths depending on compiler, however there was a fundamental difference in precision of the conversion from float to String depending compiler/platform. Essentially one used `%.16lg` while the other used `%lg`. This led to surprisingly low precision (not even able to print out a timestamp properly). I've tweaked it so that this low precision codepath uses the same high precision as the other codepath.
