### PR TITLE
Add code sample language parity check to `make_rst.py`

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -141,6 +141,9 @@ class State:
         self.classes: OrderedDict[str, ClassDef] = OrderedDict()
         self.current_class: str = ""
 
+        # Additional content and structure checks and validators.
+        self.script_language_parity_check: ScriptLanguageParityCheck = ScriptLanguageParityCheck()
+
     def parse_class(self, class_root: ET.Element, filepath: str) -> None:
         class_name = class_root.attrib["name"]
         self.current_class = class_name
@@ -543,6 +546,9 @@ class ClassDef(DefinitionBase):
     def __init__(self, name: str) -> None:
         super().__init__("class", name)
 
+        self.class_group = "variant"
+        self.editor_class = self._is_editor_class()
+
         self.constants: OrderedDict[str, ConstantDef] = OrderedDict()
         self.enums: OrderedDict[str, EnumDef] = OrderedDict()
         self.properties: OrderedDict[str, PropertyDef] = OrderedDict()
@@ -559,6 +565,65 @@ class ClassDef(DefinitionBase):
 
         # Used to match the class with XML source for output filtering purposes.
         self.filepath: str = ""
+
+    def _is_editor_class(self) -> bool:
+        if self.name.startswith("Editor"):
+            return True
+        if self.name in EDITOR_CLASSES:
+            return True
+
+        return False
+
+    def update_class_group(self, state: State) -> None:
+        group_name = "variant"
+
+        if self.name.startswith("@"):
+            group_name = "global"
+        elif self.inherits:
+            inherits = self.inherits.strip()
+
+            while inherits in state.classes:
+                if inherits == "Node":
+                    group_name = "node"
+                    break
+                if inherits == "Resource":
+                    group_name = "resource"
+                    break
+                if inherits == "Object":
+                    group_name = "object"
+                    break
+
+                inode = state.classes[inherits].inherits
+                if inode:
+                    inherits = inode.strip()
+                else:
+                    break
+
+        self.class_group = group_name
+
+
+# Checks if code samples have both GDScript and C# variations.
+# For simplicity we assume that a GDScript example is always present, and ignore contexts
+# which don't necessarily need C# examples.
+class ScriptLanguageParityCheck:
+    def __init__(self) -> None:
+        self.hit_map: OrderedDict[str, List[Tuple[DefinitionBase, str]]] = OrderedDict()
+        self.hit_count = 0
+
+    def add_hit(self, class_name: str, context: DefinitionBase, error: str, state: State) -> None:
+        if class_name in ["@GDScript", "@GlobalScope"]:
+            return  # We don't expect these contexts to have parity.
+
+        class_def = state.classes[class_name]
+        if class_def.class_group == "variant" and class_def.name != "Object":
+            return  # Variant types are replaced with native types in C#, we don't expect parity.
+
+        self.hit_count += 1
+
+        if class_name not in self.hit_map:
+            self.hit_map[class_name] = []
+
+        self.hit_map[class_name].append((context, error))
 
 
 # Entry point for the RST generator.
@@ -589,6 +654,11 @@ def main() -> None:
         "--dry-run",
         action="store_true",
         help="If passed, no output will be generated and XML files are only checked for errors.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="If passed, enables verbose printing.",
     )
     args = parser.parse_args()
 
@@ -684,15 +754,15 @@ def main() -> None:
         if args.filter and not pattern.search(class_def.filepath):
             continue
         state.current_class = class_name
+
+        class_def.update_class_group(state)
         make_rst_class(class_def, state, args.dry_run, args.output)
 
-        group_name = get_class_group(class_def, state)
+        if class_def.class_group not in grouped_classes:
+            grouped_classes[class_def.class_group] = []
+        grouped_classes[class_def.class_group].append(class_name)
 
-        if group_name not in grouped_classes:
-            grouped_classes[group_name] = []
-        grouped_classes[group_name].append(class_name)
-
-        if is_editor_class(class_def):
+        if class_def.editor_class:
             if "editor" not in grouped_classes:
                 grouped_classes["editor"] = []
             grouped_classes["editor"].append(class_name)
@@ -703,6 +773,26 @@ def main() -> None:
     make_rst_index(grouped_classes, args.dry_run, args.output)
 
     print("")
+
+    # Print out checks.
+
+    if state.script_language_parity_check.hit_count > 0:
+        if not args.verbose:
+            print(
+                f'{STYLES["yellow"]}{state.script_language_parity_check.hit_count} code samples failed parity check. Use --verbose to get more information.{STYLES["reset"]}'
+            )
+        else:
+            print(
+                f'{STYLES["yellow"]}{state.script_language_parity_check.hit_count} code samples failed parity check:{STYLES["reset"]}'
+            )
+
+            for class_name in state.script_language_parity_check.hit_map.keys():
+                class_hits = state.script_language_parity_check.hit_map[class_name]
+                print(f'{STYLES["yellow"]}- {len(class_hits)} hits in class "{class_name}"{STYLES["reset"]}')
+
+                for context, error in class_hits:
+                    print(f"  - {error} in {format_context_name(context)}")
+        print("")
 
     # Print out warnings and errors, or lack thereof, and exit with an appropriate code.
 
@@ -758,46 +848,6 @@ def get_git_branch() -> str:
         return version.docs
 
     return "master"
-
-
-def get_class_group(class_def: ClassDef, state: State) -> str:
-    group_name = "variant"
-    class_name = class_def.name
-
-    if class_name.startswith("@"):
-        group_name = "global"
-    elif class_def.inherits:
-        inherits = class_def.inherits.strip()
-
-        while inherits in state.classes:
-            if inherits == "Node":
-                group_name = "node"
-                break
-            if inherits == "Resource":
-                group_name = "resource"
-                break
-            if inherits == "Object":
-                group_name = "object"
-                break
-
-            inode = state.classes[inherits].inherits
-            if inode:
-                inherits = inode.strip()
-            else:
-                break
-
-    return group_name
-
-
-def is_editor_class(class_def: ClassDef) -> bool:
-    class_name = class_def.name
-
-    if class_name.startswith("Editor"):
-        return True
-    if class_name in EDITOR_CLASSES:
-        return True
-
-    return False
 
 
 # Generator methods.
@@ -1642,7 +1692,7 @@ def parse_link_target(link_target: str, state: State, context_name: str) -> List
 
 def format_text_block(
     text: str,
-    context: Union[DefinitionBase, None],
+    context: DefinitionBase,
     state: State,
 ) -> str:
     # Linebreak + tabs in the XML should become two line breaks unless in a "codeblock"
@@ -1691,6 +1741,9 @@ def format_text_block(
     inside_code_tag = ""
     inside_code_tabs = False
     ignore_code_warnings = False
+
+    has_codeblocks_gdscript = False
+    has_codeblocks_csharp = False
 
     pos = 0
     tag_depth = 0
@@ -1759,6 +1812,17 @@ def format_text_block(
 
             elif tag_state.name == "codeblocks":
                 if tag_state.closing:
+                    if not has_codeblocks_gdscript or not has_codeblocks_csharp:
+                        state.script_language_parity_check.add_hit(
+                            state.current_class,
+                            context,
+                            "Only one script language sample found in [codeblocks]",
+                            state,
+                        )
+
+                    has_codeblocks_gdscript = False
+                    has_codeblocks_csharp = False
+
                     tag_depth -= 1
                     tag_text = ""
                     inside_code_tabs = False
@@ -1776,6 +1840,8 @@ def format_text_block(
                             f"{state.current_class}.xml: GDScript code block is used outside of [codeblocks] in {context_name}.",
                             state,
                         )
+                    else:
+                        has_codeblocks_gdscript = True
                     tag_text = "\n .. code-tab:: gdscript\n"
                 elif tag_state.name == "csharp":
                     if not inside_code_tabs:
@@ -1783,8 +1849,17 @@ def format_text_block(
                             f"{state.current_class}.xml: C# code block is used outside of [codeblocks] in {context_name}.",
                             state,
                         )
+                    else:
+                        has_codeblocks_csharp = True
                     tag_text = "\n .. code-tab:: csharp\n"
                 else:
+                    state.script_language_parity_check.add_hit(
+                        state.current_class,
+                        context,
+                        "Code sample is formatted with [codeblock] where [codeblocks] should be used",
+                        state,
+                    )
+
                     tag_text = "\n::\n"
 
                 inside_code = True


### PR DESCRIPTION
This adds a non-blocking validator to `make_rst.py` which can report if codeblocks are missing parity between GDScript and C# samples. It's greedy and only ignores global contexts (which are basically GDScript-only methods). We may want to exclude Variant types as well, but I'm not confident that we should. There are differences in those types, but they should probably still be documented with correct samples. cc @raulsntos though.

The report is shallow by default:

```
Checking for errors in the XML class reference...
Generating the RST class reference...

Generating the index file...

297 code samples failed parity check. Use --verbose to get more information.

No warnings or errors found in the class reference XML.
```

But using the new `--verbose` flag you can see it in its entirety:

<details>

```
297 code samples failed parity check:
- 1 hits in class "AnimatedSprite2D"
  - Only one script language sample found in [codeblocks] in method "set_frame_and_progress" description
- 1 hits in class "AnimatedSprite3D"
  - Only one script language sample found in [codeblocks] in method "set_frame_and_progress" description
- 7 hits in class "AnimationMixer"
  - Only one script language sample found in [codeblocks] in method "get_root_motion_position" description
  - Only one script language sample found in [codeblocks] in method "get_root_motion_position" description
  - Only one script language sample found in [codeblocks] in method "get_root_motion_position_accumulator" description
  - Only one script language sample found in [codeblocks] in method "get_root_motion_rotation" description
  - Only one script language sample found in [codeblocks] in method "get_root_motion_rotation_accumulator" description
  - Only one script language sample found in [codeblocks] in method "get_root_motion_scale" description
  - Only one script language sample found in [codeblocks] in method "get_root_motion_scale_accumulator" description
- 2 hits in class "Area2D"
  - Only one script language sample found in [codeblocks] in signal "area_shape_entered" description
  - Only one script language sample found in [codeblocks] in signal "body_shape_entered" description
- 2 hits in class "Area3D"
  - Only one script language sample found in [codeblocks] in signal "area_shape_entered" description
  - Only one script language sample found in [codeblocks] in signal "body_shape_entered" description
- 8 hits in class "Array"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "all" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "any" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "append_array" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "filter" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "map" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "max" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "reduce" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "sort" description
- 4 hits in class "AStarGrid2D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "HEURISTIC_EUCLIDEAN" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "HEURISTIC_MANHATTAN" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "HEURISTIC_OCTILE" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "HEURISTIC_CHEBYSHEV" description
- 1 hits in class "BitMap"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "opaque_to_polygons" description
- 3 hits in class "Callable"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "Callable" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "call_deferred" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "unbind" description
- 1 hits in class "CallbackTweener"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "set_delay" description
- 1 hits in class "Camera3D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "unproject_position" description
- 1 hits in class "CanvasGroup"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "CanvasGroup" description
- 1 hits in class "CanvasItem"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "draw_lcd_texture_rect_region" description
- 1 hits in class "CharFXTransform"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "env" description
- 1 hits in class "ConfigFile"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ConfigFile" description
- 2 hits in class "Control"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in signal "mouse_exited" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_screen_position" description
- 1 hits in class "Curve2D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "sample_baked_with_rotation" description
- 2 hits in class "Dictionary"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "has" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "has_all" description
- 1 hits in class "DirAccess"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "DirAccess" description
- 15 hits in class "DisplayServer"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_window_at_screen_position" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_check_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_icon_check_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_icon_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_icon_radio_check_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_multistate_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_radio_check_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_separator" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_add_submenu_item" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "global_menu_clear" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "screen_get_dpi" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "screen_get_position" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "screen_get_refresh_rate" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "window_set_position" description
- 1 hits in class "EditorDebuggerPlugin"
  - Only one script language sample found in [codeblocks] in class "EditorDebuggerPlugin" description
- 3 hits in class "EditorPaths"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_cache_dir" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_config_dir" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_data_dir" description
- 8 hits in class "EditorPlugin"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_get_state" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_get_unsaved_status" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_get_unsaved_status" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_get_window_layout" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_has_main_screen" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_set_state" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_set_window_layout" description
  - Only one script language sample found in [codeblocks] in method "add_inspector_plugin" description
- 1 hits in class "EditorResourceConversionPlugin"
  - Only one script language sample found in [codeblocks] in class "EditorResourceConversionPlugin" description
- 1 hits in class "EditorResourceTooltipPlugin"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_make_tooltip_for_path" description
- 1 hits in class "FileAccess"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_csv_line" description
- 7 hits in class "float"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator **" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator **" description
- 1 hits in class "Font"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_supported_variation_list" description
- 1 hits in class "FontVariation"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "FontVariation" description
- 1 hits in class "GDScript"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "new" description
- 2 hits in class "GraphEdit"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_is_in_input_hotzone" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_is_in_output_hotzone" description
- 1 hits in class "HTTPClient"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_response_headers_as_dictionary" description
- 3 hits in class "ImageTexture"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ImageTexture" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ImageTexture" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ImageTexture" description
- 2 hits in class "InputEventKey"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "key_label" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "keycode" description
- 14 hits in class "int"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator &" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator &" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator **" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator **" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator <<" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator >>" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator ^" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator |" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator |" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator ~" description
- 1 hits in class "IP"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_local_interfaces" description
- 1 hits in class "JavaScriptObject"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "JavaScriptObject" description
- 3 hits in class "JSON"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "JSON" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "JSON" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "stringify" description
- 1 hits in class "MobileVRInterface"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "MobileVRInterface" description
- 1 hits in class "MovieWriter"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_handles_file" description
- 2 hits in class "MultiplayerAPIExtension"
  - Only one script language sample found in [codeblocks] in class "MultiplayerAPIExtension" description
  - Only one script language sample found in [codeblocks] in class "MultiplayerAPIExtension" description
- 7 hits in class "Node"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_get_configuration_warnings" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_child" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_node" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_tree_string" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_tree_string_pretty" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "print_tree" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "print_tree_pretty" description
- 2 hits in class "NodePath"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "NodePath" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constructor "NodePath" description
- 1 hits in class "NoiseTexture2D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "NoiseTexture2D" description
- 1 hits in class "NoiseTexture3D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "NoiseTexture3D" description
- 3 hits in class "Object"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "Object" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_to_string" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "call_deferred" description
- 1 hits in class "OS"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_cmdline_user_args" description
- 1 hits in class "PackedColorArray"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constructor "PackedColorArray" description
- 2 hits in class "PackedDataContainer"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "PackedDataContainer" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "PackedDataContainer" description
- 1 hits in class "PackedDataContainerRef"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "PackedDataContainerRef" description
- 1 hits in class "PackedStringArray"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "PackedStringArray" description
- 1 hits in class "PackedVector2Array"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constructor "PackedVector2Array" description
- 1 hits in class "PackedVector3Array"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constructor "PackedVector3Array" description
- 1 hits in class "PhysicsRayQueryParameters2D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "create" description
- 1 hits in class "PhysicsRayQueryParameters3D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "create" description
- 3 hits in class "ProjectSettings"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "editor/run/main_run_args" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "rendering/vrs/texture" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "globalize_path" description
- 3 hits in class "PropertyTweener"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "as_relative" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "from" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "from_current" description
- 3 hits in class "RandomNumberGenerator"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RandomNumberGenerator" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "seed" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "state" description
- 5 hits in class "RDPipelineColorBlendStateAttachment"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RDPipelineColorBlendStateAttachment" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RDPipelineColorBlendStateAttachment" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RDPipelineColorBlendStateAttachment" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RDPipelineColorBlendStateAttachment" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RDPipelineColorBlendStateAttachment" description
- 5 hits in class "RegEx"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RegEx" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RegEx" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RegEx" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RegEx" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "RegEx" description
- 2 hits in class "RenderingDevice"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "compute_list_begin" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "draw_list_begin" description
- 9 hits in class "RenderingServer"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "camera_attributes_set_exposure" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "camera_attributes_set_exposure" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_rendering_info" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_test_texture" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_white_texture" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "multimesh_set_buffer" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "texture_2d_get" description
  - Only one script language sample found in [codeblocks] in method "viewport_attach_to_screen" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "viewport_get_render_info" description
- 2 hits in class "Resource"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "_setup_local_to_scene" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "emit_changed" description
- 1 hits in class "ResourceImporterCSVTranslation"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ResourceImporterCSVTranslation" description
- 1 hits in class "ResourceLoader"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_dependencies" description
- 2 hits in class "RichTextLabel"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "install_effect" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "install_effect" description
- 1 hits in class "SceneTree"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "call_group_flags" description
- 3 hits in class "ScrollContainer"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "scroll_horizontal" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "scroll_vertical" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "ensure_control_visible" description
- 1 hits in class "Signal"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "connect" description
- 1 hits in class "SkeletonIK3D"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "SkeletonIK3D" description
- 1 hits in class "SpriteFrames"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_frame_duration" description
- 23 hits in class "String"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "bigrams" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "chr" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "format" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "format" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_base_dir" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_basename" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_extension" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_file" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_slice" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_subsequence_of" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_float" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_hex_number" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_identifier" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_int" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "left" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "num" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "right" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "similarity" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "simplify_path" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "split_floats" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "to_float" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "to_int" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
- 20 hits in class "StringName"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "bigrams" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "format" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "format" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_base_dir" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_basename" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_extension" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_file" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_slice" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_subsequence_of" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_float" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_hex_number" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_identifier" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "is_valid_int" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "left" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "right" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "similarity" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "simplify_path" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "split_floats" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "to_float" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "to_int" description
- 2 hits in class "StyleBoxFlat"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "StyleBoxFlat" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "StyleBoxFlat" description
- 1 hits in class "SyntaxHighlighter"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_line_syntax_highlighting" description
- 2 hits in class "TextServer"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "string_get_character_breaks" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "string_get_word_breaks" description
- 1 hits in class "TextServerDummy"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "TextServerDummy" description
- 1 hits in class "TileMap"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_cell_tile_data" description
- 1 hits in class "TileSetAtlasSource"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "TRANSFORM_FLIP_H" description
- 1 hits in class "TLSOptions"
  - Only one script language sample found in [codeblocks] in class "TLSOptions" description
- 2 hits in class "UndoRedo"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "add_do_reference" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "add_undo_reference" description
- 3 hits in class "UPNP"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "UPNP" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "UPNP" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "UPNP" description
- 5 hits in class "Vector2"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "from_angle" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator +" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator -" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
- 8 hits in class "Vector2i"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator +" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator -" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
- 4 hits in class "Vector3"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator +" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator -" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
- 8 hits in class "Vector3i"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator +" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator -" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
- 6 hits in class "Vector4"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator +" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator -" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
- 8 hits in class "Vector4i"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator %" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator *" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator +" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator -" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in operator "operator /" description
- 2 hits in class "Viewport"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in property "vrs_texture" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "get_texture" description
- 2 hits in class "VisualShaderNodeColorFunc"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "FUNC_GRAYSCALE" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "FUNC_SEPIA" description
- 9 hits in class "VisualShaderNodeColorOp"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_SCREEN" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_DIFFERENCE" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_DARKEN" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_LIGHTEN" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_OVERLAY" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_DODGE" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_BURN" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_SOFT_LIGHT" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in constant "OP_HARD_LIGHT" description
- 1 hits in class "VisualShaderNodeCustom"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "VisualShaderNodeCustom" description
- 2 hits in class "WebRTCPeerConnection"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "create_data_channel" description
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "initialize" description
- 1 hits in class "WebSocketPeer"
  - Only one script language sample found in [codeblocks] in class "WebSocketPeer" description
- 1 hits in class "WebXRInterface"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "WebXRInterface" description
- 1 hits in class "Window"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in signal "files_dropped" description
- 1 hits in class "XRInterface"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in method "set_environment_blend_mode" description
- 1 hits in class "ZIPPacker"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ZIPPacker" description
- 1 hits in class "ZIPReader"
  - Code sample is formatted with [codeblock] where [codeblocks] should be used in class "ZIPReader" description
```

</details>

Here's how it looks colorized:

<img width="567" alt="Code_2024-01-08_21-09-11" src="https://github.com/godotengine/godot/assets/11782833/c0cb1604-e8b7-40c6-9643-316e737bfdbe">

-----

The purpose of this is to provide a tool for documentation contributors to quickly find pieces of the docs missing C# samples. I don't think this is something we can currently enforce on the CI, but maybe one day, after increasing completion and adjusting the settings of this validator.

Inspired by [Juan's tweet from a few days ago](https://twitter.com/YuriSizov/status/1741140405842853982).