### PR TITLE
Add const lvalue ref to `core/*` container parameters

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -688,7 +688,7 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 	return err;
 }
 
-bool ProjectSettings::has_setting(String p_var) const {
+bool ProjectSettings::has_setting(const String &p_var) const {
 	_THREAD_SAFE_METHOD_
 
 	return props.has(p_var);
@@ -971,7 +971,7 @@ Error ProjectSettings::_save_custom_bnd(const String &p_file) { // add other par
 }
 
 #ifdef TOOLS_ENABLED
-bool _csproj_exists(String p_root_dir) {
+bool _csproj_exists(const String &p_root_dir) {
 	Ref<DirAccess> dir = DirAccess::open(p_root_dir);
 	ERR_FAIL_COND_V(dir.is_null(), false);
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -161,7 +161,7 @@ public:
 	void store_global_class_list(const Array &p_classes);
 	String get_global_class_list_path() const;
 
-	bool has_setting(String p_var) const;
+	bool has_setting(const String &p_var) const;
 	String localize_path(const String &p_path) const;
 	String globalize_path(const String &p_path) const;
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -257,7 +257,7 @@ String OS::get_executable_path() const {
 	return ::OS::get_singleton()->get_executable_path();
 }
 
-Error OS::shell_open(String p_uri) {
+Error OS::shell_open(const String &p_uri) {
 	if (p_uri.begins_with("res://")) {
 		WARN_PRINT("Attempting to open an URL with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
 	} else if (p_uri.begins_with("user://")) {
@@ -266,7 +266,7 @@ Error OS::shell_open(String p_uri) {
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
 
-Error OS::shell_show_in_file_manager(String p_path, bool p_open_folder) {
+Error OS::shell_show_in_file_manager(const String &p_path, bool p_open_folder) {
 	if (p_path.begins_with("res://")) {
 		WARN_PRINT("Attempting to explore file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_file_manager()`.");
 	} else if (p_path.begins_with("user://")) {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -157,8 +157,8 @@ public:
 	int create_process(const String &p_path, const Vector<String> &p_arguments, bool p_open_console = false);
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
-	Error shell_open(String p_uri);
-	Error shell_show_in_file_manager(String p_path, bool p_open_folder = true);
+	Error shell_open(const String &p_uri);
+	Error shell_show_in_file_manager(const String &p_path, bool p_open_folder = true);
 
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;

--- a/core/crypto/aes_context.cpp
+++ b/core/crypto/aes_context.cpp
@@ -30,7 +30,7 @@
 
 #include "core/crypto/aes_context.h"
 
-Error AESContext::start(Mode p_mode, PackedByteArray p_key, PackedByteArray p_iv) {
+Error AESContext::start(Mode p_mode, const PackedByteArray &p_key, const PackedByteArray &p_iv) {
 	ERR_FAIL_COND_V_MSG(mode != MODE_MAX, ERR_ALREADY_IN_USE, "AESContext already started. Call 'finish' before starting a new one.");
 	ERR_FAIL_COND_V_MSG(p_mode < 0 || p_mode >= MODE_MAX, ERR_INVALID_PARAMETER, "Invalid mode requested.");
 	// Key check.
@@ -52,7 +52,7 @@ Error AESContext::start(Mode p_mode, PackedByteArray p_key, PackedByteArray p_iv
 	return OK;
 }
 
-PackedByteArray AESContext::update(PackedByteArray p_src) {
+PackedByteArray AESContext::update(const PackedByteArray &p_src) {
 	ERR_FAIL_COND_V_MSG(mode < 0 || mode >= MODE_MAX, PackedByteArray(), "AESContext not started. Call 'start' before calling 'update'.");
 	int len = p_src.size();
 	ERR_FAIL_COND_V_MSG(len % 16, PackedByteArray(), "The number of bytes to be encrypted must be multiple of 16. Add padding if needed");

--- a/core/crypto/aes_context.h
+++ b/core/crypto/aes_context.h
@@ -55,8 +55,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	Error start(Mode p_mode, PackedByteArray p_key, PackedByteArray p_iv = PackedByteArray());
-	PackedByteArray update(PackedByteArray p_src);
+	Error start(Mode p_mode, const PackedByteArray &p_key, const PackedByteArray &p_iv = PackedByteArray());
+	PackedByteArray update(const PackedByteArray &p_src);
 	PackedByteArray get_iv_state();
 	void finish();
 

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -124,7 +124,7 @@ HMACContext *HMACContext::create() {
 
 /// Crypto
 
-void (*Crypto::_load_default_certificates)(String p_path) = nullptr;
+void (*Crypto::_load_default_certificates)(const String &p_path) = nullptr;
 Crypto *(*Crypto::_create)() = nullptr;
 Crypto *Crypto::create() {
 	if (_create) {
@@ -133,13 +133,13 @@ Crypto *Crypto::create() {
 	ERR_FAIL_V_MSG(nullptr, "Crypto is not available when the mbedtls module is disabled.");
 }
 
-void Crypto::load_default_certificates(String p_path) {
+void Crypto::load_default_certificates(const String &p_path) {
 	if (_load_default_certificates) {
 		_load_default_certificates(p_path);
 	}
 }
 
-PackedByteArray Crypto::hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg) {
+PackedByteArray Crypto::hmac_digest(HashingContext::HashType p_hash_type, const PackedByteArray &p_key, const PackedByteArray &p_msg) {
 	Ref<HMACContext> ctx = Ref<HMACContext>(HMACContext::create());
 	ERR_FAIL_COND_V_MSG(ctx.is_null(), PackedByteArray(), "HMAC is not available without mbedtls module.");
 	Error err = ctx->start(p_hash_type, p_key);
@@ -151,7 +151,7 @@ PackedByteArray Crypto::hmac_digest(HashingContext::HashType p_hash_type, Packed
 
 // Compares two HMACS for equality without leaking timing information in order to prevent timing attacks.
 // @see: https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy
-bool Crypto::constant_time_compare(PackedByteArray p_trusted, PackedByteArray p_received) {
+bool Crypto::constant_time_compare(const PackedByteArray &p_trusted, const PackedByteArray &p_received) {
 	const uint8_t *t = p_trusted.ptr();
 	const uint8_t *r = p_received.ptr();
 	int tlen = p_trusted.size();

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -46,10 +46,10 @@ protected:
 
 public:
 	static CryptoKey *create();
-	virtual Error load(String p_path, bool p_public_only = false) = 0;
-	virtual Error save(String p_path, bool p_public_only = false) = 0;
+	virtual Error load(const String &p_path, bool p_public_only = false) = 0;
+	virtual Error save(const String &p_path, bool p_public_only = false) = 0;
 	virtual String save_to_string(bool p_public_only = false) = 0;
-	virtual Error load_from_string(String p_string_key, bool p_public_only = false) = 0;
+	virtual Error load_from_string(const String &p_string_key, bool p_public_only = false) = 0;
 	virtual bool is_public_only() const = 0;
 };
 
@@ -62,9 +62,9 @@ protected:
 
 public:
 	static X509Certificate *create();
-	virtual Error load(String p_path) = 0;
+	virtual Error load(const String &p_path) = 0;
 	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len) = 0;
-	virtual Error save(String p_path) = 0;
+	virtual Error save(const String &p_path) = 0;
 	virtual String save_to_string() = 0;
 	virtual Error load_from_string(const String &string) = 0;
 };
@@ -113,8 +113,8 @@ protected:
 public:
 	static HMACContext *create();
 
-	virtual Error start(HashingContext::HashType p_hash_type, PackedByteArray p_key) = 0;
-	virtual Error update(PackedByteArray p_data) = 0;
+	virtual Error start(HashingContext::HashType p_hash_type, const PackedByteArray &p_key) = 0;
+	virtual Error update(const PackedByteArray &p_data) = 0;
 	virtual PackedByteArray finish() = 0;
 
 	HMACContext() {}
@@ -127,26 +127,26 @@ class Crypto : public RefCounted {
 protected:
 	static void _bind_methods();
 	static Crypto *(*_create)();
-	static void (*_load_default_certificates)(String p_path);
+	static void (*_load_default_certificates)(const String &p_path);
 
 public:
 	static Crypto *create();
-	static void load_default_certificates(String p_path);
+	static void load_default_certificates(const String &p_path);
 
 	virtual PackedByteArray generate_random_bytes(int p_bytes) = 0;
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes) = 0;
-	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) = 0;
+	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, const String &p_issuer_name, const String &p_not_before, const String &p_not_after) = 0;
 
-	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Ref<CryptoKey> p_key) = 0;
-	virtual bool verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key) = 0;
-	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext) = 0;
-	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext) = 0;
+	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, Ref<CryptoKey> p_key) = 0;
+	virtual bool verify(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, const Vector<uint8_t> &p_signature, Ref<CryptoKey> p_key) = 0;
+	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_plaintext) = 0;
+	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_ciphertext) = 0;
 
-	PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg);
+	PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, const PackedByteArray &p_key, const PackedByteArray &p_msg);
 
 	// Compares two PackedByteArrays for equality without leaking timing information in order to prevent timing attacks.
 	// @see: https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy
-	bool constant_time_compare(PackedByteArray p_trusted, PackedByteArray p_received);
+	bool constant_time_compare(const PackedByteArray &p_trusted, const PackedByteArray &p_received);
 
 	Crypto() {}
 };

--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -47,7 +47,7 @@ Error HashingContext::start(HashType p_type) {
 	return ERR_UNAVAILABLE;
 }
 
-Error HashingContext::update(PackedByteArray p_chunk) {
+Error HashingContext::update(const PackedByteArray &p_chunk) {
 	ERR_FAIL_NULL_V(ctx, ERR_UNCONFIGURED);
 	size_t len = p_chunk.size();
 	ERR_FAIL_COND_V(len == 0, FAILED);

--- a/core/crypto/hashing_context.h
+++ b/core/crypto/hashing_context.h
@@ -54,7 +54,7 @@ protected:
 
 public:
 	Error start(HashType p_type);
-	Error update(PackedByteArray p_chunk);
+	Error update(const PackedByteArray &p_chunk);
 	PackedByteArray finish();
 
 	HashingContext() {}

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -127,7 +127,7 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks,
 	singleton->poll_events(true);
 }
 
-void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints, void (*p_allow_focus_steal_fn)()) {
+void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)()) {
 	register_uri_handler("tcp://", RemoteDebuggerPeerTCP::create); // TCP is the default protocol. Platforms/modules can add more.
 	if (p_uri.is_empty()) {
 		return;

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -108,7 +108,7 @@ public:
 
 	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; };
 
-	static void initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints, void (*p_allow_focus_steal_fn)());
+	static void initialize(const String &p_uri, bool p_skip_breakpoints, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)());
 	static void deinitialize();
 	static void register_profiler(const StringName &p_name, const Profiler &p_profiler);
 	static void unregister_profiler(const StringName &p_name);

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -92,7 +92,7 @@ public:
 	}
 };
 
-Error RemoteDebugger::_put_msg(String p_message, Array p_data) {
+Error RemoteDebugger::_put_msg(const String &p_message, const Array &p_data) {
 	Array msg;
 	msg.push_back(p_message);
 	msg.push_back(Thread::get_caller_id());

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -98,7 +98,7 @@ private:
 	static void _err_handler(void *p_this, const char *p_func, const char *p_file, int p_line, const char *p_err, const char *p_descr, bool p_editor_notify, ErrorHandlerType p_type);
 
 	ErrorMessage _create_overflow_error(const String &p_what, const String &p_descr);
-	Error _put_msg(String p_message, Array p_data);
+	Error _put_msg(const String &p_message, const Array &p_data);
 
 	bool is_peer_connected() { return peer->is_peer_connected(); }
 	void flush_output();

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -914,7 +914,7 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 		return ERR_INVALID_DATA;
 	}
 
-	String library_path = GDExtension::find_extension_library(p_path, config, [](String p_feature) { return OS::get_singleton()->has_feature(p_feature); });
+	String library_path = GDExtension::find_extension_library(p_path, config, [](const String &p_feature) { return OS::get_singleton()->has_feature(p_feature); });
 
 	if (library_path.is_empty()) {
 		const String os_arch = OS::get_singleton()->get_name().to_lower() + "." + Engine::get_singleton()->get_architecture_name();

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -455,7 +455,7 @@ static String _hex_str(uint8_t p_byte) {
 	return ret;
 }
 
-void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid, Dictionary p_joypad_info) {
+void Input::joy_connection_changed(int p_idx, bool p_connected, const String &p_name, const String &p_guid, const Dictionary &p_joypad_info) {
 	_THREAD_SAFE_METHOD_
 
 	// Clear the pressed status if a Joypad gets disconnected.
@@ -1414,7 +1414,7 @@ void Input::_get_mapped_hat_events(const JoyDeviceMapping &mapping, HatDir p_hat
 	}
 }
 
-JoyButton Input::_get_output_button(String output) {
+JoyButton Input::_get_output_button(const String &output) {
 	for (int i = 0; i < (int)JoyButton::SDL_MAX; i++) {
 		if (output == _joy_buttons[i]) {
 			return JoyButton(i);
@@ -1423,7 +1423,7 @@ JoyButton Input::_get_output_button(String output) {
 	return JoyButton::INVALID;
 }
 
-JoyAxis Input::_get_output_axis(String output) {
+JoyAxis Input::_get_output_axis(const String &output) {
 	for (int i = 0; i < (int)JoyAxis::SDL_MAX; i++) {
 		if (output == _joy_axes[i]) {
 			return JoyAxis(i);
@@ -1432,7 +1432,7 @@ JoyAxis Input::_get_output_axis(String output) {
 	return JoyAxis::INVALID;
 }
 
-void Input::parse_mapping(String p_mapping) {
+void Input::parse_mapping(const String &p_mapping) {
 	_THREAD_SAFE_METHOD_;
 	JoyDeviceMapping mapping;
 
@@ -1535,7 +1535,7 @@ void Input::parse_mapping(String p_mapping) {
 	map_db.push_back(mapping);
 }
 
-void Input::add_joy_mapping(String p_mapping, bool p_update_existing) {
+void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
 	parse_mapping(p_mapping);
 	if (p_update_existing) {
 		Vector<String> entry = p_mapping.split(",");
@@ -1549,7 +1549,7 @@ void Input::add_joy_mapping(String p_mapping, bool p_update_existing) {
 	}
 }
 
-void Input::remove_joy_mapping(String p_guid) {
+void Input::remove_joy_mapping(const String &p_guid) {
 	for (int i = map_db.size() - 1; i >= 0; i--) {
 		if (p_guid == map_db[i].uid) {
 			map_db.remove_at(i);
@@ -1563,7 +1563,7 @@ void Input::remove_joy_mapping(String p_guid) {
 	}
 }
 
-void Input::set_fallback_mapping(String p_guid) {
+void Input::set_fallback_mapping(const String &p_guid) {
 	for (int i = 0; i < map_db.size(); i++) {
 		if (map_db[i].uid == p_guid) {
 			fallback_mapping = i;

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -239,8 +239,8 @@ private:
 	JoyEvent _get_mapped_button_event(const JoyDeviceMapping &mapping, JoyButton p_button);
 	JoyEvent _get_mapped_axis_event(const JoyDeviceMapping &mapping, JoyAxis p_axis, float p_value, JoyAxisRange &r_range);
 	void _get_mapped_hat_events(const JoyDeviceMapping &mapping, HatDir p_hat, JoyEvent r_events[(size_t)HatDir::MAX]);
-	JoyButton _get_output_button(String output);
-	JoyAxis _get_output_axis(String output);
+	JoyButton _get_output_button(const String &output);
+	JoyAxis _get_output_axis(const String &output);
 	void _button_event(int p_device, JoyButton p_index, bool p_pressed);
 	void _axis_event(int p_device, JoyAxis p_axis, float p_value);
 	void _update_action_cache(const StringName &p_action_name, ActionState &r_action_state);
@@ -295,7 +295,7 @@ public:
 	Vector2 get_joy_vibration_strength(int p_device);
 	float get_joy_vibration_duration(int p_device);
 	uint64_t get_joy_vibration_timestamp(int p_device);
-	void joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid = "", Dictionary p_joypad_info = Dictionary());
+	void joy_connection_changed(int p_idx, bool p_connected, const String &p_name, const String &p_guid = "", const Dictionary &p_joypad_info = Dictionary());
 
 	Vector3 get_gravity() const;
 	Vector3 get_accelerometer() const;
@@ -339,13 +339,13 @@ public:
 	CursorShape get_current_cursor_shape() const;
 	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
-	void parse_mapping(String p_mapping);
+	void parse_mapping(const String &p_mapping);
 	void joy_button(int p_device, JoyButton p_button, bool p_pressed);
 	void joy_axis(int p_device, JoyAxis p_axis, float p_value);
 	void joy_hat(int p_device, BitField<HatMask> p_val);
 
-	void add_joy_mapping(String p_mapping, bool p_update_existing = false);
-	void remove_joy_mapping(String p_guid);
+	void add_joy_mapping(const String &p_mapping, bool p_update_existing = false);
+	void remove_joy_mapping(const String &p_guid);
 
 	int get_unused_joy_id();
 
@@ -353,7 +353,7 @@ public:
 	String get_joy_guid(int p_device) const;
 	bool should_ignore_device(int p_vendor_id, int p_product_id) const;
 	Dictionary get_joy_info(int p_device) const;
-	void set_fallback_mapping(String p_guid);
+	void set_fallback_mapping(const String &p_guid);
 
 	void flush_buffered_events();
 	bool is_using_input_buffering();

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -81,7 +81,7 @@ void ConfigFile::set_value(const String &p_section, const String &p_key, const V
 	}
 }
 
-Variant ConfigFile::get_value(const String &p_section, const String &p_key, Variant p_default) const {
+Variant ConfigFile::get_value(const String &p_section, const String &p_key, const Variant &p_default) const {
 	if (!values.has(p_section) || !values[p_section].has(p_key)) {
 		ERR_FAIL_COND_V_MSG(p_default.get_type() == Variant::NIL, Variant(),
 				vformat("Couldn't find the given section \"%s\" and key \"%s\", and no default was given.", p_section, p_key));

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -53,7 +53,7 @@ protected:
 
 public:
 	void set_value(const String &p_section, const String &p_key, const Variant &p_value);
-	Variant get_value(const String &p_section, const String &p_key, Variant p_default = Variant()) const;
+	Variant get_value(const String &p_section, const String &p_key, const Variant &p_default = Variant()) const;
 
 	bool has_section(const String &p_section) const;
 	bool has_section_key(const String &p_section, const String &p_key) const;

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -131,7 +131,7 @@ Error DirAccess::erase_contents_recursive() {
 	return _erase_recursive(this);
 }
 
-Error DirAccess::make_dir_recursive(String p_dir) {
+Error DirAccess::make_dir_recursive(const String &p_dir) {
 	if (p_dir.length() < 1) {
 		return OK;
 	}
@@ -188,7 +188,7 @@ DirAccess::AccessType DirAccess::get_access_type() const {
 	return _access_type;
 }
 
-String DirAccess::fix_path(String p_path) const {
+String DirAccess::fix_path(const String &p_path) const {
 	switch (_access_type) {
 		case ACCESS_RESOURCES: {
 			if (ProjectSettings::get_singleton()) {
@@ -338,7 +338,7 @@ String DirAccess::get_full_path(const String &p_path, AccessType p_access) {
 	return full;
 }
 
-Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
+Error DirAccess::copy(const String &p_from, const String &p_to, int p_chmod_flags) {
 	//printf("copy %s -> %s\n",p_from.ascii().get_data(),p_to.ascii().get_data());
 	Error err;
 	{
@@ -396,7 +396,7 @@ class DirChanger {
 	String original_dir;
 
 public:
-	DirChanger(DirAccess *p_da, String p_dir) :
+	DirChanger(DirAccess *p_da, const String &p_dir) :
 			da(p_da),
 			original_dir(p_da->get_current_dir()) {
 		p_da->change_dir(p_dir);
@@ -407,7 +407,7 @@ public:
 	}
 };
 
-Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, String p_to, int p_chmod_flags, bool p_copy_links) {
+Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links) {
 	List<String> dirs;
 
 	String curdir = get_current_dir();
@@ -460,7 +460,7 @@ Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, String p_to, int p_chmod
 	return OK;
 }
 
-Error DirAccess::copy_dir(String p_from, String p_to, int p_chmod_flags, bool p_copy_links) {
+Error DirAccess::copy_dir(const String &p_from, String p_to, int p_chmod_flags, bool p_copy_links) {
 	ERR_FAIL_COND_V_MSG(!dir_exists(p_from), ERR_FILE_NOT_FOUND, "Source directory doesn't exist.");
 
 	Ref<DirAccess> target_da = DirAccess::create_for_path(p_to);
@@ -481,7 +481,7 @@ Error DirAccess::copy_dir(String p_from, String p_to, int p_chmod_flags, bool p_
 	return err;
 }
 
-bool DirAccess::exists(String p_dir) {
+bool DirAccess::exists(const String &p_dir) {
 	Ref<DirAccess> da = DirAccess::create_for_path(p_dir);
 	return da->change_dir(p_dir) == OK;
 }

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -54,7 +54,7 @@ private:
 	static CreateFunc create_func[ACCESS_MAX]; ///< set this to instance a filesystem object
 	static Ref<DirAccess> _open(const String &p_path);
 
-	Error _copy_dir(Ref<DirAccess> &p_target_da, String p_to, int p_chmod_flags, bool p_copy_links);
+	Error _copy_dir(Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links);
 	PackedStringArray _get_contents(bool p_directories);
 
 	thread_local static Error last_dir_open_error;
@@ -68,7 +68,7 @@ protected:
 	virtual String _get_root_string() const;
 
 	AccessType get_access_type() const;
-	virtual String fix_path(String p_path) const;
+	virtual String fix_path(const String &p_path) const;
 
 	template <class T>
 	static Ref<DirAccess> _create_builtin() {
@@ -91,18 +91,18 @@ public:
 	virtual Error change_dir(String p_dir) = 0; ///< can be relative or absolute, return false on success
 	virtual String get_current_dir(bool p_include_drive = true) const = 0; ///< return current dir location
 	virtual Error make_dir(String p_dir) = 0;
-	virtual Error make_dir_recursive(String p_dir);
+	virtual Error make_dir_recursive(const String &p_dir);
 	virtual Error erase_contents_recursive(); //super dangerous, use with care!
 
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
 	virtual bool is_readable(String p_dir) { return true; };
 	virtual bool is_writable(String p_dir) { return true; };
-	static bool exists(String p_dir);
+	static bool exists(const String &p_dir);
 	virtual uint64_t get_space_left() = 0;
 
-	Error copy_dir(String p_from, String p_to, int p_chmod_flags = -1, bool p_copy_links = false);
-	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1);
+	Error copy_dir(const String &p_from, String p_to, int p_chmod_flags = -1, bool p_copy_links = false);
+	virtual Error copy(const String &p_from, const String &p_to, int p_chmod_flags = -1);
 	virtual Error rename(String p_from, String p_to) = 0;
 	virtual Error remove(String p_name) = 0;
 
@@ -112,7 +112,7 @@ public:
 
 	// Meant for editor code when we want to quickly remove a file without custom
 	// handling (e.g. removing a cache file).
-	static void remove_file_or_error(String p_path) {
+	static void remove_file_or_error(const String &p_path) {
 		Ref<DirAccess> da = create(ACCESS_FILESYSTEM);
 		if (da->file_exists(p_path)) {
 			if (da->remove(p_path) != OK) {

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -36,7 +36,7 @@
 
 static HashMap<String, Vector<uint8_t>> *files = nullptr;
 
-void FileAccessMemory::register_file(String p_name, Vector<uint8_t> p_data) {
+void FileAccessMemory::register_file(const String &p_name, const Vector<uint8_t> &p_data) {
 	if (!files) {
 		files = memnew((HashMap<String, Vector<uint8_t>>));
 	}

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -41,7 +41,7 @@ class FileAccessMemory : public FileAccess {
 	static Ref<FileAccess> create();
 
 public:
-	static void register_file(String p_name, Vector<uint8_t> p_data);
+	static void register_file(const String &p_name, const Vector<uint8_t> &p_data);
 	static void cleanup();
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -455,7 +455,7 @@ String DirAccessPack::get_drive(int p_drive) {
 	return "";
 }
 
-PackedData::PackedDir *DirAccessPack::_find_dir(String p_dir) {
+PackedData::PackedDir *DirAccessPack::_find_dir(const String &p_dir) {
 	String nd = p_dir.replace("\\", "/");
 
 	// Special handling since simplify_path() will forbid it

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -222,7 +222,7 @@ class DirAccessPack : public DirAccess {
 	List<String> list_files;
 	bool cdir = false;
 
-	PackedData::PackedDir *_find_dir(String p_dir);
+	PackedData::PackedDir *_find_dir(const String &p_dir);
 
 public:
 	virtual Error list_dir_begin() override;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -115,7 +115,7 @@ void ZipArchive::close_handle(unzFile p_file) const {
 	unzClose(p_file);
 }
 
-unzFile ZipArchive::get_file_handle(String p_file) const {
+unzFile ZipArchive::get_file_handle(const String &p_file) const {
 	ERR_FAIL_COND_V_MSG(!file_exists(p_file), nullptr, "File '" + p_file + " doesn't exist.");
 	File file = files[p_file];
 
@@ -206,7 +206,7 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 	return true;
 }
 
-bool ZipArchive::file_exists(String p_name) const {
+bool ZipArchive::file_exists(const String &p_name) const {
 	return files.has(p_name);
 }
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -61,11 +61,11 @@ private:
 
 public:
 	void close_handle(unzFile p_file) const;
-	unzFile get_file_handle(String p_file) const;
+	unzFile get_file_handle(const String &p_file) const;
 
-	Error add_package(String p_name);
+	Error add_package(const String &p_name);
 
-	bool file_exists(String p_name) const;
+	bool file_exists(const String &p_name) const;
 
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
 	Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -80,7 +80,7 @@ void ImageFormatLoaderExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_format_loader"), &ImageFormatLoaderExtension::remove_format_loader);
 }
 
-Error ImageLoader::load_image(String p_file, Ref<Image> p_image, Ref<FileAccess> p_custom, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
+Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	ERR_FAIL_COND_V_MSG(p_image.is_null(), ERR_INVALID_PARAMETER, "Can't load an image: invalid Image object.");
 
 	Ref<FileAccess> f = p_custom;

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -91,7 +91,7 @@ class ImageLoader {
 
 protected:
 public:
-	static Error load_image(String p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
+	static Error load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
 	static void get_recognized_extensions(List<String> *p_extensions);
 	static Ref<ImageFormatLoader> recognize(const String &p_extension);
 

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -117,7 +117,7 @@ struct _IP_ResolverPrivate {
 
 	HashMap<String, List<IPAddress>> cache;
 
-	static String get_cache_key(String p_hostname, IP::Type p_type) {
+	static String get_cache_key(const String &p_hostname, IP::Type p_type) {
 		return itos(p_type) + p_hostname;
 	}
 };

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -230,7 +230,7 @@ void StdLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	}
 }
 
-CompositeLogger::CompositeLogger(Vector<Logger *> p_loggers) :
+CompositeLogger::CompositeLogger(const Vector<Logger *> &p_loggers) :
 		loggers(p_loggers) {
 }
 

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -96,7 +96,7 @@ class CompositeLogger : public Logger {
 	Vector<Logger *> loggers;
 
 public:
-	explicit CompositeLogger(Vector<Logger *> p_loggers);
+	explicit CompositeLogger(const Vector<Logger *> &p_loggers);
 
 	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
 	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type = ERR_ERROR) override;

--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -74,8 +74,8 @@ public:
 	virtual void set_ipv6_only_enabled(bool p_enabled) = 0;
 	virtual void set_tcp_no_delay_enabled(bool p_enabled) = 0;
 	virtual void set_reuse_address_enabled(bool p_enabled) = 0;
-	virtual Error join_multicast_group(const IPAddress &p_multi_address, String p_if_name) = 0;
-	virtual Error leave_multicast_group(const IPAddress &p_multi_address, String p_if_name) = 0;
+	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
+	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
 };
 
 #endif // NET_SOCKET_H

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -45,7 +45,7 @@ void PacketPeerUDP::set_broadcast_enabled(bool p_enabled) {
 	}
 }
 
-Error PacketPeerUDP::join_multicast_group(IPAddress p_multi_address, String p_if_name) {
+Error PacketPeerUDP::join_multicast_group(IPAddress p_multi_address, const String &p_if_name) {
 	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
 	ERR_FAIL_COND_V(!_sock.is_valid(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(!p_multi_address.is_valid(), ERR_INVALID_PARAMETER);
@@ -60,7 +60,7 @@ Error PacketPeerUDP::join_multicast_group(IPAddress p_multi_address, String p_if
 	return _sock->join_multicast_group(p_multi_address, p_if_name);
 }
 
-Error PacketPeerUDP::leave_multicast_group(IPAddress p_multi_address, String p_if_name) {
+Error PacketPeerUDP::leave_multicast_group(IPAddress p_multi_address, const String &p_if_name) {
 	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
 	ERR_FAIL_COND_V(!_sock.is_valid(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(!_sock->is_open(), ERR_UNCONFIGURED);

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -91,8 +91,8 @@ public:
 	int get_available_packet_count() const override;
 	int get_max_packet_size() const override;
 	void set_broadcast_enabled(bool p_enabled);
-	Error join_multicast_group(IPAddress p_multi_address, String p_if_name);
-	Error leave_multicast_group(IPAddress p_multi_address, String p_if_name);
+	Error join_multicast_group(IPAddress p_multi_address, const String &p_if_name);
+	Error leave_multicast_group(IPAddress p_multi_address, const String &p_if_name);
 
 	PacketPeerUDP();
 	~PacketPeerUDP();

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1114,7 +1114,7 @@ void ResourceLoader::set_load_callback(ResourceLoadedCallback p_callback) {
 
 ResourceLoadedCallback ResourceLoader::_loaded_callback = nullptr;
 
-Ref<ResourceFormatLoader> ResourceLoader::_find_custom_resource_format_loader(String path) {
+Ref<ResourceFormatLoader> ResourceLoader::_find_custom_resource_format_loader(const String &path) {
 	for (int i = 0; i < loader_count; ++i) {
 		if (loader[i]->get_script_instance() && loader[i]->get_script_instance()->get_script()->get_path() == path) {
 			return loader[i];
@@ -1123,7 +1123,7 @@ Ref<ResourceFormatLoader> ResourceLoader::_find_custom_resource_format_loader(St
 	return Ref<ResourceFormatLoader>();
 }
 
-bool ResourceLoader::add_custom_resource_format_loader(String script_path) {
+bool ResourceLoader::add_custom_resource_format_loader(const String &script_path) {
 	if (_find_custom_resource_format_loader(script_path).is_valid()) {
 		return false;
 	}

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -158,7 +158,7 @@ private:
 
 	static ResourceLoadedCallback _loaded_callback;
 
-	static Ref<ResourceFormatLoader> _find_custom_resource_format_loader(String path);
+	static Ref<ResourceFormatLoader> _find_custom_resource_format_loader(const String &path);
 
 	struct ThreadLoadTask {
 		WorkerThreadPool::TaskID task_id = 0; // Used if run on a worker thread from the pool.
@@ -263,7 +263,7 @@ public:
 	static void set_load_callback(ResourceLoadedCallback p_callback);
 	static ResourceLoaderImport import;
 
-	static bool add_custom_resource_format_loader(String script_path);
+	static bool add_custom_resource_format_loader(const String &script_path);
 	static void add_custom_loaders();
 	static void remove_custom_loaders();
 

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -215,7 +215,7 @@ void ResourceSaver::remove_resource_format_saver(Ref<ResourceFormatSaver> p_form
 	--saver_count;
 }
 
-Ref<ResourceFormatSaver> ResourceSaver::_find_custom_resource_format_saver(String path) {
+Ref<ResourceFormatSaver> ResourceSaver::_find_custom_resource_format_saver(const String &path) {
 	for (int i = 0; i < saver_count; ++i) {
 		if (saver[i]->get_script_instance() && saver[i]->get_script_instance()->get_script()->get_path() == path) {
 			return saver[i];
@@ -224,7 +224,7 @@ Ref<ResourceFormatSaver> ResourceSaver::_find_custom_resource_format_saver(Strin
 	return Ref<ResourceFormatSaver>();
 }
 
-bool ResourceSaver::add_custom_resource_format_saver(String script_path) {
+bool ResourceSaver::add_custom_resource_format_saver(const String &script_path) {
 	if (_find_custom_resource_format_saver(script_path).is_valid()) {
 		return false;
 	}

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -70,7 +70,7 @@ class ResourceSaver {
 	static ResourceSavedCallback save_callback;
 	static ResourceSaverGetResourceIDForPath save_get_id_for_path;
 
-	static Ref<ResourceFormatSaver> _find_custom_resource_format_saver(String path);
+	static Ref<ResourceFormatSaver> _find_custom_resource_format_saver(const String &path);
 
 public:
 	enum SaverFlags {
@@ -99,7 +99,7 @@ public:
 	static void set_save_callback(ResourceSavedCallback p_callback);
 	static void set_get_resource_id_for_path(ResourceSaverGetResourceIDForPath p_callback);
 
-	static bool add_custom_resource_format_saver(String script_path);
+	static bool add_custom_resource_format_saver(const String &script_path);
 	static void add_custom_savers();
 	static void remove_custom_savers();
 };

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -53,7 +53,7 @@ int godot_unzip_get_current_file_info(unzFile p_zip_file, unz_file_info64 &r_fil
 	return err;
 }
 
-int godot_unzip_locate_file(unzFile p_zip_file, String p_filepath, bool p_case_sensitive) {
+int godot_unzip_locate_file(unzFile p_zip_file, const String &p_filepath, bool p_case_sensitive) {
 	int err = unzGoToFirstFile(p_zip_file);
 	while (err == UNZ_OK) {
 		unz_file_info64 current_file_info;

--- a/core/io/zip_io.h
+++ b/core/io/zip_io.h
@@ -42,7 +42,7 @@
 // Get the current file info and safely convert the full filepath to a String.
 int godot_unzip_get_current_file_info(unzFile p_zip_file, unz_file_info64 &r_file_info, String &r_filepath);
 // Try to locate the file in the archive specified by the filepath (works with large paths and Unicode).
-int godot_unzip_locate_file(unzFile p_zip_file, String p_filepath, bool p_case_sensitive = true);
+int godot_unzip_locate_file(unzFile p_zip_file, const String &p_filepath, bool p_case_sensitive = true);
 
 //
 

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1494,7 +1494,7 @@ Error Expression::parse(const String &p_expression, const Vector<String> &p_inpu
 	return OK;
 }
 
-Variant Expression::execute(Array p_inputs, Object *p_base, bool p_show_error, bool p_const_calls_only) {
+Variant Expression::execute(const Array &p_inputs, Object *p_base, bool p_show_error, bool p_const_calls_only) {
 	ERR_FAIL_COND_V_MSG(error_set, Variant(), "There was previously a parse error: " + error_str + ".");
 
 	execution_error = false;

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -264,7 +264,7 @@ protected:
 
 public:
 	Error parse(const String &p_expression, const Vector<String> &p_input_names = Vector<String>());
-	Variant execute(Array p_inputs = Array(), Object *p_base = nullptr, bool p_show_error = true, bool p_const_calls_only = false);
+	Variant execute(const Array &p_inputs = Array(), Object *p_base = nullptr, bool p_show_error = true, bool p_const_calls_only = false);
 	bool has_execute_failed() const;
 	String get_error_text() const;
 

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -37,7 +37,7 @@
 
 #define SCALE_FACTOR 100000.0 // Based on CMP_EPSILON.
 
-Vector<Vector<Vector2>> Geometry2D::decompose_polygon_in_convex(Vector<Point2> polygon) {
+Vector<Vector<Vector2>> Geometry2D::decompose_polygon_in_convex(const Vector<Point2> &polygon) {
 	Vector<Vector<Vector2>> decomp;
 	List<TPPLPoly> in_poly, out_poly;
 

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -489,7 +489,7 @@ public:
 		return points;
 	}
 
-	static Vector<Vector<Vector2>> decompose_polygon_in_convex(Vector<Point2> polygon);
+	static Vector<Vector<Vector2>> decompose_polygon_in_convex(const Vector<Point2> &polygon);
 
 	static void make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size);
 	static Vector<Vector3i> partial_pack_rects(const Vector<Vector2i> &p_sizes, const Size2i &p_atlas_size);

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -449,7 +449,7 @@ static inline void _build_faces(uint8_t ***p_cell_status, int x, int y, int z, i
 	}
 }
 
-Vector<Face3> Geometry3D::wrap_geometry(Vector<Face3> p_array, real_t *p_error) {
+Vector<Face3> Geometry3D::wrap_geometry(const Vector<Face3> &p_array, real_t *p_error) {
 	int face_count = p_array.size();
 	const Face3 *faces = p_array.ptr();
 	constexpr double min_size = 1.0;

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -549,7 +549,7 @@ public:
 	}
 
 	// Create a "wrap" that encloses the given geometry.
-	static Vector<Face3> wrap_geometry(Vector<Face3> p_array, real_t *p_error = nullptr);
+	static Vector<Face3> wrap_geometry(const Vector<Face3> &p_array, real_t *p_error = nullptr);
 
 	struct MeshData {
 		struct Face {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -165,7 +165,7 @@ struct PropertyInfo {
 
 	PropertyInfo() {}
 
-	PropertyInfo(const Variant::Type p_type, const String p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName()) :
+	PropertyInfo(const Variant::Type p_type, const String &p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName()) :
 			type(p_type),
 			name(p_name),
 			hint(p_hint),

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -239,7 +239,7 @@ public:
 
 	void get_core_type_words(List<String> *p_core_type_words) const;
 	virtual void get_reserved_words(List<String> *p_words) const = 0;
-	virtual bool is_control_flow_keyword(String p_string) const = 0;
+	virtual bool is_control_flow_keyword(const String &p_string) const = 0;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const = 0;
 	virtual void get_doc_comment_delimiters(List<String> *p_delimiters) const = 0;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -229,7 +229,7 @@ public:
 			p_words->push_back(ret[i]);
 		}
 	}
-	EXBIND1RC(bool, is_control_flow_keyword, String)
+	EXBIND1RC(bool, is_control_flow_keyword, const String &)
 
 	GDVIRTUAL0RC(Vector<String>, _get_comment_delimiters)
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -298,7 +298,7 @@ String OS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
 	return ".";
 }
 
-Error OS::shell_open(String p_uri) {
+Error OS::shell_open(const String &p_uri) {
 	return ERR_UNAVAILABLE;
 }
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -86,7 +86,7 @@ protected:
 	void _set_logger(CompositeLogger *p_logger);
 
 public:
-	typedef void (*ImeCallback)(void *p_inp, String p_text, Point2 p_selection);
+	typedef void (*ImeCallback)(void *p_inp, const String &p_text, Point2 p_selection);
 	typedef bool (*HasServerFeatureCallback)(const String &p_feature);
 
 	enum RenderThreadMode {
@@ -109,8 +109,8 @@ protected:
 	virtual void initialize() = 0;
 	virtual void initialize_joypads() = 0;
 
-	void set_current_rendering_driver_name(String p_driver_name) { _current_rendering_driver_name = p_driver_name; }
-	void set_current_rendering_method(String p_name) { _current_rendering_method = p_name; }
+	void set_current_rendering_driver_name(const String &p_driver_name) { _current_rendering_driver_name = p_driver_name; }
+	void set_current_rendering_method(const String &p_name) { _current_rendering_method = p_name; }
 
 	void set_display_driver_id(int p_display_driver_id) { _display_driver_id = p_display_driver_id; }
 
@@ -152,9 +152,9 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) { return ERR_UNAVAILABLE; }
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) { return ERR_UNAVAILABLE; }
 	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; }
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) { return ERR_UNAVAILABLE; }
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) { return ERR_UNAVAILABLE; }
 
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
@@ -176,7 +176,7 @@ public:
 	virtual bool is_process_running(const ProcessID &p_pid) const = 0;
 	virtual void vibrate_handheld(int p_duration_ms = 500) {}
 
-	virtual Error shell_open(String p_uri);
+	virtual Error shell_open(const String &p_uri);
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder = true);
 	virtual Error set_cwd(const String &p_cwd);
 

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -255,7 +255,7 @@ String Time::get_time_string_from_unix_time(int64_t p_unix_time_val) const {
 	return vformat("%02d:%02d:%02d", hour, minute, second);
 }
 
-Dictionary Time::get_datetime_dict_from_datetime_string(String p_datetime, bool p_weekday) const {
+Dictionary Time::get_datetime_dict_from_datetime_string(const String &p_datetime, bool p_weekday) const {
 	PARSE_ISO8601_STRING(Dictionary())
 	Dictionary dict;
 	dict[YEAR_KEY] = year;
@@ -273,7 +273,7 @@ Dictionary Time::get_datetime_dict_from_datetime_string(String p_datetime, bool 
 	return dict;
 }
 
-String Time::get_datetime_string_from_datetime_dict(const Dictionary p_datetime, bool p_use_space) const {
+String Time::get_datetime_string_from_datetime_dict(const Dictionary &p_datetime, bool p_use_space) const {
 	ERR_FAIL_COND_V_MSG(p_datetime.is_empty(), "", "Invalid datetime Dictionary: Dictionary is empty.");
 	EXTRACT_FROM_DICTIONARY
 	VALIDATE_YMDHMS("")
@@ -287,7 +287,7 @@ String Time::get_datetime_string_from_datetime_dict(const Dictionary p_datetime,
 	return timestamp;
 }
 
-int64_t Time::get_unix_time_from_datetime_dict(const Dictionary p_datetime) const {
+int64_t Time::get_unix_time_from_datetime_dict(const Dictionary &p_datetime) const {
 	ERR_FAIL_COND_V_MSG(p_datetime.is_empty(), 0, "Invalid datetime Dictionary: Dictionary is empty");
 	EXTRACT_FROM_DICTIONARY
 	VALIDATE_YMDHMS(0)
@@ -295,7 +295,7 @@ int64_t Time::get_unix_time_from_datetime_dict(const Dictionary p_datetime) cons
 	return day_number * SECONDS_PER_DAY + hour * 3600 + minute * 60 + second;
 }
 
-int64_t Time::get_unix_time_from_datetime_string(String p_datetime) const {
+int64_t Time::get_unix_time_from_datetime_string(const String &p_datetime) const {
 	PARSE_ISO8601_STRING(-1)
 	VALIDATE_YMDHMS(0)
 	YMD_TO_DAY_NUMBER

--- a/core/os/time.h
+++ b/core/os/time.h
@@ -59,10 +59,10 @@ public:
 	String get_datetime_string_from_unix_time(int64_t p_unix_time_val, bool p_use_space = false) const;
 	String get_date_string_from_unix_time(int64_t p_unix_time_val) const;
 	String get_time_string_from_unix_time(int64_t p_unix_time_val) const;
-	Dictionary get_datetime_dict_from_datetime_string(String p_datetime, bool p_weekday = true) const;
-	String get_datetime_string_from_datetime_dict(const Dictionary p_datetime, bool p_use_space = false) const;
-	int64_t get_unix_time_from_datetime_dict(const Dictionary p_datetime) const;
-	int64_t get_unix_time_from_datetime_string(String p_datetime) const;
+	Dictionary get_datetime_dict_from_datetime_string(const String &p_datetime, bool p_weekday = true) const;
+	String get_datetime_string_from_datetime_dict(const Dictionary &p_datetime, bool p_use_space = false) const;
+	int64_t get_unix_time_from_datetime_dict(const Dictionary &p_datetime) const;
+	int64_t get_unix_time_from_datetime_string(const String &p_datetime) const;
 	String get_offset_string_from_offset_minutes(int64_t p_offset_minutes) const;
 
 	// Methods that get information from OS.

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -68,7 +68,7 @@ void remove_print_handler(const PrintHandlerList *p_handler) {
 	ERR_FAIL_NULL(l);
 }
 
-void __print_line(String p_string) {
+void __print_line(const String &p_string) {
 	if (!CoreGlobals::print_line_enabled) {
 		return;
 	}
@@ -85,7 +85,7 @@ void __print_line(String p_string) {
 	_global_unlock();
 }
 
-void __print_line_rich(String p_string) {
+void __print_line_rich(const String &p_string) {
 	if (!CoreGlobals::print_line_enabled) {
 		return;
 	}
@@ -178,7 +178,7 @@ void __print_line_rich(String p_string) {
 	_global_unlock();
 }
 
-void print_error(String p_string) {
+void print_error(const String &p_string) {
 	if (!CoreGlobals::print_error_enabled) {
 		return;
 	}
@@ -199,6 +199,6 @@ bool is_print_verbose_enabled() {
 	return OS::get_singleton()->is_stdout_verbose();
 }
 
-String stringify_variants(Variant p_var) {
+String stringify_variants(const Variant &p_var) {
 	return p_var.operator String();
 }

--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -46,19 +46,19 @@ struct PrintHandlerList {
 	PrintHandlerList() {}
 };
 
-String stringify_variants(Variant p_var);
+String stringify_variants(const Variant &p_var);
 
 template <typename... Args>
-String stringify_variants(Variant p_var, Args... p_args) {
+String stringify_variants(const Variant &p_var, Args... p_args) {
 	return p_var.operator String() + " " + stringify_variants(p_args...);
 }
 
 void add_print_handler(PrintHandlerList *p_handler);
 void remove_print_handler(const PrintHandlerList *p_handler);
 
-extern void __print_line(String p_string);
-extern void __print_line_rich(String p_string);
-extern void print_error(String p_string);
+extern void __print_line(const String &p_string);
+extern void __print_line_rich(const String &p_string);
+extern void print_error(const String &p_string);
 extern bool is_print_verbose_enabled();
 
 // This version avoids processing the text to be printed until it actually has to be printed, saving some CPU usage.
@@ -69,21 +69,21 @@ extern bool is_print_verbose_enabled();
 		}                                 \
 	}
 
-inline void print_line(Variant v) {
+inline void print_line(const Variant &v) {
 	__print_line(stringify_variants(v));
 }
 
-inline void print_line_rich(Variant v) {
+inline void print_line_rich(const Variant &v) {
 	__print_line_rich(stringify_variants(v));
 }
 
 template <typename... Args>
-void print_line(Variant p_var, Args... p_args) {
+void print_line(const Variant &p_var, Args... p_args) {
 	__print_line(stringify_variants(p_var, p_args...));
 }
 
 template <typename... Args>
-void print_line_rich(Variant p_var, Args... p_args) {
+void print_line_rich(const Variant &p_var, Args... p_args) {
 	__print_line_rich(stringify_variants(p_var, p_args...));
 }
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1438,7 +1438,7 @@ Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allo
 	return ret;
 }
 
-String String::join(Vector<String> parts) const {
+String String::join(const Vector<String> &parts) const {
 	String ret;
 	for (int i = 0; i < parts.size(); ++i) {
 		if (i > 0) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -361,7 +361,7 @@ public:
 	Vector<int> split_ints(const String &p_splitter, bool p_allow_empty = true) const;
 	Vector<int> split_ints_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
 
-	String join(Vector<String> parts) const;
+	String join(const Vector<String> &parts) const;
 
 	static char32_t char_uppercase(char32_t p_char);
 	static char32_t char_lowercase(char32_t p_char);

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -100,7 +100,7 @@ public:
 	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
 	Size count(const T &p_val) const { return _cowdata.count(p_val); }
 
-	void append_array(Vector<T> p_other);
+	void append_array(const Vector<T> &p_other);
 
 	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
@@ -300,7 +300,7 @@ void Vector<T>::reverse() {
 }
 
 template <class T>
-void Vector<T>::append_array(Vector<T> p_other) {
+void Vector<T>::append_array(const Vector<T> &p_other) {
 	const Size ds = p_other.size();
 	if (ds == 0) {
 		return;

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -216,7 +216,7 @@ struct PtrToArg<ObjectID> {
 			}                                                                            \
 			return ret;                                                                  \
 		}                                                                                \
-		_FORCE_INLINE_ static void encode(Vector<m_type> p_vec, void *p_ptr) {           \
+		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) {    \
 			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);              \
 			int len = p_vec.size();                                                      \
 			dv->resize(len);                                                             \
@@ -246,49 +246,49 @@ struct PtrToArg<ObjectID> {
 	}
 
 // No EncodeT because direct pointer conversion not possible.
-#define MAKE_VECARG_ALT(m_type, m_type_alt)                                              \
-	template <>                                                                          \
-	struct PtrToArg<Vector<m_type_alt>> {                                                \
-		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {            \
-			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
-			Vector<m_type_alt> ret;                                                      \
-			int len = dvs->size();                                                       \
-			ret.resize(len);                                                             \
-			{                                                                            \
-				const m_type *r = dvs->ptr();                                            \
-				for (int i = 0; i < len; i++) {                                          \
-					ret.write[i] = r[i];                                                 \
-				}                                                                        \
-			}                                                                            \
-			return ret;                                                                  \
-		}                                                                                \
-		_FORCE_INLINE_ static void encode(Vector<m_type_alt> p_vec, void *p_ptr) {       \
-			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);              \
-			int len = p_vec.size();                                                      \
-			dv->resize(len);                                                             \
-			{                                                                            \
-				m_type *w = dv->ptrw();                                                  \
-				for (int i = 0; i < len; i++) {                                          \
-					w[i] = p_vec[i];                                                     \
-				}                                                                        \
-			}                                                                            \
-		}                                                                                \
-	};                                                                                   \
-	template <>                                                                          \
-	struct PtrToArg<const Vector<m_type_alt> &> {                                        \
-		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {            \
-			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
-			Vector<m_type_alt> ret;                                                      \
-			int len = dvs->size();                                                       \
-			ret.resize(len);                                                             \
-			{                                                                            \
-				const m_type *r = dvs->ptr();                                            \
-				for (int i = 0; i < len; i++) {                                          \
-					ret.write[i] = r[i];                                                 \
-				}                                                                        \
-			}                                                                            \
-			return ret;                                                                  \
-		}                                                                                \
+#define MAKE_VECARG_ALT(m_type, m_type_alt)                                               \
+	template <>                                                                           \
+	struct PtrToArg<Vector<m_type_alt>> {                                                 \
+		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {             \
+			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr);  \
+			Vector<m_type_alt> ret;                                                       \
+			int len = dvs->size();                                                        \
+			ret.resize(len);                                                              \
+			{                                                                             \
+				const m_type *r = dvs->ptr();                                             \
+				for (int i = 0; i < len; i++) {                                           \
+					ret.write[i] = r[i];                                                  \
+				}                                                                         \
+			}                                                                             \
+			return ret;                                                                   \
+		}                                                                                 \
+		_FORCE_INLINE_ static void encode(const Vector<m_type_alt> &p_vec, void *p_ptr) { \
+			Vector<m_type> *dv = reinterpret_cast<Vector<m_type> *>(p_ptr);               \
+			int len = p_vec.size();                                                       \
+			dv->resize(len);                                                              \
+			{                                                                             \
+				m_type *w = dv->ptrw();                                                   \
+				for (int i = 0; i < len; i++) {                                           \
+					w[i] = p_vec[i];                                                      \
+				}                                                                         \
+			}                                                                             \
+		}                                                                                 \
+	};                                                                                    \
+	template <>                                                                           \
+	struct PtrToArg<const Vector<m_type_alt> &> {                                         \
+		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {             \
+			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr);  \
+			Vector<m_type_alt> ret;                                                       \
+			int len = dvs->size();                                                        \
+			ret.resize(len);                                                              \
+			{                                                                             \
+				const m_type *r = dvs->ptr();                                             \
+				for (int i = 0; i < len; i++) {                                           \
+					ret.write[i] = r[i];                                                  \
+				}                                                                         \
+			}                                                                             \
+			return ret;                                                                   \
+		}                                                                                 \
 	}
 
 MAKE_VECARG_ALT(String, StringName);
@@ -296,40 +296,40 @@ MAKE_VECARG_ALT(String, StringName);
 // For stuff that gets converted to Array vectors.
 
 // No EncodeT because direct pointer conversion not possible.
-#define MAKE_VECARR(m_type)                                                    \
-	template <>                                                                \
-	struct PtrToArg<Vector<m_type>> {                                          \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {      \
-			const Array *arr = reinterpret_cast<const Array *>(p_ptr);         \
-			Vector<m_type> ret;                                                \
-			int len = arr->size();                                             \
-			ret.resize(len);                                                   \
-			for (int i = 0; i < len; i++) {                                    \
-				ret.write[i] = (*arr)[i];                                      \
-			}                                                                  \
-			return ret;                                                        \
-		}                                                                      \
-		_FORCE_INLINE_ static void encode(Vector<m_type> p_vec, void *p_ptr) { \
-			Array *arr = reinterpret_cast<Array *>(p_ptr);                     \
-			int len = p_vec.size();                                            \
-			arr->resize(len);                                                  \
-			for (int i = 0; i < len; i++) {                                    \
-				(*arr)[i] = p_vec[i];                                          \
-			}                                                                  \
-		}                                                                      \
-	};                                                                         \
-	template <>                                                                \
-	struct PtrToArg<const Vector<m_type> &> {                                  \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {      \
-			const Array *arr = reinterpret_cast<const Array *>(p_ptr);         \
-			Vector<m_type> ret;                                                \
-			int len = arr->size();                                             \
-			ret.resize(len);                                                   \
-			for (int i = 0; i < len; i++) {                                    \
-				ret.write[i] = (*arr)[i];                                      \
-			}                                                                  \
-			return ret;                                                        \
-		}                                                                      \
+#define MAKE_VECARR(m_type)                                                           \
+	template <>                                                                       \
+	struct PtrToArg<Vector<m_type>> {                                                 \
+		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
+			Vector<m_type> ret;                                                       \
+			int len = arr->size();                                                    \
+			ret.resize(len);                                                          \
+			for (int i = 0; i < len; i++) {                                           \
+				ret.write[i] = (*arr)[i];                                             \
+			}                                                                         \
+			return ret;                                                               \
+		}                                                                             \
+		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
+			Array *arr = reinterpret_cast<Array *>(p_ptr);                            \
+			int len = p_vec.size();                                                   \
+			arr->resize(len);                                                         \
+			for (int i = 0; i < len; i++) {                                           \
+				(*arr)[i] = p_vec[i];                                                 \
+			}                                                                         \
+		}                                                                             \
+	};                                                                                \
+	template <>                                                                       \
+	struct PtrToArg<const Vector<m_type> &> {                                         \
+		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
+			Vector<m_type> ret;                                                       \
+			int len = arr->size();                                                    \
+			ret.resize(len);                                                          \
+			for (int i = 0; i < len; i++) {                                           \
+				ret.write[i] = (*arr)[i];                                             \
+			}                                                                         \
+			return ret;                                                               \
+		}                                                                             \
 	}
 
 MAKE_VECARR(Variant);
@@ -337,49 +337,49 @@ MAKE_VECARR(RID);
 MAKE_VECARR(Plane);
 
 // No EncodeT because direct pointer conversion not possible.
-#define MAKE_DVECARR(m_type)                                                   \
-	template <>                                                                \
-	struct PtrToArg<Vector<m_type>> {                                          \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {      \
-			const Array *arr = reinterpret_cast<const Array *>(p_ptr);         \
-			Vector<m_type> ret;                                                \
-			int len = arr->size();                                             \
-			ret.resize(len);                                                   \
-			{                                                                  \
-				m_type *w = ret.ptrw();                                        \
-				for (int i = 0; i < len; i++) {                                \
-					w[i] = (*arr)[i];                                          \
-				}                                                              \
-			}                                                                  \
-			return ret;                                                        \
-		}                                                                      \
-		_FORCE_INLINE_ static void encode(Vector<m_type> p_vec, void *p_ptr) { \
-			Array *arr = reinterpret_cast<Array *>(p_ptr);                     \
-			int len = p_vec.size();                                            \
-			arr->resize(len);                                                  \
-			{                                                                  \
-				const m_type *r = p_vec.ptr();                                 \
-				for (int i = 0; i < len; i++) {                                \
-					(*arr)[i] = r[i];                                          \
-				}                                                              \
-			}                                                                  \
-		}                                                                      \
-	};                                                                         \
-	template <>                                                                \
-	struct PtrToArg<const Vector<m_type> &> {                                  \
-		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {      \
-			const Array *arr = reinterpret_cast<const Array *>(p_ptr);         \
-			Vector<m_type> ret;                                                \
-			int len = arr->size();                                             \
-			ret.resize(len);                                                   \
-			{                                                                  \
-				m_type *w = ret.ptrw();                                        \
-				for (int i = 0; i < len; i++) {                                \
-					w[i] = (*arr)[i];                                          \
-				}                                                              \
-			}                                                                  \
-			return ret;                                                        \
-		}                                                                      \
+#define MAKE_DVECARR(m_type)                                                          \
+	template <>                                                                       \
+	struct PtrToArg<Vector<m_type>> {                                                 \
+		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
+			Vector<m_type> ret;                                                       \
+			int len = arr->size();                                                    \
+			ret.resize(len);                                                          \
+			{                                                                         \
+				m_type *w = ret.ptrw();                                               \
+				for (int i = 0; i < len; i++) {                                       \
+					w[i] = (*arr)[i];                                                 \
+				}                                                                     \
+			}                                                                         \
+			return ret;                                                               \
+		}                                                                             \
+		_FORCE_INLINE_ static void encode(const Vector<m_type> &p_vec, void *p_ptr) { \
+			Array *arr = reinterpret_cast<Array *>(p_ptr);                            \
+			int len = p_vec.size();                                                   \
+			arr->resize(len);                                                         \
+			{                                                                         \
+				const m_type *r = p_vec.ptr();                                        \
+				for (int i = 0; i < len; i++) {                                       \
+					(*arr)[i] = r[i];                                                 \
+				}                                                                     \
+			}                                                                         \
+		}                                                                             \
+	};                                                                                \
+	template <>                                                                       \
+	struct PtrToArg<const Vector<m_type> &> {                                         \
+		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {             \
+			const Array *arr = reinterpret_cast<const Array *>(p_ptr);                \
+			Vector<m_type> ret;                                                       \
+			int len = arr->size();                                                    \
+			ret.resize(len);                                                          \
+			{                                                                         \
+				m_type *w = ret.ptrw();                                               \
+				for (int i = 0; i < len; i++) {                                       \
+					w[i] = (*arr)[i];                                                 \
+				}                                                                     \
+			}                                                                         \
+			return ret;                                                               \
+		}                                                                             \
 	}
 
 // Special case for IPAddress.
@@ -427,7 +427,7 @@ struct PtrToArg<Vector<Face3>> {
 		}
 		return ret;
 	}
-	_FORCE_INLINE_ static void encode(Vector<Face3> p_vec, void *p_ptr) {
+	_FORCE_INLINE_ static void encode(const Vector<Face3> &p_vec, void *p_ptr) {
 		Vector<Vector3> *arr = reinterpret_cast<Vector<Vector3> *>(p_ptr);
 		int len = p_vec.size();
 		arr->resize(len * 3);

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1676,7 +1676,7 @@ Variant::operator String() const {
 	return stringify(0);
 }
 
-String stringify_variant_clean(const Variant p_variant, int recursion_count) {
+String stringify_variant_clean(const Variant &p_variant, int recursion_count) {
 	String s = p_variant.stringify(recursion_count);
 
 	// Wrap strings in quotes to avoid ambiguity.

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -109,7 +109,7 @@ int64_t VariantUtilityFunctions::posmod(int64_t b, int64_t r) {
 	return Math::posmod(b, r);
 }
 
-Variant VariantUtilityFunctions::floor(Variant x, Callable::CallError &r_error) {
+Variant VariantUtilityFunctions::floor(const Variant &x, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_OK;
 	switch (x.get_type()) {
 		case Variant::INT: {
@@ -153,7 +153,7 @@ int64_t VariantUtilityFunctions::floori(double x) {
 	return int64_t(Math::floor(x));
 }
 
-Variant VariantUtilityFunctions::ceil(Variant x, Callable::CallError &r_error) {
+Variant VariantUtilityFunctions::ceil(const Variant &x, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_OK;
 	switch (x.get_type()) {
 		case Variant::INT: {
@@ -197,7 +197,7 @@ int64_t VariantUtilityFunctions::ceili(double x) {
 	return int64_t(Math::ceil(x));
 }
 
-Variant VariantUtilityFunctions::round(Variant x, Callable::CallError &r_error) {
+Variant VariantUtilityFunctions::round(const Variant &x, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_OK;
 	switch (x.get_type()) {
 		case Variant::INT: {

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -52,13 +52,13 @@ struct VariantUtilityFunctions {
 	static double fmod(double b, double r);
 	static double fposmod(double b, double r);
 	static int64_t posmod(int64_t b, int64_t r);
-	static Variant floor(Variant x, Callable::CallError &r_error);
+	static Variant floor(const Variant &x, Callable::CallError &r_error);
 	static double floorf(double x);
 	static int64_t floori(double x);
-	static Variant ceil(Variant x, Callable::CallError &r_error);
+	static Variant ceil(const Variant &x, Callable::CallError &r_error);
 	static double ceilf(double x);
 	static int64_t ceili(double x);
-	static Variant round(Variant x, Callable::CallError &r_error);
+	static Variant round(const Variant &x, Callable::CallError &r_error);
 	static double roundf(double x);
 	static int64_t roundi(double x);
 	static Variant abs(const Variant &x, Callable::CallError &r_error);

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -787,11 +787,11 @@ Ref<NetSocket> NetSocketPosix::accept(IPAddress &r_ip, uint16_t &r_port) {
 	return Ref<NetSocket>(ns);
 }
 
-Error NetSocketPosix::join_multicast_group(const IPAddress &p_multi_address, String p_if_name) {
+Error NetSocketPosix::join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
 	return _change_multicast_group(p_multi_address, p_if_name, true);
 }
 
-Error NetSocketPosix::leave_multicast_group(const IPAddress &p_multi_address, String p_if_name) {
+Error NetSocketPosix::leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
 	return _change_multicast_group(p_multi_address, p_if_name, false);
 }
 

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -98,8 +98,8 @@ public:
 	virtual void set_tcp_no_delay_enabled(bool p_enabled);
 	virtual void set_reuse_address_enabled(bool p_enabled);
 	virtual void set_reuse_port_enabled(bool p_enabled);
-	virtual Error join_multicast_group(const IPAddress &p_multi_address, String p_if_name);
-	virtual Error leave_multicast_group(const IPAddress &p_multi_address, String p_if_name);
+	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name);
+	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name);
 
 	NetSocketPosix();
 	~NetSocketPosix();

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -639,7 +639,7 @@ String OS_Unix::get_locale() const {
 	return locale;
 }
 
-Error OS_Unix::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Unix::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	String path = p_path;
 
 	if (FileAccess::exists(path) && path.is_relative_path()) {
@@ -677,7 +677,7 @@ Error OS_Unix::close_dynamic_library(void *p_library_handle) {
 	return OK;
 }
 
-Error OS_Unix::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional) {
+Error OS_Unix::get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional) {
 	const char *error;
 	dlerror(); // Clear existing errors
 

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -55,9 +55,9 @@ public:
 
 	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
 	virtual Error set_cwd(const String &p_cwd) override;
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -68,7 +68,7 @@ struct DirAccessWindowsPrivate {
 	WIN32_FIND_DATAW fu; // Unicode version.
 };
 
-String DirAccessWindows::fix_path(String p_path) const {
+String DirAccessWindows::fix_path(const String &p_path) const {
 	String r_path = DirAccess::fix_path(p_path);
 	if (r_path.is_absolute_path() && !r_path.is_network_share_path() && r_path.length() > MAX_PATH) {
 		r_path = "\\\\?\\" + r_path.replace("/", "\\");

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -54,7 +54,7 @@ class DirAccessWindows : public DirAccess {
 	bool _cishidden = false;
 
 protected:
-	virtual String fix_path(String p_path) const override;
+	virtual String fix_path(const String &p_path) const override;
 
 public:
 	virtual Error list_dir_begin() override; ///< This starts dir listing

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2597,7 +2597,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 	}
 }
 
-bool GDScriptLanguage::is_control_flow_keyword(String p_keyword) const {
+bool GDScriptLanguage::is_control_flow_keyword(const String &p_keyword) const {
 	// Please keep alphabetical order.
 	return p_keyword == "break" ||
 			p_keyword == "continue" ||

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -540,7 +540,7 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	virtual void get_reserved_words(List<String> *p_words) const override;
-	virtual bool is_control_flow_keyword(String p_keywords) const override;
+	virtual bool is_control_flow_keyword(const String &p_keywords) const override;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const override;
 	virtual void get_doc_comment_delimiters(List<String> *p_delimiters) const override;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const override;

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -53,7 +53,7 @@ CryptoKey *CryptoKeyMbedTLS::create() {
 	return memnew(CryptoKeyMbedTLS);
 }
 
-Error CryptoKeyMbedTLS::load(String p_path, bool p_public_only) {
+Error CryptoKeyMbedTLS::load(const String &p_path, bool p_public_only) {
 	ERR_FAIL_COND_V_MSG(locks, ERR_ALREADY_IN_USE, "Key is in use");
 
 	PackedByteArray out;
@@ -79,7 +79,7 @@ Error CryptoKeyMbedTLS::load(String p_path, bool p_public_only) {
 	return OK;
 }
 
-Error CryptoKeyMbedTLS::save(String p_path, bool p_public_only) {
+Error CryptoKeyMbedTLS::save(const String &p_path, bool p_public_only) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_INVALID_PARAMETER, "Cannot save CryptoKeyMbedTLS file '" + p_path + "'.");
 
@@ -103,7 +103,7 @@ Error CryptoKeyMbedTLS::save(String p_path, bool p_public_only) {
 	return OK;
 }
 
-Error CryptoKeyMbedTLS::load_from_string(String p_string_key, bool p_public_only) {
+Error CryptoKeyMbedTLS::load_from_string(const String &p_string_key, bool p_public_only) {
 	int ret = 0;
 	if (p_public_only) {
 		ret = mbedtls_pk_parse_public_key(&pkey, (unsigned char *)p_string_key.utf8().get_data(), p_string_key.utf8().size());
@@ -138,7 +138,7 @@ X509Certificate *X509CertificateMbedTLS::create() {
 	return memnew(X509CertificateMbedTLS);
 }
 
-Error X509CertificateMbedTLS::load(String p_path) {
+Error X509CertificateMbedTLS::load(const String &p_path) {
 	ERR_FAIL_COND_V_MSG(locks, ERR_ALREADY_IN_USE, "Certificate is already in use.");
 
 	PackedByteArray out;
@@ -170,7 +170,7 @@ Error X509CertificateMbedTLS::load_from_memory(const uint8_t *p_buffer, int p_le
 	return OK;
 }
 
-Error X509CertificateMbedTLS::save(String p_path) {
+Error X509CertificateMbedTLS::save(const String &p_path) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_INVALID_PARAMETER, vformat("Cannot save X509CertificateMbedTLS file '%s'.", p_path));
 
@@ -235,7 +235,7 @@ HMACContext *HMACContextMbedTLS::create() {
 	return memnew(HMACContextMbedTLS);
 }
 
-Error HMACContextMbedTLS::start(HashingContext::HashType p_hash_type, PackedByteArray p_key) {
+Error HMACContextMbedTLS::start(HashingContext::HashType p_hash_type, const PackedByteArray &p_key) {
 	ERR_FAIL_COND_V_MSG(ctx != nullptr, ERR_FILE_ALREADY_IN_USE, "HMACContext already started.");
 
 	// HMAC keys can be any size.
@@ -255,7 +255,7 @@ Error HMACContextMbedTLS::start(HashingContext::HashType p_hash_type, PackedByte
 	return ret ? FAILED : OK;
 }
 
-Error HMACContextMbedTLS::update(PackedByteArray p_data) {
+Error HMACContextMbedTLS::update(const PackedByteArray &p_data) {
 	ERR_FAIL_NULL_V_MSG(ctx, ERR_INVALID_DATA, "Start must be called before update.");
 
 	ERR_FAIL_COND_V_MSG(p_data.is_empty(), ERR_INVALID_PARAMETER, "Src must not be empty.");
@@ -338,7 +338,7 @@ X509CertificateMbedTLS *CryptoMbedTLS::get_default_certificates() {
 	return default_certs;
 }
 
-void CryptoMbedTLS::load_default_certificates(String p_path) {
+void CryptoMbedTLS::load_default_certificates(const String &p_path) {
 	ERR_FAIL_COND(default_certs != nullptr);
 
 	default_certs = memnew(X509CertificateMbedTLS);
@@ -380,7 +380,7 @@ Ref<CryptoKey> CryptoMbedTLS::generate_rsa(int p_bytes) {
 	return out;
 }
 
-Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) {
+Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoKey> p_key, const String &p_issuer_name, const String &p_not_before, const String &p_not_after) {
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
 	ERR_FAIL_COND_V_MSG(key.is_null(), nullptr, "Invalid private key argument.");
 	mbedtls_x509write_cert crt;
@@ -452,7 +452,7 @@ mbedtls_md_type_t CryptoMbedTLS::md_type_from_hashtype(HashingContext::HashType 
 	}
 }
 
-Vector<uint8_t> CryptoMbedTLS::sign(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Ref<CryptoKey> p_key) {
+Vector<uint8_t> CryptoMbedTLS::sign(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, Ref<CryptoKey> p_key) {
 	int size;
 	mbedtls_md_type_t type = CryptoMbedTLS::md_type_from_hashtype(p_hash_type, size);
 	ERR_FAIL_COND_V_MSG(type == MBEDTLS_MD_NONE, Vector<uint8_t>(), "Invalid hash type.");
@@ -470,7 +470,7 @@ Vector<uint8_t> CryptoMbedTLS::sign(HashingContext::HashType p_hash_type, Vector
 	return out;
 }
 
-bool CryptoMbedTLS::verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key) {
+bool CryptoMbedTLS::verify(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, const Vector<uint8_t> &p_signature, Ref<CryptoKey> p_key) {
 	int size;
 	mbedtls_md_type_t type = CryptoMbedTLS::md_type_from_hashtype(p_hash_type, size);
 	ERR_FAIL_COND_V_MSG(type == MBEDTLS_MD_NONE, false, "Invalid hash type.");
@@ -480,7 +480,7 @@ bool CryptoMbedTLS::verify(HashingContext::HashType p_hash_type, Vector<uint8_t>
 	return mbedtls_pk_verify(&(key->pkey), type, p_hash.ptr(), size, p_signature.ptr(), p_signature.size()) == 0;
 }
 
-Vector<uint8_t> CryptoMbedTLS::encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext) {
+Vector<uint8_t> CryptoMbedTLS::encrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_plaintext) {
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
 	ERR_FAIL_COND_V_MSG(!key.is_valid(), Vector<uint8_t>(), "Invalid key provided.");
 	uint8_t buf[1024];
@@ -493,7 +493,7 @@ Vector<uint8_t> CryptoMbedTLS::encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_p
 	return out;
 }
 
-Vector<uint8_t> CryptoMbedTLS::decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext) {
+Vector<uint8_t> CryptoMbedTLS::decrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_ciphertext) {
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
 	ERR_FAIL_COND_V_MSG(!key.is_valid(), Vector<uint8_t>(), "Invalid key provided.");
 	ERR_FAIL_COND_V_MSG(key->is_public_only(), Vector<uint8_t>(), "Invalid key provided. Cannot decrypt using a public_only key.");

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -51,10 +51,10 @@ public:
 	static void make_default() { CryptoKey::_create = create; }
 	static void finalize() { CryptoKey::_create = nullptr; }
 
-	virtual Error load(String p_path, bool p_public_only);
-	virtual Error save(String p_path, bool p_public_only);
+	virtual Error load(const String &p_path, bool p_public_only);
+	virtual Error save(const String &p_path, bool p_public_only);
 	virtual String save_to_string(bool p_public_only);
-	virtual Error load_from_string(String p_string_key, bool p_public_only);
+	virtual Error load_from_string(const String &p_string_key, bool p_public_only);
 	virtual bool is_public_only() const { return public_only; };
 
 	CryptoKeyMbedTLS() {
@@ -82,9 +82,9 @@ public:
 	static void make_default() { X509Certificate::_create = create; }
 	static void finalize() { X509Certificate::_create = nullptr; }
 
-	virtual Error load(String p_path);
+	virtual Error load(const String &p_path);
 	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len);
-	virtual Error save(String p_path);
+	virtual Error save(const String &p_path);
 	virtual String save_to_string();
 	virtual Error load_from_string(const String &p_string_key);
 
@@ -116,8 +116,8 @@ public:
 
 	static bool is_md_type_allowed(mbedtls_md_type_t p_md_type);
 
-	virtual Error start(HashingContext::HashType p_hash_type, PackedByteArray p_key);
-	virtual Error update(PackedByteArray p_data);
+	virtual Error start(HashingContext::HashType p_hash_type, const PackedByteArray &p_key);
+	virtual Error update(const PackedByteArray &p_data);
 	virtual PackedByteArray finish();
 
 	HMACContextMbedTLS() {}
@@ -135,16 +135,16 @@ public:
 	static void initialize_crypto();
 	static void finalize_crypto();
 	static X509CertificateMbedTLS *get_default_certificates();
-	static void load_default_certificates(String p_path);
+	static void load_default_certificates(const String &p_path);
 	static mbedtls_md_type_t md_type_from_hashtype(HashingContext::HashType p_hash_type, int &r_size);
 
 	virtual PackedByteArray generate_random_bytes(int p_bytes);
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes);
-	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after);
-	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Ref<CryptoKey> p_key);
-	virtual bool verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key);
-	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext);
-	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext);
+	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, const String &p_issuer_name, const String &p_not_before, const String &p_not_after);
+	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, Ref<CryptoKey> p_key);
+	virtual bool verify(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, const Vector<uint8_t> &p_signature, Ref<CryptoKey> p_key);
+	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_plaintext);
+	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_ciphertext);
 
 	CryptoMbedTLS();
 	~CryptoMbedTLS();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -307,7 +307,7 @@ void CSharpLanguage::get_reserved_words(List<String> *p_words) const {
 	}
 }
 
-bool CSharpLanguage::is_control_flow_keyword(String p_keyword) const {
+bool CSharpLanguage::is_control_flow_keyword(const String &p_keyword) const {
 	return p_keyword == "break" ||
 			p_keyword == "case" ||
 			p_keyword == "catch" ||

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -493,7 +493,7 @@ public:
 
 	/* EDITOR FUNCTIONS */
 	void get_reserved_words(List<String> *p_words) const override;
-	bool is_control_flow_keyword(String p_keyword) const override;
+	bool is_control_flow_keyword(const String &p_keyword) const override;
 	void get_comment_delimiters(List<String> *p_delimiters) const override;
 	void get_doc_comment_delimiters(List<String> *p_delimiters) const override;
 	void get_string_delimiters(List<String> *p_delimiters) const override;

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -218,7 +218,7 @@ bool DirAccessJAndroid::dir_exists(String p_dir) {
 	}
 }
 
-Error DirAccessJAndroid::make_dir_recursive(String p_dir) {
+Error DirAccessJAndroid::make_dir_recursive(const String &p_dir) {
 	// Check if the directory exists already
 	if (dir_exists(p_dir)) {
 		return ERR_ALREADY_EXISTS;

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -77,7 +77,7 @@ public:
 	virtual bool dir_exists(String p_dir) override;
 
 	virtual Error make_dir(String p_dir) override;
-	virtual Error make_dir_recursive(String p_dir) override;
+	virtual Error make_dir_recursive(const String &p_dir) override;
 
 	virtual Error rename(String p_from, String p_to) override;
 	virtual Error remove(String p_name) override;

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -106,7 +106,7 @@ Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
 	return OK;
 }
 
-Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, String p_if_name) {
+Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
 	Error err = NetSocketPosix::join_multicast_group(p_multi_address, p_if_name);
 	if (err != OK) {
 		return err;
@@ -120,7 +120,7 @@ Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, S
 	return OK;
 }
 
-Error NetSocketAndroid::leave_multicast_group(const IPAddress &p_multi_address, String p_if_name) {
+Error NetSocketAndroid::leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
 	Error err = NetSocketPosix::leave_multicast_group(p_multi_address, p_if_name);
 	if (err != OK) {
 		return err;

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -67,8 +67,8 @@ public:
 	virtual void close();
 
 	virtual Error set_broadcasting_enabled(bool p_enabled);
-	virtual Error join_multicast_group(const IPAddress &p_multi_address, String p_if_name);
-	virtual Error leave_multicast_group(const IPAddress &p_multi_address, String p_if_name);
+	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name);
+	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name);
 
 	NetSocketAndroid() {}
 	~NetSocketAndroid();

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -162,7 +162,7 @@ Vector<String> OS_Android::get_granted_permissions() const {
 	return godot_java->get_granted_permissions();
 }
 
-Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Android::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	String path = p_path;
 	bool so_file_exists = true;
 	if (!FileAccess::exists(path)) {
@@ -338,7 +338,7 @@ void OS_Android::main_loop_focusin() {
 	audio_driver_android.set_pause(false);
 }
 
-Error OS_Android::shell_open(String p_uri) {
+Error OS_Android::shell_open(const String &p_uri) {
 	return godot_io_java->open_uri(p_uri);
 }
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -113,7 +113,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title) override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 
 	virtual String get_name() const override;
 	virtual String get_distribution_name() const override;
@@ -134,7 +134,7 @@ public:
 	void set_native_window(ANativeWindow *p_native_window);
 	ANativeWindow *get_native_window() const;
 
-	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_open(const String &p_uri) override;
 
 	virtual Vector<String> get_system_fonts() const override;
 	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -103,16 +103,16 @@ public:
 	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;
 	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
 	virtual String get_name() const override;
 	virtual String get_distribution_name() const override;
 	virtual String get_version() const override;
 	virtual String get_model_name() const override;
 
-	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_open(const String &p_uri) override;
 
 	virtual String get_user_data_dir() const override;
 

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -219,7 +219,7 @@ _FORCE_INLINE_ String OS_IOS::get_framework_executable(const String &p_path) {
 	return p_path;
 }
 
-Error OS_IOS::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_IOS::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	if (p_path.length() == 0) {
 		// Static xcframework.
 		p_library_handle = RTLD_SELF;
@@ -272,7 +272,7 @@ Error OS_IOS::close_dynamic_library(void *p_library_handle) {
 	return OS_Unix::close_dynamic_library(p_library_handle);
 }
 
-Error OS_IOS::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional) {
+Error OS_IOS::get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional) {
 	if (p_library_handle == RTLD_SELF) {
 		void **ptr = OS_IOS::dynamic_symbol_lookup_table.getptr(p_name);
 		if (ptr) {
@@ -305,7 +305,7 @@ String OS_IOS::get_model_name() const {
 	return OS_Unix::get_model_name();
 }
 
-Error OS_IOS::shell_open(String p_uri) {
+Error OS_IOS::shell_open(const String &p_uri) {
 	NSString *urlPath = [[NSString alloc] initWithUTF8String:p_uri.utf8().get_data()];
 	NSURL *url = [NSURL URLWithString:urlPath];
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -486,7 +486,7 @@ Vector<String> OS_LinuxBSD::lspci_get_device_value(Vector<String> vendor_device_
 	return values;
 }
 
-Error OS_LinuxBSD::shell_open(String p_uri) {
+Error OS_LinuxBSD::shell_open(const String &p_uri) {
 	Error ok;
 	int err_code;
 	List<String> args;

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -118,7 +118,7 @@ public:
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 
-	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_open(const String &p_uri) override;
 
 	virtual String get_unique_id() const override;
 	virtual String get_processor_name() const override;

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -85,7 +85,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 
 	virtual MainLoop *get_main_loop() const override;
 
@@ -98,7 +98,7 @@ public:
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 
-	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_open(const String &p_uri) override;
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder) override;
 
 	virtual String get_locale() const override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -217,7 +217,7 @@ _FORCE_INLINE_ String OS_MacOS::get_framework_executable(const String &p_path) {
 	return p_path;
 }
 
-Error OS_MacOS::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	String path = get_framework_executable(p_path);
 
 	if (!FileAccess::exists(path)) {
@@ -353,7 +353,7 @@ Error OS_MacOS::shell_show_in_file_manager(String p_path, bool p_open_folder) {
 	return OK;
 }
 
-Error OS_MacOS::shell_open(String p_uri) {
+Error OS_MacOS::shell_open(const String &p_uri) {
 	NSString *string = [NSString stringWithUTF8String:p_uri.utf8().get_data()];
 	NSURL *uri = [[NSURL alloc] initWithString:string];
 	if (!uri || !uri.scheme || [uri.scheme isEqual:@"file"]) {

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -150,7 +150,7 @@ String OS_Web::get_executable_path() const {
 	return OS::get_executable_path();
 }
 
-Error OS_Web::shell_open(String p_uri) {
+Error OS_Web::shell_open(const String &p_uri) {
 	// Open URI in a new tab, browser will deal with it by protocol.
 	godot_js_os_shell_open(p_uri.utf8().get_data());
 	return OK;
@@ -239,7 +239,7 @@ bool OS_Web::is_userfs_persistent() const {
 	return idb_available;
 }
 
-Error OS_Web::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Web::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	String path = p_path.get_file();
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
 	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, dlerror()));

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -89,7 +89,7 @@ public:
 	int get_default_thread_pool_size() const override { return 1; }
 
 	String get_executable_path() const override;
-	Error shell_open(String p_uri) override;
+	Error shell_open(const String &p_uri) override;
 	String get_name() const override;
 
 	// Override default OS implementation which would block the main thread with delay_usec.
@@ -107,7 +107,7 @@ public:
 
 	void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
-	Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 
 	void resume_audio();
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -352,7 +352,7 @@ void debug_dynamic_library_check_dependencies(const String &p_root_path, const S
 }
 #endif
 
-Error OS_Windows::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	String path = p_path.replace("/", "\\");
 
 	if (!FileAccess::exists(path)) {
@@ -418,7 +418,7 @@ Error OS_Windows::close_dynamic_library(void *p_library_handle) {
 	return OK;
 }
 
-Error OS_Windows::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional) {
+Error OS_Windows::get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional) {
 	p_symbol_handle = (void *)GetProcAddress((HMODULE)p_library_handle, p_name.utf8().get_data());
 	if (!p_symbol_handle) {
 		if (!p_optional) {
@@ -1333,7 +1333,7 @@ String OS_Windows::get_stdin_string() {
 	return String();
 }
 
-Error OS_Windows::shell_open(String p_uri) {
+Error OS_Windows::shell_open(const String &p_uri) {
 	INT_PTR ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, (LPCWSTR)(p_uri.utf16().get_data()), nullptr, nullptr, SW_SHOWNORMAL);
 	if (ret > 32) {
 		return OK;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -155,9 +155,9 @@ public:
 
 	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
 	virtual MainLoop *get_main_loop() const override;
 
@@ -213,7 +213,7 @@ public:
 
 	virtual String get_unique_id() const override;
 
-	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_open(const String &p_uri) override;
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder) override;
 
 	void run();

--- a/tests/core/test_crypto.h
+++ b/tests/core/test_crypto.h
@@ -39,13 +39,13 @@ namespace TestCrypto {
 class _MockCrypto : public Crypto {
 	virtual PackedByteArray generate_random_bytes(int p_bytes) { return PackedByteArray(); }
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes) { return nullptr; }
-	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) { return nullptr; }
+	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, const String &p_issuer_name, const String &p_not_before, const String &p_not_after) { return nullptr; }
 
-	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Ref<CryptoKey> p_key) { return Vector<uint8_t>(); }
-	virtual bool verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key) { return false; }
-	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext) { return Vector<uint8_t>(); }
-	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext) { return Vector<uint8_t>(); }
-	virtual PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg) { return PackedByteArray(); }
+	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, Ref<CryptoKey> p_key) { return Vector<uint8_t>(); }
+	virtual bool verify(HashingContext::HashType p_hash_type, const Vector<uint8_t> &p_hash, const Vector<uint8_t> &p_signature, Ref<CryptoKey> p_key) { return false; }
+	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_plaintext) { return Vector<uint8_t>(); }
+	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_ciphertext) { return Vector<uint8_t>(); }
+	virtual PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, const PackedByteArray &p_key, const PackedByteArray &p_msg) { return PackedByteArray(); }
 };
 
 PackedByteArray raw_to_pba(const uint8_t *arr, size_t len) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Adds const lvalue reference to the core container types specified in the [documentation](https://docs.godotengine.org/en/stable/development/cpp/core_types.html) that are declared in function parameters in `core/*` files

initial: https://github.com/godotengine/godot/pull/51156
`editor/*`: https://github.com/godotengine/godot/pull/88368
`modules/*`: https://github.com/godotengine/godot/pull/88915
`platform/*`: https://github.com/godotengine/godot/pull/88971
`servers/*`: https://github.com/godotengine/godot/pull/88972
`scene/*`: https://github.com/godotengine/godot/pull/88974
others: https://github.com/godotengine/godot/pull/88975