### PR TITLE
Add documentation to EditorExportPlatformWeb

### DIFF
--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -4,6 +4,8 @@
 		Exporter for the Web.
 	</brief_description>
 	<description>
+		The Web exporter customizes how a web build is handled. In the editor's "Export" window, it is created when adding a new "Web" preset.
+		[b]Note:[/b] Godot on Web is rendered inside a [code]&lt;canvas&gt;[/code] tag. Normally, the canvas cannot be positioned or resized manually, but otherwise acts as the main [Window] of the application.
 	</description>
 	<tutorials>
 		<link title="Exporting for the Web">$DOCS_URL/tutorials/export/exporting_for_web.html</link>
@@ -11,45 +13,77 @@
 	</tutorials>
 	<members>
 		<member name="custom_template/debug" type="String" setter="" getter="">
-			Path to the custom export template. If left empty, default template is used.
+			File path to the custom export template used for debug builds. If left empty, the default template is used.
 		</member>
 		<member name="custom_template/release" type="String" setter="" getter="">
-			Path to the custom export template. If left empty, default template is used.
+			File path to the custom export template used for release builds. If left empty, the default template is used.
 		</member>
 		<member name="html/canvas_resize_policy" type="int" setter="" getter="">
-			The canvas resize policy determines how the canvas should be resized by Godot.
+			Determines how the canvas should be resized by Godot.
+			- [b]None:[/b] The canvas is not automatically resized.
+			- [b]Project:[/b] The size of the canvas is dependent on the [ProjectSettings].
+			- [b]Adaptive:[/b] The canvas is automatically resized to fit as much of the web page as possible.
 		</member>
 		<member name="html/custom_html_shell" type="String" setter="" getter="">
+			The custom HTML page that wraps the exported web build. If left empty, the default HTML shell is used.
+			For more information, see the [url=$DOCS_URL/tutorials/platform/web/customizing_html5_shell.html]Customizing HTML5 Shell[/url] tutorial.
 		</member>
 		<member name="html/experimental_virtual_keyboard" type="bool" setter="" getter="">
+			If [code]true[/code], embeds support for a virtual keyboard into the web page, which is shown when necessary on touchscreen devices.
+			[b]Warning:[/b] This feature is experimental and may be changed in a future release.
 		</member>
 		<member name="html/export_icon" type="bool" setter="" getter="">
+			If [code]true[/code], the project icon will be used as the favicon for this application's web page.
 		</member>
 		<member name="html/focus_canvas_on_start" type="bool" setter="" getter="">
+			If [code]true[/code], the canvas will be focused as soon as the application is loaded, if the browser window is already in focus.
 		</member>
 		<member name="html/head_include" type="String" setter="" getter="">
+			Additional HTML tags to include inside the [code]&lt;head&gt;[/code], such as [code]&lt;meta&gt;[/code] tags.
+			[b]Note:[/b] You do not need to add a [code]&lt;title&gt;[/code] tag, as it is automatically included based on the project's name.
 		</member>
 		<member name="progressive_web_app/background_color" type="Color" setter="" getter="">
+			The background color used behind the web application.
 		</member>
 		<member name="progressive_web_app/display" type="int" setter="" getter="">
+			The [url=https://developer.mozilla.org/en-US/docs/Web/Manifest/display/]display mode[/url] to use for this progressive web application. Different browsers and platforms may not behave the same.
+			- [b]Fullscreen:[/b] Displays the app in fullscreen and hides all of the browser's UI elements.
+			- [b]Standalone:[/b] Displays the app in a separate window and hides all of the browser's UI elements.
+			- [b]Minimal UI:[/b] Displays the app in a separate window and only shows the browser's UI elements for navigation.
+			- [b]Browser:[/b] Displays the app as a normal web page.
 		</member>
 		<member name="progressive_web_app/enabled" type="bool" setter="" getter="">
+			If [code]true[/code], turns this web build into a [url=https://en.wikipedia.org/wiki/Progressive_web_app]progressive web application[/url] (PWA).
 		</member>
 		<member name="progressive_web_app/icon_144x144" type="String" setter="" getter="">
+			File path to the smallest icon for this web application. If not defined, defaults to the project icon.
+			[b]Note:[/b] If the icon is not 144x144, it will be automatically resized for the final build.
 		</member>
 		<member name="progressive_web_app/icon_180x180" type="String" setter="" getter="">
+			File path to the small icon for this web application. If not defined, defaults to the project icon.
+			[b]Note:[/b] If the icon is not 180x180, it will be automatically resized for the final build.
 		</member>
 		<member name="progressive_web_app/icon_512x512" type="String" setter="" getter="">
+			File path to the smallest icon for this web application. If not defined, defaults to the project icon.
+			[b]Note:[/b] If the icon is not 512x512, it will be automatically resized for the final build.
 		</member>
 		<member name="progressive_web_app/offline_page" type="String" setter="" getter="">
+			The page to display, should the server hosting the page not be available. This page is saved in the client's machine.
 		</member>
 		<member name="progressive_web_app/orientation" type="int" setter="" getter="">
+			The orientation to use when the web application is run through a mobile device.
+			- [b]Any:[/b] No orientation is forced.
+			- [b]Landscape:[/b] Forces a horizontal layout (wider than it is taller).
+			- [b]Portrait:[/b] Forces a vertical layout (taller than it is wider).
 		</member>
 		<member name="variant/extensions_support" type="bool" setter="" getter="">
+			If [code]true[/code] enables [GDExtension] support for this web build.
 		</member>
 		<member name="vram_texture_compression/for_desktop" type="bool" setter="" getter="">
+			If [code]true[/code], allows textures to be optimized for desktop through the S3TC algorithm.
 		</member>
 		<member name="vram_texture_compression/for_mobile" type="bool" setter="" getter="">
+			If [code]true[/code] allows textures to be optimized for mobile through the ETC2 algorithm.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
This PR fills in the class reference of **EditorExportPlatformWeb**. Yeah.

This also has the side-effect of displaying them when hovering over the settings in the Export window, which is really, really good:
![image](https://github.com/godotengine/godot/assets/66727710/8a59185e-235b-473e-a8de-03af8d57689e)


Would be nice to get some feedback on factual correctness, sooner than later.

------
###### Sidenote, isn't it funny that [html/experimental_virtual_keyboard has been "experimental" for 2 years](https://github.com/godotengine/godot/pull/46913)? What a funny setting name.
