### PR TITLE
C#: Integrate script/assembly generation into SCons

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -128,16 +128,6 @@ jobs:
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
 
-      - name: Generate C# glue
-        if: ${{ matrix.build-mono }}
-        run: |
-          ${{ matrix.bin }} --headless --generate-mono-glue ./modules/mono/glue
-
-      - name: Build .NET solutions
-        if: ${{ matrix.build-mono }}
-        run: |
-          ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
-
       - name: Prepare artifact
         if: ${{ matrix.artifact }}
         run: |

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import build_scripts.mono_configure as mono_configure
+import build_scripts.build_assemblies as build_assemblies
+from methods import glob_recursive
 
 Import("env")
 Import("env_modules")
@@ -27,3 +29,29 @@ if env["platform"] in ["macos", "ios"]:
 if env.editor_build:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")
     SConscript("editor/script_templates/SCsub")
+
+    # Build glue & assemblies
+
+    if env["build_dotnet"]:
+        glue_targets = [  # Hardcoded names
+            "glue/GodotSharp/GodotSharp/Generated/GD_constants.cs",
+            "glue/GodotSharp/GodotSharp/Generated/GD_extensions.cs",
+            "glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props",
+            "glue/GodotSharp/GodotSharp/Generated/NativeCalls.cs",
+            "glue/GodotSharp/GodotSharpEditor/Generated/EditorNativeCalls.cs",
+            "glue/GodotSharp/GodotSharpEditor/Generated/GeneratedIncludes.props",
+        ]
+        glue_sources = [f"#bin/godot{env['PROGSUFFIX']}"]
+        env["BUILDERS"]["DotNetGlue"] = Builder(action=env.Run(build_assemblies.dotnet_glue, "Building DotNet glue..."))
+        env.Alias("dotnet_glue", [env.DotNetGlue(glue_targets, glue_sources)])
+
+        assemblies_targets = []
+        for build_config in ["Debug", "Release"]:
+            assemblies_targets += [
+                f"#bin/GodotSharp/Api/{build_config}/{target}" for target in build_assemblies.target_filenames
+            ]
+        assemblies_sources = glob_recursive("**/*.cs", "glue")
+        env["BUILDERS"]["DotNetAssemblies"] = Builder(
+            action=env.Run(build_assemblies.dotnet_assemblies, "Building DotNet assemblies...")
+        )
+        env.Alias("dotnet_assemblies", [env.DotNetAssemblies(assemblies_targets, assemblies_sources)])

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -4,8 +4,21 @@ import os
 import os.path
 import shlex
 import subprocess
+import sys
 from dataclasses import dataclass
 from typing import Optional, List
+
+target_filenames = [
+    "GodotSharp.dll",
+    "GodotSharp.pdb",
+    "GodotSharp.xml",
+    "GodotSharpEditor.dll",
+    "GodotSharpEditor.pdb",
+    "GodotSharpEditor.xml",
+    "GodotPlugins.dll",
+    "GodotPlugins.pdb",
+    "GodotPlugins.runtimeconfig.json",
+]
 
 
 def find_dotnet_cli():
@@ -194,18 +207,6 @@ def run_msbuild(tools: ToolsLocation, sln: str, msbuild_args: Optional[List[str]
 
 
 def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, precision):
-    target_filenames = [
-        "GodotSharp.dll",
-        "GodotSharp.pdb",
-        "GodotSharp.xml",
-        "GodotSharpEditor.dll",
-        "GodotSharpEditor.pdb",
-        "GodotSharpEditor.xml",
-        "GodotPlugins.dll",
-        "GodotPlugins.pdb",
-        "GodotPlugins.runtimeconfig.json",
-    ]
-
     for build_config in ["Debug", "Release"]:
         editor_api_dir = os.path.join(output_dir, "GodotSharp", "Api", build_config)
 
@@ -425,5 +426,27 @@ def main():
     sys.exit(exit_code)
 
 
+def dotnet_glue(target, source, env):
+    subprocess.call([f"./bin/godot{env['PROGSUFFIX']}", "--headless", "--generate-mono-glue", "modules/mono/glue"])
+
+
+def dotnet_assemblies(target, source, env):
+    subprocess.call(
+        [
+            sys.executable,
+            "./modules/mono/build_scripts/build_assemblies.py",
+            "--godot-output-dir=./bin",
+            f"--godot-platform={env['platform']}",
+            f"--precision={env['precision']}",
+        ]
+    )
+
+
 if __name__ == "__main__":
-    main()
+    try:
+        from platform_methods import subprocess_main
+
+        subprocess_main(globals())
+    except:
+        # Invoked directly
+        main()

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -13,6 +13,14 @@ def can_build(env, platform):
     return True
 
 
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable("build_dotnet", "Generate dotnet glue and assemblies", True),
+    ]
+
+
 def configure(env):
     platform = env["platform"]
 


### PR DESCRIPTION
QOL for C# engine development workflow. Now SCons is capable of generating C# glue & building .NET assemblies via dedicated SCons builders. This behavior is enabled by default if the mono module is enabled. If the old generation method is preferred or you simply don't want to generate these files, this can be disabled with `dotnet_build=no`