### PR TITLE
Implement Unique Node IDs

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -242,6 +242,16 @@ void ResourceUID::clear() {
 	unique_ids.clear();
 	changed = false;
 }
+
+uint32_t ResourceUID::generate_random_u32() const {
+	uint32_t num;
+	Error err = ((CryptoCore::RandomGenerator *)crypto)->get_random_bytes((uint8_t *)&num, sizeof(uint32_t));
+	if (err != OK) {
+		num = 0;
+	}
+	return num;
+}
+
 void ResourceUID::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("id_to_text", "id"), &ResourceUID::id_to_text);
 	ClassDB::bind_method(D_METHOD("text_to_id", "text_id"), &ResourceUID::text_to_id);

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -77,6 +77,8 @@ public:
 	Error save_to_cache();
 	Error update_cache();
 
+	uint32_t generate_random_u32() const;
+
 	void clear();
 
 	static ResourceUID *get_singleton() { return singleton; }

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -114,6 +114,18 @@ public:
 			return (char32_t)_data->name[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
 		}
 	}
+
+	_FORCE_INLINE_ bool is_node_unique_id() const {
+		if (!_data) {
+			return false;
+		}
+		if (_data->cname != nullptr) {
+			return (char32_t)_data->cname[0] == (char32_t)'@' && (char32_t)_data->cname[1] == (char32_t)'@';
+		} else {
+			return (char32_t)_data->name[0] == (char32_t)'@' && (char32_t)_data->name[1] == (char32_t)'@';
+		}
+	}
+
 	_FORCE_INLINE_ bool operator<(const StringName &p_name) const {
 		return _data < p_name._data;
 	}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1757,6 +1757,14 @@ Node *Node::find_parent(const String &p_pattern) const {
 	return nullptr;
 }
 
+void Node::set_unique_scene_id(int32_t p_unique_id) {
+	data.unique_scene_id = p_unique_id;
+}
+
+int32_t Node::get_unique_scene_id() const {
+	return data.unique_scene_id;
+}
+
 Window *Node::get_window() const {
 	ERR_THREAD_GUARD_V(nullptr);
 	Viewport *vp = get_viewport();
@@ -3453,6 +3461,12 @@ void Node::_bind_methods() {
 	}
 	ClassDB::bind_method(D_METHOD("set_thread_safe", "property", "value"), &Node::set_thread_safe);
 	ClassDB::bind_method(D_METHOD("notify_thread_safe", "what"), &Node::notify_thread_safe);
+
+	// No property or serialization for this because it's unique.
+	ClassDB::bind_method(D_METHOD("set_unique_scene_id", "id"), &Node::set_unique_scene_id);
+	ClassDB::bind_method(D_METHOD("get_unique_scene_id"), &Node::get_unique_scene_id);
+
+	BIND_CONSTANT(UNIQUE_SCENE_ID_UNASSIGNED);
 
 	BIND_CONSTANT(NOTIFICATION_ENTER_TREE);
 	BIND_CONSTANT(NOTIFICATION_EXIT_TREE);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -112,6 +112,10 @@ public:
 		bool operator()(const Node *p_a, const Node *p_b) const { return p_b->is_greater_than(p_a); }
 	};
 
+	enum {
+		UNIQUE_SCENE_ID_UNASSIGNED = 0
+	};
+
 	static int orphan_node_count;
 
 	void _update_process(bool p_enable, bool p_for_children);
@@ -210,6 +214,8 @@ private:
 
 		bool display_folded = false;
 		bool editable_instance = false;
+
+		int32_t unique_scene_id = UNIQUE_SCENE_ID_UNASSIGNED;
 
 		mutable NodePath *path_cache = nullptr;
 
@@ -405,6 +411,9 @@ public:
 	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true);
 	Node *get_parent() const;
 	Node *find_parent(const String &p_pattern) const;
+
+	void set_unique_scene_id(int32_t p_unique_id);
+	int32_t get_unique_scene_id() const;
 
 	Window *get_window() const;
 	Window *get_last_exclusive_window() const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_string_names.h"
+#include "core/crypto/crypto_core.h"
 #include "core/io/missing_resource.h"
 #include "core/io/resource_loader.h"
 #include "core/templates/local_vector.h"
@@ -43,7 +44,9 @@
 #include "scene/main/missing_node.h"
 #include "scene/property_utils.h"
 
-#define PACKED_SCENE_VERSION 3
+#define PACKED_SCENE_VERSION 4
+
+#define MIN_UNIQUE_ID_PACKED_SCENE_VERSION 4
 
 #ifdef TOOLS_ENABLED
 SceneState::InstantiationWarningNotify SceneState::instantiation_warn_notify = nullptr;
@@ -127,14 +130,14 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	// Nodes where instantiation failed (because something is missing.)
 	List<Node *> stray_instances;
 
-#define NODE_FROM_ID(p_name, p_id)                      \
-	Node *p_name;                                       \
-	if (p_id & FLAG_ID_IS_PATH) {                       \
-		NodePath np = node_paths[p_id & FLAG_MASK];     \
-		p_name = ret_nodes[0]->get_node_or_null(np);    \
-	} else {                                            \
-		ERR_FAIL_INDEX_V(p_id &FLAG_MASK, nc, nullptr); \
-		p_name = ret_nodes[p_id & FLAG_MASK];           \
+#define NODE_FROM_ID(p_name, p_id)                          \
+	Node *p_name;                                           \
+	if (p_id & FLAG_ID_IS_PATH) {                           \
+		NodePath np = _get_path_by_index(p_id & FLAG_MASK); \
+		p_name = ret_nodes[0]->get_node_or_null(np);        \
+	} else {                                                \
+		ERR_FAIL_INDEX_V(p_id &FLAG_MASK, nc, nullptr);     \
+		p_name = ret_nodes[p_id & FLAG_MASK];               \
 	}
 
 	int nc = nodes.size();
@@ -175,8 +178,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			NODE_FROM_ID(nparent, n.parent);
 #ifdef DEBUG_ENABLED
 			if (!nparent && (n.parent & FLAG_ID_IS_PATH)) {
-				WARN_PRINT(String("Parent path '" + String(node_paths[n.parent & FLAG_MASK]) + "' for node '" + String(snames[n.name]) + "' has vanished when instantiating: '" + get_path() + "'.").ascii().get_data());
-				old_parent_path = String(node_paths[n.parent & FLAG_MASK]).trim_prefix("./").replace("/", "@");
+				WARN_PRINT(String("Parent path '" + String(_get_path_by_index(n.parent & FLAG_MASK)) + "' for node '" + String(snames[n.name]) + "' has vanished when instantiating: '" + get_path() + "'.").ascii().get_data());
+				old_parent_path = String(_get_path_by_index(n.parent & FLAG_MASK)).trim_prefix("./").replace("/", "@");
 				nparent = ret_nodes[0];
 			}
 #endif
@@ -453,6 +456,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				node->set_name(old_parent_path + "#" + node->get_name());
 			}
 
+			node->set_unique_scene_id(uint32_t(n.unique_id));
+
 			if (n.owner >= 0) {
 				NODE_FROM_ID(owner, n.owner);
 				if (owner) {
@@ -586,7 +591,7 @@ static int _vm_get_variant(const Variant &p_variant, HashMap<Variant, int, Varia
 	return idx;
 }
 
-Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, HashMap<StringName, int> &name_map, HashMap<Variant, int, VariantHasher, VariantComparator> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map) {
+Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, HashMap<StringName, int> &name_map, HashMap<Variant, int, VariantHasher, VariantComparator> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map, RBMap<int32_t, int32_t> &id_to_node_rbmap) {
 	// this function handles all the work related to properly packing scenes, be it
 	// instantiated or inherited.
 	// given the complexity of this process, an attempt will be made to properly
@@ -836,13 +841,36 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			nd.parent = p_parent_idx;
 		}
 
+		int32_t unique_scene_id = p_node->get_unique_scene_id();
+		if (unique_scene_id == Node::UNIQUE_SCENE_ID_UNASSIGNED || id_to_node_rbmap.has(unique_scene_id)) {
+			// Unassigned or clash somehow.
+
+			while (true) {
+				unique_scene_id = int32_t(ResourceUID::get_singleton()->generate_random_u32());
+
+				if (unique_scene_id == Node::UNIQUE_SCENE_ID_UNASSIGNED) {
+					unique_scene_id = 1;
+				}
+				if (id_to_node_rbmap.has(unique_scene_id)) {
+					// While there is one in a four billion chance for a clash, the scenario where one scene is instantiated multiple times is common, so it must reassign the local id.
+					continue;
+				}
+				break;
+			}
+
+			p_node->set_unique_scene_id(unique_scene_id);
+		}
+
+		nd.unique_id = int32_t(unique_scene_id); // cast to int32_t to fit on array, but its fine.
+		id_to_node_rbmap.insert(unique_scene_id, idx);
+
 		parent_node = idx;
 		nodes.push_back(nd);
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *c = p_node->get_child(i);
-		Error err = _parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map);
+		Error err = _parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map, id_to_node_rbmap);
 		if (err) {
 			return err;
 		}
@@ -1060,6 +1088,7 @@ Error SceneState::pack(Node *p_scene) {
 	HashMap<Variant, int, VariantHasher, VariantComparator> variant_map;
 	HashMap<Node *, int> node_map;
 	HashMap<Node *, int> nodepath_map;
+	RBMap<int32_t, int32_t> id_to_node_rbmap; // Needs to be sorted, so RBMap.
 
 	// If using scene inheritance, pack the scene it inherits from.
 	if (scene->get_scene_inherited_state().is_valid()) {
@@ -1071,7 +1100,7 @@ Error SceneState::pack(Node *p_scene) {
 	}
 
 	// Instanced, only direct sub-scenes are supported of course.
-	Error err = _parse_node(scene, scene, -1, name_map, variant_map, node_map, nodepath_map);
+	Error err = _parse_node(scene, scene, -1, name_map, variant_map, node_map, nodepath_map, id_to_node_rbmap);
 	if (err) {
 		clear();
 		ERR_FAIL_V(err);
@@ -1098,13 +1127,42 @@ Error SceneState::pack(Node *p_scene) {
 
 	node_paths.resize(nodepath_map.size());
 	for (const KeyValue<Node *, int> &E : nodepath_map) {
-		node_paths.write[E.value] = scene->get_path_to(E.key);
+		Vector<StringName> id_path;
+
+		bool id_path_valid = false;
+		Node *base = E.key;
+		while (base && base->get_unique_scene_id() != Node::UNIQUE_SCENE_ID_UNASSIGNED) {
+			id_path.push_back("@@" + itos(base->get_unique_scene_id()));
+			base = base->get_owner();
+			if (base == p_scene) {
+				id_path_valid = true;
+				break;
+			}
+		}
+
+		if (id_path_valid) {
+			id_path.reverse();
+			node_paths.write[E.value] = NodePath(id_path, false);
+		} else {
+			node_paths.write[E.value] = scene->get_path_to(E.key);
+		}
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// Build node path cache
 		for (const KeyValue<Node *, int> &E : node_map) {
 			node_path_cache[scene->get_path_to(E.key)] = E.value;
+		}
+	}
+
+	id_to_node_map.resize(id_to_node_rbmap.size() * 2);
+	{
+		int *id_to_node_mapw = id_to_node_map.ptrw();
+		int map_idx = 0;
+		for (const KeyValue<int32_t, int32_t> &K : id_to_node_rbmap) {
+			id_to_node_mapw[map_idx + 0] = K.key;
+			id_to_node_mapw[map_idx + 1] = K.value;
+			map_idx += 2;
 		}
 	}
 
@@ -1126,6 +1184,8 @@ void SceneState::clear() {
 	connections.clear();
 	node_path_cache.clear();
 	node_paths.clear();
+	node_paths_expanded_cache.clear();
+	id_to_node_map.clear();
 	editable_instances.clear();
 	base_scene_idx = -1;
 }
@@ -1153,6 +1213,9 @@ Error SceneState::copy_from(const Ref<SceneState> &p_scene_state) {
 	for (const NodePath &E : p_scene_state->node_paths) {
 		node_paths.append(E);
 	}
+
+	id_to_node_map = p_scene_state->id_to_node_map;
+
 	for (const NodePath &E : p_scene_state->editable_instances) {
 		editable_instances.append(E);
 	}
@@ -1380,6 +1443,9 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 			nd.index = (name_index >> NAME_INDEX_BITS);
 			nd.index--; //0 is invalid, stored as 1
 			nd.instance = r[idx++];
+			if (version >= MIN_UNIQUE_ID_PACKED_SCENE_VERSION) {
+				nd.unique_id = r[idx++];
+			}
 			nd.properties.resize(r[idx++]);
 			for (int j = 0; j < nd.properties.size(); j++) {
 				nd.properties.write[j].name = r[idx++];
@@ -1432,6 +1498,10 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		base_scene_idx = p_dictionary["base_scene"];
 	}
 
+	if (p_dictionary.has("id_to_nodes")) {
+		id_to_node_map = p_dictionary["id_to_nodes"];
+	}
+
 	editable_instances.resize(ei.size());
 	for (int i = 0; i < editable_instances.size(); i++) {
 		editable_instances.write[i] = ei[i];
@@ -1470,6 +1540,7 @@ Dictionary SceneState::get_bundled_scene() const {
 		}
 		rnodes.push_back(name_index);
 		rnodes.push_back(nd.instance);
+		rnodes.push_back(nd.unique_id);
 		rnodes.push_back(nd.properties.size());
 		for (int j = 0; j < nd.properties.size(); j++) {
 			rnodes.push_back(nd.properties[j].name);
@@ -1519,6 +1590,8 @@ Dictionary SceneState::get_bundled_scene() const {
 		d["base_scene"] = base_scene_idx;
 	}
 
+	d["id_to_nodes"] = id_to_node_map;
+
 	d["version"] = PACKED_SCENE_VERSION;
 
 	return d;
@@ -1544,6 +1617,11 @@ StringName SceneState::get_node_name(int p_idx) const {
 int SceneState::get_node_index(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, nodes.size(), -1);
 	return nodes[p_idx].index;
+}
+
+int SceneState::get_node_unique_id(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, nodes.size(), -1);
+	return nodes[p_idx].unique_id;
 }
 
 bool SceneState::is_node_instance_placeholder(int p_idx) const {
@@ -1589,7 +1667,94 @@ Vector<StringName> SceneState::get_node_groups(int p_idx) const {
 	return groups;
 }
 
-NodePath SceneState::get_node_path(int p_idx, bool p_for_parent) const {
+int SceneState::_find_node_by_id(int p_id) const {
+	if (id_to_node_map.size() == 0) {
+		return -1; // No node.
+	}
+
+	int map_size = id_to_node_map.size();
+	ERR_FAIL_COND_V(map_size & 1, -1);
+	const int *map = id_to_node_map.ptr();
+
+	int low = 0;
+	int high = map_size / 2;
+	int middle = 0;
+
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_V(low > high, -1);
+#endif
+
+	while (low <= high) {
+		middle = (low + high) / 2;
+		int pos = middle << 1;
+		int id = map[pos];
+		if (id == p_id) { //match
+			return map[pos + 1];
+		} else if (p_id < id) {
+			high = middle - 1; //search low end of array
+		} else {
+			low = middle + 1; //search high end of array
+		}
+	}
+
+	return -1;
+}
+
+NodePath SceneState::_get_path_by_index(int p_idx, bool p_expand_ids) const {
+	if (p_expand_ids) {
+		// Use cache when available.
+		if (node_paths_expanded_cache.size() == 0) {
+			node_paths_expanded_cache.resize(node_paths.size());
+		} else if (!node_paths_expanded_cache[p_idx].is_empty()) {
+			return node_paths_expanded_cache[p_idx];
+		}
+
+		Vector<StringName> ret_path;
+		Vector<StringName> path_names = node_paths[p_idx].get_names();
+		const SceneState *base_state = this; // Start by this one.
+
+		for (int i = 0; i < path_names.size(); i++) {
+			if (path_names[i].is_node_unique_id()) {
+				int32_t subindex_id = String::to_int(path_names[i].operator String().ptr() + 2);
+				int node_index = -1;
+
+				while (node_index == -1) {
+					node_index = base_state->_find_node_by_id(subindex_id);
+					if (base_state->base_scene_idx != -1) {
+						// There is inheritance at play, try with parent.
+						Ref<PackedScene> parent = base_state->variants[base_state->base_scene_idx];
+						if (parent.is_valid()) {
+							base_state = parent->get_state().ptr();
+							continue;
+						}
+					}
+					break;
+				}
+
+				ERR_FAIL_COND_V_MSG(node_index == -1, NodePath(), "Failed to locate node by unique scene id: " + itos(subindex_id) + " May have been removed");
+
+				NodePath path_part = base_state->get_node_path(node_index, false, true);
+				// Append it.
+				ret_path.append_array(path_part.get_names());
+				if (i + 1 < path_names.size() && path_names[i + 1].is_node_unique_id()) {
+					// Get the next scene state from the node instance and continue.
+					Ref<PackedScene> sdata = base_state->variants[base_state->nodes[node_index].instance & FLAG_MASK];
+					base_state = sdata->get_state().ptr();
+				}
+			} else {
+				ret_path.append(path_names[i]);
+			}
+		}
+
+		NodePath ret(ret_path, false);
+		node_paths_expanded_cache.write[p_idx] = ret;
+		return ret;
+	} else {
+		return node_paths[p_idx];
+	}
+}
+
+NodePath SceneState::get_node_path(int p_idx, bool p_for_parent, bool p_no_dot, bool p_expand_ids) const {
 	ERR_FAIL_INDEX_V(p_idx, nodes.size(), NodePath());
 
 	if (nodes[p_idx].parent < 0 || nodes[p_idx].parent == NO_PARENT_SAVED) {
@@ -1605,7 +1770,9 @@ NodePath SceneState::get_node_path(int p_idx, bool p_for_parent) const {
 	int nidx = p_idx;
 	while (true) {
 		if (nodes[nidx].parent == NO_PARENT_SAVED || nodes[nidx].parent < 0) {
-			sub_path.insert(0, ".");
+			if (!p_no_dot || sub_path.size() == 0) {
+				sub_path.insert(0, ".");
+			}
 			break;
 		}
 
@@ -1614,7 +1781,8 @@ NodePath SceneState::get_node_path(int p_idx, bool p_for_parent) const {
 		}
 
 		if (nodes[nidx].parent & FLAG_ID_IS_PATH) {
-			base_path = node_paths[nodes[nidx].parent & FLAG_MASK];
+			int path_index = nodes[nidx].parent & FLAG_MASK;
+			base_path = _get_path_by_index(path_index, p_expand_ids);
 			break;
 		} else {
 			nidx = nodes[nidx].parent & FLAG_MASK;
@@ -1662,15 +1830,15 @@ Variant SceneState::get_node_property_value(int p_idx, int p_prop) const {
 	return variants[nodes[p_idx].properties[p_prop].value];
 }
 
-NodePath SceneState::get_node_owner_path(int p_idx) const {
+NodePath SceneState::get_node_owner_path(int p_idx, bool p_expand_ids) const {
 	ERR_FAIL_INDEX_V(p_idx, nodes.size(), NodePath());
 	if (nodes[p_idx].owner < 0 || nodes[p_idx].owner == NO_PARENT_SAVED) {
 		return NodePath(); //root likely
 	}
 	if (nodes[p_idx].owner & FLAG_ID_IS_PATH) {
-		return node_paths[nodes[p_idx].owner & FLAG_MASK];
+		return _get_path_by_index(nodes[p_idx].owner & FLAG_MASK, p_expand_ids);
 	} else {
-		return get_node_path(nodes[p_idx].owner & FLAG_MASK);
+		return get_node_path(nodes[p_idx].owner & FLAG_MASK, false, false, p_expand_ids);
 	}
 }
 
@@ -1678,12 +1846,12 @@ int SceneState::get_connection_count() const {
 	return connections.size();
 }
 
-NodePath SceneState::get_connection_source(int p_idx) const {
+NodePath SceneState::get_connection_source(int p_idx, bool p_expand_ids) const {
 	ERR_FAIL_INDEX_V(p_idx, connections.size(), NodePath());
 	if (connections[p_idx].from & FLAG_ID_IS_PATH) {
-		return node_paths[connections[p_idx].from & FLAG_MASK];
+		return _get_path_by_index(connections[p_idx].from & FLAG_MASK, p_expand_ids);
 	} else {
-		return get_node_path(connections[p_idx].from & FLAG_MASK);
+		return get_node_path(connections[p_idx].from & FLAG_MASK, false, false, p_expand_ids);
 	}
 }
 
@@ -1692,12 +1860,12 @@ StringName SceneState::get_connection_signal(int p_idx) const {
 	return names[connections[p_idx].signal];
 }
 
-NodePath SceneState::get_connection_target(int p_idx) const {
+NodePath SceneState::get_connection_target(int p_idx, bool p_expand_ids) const {
 	ERR_FAIL_INDEX_V(p_idx, connections.size(), NodePath());
 	if (connections[p_idx].to & FLAG_ID_IS_PATH) {
-		return node_paths[connections[p_idx].to & FLAG_MASK];
+		return _get_path_by_index(connections[p_idx].to & FLAG_MASK, p_expand_ids);
 	} else {
-		return get_node_path(connections[p_idx].to & FLAG_MASK);
+		return get_node_path(connections[p_idx].to & FLAG_MASK, false, false, p_expand_ids);
 	}
 }
 
@@ -1736,7 +1904,7 @@ bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p
 			NodePath np_from;
 
 			if (c.from & FLAG_ID_IS_PATH) {
-				np_from = ss->node_paths[c.from & FLAG_MASK];
+				np_from = ss->_get_path_by_index(c.from & FLAG_MASK);
 			} else {
 				np_from = ss->get_node_path(c.from);
 			}
@@ -1744,7 +1912,7 @@ bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p
 			NodePath np_to;
 
 			if (c.to & FLAG_ID_IS_PATH) {
-				np_to = ss->node_paths[c.to & FLAG_MASK];
+				np_to = ss->_get_path_by_index(c.to & FLAG_MASK);
 			} else {
 				np_to = ss->get_node_path(c.to);
 			}
@@ -1788,7 +1956,7 @@ int SceneState::add_node_path(const NodePath &p_path) {
 	return (node_paths.size() - 1) | FLAG_ID_IS_PATH;
 }
 
-int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index) {
+int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int p_unique_id) {
 	NodeData nd;
 	nd.parent = p_parent;
 	nd.owner = p_owner;
@@ -1797,9 +1965,16 @@ int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int 
 	nd.instance = p_instance;
 	nd.index = p_index;
 
+	int node_id = nodes.size();
+
+	if (p_unique_id != Node::UNIQUE_SCENE_ID_UNASSIGNED) {
+		id_to_node_map.push_back(p_unique_id);
+		id_to_node_map.push_back(node_id);
+	}
+
 	nodes.push_back(nd);
 
-	return nodes.size() - 1;
+	return node_id;
 }
 
 void SceneState::add_node_property(int p_node, int p_name, int p_value, bool p_deferred_node_path) {
@@ -1847,6 +2022,13 @@ void SceneState::add_connection(int p_from, int p_to, int p_signal, int p_method
 
 void SceneState::add_editable_instance(const NodePath &p_path) {
 	editable_instances.push_back(p_path);
+}
+
+void SceneState::finalize_adding() {
+	if (id_to_node_map.size()) {
+		SortArray<NodeToIdSort> sort;
+		sort.sort((NodeToIdSort *)(id_to_node_map.ptrw()), id_to_node_map.size() / 2);
+	}
 }
 
 bool SceneState::remove_group_references(const StringName &p_name) {

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -40,7 +40,11 @@ class SceneState : public RefCounted {
 	Vector<StringName> names;
 	Vector<Variant> variants;
 	Vector<NodePath> node_paths;
+	mutable Vector<NodePath> node_paths_expanded_cache;
+	TypedArray<PackedInt32Array> node_path_ids;
 	Vector<NodePath> editable_instances;
+	Vector<int> id_to_node_map;
+
 	mutable HashMap<NodePath, int> node_path_cache;
 	mutable HashMap<int, int> base_scene_node_remap;
 
@@ -59,6 +63,7 @@ class SceneState : public RefCounted {
 		int name = 0;
 		int instance = 0;
 		int index = 0;
+		int unique_id = 0;
 
 		struct Property {
 			int name = 0;
@@ -89,7 +94,7 @@ class SceneState : public RefCounted {
 
 	Vector<ConnectionData> connections;
 
-	Error _parse_node(Node *p_owner, Node *p_node, int p_parent_idx, HashMap<StringName, int> &name_map, HashMap<Variant, int, VariantHasher, VariantComparator> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map);
+	Error _parse_node(Node *p_owner, Node *p_node, int p_parent_idx, HashMap<StringName, int> &name_map, HashMap<Variant, int, VariantHasher, VariantComparator> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map, RBMap<int32_t, int32_t> &id_to_node_rbmap);
 	Error _parse_connections(Node *p_owner, Node *p_node, HashMap<StringName, int> &name_map, HashMap<Variant, int, VariantHasher, VariantComparator> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map);
 
 	String path;
@@ -100,7 +105,18 @@ class SceneState : public RefCounted {
 
 	Vector<String> _get_node_groups(int p_idx) const;
 
+	NodePath _get_path_by_index(int p_idx, bool p_expand_ids = true) const;
+
 	int _find_base_scene_node_remap_key(int p_idx) const;
+	int _find_node_by_id(int p_id) const;
+
+	struct NodeToIdSort {
+		int id;
+		int node;
+		bool operator<(const NodeToIdSort &p_sort) const {
+			return id < p_sort.id;
+		}
+	};
 
 #ifdef TOOLS_ENABLED
 public:
@@ -166,13 +182,14 @@ public:
 	int get_node_count() const;
 	StringName get_node_type(int p_idx) const;
 	StringName get_node_name(int p_idx) const;
-	NodePath get_node_path(int p_idx, bool p_for_parent = false) const;
-	NodePath get_node_owner_path(int p_idx) const;
+	NodePath get_node_path(int p_idx, bool p_for_parent = false, bool p_no_dot = false, bool p_expand_ids = true) const;
+	NodePath get_node_owner_path(int p_idx, bool p_expand_ids = false) const;
 	Ref<PackedScene> get_node_instance(int p_idx) const;
 	String get_node_instance_placeholder(int p_idx) const;
 	bool is_node_instance_placeholder(int p_idx) const;
 	Vector<StringName> get_node_groups(int p_idx) const;
 	int get_node_index(int p_idx) const;
+	int get_node_unique_id(int p_idx) const;
 
 	int get_node_property_count(int p_idx) const;
 	StringName get_node_property_name(int p_idx, int p_prop) const;
@@ -180,9 +197,9 @@ public:
 	Vector<String> get_node_deferred_nodepath_properties(int p_idx) const;
 
 	int get_connection_count() const;
-	NodePath get_connection_source(int p_idx) const;
+	NodePath get_connection_source(int p_idx, bool p_expand_ids = true) const;
 	StringName get_connection_signal(int p_idx) const;
-	NodePath get_connection_target(int p_idx) const;
+	NodePath get_connection_target(int p_idx, bool p_expand_ids = true) const;
 	StringName get_connection_method(int p_idx) const;
 	int get_connection_flags(int p_idx) const;
 	int get_connection_unbinds(int p_idx) const;
@@ -197,12 +214,14 @@ public:
 	int add_name(const StringName &p_name);
 	int add_value(const Variant &p_value);
 	int add_node_path(const NodePath &p_path);
-	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index);
+	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int p_unique_id);
 	void add_node_property(int p_node, int p_name, int p_value, bool p_deferred_node_path = false);
 	void add_node_group(int p_node, int p_group);
 	void set_base_scene(int p_idx);
 	void add_connection(int p_from, int p_to, int p_signal, int p_method, int p_flags, int p_unbinds, const Vector<int> &p_binds);
 	void add_editable_instance(const NodePath &p_path);
+
+	void finalize_adding();
 
 	bool remove_group_references(const StringName &p_name);
 	bool rename_group_references(const StringName &p_old_name, const StringName &p_new_name);


### PR DESCRIPTION
* Scene instantiation and inheritance now use unique IDs for referencing.
* Ensures that if a node is moved or renamed, **the scene that inherits keeps functioning by still referencing that node properly (which it does by ID, no longer by path)**.
* Eventually will be extended to Asset IO

**WARNING**: THIS NEEDS A LOT OF TESTING AND REVIEW - DO NOT USE IN YOUR PROJECT, IT WILL BREAK IT.

Note: This bumps the binary format version, files saved with this will no longer work in earlier versions of Godot.

Note: ResourceFormatText::save_as_binary is broken with this, but this function is no longer in use, should it be removed as part of this PR?

Note: I am allowing negative numbers in there for IDs (only 0 is unassigned), I may as well not, let me know if you want me to change this.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
