### PR TITLE
Remove the ability to open the top popup menus with right-click

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -102,7 +102,7 @@ void MenuBar::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
-		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::LEFT || mb->get_button_index() == MouseButton::RIGHT)) {
+		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::LEFT)) {
 			int index = _get_index_at_point(mb->get_position());
 			if (index >= 0) {
 				_open_popup(index);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related to #86952

This is kind of a weird behavior and is pretty none-standard across software I've seen. It also leads to weird bugs, where you can right click select check boxes, but only when the popup menu was opened with a right-click.

![image](https://github.com/godotengine/godot/assets/105675984/473b5e97-c959-4cd6-8320-95f1f931c0cb)
