### PR TITLE
C#: Fix return type hint for methods.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2365,6 +2365,8 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		MethodInfo mi;
 		mi.name = name;
 
+		mi.return_val = PropertyInfo::from_dict(method_info_dict["return_val"]);
+
 		Array params = method_info_dict["params"];
 
 		for (int j = 0; j < params.size(); j++) {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -662,6 +662,19 @@ namespace Godot.Bridge
 
                             methodInfo.Add("name", method.Name);
 
+                            var returnVal = new Collections.Dictionary()
+                            {
+                                { "name", method.ReturnVal.Name },
+                                { "type", (int)method.ReturnVal.Type },
+                                { "usage", (int)method.ReturnVal.Usage }
+                            };
+                            if (method.ReturnVal.ClassName != null)
+                            {
+                                returnVal["class_name"] = method.ReturnVal.ClassName;
+                            }
+
+                            methodInfo.Add("return_val", returnVal);
+
                             var methodParams = new Collections.Array();
 
                             if (method.Arguments != null)


### PR DESCRIPTION
As https://github.com/godotengine/godot/issues/86256#issuecomment-1874179213 mentioned, the bridge didn't pass return-type info for methods to `CSharpScript` before.

Will completely close #86256.

Minimal reproduction: 
[csharp_type_test.zip](https://github.com/godotengine/godot/files/13866111/csharp_type_test.zip)
