### PR TITLE
SCons: Fix `CCFLAGS`, `LINKFLAGS`, etc. command line overrides

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -259,13 +259,16 @@ opts.Add(BoolVariable("builtin_zlib", "Use the built-in zlib library", True))
 opts.Add(BoolVariable("builtin_zstd", "Use the built-in Zstd library", True))
 
 # Compilation environment setup
-opts.Add("CXX", "C++ compiler")
-opts.Add("CC", "C compiler")
-opts.Add("LINK", "Linker")
-opts.Add("CCFLAGS", "Custom flags for both the C and C++ compilers")
-opts.Add("CFLAGS", "Custom flags for the C compiler")
-opts.Add("CXXFLAGS", "Custom flags for the C++ compiler")
-opts.Add("LINKFLAGS", "Custom flags for the linker")
+# CXX, CC, and LINK directly set the equivalent `env` values (which may still
+# be overridden for a specific platform), the lowercase ones are appended.
+opts.Add("CXX", "C++ compiler binary")
+opts.Add("CC", "C compiler binary")
+opts.Add("LINK", "Linker binary")
+opts.Add("cppdefines", "Custom defines for the pre-processor")
+opts.Add("ccflags", "Custom flags for both the C and C++ compilers")
+opts.Add("cxxflags", "Custom flags for the C++ compiler")
+opts.Add("cflags", "Custom flags for the C compiler")
+opts.Add("linkflags", "Custom flags for the linker")
 
 # Update the environment to have all above options defined
 # in following code (especially platform and custom_modules).
@@ -507,21 +510,11 @@ if selected_platform in platform_list:
         env.extra_suffix += "." + env["extra_suffix"]
 
     # Environment flags
-    CCFLAGS = env.get("CCFLAGS", "")
-    env["CCFLAGS"] = ""
-    env.Append(CCFLAGS=str(CCFLAGS).split())
-
-    CFLAGS = env.get("CFLAGS", "")
-    env["CFLAGS"] = ""
-    env.Append(CFLAGS=str(CFLAGS).split())
-
-    CXXFLAGS = env.get("CXXFLAGS", "")
-    env["CXXFLAGS"] = ""
-    env.Append(CXXFLAGS=str(CXXFLAGS).split())
-
-    LINKFLAGS = env.get("LINKFLAGS", "")
-    env["LINKFLAGS"] = ""
-    env.Append(LINKFLAGS=str(LINKFLAGS).split())
+    env.Append(CPPDEFINES=env.get("cppdefines", "").split())
+    env.Append(CCFLAGS=env.get("ccflags", "").split())
+    env.Append(CXXFLAGS=env.get("cxxflags", "").split())
+    env.Append(CFLAGS=env.get("cflags", "").split())
+    env.Append(LINKFLAGS=env.get("linkflags", "").split())
 
     # Feature build profile
     disabled_classes = []


### PR DESCRIPTION
Also adds `CPPDEFINES` which allows passing new pre-processor defines, letting SCons handle passing `-D` or `/D` based on the compiler.

Following this discussion: https://github.com/godotengine/godot-nir-static/pull/4/files#r1443246323

I had to rename the variables like `CCFLAGS`/`LINKFLAGS` to `ccflags`/`linkflags` because command line options share the same namespace with the actual SCons env variables, and replacing those on the fly was messy (required using a temporary variable) and would probably also destroy some important initial setup done by SCons (or here with the addition of `cppdefines`, done by us before these options are parsed).

This breaks compatibility (`scons CCFLAGS="-Wall"` will no longer work, needs to be `scons ccflags="-Wall"`), but it makes it clearer that those options are Godot-specific and just append to their uppercase SCons env counterpart.

The options support space-separated arguments, e.g. `scons cppdefines="MY_DEFINE MY_OTHER_DEFINE"`. Appending such a string (or deque, depending on SCons version) to `env["CPPDEFINES"]` automatically handles splitting arguments.

`CC`/`CXX`/`LINK` stay uppercase as those actually override `env["CC"]`, etc. It's still bug prone as some platform `detect.py` sometimes reset `env["CC"]` manually, but improving that is for a future effort, if the need arises.

CC @shana 