### PR TITLE
Add class reference documentation for GDExtension & GDExtensionManager

### DIFF
--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -1,31 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GDExtension" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		A native library for GDExtension.
 	</brief_description>
 	<description>
+		The [GDExtension] resource type represents a [url=https://en.wikipedia.org/wiki/Shared_library]shared library[/url] which can expand the functionality of the engine. The [GDExtensionManager] singleton is responsible for loading, reloading, and unloading [GDExtension] resources.
+		[b]Note:[/b] GDExtension itself is not a scripting language and has no relation to [GDScript] resources.
 	</description>
 	<tutorials>
+		<link title="GDExtension overview">$DOCS_URL/tutorials/scripting/gdextension/what_is_gdextension.html</link>
+		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/gdextension/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>
 		<method name="close_library">
 			<return type="void" />
 			<description>
+				Closes the current library.
+				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.unload_extension].
 			</description>
 		</method>
 		<method name="get_minimum_library_initialization_level" qualifiers="const">
 			<return type="int" enum="GDExtension.InitializationLevel" />
 			<description>
+				Returns the lowest level required for this extension to be properly initialized (see the [enum InitializationLevel] enum).
 			</description>
 		</method>
 		<method name="initialize_library">
 			<return type="void" />
 			<param index="0" name="level" type="int" enum="GDExtension.InitializationLevel" />
 			<description>
+				Initializes the library bound to this GDextension at the given initialization [param level].
+				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.load_extension].
 			</description>
 		</method>
 		<method name="is_library_open" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if this extension's library has been opened.
 			</description>
 		</method>
 		<method name="open_library">
@@ -33,17 +44,23 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="entry_symbol" type="String" />
 			<description>
+				Opens the library at the specified [param path].
+				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.load_extension].
 			</description>
 		</method>
 	</methods>
 	<constants>
 		<constant name="INITIALIZATION_LEVEL_CORE" value="0" enum="InitializationLevel">
+			The library is initialized at the same time as the core features of the engine.
 		</constant>
 		<constant name="INITIALIZATION_LEVEL_SERVERS" value="1" enum="InitializationLevel">
+			The library is initialized at the same time as the engine's servers (such as [RenderingServer] or [PhysicsServer3D]).
 		</constant>
 		<constant name="INITIALIZATION_LEVEL_SCENE" value="2" enum="InitializationLevel">
+			The library is initialized at the same time as the engine's scene-related classes.
 		</constant>
 		<constant name="INITIALIZATION_LEVEL_EDITOR" value="3" enum="InitializationLevel">
+			The library is initialized at the same time as the engine's editor classes. Only happens when loading the GDExtension in the editor.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/GDExtensionManager.xml
+++ b/doc/classes/GDExtensionManager.xml
@@ -1,65 +1,82 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GDExtensionManager" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Provides access to GDExtension functionality.
 	</brief_description>
 	<description>
+		The GDExtensionManager loads, initializes, and keeps track of all available [GDExtension] libraries in the project.
+		[b]Note:[/b] Do not worry about GDExtension unless you know what you are doing.
 	</description>
 	<tutorials>
+		<link title="GDExtension overview">$DOCS_URL/tutorials/scripting/gdextension/what_is_gdextension.html</link>
+		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/gdextension/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_extension">
 			<return type="GDExtension" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Returns the [GDExtension] at the given file [param path], or [code]null[/code] if it has not been loaded or does not exist.
 			</description>
 		</method>
 		<method name="get_loaded_extensions" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
+				Returns the file paths of all currently loaded extensions.
 			</description>
 		</method>
 		<method name="is_extension_loaded" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Returns [code]true[/code] if the extension at the given file [param path] has already been loaded successfully. See also [method get_loaded_extensions].
 			</description>
 		</method>
 		<method name="load_extension">
 			<return type="int" enum="GDExtensionManager.LoadStatus" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Loads an extension by absolute file path. The [param path] needs to point to a valid [GDExtension]. Returns [constant LOAD_STATUS_OK] if successful.
 			</description>
 		</method>
 		<method name="reload_extension">
 			<return type="int" enum="GDExtensionManager.LoadStatus" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Reloads the extension at the given file path. The [param path] needs to point to a valid [GDExtension], otherwise this method may return either [constant LOAD_STATUS_NOT_LOADED] or [constant LOAD_STATUS_FAILED]. 
+				[b]Note:[/b] You can only reload extensions in the editor. In release builds, this method always fails and returns [constant LOAD_STATUS_FAILED].
 			</description>
 		</method>
 		<method name="unload_extension">
 			<return type="int" enum="GDExtensionManager.LoadStatus" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Unloads an extension by file path. The [param path] needs to point to an already loaded [GDExtension], otherwise this method returns [constant LOAD_STATUS_NOT_LOADED].
 			</description>
 		</method>
 	</methods>
 	<signals>
 		<signal name="extensions_reloaded">
 			<description>
-				Emitted after the editor has automatically reloaded any extensions.
+				Emitted after the editor has finished reloading one or more extensions.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="LOAD_STATUS_OK" value="0" enum="LoadStatus">
+			The extension has loaded successfully.
 		</constant>
 		<constant name="LOAD_STATUS_FAILED" value="1" enum="LoadStatus">
+			The extension has failed to load, possibly because it does not exist or has missing dependencies.
 		</constant>
 		<constant name="LOAD_STATUS_ALREADY_LOADED" value="2" enum="LoadStatus">
+			The extension has already been loaded.
 		</constant>
 		<constant name="LOAD_STATUS_NOT_LOADED" value="3" enum="LoadStatus">
+			The extension has not been loaded.
 		</constant>
 		<constant name="LOAD_STATUS_NEEDS_RESTART" value="4" enum="LoadStatus">
+			The extension requires the application to restart to fully load.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION

This PR fills in the class reference of **GDExtension** and **GDExtensionManager**. It also links to the existing tutorials.

I don't know what else to say.

More feedback and useful insight is necessary from actual GDExtension developers. A few of these descriptions are unfortunately still barren.