### PR TITLE
[GDScript] Fix lifetime of call base object

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2050,6 +2050,10 @@ void Object::detach_from_objectdb() {
 }
 
 Object::~Object() {
+#ifdef DEBUG_ENABLED
+	CRASH_COND_MSG(_lock_index.get() != 1, "TODO message for object.");
+#endif // DEBUG_ENABLED
+
 	if (script_instance) {
 		memdelete(script_instance);
 	}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -708,11 +708,27 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 											gen->write_call_method_bind(result, base, method, arguments);
 										}
 									} else {
+										// Make temporary if member variable and ref-counted.
+										if (ClassDB::is_parent_class(class_name, "RefCounted") && base.mode == GDScriptCodeGenerator::Address::MEMBER) {
+											GDScriptCodeGenerator::Address temp = codegen.add_temporary(base.type);
+											gen->write_assign(temp, base);
+
+											base = temp;
+										}
+
 										gen->write_call(result, base, call->function_name, arguments);
 									}
 								} else if (base.type.has_type && base.type.kind == GDScriptDataType::BUILTIN) {
 									gen->write_call_builtin_type(result, base, base.type.builtin_type, call->function_name, arguments);
 								} else {
+									// Make temporary if member variable.
+									if (base.mode == GDScriptCodeGenerator::Address::MEMBER) {
+										GDScriptCodeGenerator::Address temp = codegen.add_temporary(base.type);
+										gen->write_assign(temp, base);
+
+										base = temp;
+									}
+
 									gen->write_call(result, base, call->function_name, arguments);
 								}
 								if (base.mode == GDScriptCodeGenerator::Address::TEMPORARY) {

--- a/modules/gdscript/tests/scripts/runtime/features/ref_counted_lifetime.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/ref_counted_lifetime.gd
@@ -1,0 +1,26 @@
+# https://github.com/godotengine/godot/issues/86788
+
+extends Node
+
+class MyClassTyped:
+	func enter(outer):
+		outer.my_class_typed = MyClassTyped.new()
+		exit()
+
+	func exit():
+		pass
+
+class MyClassUnTyped:
+	func enter(outer):
+		outer.my_class_untyped = MyClassUnTyped.new()
+		exit()
+
+	func exit():
+		pass
+
+var my_class_typed := MyClassTyped.new()
+var my_class_untyped = MyClassUnTyped.new()
+
+func test():
+	my_class_typed.enter(self)
+	my_class_untyped.enter(self)

--- a/modules/gdscript/tests/scripts/runtime/features/ref_counted_lifetime.out
+++ b/modules/gdscript/tests/scripts/runtime/features/ref_counted_lifetime.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Ensures that the lifetime of an `Object` outlasts calls to it

Also adds a check to `Object::~Object()` to check for locked state

This solves the immediate problem but might not be elegant, needs deeper investigation, but this should solve the problems

This makes member variables used as the base for a call persist until the end of the call, as a temporary

* Fixes: https://github.com/godotengine/godot/issues/86788 (needs confirmation)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
