### PR TITLE
Overhaul multicaret editing and selection in TextEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -14,7 +14,7 @@
 			<return type="void" />
 			<param index="0" name="replace" type="bool" />
 			<description>
-				Override this method to define how the selected entry should be inserted. If [param replace] is true, any existing text should be replaced.
+				Override this method to define how the selected entry should be inserted. If [param replace] is [code]true[/code], any existing text should be replaced.
 			</description>
 		</method>
 		<method name="_filter_code_completion_candidates" qualifiers="virtual const">
@@ -29,7 +29,7 @@
 			<return type="void" />
 			<param index="0" name="force" type="bool" />
 			<description>
-				Override this method to define what happens when the user requests code completion. If [param force] is true, any checks should be bypassed.
+				Override this method to define what happens when the user requests code completion. If [param force] is [code]true[/code], any checks should be bypassed.
 			</description>
 		</method>
 		<method name="add_auto_brace_completion_pair">
@@ -123,7 +123,7 @@
 			<return type="void" />
 			<param index="0" name="replace" type="bool" default="false" />
 			<description>
-				Inserts the selected entry into the text. If [param replace] is true, any existing text is replaced rather than merged.
+				Inserts the selected entry into the text. If [param replace] is [code]true[/code], any existing text is replaced rather than merged.
 			</description>
 		</method>
 		<method name="convert_indent">
@@ -144,6 +144,12 @@
 				Code regions are delimited using start and end tags (respectively [code]region[/code] and [code]endregion[/code] by default) preceded by one line comment delimiter. (eg. [code]#region[/code] and [code]#endregion[/code])
 			</description>
 		</method>
+		<method name="delete_lines">
+			<return type="void" />
+			<description>
+				Deletes all lines that are selected or have a caret on them.
+			</description>
+		</method>
 		<method name="do_indent">
 			<return type="void" />
 			<description>
@@ -154,6 +160,12 @@
 			<return type="void" />
 			<description>
 				Duplicates all lines currently selected with any caret. Duplicates the entire line beneath the current one no matter where the caret is within the line.
+			</description>
+		</method>
+		<method name="duplicate_selection">
+			<return type="void" />
+			<description>
+				Duplicates all selected text and duplicates all lines with a caret on them.
 			</description>
 		</method>
 		<method name="fold_all_lines">
@@ -379,6 +391,18 @@
 				Returns whether the line at the specified index is folded or not.
 			</description>
 		</method>
+		<method name="move_lines_down">
+			<return type="void" />
+			<description>
+				Moves all lines down that are selected or have a caret on them.
+			</description>
+		</method>
+		<method name="move_lines_up">
+			<return type="void" />
+			<description>
+				Moves all lines up that are selected or have a caret on them.
+			</description>
+		</method>
 		<method name="remove_comment_delimiter">
 			<return type="void" />
 			<param index="0" name="start_key" type="String" />
@@ -397,7 +421,7 @@
 			<return type="void" />
 			<param index="0" name="force" type="bool" default="false" />
 			<description>
-				Emits [signal code_completion_requested], if [param force] is true will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path or signal.
+				Emits [signal code_completion_requested], if [param force] is [code]true[/code] will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path, or signal.
 			</description>
 		</method>
 		<method name="set_code_completion_selected_index">
@@ -465,6 +489,12 @@
 			<param index="0" name="line" type="int" />
 			<description>
 				Toggle the folding of the code block at the given line.
+			</description>
+		</method>
+		<method name="toggle_foldable_lines_at_carets">
+			<return type="void" />
+			<description>
+				Toggle the folding of the code block on all lines with a caret on them.
 			</description>
 		</method>
 		<method name="unfold_all_lines">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A multiline text editor. It also has limited facilities for editing code, such as syntax highlighting support. For more advanced facilities for editing code, see [CodeEdit].
-		[b]Note:[/b] Most viewport, caret and edit methods contain a [code]caret_index[/code] argument for [member caret_multiple] support. The argument should be one of the following: [code]-1[/code] for all carets, [code]0[/code] for the main caret, or greater than [code]0[/code] for secondary carets.
+		[b]Note:[/b] Most viewport, caret, and edit methods contain a [code]caret_index[/code] argument for [member caret_multiple] support. The argument should be one of the following: [code]-1[/code] for all carets, [code]0[/code] for the main caret, or greater than [code]0[/code] for secondary carets in the order they were created.
 		[b]Note:[/b] When holding down [kbd]Alt[/kbd], the vertical scroll wheel will scroll 5 times as fast as it would normally do. This also works in the Godot script editor.
 	</description>
 	<tutorials>
@@ -67,7 +67,7 @@
 			<return type="void" />
 			<param index="0" name="below" type="bool" />
 			<description>
-				Adds an additional caret above or below every caret. If [param below] is true the new caret will be added below and above otherwise.
+				Adds an additional caret above or below every caret. If [param below] is [code]true[/code] the new caret will be added below and above otherwise.
 			</description>
 		</method>
 		<method name="add_gutter">
@@ -83,7 +83,7 @@
 				Adds a selection and a caret for the next occurrence of the current selection. If there is no active selection, selects word under caret.
 			</description>
 		</method>
-		<method name="adjust_carets_after_edit">
+		<method name="adjust_carets_after_edit" deprecated="No longer necessary since methods now adjust carets themselves.">
 			<return type="void" />
 			<param index="0" name="caret" type="int" />
 			<param index="1" name="from_line" type="int" />
@@ -91,7 +91,7 @@
 			<param index="3" name="to_line" type="int" />
 			<param index="4" name="to_col" type="int" />
 			<description>
-				Reposition the carets affected by the edit. This assumes edits are applied in edit order, see [method get_caret_index_edit_order].
+				This method does nothing.
 			</description>
 		</method>
 		<method name="adjust_viewport_to_caret">
@@ -120,6 +120,23 @@
 				Starts a multipart edit. All edits will be treated as one action until [method end_complex_operation] is called.
 			</description>
 		</method>
+		<method name="begin_multicaret_edit">
+			<return type="void" />
+			<description>
+				Starts an edit for multiple carets. The edit must be ended with [method end_multicaret_edit]. Multicaret edits can be used to edit text at multiple carets and delay merging the carets until the end, so the caret indexes aren't affected immediately. [method begin_multicaret_edit] and [method end_multicaret_edit] can be nested, and the merge will happen at the last [method end_multicaret_edit].
+				Example usage:
+				[codeblock]
+				begin_complex_operation()
+				begin_multicaret_edit()
+				for i in range(get_caret_count()):
+				    if multicaret_edit_ignore_caret(i):
+				        continue
+				    # Logic here.
+				end_multicaret_edit()
+				end_complex_operation()
+				[/codeblock]
+			</description>
+		</method>
 		<method name="cancel_ime">
 			<return type="void" />
 			<description>
@@ -143,6 +160,20 @@
 			<return type="void" />
 			<description>
 				Clears the undo history.
+			</description>
+		</method>
+		<method name="collapse_carets">
+			<return type="void" />
+			<param index="0" name="from_line" type="int" />
+			<param index="1" name="from_column" type="int" />
+			<param index="2" name="to_line" type="int" />
+			<param index="3" name="to_column" type="int" />
+			<param index="4" name="inclusive" type="bool" default="false" />
+			<description>
+				Collapse all carets in the given range to the [param from_line] and [param from_column] position.
+				[param inclusive] applies to both ends.
+				If [method is_in_mulitcaret_edit] is [code]true[/code], carets that are collapsed will be [code]true[/code] for [method multicaret_edit_ignore_caret].
+				[method merge_overlapping_carets] will be called if any carets were collapsed.
 			</description>
 		</method>
 		<method name="copy">
@@ -185,6 +216,12 @@
 				Ends a multipart edit, started with [method begin_complex_operation]. If called outside a complex operation, the current operation is pushed onto the undo/redo stack.
 			</description>
 		</method>
+		<method name="end_multicaret_edit">
+			<return type="void" />
+			<description>
+				Ends an edit for multiple carets, that was started with [method begin_multicaret_edit]. If this was the last [method end_multicaret_edit] and [method merge_overlapping_carets] was called, carets will be merged.
+			</description>
+		</method>
 		<method name="get_caret_column" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
@@ -205,7 +242,7 @@
 				Returns the caret pixel draw position.
 			</description>
 		</method>
-		<method name="get_caret_index_edit_order">
+		<method name="get_caret_index_edit_order" deprecated="Carets no longer need to be edited in any specific order. If the carets need to be sorted, use [method get_sorted_carets] instead.">
 			<return type="PackedInt32Array" />
 			<description>
 				Returns a list of caret indexes in their edit order, this done from bottom to top. Edit order refers to the way actions such as [method insert_text_at_caret] are applied.
@@ -365,11 +402,11 @@
 		</method>
 		<method name="get_line_ranges_from_carets" qualifiers="const">
 			<return type="Vector2i[]" />
-			<param index="0" name="p_only_selections" type="bool" default="false" />
-			<param index="1" name="p_merge_adjacent" type="bool" default="true" />
+			<param index="0" name="only_selections" type="bool" default="false" />
+			<param index="1" name="merge_adjacent" type="bool" default="true" />
 			<description>
 				Returns an [Array] of line ranges where [code]x[/code] is the first line and [code]y[/code] is the last line. All lines within these ranges will have a caret on them or be part of a selection. Each line will only be part of one line range, even if it has multiple carets on it.
-				If a selection's end column ([method get_selection_to_column]) is at column [code]0[/code], that line will not be included. If a selection begins on the line after another selection ends and [param p_merge_adjacent] is [code]true[/code], or they begin and end on the same line, one line range will include both selections.
+				If a selection's end column ([method get_selection_to_column]) is at column [code]0[/code], that line will not be included. If a selection begins on the line after another selection ends and [param merge_adjacent] is [code]true[/code], or they begin and end on the same line, one line range will include both selections.
 			</description>
 		</method>
 		<method name="get_line_width" qualifiers="const">
@@ -528,12 +565,13 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<param index="2" name="include_edges" type="bool" default="true" />
+			<param index="3" name="only_selections" type="bool" default="true" />
 			<description>
 				Returns the caret index of the selection at the given [param line] and [param column], or [code]-1[/code] if there is none.
-				If [param include_edges] is [code]false[/code], the position must be inside the selection and not at either end.
+				If [param include_edges] is [code]false[/code], the position must be inside the selection and not at either end. If [param only_selections] is [code]false[/code], carets without a selection will also be considered.
 			</description>
 		</method>
-		<method name="get_selection_column" qualifiers="const" is_deprecated="true">
+		<method name="get_selection_column" qualifiers="const" deprecated="Use [method get_selection_origin_column] instead.">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
@@ -544,17 +582,17 @@
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
-				Returns the selection begin column.
+				Returns the selection begin column. Returns the caret column if there is no selection.
 			</description>
 		</method>
 		<method name="get_selection_from_line" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
-				Returns the selection begin line.
+				Returns the selection begin line. Returns the caret line if there is no selection.
 			</description>
 		</method>
-		<method name="get_selection_line" qualifiers="const">
+		<method name="get_selection_line" qualifiers="const" deprecated="Use [method get_selection_origin_line] instead.">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
@@ -567,18 +605,40 @@
 				Returns the current selection mode.
 			</description>
 		</method>
+		<method name="get_selection_origin_column" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
+			<description>
+				Returns the origin column of the selection. This is the opposite end from the caret.
+			</description>
+		</method>
+		<method name="get_selection_origin_line" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
+			<description>
+				Returns the origin line of the selection. This is the opposite end from the caret.
+			</description>
+		</method>
 		<method name="get_selection_to_column" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
-				Returns the selection end column.
+				Returns the selection end column. Returns the caret column if there is no selection.
 			</description>
 		</method>
 		<method name="get_selection_to_line" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
-				Returns the selection end line.
+				Returns the selection end line. Returns the caret line if there is no selection.
+			</description>
+		</method>
+		<method name="get_sorted_carets" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<param index="0" name="include_ignored_carets" type="bool" default="false" />
+			<description>
+				Returns the carets sorted by selection beginning from lowest line and column to highest (from top to bottom of text).
+				If [param include_ignored_carets] is [code]false[/code], carets from [method multicaret_edit_ignore_caret] will be ignored.
 			</description>
 		</method>
 		<method name="get_tab_size" qualifiers="const">
@@ -672,12 +732,32 @@
 				Inserts a new line with [param text] at [param line].
 			</description>
 		</method>
+		<method name="insert_text">
+			<return type="void" />
+			<param index="0" name="text" type="String" />
+			<param index="1" name="line" type="int" />
+			<param index="2" name="column" type="int" />
+			<param index="3" name="before_selection_begin" type="bool" default="true" />
+			<param index="4" name="before_selection_end" type="bool" default="false" />
+			<description>
+				Inserts the [param text] at [param line] and [param column].
+				If [param before_selection_begin] is [code]true[/code], carets and selections that begin at [param line] and [param column] will moved to the end of the inserted text, along with all carets after it.
+				If [param before_selection_end] is [code]true[/code], selections that end at [param line] and [param column] will be extended to the end of the inserted text. These parameters can be used to insert text inside of or outside of selections.
+			</description>
+		</method>
 		<method name="insert_text_at_caret">
 			<return type="void" />
 			<param index="0" name="text" type="String" />
 			<param index="1" name="caret_index" type="int" default="-1" />
 			<description>
 				Insert the specified text at the caret position.
+			</description>
+		</method>
+		<method name="is_caret_after_selection_origin" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="caret_index" type="int" default="0" />
+			<description>
+				Returns [code]true[/code] if the caret of the selection is after the selection origin. This can be used to determine the direction of the selection.
 			</description>
 		</method>
 		<method name="is_caret_visible" qualifiers="const">
@@ -690,7 +770,7 @@
 		<method name="is_dragging_cursor" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the user is dragging their mouse for scrolling or selecting.
+				Returns [code]true[/code] if the user is dragging their mouse for scrolling, selecting, or text dragging.
 			</description>
 		</method>
 		<method name="is_gutter_clickable" qualifiers="const">
@@ -712,6 +792,12 @@
 			<param index="0" name="gutter" type="int" />
 			<description>
 				Returns whether the gutter is overwritable.
+			</description>
+		</method>
+		<method name="is_in_mulitcaret_edit" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if a [method begin_multicaret_edit] has been called and [method end_multicaret_edit] has not yet been called.
 			</description>
 		</method>
 		<method name="is_line_gutter_clickable" qualifiers="const">
@@ -768,7 +854,16 @@
 			<return type="void" />
 			<description>
 				Merges any overlapping carets. Will favor the newest caret, or the caret with a selection.
+				If [method is_in_mulitcaret_edit] is [code]true[/code], the merge will be queued to happen at the end of the multicaret edit. See [method begin_multicaret_edit] and [method end_multicaret_edit].
 				[b]Note:[/b] This is not called when a caret changes position but after certain actions, so it is possible to get into a state where carets overlap.
+			</description>
+		</method>
+		<method name="multicaret_edit_ignore_caret" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="caret_index" type="int" />
+			<description>
+				Returns [code]true[/code] if the given [param caret_index] should be ignored as part of a multicaret edit. See [method begin_multicaret_edit] and [method end_multicaret_edit]. Carets that should be ignored are ones that were part of removed text and will likely be merged at the end of the edit, or carets that were added during the edit.
+				It is recommended to [code]continue[/code] within a loop iterating on multiple carets if a caret should be ignored.
 			</description>
 		</method>
 		<method name="paste">
@@ -806,6 +901,15 @@
 				Removes the gutter from this [TextEdit].
 			</description>
 		</method>
+		<method name="remove_line_at">
+			<return type="void" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="move_carets_down" type="bool" default="true" />
+			<description>
+				Removes the line of text at [param line]. Carets on this line will attempt to match their previous visual x position.
+				If [param move_carets_down] is [code]true[/code] carets will move to the next line down, otherwise carets will move up.
+			</description>
+		</method>
 		<method name="remove_secondary_carets">
 			<return type="void" />
 			<description>
@@ -820,7 +924,6 @@
 			<param index="3" name="to_column" type="int" />
 			<description>
 				Removes text between the given positions.
-				[b]Note:[/b] This does not adjust the caret or selection, which as a result it can end up in an invalid position.
 			</description>
 		</method>
 		<method name="search" qualifiers="const">
@@ -854,14 +957,15 @@
 		</method>
 		<method name="select">
 			<return type="void" />
-			<param index="0" name="from_line" type="int" />
-			<param index="1" name="from_column" type="int" />
-			<param index="2" name="to_line" type="int" />
-			<param index="3" name="to_column" type="int" />
+			<param index="0" name="origin_line" type="int" />
+			<param index="1" name="origin_column" type="int" />
+			<param index="2" name="caret_line" type="int" />
+			<param index="3" name="caret_column" type="int" />
 			<param index="4" name="caret_index" type="int" default="0" />
 			<description>
-				Perform selection, from line/column to line/column.
+				Selects text from [param origin_line] and [param origin_column] to [param caret_line] and [param caret_column] for the given [param caret_index]. This moves the selection origin and the caret. If the positions are the same, the selection will be deselected.
 				If [member selecting_enabled] is [code]false[/code], no selection will occur.
+				[b]Note:[/b] If supporting multiple carets this will not check for any overlap. See [method merge_overlapping_carets].
 			</description>
 		</method>
 		<method name="select_all">
@@ -897,9 +1001,10 @@
 			<param index="3" name="wrap_index" type="int" default="0" />
 			<param index="4" name="caret_index" type="int" default="0" />
 			<description>
-				Moves the caret to the specified [param line] index.
+				Moves the caret to the specified [param line] index. The caret column will be moved to the same visual position it was at the last time [method set_caret_column] was called, or clamped to the end of the line.
 				If [param adjust_viewport] is [code]true[/code], the viewport will center at the caret position after the move occurs.
 				If [param can_be_hidden] is [code]true[/code], the specified [param line] can be hidden.
+				If [param wrap_index] is [code]-1[/code], the caret column will be clamped to the [param line]'s length. If [param wrap_index] is greater than [code]-1[/code], the column will be moved to attempt to match the visual x position on the line's [param wrap_index] to the position from the last time [method set_caret_column] was called.
 				[b]Note:[/b] If supporting multiple carets this will not check for any overlap. See [method merge_overlapping_carets].
 			</description>
 		</method>
@@ -964,7 +1069,8 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="new_text" type="String" />
 			<description>
-				Sets the text for a specific line.
+				Sets the text for a specific [param line].
+				Carets on the line will attempt to keep their visual x position.
 			</description>
 		</method>
 		<method name="set_line_as_center_visible">
@@ -1072,6 +1178,26 @@
 				Sets the current selection mode.
 			</description>
 		</method>
+		<method name="set_selection_origin_column">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="caret_index" type="int" default="0" />
+			<description>
+				Sets the selection origin column to the [param column] for the given [param caret_index]. If the selection origin is moved to the caret position, the selection will deselect.
+			</description>
+		</method>
+		<method name="set_selection_origin_line">
+			<return type="void" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="can_be_hidden" type="bool" default="true" />
+			<param index="2" name="wrap_index" type="int" default="-1" />
+			<param index="3" name="caret_index" type="int" default="0" />
+			<description>
+				Sets the selection origin line to the [param line] for the given [param caret_index]. If the selection origin is moved to the caret position, the selection will deselect. 
+				If [param can_be_hidden] is [code]false[/code], The line will be set to the nearest unhidden line below or above.
+				If [param wrap_index] is [code]-1[/code], the selection origin column will be clamped to the [param line]'s length. If [param wrap_index] is greater than [code]-1[/code], the column will be moved to attempt to match the visual x position on the line's [param wrap_index] to the position from the last time [method set_selection_origin_column] or [method select] was called.
+			</description>
+		</method>
 		<method name="set_tab_size">
 			<return type="void" />
 			<param index="0" name="size" type="int" />
@@ -1105,7 +1231,7 @@
 			<param index="0" name="from_line" type="int" />
 			<param index="1" name="to_line" type="int" />
 			<description>
-				Swaps the two lines.
+				Swaps the two lines. Carets will be swapped with the lines.
 			</description>
 		</method>
 		<method name="tag_saved_version">
@@ -1156,7 +1282,7 @@
 			If [code]true[/code], the selected text will be deselected when focus is lost.
 		</member>
 		<member name="drag_and_drop_selection_enabled" type="bool" setter="set_drag_and_drop_selection_enabled" getter="is_drag_and_drop_selection_enabled" default="true">
-			If [code]true[/code], allow drag and drop of selected text.
+			If [code]true[/code], allow drag and drop of selected text. Text can still be dropped from other sources.
 		</member>
 		<member name="draw_control_chars" type="bool" setter="set_draw_control_chars" getter="get_draw_control_chars" default="false">
 			If [code]true[/code], control characters are displayed.
@@ -1247,7 +1373,7 @@
 	<signals>
 		<signal name="caret_changed">
 			<description>
-				Emitted when the caret changes position.
+				Emitted when any caret changes position.
 			</description>
 		</signal>
 		<signal name="gutter_added">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -58,7 +58,7 @@
 		<method name="add_caret">
 			<return type="int" />
 			<param index="0" name="line" type="int" />
-			<param index="1" name="col" type="int" />
+			<param index="1" name="column" type="int" />
 			<description>
 				Adds a new caret at the given location. Returns the index of the new caret, or [code]-1[/code] if the location is invalid.
 			</description>
@@ -363,6 +363,15 @@
 				[b]Note:[/b] The return value is influenced by [theme_item line_spacing] and [theme_item font_size]. And it will not be less than [code]1[/code].
 			</description>
 		</method>
+		<method name="get_line_ranges_from_carets" qualifiers="const">
+			<return type="Vector2i[]" />
+			<param index="0" name="p_only_selections" type="bool" default="false" />
+			<param index="1" name="p_merge_adjacent" type="bool" default="true" />
+			<description>
+				Returns an [Array] of line ranges where [code]x[/code] is the first line and [code]y[/code] is the last line. All lines within these ranges will have a caret on them or be part of a selection. Each line will only be part of one line range, even if it has multiple carets on it.
+				If a selection's end column ([method get_selection_to_column]) is at column [code]0[/code], that line will not be included. If a selection begins on the line after another selection ends and [param p_merge_adjacent] is [code]true[/code], or they begin and end on the same line, one line range will include both selections.
+			</description>
+		</method>
 		<method name="get_line_width" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="line" type="int" />
@@ -514,7 +523,17 @@
 				Returns the text inside the selection of a caret, or all the carets if [param caret_index] is its default value [code]-1[/code].
 			</description>
 		</method>
-		<method name="get_selection_column" qualifiers="const">
+		<method name="get_selection_at_line_column" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="column" type="int" />
+			<param index="2" name="include_edges" type="bool" default="true" />
+			<description>
+				Returns the caret index of the selection at the given [param line] and [param column], or [code]-1[/code] if there is none.
+				If [param include_edges] is [code]false[/code], the position must be inside the selection and not at either end.
+			</description>
+		</method>
+		<method name="get_selection_column" qualifiers="const" is_deprecated="true">
 			<return type="int" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
@@ -809,7 +828,7 @@
 			<param index="0" name="text" type="String" />
 			<param index="1" name="flags" type="int" />
 			<param index="2" name="from_line" type="int" />
-			<param index="3" name="from_colum" type="int" />
+			<param index="3" name="from_column" type="int" />
 			<description>
 				Perform a search inside the text. Search flags can be specified in the [enum SearchFlags] enum.
 				In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line. If no results are found, both are equal to [code]-1[/code].
@@ -1049,9 +1068,6 @@
 		<method name="set_selection_mode">
 			<return type="void" />
 			<param index="0" name="mode" type="int" enum="TextEdit.SelectionMode" />
-			<param index="1" name="line" type="int" default="-1" />
-			<param index="2" name="column" type="int" default="-1" />
-			<param index="3" name="caret_index" type="int" default="0" />
 			<description>
 				Sets the current selection mode.
 			</description>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -173,10 +173,8 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 	if (pos.x != -1) {
 		if (!preserve_cursor && !is_selection_only()) {
 			text_editor->unfold_line(pos.y);
-			text_editor->set_caret_line(pos.y, false);
-			text_editor->set_caret_column(pos.x + text.length(), false);
-			text_editor->center_viewport_to_caret(0);
 			text_editor->select(pos.y, pos.x, pos.y, pos.x + text.length());
+			text_editor->center_viewport_to_caret(0);
 
 			line_col_changed_for_result = true;
 		}
@@ -216,7 +214,7 @@ void FindReplaceBar::_replace() {
 	text_editor->begin_complex_operation();
 	if (selection_enabled && is_selection_only()) {
 		// Restrict search_current() to selected region.
-		text_editor->set_caret_line(selection_begin.width, false, true, 0, 0);
+		text_editor->set_caret_line(selection_begin.width, false, true, -1, 0);
 		text_editor->set_caret_column(selection_begin.height, true, 0);
 	}
 
@@ -285,10 +283,10 @@ void FindReplaceBar::_replace_all() {
 	text_editor->begin_complex_operation();
 
 	if (selection_enabled && is_selection_only()) {
-		text_editor->set_caret_line(selection_begin.width, false, true, 0, 0);
+		text_editor->set_caret_line(selection_begin.width, false, true, -1, 0);
 		text_editor->set_caret_column(selection_begin.height, true, 0);
 	} else {
-		text_editor->set_caret_line(0, false, true, 0, 0);
+		text_editor->set_caret_line(0, false, true, -1, 0);
 		text_editor->set_caret_column(0, true, 0);
 	}
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -33,7 +33,6 @@
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
-#include "core/templates/pair.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/plugins/script_editor_plugin.h"
@@ -810,22 +809,22 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 	}
 
 	if (ED_IS_SHORTCUT("script_text_editor/move_up", key_event)) {
-		move_lines_up();
+		text_editor->move_lines_up();
 		accept_event();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/move_down", key_event)) {
-		move_lines_down();
+		text_editor->move_lines_down();
 		accept_event();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/delete_line", key_event)) {
-		delete_lines();
+		text_editor->delete_lines();
 		accept_event();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/duplicate_selection", key_event)) {
-		duplicate_selection();
+		text_editor->duplicate_selection();
 		accept_event();
 		return;
 	}
@@ -1114,31 +1113,23 @@ void CodeTextEditor::trim_trailing_whitespace() {
 					break;
 				}
 			}
-			text_editor->set_line(i, line.substr(0, end));
+			text_editor->remove_text(i, end, i, line.length());
 		}
 	}
 
 	if (trimmed_whitespace) {
 		text_editor->merge_overlapping_carets();
 		text_editor->end_complex_operation();
-		text_editor->queue_redraw();
 	}
 }
 
 void CodeTextEditor::insert_final_newline() {
 	int final_line = text_editor->get_line_count() - 1;
-
 	String line = text_editor->get_line(final_line);
 
 	// Length 0 means it's already an empty line, no need to add a newline.
 	if (line.length() > 0 && !line.ends_with("\n")) {
-		text_editor->begin_complex_operation();
-
-		line += "\n";
-		text_editor->set_line(final_line, line);
-
-		text_editor->end_complex_operation();
-		text_editor->queue_redraw();
+		text_editor->insert_text("\n", final_line, line.length(), false);
 	}
 }
 
@@ -1147,9 +1138,12 @@ void CodeTextEditor::convert_case(CaseStyle p_case) {
 		return;
 	}
 	text_editor->begin_complex_operation();
+	text_editor->begin_multicaret_edit();
 
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-	for (const int &c : caret_edit_order) {
+	for (int c = 0; c < text_editor->get_caret_count(); c++) {
+		if (text_editor->multicaret_edit_ignore_caret(c)) {
+			continue;
+		}
 		if (!text_editor->has_selection(c)) {
 			continue;
 		}
@@ -1190,6 +1184,7 @@ void CodeTextEditor::convert_case(CaseStyle p_case) {
 			text_editor->set_line(i, new_line);
 		}
 	}
+	text_editor->end_multicaret_edit();
 	text_editor->end_complex_operation();
 }
 
@@ -1198,308 +1193,24 @@ void CodeTextEditor::set_indent_using_spaces(bool p_use_spaces) {
 	indentation_txt->set_text(p_use_spaces ? TTR("Spaces", "Indentation") : TTR("Tabs", "Indentation"));
 }
 
-void CodeTextEditor::move_lines_up() {
-	text_editor->begin_complex_operation();
-
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-
-	// Lists of carets representing each group.
-	Vector<Vector<int>> caret_groups;
-	Vector<Pair<int, int>> group_borders;
-
-	// Search for groups of carets and their selections residing on the same lines.
-	for (int i = 0; i < caret_edit_order.size(); i++) {
-		int c = caret_edit_order[i];
-
-		Vector<int> new_group{ c };
-		Pair<int, int> group_border;
-		group_border.first = _get_affected_lines_from(c);
-		group_border.second = _get_affected_lines_to(c);
-
-		for (int j = i; j < caret_edit_order.size() - 1; j++) {
-			int c_current = caret_edit_order[j];
-			int c_next = caret_edit_order[j + 1];
-
-			int next_start_pos = _get_affected_lines_from(c_next);
-			int next_end_pos = _get_affected_lines_to(c_next);
-
-			int current_start_pos = text_editor->has_selection(c_current) ? text_editor->get_selection_from_line(c_current) : text_editor->get_caret_line(c_current);
-
-			i = j;
-			if (next_end_pos != current_start_pos && next_end_pos + 1 != current_start_pos) {
-				break;
-			}
-			group_border.first = next_start_pos;
-			new_group.push_back(c_next);
-			// If the last caret is added to the current group there is no need to process it again.
-			if (j + 1 == caret_edit_order.size() - 1) {
-				i++;
-			}
-		}
-		group_borders.push_back(group_border);
-		caret_groups.push_back(new_group);
-	}
-
-	for (int i = group_borders.size() - 1; i >= 0; i--) {
-		if (group_borders[i].first - 1 < 0) {
-			continue;
-		}
-
-		// If the group starts overlapping with the upper group don't move it.
-		if (i < group_borders.size() - 1 && group_borders[i].first - 1 <= group_borders[i + 1].second) {
-			continue;
-		}
-
-		// We have to remember caret positions and selections prior to line swapping.
-		Vector<Vector<int>> caret_group_parameters;
-
-		for (int j = 0; j < caret_groups[i].size(); j++) {
-			int c = caret_groups[i][j];
-			int cursor_line = text_editor->get_caret_line(c);
-			int cursor_column = text_editor->get_caret_column(c);
-
-			if (!text_editor->has_selection(c)) {
-				caret_group_parameters.push_back(Vector<int>{ -1, -1, -1, -1, cursor_line, cursor_column });
-				continue;
-			}
-			int from_line = text_editor->get_selection_from_line(c);
-			int from_col = text_editor->get_selection_from_column(c);
-			int to_line = text_editor->get_selection_to_line(c);
-			int to_column = text_editor->get_selection_to_column(c);
-			caret_group_parameters.push_back(Vector<int>{ from_line, from_col, to_line, to_column, cursor_line, cursor_column });
-		}
-
-		for (int line_id = group_borders[i].first; line_id <= group_borders[i].second; line_id++) {
-			text_editor->unfold_line(line_id);
-			text_editor->unfold_line(line_id - 1);
-
-			text_editor->swap_lines(line_id - 1, line_id);
-		}
-
-		for (int j = 0; j < caret_groups[i].size(); j++) {
-			int c = caret_groups[i][j];
-			const Vector<int> &caret_parameters = caret_group_parameters[j];
-			text_editor->set_caret_line(caret_parameters[4] - 1, c == 0, true, 0, c);
-			text_editor->set_caret_column(caret_parameters[5], c == 0, c);
-
-			if (caret_parameters[0] >= 0) {
-				text_editor->select(caret_parameters[0] - 1, caret_parameters[1], caret_parameters[2] - 1, caret_parameters[3], c);
-			}
-		}
-	}
-
-	text_editor->end_complex_operation();
-	text_editor->merge_overlapping_carets();
-	text_editor->queue_redraw();
-}
-
-void CodeTextEditor::move_lines_down() {
-	text_editor->begin_complex_operation();
-
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-
-	// Lists of carets representing each group.
-	Vector<Vector<int>> caret_groups;
-	Vector<Pair<int, int>> group_borders;
-	Vector<int> group_border_ends;
-	// Search for groups of carets and their selections residing on the same lines.
-	for (int i = 0; i < caret_edit_order.size(); i++) {
-		int c = caret_edit_order[i];
-
-		Vector<int> new_group{ c };
-		Pair<int, int> group_border;
-		group_border.first = _get_affected_lines_from(c);
-		group_border.second = _get_affected_lines_to(c);
-
-		for (int j = i; j < caret_edit_order.size() - 1; j++) {
-			int c_current = caret_edit_order[j];
-			int c_next = caret_edit_order[j + 1];
-
-			int next_start_pos = _get_affected_lines_from(c_next);
-			int next_end_pos = _get_affected_lines_to(c_next);
-
-			int current_start_pos = text_editor->has_selection(c_current) ? text_editor->get_selection_from_line(c_current) : text_editor->get_caret_line(c_current);
-
-			i = j;
-			if (next_end_pos == current_start_pos || next_end_pos + 1 == current_start_pos) {
-				group_border.first = next_start_pos;
-				new_group.push_back(c_next);
-				// If the last caret is added to the current group there is no need to process it again.
-				if (j + 1 == caret_edit_order.size() - 1) {
-					i++;
-				}
-			} else {
-				break;
-			}
-		}
-		group_borders.push_back(group_border);
-		group_border_ends.push_back(text_editor->has_selection(c) ? text_editor->get_selection_to_line(c) : text_editor->get_caret_line(c));
-		caret_groups.push_back(new_group);
-	}
-
-	for (int i = 0; i < group_borders.size(); i++) {
-		if (group_border_ends[i] + 1 > text_editor->get_line_count() - 1) {
-			continue;
-		}
-
-		// If the group starts overlapping with the upper group don't move it.
-		if (i > 0 && group_border_ends[i] + 1 >= group_borders[i - 1].first) {
-			continue;
-		}
-
-		// We have to remember caret positions and selections prior to line swapping.
-		Vector<Vector<int>> caret_group_parameters;
-
-		for (int j = 0; j < caret_groups[i].size(); j++) {
-			int c = caret_groups[i][j];
-			int cursor_line = text_editor->get_caret_line(c);
-			int cursor_column = text_editor->get_caret_column(c);
-
-			if (!text_editor->has_selection(c)) {
-				caret_group_parameters.push_back(Vector<int>{ -1, -1, -1, -1, cursor_line, cursor_column });
-				continue;
-			}
-			int from_line = text_editor->get_selection_from_line(c);
-			int from_col = text_editor->get_selection_from_column(c);
-			int to_line = text_editor->get_selection_to_line(c);
-			int to_column = text_editor->get_selection_to_column(c);
-			caret_group_parameters.push_back(Vector<int>{ from_line, from_col, to_line, to_column, cursor_line, cursor_column });
-		}
-
-		for (int line_id = group_borders[i].second; line_id >= group_borders[i].first; line_id--) {
-			text_editor->unfold_line(line_id);
-			text_editor->unfold_line(line_id + 1);
-
-			text_editor->swap_lines(line_id + 1, line_id);
-		}
-
-		for (int j = 0; j < caret_groups[i].size(); j++) {
-			int c = caret_groups[i][j];
-			const Vector<int> &caret_parameters = caret_group_parameters[j];
-			text_editor->set_caret_line(caret_parameters[4] + 1, c == 0, true, 0, c);
-			text_editor->set_caret_column(caret_parameters[5], c == 0, c);
-
-			if (caret_parameters[0] >= 0) {
-				text_editor->select(caret_parameters[0] + 1, caret_parameters[1], caret_parameters[2] + 1, caret_parameters[3], c);
-			}
-		}
-	}
-
-	text_editor->merge_overlapping_carets();
-	text_editor->end_complex_operation();
-	text_editor->queue_redraw();
-}
-
-void CodeTextEditor::delete_lines() {
-	text_editor->begin_complex_operation();
-
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-	Vector<int> lines;
-	int last_line = INT_MAX;
-	for (const int &c : caret_edit_order) {
-		for (int line = _get_affected_lines_to(c); line >= _get_affected_lines_from(c); line--) {
-			if (line >= last_line) {
-				continue;
-			}
-			last_line = line;
-			lines.append(line);
-		}
-	}
-
-	for (const int &line : lines) {
-		if (line != text_editor->get_line_count() - 1) {
-			text_editor->remove_text(line, 0, line + 1, 0);
-		} else {
-			text_editor->remove_text(line - 1, text_editor->get_line(line - 1).length(), line, text_editor->get_line(line).length());
-		}
-		// Readjust carets.
-		int new_line = MIN(line, text_editor->get_line_count() - 1);
-		text_editor->unfold_line(new_line);
-		for (const int &c : caret_edit_order) {
-			if (text_editor->get_caret_line(c) == line || (text_editor->get_caret_line(c) == line + 1 && text_editor->get_caret_column(c) == 0)) {
-				text_editor->deselect(c);
-				text_editor->set_caret_line(new_line, c == 0, true, 0, c);
-				continue;
-			}
-			if (text_editor->get_caret_line(c) > line) {
-				text_editor->set_caret_line(text_editor->get_caret_line(c) - 1, c == 0, true, 0, c);
-				continue;
-			}
-			break;
-		}
-	}
-	text_editor->merge_overlapping_carets();
-	text_editor->end_complex_operation();
-}
-
-void CodeTextEditor::duplicate_selection() {
-	text_editor->begin_complex_operation();
-
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-	for (const int &c : caret_edit_order) {
-		const int cursor_column = text_editor->get_caret_column(c);
-		int from_line = text_editor->get_caret_line(c);
-		int to_line = text_editor->get_caret_line(c);
-		int from_column = 0;
-		int to_column = 0;
-		int cursor_new_line = to_line + 1;
-		int cursor_new_column = text_editor->get_caret_column(c);
-		String new_text = "\n" + text_editor->get_line(from_line);
-		bool selection_active = false;
-
-		text_editor->set_caret_column(text_editor->get_line(from_line).length(), c == 0, c);
-		if (text_editor->has_selection(c)) {
-			from_column = text_editor->get_selection_from_column(c);
-			to_column = text_editor->get_selection_to_column(c);
-
-			from_line = text_editor->get_selection_from_line(c);
-			to_line = text_editor->get_selection_to_line(c);
-			cursor_new_line = to_line + text_editor->get_caret_line(c) - from_line;
-			cursor_new_column = to_column == cursor_column ? 2 * to_column - from_column : to_column;
-			new_text = text_editor->get_selected_text(c);
-			selection_active = true;
-
-			text_editor->set_caret_line(to_line, c == 0, true, 0, c);
-			text_editor->set_caret_column(to_column, c == 0, c);
-		}
-
-		for (int i = from_line; i <= to_line; i++) {
-			text_editor->unfold_line(i);
-		}
-		text_editor->deselect(c);
-		text_editor->insert_text_at_caret(new_text, c);
-		text_editor->set_caret_line(cursor_new_line, c == 0, true, 0, c);
-		text_editor->set_caret_column(cursor_new_column, c == 0, c);
-		if (selection_active) {
-			text_editor->select(to_line, to_column, 2 * to_line - from_line, to_line == from_line ? 2 * to_column - from_column : to_column, c);
-		}
-	}
-	text_editor->merge_overlapping_carets();
-	text_editor->end_complex_operation();
-	text_editor->queue_redraw();
-}
-
 void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 	text_editor->begin_complex_operation();
+	text_editor->begin_multicaret_edit();
 
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-	caret_edit_order.reverse();
-	int last_line = -1;
+	Vector<Point2i> line_ranges = text_editor->get_line_ranges_from_carets();
 	int folded_to = 0;
-	for (const int &c1 : caret_edit_order) {
-		int from = _get_affected_lines_from(c1);
-		from += from == last_line ? 1 + folded_to : 0;
-		int to = _get_affected_lines_to(c1);
-		last_line = to;
+	for (Point2i line_range : line_ranges) {
+		int from_line = line_range.x;
+		int to_line = line_range.y;
 		// If last line is folded, extends to the end of the folded section
-		if (text_editor->is_line_folded(to)) {
-			folded_to = text_editor->get_next_visible_line_offset_from(to + 1, 1) - 1;
-			to += folded_to;
+		if (text_editor->is_line_folded(to_line)) {
+			folded_to = text_editor->get_next_visible_line_offset_from(to_line + 1, 1) - 1;
+			to_line += folded_to;
 		}
 		// Check first if there's any uncommented lines in selection.
 		bool is_commented = true;
 		bool is_all_empty = true;
-		for (int line = from; line <= to; line++) {
+		for (int line = from_line; line <= to_line; line++) {
 			// `+ delimiter.length()` here because comment delimiter is not actually `in comment` so we check first character after it
 			int delimiter_idx = text_editor->is_in_comment(line, text_editor->get_first_non_whitespace_column(line) + delimiter.length());
 			// Empty lines should not be counted.
@@ -1515,58 +1226,24 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		// Special case for commenting empty lines, treat it/them as uncommented lines.
 		is_commented = is_commented && !is_all_empty;
 
-		// Caret positions need to be saved since they could be moved at the eol.
-		Vector<int> caret_cols;
-		Vector<int> selection_to_cols;
-		for (const int &c2 : caret_edit_order) {
-			if (text_editor->get_caret_line(c2) >= from && text_editor->get_caret_line(c2) <= to) {
-				caret_cols.append(text_editor->get_caret_column(c2));
-			}
-			if (text_editor->has_selection(c2) && text_editor->get_selection_to_line(c2) >= from && text_editor->get_selection_to_line(c2) <= to) {
-				selection_to_cols.append(text_editor->get_selection_to_column(c2));
-			}
-		}
-
 		// Comment/uncomment.
-		for (int line = from; line <= to; line++) {
-			String line_text = text_editor->get_line(line);
+		for (int line = from_line; line <= to_line; line++) {
 			if (is_all_empty) {
-				text_editor->set_line(line, delimiter);
+				text_editor->insert_text(delimiter, line, 0);
 				continue;
 			}
 
 			if (is_commented) {
-				text_editor->set_line(line, line_text.replace_first(delimiter, ""));
+				int delimiter_column = text_editor->get_line(line).find(delimiter);
+				text_editor->remove_text(line, delimiter_column, line, delimiter_column + delimiter.length());
 			} else {
-				text_editor->set_line(line, line_text.insert(text_editor->get_first_non_whitespace_column(line), delimiter));
-			}
-		}
-
-		// Readjust carets and selections.
-		int caret_i = 0;
-		int selection_i = 0;
-		int offset = (is_commented ? -1 : 1) * delimiter.length();
-		for (const int &c2 : caret_edit_order) {
-			bool is_line_selection = text_editor->has_selection(c2) && text_editor->get_selection_from_line(c2) < text_editor->get_selection_to_line(c2);
-			if (text_editor->get_caret_line(c2) >= from && text_editor->get_caret_line(c2) <= to) {
-				int caret_col = caret_cols[caret_i++];
-				caret_col += (is_line_selection && caret_col == 0) ? 0 : offset;
-				text_editor->set_caret_column(caret_col, c2 == 0, c2);
-			}
-			if (text_editor->has_selection(c2) && text_editor->get_selection_to_line(c2) >= from && text_editor->get_selection_to_line(c2) <= to) {
-				int from_col = text_editor->get_selection_from_column(c2);
-				from_col += (is_line_selection && from_col == 0) ? 0 : offset;
-				int to_col = selection_to_cols[selection_i++];
-				to_col += (to_col == 0) ? 0 : offset;
-				text_editor->select(
-						text_editor->get_selection_from_line(c2), from_col,
-						text_editor->get_selection_to_line(c2), to_col, c2);
+				text_editor->insert_text(delimiter, line, text_editor->get_first_non_whitespace_column(line));
 			}
 		}
 	}
-	text_editor->merge_overlapping_carets();
+
+	text_editor->end_multicaret_edit();
 	text_editor->end_complex_operation();
-	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::goto_line(int p_line) {
@@ -1813,22 +1490,6 @@ void CodeTextEditor::_toggle_scripts_pressed() {
 	update_toggle_scripts_button();
 }
 
-int CodeTextEditor::_get_affected_lines_from(int p_caret) {
-	return text_editor->has_selection(p_caret) ? text_editor->get_selection_from_line(p_caret) : text_editor->get_caret_line(p_caret);
-}
-
-int CodeTextEditor::_get_affected_lines_to(int p_caret) {
-	if (!text_editor->has_selection(p_caret)) {
-		return text_editor->get_caret_line(p_caret);
-	}
-	int line = text_editor->get_selection_to_line(p_caret);
-	// Don't affect a line with no selected characters.
-	if (text_editor->get_selection_to_column(p_caret) == 0) {
-		line--;
-	}
-	return line;
-}
-
 void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
@@ -1877,13 +1538,12 @@ void CodeTextEditor::set_warning_count(int p_warning_count) {
 }
 
 void CodeTextEditor::toggle_bookmark() {
-	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
-	caret_edit_order.reverse();
+	Vector<int> sorted_carets = text_editor->get_sorted_carets();
 	int last_line = -1;
-	for (const int &c : caret_edit_order) {
-		int from = text_editor->has_selection(c) ? text_editor->get_selection_from_line(c) : text_editor->get_caret_line(c);
+	for (const int &c : sorted_carets) {
+		int from = text_editor->get_selection_from_line(c);
 		from += from == last_line ? 1 : 0;
-		int to = text_editor->has_selection(c) ? text_editor->get_selection_to_line(c) : text_editor->get_caret_line(c);
+		int to = text_editor->get_selection_to_line(c);
 		if (to < from) {
 			continue;
 		}

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -207,9 +207,6 @@ class CodeTextEditor : public VBoxContainer {
 
 	void _toggle_scripts_pressed();
 
-	int _get_affected_lines_from(int p_caret);
-	int _get_affected_lines_to(int p_caret);
-
 protected:
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script() {}
@@ -237,11 +234,6 @@ public:
 	void convert_case(CaseStyle p_case);
 
 	void set_indent_using_spaces(bool p_use_spaces);
-
-	void move_lines_up();
-	void move_lines_down();
-	void delete_lines();
-	void duplicate_selection();
 
 	/// Toggle inline comment on currently selected lines, or on current line if nothing is selected,
 	/// by adding or removing comment delimiter

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -380,10 +380,10 @@ void TextEditor::_edit_option(int p_op) {
 			callable_mp((Control *)tx, &Control::grab_focus).call_deferred();
 		} break;
 		case EDIT_MOVE_LINE_UP: {
-			code_editor->move_lines_up();
+			code_editor->get_text_editor()->move_lines_up();
 		} break;
 		case EDIT_MOVE_LINE_DOWN: {
-			code_editor->move_lines_down();
+			code_editor->get_text_editor()->move_lines_down();
 		} break;
 		case EDIT_INDENT: {
 			tx->indent_lines();
@@ -392,24 +392,16 @@ void TextEditor::_edit_option(int p_op) {
 			tx->unindent_lines();
 		} break;
 		case EDIT_DELETE_LINE: {
-			code_editor->delete_lines();
+			code_editor->get_text_editor()->delete_lines();
 		} break;
 		case EDIT_DUPLICATE_SELECTION: {
-			code_editor->duplicate_selection();
+			code_editor->get_text_editor()->duplicate_selection();
 		} break;
 		case EDIT_DUPLICATE_LINES: {
 			code_editor->get_text_editor()->duplicate_lines();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			int previous_line = -1;
-			for (int caret_idx : tx->get_caret_index_edit_order()) {
-				int line_idx = tx->get_caret_line(caret_idx);
-				if (line_idx != previous_line) {
-					tx->toggle_foldable_line(line_idx);
-					previous_line = line_idx;
-				}
-			}
-			tx->queue_redraw();
+			tx->toggle_foldable_lines_at_carets();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
 			tx->fold_all_lines();

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -531,7 +531,7 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 				if (!tx->has_selection()) {
-					tx->set_caret_line(row, true, false);
+					tx->set_caret_line(row, true, false, -1);
 					tx->set_caret_column(col);
 				}
 			}

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1007,7 +1007,7 @@ void TextShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 				if (!tx->has_selection()) {
-					tx->set_caret_line(row, true, false);
+					tx->set_caret_line(row, true, false, -1);
 					tx->set_caret_column(col);
 				}
 			}

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -650,10 +650,10 @@ void TextShaderEditor::_menu_option(int p_option) {
 			code_editor->get_text_editor()->select_all();
 		} break;
 		case EDIT_MOVE_LINE_UP: {
-			code_editor->move_lines_up();
+			code_editor->get_text_editor()->move_lines_up();
 		} break;
 		case EDIT_MOVE_LINE_DOWN: {
-			code_editor->move_lines_down();
+			code_editor->get_text_editor()->move_lines_down();
 		} break;
 		case EDIT_INDENT: {
 			if (shader.is_null() && shader_inc.is_null()) {
@@ -668,10 +668,10 @@ void TextShaderEditor::_menu_option(int p_option) {
 			code_editor->get_text_editor()->unindent_lines();
 		} break;
 		case EDIT_DELETE_LINE: {
-			code_editor->delete_lines();
+			code_editor->get_text_editor()->delete_lines();
 		} break;
 		case EDIT_DUPLICATE_SELECTION: {
-			code_editor->duplicate_selection();
+			code_editor->get_text_editor()->duplicate_selection();
 		} break;
 		case EDIT_DUPLICATE_LINES: {
 			code_editor->get_text_editor()->duplicate_lines();

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -315,3 +315,11 @@ Validate extension JSON: Error: Field 'classes/TextServer/methods/shaped_text_ge
 Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_get_word_breaks/arguments': size changed value in new API, from 2 to 3.
 
 Added optional argument. Compatibility method registered.
+
+
+GH-86978
+--------
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/set_selection_mode/arguments': size changed value in new API, from 4 to 1.
+
+Removed optional arguments set_selection_mode, use set_selection_origin_line/column instead. 
+Compatibility methods registered.

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -624,6 +624,18 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 	return TextEdit::get_cursor_shape(p_pos);
 }
 
+void CodeEdit::_unhide_carets() {
+	// Unfold caret and selection origin.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (_is_line_hidden(get_caret_line(i))) {
+			unfold_line(get_caret_line(i));
+		}
+		if (has_selection(i) && _is_line_hidden(get_selection_origin_line(i))) {
+			unfold_line(get_selection_origin_line(i));
+		}
+	}
+}
+
 /* Text manipulation */
 
 // Overridable actions
@@ -2846,10 +2858,12 @@ void CodeEdit::_gutter_clicked(int p_line, int p_gutter) {
 
 	if (p_gutter == line_number_gutter) {
 		remove_secondary_carets();
-		set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_LINE, p_line, 0);
-		select(p_line, 0, p_line + 1, 0);
-		set_caret_line(p_line + 1);
-		set_caret_column(0);
+		set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_LINE);
+		if (p_line == get_line_count() - 1) {
+			select(p_line, 0, p_line, INT_MAX);
+		} else {
+			select(p_line, 0, p_line + 1, 0);
+		}
 		return;
 	}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -641,9 +641,12 @@ void CodeEdit::_unhide_carets() {
 // Overridable actions
 void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) {
 	start_action(EditAction::ACTION_TYPING);
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
 		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+		if (p_caret == -1 && multicaret_edit_ignore_caret(i)) {
 			continue;
 		}
 
@@ -703,6 +706,7 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 			insert_text_at_caret(chr, i);
 		}
 	}
+	end_multicaret_edit();
 	end_action();
 }
 
@@ -717,64 +721,78 @@ void CodeEdit::_backspace_internal(int p_caret) {
 	}
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
 		if (p_caret != -1 && p_caret != i) {
 			continue;
 		}
-
-		int cc = get_caret_column(i);
-		int cl = get_caret_line(i);
-
-		if (cc == 0 && cl == 0) {
+		if (p_caret == -1 && multicaret_edit_ignore_caret(i)) {
 			continue;
 		}
 
-		if (cl > 0 && _is_line_hidden(cl - 1)) {
-			unfold_line(get_caret_line(i) - 1);
+		int to_line = get_caret_line(i);
+		int to_column = get_caret_column(i);
+
+		if (to_column == 0 && to_line == 0) {
+			continue;
 		}
 
-		int prev_line = cc ? cl : cl - 1;
-		int prev_column = cc ? (cc - 1) : (get_line(cl - 1).length());
+		if (to_line > 0 && _is_line_hidden(to_line - 1)) {
+			unfold_line(to_line - 1);
+		}
 
-		merge_gutters(prev_line, cl);
+		int from_line = to_column > 0 ? to_line : to_line - 1;
+		int from_column = to_column > 0 ? (to_column - 1) : (get_line(to_line - 1).length());
 
-		if (auto_brace_completion_enabled && cc > 0) {
-			int idx = _get_auto_brace_pair_open_at_pos(cl, cc);
+		merge_gutters(from_line, to_line);
+
+		if (auto_brace_completion_enabled && to_column > 0) {
+			int idx = _get_auto_brace_pair_open_at_pos(to_line, to_column);
 			if (idx != -1) {
-				prev_column = cc - auto_brace_completion_pairs[idx].open_key.length();
+				from_column = to_column - auto_brace_completion_pairs[idx].open_key.length();
 
-				if (_get_auto_brace_pair_close_at_pos(cl, cc) == idx) {
-					cc += auto_brace_completion_pairs[idx].close_key.length();
+				if (_get_auto_brace_pair_close_at_pos(to_line, to_column) == idx) {
+					to_column += auto_brace_completion_pairs[idx].close_key.length();
 				}
-
-				remove_text(prev_line, prev_column, cl, cc);
-
-				set_caret_line(prev_line, false, true, 0, i);
-				set_caret_column(prev_column, i == 0, i);
-
-				adjust_carets_after_edit(i, prev_line, prev_column, cl, cc);
-				continue;
 			}
 		}
 
 		// For space indentation we need to do a basic unindent if there are no chars to the left, acting the same way as tabs.
-		if (indent_using_spaces && cc != 0) {
-			if (get_first_non_whitespace_column(cl) >= cc) {
-				prev_column = cc - _calculate_spaces_till_next_left_indent(cc);
-				prev_line = cl;
+		if (indent_using_spaces && to_column != 0) {
+			if (get_first_non_whitespace_column(to_line) >= to_column) {
+				from_column = to_column - _calculate_spaces_till_next_left_indent(to_column);
+				from_line = to_line;
 			}
 		}
 
-		remove_text(prev_line, prev_column, cl, cc);
+		remove_text(from_line, from_column, to_line, to_column);
 
-		set_caret_line(prev_line, false, true, 0, i);
-		set_caret_column(prev_column, i == 0, i);
-
-		adjust_carets_after_edit(i, prev_line, prev_column, cl, cc);
+		set_caret_line(from_line, false, true, -1, i);
+		set_caret_column(from_column, i == 0, i);
 	}
-	merge_overlapping_carets();
+
+	end_multicaret_edit();
 	end_complex_operation();
+}
+
+void CodeEdit::_cut_internal(int p_caret) {
+	// Overridden to unfold lines.
+	_copy_internal(p_caret);
+
+	if (!is_editable()) {
+		return;
+	}
+
+	if (has_selection(p_caret)) {
+		delete_selection(p_caret);
+		return;
+	}
+	if (p_caret == -1) {
+		delete_lines();
+	} else {
+		unfold_line(get_caret_line(p_caret));
+		remove_line_at(get_caret_line(p_caret));
+	}
 }
 
 /* Indent management */
@@ -850,13 +868,17 @@ void CodeEdit::do_indent() {
 	}
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
 		int spaces_to_add = _calculate_spaces_till_next_right_indent(get_caret_column(i));
 		if (spaces_to_add > 0) {
 			insert_text_at_caret(String(" ").repeat(spaces_to_add), i);
 		}
 	}
+	end_multicaret_edit();
 	end_complex_operation();
 }
 
@@ -866,51 +888,28 @@ void CodeEdit::indent_lines() {
 	}
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &c : caret_edit_order) {
-		// This value informs us by how much we changed selection position by indenting right.
-		// Default is 1 for tab indentation.
-		int selection_offset = 1;
+	begin_multicaret_edit();
 
-		int start_line = get_caret_line(c);
-		int end_line = start_line;
-		if (has_selection(c)) {
-			start_line = get_selection_from_line(c);
-			end_line = get_selection_to_line(c);
-
-			// Ignore the last line if the selection is not past the first column.
-			if (get_selection_to_column(c) == 0) {
-				selection_offset = 0;
-				end_line--;
-			}
-		}
-
-		for (int i = start_line; i <= end_line; i++) {
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
+	for (Point2i line_range : line_ranges) {
+		for (int i = line_range.x; i <= line_range.y; i++) {
 			const String line_text = get_line(i);
-			if (line_text.size() == 0 && has_selection(c)) {
+			if (line_text.size() == 0) {
+				// Ignore empty lines.
 				continue;
 			}
 
-			if (!indent_using_spaces) {
-				set_line(i, '\t' + line_text);
-				continue;
+			if (indent_using_spaces) {
+				int spaces_to_add = _calculate_spaces_till_next_right_indent(get_first_non_whitespace_column(i));
+				insert_text(String(" ").repeat(spaces_to_add), i, 0, false);
+			} else {
+				insert_text("\t", i, 0, false);
 			}
-
-			// We don't really care where selection is - we just need to know indentation level at the beginning of the line.
-			// Since we will add this many spaces, we want to move the whole selection and caret by this much.
-			int spaces_to_add = _calculate_spaces_till_next_right_indent(get_first_non_whitespace_column(i));
-			set_line(i, String(" ").repeat(spaces_to_add) + line_text);
-			selection_offset = spaces_to_add;
 		}
-
-		// Fix selection and caret being off after shifting selection right.
-		if (has_selection(c)) {
-			select(start_line, get_selection_from_column(c) + selection_offset, get_selection_to_line(c), get_selection_to_column(c) + selection_offset, c);
-		}
-		set_caret_column(get_caret_column(c) + selection_offset, false, c);
 	}
+
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
 }
 
 void CodeEdit::unindent_lines() {
@@ -919,76 +918,25 @@ void CodeEdit::unindent_lines() {
 	}
 
 	begin_complex_operation();
+	begin_multicaret_edit();
 
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &c : caret_edit_order) {
-		// Moving caret and selection after unindenting can get tricky because
-		// changing content of line can move caret and selection on its own (if new line ends before previous position of either)
-		// therefore we just remember initial values and at the end of the operation offset them by number of removed characters.
-		int removed_characters = 0;
-		int initial_selection_end_column = 0;
-		int initial_cursor_column = get_caret_column(c);
-
-		int start_line = get_caret_line(c);
-		int end_line = start_line;
-		if (has_selection(c)) {
-			start_line = get_selection_from_line(c);
-			end_line = get_selection_to_line(c);
-
-			// Ignore the last line if the selection is not past the first column.
-			initial_selection_end_column = get_selection_to_column(c);
-			if (initial_selection_end_column == 0) {
-				end_line--;
-			}
-		}
-
-		bool first_line_edited = false;
-		bool last_line_edited = false;
-
-		for (int i = start_line; i <= end_line; i++) {
-			String line_text = get_line(i);
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
+	for (Point2i line_range : line_ranges) {
+		for (int i = line_range.x; i <= line_range.y; i++) {
+			const String line_text = get_line(i);
 
 			if (line_text.begins_with("\t")) {
-				line_text = line_text.substr(1, line_text.length());
-
-				set_line(i, line_text);
-				removed_characters = 1;
-
-				first_line_edited = (i == start_line) ? true : first_line_edited;
-				last_line_edited = (i == end_line) ? true : last_line_edited;
-				continue;
-			}
-
-			if (line_text.begins_with(" ")) {
-				// When unindenting we aim to remove spaces before line that has selection no matter what is selected.
-				// Here we remove only enough spaces to align text to nearest full multiple of indentation_size.
-				// In case where selection begins at the start of indentation_size multiple we remove whole indentation level.
+				remove_text(i, 0, i, 1);
+			} else if (line_text.begins_with(" ")) {
+				// Remove only enough spaces to align text to nearest full multiple of indentation_size.
 				int spaces_to_remove = _calculate_spaces_till_next_left_indent(get_first_non_whitespace_column(i));
-				line_text = line_text.substr(spaces_to_remove, line_text.length());
-
-				set_line(i, line_text);
-				removed_characters = spaces_to_remove;
-
-				first_line_edited = (i == start_line) ? true : first_line_edited;
-				last_line_edited = (i == end_line) ? true : last_line_edited;
+				remove_text(i, 0, i, spaces_to_remove);
 			}
 		}
-
-		if (has_selection(c)) {
-			// Fix selection being off by one on the first line.
-			if (first_line_edited) {
-				select(get_selection_from_line(c), get_selection_from_column(c) - removed_characters, get_selection_to_line(c), initial_selection_end_column, c);
-			}
-
-			// Fix selection being off by one on the last line.
-			if (last_line_edited) {
-				select(get_selection_from_line(c), get_selection_from_column(c), get_selection_to_line(c), initial_selection_end_column - removed_characters, c);
-			}
-		}
-		set_caret_column(initial_cursor_column - removed_characters, false, c);
 	}
+
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
 }
 
 void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
@@ -1003,27 +951,6 @@ void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
 	ERR_FAIL_COND(p_from_line >= get_line_count());
 	ERR_FAIL_COND(p_to_line >= get_line_count());
 	ERR_FAIL_COND(p_to_line < p_from_line);
-
-	// Store caret states.
-	Vector<int> caret_columns;
-	Vector<Pair<int, int>> from_selections;
-	Vector<Pair<int, int>> to_selections;
-	caret_columns.resize(get_caret_count());
-	from_selections.resize(get_caret_count());
-	to_selections.resize(get_caret_count());
-	for (int c = 0; c < get_caret_count(); c++) {
-		caret_columns.write[c] = get_caret_column(c);
-
-		// Set "selection_from_line" to -1 to allow checking if there was a selection later.
-		if (!has_selection(c)) {
-			from_selections.write[c].first = -1;
-			continue;
-		}
-		from_selections.write[c].first = get_selection_from_line(c);
-		from_selections.write[c].second = get_selection_from_column(c);
-		to_selections.write[c].first = get_selection_to_line(c);
-		to_selections.write[c].second = get_selection_to_column(c);
-	}
 
 	// Check lines within range.
 	const char32_t from_indent_char = indent_using_spaces ? '\t' : ' ';
@@ -1056,21 +983,8 @@ void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
 			line_changed = true;
 			if (!changed_indentation) {
 				begin_complex_operation();
+				begin_multicaret_edit();
 				changed_indentation = true;
-			}
-
-			// Calculate new caret state.
-			for (int c = 0; c < get_caret_count(); c++) {
-				if (get_caret_line(c) != i || caret_columns[c] <= j) {
-					continue;
-				}
-				caret_columns.write[c] += size_diff;
-
-				if (from_selections.write[c].first == -1) {
-					continue;
-				}
-				from_selections.write[c].second = from_selections[c].first == i ? from_selections[c].second + size_diff : from_selections[c].second;
-				to_selections.write[c].second = to_selections[c].first == i ? to_selections[c].second + size_diff : to_selections[c].second;
 			}
 
 			// Calculate new line.
@@ -1081,6 +995,7 @@ void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
 		}
 
 		if (line_changed) {
+			// Use set line to preserve carets visual position.
 			set_line(i, line);
 		}
 	}
@@ -1089,16 +1004,9 @@ void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
 		return;
 	}
 
-	// Restore caret states.
-	for (int c = 0; c < get_caret_count(); c++) {
-		set_caret_column(caret_columns[c], c == 0, c);
-		if (from_selections.write[c].first != -1) {
-			select(from_selections.write[c].first, from_selections.write[c].second, to_selections.write[c].first, to_selections.write[c].second, c);
-		}
-	}
 	merge_overlapping_carets();
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
 }
 
 int CodeEdit::_calculate_spaces_till_next_left_indent(int p_column) const {
@@ -1119,15 +1027,22 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 	}
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
 		// When not splitting the line, we need to factor in indentation from the end of the current line.
 		const int cc = p_split_current_line ? get_caret_column(i) : get_line(get_caret_line(i)).length();
 		const int cl = get_caret_line(i);
 
 		const String line = get_line(cl);
 
-		String ins = "\n";
+		String ins = "";
+		if (!p_above) {
+			ins = "\n";
+		}
 
 		// Append current indentation.
 		int space_count = 0;
@@ -1149,6 +1064,9 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 				continue;
 			}
 			break;
+		}
+		if (p_above) {
+			ins += "\n";
 		}
 
 		if (is_line_folded(cl)) {
@@ -1195,33 +1113,22 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 			}
 		}
 
-		bool first_line = false;
-		if (!p_split_current_line) {
+		if (p_split_current_line) {
+			insert_text_at_caret(ins, i);
+		} else {
+			insert_text(ins, cl, p_above ? 0 : get_line(cl).length(), p_above, p_above);
 			deselect(i);
-
-			if (p_above) {
-				if (cl > 0) {
-					set_caret_line(cl - 1, false, true, 0, i);
-					set_caret_column(get_line(get_caret_line(i)).length(), i == 0, i);
-				} else {
-					set_caret_column(0, i == 0, i);
-					first_line = true;
-				}
-			} else {
-				set_caret_column(line.length(), i == 0, i);
-			}
+			set_caret_line(p_above ? cl : cl + 1, false, true, -1, i);
+			set_caret_column(get_line(get_caret_line(i)).length(), i == 0, i);
 		}
-
-		insert_text_at_caret(ins, i);
-
-		if (first_line) {
-			set_caret_line(0, i == 0, true, 0, i);
-		} else if (brace_indent) {
+		if (brace_indent) {
+			// Move to inner indented line.
 			set_caret_line(get_caret_line(i) - 1, false, true, 0, i);
 			set_caret_column(get_line(get_caret_line(i)).length(), i == 0, i);
 		}
 	}
 
+	end_multicaret_edit();
 	end_complex_operation();
 }
 
@@ -1712,27 +1619,8 @@ void CodeEdit::fold_line(int p_line) {
 		_set_line_as_hidden(i, true);
 	}
 
-	for (int i = 0; i < get_caret_count(); i++) {
-		// Fix selection.
-		if (has_selection(i)) {
-			if (_is_line_hidden(get_selection_from_line(i)) && _is_line_hidden(get_selection_to_line(i))) {
-				deselect(i);
-			} else if (_is_line_hidden(get_selection_from_line(i))) {
-				select(p_line, 9999, get_selection_to_line(i), get_selection_to_column(i), i);
-			} else if (_is_line_hidden(get_selection_to_line(i))) {
-				select(get_selection_from_line(i), get_selection_from_column(i), p_line, 9999, i);
-			}
-		}
-
-		// Reset caret.
-		if (_is_line_hidden(get_caret_line(i))) {
-			set_caret_line(p_line, false, false, 0, i);
-			set_caret_column(get_line(p_line).length(), false, i);
-		}
-	}
-
-	merge_overlapping_carets();
-	queue_redraw();
+	// Collapse any carets in the hidden area.
+	collapse_carets(p_line, get_line(p_line).length(), end_line, get_line(end_line).length(), true);
 }
 
 void CodeEdit::unfold_line(int p_line) {
@@ -1781,6 +1669,23 @@ void CodeEdit::toggle_foldable_line(int p_line) {
 	fold_line(p_line);
 }
 
+void CodeEdit::toggle_foldable_lines_at_carets() {
+	begin_multicaret_edit();
+	int previous_line = -1;
+	Vector<int> sorted = get_sorted_carets();
+	for (int caret_idx : sorted) {
+		if (multicaret_edit_ignore_caret(caret_idx)) {
+			continue;
+		}
+		int line_idx = get_caret_line(caret_idx);
+		if (line_idx != previous_line) {
+			toggle_foldable_line(line_idx);
+			previous_line = line_idx;
+		}
+	}
+	end_multicaret_edit();
+}
+
 bool CodeEdit::is_line_folded(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), false);
 	return p_line + 1 < get_line_count() && !_is_line_hidden(p_line) && _is_line_hidden(p_line + 1);
@@ -1807,49 +1712,29 @@ void CodeEdit::create_code_region() {
 		WARN_PRINT_ONCE("Cannot create code region without any one line comment delimiters");
 		return;
 	}
-	begin_complex_operation();
-	// Merge selections if selection starts on the same line the previous one ends.
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	Vector<int> carets_to_remove;
-	for (int i = 1; i < caret_edit_order.size(); i++) {
-		int current_caret = caret_edit_order[i - 1];
-		int next_caret = caret_edit_order[i];
-		if (get_selection_from_line(current_caret) == get_selection_to_line(next_caret)) {
-			select(get_selection_from_line(next_caret), get_selection_from_column(next_caret), get_selection_to_line(current_caret), get_selection_to_column(current_caret), next_caret);
-			carets_to_remove.append(current_caret);
-		}
-	}
-	// Sort and remove backwards to preserve indices.
-	carets_to_remove.sort();
-	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
-		remove_caret(carets_to_remove[i]);
-	}
+	String region_name = atr(ETR("New Code Region"));
 
-	// Adding start and end region tags.
-	int first_region_start = -1;
-	for (int caret_idx : get_caret_index_edit_order()) {
-		if (!has_selection(caret_idx)) {
-			continue;
-		}
-		int from_line = get_selection_from_line(caret_idx);
-		if (first_region_start == -1 || from_line < first_region_start) {
-			first_region_start = from_line;
-		}
-		int to_line = get_selection_to_line(caret_idx);
-		set_line(to_line, get_line(to_line) + "\n" + code_region_end_string);
-		insert_line_at(from_line, code_region_start_string + " " + atr(ETR("New Code Region")));
-		fold_line(from_line);
+	begin_complex_operation();
+	begin_multicaret_edit();
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets(true, false);
+
+	// Add start and end region tags.
+	int line_offset = 0;
+	for (Point2i line_range : line_ranges) {
+		insert_text("\n" + code_region_end_string, line_range.y + line_offset, get_line(line_range.y + line_offset).length());
+		insert_line_at(line_range.x + line_offset, code_region_start_string + " " + region_name);
+		fold_line(line_range.x + line_offset);
+		line_offset += 2;
 	}
+	int first_region_start = line_ranges[0].x;
 
 	// Select name of the first region to allow quick edit.
 	remove_secondary_carets();
-	set_caret_line(first_region_start);
-	int tag_length = code_region_start_string.length() + atr(ETR("New Code Region")).length() + 1;
-	set_caret_column(tag_length);
+	int tag_length = code_region_start_string.length() + region_name.length() + 1;
 	select(first_region_start, code_region_start_string.length() + 1, first_region_start, tag_length);
 
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
 }
 
 String CodeEdit::get_code_region_start_tag() const {
@@ -2248,8 +2133,12 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 
 	char32_t caret_last_completion_char = 0;
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
 		int caret_line = get_caret_line(i);
 
 		const String &insert_text = code_completion_options[code_completion_current_selected].insert_text;
@@ -2282,8 +2171,6 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 
 			// Replace.
 			remove_text(caret_line, get_caret_column(i) - code_completion_base.length(), caret_remove_line, caret_col);
-			adjust_carets_after_edit(i, caret_line, caret_col - code_completion_base.length(), caret_remove_line, caret_col);
-			set_caret_column(get_caret_column(i) - code_completion_base.length(), false, i);
 			insert_text_at_caret(insert_text, i);
 		} else {
 			// Get first non-matching char.
@@ -2299,8 +2186,6 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 
 			// Remove base completion text.
 			remove_text(caret_line, get_caret_column(i) - code_completion_base.length(), caret_line, get_caret_column(i));
-			adjust_carets_after_edit(i, caret_line, get_caret_column(i) - code_completion_base.length(), caret_line, get_caret_column(i));
-			set_caret_column(get_caret_column(i) - code_completion_base.length(), false, i);
 
 			// Merge with text.
 			insert_text_at_caret(insert_text.substr(0, code_completion_base.length()), i);
@@ -2325,12 +2210,10 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 		if (has_string_delimiter(String::chr(last_completion_char))) {
 			if (post_brace_pair != -1 && last_char_matches) {
 				remove_text(caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
-				adjust_carets_after_edit(i, caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
 			}
 		} else {
 			if (pre_brace_pair != -1 && pre_brace_pair != post_brace_pair && last_char_matches) {
 				remove_text(caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
-				adjust_carets_after_edit(i, caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
 			} else if (auto_brace_completion_enabled && pre_brace_pair != -1) {
 				insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key, i);
 				set_caret_column(get_caret_column(i) - auto_brace_completion_pairs[pre_brace_pair].close_key.length(), i == 0, i);
@@ -2341,13 +2224,16 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 			pre_brace_pair = _get_auto_brace_pair_open_at_pos(caret_line, get_caret_column(i) + 1);
 			if (pre_brace_pair != -1 && pre_brace_pair == _get_auto_brace_pair_close_at_pos(caret_line, get_caret_column(i) - 1)) {
 				remove_text(caret_line, get_caret_column(i) - 2, caret_line, get_caret_column(i));
-				adjust_carets_after_edit(i, caret_line, get_caret_column(i) - 2, caret_line, get_caret_column(i));
-				if (_get_auto_brace_pair_close_at_pos(caret_line, get_caret_column(i) - 1) != pre_brace_pair) {
-					set_caret_column(get_caret_column(i) - 1, i == 0, i);
+				if (_get_auto_brace_pair_close_at_pos(caret_line, get_caret_column(i) + 1) != pre_brace_pair) {
+					set_caret_column(get_caret_column(i) + 1, i == 0, i);
+				} else {
+					set_caret_column(get_caret_column(i) + 2, i == 0, i);
 				}
 			}
 		}
 	}
+
+	end_multicaret_edit();
 	end_complex_operation();
 
 	cancel_code_completion();
@@ -2430,65 +2316,154 @@ void CodeEdit::set_symbol_lookup_word_as_valid(bool p_valid) {
 }
 
 /* Text manipulation */
-void CodeEdit::duplicate_lines() {
+void CodeEdit::move_lines_up() {
 	begin_complex_operation();
+	begin_multicaret_edit();
 
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &caret_index : caret_edit_order) {
-		// The text that will be inserted. All lines in one string.
-		String insert_text;
-
-		// The new line position of the caret after the operation.
-		int new_caret_line = get_caret_line(caret_index);
-		// The new column position of the caret after the operation.
-		int new_caret_column = get_caret_column(caret_index);
-		// The caret positions of the selection. Stays -1 if there is no selection.
-		int select_from_line = -1;
-		int select_to_line = -1;
-		int select_from_column = -1;
-		int select_to_column = -1;
-		// Number of lines of the selection.
-		int select_num_lines = -1;
-
-		if (has_selection(caret_index)) {
-			select_from_line = get_selection_from_line(caret_index);
-			select_to_line = get_selection_to_line(caret_index);
-			select_from_column = get_selection_from_column(caret_index);
-			select_to_column = get_selection_to_column(caret_index);
-			select_num_lines = select_to_line - select_from_line + 1;
-
-			for (int i = select_from_line; i <= select_to_line; i++) {
-				insert_text += "\n" + get_line(i);
-				unfold_line(i);
-			}
-			new_caret_line = select_to_line + select_num_lines;
-		} else {
-			insert_text = "\n" + get_line(new_caret_line);
-			new_caret_line++;
-
-			unfold_line(get_caret_line(caret_index));
+	// Move lines up by swapping each line with the one above it.
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
+	for (Point2i line_range : line_ranges) {
+		if (line_range.x == 0) {
+			continue;
 		}
-
-		// The text will be inserted at the end of the current line.
-		set_caret_column(get_line(get_caret_line(caret_index)).length(), false, caret_index);
-
-		deselect(caret_index);
-
-		insert_text_at_caret(insert_text, caret_index);
-		set_caret_line(new_caret_line, false, true, 0, caret_index);
-		set_caret_column(new_caret_column, true, caret_index);
-
-		if (select_from_line != -1) {
-			// Advance the selection by the number of duplicated lines.
-			select_from_line += select_num_lines;
-			select_to_line += select_num_lines;
-
-			select(select_from_line, select_from_column, select_to_line, select_to_column, caret_index);
+		unfold_line(line_range.x - 1);
+		for (int line = line_range.x; line <= line_range.y; line++) {
+			unfold_line(line);
+			swap_lines(line - 1, line);
 		}
 	}
 
+	// Fix selection if it ended at column 0, since it wasn't moved.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (has_selection(i) && get_selection_to_column(i) == 0 && get_selection_to_line(i) != 0) {
+			if (is_caret_after_selection_origin(i)) {
+				set_caret_line(get_caret_line(i) - 1, false, true, -1, i);
+			} else {
+				set_selection_origin_line(get_selection_origin_line(i) - 1, true, -1, i);
+			}
+		}
+	}
+
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
+}
+
+void CodeEdit::move_lines_down() {
+	begin_complex_operation();
+	begin_multicaret_edit();
+
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
+
+	// Fix selection if it ended at column 0, since it won't be moved.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (has_selection(i) && get_selection_to_column(i) == 0 && get_selection_to_line(i) != get_line_count() - 1) {
+			if (is_caret_after_selection_origin(i)) {
+				set_caret_line(get_caret_line(i) + 1, false, true, -1, i);
+			} else {
+				set_selection_origin_line(get_selection_origin_line(i) + 1, true, -1, i);
+			}
+		}
+	}
+
+	// Move lines down by swapping each line with the one below it.
+	for (Point2i line_range : line_ranges) {
+		if (line_range.y == get_line_count() - 1) {
+			continue;
+		}
+		unfold_line(line_range.y + 1);
+		for (int line = line_range.y; line >= line_range.x; line--) {
+			unfold_line(line);
+			swap_lines(line + 1, line);
+		}
+	}
+
+	end_multicaret_edit();
+	end_complex_operation();
+}
+
+void CodeEdit::delete_lines() {
+	begin_complex_operation();
+	begin_multicaret_edit();
+
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
+	int line_offset = 0;
+	for (Point2i line_range : line_ranges) {
+		// Remove last line of range separately to preserve carets.
+		unfold_line(line_range.y + line_offset);
+		remove_line_at(line_range.y + line_offset);
+		if (line_range.x != line_range.y) {
+			remove_text(line_range.x + line_offset, 0, line_range.y + line_offset, 0);
+		}
+		line_offset += line_range.x - line_range.y - 1;
+	}
+
+	// Deselect all.
+	deselect();
+
+	end_multicaret_edit();
+	end_complex_operation();
+}
+
+void CodeEdit::duplicate_selection() {
+	begin_complex_operation();
+	begin_multicaret_edit();
+
+	// Duplicate lines from carets without selections first.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
+		for (int l = get_selection_from_line(i); l <= get_selection_to_line(i); l++) {
+			unfold_line(l);
+		}
+		if (has_selection(i)) {
+			continue;
+		}
+
+		String text_to_insert = get_line(get_caret_line(i)) + "\n";
+		// Insert new text before the line, so the caret is on the second one.
+		insert_text(text_to_insert, get_caret_line(i), 0);
+	}
+
+	// Duplicate selections.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
+		if (!has_selection(i)) {
+			continue;
+		}
+
+		// Insert new text before the selection, so the caret is on the second one.
+		insert_text(get_selected_text(i), get_selection_from_line(i), get_selection_from_column(i));
+	}
+
+	end_multicaret_edit();
+	end_complex_operation();
+}
+
+void CodeEdit::duplicate_lines() {
+	begin_complex_operation();
+	begin_multicaret_edit();
+
+	Vector<Point2i> line_ranges = get_line_ranges_from_carets(false, false);
+	int line_offset = 0;
+	for (Point2i line_range : line_ranges) {
+		// The text that will be inserted. All lines in one string.
+		String text_to_insert;
+
+		for (int i = line_range.x + line_offset; i <= line_range.y + line_offset; i++) {
+			text_to_insert += get_line(i) + "\n";
+			unfold_line(i);
+		}
+
+		// Insert new text before the line.
+		insert_text(text_to_insert, line_range.x + line_offset, 0);
+		line_offset += line_range.y - line_range.x + 1;
+	}
+
+	end_multicaret_edit();
+	end_complex_operation();
 }
 
 /* Visual */
@@ -2590,6 +2565,7 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("fold_all_lines"), &CodeEdit::fold_all_lines);
 	ClassDB::bind_method(D_METHOD("unfold_all_lines"), &CodeEdit::unfold_all_lines);
 	ClassDB::bind_method(D_METHOD("toggle_foldable_line", "line"), &CodeEdit::toggle_foldable_line);
+	ClassDB::bind_method(D_METHOD("toggle_foldable_lines_at_carets"), &CodeEdit::toggle_foldable_lines_at_carets);
 
 	ClassDB::bind_method(D_METHOD("is_line_folded", "line"), &CodeEdit::is_line_folded);
 	ClassDB::bind_method(D_METHOD("get_folded_lines"), &CodeEdit::get_folded_lines);
@@ -2691,6 +2667,10 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_symbol_lookup_word_as_valid", "valid"), &CodeEdit::set_symbol_lookup_word_as_valid);
 
 	/* Text manipulation */
+	ClassDB::bind_method(D_METHOD("move_lines_up"), &CodeEdit::move_lines_up);
+	ClassDB::bind_method(D_METHOD("move_lines_down"), &CodeEdit::move_lines_down);
+	ClassDB::bind_method(D_METHOD("delete_lines"), &CodeEdit::delete_lines);
+	ClassDB::bind_method(D_METHOD("duplicate_selection"), &CodeEdit::duplicate_selection);
 	ClassDB::bind_method(D_METHOD("duplicate_lines"), &CodeEdit::duplicate_lines);
 
 	/* Inspector */

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -309,6 +309,8 @@ protected:
 	static void _bind_compatibility_methods();
 #endif
 
+	virtual void _unhide_carets() override;
+
 	/* Text manipulation */
 
 	// Overridable actions

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -316,6 +316,7 @@ protected:
 	// Overridable actions
 	virtual void _handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) override;
 	virtual void _backspace_internal(int p_caret) override;
+	virtual void _cut_internal(int p_caret) override;
 
 	GDVIRTUAL1(_confirm_code_completion, bool)
 	GDVIRTUAL1(_request_code_completion, bool)
@@ -411,6 +412,7 @@ public:
 	void fold_all_lines();
 	void unfold_all_lines();
 	void toggle_foldable_line(int p_line);
+	void toggle_foldable_lines_at_carets();
 
 	bool is_line_folded(int p_line) const;
 	TypedArray<int> get_folded_lines() const;
@@ -491,6 +493,10 @@ public:
 	void set_symbol_lookup_word_as_valid(bool p_valid);
 
 	/* Text manipulation */
+	void move_lines_up();
+	void move_lines_down();
+	void delete_lines();
+	void duplicate_selection();
 	void duplicate_lines();
 
 	CodeEdit();

--- a/scene/gui/text_edit.compat.inc
+++ b/scene/gui/text_edit.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  text_edit.compat.inc                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void TextEdit::_set_selection_mode_compat_86978(SelectionMode p_mode, int p_line, int p_column, int p_caret) {
+	set_selection_mode(p_mode);
+}
+
+void TextEdit::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_selection_mode", "mode", "line", "column", "caret_index"), &TextEdit::_set_selection_mode_compat_86978, DEFVAL(-1), DEFVAL(-1), DEFVAL(0));
+}
+
+#endif

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "text_edit.h"
+#include "text_edit.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
@@ -1771,13 +1772,12 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 						// Remove caret at clicked location.
 						if (get_caret_count() > 1) {
-							for (int i = 0; i < get_caret_count(); i++) {
-								// Deselect if clicked on caret or its selection.
-								if (_selection_contains(i, line, col, true, false)) {
-									remove_caret(i);
-									last_dblclk = 0;
-									return;
-								}
+							// Deselect if clicked on caret or its selection.
+							int clicked_caret = get_selection_at_line_column(line, col, true, false);
+							if (clicked_caret != -1) {
+								remove_caret(clicked_caret);
+								last_dblclk = 0;
+								return;
 							}
 						}
 
@@ -2302,30 +2302,24 @@ void TextEdit::_new_line(bool p_split_current_line, bool p_above) {
 	}
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
-		bool first_line = false;
-		if (!p_split_current_line) {
-			deselect(i);
-			if (p_above) {
-				if (get_caret_line(i) > 0) {
-					set_caret_line(get_caret_line(i) - 1, false, true, 0, i);
-					set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
-				} else {
-					set_caret_column(0, i == 0, i);
-					first_line = true;
-				}
-			} else {
-				set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
-			}
+	begin_multicaret_edit();
+
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (multicaret_edit_ignore_caret(i)) {
+			continue;
 		}
-
-		insert_text_at_caret("\n", i);
-
-		if (first_line) {
-			set_caret_line(0, i == 0, true, 0, i);
+		if (p_split_current_line) {
+			insert_text_at_caret("\n", i);
+		} else {
+			int line = get_caret_line(i);
+			insert_text("\n", line, p_above ? 0 : text[line].length(), p_above, p_above);
+			deselect(i);
+			set_caret_line(p_above ? line : line + 1, false, true, -1, i);
+			set_caret_column(0, i == 0, i);
 		}
 	}
+
+	end_multicaret_edit();
 	end_complex_operation();
 }
 
@@ -2585,58 +2579,47 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 	}
 
 	start_action(EditAction::ACTION_BACKSPACE);
-	Vector<int> carets_to_remove;
+	begin_multicaret_edit();
 
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int i = 0; i < caret_edit_order.size(); i++) {
-		int caret_idx = caret_edit_order[i];
-		if (get_caret_column(caret_idx) == 0 && get_caret_line(caret_idx) == 0 && !has_selection(caret_idx)) {
+	Vector<int> sorted_carets = get_sorted_carets();
+	sorted_carets.reverse();
+	for (int i = 0; i < sorted_carets.size(); i++) {
+		int caret_index = sorted_carets[i];
+		if (multicaret_edit_ignore_caret(caret_index)) {
 			continue;
 		}
 
-		if (has_selection(caret_idx) || (!p_all_to_left && !p_word) || get_caret_column(caret_idx) == 0) {
-			backspace(caret_idx);
+		if (get_caret_column(caret_index) == 0 && get_caret_line(caret_index) == 0 && !has_selection(caret_index)) {
+			continue;
+		}
+
+		if (has_selection(caret_index) || (!p_all_to_left && !p_word) || get_caret_column(caret_index) == 0) {
+			backspace(caret_index);
 			continue;
 		}
 
 		if (p_all_to_left) {
-			int caret_current_column = get_caret_column(caret_idx);
-			set_caret_column(0, caret_idx == 0, caret_idx);
-			_remove_text(get_caret_line(caret_idx), 0, get_caret_line(caret_idx), caret_current_column);
-			adjust_carets_after_edit(caret_idx, get_caret_line(caret_idx), caret_current_column, get_caret_line(caret_idx), get_caret_column(caret_idx));
-
-			// Check for any overlapping carets since we removed the entire line.
-			for (int j = i + 1; j < caret_edit_order.size(); j++) {
-				// Selection only end on this line, only the one as carets cannot overlap.
-				if (has_selection(caret_edit_order[j]) && get_selection_from_line(caret_edit_order[j]) != get_caret_line(caret_idx) && get_selection_to_line(caret_edit_order[j]) == get_caret_line(caret_idx)) {
-					carets.write[caret_edit_order[j]].selection.to_column = 0;
-					break;
-				}
-
-				// Check for caret.
-				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx) || (has_selection(caret_edit_order[j]) && get_selection_from_line(caret_edit_order[j]) != get_caret_line(caret_idx))) {
-					break;
-				}
-
-				deselect(caret_edit_order[j]);
-				carets_to_remove.push_back(caret_edit_order[j]);
-				set_caret_column(0, caret_idx == 0, caret_idx);
-				i = j;
-			}
+			// Remove everything to left of caret to the start of the line.
+			int caret_current_column = get_caret_column(caret_index);
+			_remove_text(get_caret_line(caret_index), 0, get_caret_line(caret_index), caret_current_column);
+			collapse_carets(get_caret_line(caret_index), 0, get_caret_line(caret_index), caret_current_column);
+			set_caret_column(0, caret_index == 0, caret_index);
+			_offset_carets_after(get_caret_line(caret_index), caret_current_column, get_caret_line(caret_index), 0);
 			continue;
 		}
 
 		if (p_word) {
-			// Save here as the caret may change when resolving overlaps.
-			int from_column = get_caret_column(caret_idx);
-			int column = get_caret_column(caret_idx);
+			// Remove text to the start of the word left of the caret.
+			int from_column = get_caret_column(caret_index);
+			int column = get_caret_column(caret_index);
 			// Check for the case "<word><space><caret>" and ignore the space.
 			// No need to check for column being 0 since it is checked above.
-			if (is_whitespace(text[get_caret_line(caret_idx)][get_caret_column(caret_idx) - 1])) {
+			if (is_whitespace(text[get_caret_line(caret_index)][get_caret_column(caret_index) - 1])) {
 				column -= 1;
 			}
+
 			// Get a list with the indices of the word bounds of the given text line.
-			const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(caret_idx))->get_rid());
+			const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(caret_index))->get_rid());
 			if (words.is_empty() || column <= words[0]) {
 				// If "words" is empty, meaning no words are left, we can remove everything until the beginning of the line.
 				column = 0;
@@ -2650,57 +2633,14 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 				}
 			}
 
-			// Check for any other carets in this range.
-			int overlapping_caret_index = -1;
-			for (int j = i + 1; j < caret_edit_order.size(); j++) {
-				// Check caret and selection in on the right line.
-				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx) && (!has_selection(caret_edit_order[j]) || get_selection_to_line(caret_edit_order[j]) != get_caret_line(caret_idx))) {
-					break;
-				}
-
-				// If it has a selection, check it ends with in the range.
-				if ((has_selection(caret_edit_order[j]) && get_selection_to_column(caret_edit_order[j]) < column)) {
-					break;
-				}
-
-				// If it has a selection and it starts outside our word, we need to adjust the selection, and handle it later to prevent overlap.
-				if ((has_selection(caret_edit_order[j]) && get_selection_from_column(caret_edit_order[j]) < column)) {
-					carets.write[caret_edit_order[j]].selection.to_column = column;
-					overlapping_caret_index = caret_edit_order[j];
-					break;
-				}
-
-				// Otherwise we can remove it.
-				if (get_caret_column(caret_edit_order[j]) > column || (has_selection(caret_edit_order[j]) && get_selection_from_column(caret_edit_order[j]) > column)) {
-					deselect(caret_edit_order[j]);
-					carets_to_remove.push_back(caret_edit_order[j]);
-					set_caret_column(0, caret_idx == 0, caret_idx);
-					i = j;
-				}
-			}
-
-			_remove_text(get_caret_line(caret_idx), column, get_caret_line(caret_idx), from_column);
-
-			set_caret_line(get_caret_line(caret_idx), false, true, 0, caret_idx);
-			set_caret_column(column, caret_idx == 0, caret_idx);
-			adjust_carets_after_edit(caret_idx, get_caret_line(caret_idx), column, get_caret_line(caret_idx), from_column);
-
-			// Now we can clean up the overlapping caret.
-			if (overlapping_caret_index != -1) {
-				backspace(overlapping_caret_index);
-				i++;
-				carets_to_remove.push_back(overlapping_caret_index);
-				set_caret_column(get_caret_column(overlapping_caret_index), caret_idx == 0, caret_idx);
-			}
-			continue;
+			_remove_text(get_caret_line(caret_index), column, get_caret_line(caret_index), from_column);
+			collapse_carets(get_caret_line(caret_index), column, get_caret_line(caret_index), from_column);
+			set_caret_column(column, caret_index == 0, caret_index);
+			_offset_carets_after(get_caret_line(caret_index), from_column, get_caret_line(caret_index), column);
 		}
 	}
 
-	// Sort and remove backwards to preserve indexes.
-	carets_to_remove.sort();
-	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
-		remove_caret(carets_to_remove[i]);
-	}
+	end_multicaret_edit();
 	end_action();
 }
 
@@ -2710,61 +2650,40 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 	}
 
 	start_action(EditAction::ACTION_DELETE);
-	Vector<int> carets_to_remove;
+	begin_multicaret_edit();
 
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int i = 0; i < caret_edit_order.size(); i++) {
-		int caret_idx = caret_edit_order[i];
-		if (has_selection(caret_idx)) {
-			delete_selection(caret_idx);
+	Vector<int> sorted_carets = get_sorted_carets();
+	for (int i = 0; i < sorted_carets.size(); i++) {
+		int caret_index = sorted_carets[i];
+		if (multicaret_edit_ignore_caret(caret_index)) {
 			continue;
 		}
-		int curline_len = text[get_caret_line(caret_idx)].length();
 
-		if (get_caret_line(caret_idx) == text.size() - 1 && get_caret_column(caret_idx) == curline_len) {
+		if (has_selection(caret_index)) {
+			delete_selection(caret_index);
+			continue;
+		}
+
+		int curline_len = text[get_caret_line(caret_index)].length();
+		if (get_caret_line(caret_index) == text.size() - 1 && get_caret_column(caret_index) == curline_len) {
 			continue; // Last line, last column: Nothing to do.
 		}
 
-		int next_line = get_caret_column(caret_idx) < curline_len ? get_caret_line(caret_idx) : get_caret_line(caret_idx) + 1;
+		int next_line = get_caret_column(caret_index) < curline_len ? get_caret_line(caret_index) : get_caret_line(caret_index) + 1;
 		int next_column;
 
 		if (p_all_to_right) {
-			// Get caret furthest to the left.
-			for (int j = i + 1; j < caret_edit_order.size(); j++) {
-				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
-					break;
-				}
-
-				if (has_selection(caret_edit_order[j]) && get_selection_from_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
-					break;
-				}
-
-				if (!has_selection(caret_edit_order[j])) {
-					i = j;
-					caret_idx = caret_edit_order[i];
-				}
-			}
-
-			if (get_caret_column(caret_idx) == curline_len) {
+			if (get_caret_column(caret_index) == curline_len) {
 				continue;
 			}
 
 			// Delete everything to right of caret.
 			next_column = curline_len;
-			next_line = get_caret_line(caret_idx);
-
-			// Remove overlapping carets.
-			for (int j = i - 1; j >= 0; j--) {
-				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
-					break;
-				}
-				carets_to_remove.push_back(caret_edit_order[j]);
-			}
-
-		} else if (p_word && get_caret_column(caret_idx) < curline_len - 1) {
+			next_line = get_caret_line(caret_index);
+		} else if (p_word && get_caret_column(caret_index) < curline_len - 1) {
 			// Delete next word to right of caret.
-			int line = get_caret_line(caret_idx);
-			int column = get_caret_column(caret_idx);
+			int line = get_caret_line(caret_index);
+			int column = get_caret_column(caret_index);
 
 			PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(line)->get_rid());
 			for (int j = 1; j < words.size(); j = j + 2) {
@@ -2776,49 +2695,22 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 
 			next_line = line;
 			next_column = column;
-
-			// Remove overlapping carets.
-			for (int j = i - 1; j >= 0; j--) {
-				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
-					break;
-				}
-
-				if (get_caret_column(caret_edit_order[j]) > column) {
-					break;
-				}
-				carets_to_remove.push_back(caret_edit_order[j]);
-			}
 		} else {
 			// Delete one character.
 			if (caret_mid_grapheme_enabled) {
-				next_column = get_caret_column(caret_idx) < curline_len ? (get_caret_column(caret_idx) + 1) : 0;
+				next_column = get_caret_column(caret_index) < curline_len ? (get_caret_column(caret_index) + 1) : 0;
 			} else {
-				next_column = get_caret_column(caret_idx) < curline_len ? TS->shaped_text_next_character_pos(text.get_line_data(get_caret_line(caret_idx))->get_rid(), (get_caret_column(caret_idx))) : 0;
-			}
-
-			// Remove overlapping carets.
-			if (i > 0) {
-				int prev_caret_idx = caret_edit_order[i - 1];
-				if (get_caret_line(prev_caret_idx) == next_line && get_caret_column(prev_caret_idx) == next_column) {
-					carets_to_remove.push_back(prev_caret_idx);
-				}
+				next_column = get_caret_column(caret_index) < curline_len ? TS->shaped_text_next_character_pos(text.get_line_data(get_caret_line(caret_index))->get_rid(), (get_caret_column(caret_index))) : 0;
 			}
 		}
 
-		_remove_text(get_caret_line(caret_idx), get_caret_column(caret_idx), next_line, next_column);
-		adjust_carets_after_edit(caret_idx, get_caret_line(caret_idx), get_caret_column(caret_idx), next_line, next_column);
+		_remove_text(get_caret_line(caret_index), get_caret_column(caret_index), next_line, next_column);
+		collapse_carets(get_caret_line(caret_index), get_caret_column(caret_index), next_line, next_column);
+		_offset_carets_after(next_line, next_column, get_caret_line(caret_index), get_caret_column(caret_index));
 	}
 
-	// Sort and remove backwards to preserve indexes.
-	carets_to_remove.sort();
-	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
-		remove_caret(carets_to_remove[i]);
-	}
-
-	// If we are deleting from the end of a line, due to column preservation we could still overlap with another caret.
-	merge_overlapping_carets();
+	end_multicaret_edit();
 	end_action();
-	queue_redraw();
 }
 
 void TextEdit::_move_caret_document_start(bool p_select) {
@@ -2858,51 +2750,6 @@ bool TextEdit::_clear_carets_and_selection() {
 	}
 
 	return false;
-}
-
-void TextEdit::_get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x) const {
-	if (p_last_fit_x == -1) {
-		p_last_fit_x = _get_column_x_offset_for_line(p_old_column, p_old_line, p_old_column);
-	}
-
-	// Calculate the new line and wrap index.
-	p_new_line = p_old_line;
-	int caret_wrap_index = p_old_wrap_index;
-	if (p_below) {
-		if (caret_wrap_index < get_line_wrap_count(p_new_line)) {
-			caret_wrap_index++;
-		} else {
-			p_new_line++;
-			caret_wrap_index = 0;
-		}
-	} else {
-		if (caret_wrap_index == 0) {
-			p_new_line--;
-			caret_wrap_index = get_line_wrap_count(p_new_line);
-		} else {
-			caret_wrap_index--;
-		}
-	}
-
-	// Boundary checks.
-	if (p_new_line < 0) {
-		p_new_line = 0;
-	}
-	if (p_new_line >= text.size()) {
-		p_new_line = text.size() - 1;
-	}
-
-	p_new_column = _get_char_pos_for_line(p_last_fit_x, p_new_line, caret_wrap_index);
-	if (p_new_column != 0 && get_line_wrapping_mode() != LineWrappingMode::LINE_WRAPPING_NONE && caret_wrap_index < get_line_wrap_count(p_new_line)) {
-		Vector<String> rows = get_line_wrapped_text(p_new_line);
-		int row_end_col = 0;
-		for (int i = 0; i < caret_wrap_index + 1; i++) {
-			row_end_col += rows[i].length();
-		}
-		if (p_new_column >= row_end_col) {
-			p_new_column -= 1;
-		}
-	}
 }
 
 void TextEdit::_update_placeholder() {
@@ -3070,53 +2917,48 @@ void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 
 	if (p_data.get_type() == Variant::STRING && is_editable()) {
 		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
-		int caret_row_tmp = pos.y;
-		int caret_column_tmp = pos.x;
-		if (selection_drag_attempt) {
+		int drop_at_line = pos.y;
+		int drop_at_column = pos.x;
+		int selection_index = get_selection_at_line_column(drop_at_line, drop_at_column, !Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL));
+
+		// Remove drag caret before the complex operation starts so it won't appear in undo.
+		remove_caret(drag_caret_index);
+
+		if (selection_drag_attempt && selection_index >= 0 && selection_index == drag_and_drop_origin_caret_index) {
+			// Dropped onto original selection, do nothing.
 			selection_drag_attempt = false;
-			if (!is_mouse_over_selection(!Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL))) {
-				// Set caret back at selection for undo / redo.
-				set_caret_line(get_selection_to_line(), false, false);
-				set_caret_column(get_selection_to_column());
+			return;
+		}
 
-				begin_complex_operation();
-				if (!Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
-					if (caret_row_tmp > get_selection_to_line()) {
-						caret_row_tmp = caret_row_tmp - (get_selection_to_line() - get_selection_from_line());
-					} else if (caret_row_tmp == get_selection_to_line() && caret_column_tmp >= get_selection_to_column()) {
-						caret_column_tmp = caret_column_tmp - (get_selection_to_column() - get_selection_from_column());
-					}
-					delete_selection();
-				} else {
-					deselect();
-				}
+		begin_complex_operation();
+		begin_multicaret_edit();
+		if (selection_drag_attempt) {
+			// Drop from self.
+			selection_drag_attempt = false;
+			if (!Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
+				// Delete all selections.
+				int temp_caret = add_caret(drop_at_line, drop_at_column);
 
-				remove_secondary_carets();
-				set_caret_line(caret_row_tmp, true, false);
-				set_caret_column(caret_column_tmp);
-				insert_text_at_caret(p_data);
-				end_complex_operation();
+				delete_selection();
+
+				// Use a temporary caret to update the drop at position.
+				drop_at_line = get_caret_line(temp_caret);
+				drop_at_column = get_caret_column(temp_caret);
 			}
-		} else if (is_mouse_over_selection()) {
-			remove_secondary_carets();
-			caret_row_tmp = get_selection_from_line();
-			caret_column_tmp = get_selection_from_column();
-			set_caret_line(caret_row_tmp, true, false);
-			set_caret_column(caret_column_tmp);
-			insert_text_at_caret(p_data);
-			grab_focus();
-		} else {
-			remove_secondary_carets();
-			deselect();
-			set_caret_line(caret_row_tmp, true, false);
-			set_caret_column(caret_column_tmp);
-			insert_text_at_caret(p_data);
-			grab_focus();
 		}
+		remove_secondary_carets();
+		deselect();
 
-		if (caret_row_tmp != get_caret_line() || caret_column_tmp != get_caret_column()) {
-			select(caret_row_tmp, caret_column_tmp, get_caret_line(), get_caret_column());
-		}
+		// Insert the dragged text.
+		set_caret_line(drop_at_line, true, false, -1);
+		set_caret_column(drop_at_column);
+		insert_text_at_caret(p_data);
+
+		select(drop_at_line, drop_at_column, get_caret_line(), get_caret_column());
+		grab_focus();
+		adjust_viewport_to_caret();
+		end_multicaret_edit();
+		end_complex_operation();
 	}
 }
 
@@ -3475,17 +3317,36 @@ void TextEdit::set_line(int p_line, const String &p_new_text) {
 		return;
 	}
 	begin_complex_operation();
-	_remove_text(p_line, 0, p_line, text[p_line].length());
-	_insert_text(p_line, 0, p_new_text);
-	for (int i = 0; i < carets.size(); i++) {
-		if (get_caret_line(i) == p_line && get_caret_column(i) > p_new_text.length()) {
-			set_caret_column(p_new_text.length(), false, i);
-		}
 
-		if (has_selection(i) && p_line == get_selection_to_line(i) && get_selection_to_column(i) > text[p_line].length()) {
-			carets.write[i].selection.to_column = text[p_line].length();
+	int old_column = text[p_line].length();
+
+	// Set the affected carets column to update their last offset x.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (_is_line_col_in_range(get_caret_line(i), get_caret_column(i), p_line, 0, p_line, old_column)) {
+			set_caret_column(get_caret_column(i), false, i);
+		}
+		if (has_selection(i) && _is_line_col_in_range(get_selection_origin_line(i), get_selection_origin_column(i), p_line, 0, p_line, old_column)) {
+			set_selection_origin_column(get_selection_origin_column(i), i);
 		}
 	}
+
+	_remove_text(p_line, 0, p_line, old_column);
+	int new_line, new_column;
+	_insert_text(p_line, 0, p_new_text, &new_line, &new_column);
+
+	// Don't offset carets that were on the old line.
+	_offset_carets_after(p_line, old_column, new_line, new_column, false, false);
+
+	// Set the caret lines to update the column to match visually.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (_is_line_col_in_range(get_caret_line(i), get_caret_column(i), p_line, 0, p_line, old_column)) {
+			set_caret_line(get_caret_line(i), false, true, 0, i);
+		}
+		if (has_selection(i) && _is_line_col_in_range(get_selection_origin_line(i), get_selection_origin_column(i), p_line, 0, p_line, old_column)) {
+			set_selection_origin_line(get_selection_origin_line(i), true, 0, i);
+		}
+	}
+	merge_overlapping_carets();
 	end_complex_operation();
 }
 
@@ -3539,47 +3400,126 @@ void TextEdit::swap_lines(int p_from_line, int p_to_line) {
 	ERR_FAIL_INDEX(p_from_line, text.size());
 	ERR_FAIL_INDEX(p_to_line, text.size());
 
-	String tmp = get_line(p_from_line);
-	String tmp2 = get_line(p_to_line);
+	if (p_from_line == p_to_line) {
+		return;
+	}
+
+	String from_line_text = get_line(p_from_line);
+	String to_line_text = get_line(p_to_line);
 	begin_complex_operation();
-	set_line(p_to_line, tmp);
-	set_line(p_from_line, tmp2);
+	begin_multicaret_edit();
+	// Don't use set_line to avoid clamping and updating carets.
+	_remove_text(p_to_line, 0, p_to_line, text[p_to_line].length());
+	_insert_text(p_to_line, 0, from_line_text);
+	_remove_text(p_from_line, 0, p_from_line, text[p_from_line].length());
+	_insert_text(p_from_line, 0, to_line_text);
+
+	// Swap carets.
+	for (int i = 0; i < get_caret_count(); i++) {
+		bool selected = has_selection(i);
+		if (get_caret_line(i) == p_from_line || get_caret_line(i) == p_to_line) {
+			int caret_new_line = get_caret_line(i) == p_from_line ? p_to_line : p_from_line;
+			int caret_column = get_caret_column(i);
+			set_caret_line(caret_new_line, false, true, -1, i);
+			set_caret_column(caret_column, false, i);
+		}
+		if (selected && (get_selection_origin_line(i) == p_from_line || get_selection_origin_line(i) == p_to_line)) {
+			int origin_new_line = get_selection_origin_line(i) == p_from_line ? p_to_line : p_from_line;
+			int origin_column = get_selection_origin_column(i);
+			select(origin_new_line, origin_column, get_caret_line(i), get_caret_column(i), i);
+		}
+	}
+	// If only part of a selection was changed, it may now overlap.
+	merge_overlapping_carets();
+
+	end_multicaret_edit();
 	end_complex_operation();
 }
 
-void TextEdit::insert_line_at(int p_at, const String &p_text) {
-	ERR_FAIL_INDEX(p_at, text.size());
+void TextEdit::insert_line_at(int p_line, const String &p_text) {
+	ERR_FAIL_INDEX(p_line, text.size());
 
-	_insert_text(p_at, 0, p_text + "\n");
+	// Use a complex operation so subsequent calls aren't merged together.
+	begin_complex_operation();
 
-	for (int i = 0; i < carets.size(); i++) {
-		if (get_caret_line(i) >= p_at) {
-			// Offset caret when located after inserted line.
-			set_caret_line(get_caret_line(i) + 1, false, true, 0, i);
-		}
-		if (has_selection(i)) {
-			if (get_selection_from_line(i) >= p_at) {
-				// Offset selection when located after inserted line.
-				select(get_selection_from_line(i) + 1, get_selection_from_column(i), get_selection_to_line(i) + 1, get_selection_to_column(i), i);
-			} else if (get_selection_to_line(i) >= p_at) {
-				// Extend selection that includes inserted line.
-				select(get_selection_from_line(i), get_selection_from_column(i), get_selection_to_line(i) + 1, get_selection_to_column(i), i);
+	int new_line, new_column;
+	_insert_text(p_line, 0, p_text + "\n", &new_line, &new_column);
+	_offset_carets_after(p_line, 0, new_line, new_column);
+
+	end_complex_operation();
+}
+
+void TextEdit::remove_line_at(int p_line, bool p_move_carets_down) {
+	ERR_FAIL_INDEX(p_line, text.size());
+
+	if (get_line_count() == 1) {
+		// Only one line, just remove contents.
+		begin_complex_operation();
+		int line_length = get_line(p_line).length();
+		_remove_text(p_line, 0, p_line, line_length);
+		collapse_carets(p_line, 0, p_line, line_length, true);
+		end_complex_operation();
+		return;
+	}
+
+	begin_complex_operation();
+
+	bool is_last_line = p_line == get_line_count() - 1;
+	int from_line = is_last_line ? p_line - 1 : p_line;
+	int next_line = is_last_line ? p_line : p_line + 1;
+	int from_column = is_last_line ? get_line(from_line).length() : 0;
+	int next_column = is_last_line ? get_line(next_line).length() : 0;
+
+	if ((!is_last_line && p_move_carets_down) || (p_line != 0 && !p_move_carets_down)) {
+		// Set the carets column to update their last offset x.
+		for (int i = 0; i < get_caret_count(); i++) {
+			if (get_caret_line(i) == p_line) {
+				set_caret_column(get_caret_column(i), false, i);
+			}
+			if (has_selection(i) && get_selection_origin_line(i) == p_line) {
+				set_selection_origin_column(get_selection_origin_column(i), i);
 			}
 		}
 	}
 
-	// Need to apply the above adjustments to the undo / redo carets.
-	current_op.end_carets = carets;
-	queue_redraw();
+	// Remove line.
+	_remove_text(from_line, from_column, next_line, next_column);
+
+	begin_multicaret_edit();
+	if ((is_last_line && p_move_carets_down) || (p_line == 0 && !p_move_carets_down)) {
+		// Collapse carets.
+		collapse_carets(from_line, from_column, next_line, next_column, true);
+	} else {
+		// Move carets to visually line up.
+		int target_line = p_move_carets_down ? p_line : p_line - 1;
+		for (int i = 0; i < get_caret_count(); i++) {
+			bool selected = has_selection(i);
+			if (get_caret_line(i) == p_line) {
+				set_caret_line(target_line, i == 0, true, 0, i);
+			}
+			if (selected && get_selection_origin_line(i) == p_line) {
+				set_selection_origin_line(target_line, true, 0, i);
+				select(get_selection_origin_line(i), get_selection_origin_column(i), get_caret_line(i), get_caret_column(i), i);
+			}
+		}
+
+		merge_overlapping_carets();
+	}
+	_offset_carets_after(next_line, next_column, from_line, from_column);
+	end_multicaret_edit();
+	end_complex_operation();
 }
 
 void TextEdit::insert_text_at_caret(const String &p_text, int p_caret) {
-	ERR_FAIL_COND(p_caret > carets.size());
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
 		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+		if (p_caret == -1 && multicaret_edit_ignore_caret(i)) {
 			continue;
 		}
 
@@ -3588,22 +3528,35 @@ void TextEdit::insert_text_at_caret(const String &p_text, int p_caret) {
 		int from_line = get_caret_line(i);
 		int from_col = get_caret_column(i);
 
-		int new_column, new_line;
+		int new_line, new_column;
 		_insert_text(from_line, from_col, p_text, &new_line, &new_column);
 		_update_scrollbars();
+		_offset_carets_after(from_line, from_col, new_line, new_column);
 
-		set_caret_line(new_line, false, true, 0, i);
+		set_caret_line(new_line, false, true, -1, i);
 		set_caret_column(new_column, i == 0, i);
-
-		adjust_carets_after_edit(i, new_line, new_column, from_line, from_col);
 	}
 
 	if (has_ime_text()) {
 		_update_ime_text();
 	}
 
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
+}
+
+void TextEdit::insert_text(const String &p_text, int p_line, int p_column, bool p_before_selection_begin, bool p_before_selection_end) {
+	ERR_FAIL_INDEX(p_line, text.size());
+	ERR_FAIL_INDEX(p_column, text[p_line].length() + 1);
+
+	begin_complex_operation();
+
+	int new_line, new_column;
+	_insert_text(p_line, p_column, p_text, &new_line, &new_column);
+
+	_offset_carets_after(p_line, p_column, new_line, new_column, p_before_selection_begin, p_before_selection_end);
+
+	end_complex_operation();
 }
 
 void TextEdit::remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column) {
@@ -3614,7 +3567,13 @@ void TextEdit::remove_text(int p_from_line, int p_from_column, int p_to_line, in
 	ERR_FAIL_COND(p_to_line < p_from_line);
 	ERR_FAIL_COND(p_to_line == p_from_line && p_to_column < p_from_column);
 
+	begin_complex_operation();
+
 	_remove_text(p_from_line, p_from_column, p_to_line, p_to_column);
+	collapse_carets(p_from_line, p_from_column, p_to_line, p_to_column);
+	_offset_carets_after(p_to_line, p_to_column, p_from_line, p_from_column);
+
+	end_complex_operation();
 }
 
 int TextEdit::get_last_unhidden_line() const {
@@ -4453,16 +4412,9 @@ bool TextEdit::is_mouse_over_selection(bool p_edges, int p_caret) const {
 	int line = pos.y;
 	int column = pos.x;
 
-	for (int i = 0; i < get_caret_count(); i++) {
-		if (p_caret != -1 && p_caret != i) {
-			continue;
-		}
-
-		if (_selection_contains(i, line, column, p_edges)) {
-			return true;
-		}
+	if ((p_caret == -1 && get_selection_at_line_column(line, column, p_edges) != -1) || (p_caret != -1 && _selection_contains(p_caret, line, column, p_edges))) {
+		return true;
 	}
-
 	return false;
 }
 
@@ -4558,23 +4510,24 @@ int TextEdit::add_caret(int p_line, int p_column) {
 	p_line = CLAMP(p_line, 0, text.size() - 1);
 	p_column = CLAMP(p_column, 0, get_line(p_line).length());
 
-	for (int i = 0; i < carets.size(); i++) {
-		if (get_caret_line(i) == p_line && get_caret_column(i) == p_column) {
+	if (!is_in_mulitcaret_edit()) {
+		// Carets cannot overlap.
+		if (get_selection_at_line_column(p_line, p_column, true, false) != -1) {
 			return -1;
-		}
-
-		if (has_selection(i)) {
-			if (p_line >= get_selection_from_line(i) && p_line <= get_selection_to_line(i) && (p_line > get_selection_from_line(i) || p_column >= get_selection_from_column(i)) && (p_line < get_selection_to_line(i) || p_column <= get_selection_to_column(i))) {
-				return -1;
-			}
 		}
 	}
 
 	carets.push_back(Caret());
-	set_caret_line(p_line, false, false, 0, carets.size() - 1);
-	set_caret_column(p_column, false, carets.size() - 1);
-	caret_index_edit_dirty = true;
-	return carets.size() - 1;
+	int new_index = carets.size() - 1;
+	set_caret_line(p_line, false, false, -1, new_index);
+	set_caret_column(p_column, false, new_index);
+	_caret_changed(new_index);
+
+	if (is_in_mulitcaret_edit()) {
+		multicaret_edit_ignore_carets.insert(new_index);
+		merge_overlapping_carets();
+	}
+	return new_index;
 }
 
 void TextEdit::remove_caret(int p_caret) {
@@ -4583,7 +4536,6 @@ void TextEdit::remove_caret(int p_caret) {
 
 	_caret_changed(p_caret);
 	carets.remove_at(p_caret);
-	caret_index_edit_dirty = true;
 
 	if (drag_caret_index >= 0) {
 		if (p_caret == drag_caret_index) {
@@ -4615,226 +4567,335 @@ int TextEdit::get_caret_count() const {
 	return carets.size();
 }
 
-void TextEdit::merge_overlapping_carets() {
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int i = 0; i < caret_edit_order.size() - 1; i++) {
-		int first_caret = caret_edit_order[i];
-		int second_caret = caret_edit_order[i + 1];
+void TextEdit::add_caret_at_carets(bool p_below) {
+	const int last_line_max_wrap = get_line_wrap_count(text.size() - 1);
 
-		// Both have selection.
-		if (has_selection(first_caret) && has_selection(second_caret)) {
-			bool should_merge = false;
-			if (get_selection_from_line(first_caret) >= get_selection_from_line(second_caret) && get_selection_from_line(first_caret) <= get_selection_to_line(second_caret) && (get_selection_from_line(first_caret) > get_selection_from_line(second_caret) || get_selection_from_column(first_caret) >= get_selection_from_column(second_caret)) && (get_selection_from_line(first_caret) < get_selection_to_line(second_caret) || get_selection_from_column(first_caret) <= get_selection_to_column(second_caret))) {
-				should_merge = true;
-			}
+	begin_multicaret_edit();
+	int view_target_caret = -1;
+	int view_line = p_below ? -1 : INT_MAX;
+	int num_carets = get_caret_count();
+	for (int i = 0; i < num_carets; i++) {
+		const int caret_line = get_caret_line(i);
+		const int caret_column = get_caret_column(i);
+		const bool is_selected = has_selection(i) || carets[i].last_fit_x != carets[i].selection.origin_last_fit_x;
+		const int selection_origin_line = get_selection_origin_line(i);
+		const int selection_origin_column = get_selection_origin_column(i);
+		const int caret_wrap_index = get_caret_wrap_index(i);
+		const int selection_origin_wrap_index = !is_selected ? -1 : get_line_wrap_index_at_column(selection_origin_line, selection_origin_column);
 
-			if (get_selection_to_line(first_caret) >= get_selection_from_line(second_caret) && get_selection_to_line(first_caret) <= get_selection_to_line(second_caret) && (get_selection_to_line(first_caret) > get_selection_from_line(second_caret) || get_selection_to_column(first_caret) >= get_selection_from_column(second_caret)) && (get_selection_to_line(first_caret) < get_selection_to_line(second_caret) || get_selection_to_column(first_caret) <= get_selection_to_column(second_caret))) {
-				should_merge = true;
-			}
+		if (caret_line == 0 && !p_below && (caret_wrap_index == 0 || selection_origin_wrap_index == 0)) {
+			// Can't add above the first line.
+			continue;
+		}
+		if (caret_line == text.size() - 1 && p_below && (caret_wrap_index == last_line_max_wrap || selection_origin_wrap_index == last_line_max_wrap)) {
+			// Can't add below the last line.
+			continue;
+		}
 
-			if (!should_merge) {
-				continue;
-			}
+		// Add a new caret.
+		int new_caret_index = add_caret(caret_line, caret_column);
 
-			// Save the newest one for Click + Drag.
-			int caret_to_save = first_caret;
-			int caret_to_remove = second_caret;
-			if (first_caret < second_caret) {
-				caret_to_save = second_caret;
-				caret_to_remove = first_caret;
-			}
+		// Copy the selection origin and last fit.
+		set_selection_origin_line(selection_origin_line, true, -1, new_caret_index);
+		set_selection_origin_column(selection_origin_column, new_caret_index);
+		carets.write[new_caret_index].last_fit_x = carets[i].last_fit_x;
+		carets.write[new_caret_index].selection.origin_last_fit_x = carets[i].selection.origin_last_fit_x;
 
-			int from_line = MIN(get_selection_from_line(caret_to_save), get_selection_from_line(caret_to_remove));
-			int to_line = MAX(get_selection_to_line(caret_to_save), get_selection_to_line(caret_to_remove));
-			int from_col = get_selection_from_column(caret_to_save);
-			int to_col = get_selection_to_column(caret_to_save);
-			int selection_line = get_selection_line(caret_to_save);
-			int selection_col = get_selection_column(caret_to_save);
-
-			bool at_from = (get_caret_line(caret_to_save) == get_selection_from_line(caret_to_save) && get_caret_column(caret_to_save) == get_selection_from_column(caret_to_save));
-
-			if (at_from) {
-				if (get_selection_line(caret_to_remove) > get_selection_line(caret_to_save) || (get_selection_line(caret_to_remove) == get_selection_line(caret_to_save) && get_selection_column(caret_to_remove) >= get_selection_column(caret_to_save))) {
-					selection_line = get_selection_line(caret_to_remove);
-					selection_col = get_selection_column(caret_to_remove);
+		// Move the caret up or down one visible line.
+		if (!p_below) {
+			// Move caret up.
+			if (caret_wrap_index > 0) {
+				set_caret_line(caret_line, false, false, caret_wrap_index - 1, new_caret_index);
+			} else {
+				int new_line = caret_line - get_next_visible_line_offset_from(caret_line - 1, -1);
+				if (is_line_wrapped(new_line)) {
+					set_caret_line(new_line, false, false, get_line_wrap_count(new_line), new_caret_index);
+				} else {
+					set_caret_line(new_line, false, false, 0, new_caret_index);
 				}
-			} else if (get_selection_line(caret_to_remove) < get_selection_line(caret_to_save) || (get_selection_line(caret_to_remove) == get_selection_line(caret_to_save) && get_selection_column(caret_to_remove) <= get_selection_column(caret_to_save))) {
-				selection_line = get_selection_line(caret_to_remove);
-				selection_col = get_selection_column(caret_to_remove);
 			}
-
-			if (get_selection_from_line(caret_to_remove) < get_selection_from_line(caret_to_save) || (get_selection_from_line(caret_to_remove) == get_selection_from_line(caret_to_save) && get_selection_from_column(caret_to_remove) <= get_selection_from_column(caret_to_save))) {
-				from_col = get_selection_from_column(caret_to_remove);
+			// Move selection origin up.
+			if (is_selected) {
+				if (selection_origin_wrap_index > 0) {
+					set_selection_origin_line(caret_line, false, selection_origin_wrap_index - 1, new_caret_index);
+				} else {
+					int new_line = selection_origin_line - get_next_visible_line_offset_from(selection_origin_line - 1, -1);
+					if (is_line_wrapped(new_line)) {
+						set_selection_origin_line(new_line, false, get_line_wrap_count(new_line), new_caret_index);
+					} else {
+						set_selection_origin_line(new_line, false, 0, new_caret_index);
+					}
+				}
+			}
+			if (get_caret_line(new_caret_index) < view_line) {
+				view_line = get_caret_line(new_caret_index);
+				view_target_caret = new_caret_index;
+			}
+		} else {
+			// Move caret down.
+			if (caret_wrap_index < get_line_wrap_count(caret_line)) {
+				set_caret_line(caret_line, false, false, caret_wrap_index + 1, new_caret_index);
 			} else {
-				to_col = get_selection_to_column(caret_to_remove);
+				int new_line = caret_line + get_next_visible_line_offset_from(CLAMP(caret_line + 1, 0, text.size() - 1), 1);
+				set_caret_line(new_line, false, false, 0, new_caret_index);
 			}
-
-			select(from_line, from_col, to_line, to_col, caret_to_save);
-			set_selection_mode(selecting_mode, selection_line, selection_col, caret_to_save);
-			set_caret_line((at_from ? from_line : to_line), caret_to_save == 0, true, 0, caret_to_save);
-			set_caret_column((at_from ? from_col : to_col), caret_to_save == 0, caret_to_save);
-			remove_caret(caret_to_remove);
-			i--;
-			caret_edit_order = get_caret_index_edit_order();
-			continue;
+			// Move selection origin down.
+			if (is_selected) {
+				if (selection_origin_wrap_index < get_line_wrap_count(selection_origin_line)) {
+					set_selection_origin_line(selection_origin_line, false, selection_origin_wrap_index + 1, new_caret_index);
+				} else {
+					int new_line = selection_origin_line + get_next_visible_line_offset_from(CLAMP(selection_origin_line + 1, 0, text.size() - 1), 1);
+					set_selection_origin_line(new_line, false, 0, new_caret_index);
+				}
+			}
+			if (get_caret_line(new_caret_index) > view_line) {
+				view_line = get_caret_line(new_caret_index);
+				view_target_caret = new_caret_index;
+			}
+		}
+		if (is_selected) {
+			// Make sure selection is active.
+			select(get_selection_origin_line(new_caret_index), get_selection_origin_column(new_caret_index), get_caret_line(new_caret_index), get_caret_column(new_caret_index), new_caret_index);
+			carets.write[new_caret_index].last_fit_x = carets[i].last_fit_x;
+			carets.write[new_caret_index].selection.origin_last_fit_x = carets[i].selection.origin_last_fit_x;
 		}
 
-		// Only first has selection.
-		if (has_selection(first_caret)) {
-			if (get_caret_line(second_caret) >= get_selection_from_line(first_caret) && get_caret_line(second_caret) <= get_selection_to_line(first_caret) && (get_caret_line(second_caret) > get_selection_from_line(first_caret) || get_caret_column(second_caret) >= get_selection_from_column(first_caret)) && (get_caret_line(second_caret) < get_selection_to_line(first_caret) || get_caret_column(second_caret) <= get_selection_to_column(first_caret))) {
-				remove_caret(second_caret);
-				caret_edit_order = get_caret_index_edit_order();
-				i--;
-			}
-			continue;
-		}
-
-		// Only second has selection.
-		if (has_selection(second_caret)) {
-			if (get_caret_line(first_caret) >= get_selection_from_line(second_caret) && get_caret_line(first_caret) <= get_selection_to_line(second_caret) && (get_caret_line(first_caret) > get_selection_from_line(second_caret) || get_caret_column(first_caret) >= get_selection_from_column(second_caret)) && (get_caret_line(first_caret) < get_selection_to_line(second_caret) || get_caret_column(first_caret) <= get_selection_to_column(second_caret))) {
-				remove_caret(first_caret);
-				caret_edit_order = get_caret_index_edit_order();
-				i--;
-			}
-			continue;
-		}
-
-		// Both have no selection.
-		if (get_caret_line(first_caret) == get_caret_line(second_caret) && get_caret_column(first_caret) == get_caret_column(second_caret)) {
-			// Save the newest one for Click + Drag.
-			if (first_caret < second_caret) {
-				remove_caret(first_caret);
-			} else {
-				remove_caret(second_caret);
-			}
-			i--;
-			caret_edit_order = get_caret_index_edit_order();
-			continue;
+		bool check_edges = !has_selection(0) || !has_selection(new_caret_index);
+		bool will_merge_with_main_caret = _selection_contains(0, get_caret_line(new_caret_index), get_caret_column(new_caret_index), check_edges, false) || _selection_contains(new_caret_index, get_caret_line(0), get_caret_column(0), check_edges, false);
+		if (will_merge_with_main_caret) {
+			// Move next to the main caret so it stays the main caret after merging.
+			Caret new_caret = carets[new_caret_index];
+			carets.remove_at(new_caret_index);
+			carets.insert(0, new_caret);
+			i++;
 		}
 	}
-}
 
-void TextEdit::add_caret_at_carets(bool p_below) {
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &caret_index : caret_edit_order) {
-		const int caret_line = get_caret_line(caret_index);
-		const int caret_column = get_caret_column(caret_index);
-
-		// The last fit x will be cleared if the caret has a selection,
-		// but if it does not have a selection the last fit x will be
-		// transferred to the new caret.
-		int caret_from_column = 0, caret_to_column = 0, caret_last_fit_x = carets[caret_index].last_fit_x;
-		if (has_selection(caret_index)) {
-			// If the selection goes over multiple lines, deselect it.
-			if (get_selection_from_line(caret_index) != get_selection_to_line(caret_index)) {
-				deselect(caret_index);
-			} else {
-				caret_from_column = get_selection_from_column(caret_index);
-				caret_to_column = get_selection_to_column(caret_index);
-				caret_last_fit_x = -1;
-				carets.write[caret_index].last_fit_x = _get_column_x_offset_for_line(caret_column, caret_line, caret_column);
-			}
-		}
-
-		// Get the line and column of the new caret as if you would move the caret by pressing the arrow keys.
-		int new_caret_line, new_caret_column, new_caret_from_column = 0, new_caret_to_column = 0;
-		_get_above_below_caret_line_column(caret_line, get_caret_wrap_index(caret_index), caret_column, p_below, new_caret_line, new_caret_column, caret_last_fit_x);
-
-		// If the caret does have a selection calculate the new from and to columns.
-		if (caret_from_column != caret_to_column) {
-			// We only need to calculate the selection columns if the column of the caret changed.
-			if (caret_column != new_caret_column) {
-				int _; // Unused placeholder for p_new_line.
-				_get_above_below_caret_line_column(caret_line, get_caret_wrap_index(caret_index), caret_from_column, p_below, _, new_caret_from_column);
-				_get_above_below_caret_line_column(caret_line, get_caret_wrap_index(caret_index), caret_to_column, p_below, _, new_caret_to_column);
-			} else {
-				new_caret_from_column = caret_from_column;
-				new_caret_to_column = caret_to_column;
-			}
-		}
-
-		// Add the new caret.
-		const int new_caret_index = add_caret(new_caret_line, new_caret_column);
-
-		if (new_caret_index == -1) {
-			continue;
-		}
-		// Also add the selection if there should be one.
-		if (new_caret_from_column != new_caret_to_column) {
-			select(new_caret_line, new_caret_from_column, new_caret_line, new_caret_to_column, new_caret_index);
-			// Necessary to properly modify the selection after adding the new caret.
-			carets.write[new_caret_index].selection.selecting_line = new_caret_line;
-			carets.write[new_caret_index].selection.selecting_column = new_caret_column == new_caret_from_column ? new_caret_to_column : new_caret_from_column;
-			continue;
-		}
-
-		// Copy the last fit x over.
-		carets.write[new_caret_index].last_fit_x = carets[caret_index].last_fit_x;
+	// Show the topmost caret if added above or bottommost caret if added below.
+	if (view_target_caret >= 0 && view_target_caret < get_caret_count()) {
+		adjust_viewport_to_caret(view_target_caret);
 	}
 
 	merge_overlapping_carets();
-	queue_redraw();
+	end_multicaret_edit();
 }
 
-Vector<int> TextEdit::get_caret_index_edit_order() {
-	if (!caret_index_edit_dirty) {
-		return caret_index_edit_order;
+struct _CaretSortComparator {
+	_FORCE_INLINE_ bool operator()(const Vector3i &a, const Vector3i &b) const {
+		// x is column, y is line, z is caret index.
+		if (a.y == b.y) {
+			return a.x < b.x;
+		}
+		return a.y < b.y;
 	}
+};
 
-	caret_index_edit_order.clear();
-	caret_index_edit_order.push_back(0);
-	for (int i = 1; i < carets.size(); i++) {
-		int j = 0;
-
-		int line = has_selection(i) ? get_selection_to_line(i) : carets[i].line;
-		int col = has_selection(i) ? get_selection_to_column(i) : carets[i].column;
-
-		for (; j < caret_index_edit_order.size(); j++) {
-			int idx = caret_index_edit_order[j];
-			int other_line = has_selection(idx) ? get_selection_to_line(idx) : carets[idx].line;
-			int other_col = has_selection(idx) ? get_selection_to_column(idx) : carets[idx].column;
-			if (line > other_line || (line == other_line && col > other_col)) {
-				break;
-			}
-		}
-		caret_index_edit_order.insert(j, i);
-	}
-	caret_index_edit_dirty = false;
-	return caret_index_edit_order;
-}
-
-void TextEdit::adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col) {
-	int edit_height = p_from_line - p_to_line;
-	int edit_size = ((edit_height == 0) ? p_from_col : 0) - p_to_col;
-
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int j = 0; j < caret_edit_order.size(); j++) {
-		if (caret_edit_order[j] == p_caret) {
-			return;
-		}
-
-		// Adjust caret.
-		// set_caret_line could adjust the column, so save here.
-		int cc = get_caret_column(caret_edit_order[j]);
-		if (edit_height != 0) {
-			set_caret_line(get_caret_line(caret_edit_order[j]) + edit_height, false, true, 0, caret_edit_order[j]);
-		}
-		if (get_caret_line(p_caret) == get_caret_line(caret_edit_order[j])) {
-			set_caret_column(cc + edit_size, false, caret_edit_order[j]);
-		}
-
-		// Adjust selection.
-		if (!has_selection(caret_edit_order[j])) {
+Vector<int> TextEdit::get_sorted_carets(bool p_include_ignored_carets) const {
+	// Returns caret indexes sorted by selection start or caret position from top to bottom of text.
+	Vector<Vector3i> caret_line_col_indexes;
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (!p_include_ignored_carets && multicaret_edit_ignore_caret(i)) {
 			continue;
 		}
-		if (edit_height != 0) {
-			carets.write[caret_edit_order[j]].selection.from_line += edit_height;
-			carets.write[caret_edit_order[j]].selection.to_line += edit_height;
+		caret_line_col_indexes.push_back(Vector3i(get_selection_from_column(i), get_selection_from_line(i), i));
+	}
+	caret_line_col_indexes.sort_custom<_CaretSortComparator>();
+	Vector<int> sorted;
+	sorted.resize(caret_line_col_indexes.size());
+	for (int i = 0; i < caret_line_col_indexes.size(); i++) {
+		sorted.set(i, caret_line_col_indexes[i].z);
+	}
+	return sorted;
+}
+
+void TextEdit::collapse_carets(int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_inclusive) {
+	// Collapse carets in the selected range to the from position.
+
+	// Clamp the collapse target position.
+	int collapse_line = CLAMP(p_from_line, 0, text.size() - 1);
+	int collapse_column = CLAMP(p_from_column, 0, text[collapse_line].length());
+
+	// Swap the lines if they are in the wrong order.
+	if (p_from_line > p_to_line) {
+		SWAP(p_from_line, p_to_line);
+		SWAP(p_from_column, p_to_column);
+	}
+	if (p_from_line == p_to_line && p_from_column > p_to_column) {
+		SWAP(p_from_column, p_to_column);
+	}
+	bool any_collapsed = false;
+
+	// Intentionally includes carets in the multicaret_edit_ignore list so that they are moved together.
+	for (int i = 0; i < get_caret_count(); i++) {
+		bool is_caret_in = _is_line_col_in_range(get_caret_line(i), get_caret_column(i), p_from_line, p_from_column, p_to_line, p_to_column, p_inclusive);
+		if (!has_selection(i)) {
+			if (is_caret_in) {
+				// Caret was in the collapsed area.
+				set_caret_line(collapse_line, false, true, -1, i);
+				set_caret_column(collapse_column, false, i);
+				if (is_in_mulitcaret_edit()) {
+					multicaret_edit_ignore_carets.insert(i);
+				}
+				any_collapsed = true;
+			}
+		} else {
+			bool is_origin_in = _is_line_col_in_range(get_selection_origin_line(i), get_selection_origin_column(i), p_from_line, p_from_column, p_to_line, p_to_column, p_inclusive);
+
+			if (is_caret_in && is_origin_in) {
+				// Selection was completely encapsulated.
+				deselect(i);
+				set_caret_line(collapse_line, false, true, -1, i);
+				set_caret_column(collapse_column, false, i);
+				if (is_in_mulitcaret_edit()) {
+					multicaret_edit_ignore_carets.insert(i);
+				}
+				any_collapsed = true;
+			} else if (is_caret_in) {
+				// Only caret was inside.
+				set_caret_line(collapse_line, false, true, -1, i);
+				set_caret_column(collapse_column, false, i);
+				any_collapsed = true;
+			} else if (is_origin_in) {
+				// Only selection origin was inside.
+				set_selection_origin_line(collapse_line, true, -1, i);
+				set_selection_origin_column(collapse_column, i);
+				any_collapsed = true;
+			}
 		}
-		if (get_caret_line(p_caret) == get_selection_from_line(caret_edit_order[j])) {
-			carets.write[caret_edit_order[j]].selection.from_column += edit_size;
+		if (!p_inclusive && !any_collapsed) {
+			if ((get_caret_line(i) == collapse_line && get_caret_column(i) == collapse_column) || (get_selection_origin_line(i) == collapse_line && get_selection_origin_column(i) == collapse_column)) {
+				// Make sure to queue a merge, even if we didn't include it.
+				any_collapsed = true;
+			}
 		}
 	}
+	if (any_collapsed) {
+		merge_overlapping_carets();
+	}
+}
+
+void TextEdit::merge_overlapping_carets() {
+	if (is_in_mulitcaret_edit()) {
+		// Queue merge to be performed the end of the multicaret edit.
+		multicaret_edit_merge_queued = true;
+		return;
+	}
+
+	multicaret_edit_merge_queued = false;
+	multicaret_edit_ignore_carets.clear();
+
+	if (get_caret_count() == 1) {
+		return;
+	}
+
+	Vector<int> sorted_carets = get_sorted_carets(true);
+	for (int i = 0; i < sorted_carets.size() - 1; i++) {
+		int first_caret = sorted_carets[i];
+		int second_caret = sorted_carets[i + 1];
+
+		bool merge_carets;
+		if (!has_selection(first_caret) || !has_selection(second_caret)) {
+			// Merge if touching.
+			merge_carets = get_selection_from_line(second_caret) < get_selection_to_line(first_caret) || (get_selection_from_line(second_caret) == get_selection_to_line(first_caret) && get_selection_from_column(second_caret) <= get_selection_to_column(first_caret));
+		} else {
+			// Merge two selections if overlapping.
+			merge_carets = get_selection_from_line(second_caret) < get_selection_to_line(first_caret) || (get_selection_from_line(second_caret) == get_selection_to_line(first_caret) && get_selection_from_column(second_caret) < get_selection_to_column(first_caret));
+		}
+
+		if (!merge_carets) {
+			continue;
+		}
+
+		// Save the newest one for Click + Drag.
+		int caret_to_save = first_caret;
+		int caret_to_remove = second_caret;
+		if (first_caret < second_caret) {
+			caret_to_save = second_caret;
+			caret_to_remove = first_caret;
+		}
+
+		if (get_selection_from_line(caret_to_save) != get_selection_from_line(caret_to_remove) || get_selection_to_line(caret_to_save) != get_selection_to_line(caret_to_remove) || get_selection_from_column(caret_to_save) != get_selection_from_column(caret_to_remove) || get_selection_to_column(caret_to_save) != get_selection_to_column(caret_to_remove)) {
+			// Selections are not the same, merge them into one bigger selection.
+			int new_from_line = MIN(get_selection_from_line(caret_to_remove), get_selection_from_line(caret_to_save));
+			int new_to_line = MAX(get_selection_to_line(caret_to_remove), get_selection_to_line(caret_to_save));
+			int new_from_col;
+			int new_to_col;
+			if (get_selection_from_line(caret_to_remove) < get_selection_from_line(caret_to_save)) {
+				new_from_col = get_selection_from_column(caret_to_remove);
+			} else if (get_selection_from_line(caret_to_remove) > get_selection_from_line(caret_to_save)) {
+				new_from_col = get_selection_from_column(caret_to_save);
+			} else {
+				new_from_col = MIN(get_selection_from_column(caret_to_remove), get_selection_from_column(caret_to_save));
+			}
+			if (get_selection_to_line(caret_to_remove) < get_selection_to_line(caret_to_save)) {
+				new_to_col = get_selection_to_column(caret_to_save);
+			} else if (get_selection_to_line(caret_to_remove) > get_selection_to_line(caret_to_save)) {
+				new_to_col = get_selection_to_column(caret_to_remove);
+			} else {
+				new_to_col = MAX(get_selection_to_column(caret_to_remove), get_selection_to_column(caret_to_save));
+			}
+
+			// Use the direction from the last caret or the saved one.
+			int caret_dir_to_copy;
+			if (has_selection(caret_to_remove) && has_selection(caret_to_save)) {
+				caret_dir_to_copy = caret_to_remove == get_caret_count() - 1 ? caret_to_remove : caret_to_save;
+			} else {
+				caret_dir_to_copy = !has_selection(caret_to_remove) ? caret_to_save : caret_to_remove;
+			}
+
+			if (is_caret_after_selection_origin(caret_dir_to_copy)) {
+				select(new_from_line, new_from_col, new_to_line, new_to_col, caret_to_save);
+			} else {
+				select(new_to_line, new_to_col, new_from_line, new_from_col, caret_to_save);
+			}
+		}
+
+		if (caret_to_save == 0) {
+			adjust_viewport_to_caret(caret_to_save);
+		}
+		remove_caret(caret_to_remove);
+
+		// Update the rest of the sorted list.
+		for (int j = i; j < sorted_carets.size(); j++) {
+			if (sorted_carets[j] > caret_to_remove) {
+				// Shift the index since a caret before it was removed.
+				sorted_carets.write[j] -= 1;
+			}
+		}
+		// Remove the caret from the sorted array.
+		sorted_carets.remove_at(caret_to_remove == first_caret ? i : i + 1);
+
+		// Process the caret again, since it and the next caret might also overlap.
+		i--;
+	}
+}
+
+// Starts a multicaret edit operation. Call this before iterating over the carets and call [end_multicaret_edit] afterwards.
+void TextEdit::begin_multicaret_edit() {
+	multicaret_edit_count++;
+}
+
+void TextEdit::end_multicaret_edit() {
+	if (multicaret_edit_count > 0) {
+		multicaret_edit_count--;
+	}
+	if (multicaret_edit_count != 0) {
+		return;
+	}
+
+	// This was the last multicaret edit operation.
+	if (multicaret_edit_merge_queued) {
+		merge_overlapping_carets();
+	}
+	multicaret_edit_ignore_carets.clear();
+}
+
+bool TextEdit::is_in_mulitcaret_edit() const {
+	return multicaret_edit_count > 0;
+}
+
+bool TextEdit::multicaret_edit_ignore_caret(int p_caret) const {
+	return multicaret_edit_ignore_carets.has(p_caret);
 }
 
 bool TextEdit::is_caret_visible(int p_caret) const {
@@ -5078,8 +5139,6 @@ void TextEdit::select_word_under_caret(int p_caret) {
 		}
 
 		select(get_caret_line(c), begin, get_caret_line(c), end, c);
-		// Move the caret to the end of the word for easier editing.
-		set_caret_column(end, false, c);
 	}
 	merge_overlapping_carets();
 }
@@ -5237,10 +5296,10 @@ String TextEdit::get_selected_text(int p_caret) {
 	return selected_text.as_string();
 }
 
-int TextEdit::get_selection_at_line_column(int p_line, int p_column, bool p_include_edges) const {
+int TextEdit::get_selection_at_line_column(int p_line, int p_column, bool p_include_edges, bool p_only_selections) const {
 	// Return the caret index of the found selection, or -1.
 	for (int i = 0; i < get_caret_count(); i++) {
-		if (_selection_contains(i, p_line, p_column, p_include_edges, true)) {
+		if (_selection_contains(i, p_line, p_column, p_include_edges, p_only_selections)) {
 			return i;
 		}
 	}
@@ -5356,29 +5415,10 @@ void TextEdit::set_selection_origin_column(int p_column, int p_caret) {
 	if (has_selection(p_caret) && get_caret_line(p_caret) == get_selection_origin_line(p_caret) && get_caret_column(p_caret) == get_selection_origin_column(p_caret)) {
 		deselect(p_caret);
 	}
-}
 
-String TextEdit::get_selected_text(int p_caret) {
-	ERR_FAIL_COND_V(p_caret > carets.size(), "");
-
-	StringBuilder selected_text;
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int i = caret_edit_order.size() - 1; i >= 0; i--) {
-		int caret_idx = caret_edit_order[i];
-		if (p_caret != -1 && p_caret != caret_idx) {
-			continue;
-		}
-
-		if (!has_selection(caret_idx)) {
-			continue;
-		}
-		selected_text += _base_get_text(get_selection_from_line(caret_idx), get_selection_from_column(caret_idx), get_selection_to_line(caret_idx), get_selection_to_column(caret_idx));
-		if (p_caret == -1 && i != 0) {
-			selected_text += "\n";
-		}
+	if (selection_moved && has_selection(p_caret)) {
+		_selection_changed(p_caret);
 	}
-
-	return selected_text.as_string();
 }
 
 int TextEdit::get_selection_origin_line(int p_caret) const {
@@ -5464,9 +5504,12 @@ void TextEdit::delete_selection(int p_caret) {
 	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
 		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+		if (p_caret == -1 && multicaret_edit_ignore_caret(i)) {
 			continue;
 		}
 
@@ -5474,16 +5517,21 @@ void TextEdit::delete_selection(int p_caret) {
 			continue;
 		}
 
-		selecting_mode = SelectionMode::SELECTION_MODE_NONE;
-		_remove_text(get_selection_from_line(i), get_selection_from_column(i), get_selection_to_line(i), get_selection_to_column(i));
-		set_caret_line(get_selection_from_line(i), false, false, 0, i);
-		set_caret_column(get_selection_from_column(i), i == 0, i);
-		carets.write[i].selection.active = false;
+		int selection_from_line = get_selection_from_line(i);
+		int selection_from_column = get_selection_from_column(i);
+		int selection_to_line = get_selection_to_line(i);
+		int selection_to_column = get_selection_to_column(i);
 
-		adjust_carets_after_edit(i, carets[i].selection.from_line, carets[i].selection.from_column, carets[i].selection.to_line, carets[i].selection.to_column);
+		_remove_text(selection_from_line, selection_from_column, selection_to_line, selection_to_column);
+		_offset_carets_after(selection_to_line, selection_to_column, selection_from_line, selection_from_column);
+		merge_overlapping_carets();
+
+		deselect(i);
+		set_caret_line(selection_from_line, false, false, -1, i);
+		set_caret_column(selection_from_column, i == 0, i);
 	}
+	end_multicaret_edit();
 	end_complex_operation();
-	queue_redraw();
 }
 
 /* Line wrapping. */
@@ -6325,8 +6373,10 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("swap_lines", "from_line", "to_line"), &TextEdit::swap_lines);
 
 	ClassDB::bind_method(D_METHOD("insert_line_at", "line", "text"), &TextEdit::insert_line_at);
+	ClassDB::bind_method(D_METHOD("remove_line_at", "line", "move_carets_down"), &TextEdit::remove_line_at, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("insert_text_at_caret", "text", "caret_index"), &TextEdit::insert_text_at_caret, DEFVAL(-1));
 
+	ClassDB::bind_method(D_METHOD("insert_text", "text", "line", "column", "before_selection_begin", "before_selection_end"), &TextEdit::insert_text, DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_text", "from_line", "from_column", "to_line", "to_column"), &TextEdit::remove_text);
 
 	ClassDB::bind_method(D_METHOD("get_last_unhidden_line"), &TextEdit::get_last_unhidden_line);
@@ -6459,12 +6509,17 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_caret", "line", "column"), &TextEdit::add_caret);
 	ClassDB::bind_method(D_METHOD("remove_caret", "caret"), &TextEdit::remove_caret);
 	ClassDB::bind_method(D_METHOD("remove_secondary_carets"), &TextEdit::remove_secondary_carets);
-	ClassDB::bind_method(D_METHOD("merge_overlapping_carets"), &TextEdit::merge_overlapping_carets);
 	ClassDB::bind_method(D_METHOD("get_caret_count"), &TextEdit::get_caret_count);
 	ClassDB::bind_method(D_METHOD("add_caret_at_carets", "below"), &TextEdit::add_caret_at_carets);
 
-	ClassDB::bind_method(D_METHOD("get_caret_index_edit_order"), &TextEdit::get_caret_index_edit_order);
-	ClassDB::bind_method(D_METHOD("adjust_carets_after_edit", "caret", "from_line", "from_col", "to_line", "to_col"), &TextEdit::adjust_carets_after_edit);
+	ClassDB::bind_method(D_METHOD("get_sorted_carets", "include_ignored_carets"), &TextEdit::get_sorted_carets, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("collapse_carets", "from_line", "from_column", "to_line", "to_column", "inclusive"), &TextEdit::collapse_carets, DEFVAL(false));
+
+	ClassDB::bind_method(D_METHOD("merge_overlapping_carets"), &TextEdit::merge_overlapping_carets);
+	ClassDB::bind_method(D_METHOD("begin_multicaret_edit"), &TextEdit::begin_multicaret_edit);
+	ClassDB::bind_method(D_METHOD("end_multicaret_edit"), &TextEdit::end_multicaret_edit);
+	ClassDB::bind_method(D_METHOD("is_in_mulitcaret_edit"), &TextEdit::is_in_mulitcaret_edit);
+	ClassDB::bind_method(D_METHOD("multicaret_edit_ignore_caret", "caret_index"), &TextEdit::multicaret_edit_ignore_caret);
 
 	ClassDB::bind_method(D_METHOD("is_caret_visible", "caret_index"), &TextEdit::is_caret_visible, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_caret_draw_pos", "caret_index"), &TextEdit::get_caret_draw_pos, DEFVAL(0));
@@ -6507,8 +6562,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_selection", "caret_index"), &TextEdit::has_selection, DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("get_selected_text", "caret_index"), &TextEdit::get_selected_text, DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("get_selection_at_line_column", "line", "column", "include_edges"), &TextEdit::get_selection_at_line_column, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("get_line_ranges_from_carets", "p_only_selections", "p_merge_adjacent"), &TextEdit::get_line_ranges_from_carets_typed_array, DEFVAL(false), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_selection_at_line_column", "line", "column", "include_edges", "only_selections"), &TextEdit::get_selection_at_line_column, DEFVAL(true), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_line_ranges_from_carets", "only_selections", "merge_adjacent"), &TextEdit::get_line_ranges_from_carets_typed_array, DEFVAL(false), DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("get_selection_origin_line", "caret_index"), &TextEdit::get_selection_origin_line, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_selection_origin_column", "caret_index"), &TextEdit::get_selection_origin_column, DEFVAL(0));
@@ -6657,6 +6712,14 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_menu_visible"), &TextEdit::is_menu_visible);
 	ClassDB::bind_method(D_METHOD("menu_option", "option"), &TextEdit::menu_option);
 
+	/* Deprecated */
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("adjust_carets_after_edit", "caret", "from_line", "from_col", "to_line", "to_col"), &TextEdit::adjust_carets_after_edit);
+	ClassDB::bind_method(D_METHOD("get_caret_index_edit_order"), &TextEdit::get_caret_index_edit_order);
+	ClassDB::bind_method(D_METHOD("get_selection_line", "caret_index"), &TextEdit::get_selection_line, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_selection_column", "caret_index"), &TextEdit::get_selection_column, DEFVAL(0));
+#endif
+
 	/* Inspector */
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "placeholder_text", PROPERTY_HINT_MULTILINE_TEXT), "set_placeholder", "get_placeholder");
@@ -6724,7 +6787,7 @@ void TextEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("gutter_added"));
 	ADD_SIGNAL(MethodInfo("gutter_removed"));
 
-	/* Theme items */
+	// Theme items
 	/* Search */
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, search_result_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, search_result_border_color);
@@ -6828,14 +6891,17 @@ void TextEdit::_set_symbol_lookup_word(const String &p_symbol) {
 
 // Overridable actions
 void TextEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) {
-	ERR_FAIL_COND(p_caret > carets.size());
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
 	if (!editable) {
 		return;
 	}
 
 	start_action(EditAction::ACTION_TYPING);
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (p_caret == -1 && multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
 		if (p_caret != -1 && p_caret != i) {
 			continue;
 		}
@@ -6853,6 +6919,7 @@ void TextEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 		const char32_t chr[2] = { (char32_t)p_unicode, 0 };
 		insert_text_at_caret(chr, i);
 	}
+	end_multicaret_edit();
 	end_action();
 }
 
@@ -6868,194 +6935,163 @@ void TextEdit::_backspace_internal(int p_caret) {
 	}
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (const int &i : caret_edit_order) {
+	begin_multicaret_edit();
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (p_caret == -1 && multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
 		if (p_caret != -1 && p_caret != i) {
 			continue;
 		}
 
-		int cc = get_caret_column(i);
-		int cl = get_caret_line(i);
+		int to_line = get_caret_line(i);
+		int to_column = get_caret_column(i);
 
-		if (cc == 0 && cl == 0) {
+		if (to_column == 0 && to_line == 0) {
 			continue;
 		}
 
-		int prev_line = cc ? cl : cl - 1;
-		int prev_column = cc ? (cc - 1) : (text[cl - 1].length());
+		int from_line = to_column > 0 ? to_line : to_line - 1;
+		int from_column = to_column > 0 ? (to_column - 1) : (text[to_line - 1].length());
 
-		merge_gutters(prev_line, cl);
+		merge_gutters(from_line, to_line);
 
-		if (_is_line_hidden(cl)) {
-			_set_line_as_hidden(prev_line, true);
-		}
-		_remove_text(prev_line, prev_column, cl, cc);
+		_remove_text(from_line, from_column, to_line, to_column);
+		collapse_carets(from_line, from_column, to_line, to_column);
+		_offset_carets_after(to_line, to_column, from_line, from_column);
 
-		set_caret_line(prev_line, false, true, 0, i);
-		set_caret_column(prev_column, i == 0, i);
-
-		adjust_carets_after_edit(i, prev_line, prev_column, cl, cc);
+		set_caret_line(from_line, false, true, -1, i);
+		set_caret_column(from_column, i == 0, i);
 	}
-	merge_overlapping_carets();
+	end_multicaret_edit();
 	end_complex_operation();
 }
 
 void TextEdit::_cut_internal(int p_caret) {
-	ERR_FAIL_COND(p_caret > carets.size());
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
+
+	_copy_internal(p_caret);
+
 	if (!editable) {
 		return;
 	}
 
 	if (has_selection(p_caret)) {
-		DisplayServer::get_singleton()->clipboard_set(get_selected_text(p_caret));
 		delete_selection(p_caret);
-		cut_copy_line = "";
 		return;
 	}
 
+	// Remove full lines.
 	begin_complex_operation();
-	Vector<int> carets_to_remove;
-
-	StringBuilder clipboard;
-	// This is the exception and has to edit in reverse order else the string copied to the clipboard will be backwards.
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int i = caret_edit_order.size() - 1; i >= 0; i--) {
-		int caret_idx = caret_edit_order[i];
-		if (p_caret != -1 && p_caret != caret_idx) {
-			continue;
-		}
-
-		int cl = get_caret_line(caret_idx);
-		int cc = get_caret_column(caret_idx);
-		int indent_level = get_indent_level(cl);
-		double hscroll = get_h_scroll();
-
-		// Check for overlapping carets.
-		// We don't need to worry about selections as that is caught before this entire section.
-		for (int j = i - 1; j >= 0; j--) {
-			if (get_caret_line(caret_edit_order[j]) == cl) {
-				carets_to_remove.push_back(caret_edit_order[j]);
-				i = j;
-			}
-		}
-
-		clipboard += text[cl];
-		if (p_caret == -1 && caret_idx != 0) {
-			clipboard += "\n";
-		}
-
-		if (cl == 0 && get_line_count() > 1) {
-			_remove_text(cl, 0, cl + 1, 0);
-			adjust_carets_after_edit(caret_idx, cl, 0, cl + 1, text[cl].length());
-		} else {
-			_remove_text(cl, 0, cl, text[cl].length());
-			set_caret_column(0, false, caret_idx);
-			backspace(caret_idx);
-			set_caret_line(get_caret_line(caret_idx) + 1, caret_idx == 0, 0, 0, caret_idx);
-		}
-
-		// Correct the visually perceived caret column taking care of indentation level of the lines.
-		int diff_indent = indent_level - get_indent_level(get_caret_line(caret_idx));
-		cc += diff_indent;
-		if (diff_indent != 0) {
-			cc += diff_indent > 0 ? -1 : 1;
-		}
-
-		// Restore horizontal scroll and caret column modified by the backspace() call.
-		set_h_scroll(hscroll);
-		set_caret_column(cc, caret_idx == 0, caret_idx);
+	begin_multicaret_edit();
+	Vector<Point2i> line_ranges;
+	if (p_caret == -1) {
+		line_ranges = get_line_ranges_from_carets();
+	} else {
+		line_ranges.push_back(Point2i(get_caret_line(p_caret), get_caret_line(p_caret)));
 	}
-
-	// Sort and remove backwards to preserve indexes.
-	carets_to_remove.sort();
-	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
-		remove_caret(carets_to_remove[i]);
+	int line_offset = 0;
+	for (Point2i line_range : line_ranges) {
+		// Preserve carets on the last line.
+		remove_line_at(line_range.y + line_offset);
+		if (line_range.x != line_range.y) {
+			remove_text(line_range.x + line_offset, 0, line_range.y + line_offset, 0);
+		}
+		line_offset += line_range.x - line_range.y - 1;
 	}
+	end_multicaret_edit();
 	end_complex_operation();
-
-	String clipboard_string = clipboard.as_string();
-	DisplayServer::get_singleton()->clipboard_set(clipboard_string);
-	cut_copy_line = clipboard_string;
 }
 
 void TextEdit::_copy_internal(int p_caret) {
-	ERR_FAIL_COND(p_caret > carets.size());
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
 	if (has_selection(p_caret)) {
 		DisplayServer::get_singleton()->clipboard_set(get_selected_text(p_caret));
 		cut_copy_line = "";
 		return;
 	}
 
+	// Copy full lines.
 	StringBuilder clipboard;
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	for (int i = caret_edit_order.size() - 1; i >= 0; i--) {
-		int caret_idx = caret_edit_order[i];
-		if (p_caret != -1 && p_caret != caret_idx) {
-			continue;
-		}
-
-		int cl = get_caret_line(caret_idx);
-		if (text[cl].length() != 0) {
-			clipboard += _base_get_text(cl, 0, cl, text[cl].length());
-			if (p_caret == -1 && i != 0) {
-				clipboard += "\n";
+	Vector<Point2i> line_ranges;
+	if (p_caret == -1) {
+		// When there are multiple carets on a line, only copy it once.
+		line_ranges = get_line_ranges_from_carets(false, true);
+	} else {
+		line_ranges.push_back(Point2i(get_caret_line(p_caret), get_caret_line(p_caret)));
+	}
+	for (Point2i line_range : line_ranges) {
+		for (int i = line_range.x; i <= line_range.y; i++) {
+			if (text[i].length() != 0) {
+				clipboard += _base_get_text(i, 0, i, text[i].length());
 			}
+			clipboard += "\n";
 		}
 	}
 
 	String clipboard_string = clipboard.as_string();
 	DisplayServer::get_singleton()->clipboard_set(clipboard_string);
-	cut_copy_line = clipboard_string;
+	// Set the cut copy line so we know to paste as a line.
+	if (get_caret_count() == 1) {
+		cut_copy_line = clipboard_string;
+	} else {
+		cut_copy_line = "";
+	}
 }
 
 void TextEdit::_paste_internal(int p_caret) {
-	ERR_FAIL_COND(p_caret > carets.size());
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
 	if (!editable) {
 		return;
 	}
 
 	String clipboard = DisplayServer::get_singleton()->clipboard_get();
+
+	// Paste a full line. Ignore '\r' characters that may have been added to the clipboard by the OS.
+	if (get_caret_count() == 1 && !has_selection(0) && !cut_copy_line.is_empty() && cut_copy_line == clipboard.replace("\r", "")) {
+		insert_text(clipboard, get_caret_line(), 0);
+		return;
+	}
+
+	// Paste text at each caret or one line per caret.
 	Vector<String> clipboad_lines = clipboard.split("\n");
-	bool insert_line_per_caret = p_caret == -1 && carets.size() > 1 && clipboad_lines.size() == carets.size();
+	bool insert_line_per_caret = p_caret == -1 && get_caret_count() > 1 && clipboad_lines.size() == get_caret_count();
 
 	begin_complex_operation();
-	Vector<int> caret_edit_order = get_caret_index_edit_order();
-	int clipboad_line = clipboad_lines.size() - 1;
-	for (const int &i : caret_edit_order) {
-		if (p_caret != -1 && p_caret != i) {
+	begin_multicaret_edit();
+	Vector<int> sorted_carets = get_sorted_carets();
+	for (int i = 0; i < get_caret_count(); i++) {
+		int caret_index = sorted_carets[i];
+		if (p_caret != -1 && p_caret != caret_index) {
 			continue;
 		}
 
-		if (has_selection(i)) {
-			delete_selection(i);
-		} else if (!cut_copy_line.is_empty() && cut_copy_line == clipboard) {
-			set_caret_column(0, i == 0, i);
-			String ins = "\n";
-			clipboard += ins;
+		if (has_selection(caret_index)) {
+			delete_selection(caret_index);
 		}
 
 		if (insert_line_per_caret) {
-			clipboard = clipboad_lines[clipboad_line];
+			clipboard = clipboad_lines[i];
 		}
 
-		insert_text_at_caret(clipboard, i);
-		clipboad_line--;
+		insert_text_at_caret(clipboard, caret_index);
 	}
+	end_multicaret_edit();
 	end_complex_operation();
 }
 
 void TextEdit::_paste_primary_clipboard_internal(int p_caret) {
-	ERR_FAIL_COND(p_caret > carets.size());
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
 	if (!is_editable() || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
 		return;
 	}
 
 	String paste_buffer = DisplayServer::get_singleton()->clipboard_get_primary();
 
-	if (carets.size() == 1) {
+	if (get_caret_count() == 1) {
 		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
 		deselect();
-		set_caret_line(pos.y, true, false);
+		set_caret_line(pos.y, true, false, -1);
 		set_caret_column(pos.x);
 	}
 
@@ -7334,7 +7370,6 @@ void TextEdit::_caret_changed(int p_caret) {
 void TextEdit::_emit_caret_changed() {
 	emit_signal(SNAME("caret_changed"));
 	caret_pos_dirty = false;
-	caret_index_edit_dirty = true;
 }
 
 void TextEdit::_reset_caret_blink_timer() {
@@ -7389,6 +7424,63 @@ bool TextEdit::_is_line_col_in_range(int p_line, int p_column, int p_from_line, 
 		}
 	}
 	return false;
+}
+
+void TextEdit::_offset_carets_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column, bool p_include_selection_begin, bool p_include_selection_end) {
+	// Moves all carets at or after old_line and old_column.
+	// Called after deleting or inserting text so that the carets stay with the text they are at.
+
+	int edit_height = p_new_line - p_old_line;
+	int edit_size = p_new_column - p_old_column;
+	if (edit_height == 0 && edit_size == 0) {
+		return;
+	}
+
+	// Intentionally includes carets in the multicaret_edit_ignore list so that they are moved together.
+	for (int i = 0; i < get_caret_count(); i++) {
+		bool selected = has_selection(i);
+		bool caret_at_end = selected && is_caret_after_selection_origin(i);
+		bool include_caret_at = caret_at_end ? p_include_selection_end : p_include_selection_begin;
+
+		// Move caret.
+		int caret_line = get_caret_line(i);
+		int caret_column = get_caret_column(i);
+		bool caret_after = caret_line > p_old_line || (caret_line == p_old_line && caret_column > p_old_column);
+		bool caret_at = caret_line == p_old_line && caret_column == p_old_column;
+		if (caret_after || (caret_at && include_caret_at)) {
+			caret_line += edit_height;
+			if (caret_line == p_new_line) {
+				caret_column += edit_size;
+			}
+
+			if (edit_height != 0) {
+				set_caret_line(caret_line, false, true, -1, i);
+			}
+			set_caret_column(caret_column, false, i);
+		}
+
+		// Move selection origin.
+		if (!selected) {
+			continue;
+		}
+		bool include_selection_origin_at = !caret_at_end ? p_include_selection_end : p_include_selection_begin;
+
+		int selection_origin_line = get_selection_origin_line(i);
+		int selection_origin_column = get_selection_origin_column(i);
+		bool selection_origin_after = selection_origin_line > p_old_line || (selection_origin_line == p_old_line && selection_origin_column > p_old_column);
+		bool selection_origin_at = selection_origin_line == p_old_line && selection_origin_column == p_old_column;
+		if (selection_origin_after || (selection_origin_at && include_selection_origin_at)) {
+			selection_origin_line += edit_height;
+			if (selection_origin_line == p_new_line) {
+				selection_origin_column += edit_size;
+			}
+			select(selection_origin_line, selection_origin_column, caret_line, caret_column, i);
+		}
+	}
+	if (!p_include_selection_begin && p_include_selection_end && has_selection()) {
+		// It is possible that two adjacent selections now overlap.
+		merge_overlapping_carets();
+	}
 }
 
 void TextEdit::_cancel_drag_and_drop_text() {
@@ -7929,6 +8021,26 @@ void TextEdit::_update_gutter_width() {
 Dictionary TextEdit::_get_line_syntax_highlighting(int p_line) {
 	return syntax_highlighter.is_null() && !setting_text ? Dictionary() : syntax_highlighter->get_line_syntax_highlighting(p_line);
 }
+
+/* Deprecated. */
+#ifndef DISABLE_DEPRECATED
+Vector<int> TextEdit::get_caret_index_edit_order() {
+	Vector<int> carets_order = get_sorted_carets();
+	carets_order.reverse();
+	return carets_order;
+}
+
+void TextEdit::adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col) {
+}
+
+int TextEdit::get_selection_line(int p_caret) const {
+	return get_selection_origin_line(p_caret);
+}
+
+int TextEdit::get_selection_column(int p_caret) const {
+	return get_selection_origin_column(p_caret);
+}
+#endif
 
 /*** Super internal Core API. Everything builds on it. ***/
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -409,11 +409,13 @@ private:
 
 	// Vector containing all the carets, index '0' is the "main caret" and should never be removed.
 	Vector<Caret> carets;
-	Vector<int> caret_index_edit_order;
 
 	bool setting_caret_line = false;
 	bool caret_pos_dirty = false;
-	bool caret_index_edit_dirty = true;
+
+	int multicaret_edit_count = 0;
+	bool multicaret_edit_merge_queued = false;
+	HashSet<int> multicaret_edit_ignore_carets;
 
 	CaretType caret_type = CaretType::CARET_TYPE_LINE;
 
@@ -440,6 +442,8 @@ private:
 
 	int _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
 	bool _is_line_col_in_range(int p_line, int p_column, int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_include_edges = true) const;
+
+	void _offset_carets_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column, bool p_include_selection_begin = true, bool p_include_selection_end = true);
 
 	void _cancel_drag_and_drop_text();
 
@@ -629,12 +633,14 @@ private:
 	void _move_caret_document_end(bool p_select);
 	bool _clear_carets_and_selection();
 
-	// Used in add_caret_at_carets
-	void _get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x = -1) const;
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	void _set_selection_mode_compat_86978(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
 
 	virtual void _update_theme_item_cache() override;
 
@@ -770,9 +776,11 @@ public:
 
 	void swap_lines(int p_from_line, int p_to_line);
 
-	void insert_line_at(int p_at, const String &p_text);
-	void insert_text_at_caret(const String &p_text, int p_caret = -1);
+	void insert_line_at(int p_line, const String &p_text);
+	void remove_line_at(int p_line, bool p_move_carets_down = true);
 
+	void insert_text_at_caret(const String &p_text, int p_caret = -1);
+	void insert_text(const String &p_text, int p_line, int p_column, bool p_before_selection_begin = true, bool p_before_selection_end = false);
 	void remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 
 	int get_last_unhidden_line() const;
@@ -859,12 +867,17 @@ public:
 	int add_caret(int p_line, int p_column);
 	void remove_caret(int p_caret);
 	void remove_secondary_carets();
-	void merge_overlapping_carets();
 	int get_caret_count() const;
 	void add_caret_at_carets(bool p_below);
 
-	Vector<int> get_caret_index_edit_order();
-	void adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col);
+	Vector<int> get_sorted_carets(bool p_include_ignored_carets = false) const;
+	void collapse_carets(int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_inclusive = false);
+
+	void merge_overlapping_carets();
+	void begin_multicaret_edit();
+	void end_multicaret_edit();
+	bool is_in_mulitcaret_edit() const;
+	bool multicaret_edit_ignore_caret(int p_caret) const;
 
 	bool is_caret_visible(int p_caret = 0) const;
 	Point2 get_caret_draw_pos(int p_caret = 0) const;
@@ -872,7 +885,7 @@ public:
 	void set_caret_line(int p_line, bool p_adjust_viewport = true, bool p_can_be_hidden = true, int p_wrap_index = 0, int p_caret = 0);
 	int get_caret_line(int p_caret = 0) const;
 
-	void set_caret_column(int p_col, bool p_adjust_viewport = true, int p_caret = 0);
+	void set_caret_column(int p_column, bool p_adjust_viewport = true, int p_caret = 0);
 	int get_caret_column(int p_caret = 0) const;
 
 	int get_caret_wrap_index(int p_caret = 0) const;
@@ -901,7 +914,7 @@ public:
 	bool has_selection(int p_caret = -1) const;
 
 	String get_selected_text(int p_caret = -1);
-	int get_selection_at_line_column(int p_line, int p_column, bool p_include_edges = true) const;
+	int get_selection_at_line_column(int p_line, int p_column, bool p_include_edges = true, bool p_only_selections = true) const;
 	Vector<Point2i> get_line_ranges_from_carets(bool p_only_selections = false, bool p_merge_adjacent = true) const;
 	TypedArray<Vector2i> get_line_ranges_from_carets_typed_array(bool p_only_selections = false, bool p_merge_adjacent = true) const;
 
@@ -1054,6 +1067,15 @@ public:
 	bool is_drawing_spaces() const;
 
 	Color get_font_color() const;
+
+	/* Deprecated. */
+#ifndef DISABLE_DEPRECATED
+	Vector<int> get_caret_index_edit_order();
+	void adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col);
+
+	int get_selection_line(int p_caret = 0) const;
+	int get_selection_column(int p_caret = 0) const;
+#endif
 
 	TextEdit(const String &p_placeholder = String());
 };

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3578,6 +3578,13 @@ bool Viewport::gui_is_drag_successful() const {
 	return gui.drag_successful;
 }
 
+void Viewport::gui_cancel_drag() {
+	ERR_MAIN_THREAD_GUARD;
+	if (gui_is_dragging()) {
+		_perform_drop();
+	}
+}
+
 void Viewport::set_input_as_handled() {
 	ERR_MAIN_THREAD_GUARD;
 	if (!handle_input_locally) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -616,6 +616,7 @@ public:
 
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
+	void gui_cancel_drag();
 
 	Control *gui_find_control(const Point2 &p_global);
 

--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -47,6 +47,9 @@ private:
 	Callable event_callback;
 	Callable input_event_callback;
 
+	String clipboard_text;
+	String primary_clipboard_text;
+
 	static Vector<String> get_rendering_drivers_func() {
 		Vector<String> drivers;
 		drivers.push_back("dummy");
@@ -97,6 +100,8 @@ public:
 		switch (p_feature) {
 			case FEATURE_MOUSE:
 			case FEATURE_CURSOR_SHAPE:
+			case FEATURE_CLIPBOARD:
+			case FEATURE_CLIPBOARD_PRIMARY:
 				return true;
 			default: {
 			}
@@ -130,6 +135,11 @@ public:
 	}
 
 	virtual Point2i mouse_get_position() const override { return mouse_position; }
+
+	virtual void clipboard_set(const String &p_text) override { clipboard_text = p_text; }
+	virtual String clipboard_get() const override { return clipboard_text; }
+	virtual void clipboard_set_primary(const String &p_text) override { primary_clipboard_text = p_text; }
+	virtual String clipboard_get_primary() const override { return primary_clipboard_text; }
 
 	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const override {
 		return Size2i(1920, 1080);

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -36,6 +36,15 @@
 #include "tests/test_macros.h"
 
 namespace TestCodeEdit {
+static inline Array build_array() {
+	return Array();
+}
+template <typename... Targs>
+static inline Array build_array(Variant item, Targs... Fargs) {
+	Array a = build_array(Fargs...);
+	a.push_front(item);
+	return a;
+}
 
 TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 	CodeEdit *code_edit = memnew(CodeEdit);
@@ -67,10 +76,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			ERR_PRINT_ON;
 
-			Array arg1;
-			arg1.push_back(0);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(0));
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
@@ -86,10 +92,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
-			Array arg1;
-			arg1.push_back(0);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(0));
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
@@ -101,10 +104,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and set text") {
-			Array arg1;
-			arg1.push_back(0);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(0));
 
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(0, true);
@@ -121,7 +121,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_DISCARD("breakpoint_toggled")
 
-			((Array)args[0])[0] = 1;
+			args = build_array(build_array(1));
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(1, true);
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -137,10 +137,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and clear") {
-			Array arg1;
-			arg1.push_back(0);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(0));
 
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(0, true);
@@ -157,7 +154,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_DISCARD("breakpoint_toggled")
 
-			((Array)args[0])[0] = 1;
+			args = build_array(build_array(1));
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(1, true);
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -173,21 +170,15 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and new lines no text") {
-			Array arg1;
-			arg1.push_back(0);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(0));
 
 			/* No text moves breakpoint. */
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Normal. */
-			((Array)args[0])[0] = 0;
-			Array arg2;
-			arg2.push_back(1);
-			args.push_back(arg2);
+			// Normal.
+			args = build_array(build_array(0), build_array(1));
 
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
@@ -195,18 +186,16 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK(code_edit->is_line_breakpointed(1));
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Non-Breaking. */
-			((Array)args[0])[0] = 1;
-			((Array)args[1])[0] = 2;
+			// Non-Breaking.
+			args = build_array(build_array(1), build_array(2));
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
 			CHECK(code_edit->is_line_breakpointed(2));
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Above. */
-			((Array)args[0])[0] = 2;
-			((Array)args[1])[0] = 3;
+			// Above.
+			args = build_array(build_array(2), build_array(3));
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -215,10 +204,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and new lines with text") {
-			Array arg1;
-			arg1.push_back(0);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(0));
 
 			/* Having text does not move breakpoint. */
 			code_edit->insert_text_at_caret("text");
@@ -241,11 +227,8 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
-			/* Above does move. */
-			((Array)args[0])[0] = 0;
-			Array arg2;
-			arg2.push_back(1);
-			args.push_back(arg2);
+			// Above does move.
+			args = build_array(build_array(0), build_array(1));
 
 			code_edit->set_caret_line(0);
 			SEND_GUI_ACTION("ui_text_newline_above");
@@ -256,10 +239,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and backspace") {
-			Array arg1;
-			arg1.push_back(1);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(1));
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -281,8 +261,8 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			ERR_PRINT_ON;
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Backspace above breakpointed line moves it. */
-			((Array)args[0])[0] = 2;
+			// Backspace above breakpointed line moves it.
+			args = build_array(build_array(2));
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(2, true);
@@ -291,9 +271,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_caret_line(1);
 
-			Array arg2;
-			arg2.push_back(1);
-			args.push_back(arg2);
+			args = build_array(build_array(2), build_array(1));
 			SEND_GUI_ACTION("ui_text_backspace");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -303,10 +281,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and delete") {
-			Array arg1;
-			arg1.push_back(1);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(1));
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -329,8 +304,8 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			ERR_PRINT_ON;
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Delete above breakpointed line moves it. */
-			((Array)args[0])[0] = 2;
+			// Delete above breakpointed line moves it.
+			args = build_array(build_array(2));
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(2, true);
@@ -339,9 +314,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_caret_line(0);
 
-			Array arg2;
-			arg2.push_back(1);
-			args.push_back(arg2);
+			args = build_array(build_array(2), build_array(1));
 			SEND_GUI_ACTION("ui_text_delete");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -351,10 +324,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and delete selection") {
-			Array arg1;
-			arg1.push_back(1);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(1));
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -367,8 +337,8 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK_FALSE(code_edit->is_line_breakpointed(0));
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Should handle breakpoint move when deleting selection by adding less text then removed. */
-			((Array)args[0])[0] = 9;
+			// Should handle breakpoint move when deleting selection by adding less text then removed.
+			args = build_array(build_array(9));
 
 			code_edit->set_text("\n\n\n\n\n\n\n\n\n");
 			code_edit->set_line_as_breakpoint(9, true);
@@ -377,9 +347,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->select(0, 0, 6, 0);
 
-			Array arg2;
-			arg2.push_back(4);
-			args.push_back(arg2);
+			args = build_array(build_array(9), build_array(4));
 			SEND_GUI_ACTION("ui_text_newline");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(9));
@@ -387,9 +355,8 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK(code_edit->is_line_breakpointed(4));
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
-			/* Should handle breakpoint move when deleting selection by adding more text then removed. */
-			((Array)args[0])[0] = 9;
-			((Array)args[1])[0] = 14;
+			// Should handle breakpoint move when deleting selection by adding more text then removed.
+			args = build_array(build_array(9), build_array(14));
 
 			code_edit->insert_text_at_caret("\n\n\n\n\n");
 			MessageQueue::get_singleton()->flush();
@@ -404,10 +371,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and undo") {
-			Array arg1;
-			arg1.push_back(1);
-			Array args;
-			args.push_back(arg1);
+			Array args = build_array(build_array(1));
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -1849,17 +1813,47 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "test\t");
 
-		/* Indent lines does entire line and works without selection. */
+		// Insert in place with multiple carets.
+		code_edit->set_text("test text");
+		code_edit->set_caret_column(5);
+		code_edit->add_caret(0, 7);
+		code_edit->add_caret(0, 2);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "te\tst \tte\txt");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->get_caret_column(0) == 7);
+		CHECK(code_edit->get_caret_column(1) == 10);
+		CHECK(code_edit->get_caret_column(2) == 3);
+		code_edit->remove_secondary_carets();
+
+		// Indent lines does entire line and works without selection.
 		code_edit->set_text("");
 		code_edit->insert_text_at_caret("test");
 		code_edit->indent_lines();
 		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_caret_column() == 5);
 
 		/* Selection does entire line. */
 		code_edit->set_text("test");
 		code_edit->select_all();
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 5);
+
+		// Selection does entire line, right to left selection.
+		code_edit->set_text("test");
+		code_edit->select(0, 4, 0, 0);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 5);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Handles multiple lines. */
 		code_edit->set_text("test\ntext");
@@ -1867,6 +1861,11 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "\ttest");
 		CHECK(code_edit->get_line(1) == "\ttext");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 5);
 
 		/* Do not indent line if last col is zero. */
 		code_edit->set_text("test\ntext");
@@ -1874,6 +1873,11 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "\ttest");
 		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Indent even if last column of first line. */
 		code_edit->set_text("test\ntext");
@@ -1881,15 +1885,53 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "\ttest");
 		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 5);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Indent even if last column of first line, reversed.
+		code_edit->set_text("test\ntext");
+		code_edit->select(1, 0, 0, 4);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 5);
 
 		/* Check selection is adjusted. */
 		code_edit->set_text("test");
 		code_edit->select(0, 1, 0, 2);
 		code_edit->do_indent();
-		CHECK(code_edit->get_selection_from_column() == 2);
-		CHECK(code_edit->get_selection_to_column() == 3);
 		CHECK(code_edit->get_line(0) == "\ttest");
-		code_edit->undo();
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 3);
+
+		// Indent once with multiple selections.
+		code_edit->set_text("test");
+		code_edit->select(0, 1, 0, 2);
+		code_edit->add_caret(0, 4);
+		code_edit->select(0, 4, 0, 3, 1);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 0);
+		CHECK(code_edit->get_selection_origin_column(0) == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 3);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 0);
+		CHECK(code_edit->get_selection_origin_column(1) == 5);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 4);
 	}
 
 	SUBCASE("[CodeEdit] indent spaces") {
@@ -1922,23 +1964,58 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "test    ");
 
-		/* Indent lines does entire line and works without selection. */
+		// Insert in place with multiple carets.
+		code_edit->set_text("test text");
+		code_edit->set_caret_column(5);
+		code_edit->add_caret(0, 7);
+		code_edit->add_caret(0, 2);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "te  st    te  xt");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->get_caret_column(0) == 10);
+		CHECK(code_edit->get_caret_column(1) == 14);
+		CHECK(code_edit->get_caret_column(2) == 4);
+		code_edit->remove_secondary_carets();
+
+		// Indent lines does entire line and works without selection.
 		code_edit->set_text("");
 		code_edit->insert_text_at_caret("test");
 		code_edit->indent_lines();
 		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_caret_column() == 8);
 
 		/* Selection does entire line. */
 		code_edit->set_text("test");
 		code_edit->select_all();
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 8);
+
+		// Selection does entire line, right to left selection.
+		code_edit->set_text("test");
+		code_edit->select(0, 4, 0, 0);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* single indent only add required spaces. */
 		code_edit->set_text(" test");
 		code_edit->select_all();
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 8);
 
 		/* Handles multiple lines. */
 		code_edit->set_text("test\ntext");
@@ -1946,6 +2023,11 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "    test");
 		CHECK(code_edit->get_line(1) == "    text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 8);
 
 		/* Do not indent line if last col is zero. */
 		code_edit->set_text("test\ntext");
@@ -1953,6 +2035,11 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "    test");
 		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Indent even if last column of first line. */
 		code_edit->set_text("test\ntext");
@@ -1960,14 +2047,53 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->do_indent();
 		CHECK(code_edit->get_line(0) == "    test");
 		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Indent even if last column of first line, right to left selection.
+		code_edit->set_text("test\ntext");
+		code_edit->select(1, 0, 0, 4);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 8);
 
 		/* Check selection is adjusted. */
 		code_edit->set_text("test");
 		code_edit->select(0, 1, 0, 2);
 		code_edit->do_indent();
-		CHECK(code_edit->get_selection_from_column() == 5);
-		CHECK(code_edit->get_selection_to_column() == 6);
 		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 5);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 6);
+
+		// Indent once with multiple selections.
+		code_edit->set_text("test");
+		code_edit->select(0, 1, 0, 2);
+		code_edit->add_caret(0, 4);
+		code_edit->select(0, 4, 0, 3, 1);
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 0);
+		CHECK(code_edit->get_selection_origin_column(0) == 5);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 6);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 0);
+		CHECK(code_edit->get_selection_origin_column(1) == 8);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 7);
 	}
 
 	SUBCASE("[CodeEdit] unindent tabs") {
@@ -2003,11 +2129,28 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->insert_text_at_caret("\ttest");
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "test");
+		CHECK(code_edit->get_caret_column() == 4);
+
+		// Unindent lines once with multiple carets.
+		code_edit->set_text("\t\ttest");
+		code_edit->set_caret_column(1);
+		code_edit->add_caret(0, 3);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 2);
+		code_edit->remove_secondary_carets();
 
 		/* Caret on col zero unindent line. */
 		code_edit->set_text("\t\ttest");
+		code_edit->set_caret_column(0);
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Check input action. */
 		code_edit->set_text("\t\ttest");
@@ -2019,13 +2162,34 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->select_all();
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 5);
 
-		/* Handles multiple lines. */
-		code_edit->set_text("\ttest\n\ttext");
+		// Selection does entire line, right to left selection.
+		code_edit->set_text("\t\ttest");
+		code_edit->select(0, 6, 0, 0);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 5);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Handles multiple lines.
+		code_edit->set_text("\t\ttest\n\t\ttext");
 		code_edit->select_all();
 		code_edit->unindent_lines();
-		CHECK(code_edit->get_line(0) == "test");
-		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_line(1) == "\ttext");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 5);
 
 		/* Do not unindent line if last col is zero. */
 		code_edit->set_text("\ttest\n\ttext");
@@ -2033,6 +2197,23 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "test");
 		CHECK(code_edit->get_line(1) == "\ttext");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Do not unindent line if last col is zero, right to left selection.
+		code_edit->set_text("\ttest\n\ttext");
+		code_edit->select(1, 0, 0, 0);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "test");
+		CHECK(code_edit->get_line(1) == "\ttext");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Unindent even if last column of first line. */
 		code_edit->set_text("\ttest\n\ttext");
@@ -2040,14 +2221,50 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "test");
 		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 4);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Check selection is adjusted. */
 		code_edit->set_text("\ttest");
 		code_edit->select(0, 1, 0, 2);
 		code_edit->unindent_lines();
-		CHECK(code_edit->get_selection_from_column() == 0);
-		CHECK(code_edit->get_selection_to_column() == 1);
 		CHECK(code_edit->get_line(0) == "test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Deselect if only the tab was selected.
+		code_edit->set_text("\ttest");
+		code_edit->select(0, 0, 0, 1);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "test");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Unindent once with multiple selections.
+		code_edit->set_text("\t\ttest");
+		code_edit->select(0, 1, 0, 2);
+		code_edit->add_caret(0, 4);
+		code_edit->select(0, 4, 0, 3, 1);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 0);
+		CHECK(code_edit->get_selection_origin_column(0) == 0);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 1);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 0);
+		CHECK(code_edit->get_selection_origin_column(1) == 3);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 2);
 	}
 
 	SUBCASE("[CodeEdit] unindent spaces") {
@@ -2089,11 +2306,28 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->insert_text_at_caret("    test");
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "test");
+		CHECK(code_edit->get_caret_column() == 4);
+
+		// Unindent lines once with multiple carets.
+		code_edit->set_text("        test");
+		code_edit->set_caret_column(1);
+		code_edit->add_caret(0, 9);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 5);
+		code_edit->remove_secondary_carets();
 
 		/* Caret on col zero unindent line. */
 		code_edit->set_text("        test");
+		code_edit->set_caret_column(0);
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Only as far as needed */
 		code_edit->set_text("       test");
@@ -2110,13 +2344,34 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->select_all();
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 8);
 
-		/* Handles multiple lines. */
-		code_edit->set_text("    test\n    text");
+		// Selection does entire line, right to left selection.
+		code_edit->set_text("        test");
+		code_edit->select(0, 12, 0, 0);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Handles multiple lines.
+		code_edit->set_text("        test\n        text");
 		code_edit->select_all();
 		code_edit->unindent_lines();
-		CHECK(code_edit->get_line(0) == "test");
-		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_line(1) == "    text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 8);
 
 		/* Do not unindent line if last col is zero. */
 		code_edit->set_text("    test\n    text");
@@ -2124,6 +2379,23 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "test");
 		CHECK(code_edit->get_line(1) == "    text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Do not unindent line if last col is zero, right to left selection.
+		code_edit->set_text("    test\n    text");
+		code_edit->select(1, 0, 0, 0);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "test");
+		CHECK(code_edit->get_line(1) == "    text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Unindent even if last column of first line. */
 		code_edit->set_text("    test\n    text");
@@ -2131,14 +2403,48 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->unindent_lines();
 		CHECK(code_edit->get_line(0) == "test");
 		CHECK(code_edit->get_line(1) == "text");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 1);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
 
 		/* Check selection is adjusted. */
 		code_edit->set_text("    test");
 		code_edit->select(0, 4, 0, 5);
 		code_edit->unindent_lines();
-		CHECK(code_edit->get_selection_from_column() == 0);
-		CHECK(code_edit->get_selection_to_column() == 1);
 		CHECK(code_edit->get_line(0) == "test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Deselect if only the tab was selected.
+		code_edit->set_text("    test");
+		code_edit->select(0, 0, 0, 4);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "test");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Unindent once with multiple selections.
+		code_edit->set_text("        test");
+		code_edit->select(0, 1, 0, 2);
+		code_edit->add_caret(0, 4);
+		code_edit->select(0, 12, 0, 10, 1);
+		code_edit->unindent_lines();
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK_FALSE(code_edit->has_selection(0));
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 0);
+		CHECK(code_edit->get_selection_origin_column(1) == 8);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 6);
 	}
 
 	SUBCASE("[CodeEdit] auto indent") {
@@ -2153,6 +2459,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "\t");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
 
 			/* new blank line should still indent. */
 			code_edit->set_text("");
@@ -2160,6 +2468,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "\t");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
 
 			/* new line above should not indent. */
 			code_edit->set_text("");
@@ -2167,6 +2477,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test:");
+			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* Whitespace between symbol and caret is okay. */
 			code_edit->set_text("");
@@ -2174,6 +2486,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:  ");
 			CHECK(code_edit->get_line(1) == "\t");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
 
 			/* Comment between symbol and caret is okay. */
 			code_edit->add_comment_delimiter("#", "");
@@ -2183,6 +2497,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test: # comment");
 			CHECK(code_edit->get_line(1) == "\t");
 			code_edit->remove_comment_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
 
 			/* Strings between symbol and caret are not okay. */
 			code_edit->add_string_delimiter("#", "");
@@ -2192,6 +2508,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test: # string");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_string_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* Non-whitespace prevents auto-indentation. */
 			code_edit->add_comment_delimiter("#", "");
@@ -2201,6 +2519,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test := 0 # comment");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* Even when there's no comments. */
 			code_edit->set_text("");
@@ -2208,6 +2528,53 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test := 0");
 			CHECK(code_edit->get_line(1) == "");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
+
+			// Preserve current indentation.
+			code_edit->set_text("\ttest");
+			code_edit->set_caret_column(3);
+			SEND_GUI_ACTION("ui_text_newline");
+			CHECK(code_edit->get_line(0) == "\tte");
+			CHECK(code_edit->get_line(1) == "\tst");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
+
+			// Preserve current indentation blank.
+			code_edit->set_text("\ttest");
+			code_edit->set_caret_column(3);
+			SEND_GUI_ACTION("ui_text_newline_blank");
+			CHECK(code_edit->get_line(0) == "\ttest");
+			CHECK(code_edit->get_line(1) == "\t");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
+
+			// Preserve current indentation above.
+			code_edit->set_text("\ttest");
+			code_edit->set_caret_column(3);
+			SEND_GUI_ACTION("ui_text_newline_above");
+			CHECK(code_edit->get_line(0) == "\t");
+			CHECK(code_edit->get_line(1) == "\ttest");
+			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 1);
+
+			// Increase existing indentation.
+			code_edit->set_text("\ttest:");
+			code_edit->set_caret_column(6);
+			SEND_GUI_ACTION("ui_text_newline");
+			CHECK(code_edit->get_line(0) == "\ttest:");
+			CHECK(code_edit->get_line(1) == "\t\t");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 2);
+
+			// Increase existing indentation blank.
+			code_edit->set_text("\ttest:");
+			code_edit->set_caret_column(3);
+			SEND_GUI_ACTION("ui_text_newline_blank");
+			CHECK(code_edit->get_line(0) == "\ttest:");
+			CHECK(code_edit->get_line(1) == "\t\t");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 2);
 
 			/* If between brace pairs an extra line is added. */
 			code_edit->set_text("");
@@ -2217,6 +2584,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test{");
 			CHECK(code_edit->get_line(1) == "\t");
 			CHECK(code_edit->get_line(2) == "}");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 1);
 
 			/* Except when we are going above. */
 			code_edit->set_text("");
@@ -2225,6 +2594,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test{}");
+			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* or below. */
 			code_edit->set_text("");
@@ -2233,6 +2604,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test{}");
 			CHECK(code_edit->get_line(1) == "");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 		}
 
 		SUBCASE("[CodeEdit] auto indent spaces") {
@@ -2246,6 +2619,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "    ");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
 
 			/* new blank line should still indent. */
 			code_edit->set_text("");
@@ -2253,6 +2628,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "    ");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
 
 			/* new line above should not indent. */
 			code_edit->set_text("");
@@ -2260,6 +2637,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test:");
+			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* Whitespace between symbol and caret is okay. */
 			code_edit->set_text("");
@@ -2267,6 +2646,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:  ");
 			CHECK(code_edit->get_line(1) == "    ");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
 
 			/* Comment between symbol and caret is okay. */
 			code_edit->add_comment_delimiter("#", "");
@@ -2276,6 +2657,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test: # comment");
 			CHECK(code_edit->get_line(1) == "    ");
 			code_edit->remove_comment_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
 
 			/* Strings between symbol and caret are not okay. */
 			code_edit->add_string_delimiter("#", "");
@@ -2285,6 +2668,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test: # string");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_string_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* Non-whitespace prevents auto-indentation. */
 			code_edit->add_comment_delimiter("#", "");
@@ -2294,6 +2679,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test := 0 # comment");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* Even when there's no comments. */
 			code_edit->set_text("");
@@ -2301,6 +2688,53 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test := 0");
 			CHECK(code_edit->get_line(1) == "");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
+
+			// Preserve current indentation.
+			code_edit->set_text("    test");
+			code_edit->set_caret_column(6);
+			SEND_GUI_ACTION("ui_text_newline");
+			CHECK(code_edit->get_line(0) == "    te");
+			CHECK(code_edit->get_line(1) == "    st");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
+
+			// Preserve current indentation blank.
+			code_edit->set_text("    test");
+			code_edit->set_caret_column(6);
+			SEND_GUI_ACTION("ui_text_newline_blank");
+			CHECK(code_edit->get_line(0) == "    test");
+			CHECK(code_edit->get_line(1) == "    ");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
+
+			// Preserve current indentation above.
+			code_edit->set_text("    test");
+			code_edit->set_caret_column(6);
+			SEND_GUI_ACTION("ui_text_newline_above");
+			CHECK(code_edit->get_line(0) == "    ");
+			CHECK(code_edit->get_line(1) == "    test");
+			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 4);
+
+			// Increase existing indentation.
+			code_edit->set_text("    test:");
+			code_edit->set_caret_column(9);
+			SEND_GUI_ACTION("ui_text_newline");
+			CHECK(code_edit->get_line(0) == "    test:");
+			CHECK(code_edit->get_line(1) == "        ");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 8);
+
+			// Increase existing indentation blank.
+			code_edit->set_text("    test:");
+			code_edit->set_caret_column(9);
+			SEND_GUI_ACTION("ui_text_newline");
+			CHECK(code_edit->get_line(0) == "    test:");
+			CHECK(code_edit->get_line(1) == "        ");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 8);
 
 			/* If between brace pairs an extra line is added. */
 			code_edit->set_text("");
@@ -2310,6 +2744,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test{");
 			CHECK(code_edit->get_line(1) == "    ");
 			CHECK(code_edit->get_line(2) == "}");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 4);
 
 			/* Except when we are going above. */
 			code_edit->set_text("");
@@ -2318,6 +2754,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test{}");
+			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* or below. */
 			code_edit->set_text("");
@@ -2326,6 +2764,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test{}");
 			CHECK(code_edit->get_line(1) == "");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 
 			/* If there is something after a colon
 			and there is a colon in the comment it
@@ -2337,6 +2777,8 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_line(0) == "test:test#:");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
+			CHECK(code_edit->get_caret_line() == 1);
+			CHECK(code_edit->get_caret_column() == 0);
 		}
 	}
 
@@ -2345,64 +2787,50 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_indent_using_spaces(false);
 
 		// Only line.
-		code_edit->insert_text_at_caret("        test");
-		code_edit->set_caret_line(0);
-		code_edit->set_caret_column(8);
-		code_edit->select(0, 8, 0, 9);
+		code_edit->set_text("        test");
+		code_edit->select(0, 9, 0, 8);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(0) == "\t\ttest");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 3);
 		CHECK(code_edit->get_caret_column() == 2);
-		CHECK(code_edit->get_selection_from_column() == 2);
-		CHECK(code_edit->get_selection_to_column() == 3);
 
 		// First line.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("        test\n");
-		code_edit->set_caret_line(0);
-		code_edit->set_caret_column(8);
+		code_edit->set_text("        test\n");
 		code_edit->select(0, 8, 0, 9);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(0) == "\t\ttest");
-		CHECK(code_edit->get_caret_column() == 2);
-		CHECK(code_edit->get_selection_from_column() == 2);
-		CHECK(code_edit->get_selection_to_column() == 3);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_column() == 3);
 
 		// Middle line.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("\n        test\n");
-		code_edit->set_caret_line(1);
-		code_edit->set_caret_column(8);
+		code_edit->set_text("\n        test\n");
 		code_edit->select(1, 8, 1, 9);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(1) == "\t\ttest");
-		CHECK(code_edit->get_caret_column() == 2);
-		CHECK(code_edit->get_selection_from_column() == 2);
-		CHECK(code_edit->get_selection_to_column() == 3);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_column() == 3);
 
 		// End line.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("\n        test");
-		code_edit->set_caret_line(1);
-		code_edit->set_caret_column(8);
+		code_edit->set_text("\n        test");
 		code_edit->select(1, 8, 1, 9);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(1) == "\t\ttest");
-		CHECK(code_edit->get_caret_column() == 2);
-		CHECK(code_edit->get_selection_from_column() == 2);
-		CHECK(code_edit->get_selection_to_column() == 3);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_column() == 3);
 
 		// Within provided range.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("    test\n        test\n");
-		code_edit->set_caret_line(1);
-		code_edit->set_caret_column(8);
+		code_edit->set_text("    test\n        test\n");
 		code_edit->select(1, 8, 1, 9);
 		code_edit->convert_indent(1, 1);
 		CHECK(code_edit->get_line(0) == "    test");
 		CHECK(code_edit->get_line(1) == "\t\ttest");
-		CHECK(code_edit->get_caret_column() == 2);
-		CHECK(code_edit->get_selection_from_column() == 2);
-		CHECK(code_edit->get_selection_to_column() == 3);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_column() == 3);
 	}
 
 	SUBCASE("[CodeEdit] convert indent to spaces") {
@@ -2410,64 +2838,50 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_indent_using_spaces(true);
 
 		// Only line.
-		code_edit->insert_text_at_caret("\t\ttest");
-		code_edit->set_caret_line(0);
-		code_edit->set_caret_column(2);
-		code_edit->select(0, 2, 0, 3);
+		code_edit->set_text("\t\ttest");
+		code_edit->select(0, 3, 0, 2);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(0) == "        test");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 9);
 		CHECK(code_edit->get_caret_column() == 8);
-		CHECK(code_edit->get_selection_from_column() == 8);
-		CHECK(code_edit->get_selection_to_column() == 9);
 
 		// First line.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("\t\ttest\n");
-		code_edit->set_caret_line(0);
-		code_edit->set_caret_column(2);
+		code_edit->set_text("\t\ttest\n");
 		code_edit->select(0, 2, 0, 3);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(0) == "        test");
-		CHECK(code_edit->get_caret_column() == 8);
-		CHECK(code_edit->get_selection_from_column() == 8);
-		CHECK(code_edit->get_selection_to_column() == 9);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_column() == 9);
 
 		// Middle line.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("\n\t\ttest\n");
-		code_edit->set_caret_line(1);
-		code_edit->set_caret_column(2);
+		code_edit->set_text("\n\t\ttest\n");
 		code_edit->select(1, 2, 1, 3);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(1) == "        test");
-		CHECK(code_edit->get_caret_column() == 8);
-		CHECK(code_edit->get_selection_from_column() == 8);
-		CHECK(code_edit->get_selection_to_column() == 9);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_column() == 9);
 
 		// End line.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("\n\t\ttest");
-		code_edit->set_caret_line(1);
-		code_edit->set_caret_column(2);
+		code_edit->set_text("\n\t\ttest");
 		code_edit->select(1, 2, 1, 3);
 		code_edit->convert_indent();
 		CHECK(code_edit->get_line(1) == "        test");
-		CHECK(code_edit->get_caret_column() == 8);
-		CHECK(code_edit->get_selection_from_column() == 8);
-		CHECK(code_edit->get_selection_to_column() == 9);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_column() == 9);
 
 		// Within provided range.
-		code_edit->set_text("");
-		code_edit->insert_text_at_caret("\ttest\n\t\ttest\n");
-		code_edit->set_caret_line(1);
-		code_edit->set_caret_column(2);
+		code_edit->set_text("\ttest\n\t\ttest\n");
 		code_edit->select(1, 2, 1, 3);
 		code_edit->convert_indent(1, 1);
 		CHECK(code_edit->get_line(0) == "\ttest");
 		CHECK(code_edit->get_line(1) == "        test");
-		CHECK(code_edit->get_caret_column() == 8);
-		CHECK(code_edit->get_selection_from_column() == 8);
-		CHECK(code_edit->get_selection_to_column() == 9);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_column() == 9);
 
 		// Outside of range.
 		ERR_PRINT_OFF;
@@ -2484,6 +2898,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 	CodeEdit *code_edit = memnew(CodeEdit);
 	SceneTree::get_singleton()->get_root()->add_child(code_edit);
 	code_edit->grab_focus();
+	code_edit->set_line_folding_enabled(true);
 
 	SUBCASE("[CodeEdit] folding settings") {
 		code_edit->set_line_folding_enabled(true);
@@ -2494,8 +2909,6 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 	}
 
 	SUBCASE("[CodeEdit] folding") {
-		code_edit->set_line_folding_enabled(true);
-
 		// No indent.
 		code_edit->set_text("line1\nline2\nline3");
 		for (int i = 0; i < 2; i++) {
@@ -2862,6 +3275,100 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
 	}
 
+	SUBCASE("[CodeEdit] folding carets") {
+		// Folding a line moves all carets that would be hidden.
+		code_edit->set_text("test\n\tline1\n\t\tline 2\n");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(0);
+		code_edit->add_caret(1, 3);
+		code_edit->add_caret(2, 8);
+		code_edit->add_caret(2, 1);
+		code_edit->select(2, 0, 2, 1, 3);
+
+		code_edit->fold_line(0);
+		CHECK(code_edit->is_line_folded(0));
+		CHECK_FALSE(code_edit->is_line_folded(1));
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 4);
+
+		// Undoing an action that puts the caret on a folded line unfolds it.
+		code_edit->set_text("test\n\tline1");
+		code_edit->select(1, 1, 1, 2);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test\n\tlline1");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 3);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		code_edit->fold_line(0);
+		CHECK(code_edit->is_line_folded(0));
+		CHECK_FALSE(code_edit->is_line_folded(1));
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 4);
+
+		code_edit->undo();
+		CHECK(code_edit->get_text() == "test\n\tline1");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 2);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 1);
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		CHECK_FALSE(code_edit->is_line_folded(1));
+
+		// Redoing doesn't refold.
+		code_edit->redo();
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 3);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		CHECK_FALSE(code_edit->is_line_folded(1));
+	}
+
+	SUBCASE("[CodeEdit] toggle folding carets") {
+		code_edit->set_text("test\n\tline1\ntest2\n\tline2");
+
+		// Fold lines with carets on them.
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(1);
+		code_edit->toggle_foldable_lines_at_carets();
+		CHECK(code_edit->is_line_folded(0));
+		CHECK_FALSE(code_edit->is_line_folded(2));
+
+		// Toggle fold on lines with carets.
+		code_edit->add_caret(2, 0);
+		code_edit->toggle_foldable_lines_at_carets();
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		CHECK(code_edit->is_line_folded(2));
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 1);
+		CHECK(code_edit->get_caret_line(1) == 2);
+		CHECK(code_edit->get_caret_column(1) == 0);
+
+		// Multiple carets as part of one fold.
+		code_edit->unfold_all_lines();
+		code_edit->remove_secondary_carets();
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(1);
+		code_edit->add_caret(0, 4);
+		code_edit->add_caret(1, 2);
+		code_edit->toggle_foldable_lines_at_carets();
+		CHECK(code_edit->is_line_folded(0));
+		CHECK_FALSE(code_edit->is_line_folded(2));
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 1);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 4);
+	}
+
 	memdelete(code_edit);
 }
 
@@ -2870,7 +3377,7 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 	SceneTree::get_singleton()->get_root()->add_child(code_edit);
 	code_edit->grab_focus();
 
-	SUBCASE("[CodeEdit] region folding") {
+	SUBCASE("[CodeEdit] region tags") {
 		code_edit->set_line_folding_enabled(true);
 
 		// Region tag detection.
@@ -2907,16 +3414,51 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		ERR_PRINT_ON;
 		CHECK(code_edit->get_code_region_start_tag() == "region");
 		CHECK(code_edit->get_code_region_end_tag() == "endregion");
+	}
 
-		// Region creation with selection adds start / close region lines.
+	SUBCASE("[CodeEdit] create code region") {
+		code_edit->set_line_folding_enabled(true);
+
+		// Region creation with selection adds start and close region lines. Region name is selected and the region is folded.
 		code_edit->set_text("line1\nline2\nline3");
 		code_edit->clear_comment_delimiters();
 		code_edit->add_comment_delimiter("#", "");
 		code_edit->select(1, 0, 1, 4);
 		code_edit->create_code_region();
 		CHECK(code_edit->is_line_code_region_start(1));
-		CHECK(code_edit->get_line(2).contains("line2"));
 		CHECK(code_edit->is_line_code_region_end(3));
+		CHECK(code_edit->get_text() == "line1\n#region New Code Region\nline2\n#endregion\nline3");
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selected_text() == "New Code Region");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 23);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->is_line_folded(1));
+
+		// Undo region creation. Line get unfolded.
+		code_edit->undo();
+		CHECK(code_edit->get_text() == "line1\nline2\nline3");
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 4);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK_FALSE(code_edit->is_line_folded(1));
+
+		// Redo region creation.
+		code_edit->redo();
+		CHECK(code_edit->get_text() == "line1\n#region New Code Region\nline2\n#endregion\nline3");
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selected_text() == "New Code Region");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 23);
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK_FALSE(code_edit->is_line_folded(1));
 
 		// Region creation without any selection has no effect.
 		code_edit->set_text("line1\nline2\nline3");
@@ -2925,7 +3467,7 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		code_edit->create_code_region();
 		CHECK(code_edit->get_text() == "line1\nline2\nline3");
 
-		// Region creation with multiple selections.
+		// Region creation with multiple selections. Secondary carets are removed and the first region name is selected.
 		code_edit->set_text("line1\nline2\nline3");
 		code_edit->clear_comment_delimiters();
 		code_edit->add_comment_delimiter("#", "");
@@ -2934,6 +3476,25 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		code_edit->select(2, 0, 2, 5, 1);
 		code_edit->create_code_region();
 		CHECK(code_edit->get_text() == "#region New Code Region\nline1\n#endregion\nline2\n#region New Code Region\nline3\n#endregion");
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selected_text() == "New Code Region");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 23);
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+
+		// Region creation with mixed selection and non-selection carets. Regular carets are ignored.
+		code_edit->set_text("line1\nline2\nline3");
+		code_edit->clear_comment_delimiters();
+		code_edit->add_comment_delimiter("#", "");
+		code_edit->select(0, 0, 0, 4, 0);
+		code_edit->add_caret(2, 5);
+		code_edit->create_code_region();
+		CHECK(code_edit->get_text() == "#region New Code Region\nline1\n#endregion\nline2\nline3");
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selected_text() == "New Code Region");
 
 		// Two selections on the same line create only one region.
 		code_edit->set_text("test line1\ntest line2\ntest line3");
@@ -2960,6 +3521,10 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		code_edit->add_comment_delimiter("/*", "*/");
 		code_edit->create_code_region();
 		CHECK(code_edit->get_text() == "line1\nline2\nline3");
+	}
+
+	SUBCASE("[CodeEdit] region comment delimiters") {
+		code_edit->set_line_folding_enabled(true);
 
 		// Choose one line comment delimiter.
 		code_edit->set_text("//region region_name\nline2\n//endregion");
@@ -2993,6 +3558,10 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		code_edit->clear_comment_delimiters();
 		CHECK_FALSE(code_edit->is_line_code_region_start(0));
 		CHECK_FALSE(code_edit->is_line_code_region_end(2));
+	}
+
+	SUBCASE("[CodeEdit] fold region") {
+		code_edit->set_line_folding_enabled(true);
 
 		// Fold region.
 		code_edit->clear_comment_delimiters();
@@ -3895,10 +4464,7 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 		SEND_GUI_KEY_EVENT(Key::CTRL);
 #endif
 
-		Array signal_args;
-		Array arg;
-		arg.push_back("some");
-		signal_args.push_back(arg);
+		Array signal_args = build_array(build_array("some"));
 		SIGNAL_CHECK("symbol_validate", signal_args);
 
 		SIGNAL_UNWATCH(code_edit, "symbol_validate");
@@ -3928,110 +4494,818 @@ TEST_CASE("[SceneTree][CodeEdit] line length guidelines") {
 	memdelete(code_edit);
 }
 
-TEST_CASE("[SceneTree][CodeEdit] Backspace delete") {
+TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 	CodeEdit *code_edit = memnew(CodeEdit);
 	SceneTree::get_singleton()->get_root()->add_child(code_edit);
 	code_edit->grab_focus();
 
-	/* Backspace with selection on first line. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test backspace");
-	code_edit->select(0, 0, 0, 5);
-	code_edit->backspace();
-	CHECK(code_edit->get_line(0) == "backspace");
+	SUBCASE("[SceneTree][CodeEdit] backspace") {
+		// Backspace with selection on first line.
+		code_edit->set_text("test backspace");
+		code_edit->select(0, 0, 0, 5);
+		code_edit->backspace();
+		CHECK(code_edit->get_line(0) == "backspace");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
-	/* Backspace with selection on first line and caret at the beginning of file. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test backspace");
-	code_edit->select(0, 0, 0, 5);
-	code_edit->set_caret_column(0);
-	code_edit->backspace();
-	CHECK(code_edit->get_line(0) == "backspace");
+		// Backspace with selection on first line and caret at the beginning of file.
+		code_edit->set_text("test backspace");
+		code_edit->select(0, 5, 0, 0);
+		code_edit->backspace();
+		CHECK(code_edit->get_line(0) == "backspace");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
-	/* Move caret up to the previous line on backspace if caret is at the first column. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("line 1\nline 2");
-	code_edit->set_caret_line(1);
-	code_edit->set_caret_column(0);
-	code_edit->backspace();
-	CHECK(code_edit->get_line(0) == "line 1line 2");
-	CHECK(code_edit->get_caret_line() == 0);
-	CHECK(code_edit->get_caret_column() == 6);
+		// Move caret up to the previous line on backspace if caret is at the first column.
+		code_edit->set_text("line 1\nline 2");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(0);
+		code_edit->backspace();
+		CHECK(code_edit->get_line(0) == "line 1line 2");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 6);
 
-	/* Backspace delete all text if all text is selected. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("line 1\nline 2\nline 3");
-	code_edit->select_all();
-	code_edit->backspace();
-	CHECK(code_edit->get_text().is_empty());
+		// Multiple carets with a caret at the first column.
+		code_edit->set_text("line 1\nline 2");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->add_caret(1, 0);
+		code_edit->add_caret(1, 5);
+		code_edit->backspace();
+		CHECK(code_edit->get_text() == "line 1lne2");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 7);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 6);
+		CHECK(code_edit->get_caret_line(2) == 0);
+		CHECK(code_edit->get_caret_column(2) == 9);
+		code_edit->remove_secondary_carets();
 
-	/* Backspace at the beginning without selection has no effect. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("line 1\nline 2\nline 3");
-	code_edit->set_caret_line(0);
-	code_edit->set_caret_column(0);
-	code_edit->backspace();
-	CHECK(code_edit->get_text() == "line 1\nline 2\nline 3");
+		// Multiple carets close together.
+		code_edit->set_text("line 1\nline 2");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->add_caret(1, 1);
+		code_edit->backspace();
+		CHECK(code_edit->get_text() == "line 1\nne 2");
+		CHECK(code_edit->get_caret_count() == 1);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
 
-	memdelete(code_edit);
-}
+		// Backspace delete all text if all text is selected.
+		code_edit->set_text("line 1\nline 2\nline 3");
+		code_edit->select_all();
+		code_edit->backspace();
+		CHECK(code_edit->get_text().is_empty());
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
 
-TEST_CASE("[SceneTree][CodeEdit] New Line") {
-	CodeEdit *code_edit = memnew(CodeEdit);
-	SceneTree::get_singleton()->get_root()->add_child(code_edit);
-	code_edit->grab_focus();
+		// Backspace at the beginning without selection has no effect.
+		code_edit->set_text("line 1\nline 2\nline 3");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(0);
+		code_edit->backspace();
+		CHECK(code_edit->get_text() == "line 1\nline 2\nline 3");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+	}
 
-	/* Add a new line. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test new line");
-	code_edit->set_caret_line(0);
-	code_edit->set_caret_column(13);
-	SEND_GUI_ACTION("ui_text_newline");
-	CHECK(code_edit->get_line(0) == "test new line");
-	CHECK(code_edit->get_line(1) == "");
+	SUBCASE("[TextEdit] cut") {
+		DisplayServerMock *DS = (DisplayServerMock *)(DisplayServer::get_singleton());
+		code_edit->set_line_folding_enabled(true);
 
-	/* Split line with new line. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test new line");
-	code_edit->set_caret_line(0);
-	code_edit->set_caret_column(5);
-	SEND_GUI_ACTION("ui_text_newline");
-	CHECK(code_edit->get_line(0) == "test ");
-	CHECK(code_edit->get_line(1) == "new line");
+		// Cut without a selection removes the entire line.
+		code_edit->set_text("this is\nsome\n");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(6);
 
-	/* Delete selection and split with new line. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test new line");
-	code_edit->select(0, 0, 0, 5);
-	SEND_GUI_ACTION("ui_text_newline");
-	CHECK(code_edit->get_line(0) == "");
-	CHECK(code_edit->get_line(1) == "new line");
+		code_edit->cut();
+		CHECK(DS->clipboard_get() == "this is\n");
+		CHECK(code_edit->get_text() == "some\n");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 3); // In the default font, this is the same position.
 
-	/* Blank new line below with selection should not split. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test new line");
-	code_edit->select(0, 0, 0, 5);
-	SEND_GUI_ACTION("ui_text_newline_blank");
-	CHECK(code_edit->get_line(0) == "test new line");
-	CHECK(code_edit->get_line(1) == "");
+		// Undo restores the cut text.
+		code_edit->undo();
+		CHECK(DS->clipboard_get() == "this is\n");
+		CHECK(code_edit->get_text() == "this is\nsome\n");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 6);
 
-	/* Blank new line above with selection should not split. */
-	code_edit->set_text("");
-	code_edit->insert_text_at_caret("test new line");
-	code_edit->select(0, 0, 0, 5);
-	SEND_GUI_ACTION("ui_text_newline_above");
-	CHECK(code_edit->get_line(0) == "");
-	CHECK(code_edit->get_line(1) == "test new line");
+		// Redo.
+		code_edit->redo();
+		CHECK(DS->clipboard_get() == "this is\n");
+		CHECK(code_edit->get_text() == "some\n");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 3);
 
-	memdelete(code_edit);
-}
+		// Cut unfolds the line.
+		code_edit->set_text("this is\n\tsome\n");
+		code_edit->fold_line(0);
+		CHECK(code_edit->is_line_folded(0));
 
-TEST_CASE("[SceneTree][CodeEdit] Duplicate Lines") {
-	CodeEdit *code_edit = memnew(CodeEdit);
-	SceneTree::get_singleton()->get_root()->add_child(code_edit);
-	code_edit->grab_focus();
+		code_edit->cut();
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		CHECK(DS->clipboard_get() == "this is\n");
+		CHECK(code_edit->get_text() == "\tsome\n");
+		CHECK(code_edit->get_caret_line() == 0);
 
-	code_edit->set_text(R"(extends Node
+		// Cut with a selection removes just the selection.
+		code_edit->set_text("this is\nsome\n");
+		code_edit->select(0, 5, 0, 7);
+
+		SEND_GUI_ACTION("ui_cut");
+		CHECK(code_edit->get_viewport()->is_input_handled());
+		CHECK(DS->clipboard_get() == "is");
+		CHECK(code_edit->get_text() == "this \nsome\n");
+		CHECK_FALSE(code_edit->get_caret_line());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 5);
+
+		// Cut does not change the text if not editable. Text is still added to clipboard.
+		code_edit->set_text("this is\nsome\n");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(5);
+
+		code_edit->set_editable(false);
+		code_edit->cut();
+		code_edit->set_editable(true);
+		CHECK(DS->clipboard_get() == "this is\n");
+		CHECK(code_edit->get_text() == "this is\nsome\n");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 5);
+
+		// Cut line with multiple carets.
+		code_edit->set_text("this is\nsome\n");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(3);
+		code_edit->add_caret(0, 2);
+		code_edit->add_caret(0, 4);
+		code_edit->add_caret(2, 0);
+
+		code_edit->cut();
+		CHECK(DS->clipboard_get() == "this is\n\n");
+		CHECK(code_edit->get_text() == "some");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK_FALSE(code_edit->has_selection(0));
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 2); // In the default font, this is the same position.
+		// The previous caret at index 1 was merged.
+		CHECK_FALSE(code_edit->has_selection(1));
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
+		CHECK_FALSE(code_edit->has_selection(2));
+		CHECK(code_edit->get_caret_line(2) == 0);
+		CHECK(code_edit->get_caret_column(2) == 4);
+		code_edit->remove_secondary_carets();
+
+		// Cut on the only line removes the contents.
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(2);
+
+		code_edit->cut();
+		CHECK(DS->clipboard_get() == "some\n");
+		CHECK(code_edit->get_text() == "");
+		CHECK(code_edit->get_line_count() == 1);
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Cut empty line.
+		code_edit->cut();
+		CHECK(DS->clipboard_get() == "\n");
+		CHECK(code_edit->get_text() == "");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Cut multiple lines, in order.
+		code_edit->set_text("this is\nsome\ntext to\nbe\n\ncut");
+		code_edit->set_caret_line(2);
+		code_edit->set_caret_column(7);
+		code_edit->add_caret(3, 0);
+		code_edit->add_caret(0, 2);
+
+		code_edit->cut();
+		CHECK(DS->clipboard_get() == "this is\ntext to\nbe\n");
+		CHECK(code_edit->get_text() == "some\n\ncut");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 1);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 2);
+		code_edit->remove_secondary_carets();
+
+		// Cut multiple selections, in order. Ignores regular carets.
+		code_edit->set_text("this is\nsome\ntext to\nbe\n\ncut");
+		code_edit->add_caret(3, 0);
+		code_edit->add_caret(0, 2);
+		code_edit->add_caret(2, 0);
+		code_edit->select(1, 0, 1, 2, 0);
+		code_edit->select(3, 0, 4, 0, 1);
+		code_edit->select(0, 5, 0, 3, 2);
+
+		code_edit->cut();
+		CHECK(DS->clipboard_get() == "s \nso\nbe\n");
+		CHECK(code_edit->get_text() == "thiis\nme\ntext to\n\ncut");
+		CHECK(code_edit->get_caret_count() == 4);
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line(0) == 1);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 3);
+		CHECK(code_edit->get_caret_column(1) == 0);
+		CHECK(code_edit->get_caret_line(2) == 0);
+		CHECK(code_edit->get_caret_column(2) == 3);
+		CHECK(code_edit->get_caret_line(3) == 2);
+		CHECK(code_edit->get_caret_column(3) == 0);
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] new line") {
+		// Add a new line.
+		code_edit->set_text("test new line");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(13);
+		SEND_GUI_ACTION("ui_text_newline");
+		CHECK(code_edit->get_line(0) == "test new line");
+		CHECK(code_edit->get_line(1) == "");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Split line with new line.
+		code_edit->set_text("test new line");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(5);
+		SEND_GUI_ACTION("ui_text_newline");
+		CHECK(code_edit->get_line(0) == "test ");
+		CHECK(code_edit->get_line(1) == "new line");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Delete selection and split with new line.
+		code_edit->set_text("test new line");
+		code_edit->select(0, 0, 0, 5);
+		SEND_GUI_ACTION("ui_text_newline");
+		CHECK(code_edit->get_line(0) == "");
+		CHECK(code_edit->get_line(1) == "new line");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Blank new line below with selection should not split.
+		code_edit->set_text("test new line");
+		code_edit->select(0, 0, 0, 5);
+		SEND_GUI_ACTION("ui_text_newline_blank");
+		CHECK(code_edit->get_line(0) == "test new line");
+		CHECK(code_edit->get_line(1) == "");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Blank new line above with selection should not split.
+		code_edit->set_text("test new line");
+		code_edit->select(0, 0, 0, 5);
+		SEND_GUI_ACTION("ui_text_newline_above");
+		CHECK(code_edit->get_line(0) == "");
+		CHECK(code_edit->get_line(1) == "test new line");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Multiple new lines with multiple carets.
+		code_edit->set_text("test new line");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(5);
+		code_edit->add_caret(0, 8);
+		SEND_GUI_ACTION("ui_text_newline");
+		CHECK(code_edit->get_line(0) == "test ");
+		CHECK(code_edit->get_line(1) == "new");
+		CHECK(code_edit->get_line(2) == " line");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 1);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 2);
+		CHECK(code_edit->get_caret_column(1) == 0);
+
+		// Multiple blank new lines with multiple carets.
+		code_edit->set_text("test new line");
+		code_edit->remove_secondary_carets();
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(5);
+		code_edit->add_caret(0, 8);
+		SEND_GUI_ACTION("ui_text_newline_blank");
+		CHECK(code_edit->get_line(0) == "test new line");
+		CHECK(code_edit->get_line(1) == "");
+		CHECK(code_edit->get_line(2) == "");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 2);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 0);
+
+		// Multiple new lines above with multiple carets.
+		code_edit->set_text("test new line");
+		code_edit->remove_secondary_carets();
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(5);
+		code_edit->add_caret(0, 8);
+		SEND_GUI_ACTION("ui_text_newline_above");
+		CHECK(code_edit->get_line(0) == "");
+		CHECK(code_edit->get_line(1) == "");
+		CHECK(code_edit->get_line(2) == "test new line");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 0);
+
+		// See '[CodeEdit] auto indent' tests for tests about new line with indentation.
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] move lines up") {
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+
+		// Move line up with caret on it.
+		code_edit->set_caret_line(2);
+		code_edit->set_caret_column(1);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nto\nlines\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Undo.
+		code_edit->undo();
+		CHECK(code_edit->get_text() == "test\nlines\nto\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Redo.
+		code_edit->redo();
+		CHECK(code_edit->get_text() == "test\nto\nlines\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Does nothing at the first line.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(1);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nlines\nto\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Works on empty line.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->set_caret_line(3);
+		code_edit->set_caret_column(0);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nlines\n\nto\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Move multiple lines up with selection.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(4, 0, 5, 1);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nlines\nto\nmove\naround\n");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 3);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 4);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Does not affect line with selection end at column 0.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(4, 0, 5, 0);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nlines\nto\nmove\n\naround");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 3);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 4);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Move multiple lines up with selection, right to left selection.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(5, 2, 4, 1);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nlines\nto\nmove\naround\n");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 4);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_line() == 3);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Move multiple lines with multiple carets. A line with multiple carets is only moved once.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(5, 2, 5, 4);
+		code_edit->add_caret(4, 0);
+		code_edit->add_caret(4, 4);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "test\nlines\nto\nmove\naround\n");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 4);
+		CHECK(code_edit->get_selection_origin_column(0) == 2);
+		CHECK(code_edit->get_caret_line(0) == 4);
+		CHECK(code_edit->get_caret_column(0) == 4);
+		CHECK_FALSE(code_edit->has_selection(1));
+		CHECK(code_edit->get_caret_line(1) == 3);
+		CHECK(code_edit->get_caret_column(1) == 0);
+		CHECK_FALSE(code_edit->has_selection(2));
+		CHECK(code_edit->get_caret_line(2) == 3);
+		CHECK(code_edit->get_caret_column(2) == 4);
+
+		// Move multiple separate lines with multiple selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(2, 2, 1, 4);
+		code_edit->add_caret(5, 0);
+		code_edit->select(5, 0, 5, 1, 1);
+		code_edit->move_lines_up();
+		CHECK(code_edit->get_text() == "lines\nto\ntest\n\naround\nmove");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 1);
+		CHECK(code_edit->get_selection_origin_column(0) == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 4);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 4);
+		CHECK(code_edit->get_selection_origin_column(1) == 0);
+		CHECK(code_edit->get_caret_line(1) == 4);
+		CHECK(code_edit->get_caret_column(1) == 1);
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] move lines down") {
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+
+		// Move line down with caret on it.
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(1);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "test\nto\nlines\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Undo.
+		code_edit->undo();
+		CHECK(code_edit->get_text() == "test\nlines\nto\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Redo.
+		code_edit->redo();
+		CHECK(code_edit->get_text() == "test\nto\nlines\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Does nothing at the last line.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->set_caret_line(5);
+		code_edit->set_caret_column(1);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "test\nlines\nto\n\nmove\naround");
+		CHECK(code_edit->get_caret_line() == 5);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Works on empty line.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->set_caret_line(3);
+		code_edit->set_caret_column(0);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "test\nlines\nto\nmove\n\naround");
+		CHECK(code_edit->get_caret_line() == 4);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Move multiple lines down with selection.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(1, 0, 2, 1);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "test\n\nlines\nto\nmove\naround");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 2);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 3);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Does not affect line with selection end at column 0.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(1, 0, 2, 0);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "test\nto\nlines\n\nmove\naround");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 2);
+		CHECK(code_edit->get_selection_origin_column() == 0);
+		CHECK(code_edit->get_caret_line() == 3);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Move multiple lines down with selection, right to left selection.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(2, 2, 1, 1);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "test\n\nlines\nto\nmove\naround");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 3);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Move multiple lines with multiple carets. A line with multiple carets is only moved once.
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(1, 2, 1, 4);
+		code_edit->add_caret(0, 0);
+		code_edit->add_caret(0, 1);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "to\ntest\nlines\n\nmove\naround");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 2);
+		CHECK(code_edit->get_selection_origin_column(0) == 2);
+		CHECK(code_edit->get_caret_line(0) == 2);
+		CHECK(code_edit->get_caret_column(0) == 4);
+		CHECK_FALSE(code_edit->has_selection(1));
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 0);
+		CHECK_FALSE(code_edit->has_selection(2));
+		CHECK(code_edit->get_caret_line(2) == 1);
+		CHECK(code_edit->get_caret_column(2) == 1);
+
+		// Move multiple separate lines with multiple selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\nmove\naround");
+		code_edit->select(0, 2, 1, 4);
+		code_edit->add_caret(4, 0);
+		code_edit->select(4, 0, 4, 2, 1);
+		code_edit->move_lines_down();
+		CHECK(code_edit->get_text() == "to\ntest\nlines\n\naround\nmove");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 1);
+		CHECK(code_edit->get_selection_origin_column(0) == 2);
+		CHECK(code_edit->get_caret_line(0) == 2);
+		CHECK(code_edit->get_caret_column(0) == 4);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 5);
+		CHECK(code_edit->get_selection_origin_column(1) == 0);
+		CHECK(code_edit->get_caret_line(1) == 5);
+		CHECK(code_edit->get_caret_column(1) == 2);
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] delete lines") {
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+
+		// Delete line with caret on it.
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(1);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "test\nto\n\ndelete");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Undo.
+		code_edit->undo();
+		CHECK(code_edit->get_text() == "test\nlines\nto\n\ndelete");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Redo.
+		code_edit->redo();
+		CHECK(code_edit->get_text() == "test\nto\n\ndelete");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Delete empty line.
+		code_edit->set_caret_line(2);
+		code_edit->set_caret_column(0);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "test\nto\ndelete");
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Deletes only one line when there are multiple carets on it. Carets move down and the column gets clamped.
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(0);
+		code_edit->add_caret(0, 1);
+		code_edit->add_caret(0, 4);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "to\ndelete");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 0);
+		CHECK(code_edit->get_caret_column(1) == 1);
+		CHECK(code_edit->get_caret_line(2) == 0);
+		CHECK(code_edit->get_caret_column(2) == 2);
+
+		// Delete multiple lines with selection.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+		code_edit->select(0, 1, 2, 1);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "\ndelete");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Does not affect line with selection end at column 0.
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+		code_edit->select(0, 1, 1, 0);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "lines\nto\n\ndelete");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Delete multiple lines with multiple carets.
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(2);
+		code_edit->add_caret(1, 0);
+		code_edit->add_caret(4, 5);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "to\n");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 0);
+
+		// Delete multiple separate lines with multiple selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+		code_edit->add_caret(4, 5);
+		code_edit->select(0, 1, 1, 1);
+		code_edit->select(5, 5, 4, 0, 1);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "to\n");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_column(0) == 1);
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 0);
+
+		// Deletes contents when there is only one line.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(4);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] duplicate selection") {
+		code_edit->set_text("test\nlines\nto\n\nduplicate");
+
+		// Duplicate selected text.
+		code_edit->select(0, 1, 1, 2);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test\nliest\nlines\nto\n\nduplicate");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 2);
+
+		// Undo.
+		code_edit->undo();
+		CHECK(code_edit->get_text() == "test\nlines\nto\n\nduplicate");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 0);
+		CHECK(code_edit->get_selection_origin_column() == 1);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 2);
+
+		// Redo.
+		code_edit->redo();
+		CHECK(code_edit->get_text() == "test\nliest\nlines\nto\n\nduplicate");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 1);
+		CHECK(code_edit->get_selection_origin_column() == 2);
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 2);
+
+		// Duplicate selected text, right to left selection.
+		code_edit->set_text("test\nlines\nto\n\nduplicate");
+		code_edit->select(1, 1, 0, 2);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test\nlst\nlines\nto\n\nduplicate");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 2);
+		CHECK(code_edit->get_selection_origin_column() == 1);
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 1);
+
+		// Duplicate line if there is no selection.
+		code_edit->deselect();
+		code_edit->set_text("test\nlines\nto\n\nduplicate");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test\nlines\nlines\nto\n\nduplicate");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 2);
+		CHECK(code_edit->get_caret_column() == 2);
+
+		// Duplicate multiple lines.
+		code_edit->deselect();
+		code_edit->set_text("test\nlines\nto\n\nduplicate");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->add_caret(5, 0);
+		code_edit->add_caret(0, 4);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test\ntest\nlines\nlines\nto\n\nduplicate\nduplicate");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line(0) == 3);
+		CHECK(code_edit->get_caret_column(0) == 2);
+		CHECK(code_edit->get_caret_line(1) == 7);
+		CHECK(code_edit->get_caret_column(1) == 0);
+		CHECK(code_edit->get_caret_line(2) == 1);
+		CHECK(code_edit->get_caret_column(2) == 4);
+
+		// Duplicate multiple separate selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\nduplicate");
+		code_edit->add_caret(4, 4);
+		code_edit->add_caret(0, 1);
+		code_edit->add_caret(0, 4);
+		code_edit->select(2, 0, 2, 1, 0);
+		code_edit->select(3, 0, 4, 4, 1);
+		code_edit->select(0, 1, 0, 0, 2);
+		code_edit->select(0, 2, 0, 4, 3);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "ttestst\nlines\ntto\n\ndupl\nduplicate");
+		CHECK(code_edit->get_caret_count() == 4);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 2);
+		CHECK(code_edit->get_selection_origin_column(0) == 1);
+		CHECK(code_edit->get_caret_line(0) == 2);
+		CHECK(code_edit->get_caret_column(0) == 2);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 4);
+		CHECK(code_edit->get_selection_origin_column(1) == 4);
+		CHECK(code_edit->get_caret_line(1) == 5);
+		CHECK(code_edit->get_caret_column(1) == 4);
+		CHECK(code_edit->has_selection(2));
+		CHECK(code_edit->get_selection_origin_line(2) == 0);
+		CHECK(code_edit->get_selection_origin_column(2) == 2);
+		CHECK(code_edit->get_caret_line(2) == 0);
+		CHECK(code_edit->get_caret_column(2) == 1);
+		CHECK(code_edit->has_selection(3));
+		CHECK(code_edit->get_selection_origin_line(3) == 0);
+		CHECK(code_edit->get_selection_origin_column(3) == 5);
+		CHECK(code_edit->get_caret_line(3) == 0);
+		CHECK(code_edit->get_caret_column(3) == 7);
+
+		// Duplicate adjacent selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\nduplicate");
+		code_edit->add_caret(1, 2);
+		code_edit->select(1, 0, 1, 1, 0);
+		code_edit->select(1, 1, 1, 4, 1);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test\nllineines\nto\n\nduplicate");
+		CHECK(code_edit->get_caret_count() == 2);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 1);
+		CHECK(code_edit->get_selection_origin_column(0) == 1);
+		CHECK(code_edit->get_caret_line(0) == 1);
+		CHECK(code_edit->get_caret_column(0) == 2);
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 1);
+		CHECK(code_edit->get_selection_origin_column(1) == 5);
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 8);
+
+		// Duplicate lines then duplicate selections when there are both selections and non-selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test duplicate");
+		code_edit->select(0, 14, 0, 13, 0);
+		code_edit->add_caret(0, 8);
+		code_edit->add_caret(0, 4);
+		code_edit->select(0, 2, 0, 4, 2);
+		code_edit->duplicate_selection();
+		CHECK(code_edit->get_text() == "test duplicate\ntestst duplicatee");
+		CHECK(code_edit->get_caret_count() == 3);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 1);
+		CHECK(code_edit->get_selection_origin_column(0) == 17);
+		CHECK(code_edit->get_caret_line(0) == 1);
+		CHECK(code_edit->get_caret_column(0) == 16);
+		CHECK_FALSE(code_edit->has_selection(1));
+		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_column(1) == 10);
+		CHECK(code_edit->has_selection(2));
+		CHECK(code_edit->get_selection_origin_line(2) == 1);
+		CHECK(code_edit->get_selection_origin_column(2) == 4);
+		CHECK(code_edit->get_caret_line(2) == 1);
+		CHECK(code_edit->get_caret_column(2) == 6);
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] duplicate lines") {
+		String reset_text = R"(extends Node
 
 func _ready():
 	var a := len(OS.get_cmdline_args())
@@ -4041,65 +5315,159 @@ func _ready():
 		print("This is the solution: ", sin(i))
 	var pos = get_index() - 1
 	print("Make sure this exits: %b" % pos)
+)";
+
+		code_edit->set_text(reset_text);
+
+		// Duplicate a single line without selection.
+		code_edit->set_caret_line(0);
+		code_edit->duplicate_lines();
+		CHECK(code_edit->get_line(0) == "extends Node");
+		CHECK(code_edit->get_line(1) == "extends Node");
+		CHECK(code_edit->get_line(2) == "");
+		CHECK(code_edit->get_caret_line() == 1);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Duplicate multiple lines with selection.
+		code_edit->set_text(reset_text);
+		code_edit->select(4, 8, 6, 15);
+		code_edit->duplicate_lines();
+		CHECK(code_edit->get_text() == R"(extends Node
+
+func _ready():
+	var a := len(OS.get_cmdline_args())
+	var b := get_child_count()
+	var c := a + b
+	for i in range(c):
+	var b := get_child_count()
+	var c := a + b
+	for i in range(c):
+		print("This is the solution: ", sin(i))
+	var pos = get_index() - 1
+	print("Make sure this exits: %b" % pos)
 )");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 7);
+		CHECK(code_edit->get_selection_origin_column() == 8);
+		CHECK(code_edit->get_caret_line() == 9);
+		CHECK(code_edit->get_caret_column() == 15);
 
-	/* Duplicate a single line without selection. */
-	code_edit->set_caret_line(0);
-	code_edit->duplicate_lines();
-	CHECK(code_edit->get_line(0) == "extends Node");
-	CHECK(code_edit->get_line(1) == "extends Node");
-	CHECK(code_edit->get_line(2) == "");
+		// Duplicate multiple lines with right to left selection.
+		code_edit->set_text(reset_text);
+		code_edit->select(6, 15, 4, 8);
+		code_edit->duplicate_lines();
+		CHECK(code_edit->get_text() == R"(extends Node
 
-	/* Duplicate multiple lines with selection. */
-	code_edit->set_caret_line(6);
-	code_edit->set_caret_column(15);
-	code_edit->select(4, 8, 6, 15);
-	code_edit->duplicate_lines();
-	CHECK(code_edit->get_line(6) == "\tvar c := a + b");
-	CHECK(code_edit->get_line(7) == "\tvar a := len(OS.get_cmdline_args())");
-	CHECK(code_edit->get_line(8) == "\tvar b := get_child_count()");
-	CHECK(code_edit->get_line(9) == "\tvar c := a + b");
-	CHECK(code_edit->get_line(10) == "\tfor i in range(c):");
+func _ready():
+	var a := len(OS.get_cmdline_args())
+	var b := get_child_count()
+	var c := a + b
+	for i in range(c):
+	var b := get_child_count()
+	var c := a + b
+	for i in range(c):
+		print("This is the solution: ", sin(i))
+	var pos = get_index() - 1
+	print("Make sure this exits: %b" % pos)
+)");
+		CHECK(code_edit->has_selection());
+		CHECK(code_edit->get_selection_origin_line() == 9);
+		CHECK(code_edit->get_selection_origin_column() == 15);
+		CHECK(code_edit->get_caret_line() == 7);
+		CHECK(code_edit->get_caret_column() == 8);
 
-	/* Duplicate single lines with multiple carets. */
-	code_edit->deselect();
-	code_edit->set_caret_line(10);
-	code_edit->set_caret_column(1);
-	code_edit->add_caret(11, 2);
-	code_edit->add_caret(12, 1);
-	code_edit->duplicate_lines();
-	CHECK(code_edit->get_line(9) == "\tvar c := a + b");
-	CHECK(code_edit->get_line(10) == "\tfor i in range(c):");
-	CHECK(code_edit->get_line(11) == "\tfor i in range(c):");
-	CHECK(code_edit->get_line(12) == "\t\tprint(\"This is the solution: \", sin(i))");
-	CHECK(code_edit->get_line(13) == "\t\tprint(\"This is the solution: \", sin(i))");
-	CHECK(code_edit->get_line(14) == "\tvar pos = get_index() - 1");
-	CHECK(code_edit->get_line(15) == "\tvar pos = get_index() - 1");
-	CHECK(code_edit->get_line(16) == "\tprint(\"Make sure this exits: %b\" % pos)");
+		// Duplicate single lines with multiple carets. Multiple carets on a single line only duplicate once.
+		code_edit->remove_secondary_carets();
+		code_edit->deselect();
+		code_edit->set_text(reset_text);
+		code_edit->set_caret_line(3);
+		code_edit->set_caret_column(1);
+		code_edit->add_caret(5, 1);
+		code_edit->add_caret(5, 5);
+		code_edit->add_caret(4, 2);
+		code_edit->duplicate_lines();
+		CHECK(code_edit->get_text() == R"(extends Node
 
-	/* Duplicate multiple lines with multiple carets. */
-	code_edit->select(0, 0, 1, 2, 0);
-	code_edit->select(3, 0, 4, 2, 1);
-	code_edit->select(16, 0, 17, 0, 2);
-	code_edit->set_caret_line(1, false, true, 0, 0);
-	code_edit->set_caret_column(2, false, 0);
-	code_edit->set_caret_line(4, false, true, 0, 1);
-	code_edit->set_caret_column(2, false, 1);
-	code_edit->set_caret_line(17, false, true, 0, 2);
-	code_edit->set_caret_column(0, false, 2);
-	code_edit->duplicate_lines();
-	CHECK(code_edit->get_line(1) == "extends Node");
-	CHECK(code_edit->get_line(2) == "extends Node");
-	CHECK(code_edit->get_line(3) == "extends Node");
-	CHECK(code_edit->get_line(4) == "");
-	CHECK(code_edit->get_line(6) == "\tvar a := len(OS.get_cmdline_args())");
-	CHECK(code_edit->get_line(7) == "func _ready():");
-	CHECK(code_edit->get_line(8) == "\tvar a := len(OS.get_cmdline_args())");
-	CHECK(code_edit->get_line(9) == "\tvar b := get_child_count()");
-	CHECK(code_edit->get_line(20) == "\tprint(\"Make sure this exits: %b\" % pos)");
-	CHECK(code_edit->get_line(21) == "");
-	CHECK(code_edit->get_line(22) == "\tprint(\"Make sure this exits: %b\" % pos)");
-	CHECK(code_edit->get_line(23) == "");
+func _ready():
+	var a := len(OS.get_cmdline_args())
+	var a := len(OS.get_cmdline_args())
+	var b := get_child_count()
+	var b := get_child_count()
+	var c := a + b
+	var c := a + b
+	for i in range(c):
+		print("This is the solution: ", sin(i))
+	var pos = get_index() - 1
+	print("Make sure this exits: %b" % pos)
+)");
+		CHECK(code_edit->get_caret_count() == 4);
+		CHECK_FALSE(code_edit->has_selection(0));
+		CHECK(code_edit->get_caret_line(0) == 4);
+		CHECK(code_edit->get_caret_column(0) == 1);
+		CHECK_FALSE(code_edit->has_selection(1));
+		CHECK(code_edit->get_caret_line(1) == 8);
+		CHECK(code_edit->get_caret_column(1) == 1);
+		CHECK_FALSE(code_edit->has_selection(2));
+		CHECK(code_edit->get_caret_line(2) == 8);
+		CHECK(code_edit->get_caret_column(2) == 5);
+		CHECK_FALSE(code_edit->has_selection(3));
+		CHECK(code_edit->get_caret_line(3) == 6);
+		CHECK(code_edit->get_caret_column(3) == 2);
+
+		// Duplicate multiple lines with multiple selections.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text(reset_text);
+		code_edit->add_caret(4, 2);
+		code_edit->add_caret(6, 0);
+		code_edit->add_caret(7, 8);
+		code_edit->select(0, 0, 2, 5, 0);
+		code_edit->select(3, 0, 4, 2, 1);
+		code_edit->select(7, 1, 6, 0, 2);
+		code_edit->select(7, 3, 7, 8, 3);
+		code_edit->duplicate_lines();
+		CHECK(code_edit->get_text() == R"(extends Node
+
+func _ready():
+extends Node
+
+func _ready():
+	var a := len(OS.get_cmdline_args())
+	var b := get_child_count()
+	var a := len(OS.get_cmdline_args())
+	var b := get_child_count()
+	var c := a + b
+	for i in range(c):
+		print("This is the solution: ", sin(i))
+	for i in range(c):
+		print("This is the solution: ", sin(i))
+	var pos = get_index() - 1
+	print("Make sure this exits: %b" % pos)
+)");
+		CHECK(code_edit->get_caret_count() == 4);
+		CHECK(code_edit->has_selection(0));
+		CHECK(code_edit->get_selection_origin_line(0) == 3);
+		CHECK(code_edit->get_selection_origin_column(0) == 0);
+		CHECK(code_edit->get_caret_line(0) == 5);
+		CHECK(code_edit->get_caret_column(0) == 5);
+
+		CHECK(code_edit->has_selection(1));
+		CHECK(code_edit->get_selection_origin_line(1) == 8);
+		CHECK(code_edit->get_selection_origin_column(1) == 0);
+		CHECK(code_edit->get_caret_line(1) == 9);
+		CHECK(code_edit->get_caret_column(1) == 2);
+
+		CHECK(code_edit->has_selection(2));
+		CHECK(code_edit->get_selection_origin_line(2) == 14);
+		CHECK(code_edit->get_selection_origin_column(2) == 1);
+		CHECK(code_edit->get_caret_line(2) == 13);
+		CHECK(code_edit->get_caret_column(2) == 0);
+
+		CHECK(code_edit->has_selection(3));
+		CHECK(code_edit->get_selection_origin_line(3) == 14);
+		CHECK(code_edit->get_selection_origin_column(3) == 3);
+		CHECK(code_edit->get_caret_line(3) == 14);
+		CHECK(code_edit->get_caret_column(3) == 8);
+	}
 
 	memdelete(code_edit);
 }

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -36,6 +36,23 @@
 #include "tests/test_macros.h"
 
 namespace TestTextEdit {
+static inline Array build_array() {
+	return Array();
+}
+template <typename... Targs>
+static inline Array build_array(Variant item, Targs... Fargs) {
+	Array a = build_array(Fargs...);
+	a.push_front(item);
+	return a;
+}
+static inline Array reverse_nested(Array array) {
+	Array reversed_array = array.duplicate(true);
+	reversed_array.reverse();
+	for (int i = 0; i < reversed_array.size(); i++) {
+		((Array)reversed_array[i]).reverse();
+	}
+	return reversed_array;
+}
 
 TEST_CASE("[SceneTree][TextEdit] text entry") {
 	SceneTree::get_singleton()->get_root()->set_physics_object_picking(false);
@@ -52,12 +69,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array args1;
-		args1.push_back(0);
-		args1.push_back(0);
-		Array lines_edited_args;
-		lines_edited_args.push_back(args1);
-		lines_edited_args.push_back(args1.duplicate());
+		Array lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
 
 		SUBCASE("[TextEdit] clear and set text") {
 			// "text_changed" should not be emitted on clear / set.
@@ -119,13 +131,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 
-			// Clear.
+			// Can clear even if not editable.
 			text_edit->set_editable(false);
 
-			Array lines_edited_clear_args;
-			Array new_args = args1.duplicate();
-			new_args[0] = 1;
-			lines_edited_clear_args.push_back(new_args);
+			Array lines_edited_clear_args = build_array(build_array(1, 0));
 
 			text_edit->clear();
 			MessageQueue::get_singleton()->flush();
@@ -210,6 +219,321 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_changed");
 		}
 
+		SUBCASE("[TextEdit] insert text") {
+			// insert_text is 0 indexed.
+			ERR_PRINT_OFF;
+			text_edit->insert_text("test", 1, 0);
+			ERR_PRINT_ON;
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Insert text when there is no text.
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->insert_text("tes", 0, 0);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "tes");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 3);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Insert multiple lines.
+			lines_edited_args = build_array(build_array(0, 1));
+
+			text_edit->insert_text("t\ninserting text", 0, 3);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\ninserting text");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 14);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Can insert even if not editable.
+			lines_edited_args = build_array(build_array(1, 1));
+
+			text_edit->set_editable(false);
+			text_edit->insert_text("mid", 1, 2);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\ninmidserting text");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 17);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->set_editable(true);
+
+			// Undo insert.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\ninserting text");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 14);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Redo insert.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\ninmidserting text");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 17);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Insert offsets carets after the edit.
+			text_edit->add_caret(1, 1);
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 4, 1, 6, 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 2));
+
+			text_edit->insert_text("\n ", 1, 2);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nin\n midserting text");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 2);
+			CHECK(text_edit->get_caret_column(0) == 16);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 1);
+			CHECK(text_edit->has_selection(2));
+			CHECK(text_edit->get_caret_line(2) == 2);
+			CHECK(text_edit->get_caret_column(2) == 5);
+			CHECK(text_edit->get_selection_origin_line(2) == 2);
+			CHECK(text_edit->get_selection_origin_column(2) == 3);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
+			text_edit->deselect();
+
+			// Insert text outside of selections.
+			text_edit->set_text("test text");
+			text_edit->add_caret(0, 8);
+			text_edit->select(0, 1, 0, 4, 0);
+			text_edit->select(0, 4, 0, 8, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->insert_text("a", 0, 4, true, false);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testa text");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 1);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 9);
+			CHECK(text_edit->get_selection_origin_line(1) == 0);
+			CHECK(text_edit->get_selection_origin_column(1) == 5);
+
+			// Insert text to beginning of selections.
+			text_edit->set_text("test text");
+			text_edit->add_caret(0, 8);
+			text_edit->select(0, 1, 0, 4, 0);
+			text_edit->select(0, 4, 0, 8, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->insert_text("a", 0, 4, false, false);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testa text");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 1);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 9);
+			CHECK(text_edit->get_selection_origin_line(1) == 0);
+			CHECK(text_edit->get_selection_origin_column(1) == 4);
+
+			// Insert text to end of selections.
+			text_edit->set_text("test text");
+			text_edit->add_caret(0, 8);
+			text_edit->select(0, 1, 0, 4, 0);
+			text_edit->select(0, 4, 0, 8, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->insert_text("a", 0, 4, true, true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testa text");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 5);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 1);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 9);
+			CHECK(text_edit->get_selection_origin_line(1) == 0);
+			CHECK(text_edit->get_selection_origin_column(1) == 5);
+
+			// Insert text inside of selections.
+			text_edit->set_text("test text");
+			text_edit->add_caret(0, 8);
+			text_edit->select(0, 1, 0, 4, 0);
+			text_edit->select(0, 4, 0, 8, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->insert_text("a", 0, 4, false, true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testa text");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 9);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 1);
+		}
+
+		SUBCASE("[TextEdit] remove text") {
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 2));
+
+			text_edit->set_text("test\nremoveing text\nthird line");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+
+			// remove_text is 0 indexed.
+			ERR_PRINT_OFF;
+			text_edit->remove_text(3, 0, 3, 4);
+			ERR_PRINT_ON;
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nremoveing text\nthird line");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Remove multiple lines.
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(10);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(2, 1));
+
+			text_edit->remove_text(1, 9, 2, 2);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nremoveingird line");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 17);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Can remove even if not editable.
+			lines_edited_args = build_array(build_array(1, 1));
+
+			text_edit->set_editable(false);
+			text_edit->remove_text(1, 5, 1, 6);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nremovingird line");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 16);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->set_editable(true);
+
+			// Undo remove.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nremoveingird line");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 17);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Redo remove.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nremovingird line");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 16);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Remove collapses carets and offsets carets after the edit.
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(9);
+			text_edit->add_caret(1, 10);
+			text_edit->select(1, 10, 1, 13, 1);
+			text_edit->add_caret(1, 14);
+			text_edit->add_caret(1, 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+
+			text_edit->remove_text(1, 8, 1, 11);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test\nremoving line");
+			// Caret 0 was merged into the selection.
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 10);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 8);
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 11);
+			CHECK(text_edit->get_caret_line(2) == 1);
+			CHECK(text_edit->get_caret_column(2) == 2);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
+		}
+
 		SUBCASE("[TextEdit] set and get line") {
 			// Set / Get line is 0 indexed.
 			text_edit->set_line(1, "test");
@@ -225,6 +549,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_text() == "test");
 			CHECK(text_edit->get_line(0) == "test");
 			CHECK(text_edit->get_line(1) == "");
+			CHECK(text_edit->get_line_count() == 1);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_set");
@@ -233,14 +558,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Setting to a longer line, caret and selections should be preserved.
 			text_edit->select_all();
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->has_selection());
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_line(0, "test text");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_line(0) == "test text");
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "test");
+			CHECK(text_edit->get_selection_origin_column() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("caret_changed");
@@ -299,12 +625,84 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("text_set");
-
 			ERR_PRINT_ON;
+
+			// Both ends of selection are adjusted and deselects.
+			text_edit->set_text("test text");
+			text_edit->select(0, 8, 0, 6);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->set_line(0, "test");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_line(0) == "test");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_column() == 4);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Multiple carets adjust to keep visual position.
+			text_edit->set_text("test text");
+			text_edit->set_caret_column(2);
+			text_edit->add_caret(0, 0);
+			text_edit->add_caret(0, 1);
+			text_edit->add_caret(0, 6);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->set_line(0, "\tset line");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_line(0) == "\tset line");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK_FALSE(text_edit->has_selection());
+			// In the default font, these are the same positions.
+			CHECK(text_edit->get_caret_column(0) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			// The previous caret at index 2 was merged.
+			CHECK(text_edit->get_caret_column(2) == 4);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
+
+			// Insert multiple lines.
+			text_edit->set_text("test text\nsecond line");
+			text_edit->set_caret_column(5);
+			text_edit->add_caret(1, 6);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1));
+
+			text_edit->set_line(0, "multiple\nlines");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "multiple\nlines\nsecond line");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 3); // In the default font, this is the same position.
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 6);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
 		}
 
 		SUBCASE("[TextEdit] swap lines") {
-			((Array)lines_edited_args[1])[1] = 1;
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1));
 
 			text_edit->set_text("testing\nswap");
 			MessageQueue::get_singleton()->flush();
@@ -317,15 +715,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(text_edit->get_line(0).length());
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			// Emitted twice for each line.
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0), build_array(1, 1), build_array(1, 1));
 
-			((Array)lines_edited_args[1])[1] = 0;
-			Array swap_args;
-			swap_args.push_back(1);
-			swap_args.push_back(1);
-			lines_edited_args.push_back(swap_args);
-			lines_edited_args.push_back(swap_args);
-
-			// Order does not matter. Should also work if not editable.
+			// Order does not matter. Works when not editable.
 			text_edit->set_editable(false);
 			text_edit->swap_lines(1, 0);
 			MessageQueue::get_singleton()->flush();
@@ -336,18 +729,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 			text_edit->set_editable(true);
 
-			lines_edited_args.reverse();
-
-			// Single undo/redo action
+			// Single undo/redo action.
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nswap");
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_set");
-
-			lines_edited_args.reverse();
 
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
@@ -361,36 +750,70 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			ERR_PRINT_OFF;
 			text_edit->swap_lines(-1, 0);
 			CHECK(text_edit->get_text() == "swap\ntesting");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("text_set");
-
 			text_edit->swap_lines(0, -1);
 			CHECK(text_edit->get_text() == "swap\ntesting");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("text_set");
-
 			text_edit->swap_lines(2, 0);
 			CHECK(text_edit->get_text() == "swap\ntesting");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("text_set");
-
 			text_edit->swap_lines(0, 2);
 			CHECK(text_edit->get_text() == "swap\ntesting");
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 			ERR_PRINT_ON;
+
+			// Carets are also swapped.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(2);
+			text_edit->select(0, 0, 0, 2);
+			text_edit->add_caret(1, 6);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 1), build_array(1, 1), build_array(0, 0), build_array(0, 0));
+
+			text_edit->swap_lines(0, 1);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testing\nswap");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 6);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
+
+			// Swap non adjacent lines.
+			text_edit->insert_line_at(1, "new line");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(5);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testing\nnew line\nswap");
+			SIGNAL_DISCARD("caret_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("text_changed");
+			lines_edited_args = build_array(build_array(2, 2), build_array(2, 2), build_array(0, 0), build_array(0, 0));
+
+			text_edit->swap_lines(0, 2);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "swap\nnew line\ntesting");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 5);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
 		}
 
 		SUBCASE("[TextEdit] insert line at") {
-			((Array)lines_edited_args[1])[1] = 1;
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1));
 
 			text_edit->set_text("testing\nswap");
 			MessageQueue::get_singleton()->flush();
@@ -407,9 +830,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_to_line() == 1);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
-			// Insert before should move caret and selection, and works when not editable.
+			// Insert line at inserts a line before and moves caret and selection. Works when not editable.
 			text_edit->set_editable(false);
-			lines_edited_args.remove_at(0);
+			lines_edited_args = build_array(build_array(0, 1));
 			text_edit->insert_line_at(0, "new");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nswap");
@@ -417,7 +840,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(2).size() - 1);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selection_from_line() == 1);
+			CHECK(text_edit->get_selection_from_column() == 0);
 			CHECK(text_edit->get_selection_to_line() == 2);
+			CHECK(text_edit->get_selection_to_column() == 4);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -425,19 +850,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(true);
 
 			// Can undo/redo as single action.
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 0;
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nswap");
 			CHECK(text_edit->has_selection());
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_set");
 
-			((Array)lines_edited_args[0])[0] = 0;
-			((Array)lines_edited_args[0])[1] = 1;
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nswap");
@@ -454,9 +875,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_from_line() == 0);
 			CHECK(text_edit->get_selection_to_line() == 2);
 			SIGNAL_CHECK_FALSE("caret_changed");
+			lines_edited_args = build_array(build_array(2, 3));
 
-			((Array)lines_edited_args[0])[0] = 2;
-			((Array)lines_edited_args[0])[1] = 3;
 			text_edit->insert_line_at(2, "after");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nafter\nswap");
@@ -474,24 +894,222 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			ERR_PRINT_OFF;
 			text_edit->insert_line_at(-1, "after");
 			CHECK(text_edit->get_text() == "new\ntesting\nafter\nswap");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("text_set");
-
 			text_edit->insert_line_at(4, "after");
 			CHECK(text_edit->get_text() == "new\ntesting\nafter\nswap");
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 			ERR_PRINT_ON;
+
+			// Can insert multiple lines.
+			text_edit->select(0, 1, 2, 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(2, 4));
+
+			text_edit->insert_line_at(2, "multiple\nlines");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "new\ntesting\nmultiple\nlines\nafter\nswap");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 4);
+			CHECK(text_edit->get_caret_column() == 2);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 1);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
 		}
 
-		SUBCASE("[TextEdit] insert line at caret") {
-			lines_edited_args.pop_back();
-			((Array)lines_edited_args[0])[1] = 1;
+		SUBCASE("[TextEdit] remove line at") {
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 5));
+			text_edit->set_text("testing\nremove line at\n\tremove\nlines\n\ntest");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testing\nremove line at\n\tremove\nlines\n\ntest");
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
 
+			// Remove line handles multiple carets.
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(0);
+			text_edit->add_caret(2, 7);
+			text_edit->select(2, 1, 2, 7, 1);
+			text_edit->add_caret(3, 1);
+			text_edit->add_caret(4, 5);
+			text_edit->add_caret(1, 5);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(3, 2));
+
+			text_edit->remove_line_at(2, true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "testing\nremove line at\nlines\n\ntest");
+			CHECK(text_edit->get_caret_count() == 5);
+			CHECK_FALSE(text_edit->has_selection(0)); // Same line.
+			CHECK(text_edit->get_caret_line(0) == 2);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->has_selection(1)); // Same line, clamped.
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 3); // In the default font, this is the same position.
+			CHECK_FALSE(text_edit->has_selection(2)); // Moved up.
+			CHECK(text_edit->get_caret_line(2) == 2);
+			CHECK(text_edit->get_caret_column(2) == 1);
+			CHECK_FALSE(text_edit->has_selection(3)); // Moved up.
+			CHECK(text_edit->get_caret_line(3) == 3);
+			CHECK(text_edit->get_caret_column(3) == 0);
+			CHECK_FALSE(text_edit->has_selection(4)); // Didn't move.
+			CHECK(text_edit->get_caret_line(4) == 1);
+			CHECK(text_edit->get_caret_column(4) == 5);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
+
+			// Remove first line.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(5);
+			text_edit->add_caret(4, 4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0));
+
+			text_edit->remove_line_at(0, false);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at\nlines\n\ntest");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->remove_secondary_carets();
+
+			// Remove empty line.
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(3, 2));
+
+			text_edit->remove_line_at(2, false);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at\nlines\ntest");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Remove last line.
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(2, 1));
+
+			text_edit->remove_line_at(2, true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at\nlines");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 5);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Out of bounds.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			ERR_PRINT_OFF
+			text_edit->remove_line_at(2, true);
+			ERR_PRINT_ON
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at\nlines");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Remove regular line with move caret up and not editable.
+			text_edit->set_editable(false);
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0));
+
+			text_edit->remove_line_at(1, false);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 1); // In the default font, this is the same position.
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+			text_edit->set_editable(true);
+
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at\nlines");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "remove line at");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 1);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Remove only line removes line content.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(10);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->remove_line_at(0);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_line_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+		}
+
+		SUBCASE("[TextEdit] insert text at caret") {
+			lines_edited_args = build_array(build_array(0, 1));
+
+			// Insert text at caret can insert multiple lines.
 			text_edit->insert_text_at_caret("testing\nswap");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nswap");
@@ -502,11 +1120,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_set");
 
+			// Text is inserted at caret.
 			text_edit->set_caret_line(0, false);
 			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			((Array)lines_edited_args[0])[1] = 0;
+			lines_edited_args = build_array(build_array(0, 0));
 			text_edit->insert_text_at_caret("mid");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "temidsting\nswap");
@@ -517,9 +1137,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_set");
 
+			// Selections are deleted then text is inserted. It also works even if not editable.
 			text_edit->select(0, 0, 0, text_edit->get_line(0).length());
 			CHECK(text_edit->has_selection());
-			lines_edited_args.push_back(args1.duplicate());
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
 
 			text_edit->set_editable(false);
 			text_edit->insert_text_at_caret("new line");
@@ -534,12 +1155,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 			text_edit->set_editable(true);
 
+			// Undo restores text and selection.
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "temidsting\nswap");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
 			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
@@ -589,24 +1213,19 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array args1;
-		args1.push_back(0);
-		args1.push_back(0);
-		Array lines_edited_args;
-		lines_edited_args.push_back(args1);
-		lines_edited_args.push_back(args1.duplicate());
+		Array lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
 
 		SUBCASE("[TextEdit] select all") {
+			// Select when there is no text does not select.
 			text_edit->select_all();
 			CHECK_FALSE(text_edit->has_selection());
-			ERR_PRINT_OFF;
-			CHECK(text_edit->get_selection_from_line() == -1);
-			CHECK(text_edit->get_selection_from_column() == -1);
-			CHECK(text_edit->get_selection_to_line() == -1);
-			CHECK(text_edit->get_selection_to_column() == -1);
+			CHECK(text_edit->get_selection_from_line() == 0);
+			CHECK(text_edit->get_selection_from_column() == 0);
+			CHECK(text_edit->get_selection_to_line() == 0);
+			CHECK(text_edit->get_selection_to_column() == 0);
 			CHECK(text_edit->get_selected_text() == "");
-			ERR_PRINT_ON;
 
+			// Select all selects all text.
 			text_edit->set_text("test\nselection");
 			SEND_GUI_ACTION("ui_text_select_all");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -618,10 +1237,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_to_line() == 1);
 			CHECK(text_edit->get_selection_to_column() == 9);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SelectionMode::SELECTION_MODE_SHIFT);
+			CHECK(text_edit->is_caret_after_selection_origin());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 9);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
+			// Cannot select when disabled.
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(0);
 			text_edit->set_selecting_enabled(false);
@@ -654,6 +1275,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Select word under caret with multiple carets.
 			text_edit->select_word_under_caret();
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
@@ -675,6 +1297,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			CHECK(text_edit->get_caret_count() == 2);
 
+			// Select word under caret disables selection if there is already a selection.
 			text_edit->select_word_under_caret();
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
@@ -703,6 +1326,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selected_text() == "test\ntest");
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
+			// Cannot select when disabled.
 			text_edit->set_selecting_enabled(false);
 			text_edit->select_word_under_caret();
 			CHECK_FALSE(text_edit->has_selection());
@@ -714,10 +1338,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("caret_changed");
 			text_edit->set_selecting_enabled(true);
 
-			text_edit->set_caret_line(1, false, true, 0, 0);
+			// Select word under caret when there is no word does not select.
+			text_edit->set_caret_line(1, false, true, -1, 0);
 			text_edit->set_caret_column(5, false, 0);
-
-			text_edit->set_caret_line(2, false, true, 0, 1);
+			text_edit->set_caret_line(2, false, true, -1, 1);
 			text_edit->set_caret_column(5, false, 1);
 
 			text_edit->select_word_under_caret();
@@ -739,7 +1363,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0);
 			text_edit->set_caret_line(1);
 
-			// First selection made by the implicit select_word_under_caret call
+			// First selection made by the implicit select_word_under_caret call.
 			text_edit->add_selection_for_next_occurrence();
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->get_selected_text(0) == "test");
@@ -780,7 +1404,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line(3) == 3);
 			CHECK(text_edit->get_caret_column(3) == 9);
 
-			// A different word with a new manually added caret
+			// A different word with a new manually added caret.
 			text_edit->add_caret(2, 1);
 			text_edit->select(2, 0, 2, 4, 4);
 			CHECK(text_edit->get_selected_text(4) == "rand");
@@ -795,7 +1419,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line(5) == 3);
 			CHECK(text_edit->get_caret_column(5) == 22);
 
-			// Make sure the previous selections are still active
+			// Make sure the previous selections are still active.
 			CHECK(text_edit->get_selected_text(0) == "test");
 			CHECK(text_edit->get_selected_text(1) == "test");
 			CHECK(text_edit->get_selected_text(2) == "test");
@@ -987,6 +1611,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "t");
+			CHECK(text_edit->is_caret_after_selection_origin());
 
 #ifdef MACOS_ENABLED
 			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT | KeyModifierMask::ALT)
@@ -995,10 +1620,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 #endif
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "test");
+			CHECK(text_edit->is_caret_after_selection_origin());
 
 			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "tes");
+			CHECK(text_edit->is_caret_after_selection_origin());
 
 #ifdef MACOS_ENABLED
 			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT | KeyModifierMask::ALT)
@@ -1019,11 +1646,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "t");
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin());
 
 			SEND_GUI_KEY_EVENT(Key::LEFT)
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
 
+			// Cannot select when disabled.
 			text_edit->set_selecting_enabled(false);
 			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT)
 			CHECK_FALSE(text_edit->has_selection());
@@ -1032,46 +1661,120 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] mouse drag select") {
-			/* Set size for mouse input. */
+			// Set size for mouse input.
 			text_edit->set_size(Size2(200, 200));
 
 			text_edit->set_text("this is some text\nfor selection");
 			text_edit->grab_focus();
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 1), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			// Click and drag to make a selection.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Add (2,0) to bring it past the center point of the grapheme and account for integer division flooring.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for s");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
-			CHECK(text_edit->get_selection_from_line() == 1);
-			CHECK(text_edit->get_selection_from_column() == 0);
-			CHECK(text_edit->get_selection_to_line() == 1);
-			CHECK(text_edit->get_selection_to_column() == 5);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 0);
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(text_edit->is_caret_after_selection_origin());
+			CHECK(text_edit->is_dragging_cursor());
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 9), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Releasing finishes.
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "for s");
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "for s");
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(text_edit->is_caret_after_selection_origin());
+
+			// Clicking clears selection.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 7);
 
+			// Cannot select when disabled, but caret still moves.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 1), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 0);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
 			text_edit->set_selecting_enabled(true);
+
+			// Only last caret is moved when adding a selection.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(0, 15);
+			text_edit->select(0, 11, 0, 15, 1);
+			MessageQueue::get_singleton()->flush();
+
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selection_origin_line(1) == 0);
+			CHECK(text_edit->get_selection_origin_column(1) == 11);
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 15);
+
+			CHECK(text_edit->has_selection(2));
+			CHECK(text_edit->get_selected_text(2) == "for s");
+			CHECK(text_edit->get_selection_origin_line(2) == 1);
+			CHECK(text_edit->get_selection_origin_column(2) == 5);
+			CHECK(text_edit->get_caret_line(2) == 1);
+			CHECK(text_edit->get_caret_column(2) == 0);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(2));
+
+			// Overlapping carets and selections merges them.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "s is some text\nfor s");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 5);
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 3);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin());
+
+			// Entering text stops selecting.
+			text_edit->insert_text_at_caret("a");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "thiaelection");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
 		}
 
 		SUBCASE("[TextEdit] mouse word select") {
-			/* Set size for mouse input. */
+			// Set size for mouse input.
 			text_edit->set_size(Size2(200, 200));
 
-			text_edit->set_text("this is some text\nfor selection");
+			text_edit->set_text("this is some text\nfor selection\n");
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
+			// Double click to select word.
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 2).get_center() + Point2i(2, 0), Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1081,9 +1784,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_to_column() == 3);
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 3);
+			CHECK(text_edit->is_caret_after_selection_origin());
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			// Moving mouse selects entire words at a time.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1093,15 +1798,116 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_to_column() == 13);
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 13);
+			CHECK(text_edit->is_caret_after_selection_origin());
+			CHECK(text_edit->is_dragging_cursor());
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
-			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			CHECK_FALSE(text_edit->has_selection());
+			// Moving to a word before the initial selected word reverses selection direction and keeps the initial word selected.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "some text\nfor");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK(text_edit->get_selection_from_line() == 0);
+			CHECK(text_edit->get_selection_from_column() == 8);
+			CHECK(text_edit->get_selection_to_line() == 1);
+			CHECK(text_edit->get_selection_to_column() == 3);
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin());
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
+			// Releasing finishes.
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "some text\nfor");
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 2).get_center(), MouseButtonMask::NONE, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "some text\nfor");
+			text_edit->deselect();
+
+			// Can start word select mode on an empty line.
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(2, 0).get_center() + Point2i(2, 0), Key::NONE);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 0);
+
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "selection\n");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 4);
+			CHECK(text_edit->get_selection_origin_line() == 2);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+
+			// Clicking clears selection.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+
+			// Can start word select mode when not on a word.
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 12).get_center() + Point2i(2, 0), Key::NONE);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 12);
+
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == " text\nfor selection");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 13);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 12);
+
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "some");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 12);
+
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 15).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+
+			// Add a new selection without affecting the old one.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 8).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "some");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 8);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 12);
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "ele");
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 8);
+			CHECK(text_edit->get_selection_origin_line(1) == 1);
+			CHECK(text_edit->get_selection_origin_column(1) == 5);
+
+			// Shift + double click to extend selection and start word select mode.
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 8).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			text_edit->remove_secondary_carets();
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), Key::NONE | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == " text\nfor selection");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 13);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 12);
+
+			// Cannot select when disabled, but caret still moves to end of word.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 1).get_center() + Point2i(2, 0), Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 3);
@@ -1109,32 +1915,149 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] mouse line select") {
-			/* Set size for mouse input. */
+			// Set size for mouse input.
 			text_edit->set_size(Size2(200, 200));
 
-			text_edit->set_text("this is some text\nfor selection");
+			text_edit->set_text("this is some text\nfor selection\nwith 3 lines");
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Triple click to select line.
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 2).get_center(), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 2).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_selected_text() == "for selection");
+			CHECK(text_edit->get_selected_text() == "for selection\n");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
 			CHECK(text_edit->get_selection_from_line() == 1);
 			CHECK(text_edit->get_selection_from_column() == 0);
+			CHECK(text_edit->get_selection_to_line() == 2);
+			CHECK(text_edit->get_selection_to_column() == 0);
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->is_caret_after_selection_origin());
+
+			// Moving mouse selects entire lines at a time. Selecting above reverses the selection direction.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "this is some text\nfor selection");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->get_selection_from_line() == 0);
+			CHECK(text_edit->get_selection_from_column() == 0);
 			CHECK(text_edit->get_selection_to_line() == 1);
 			CHECK(text_edit->get_selection_to_column() == 13);
-			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin());
+			CHECK(text_edit->is_dragging_cursor());
 
-			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Selecting to the last line puts the caret at end of the line.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "for selection\nwith 3 lines");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->get_selection_from_line() == 1);
+			CHECK(text_edit->get_selection_from_column() == 0);
+			CHECK(text_edit->get_selection_to_line() == 2);
+			CHECK(text_edit->get_selection_to_column() == 12);
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 12);
+			CHECK(text_edit->is_caret_after_selection_origin());
+
+			// Releasing finishes.
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "for selection\nwith 3 lines");
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 2).get_center(), MouseButtonMask::NONE, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "for selection\nwith 3 lines");
+
+			// Clicking clears selection.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 
+			// Can start line select mode on an empty line.
+			text_edit->set_text("this is some text\n\nfor selection\nwith 4 lines");
+			MessageQueue::get_singleton()->flush();
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 0).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "\n");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(2, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "\nfor selection\n");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->get_caret_line() == 3);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+
+			// Add a new selection without affecting the old one.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "\nfor selection\n");
+			CHECK(text_edit->get_caret_line(0) == 3);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "is");
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			CHECK(text_edit->get_selection_origin_line(1) == 0);
+			CHECK(text_edit->get_selection_origin_column(1) == 2);
+			text_edit->remove_secondary_carets();
+			text_edit->deselect();
+
+			// Selecting the last line puts caret at the end.
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(3, 3).get_center(), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(3, 3).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "with 4 lines");
+			CHECK(text_edit->get_caret_line() == 3);
+			CHECK(text_edit->get_caret_column() == 12);
+			CHECK(text_edit->get_selection_origin_line() == 3);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+
+			// Selecting above reverses direction.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "for selection\nwith 4 lines");
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_selection_origin_line() == 3);
+			CHECK(text_edit->get_selection_origin_column() == 12);
+
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+
+			// Shift + triple click to extend selection and restart line select mode.
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 9).get_center() + Point2i(2, 0), Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 9).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "this is some text\n\nfor selection\nwith 4 lines");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_selection_origin_line() == 3);
+			CHECK(text_edit->get_selection_origin_column() == 12);
+
+			// Cannot select when disabled, but caret still moves to the start of the next line.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 2).get_center(), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -1142,30 +2065,47 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] mouse shift click select") {
-			/* Set size for mouse input. */
+			// Set size for mouse input.
 			text_edit->set_size(Size2(200, 200));
 
 			text_edit->set_text("this is some text\nfor selection");
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			// Shift click to make a selection from the previous caret position.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 1).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_selected_text() == "for s");
+			CHECK(text_edit->get_selected_text() == "or s");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
-			CHECK(text_edit->get_selection_from_line() == 1);
-			CHECK(text_edit->get_selection_from_column() == 0);
-			CHECK(text_edit->get_selection_to_line() == 1);
-			CHECK(text_edit->get_selection_to_column() == 5);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 1);
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(text_edit->is_caret_after_selection_origin());
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 9), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Shift click above to switch selection direction. Uses original selection position.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "s some text\nf");
+			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 1);
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 6);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin());
+
+			// Clicking clears selection.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 7);
 
+			// Cannot select when disabled, but caret still moves.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 0);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
@@ -1175,111 +2115,396 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SUBCASE("[TextEdit] select and deselect") {
 			text_edit->set_text("this is some text\nfor selection");
 			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
 
+			// Select clamps input to full text.
 			text_edit->select(-1, -1, 500, 500);
+			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "this is some text\nfor selection");
+			CHECK(text_edit->is_caret_after_selection_origin(0));
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 13);
+			CHECK(text_edit->get_selection_from_line(0) == text_edit->get_selection_origin_line(0));
+			CHECK(text_edit->get_selection_from_column(0) == text_edit->get_selection_origin_column(0));
+			CHECK(text_edit->get_selection_to_line(0) == text_edit->get_caret_line(0));
+			CHECK(text_edit->get_selection_to_column(0) == text_edit->get_caret_column(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
 			text_edit->deselect();
+			MessageQueue::get_singleton()->flush();
 			CHECK_FALSE(text_edit->has_selection());
+			SIGNAL_CHECK_FALSE("caret_changed");
 
+			// Select works in the other direction.
 			text_edit->select(500, 500, -1, -1);
+			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "this is some text\nfor selection");
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(0));
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 13);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_selection_from_line(0) == text_edit->get_caret_line(0));
+			CHECK(text_edit->get_selection_from_column(0) == text_edit->get_caret_column(0));
+			CHECK(text_edit->get_selection_to_line(0) == text_edit->get_selection_origin_line(0));
+			CHECK(text_edit->get_selection_to_column(0) == text_edit->get_selection_origin_column(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
 			text_edit->deselect();
+			MessageQueue::get_singleton()->flush();
 			CHECK_FALSE(text_edit->has_selection());
+			SIGNAL_CHECK_FALSE("caret_changed");
 
+			// Select part of a line.
 			text_edit->select(0, 4, 0, 8);
+			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == " is ");
+			CHECK(text_edit->is_caret_after_selection_origin(0));
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 4);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 8);
+			CHECK(text_edit->get_selection_from_line(0) == text_edit->get_selection_origin_line(0));
+			CHECK(text_edit->get_selection_from_column(0) == text_edit->get_selection_origin_column(0));
+			CHECK(text_edit->get_selection_to_line(0) == text_edit->get_caret_line(0));
+			CHECK(text_edit->get_selection_to_column(0) == text_edit->get_caret_column(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
 			text_edit->deselect();
+			MessageQueue::get_singleton()->flush();
 			CHECK_FALSE(text_edit->has_selection());
+			SIGNAL_CHECK_FALSE("caret_changed");
 
+			// Select part of a line in the other direction.
 			text_edit->select(0, 8, 0, 4);
+			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == " is ");
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(0));
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 8);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_from_line(0) == text_edit->get_caret_line(0));
+			CHECK(text_edit->get_selection_from_column(0) == text_edit->get_caret_column(0));
+			CHECK(text_edit->get_selection_to_line(0) == text_edit->get_selection_origin_line(0));
+			CHECK(text_edit->get_selection_to_column(0) == text_edit->get_selection_origin_column(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
+			// Cannot select when disabled.
 			text_edit->set_selecting_enabled(false);
 			CHECK_FALSE(text_edit->has_selection());
 			text_edit->select(0, 8, 0, 4);
+			MessageQueue::get_singleton()->flush();
 			CHECK_FALSE(text_edit->has_selection());
+			SIGNAL_CHECK_FALSE("caret_changed");
 			text_edit->set_selecting_enabled(true);
-
-			text_edit->select(0, 8, 0, 4);
-			CHECK(text_edit->has_selection());
-			SEND_GUI_ACTION("ui_text_caret_right");
-			CHECK_FALSE(text_edit->has_selection());
-
-			text_edit->delete_selection();
-			CHECK(text_edit->get_text() == "this is some text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
-
-			text_edit->select(0, 8, 0, 4);
-			CHECK(text_edit->has_selection());
-			SEND_GUI_ACTION("ui_text_backspace");
-			CHECK(text_edit->get_text() == "thissome text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 4);
-
-			text_edit->undo();
-			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "this is some text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
-
-			text_edit->redo();
-			CHECK_FALSE(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "thissome text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 4);
-
-			text_edit->undo();
-			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "this is some text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
-
-			text_edit->select(0, 8, 0, 4);
-			CHECK(text_edit->has_selection());
-
-			text_edit->delete_selection();
-			CHECK_FALSE(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "thissome text\nfor selection");
-
-			text_edit->undo();
-			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "this is some text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
-
-			text_edit->redo();
-			CHECK_FALSE(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "thissome text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 4);
-
-			text_edit->undo();
-			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "this is some text\nfor selection");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
-
-			text_edit->set_editable(false);
-			text_edit->delete_selection();
-			text_edit->set_editable(false);
-			CHECK_FALSE(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "thissome text\nfor selection");
-
-			text_edit->undo();
-			CHECK_FALSE(text_edit->has_selection());
-			CHECK(text_edit->get_text() == "thissome text\nfor selection");
 		}
 
-		// Add readonly test?
+		SUBCASE("[TextEdit] delete selection") {
+			text_edit->set_text("this is some text\nfor selection");
+			MessageQueue::get_singleton()->flush();
+
+			// Delete selection does nothing if there is no selection.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(8);
+			CHECK_FALSE(text_edit->has_selection());
+
+			text_edit->delete_selection();
+			CHECK(text_edit->get_text() == "this is some text\nfor selection");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+
+			// Backspace removes selection.
+			text_edit->select(0, 4, 0, 8);
+			CHECK(text_edit->has_selection());
+			SEND_GUI_ACTION("ui_text_backspace");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+
+			// Undo restores previous selection.
+			text_edit->undo();
+			CHECK(text_edit->get_text() == "this is some text\nfor selection");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 4);
+
+			// Redo restores caret.
+			text_edit->redo();
+			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+
+			text_edit->undo();
+			CHECK(text_edit->get_text() == "this is some text\nfor selection");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+
+			text_edit->select(0, 4, 0, 8);
+			CHECK(text_edit->has_selection());
+
+			// Delete selection removes text, deselects, and moves caret.
+			text_edit->delete_selection();
+			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+
+			// Undo delete works.
+			text_edit->undo();
+			CHECK(text_edit->get_text() == "this is some text\nfor selection");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 4);
+
+			// Redo delete works.
+			text_edit->redo();
+			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+
+			text_edit->undo();
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "this is some text\nfor selection");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
+
+			// Can still delete if not editable.
+			text_edit->set_editable(false);
+			text_edit->delete_selection();
+			text_edit->set_editable(false);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+
+			// Cannot undo since it was not editable.
+			text_edit->undo();
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+
+			// Delete multiple adjacent selections on the same line.
+			text_edit->select(0, 0, 0, 5);
+			text_edit->add_caret(0, 8);
+			text_edit->select(0, 5, 0, 8, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+			text_edit->delete_selection();
+			CHECK(text_edit->get_text() == " text\nfor selection");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+
+			// Delete mulitline selection. Ignore non selections.
+			text_edit->remove_secondary_carets();
+			text_edit->select(1, 3, 0, 2);
+			text_edit->add_caret(1, 7);
+			text_edit->delete_selection();
+			CHECK(text_edit->get_text() == " t selection");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 6);
+		}
+
 		SUBCASE("[TextEdit] text drag") {
+			text_edit->set_size(Size2(200, 200));
+			text_edit->set_text("drag test\ndrop here ''");
+			text_edit->grab_click_focus();
+			MessageQueue::get_singleton()->flush();
+
+			// Drag and drop selected text to mouse position.
+			text_edit->select(0, 0, 0, 4);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == " test\ndrop here 'drag'");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 15);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 11);
+
+			// Undo.
+			text_edit->undo();
+			CHECK(text_edit->get_text() == "drag test\ndrop here ''");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+
+			// Redo.
+			text_edit->redo();
+			CHECK(text_edit->get_text() == " test\ndrop here 'drag'");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 15);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 11);
+
+			// Hold control when dropping to not delete selected text.
+			text_edit->select(1, 10, 1, 16);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 12).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "'drag'");
+			CHECK(text_edit->has_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_KEY_UP_EVENT(Key::CMD_OR_CTRL);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'drag' test\ndrop here 'drag'");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 6);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+
+			// Multiple caret drags entire selection.
+			text_edit->select(0, 11, 0, 7, 0);
+			text_edit->add_caret(1, 2);
+			text_edit->select(1, 2, 1, 4, 1);
+			text_edit->add_caret(1, 12);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection(true, 1));
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 12).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test\nop");
+			// Carets aren't removed from dragging, only dropping.
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 7);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 11);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			CHECK(text_edit->get_selection_origin_line(1) == 1);
+			CHECK(text_edit->get_selection_origin_column(1) == 2);
+			CHECK_FALSE(text_edit->has_selection(2));
+			CHECK(text_edit->get_caret_line(2) == 1);
+			CHECK(text_edit->get_caret_column(2) == 12);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 2);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 7);
+
+			// Drop onto same selection should do effectively nothing.
+			text_edit->select(1, 3, 1, 7);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "here");
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 7);
+			CHECK(text_edit->get_selection_origin_line() == 1);
+			CHECK(text_edit->get_selection_origin_column() == 3);
+
+			// Cannot drag when drag and drop selection is disabled. It becomes regular drag to select.
+			text_edit->set_drag_and_drop_selection_enabled(false);
+			text_edit->select(0, 1, 0, 5);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK_FALSE(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 7);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 2);
+			text_edit->set_drag_and_drop_selection_enabled(true);
+
+			// Cancel drag and drop from Escape key.
+			text_edit->select(0, 1, 0, 5);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			SEND_GUI_KEY_EVENT(Key::ESCAPE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 1);
+
+			// Cancel drag and drop from caret move key input.
+			text_edit->select(0, 1, 0, 5);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			SEND_GUI_KEY_EVENT(Key::RIGHT);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 5);
+
+			// Cancel drag and drop from text key input.
+			text_edit->select(0, 1, 0, 5);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			SEND_GUI_KEY_EVENT(Key::A);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "'A' \ndr heretest\nop 'drag'");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 2);
+		}
+
+		SUBCASE("[TextEdit] text drag to another text edit") {
 			TextEdit *target_text_edit = memnew(TextEdit);
 			SceneTree::get_singleton()->get_root()->add_child(target_text_edit);
 
@@ -1292,27 +2517,223 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("drag me");
 			text_edit->select_all();
 			text_edit->grab_click_focus();
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 7);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
 			MessageQueue::get_singleton()->flush();
 
-			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Drag text between text edits.
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag me");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 7);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
 
-			line_0 = target_text_edit->get_pos_at_line_column(0, 0);
-			line_0.y /= 2;
-			line_0.x += 401; // As empty add one.
-			SEND_GUI_MOUSE_MOTION_EVENT(line_0, MouseButtonMask::LEFT, Key::NONE);
+			Point2i target_line0 = target_text_edit->get_position() + Point2i(1, target_text_edit->get_line_height() / 2);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_line0, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
-
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 0);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_line0, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
 			CHECK(target_text_edit->get_text() == "drag me");
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 7);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 0);
+
+			// Undo is separate per TextEdit.
+			text_edit->undo();
+			CHECK(text_edit->get_text() == "drag me");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 7);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+			CHECK(target_text_edit->get_text() == "drag me");
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 7);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 0);
+
+			target_text_edit->undo();
+			CHECK(text_edit->get_text() == "drag me");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 7);
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+			CHECK(target_text_edit->get_text() == "");
+			CHECK_FALSE(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 0);
+
+			// Redo is also separate.
+			text_edit->redo();
+			CHECK(text_edit->get_text() == "");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(target_text_edit->get_text() == "");
+			CHECK_FALSE(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 0);
+
+			target_text_edit->redo();
+			CHECK(text_edit->get_text() == "");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(target_text_edit->get_text() == "drag me");
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 7);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 0);
+
+			// Hold control to not remove selected text.
+			text_edit->set_text("drag test\ndrop test");
+			MessageQueue::get_singleton()->flush();
+			target_text_edit->select(0, 0, 0, 3, 0);
+			target_text_edit->add_caret(0, 5);
+			text_edit->select(0, 5, 0, 7, 0);
+			text_edit->add_caret(0, 1);
+			text_edit->select(0, 1, 0, 0, 1);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection(true, 0));
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "d\nte");
+			CHECK(text_edit->has_selection());
+			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_KEY_UP_EVENT(Key::CMD_OR_CTRL);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "drag test\ndrop test");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 7);
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(target_text_edit->get_text() == "drag md\ntee");
+			CHECK(target_text_edit->get_caret_count() == 1);
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 1);
+			CHECK(target_text_edit->get_caret_column() == 2);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 6);
+
+			// Drop onto selected text deletes the selected text first.
+			text_edit->set_deselect_on_focus_loss_enabled(false);
+			target_text_edit->set_deselect_on_focus_loss_enabled(false);
+			text_edit->remove_secondary_carets();
+			text_edit->select(0, 5, 0, 9);
+			target_text_edit->select(0, 6, 0, 8);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection(true, 0));
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test");
+			CHECK(text_edit->has_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "drag \ndrop test");
+			CHECK(target_text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(target_text_edit->get_text() == "drag mdtest\ntee");
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 11);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 7);
+			text_edit->set_deselect_on_focus_loss_enabled(true);
+			target_text_edit->set_deselect_on_focus_loss_enabled(true);
+
+			// Can drop even when drag and drop selection is disabled.
+			target_text_edit->set_drag_and_drop_selection_enabled(false);
+			text_edit->select(0, 4, 0, 5);
+			target_text_edit->deselect();
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == " ");
+			CHECK(text_edit->has_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "drag\ndrop test");
+			CHECK(target_text_edit->get_text() == "drag md test\ntee");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 8);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 7);
+			target_text_edit->set_drag_and_drop_selection_enabled(true);
+
+			// Cannot drop when not editable.
+			target_text_edit->set_editable(false);
+			text_edit->select(0, 1, 0, 4);
+			target_text_edit->deselect();
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "rag");
+			CHECK(text_edit->has_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "drag\ndrop test");
+			CHECK(target_text_edit->get_text() == "drag md test\ntee");
+			CHECK(text_edit->has_selection());
+			CHECK_FALSE(target_text_edit->has_selection());
+			target_text_edit->set_editable(true);
+
+			// Can drag when not editable, but text will not be removed.
+			text_edit->set_editable(false);
+			text_edit->select(0, 0, 0, 4);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->is_mouse_over_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			CHECK(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->has_selection());
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
+			CHECK(text_edit->get_text() == "drag\ndrop test");
+			CHECK(target_text_edit->get_text() == "dragdrag md test\ntee");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			CHECK(target_text_edit->has_selection());
+			CHECK(target_text_edit->get_caret_line() == 0);
+			CHECK(target_text_edit->get_caret_column() == 8);
+			CHECK(target_text_edit->get_selection_origin_line() == 0);
+			CHECK(target_text_edit->get_selection_origin_column() == 4);
+			text_edit->set_editable(true);
 
 			memdelete(target_text_edit);
 		}
@@ -1324,44 +2745,41 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 	}
 
 	SUBCASE("[TextEdit] overridable actions") {
+		DisplayServerMock *DS = (DisplayServerMock *)(DisplayServer::get_singleton());
+
 		SIGNAL_WATCH(text_edit, "text_set");
 		SIGNAL_WATCH(text_edit, "text_changed");
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array args1;
-		args1.push_back(0);
-		args1.push_back(0);
-		Array lines_edited_args;
-		lines_edited_args.push_back(args1);
+		Array lines_edited_args = build_array(build_array(0, 0));
 
 		SUBCASE("[TextEdit] backspace") {
 			text_edit->set_text("this is\nsome\n");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Cannot backspace at start of text.
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Backspace at start of line removes the line.
 			text_edit->set_caret_line(2);
 			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(2, 1));
 
-			((Array)lines_edited_args[0])[0] = 2;
-			((Array)lines_edited_args[0])[1] = 1;
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
-
 			CHECK(text_edit->get_text() == "this is\nsome");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 4);
@@ -1369,10 +2787,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[0] = 1;
+			// Backspace removes a character.
+			lines_edited_args = build_array(build_array(1, 1));
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
-
 			CHECK(text_edit->get_text() == "this is\nsom");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 3);
@@ -1380,11 +2798,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Backspace when text is selected removes the selection.
 			text_edit->end_complex_operation();
 			text_edit->select(1, 0, 1, 3);
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
-
 			CHECK(text_edit->get_text() == "this is\n");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -1392,11 +2810,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Cannot backspace if not editable.
 			text_edit->set_editable(false);
 			text_edit->backspace();
 			text_edit->set_editable(true);
 			MessageQueue::get_singleton()->flush();
-
 			CHECK(text_edit->get_text() == "this is\n");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -1404,6 +2822,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Undo restores text to the previous end of complex operation.
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "this is\nsom");
@@ -1412,98 +2831,736 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is\n");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// See ui_text_backspace for more backspace tests.
 		}
 
 		SUBCASE("[TextEdit] cut") {
+			// Cut without a selection removes the entire line.
 			text_edit->set_text("this is\nsome\n");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(6);
 			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0));
 
+			text_edit->cut();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\n");
+			CHECK(text_edit->get_text() == "some\n");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 3); // In the default font, this is the same position.
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Undo restores the cut text.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\n");
+			CHECK(text_edit->get_text() == "this is\nsome\n");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 6);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\n");
+			CHECK(text_edit->get_text() == "some\n");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 3);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Cut with a selection removes just the selection.
+			text_edit->set_text("this is\nsome\n");
+			text_edit->select(0, 5, 0, 7);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			SEND_GUI_ACTION("ui_cut");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "is");
+			CHECK(text_edit->get_text() == "this \nsome\n");
+			CHECK_FALSE(text_edit->get_caret_line());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 5);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Cut does not change the text if not editable. Text is still added to clipboard.
+			text_edit->set_text("this is\nsome\n");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(5);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			ERR_PRINT_OFF;
+			text_edit->set_editable(false);
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
-			ERR_PRINT_ON; // Can't check display server content.
-
-			((Array)lines_edited_args[0])[0] = 1;
-			CHECK(text_edit->get_text() == "some\n");
+			text_edit->set_editable(true);
+			CHECK(DS->clipboard_get() == "this is\n");
+			CHECK(text_edit->get_text() == "this is\nsome\n");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 4);
+			CHECK(text_edit->get_caret_column() == 5);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Cut line with multiple carets.
+			text_edit->set_text("this is\nsome\n");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(3);
+			text_edit->add_caret(0, 2);
+			text_edit->add_caret(0, 4);
+			text_edit->add_caret(2, 0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0), build_array(1, 0));
+
+			text_edit->cut();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\n\n");
+			CHECK(text_edit->get_text() == "some");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 2); // In the default font, this is the same position.
+			// The previous caret at index 1 was merged.
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
+			CHECK_FALSE(text_edit->has_selection(2));
+			CHECK(text_edit->get_caret_line(2) == 0);
+			CHECK(text_edit->get_caret_column(2) == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			text_edit->remove_secondary_carets();
+
+			// Cut on the only line removes the contents.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->cut();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "some\n");
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_line_count() == 1);
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[0] = 0;
-			((Array)lines_edited_args[0])[1] = 1;
+			// Cut empty line.
+			text_edit->cut();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "\n");
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			// These signals are emitted even if there is no change.
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Cut multiple lines, in order.
+			text_edit->set_text("this is\nsome\ntext to\nbe\n\ncut");
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(7);
+			text_edit->add_caret(3, 0);
+			text_edit->add_caret(0, 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0), build_array(3, 2), build_array(2, 1));
+
+			text_edit->cut();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\ntext to\nbe\n");
+			CHECK(text_edit->get_text() == "some\n\ncut");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			text_edit->remove_secondary_carets();
+
+			// Cut multiple selections, in order. Ignores regular carets.
+			text_edit->set_text("this is\nsome\ntext to\nbe\n\ncut");
+			text_edit->add_caret(3, 0);
+			text_edit->add_caret(0, 2);
+			text_edit->add_caret(2, 0);
+			text_edit->select(1, 0, 1, 2, 0);
+			text_edit->select(3, 0, 4, 0, 1);
+			text_edit->select(0, 5, 0, 3, 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 1), build_array(4, 3), build_array(0, 0));
+
+			text_edit->cut();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "s \nso\nbe\n");
+			CHECK(text_edit->get_text() == "thiis\nme\ntext to\n\ncut");
+			CHECK(text_edit->get_caret_count() == 4);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(2) == 0);
+			CHECK(text_edit->get_caret_column(2) == 3);
+			CHECK(text_edit->get_caret_line(3) == 2);
+			CHECK(text_edit->get_caret_column(3) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+		}
+
+		SUBCASE("[TextEdit] copy") {
+			text_edit->set_text("this is\nsome\ntest\n\ntext");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+
+			// Copy selected text.
+			text_edit->select(0, 0, 1, 2, 0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			DS->clipboard_set_primary("");
+
+			text_edit->copy();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\nso");
+			CHECK(DS->clipboard_get_primary() == "");
+			CHECK(text_edit->get_text() == "this is\nsome\ntest\n\ntext");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 0);
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 2);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Copy with GUI action.
+			text_edit->select(0, 0, 0, 2, 0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_copy");
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "th");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Can copy even if not editable.
+			text_edit->select(2, 4, 1, 2, 0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->set_editable(false);
+			text_edit->copy();
+			text_edit->set_editable(true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "me\ntest");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			text_edit->deselect();
+
+			// Copy full line when there is no selection.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->copy();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\n");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Copy empty line.
+			text_edit->set_caret_line(3);
+			text_edit->set_caret_column(0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->copy();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "\n");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			text_edit->deselect();
+
+			// Copy full line with multiple carets on that line only copies once.
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(2);
+			text_edit->add_caret(1, 0);
+			text_edit->add_caret(1, 4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->copy();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "some\n");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			text_edit->remove_secondary_carets();
+
+			// Copy selected text from all selections with `\n` in between, in order. Ignore regular carets.
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(4, 0);
+			text_edit->add_caret(0, 4);
+			text_edit->add_caret(1, 0);
+			text_edit->select(1, 3, 2, 4, 0);
+			text_edit->select(4, 4, 4, 0, 1);
+			text_edit->select(0, 5, 0, 4, 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->copy();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == " \ne\ntest\ntext");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			text_edit->remove_secondary_carets();
+			text_edit->deselect();
+
+			// Copy multiple lines with multiple carets, in order.
+			text_edit->set_caret_line(3);
+			text_edit->set_caret_column(0);
+			text_edit->add_caret(4, 2);
+			text_edit->add_caret(0, 4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->copy();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "this is\n\ntext\n");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+		}
+
+		SUBCASE("[TextEdit] paste") {
+			// Paste text from clipboard at caret.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 1));
+			DS->clipboard_set("paste");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste");
+			CHECK(text_edit->get_text() == "this is\nsopasteme\n\ntext");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 7);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Undo.
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_text() == "this is\nsome\n");
+			CHECK(DS->clipboard_get() == "paste");
+			CHECK(text_edit->get_text() == "this is\nsome\n\ntext");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste");
+			CHECK(text_edit->get_text() == "this is\nsopasteme\n\ntext");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 7);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Paste on empty line. Use GUI action.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(2);
+			text_edit->set_caret_column(0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(2, 2));
+			DS->clipboard_set("paste2");
+
+			SEND_GUI_ACTION("ui_paste");
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste2");
+			CHECK(text_edit->get_text() == "this is\nsome\npaste2\ntext");
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 6);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Paste removes selection before pasting.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->select(0, 5, 1, 3);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0), build_array(0, 0));
+			DS->clipboard_set("paste");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste");
+			CHECK(text_edit->get_text() == "this pastee\n\ntext");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 10);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Paste multiple lines.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 3));
+			DS->clipboard_set("multi\n\nline\npaste");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "multi\n\nline\npaste");
+			CHECK(text_edit->get_text() == "tmulti\n\nline\npastehis is\nsome\n\ntext");
+			CHECK(text_edit->get_caret_line() == 3);
+			CHECK(text_edit->get_caret_column() == 5);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Paste full line after copying it.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 2));
+			DS->clipboard_set("");
+			text_edit->copy();
+			text_edit->set_caret_column(3);
+			CHECK(DS->clipboard_get() == "some\n");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "some\n");
+			CHECK(text_edit->get_text() == "this is\nsome\nsome\n\ntext");
+			CHECK(text_edit->get_caret_line() == 2);
+			CHECK(text_edit->get_caret_column() == 3);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Do not paste as line since it wasn't copied.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1));
+			DS->clipboard_set("paste\n");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste\n");
+			CHECK(text_edit->get_text() == "thispaste\n is\nsome\n\ntext");
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Paste text at each caret.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(2);
+			text_edit->add_caret(3, 4);
+			text_edit->add_caret(0, 4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1), build_array(2, 3), build_array(5, 6));
+			DS->clipboard_set("paste\ntest");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste\ntest");
+			CHECK(text_edit->get_text() == "thispaste\ntest is\nsopaste\ntestme\n\ntextpaste\ntest");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK(text_edit->get_caret_line(0) == 3);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_caret_line(1) == 6);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			CHECK(text_edit->get_caret_line(2) == 1);
+			CHECK(text_edit->get_caret_column(2) == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			text_edit->remove_secondary_carets();
+
+			// Paste line per caret when the amount of lines is equal to the number of carets.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(2);
+			text_edit->add_caret(3, 4);
+			text_edit->add_caret(0, 4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1), build_array(3, 3));
+			DS->clipboard_set("paste\ntest\n1");
+
+			text_edit->paste();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "paste\ntest\n1");
+			CHECK(text_edit->get_text() == "thispaste is\nsotestme\n\ntext1");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 6);
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			CHECK(text_edit->get_caret_line(2) == 0);
+			CHECK(text_edit->get_caret_column(2) == 9);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			text_edit->remove_secondary_carets();
+
+			// Cannot paste when not editable.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			DS->clipboard_set("no paste");
+
+			text_edit->set_editable(false);
+			text_edit->paste();
+			text_edit->set_editable(true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "no paste");
+			CHECK(text_edit->get_text() == "this is\nsome\n\ntext");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+		}
+
+		SUBCASE("[TextEdit] paste primary") {
+			// Set size for mouse input.
+			text_edit->set_size(Size2(200, 200));
+
+			text_edit->grab_focus();
+			DS->clipboard_set("");
+			DS->clipboard_set_primary("");
+			CHECK(DS->clipboard_get_primary() == "");
+
+			// Select text with mouse to put into primary clipboard.
+			text_edit->set_text("this is\nsome\n\ntext");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			CHECK(DS->clipboard_get() == "");
+			CHECK(DS->clipboard_get_primary() == "is is\nsom");
+			CHECK(text_edit->get_text() == "this is\nsome\n\ntext");
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "is is\nsom");
+			CHECK(text_edit->get_selection_origin_line() == 0);
+			CHECK(text_edit->get_selection_origin_column() == 2);
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 3);
+			SIGNAL_CHECK_FALSE("text_set");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Middle click to paste at mouse.
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(3, 4));
+
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(3, 2).get_center() + Point2i(2, 0), MouseButton::MIDDLE, MouseButtonMask::MIDDLE, Key::NONE);
+			CHECK(DS->clipboard_get_primary() == "is is\nsom");
+			CHECK(text_edit->get_text() == "this is\nsome\n\nteis is\nsomxt");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 4);
+			CHECK(text_edit->get_caret_column() == 3);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Paste at mouse position if there is only one caret.
+			text_edit->set_text("this is\nsome\n\ntext");
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			DS->clipboard_set_primary("paste");
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->paste_primary_clipboard();
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get_primary() == "paste");
+			CHECK(text_edit->get_text() == "tpastehis is\nsome\n\ntext");
+			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 6);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 0;
-			text_edit->redo();
+			// Paste at all carets if there are multiple carets.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(0);
+			text_edit->add_caret(2, 0);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_text() == "some\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 4);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
-			SIGNAL_CHECK("text_changed", empty_signal_args);
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-
-			text_edit->set_text("this is\nsome\n");
-			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
+			DS->clipboard_set_primary("paste");
+			lines_edited_args = build_array(build_array(1, 1), build_array(2, 2));
 
-			((Array)lines_edited_args[0])[0] = 0;
-			text_edit->select(0, 5, 0, 7);
-			ERR_PRINT_OFF;
-			SEND_GUI_ACTION("ui_cut");
-			CHECK(text_edit->get_viewport()->is_input_handled());
+			text_edit->paste_primary_clipboard();
 			MessageQueue::get_singleton()->flush();
-			ERR_PRINT_ON; // Can't check display server content.
-			CHECK(text_edit->get_text() == "this \nsome\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(DS->clipboard_get_primary() == "paste");
+			CHECK(text_edit->get_text() == "this is\npastesome\npaste\ntext");
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 5);
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 5);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			text_edit->set_editable(false);
-			text_edit->cut();
+			// Cannot paste if not editable.
+			text_edit->set_text("this is\nsome\n\ntext");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
 			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			DS->clipboard_set("no paste");
+
+			text_edit->set_editable(false);
+			text_edit->paste_primary_clipboard();
 			text_edit->set_editable(true);
-			CHECK(text_edit->get_text() == "this \nsome\n");
+			MessageQueue::get_singleton()->flush();
+			CHECK(DS->clipboard_get() == "no paste");
+			CHECK(text_edit->get_text() == "this is\nsome\n\ntext");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 5);
+			CHECK(text_edit->get_caret_column() == 4);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
-		}
-
-		SUBCASE("[TextEdit] copy") {
-			// TODO: Cannot test need display server support.
-		}
-
-		SUBCASE("[TextEdit] paste") {
-			// TODO: Cannot test need display server support.
-		}
-
-		SUBCASE("[TextEdit] paste primary") {
-			// TODO: Cannot test need display server support.
 		}
 
 		SIGNAL_UNWATCH(text_edit, "text_set");
@@ -1512,60 +3569,77 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_UNWATCH(text_edit, "caret_changed");
 	}
 
-	// Add undo / redo tests?
 	SUBCASE("[TextEdit] input") {
 		SIGNAL_WATCH(text_edit, "text_set");
 		SIGNAL_WATCH(text_edit, "text_changed");
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array args1;
-		args1.push_back(0);
-		args1.push_back(0);
-		Array lines_edited_args;
-		lines_edited_args.push_back(args1);
+		Array lines_edited_args = build_array(build_array(0, 0));
 
 		SUBCASE("[TextEdit] ui_text_newline_above") {
 			text_edit->set_text("this is some test text.\nthis is some test text.");
-			text_edit->select(0, 0, 0, 4);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(1, 4);
-			text_edit->select(1, 0, 1, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(0);
-			args2.push_back(1);
-			lines_edited_args.push_front(args2);
+			// Insert new line above.
+			text_edit->select(0, 0, 0, 4);
+			text_edit->add_caret(1, 4);
+			CHECK(text_edit->get_caret_count() == 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1), build_array(2, 3));
 
-			((Array)lines_edited_args[1])[1] = 1;
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is some test text.\nthis is some test text.");
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does not work if not editable.
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(4);
-
-			text_edit->set_caret_line(3, false, true, 0, 1);
+			text_edit->set_caret_line(3, false, true, -1, 1);
 			text_edit->set_caret_column(4, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
@@ -1574,31 +3648,57 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 4);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 4);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			((Array)lines_edited_args[0])[0] = 2;
-			((Array)lines_edited_args[0])[1] = 3;
+			// Works on first line, empty lines, and only happens at caret for selections.
+			text_edit->select(1, 10, 0, 0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1), build_array(4, 5));
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n\nthis is some test text.\n\n\nthis is some test text.");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 4);
 			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Insert multiple new lines above from one line.
+			text_edit->set_text("test");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(1);
+			text_edit->add_caret(0, 3);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1), build_array(1, 2));
+
+			SEND_GUI_ACTION("ui_text_newline_above");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "\n\ntest");
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1606,34 +3706,55 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 		SUBCASE("[TextEdit] ui_text_newline_blank") {
 			text_edit->set_text("this is some test text.\nthis is some test text.");
-			text_edit->select(0, 0, 0, 4);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(1, 4);
-			text_edit->select(1, 0, 1, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
+
+			// Insert new line below.
+			text_edit->select(0, 0, 0, 4);
+			text_edit->add_caret(1, 4);
+			CHECK(text_edit->get_caret_count() == 2);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1), build_array(2, 3));
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(1);
-			args2.push_back(2);
-			lines_edited_args.push_front(args2);
-
-			((Array)lines_edited_args[1])[1] = 1;
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
 			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is some test text.\nthis is some test text.");
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(0));
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
@@ -1641,75 +3762,119 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Does not work if not editable.
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
+
+			// Insert multiple new lines below from one line.
+			text_edit->set_text("test");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(1);
+			text_edit->add_caret(0, 3);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 1), build_array(0, 1));
+
+			SEND_GUI_ACTION("ui_text_newline_blank");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "test\n\n");
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 2);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
 
 		SUBCASE("[TextEdit] ui_text_newline") {
 			text_edit->set_text("this is some test text.\nthis is some test text.");
-			text_edit->select(0, 0, 0, 4);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(1, 4);
-			text_edit->select(1, 0, 1, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(1);
-			args2.push_back(1);
-			lines_edited_args.push_front(args2);
-			lines_edited_args.push_front(args2.duplicate());
-			((Array)lines_edited_args[1])[1] = 2;
-
-			lines_edited_args.push_back(lines_edited_args[2].duplicate());
-			((Array)lines_edited_args[3])[1] = 1;
+			// Insert new line at caret.
+			text_edit->select(0, 0, 0, 4);
+			text_edit->add_caret(1, 4);
+			CHECK(text_edit->get_caret_count() == 2);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			// Lines edited: deletion, insert line, insert line.
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 1), build_array(2, 3));
 
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "\n is some test text.\nthis\n is some test text.");
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is some test text.\nthis is some test text.");
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "\n is some test text.\nthis\n is some test text.");
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does not work if not editable.
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "\n is some test text.\nthis\n is some test text.");
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -1717,255 +3882,399 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] ui_text_backspace_all_to_left") {
-			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
-			text_edit->select(1, 0, 1, 4);
-			text_edit->set_caret_line(1);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(3, 4);
-			text_edit->select(3, 0, 3, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
-			MessageQueue::get_singleton()->flush();
-
 			Ref<InputEvent> tmpevent = InputEventKey::create_reference(Key::BACKSPACE | KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL);
 			InputMap::get_singleton()->action_add_event("ui_text_backspace_all_to_left", tmpevent);
 
+			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(3);
-			args2.push_back(3);
-			lines_edited_args.push_front(args2);
-
-			// With selection should be a normal backspace.
-			((Array)lines_edited_args[1])[0] = 1;
-			((Array)lines_edited_args[1])[1] = 1;
+			// Remove all text to the left.
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(5);
+			text_edit->add_caret(1, 2);
+			text_edit->add_caret(1, 8);
+			lines_edited_args = build_array(build_array(1, 1));
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
+			CHECK(text_edit->get_text() == "\nsome test text.\n\nthis is some test text.");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 3);
-			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[1] = 2;
-			((Array)lines_edited_args[1])[1] = 0;
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 5);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK_FALSE(text_edit->has_selection(2));
+			CHECK(text_edit->get_caret_line(2) == 1);
+			CHECK(text_edit->get_caret_column(2) == 8);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			// Start of line should also be a normal backspace.
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "\nsome test text.\n\nthis is some test text.");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 1);
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Acts as a normal backspace with selections.
+			text_edit->select(1, 5, 1, 9, 0);
+			text_edit->add_caret(3, 4);
+			text_edit->select(3, 7, 3, 4, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(3, 3), build_array(1, 1));
+
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "\nsome  text.\n\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 5);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 4);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Acts as a normal backspace when at the start of a line.
+			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(0, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(3, 2), build_array(1, 0));
+
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "some  text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does not work if not editable.
 			text_edit->set_caret_column(text_edit->get_line(0).length());
 			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
+			CHECK(text_edit->get_text() == "some  text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == text_edit->get_line(0).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
-			((Array)lines_edited_args[1])[0] = 0;
+			// Remove entire line content when at the end of the line.
+			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			text_edit->remove_secondary_carets();
+
+			// Removing newline effectively happens after removing text.
+			text_edit->set_text("test\nlines");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(0);
+			text_edit->add_caret(1, 4);
+
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "tests");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			text_edit->remove_secondary_carets();
+
+			// Removing newline effectively happens after removing text, reverse caret order.
+			text_edit->set_text("test\nlines");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(1, 0);
+
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "tests");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			text_edit->remove_secondary_carets();
 
 			InputMap::get_singleton()->action_erase_event("ui_text_backspace_all_to_left", tmpevent);
 		}
 
 		SUBCASE("[TextEdit] ui_text_backspace_word") {
 			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
-			text_edit->select(1, 0, 1, 4);
-			text_edit->set_caret_line(1);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(3, 4);
-			text_edit->select(3, 0, 3, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
+
+			// Acts as a normal backspace with selections.
+			text_edit->select(1, 8, 1, 15);
+			text_edit->add_caret(3, 6);
+			text_edit->select(3, 10, 3, 6, 1);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-
-			// For the second caret.
-			Array args2;
-			args2.push_back(3);
-			args2.push_back(3);
-			lines_edited_args.push_front(args2);
-
-			// With selection should be a normal backspace.
-			((Array)lines_edited_args[1])[0] = 1;
-			((Array)lines_edited_args[1])[1] = 1;
+			lines_edited_args = build_array(build_array(3, 3), build_array(1, 1));
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "\nthis is st text.\n\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 3);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 8);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 6);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			text_edit->end_complex_operation();
 
-			((Array)lines_edited_args[0])[1] = 2;
-			((Array)lines_edited_args[1])[1] = 0;
+			lines_edited_args = build_array(build_array(3, 2), build_array(1, 0));
 
 			// Start of line should also be a normal backspace.
+			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(0, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "this is st text.\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Does not work if not editable.
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "this is st text.\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
+			// FIXME: Remove after GH-77101 is fixed.
+			text_edit->start_action(TextEdit::ACTION_NONE);
+
+			// Remove text to the start of the word to the left of the caret.
 			text_edit->set_caret_column(text_edit->get_line(0).length());
-			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
+			text_edit->set_caret_column(12, false, 1);
 			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
-			((Array)lines_edited_args[1])[0] = 0;
+			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test \n is some test ");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 14);
+			CHECK(text_edit->get_text() == "this is st \nthis ime t text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 14);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 11);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 9);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is st text.\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 16);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 12);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is st \nthis ime t text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 11);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 9);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Removing newline effectively happens after removing text.
+			text_edit->set_text("test\nlines");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(0);
+			text_edit->add_caret(1, 4);
+
+			SEND_GUI_ACTION("ui_text_backspace_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "tests");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			text_edit->remove_secondary_carets();
+
+			// Removing newline effectively happens after removing text, reverse caret order.
+			text_edit->set_text("test\nlines");
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(1, 0);
+
+			SEND_GUI_ACTION("ui_text_backspace_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "tests");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			text_edit->remove_secondary_carets();
 		}
 
 		SUBCASE("[TextEdit] ui_text_backspace_word same line") {
-			text_edit->set_text("test test test");
-			text_edit->set_caret_column(4);
-			text_edit->add_caret(0, 9);
-			text_edit->add_caret(0, 15);
-
-			// For the second caret.
-			Array args2;
-			args2.push_back(0);
-			lines_edited_args.push_front(args2);
-
-			// For the third caret.
-			Array args3;
-			args2.push_back(0);
-			lines_edited_args.push_front(args2);
-
-			CHECK(text_edit->get_caret_count() == 3);
+			text_edit->set_text("test longwordtest test");
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Multiple carets on the same line is handled.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(0, 11);
+			text_edit->add_caret(0, 15);
+			text_edit->add_caret(0, 9);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "  ");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == " st test");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 0);
 			CHECK(text_edit->get_caret_column(1) == 1);
-			CHECK_FALSE(text_edit->has_selection(1));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test longwordtest test");
+			CHECK(text_edit->get_caret_count() == 4);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 11);
+			CHECK_FALSE(text_edit->has_selection(2));
 			CHECK(text_edit->get_caret_line(2) == 0);
-			CHECK(text_edit->get_caret_column(2) == 2);
-			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_column(2) == 15);
+			CHECK_FALSE(text_edit->has_selection(3));
+			CHECK(text_edit->get_caret_line(3) == 0);
+			CHECK(text_edit->get_caret_column(3) == 9);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " st test");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 1);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1973,130 +4282,267 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 		SUBCASE("[TextEdit] ui_text_backspace") {
 			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
-			text_edit->select(1, 0, 1, 4);
-			text_edit->set_caret_line(1);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(3, 4);
-			text_edit->select(3, 0, 3, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
+
+			// Remove selected text when there are selections.
+			text_edit->select(1, 0, 1, 4);
+			text_edit->add_caret(3, 4);
+			text_edit->select(3, 5, 3, 2, 1);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-
-			// For the second caret.
-			Array args2;
-			args2.push_back(3);
-			args2.push_back(3);
-			lines_edited_args.push_front(args2);
-
-			// With selection should be a normal backspace.
-			((Array)lines_edited_args[1])[0] = 1;
-			((Array)lines_edited_args[1])[1] = 1;
+			lines_edited_args = build_array(build_array(3, 3), build_array(1, 1));
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "\n is some test text.\n\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 3);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 2);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[1] = 2;
-			((Array)lines_edited_args[1])[1] = 0;
+			// Undo remove selection.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK(text_edit->get_selection_origin_line(1) == 3);
+			CHECK(text_edit->get_selection_origin_column(1) == 5);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 
-			// Start of line should also be a normal backspace.
+			// Redo remove selection.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "\n is some test text.\n\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Remove the newline when at start of line.
+			text_edit->set_caret_column(0, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(3, 2), build_array(1, 0));
+
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			text_edit->set_caret_column(text_edit->get_line(0).length());
-			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
+			// Undo remove newline.
+			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "\n is some test text.\n\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
+			// Redo remove newline.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does not work if not editable.
+			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(15, false, 1);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == text_edit->get_line(0).length());
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
-			((Array)lines_edited_args[1])[0] = 0;
+			// FIXME: Remove after GH-77101 is fixed.
+			text_edit->start_action(TextEdit::ACTION_NONE);
+
+			// Backspace removes character to the left.
+			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text\n is some test text");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 18);
+			CHECK(text_edit->get_text() == " is some test text\nthis some testtext.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 18);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 18);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 14);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			// Select the entire text, from right to left
-			text_edit->select(0, 18, 0, 0);
-			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(0);
+			// Backspace another character without changing caret.
+			SEND_GUI_ACTION("ui_text_backspace");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == " is some test tex\nthis some testext.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 17);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 13);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			text_edit->select(1, 18, 1, 0, 1);
-			text_edit->set_caret_line(1, false, true, 0, 1);
-			text_edit->set_caret_column(0, false, 1);
+			// Undo both backspaces.
+			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0), build_array(1, 1), build_array(0, 0));
+
+			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 19);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
+			// Redo both backspaces.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test tex\nthis some testext.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 17);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 13);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Backspace with multiple carets that will overlap.
+			text_edit->remove_secondary_carets();
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(8);
+			text_edit->add_caret(0, 7);
+			text_edit->add_caret(0, 9);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0), build_array(0, 0));
+
+			SEND_GUI_ACTION("ui_text_backspace");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == " is sotest tex\nthis some testext.");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 6);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Select each line of text, from right to left. Remove selection to column 0.
+			text_edit->select(0, text_edit->get_line(0).length(), 0, 0);
+			text_edit->add_caret(1, 0);
+			text_edit->select(1, text_edit->get_line(1).length(), 1, 0, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 1), build_array(0, 0));
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_text() == "\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Backspace at start of first line does nothing.
+			text_edit->remove_secondary_carets();
+			text_edit->deselect();
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_text_backspace");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "\n");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_delete_all_to_right") {
@@ -2104,101 +4550,138 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			InputMap::get_singleton()->action_add_event("ui_text_delete_all_to_right", tmpevent);
 
 			text_edit->set_text("this is some test text.\nthis is some test text.\n");
-			text_edit->select(0, 0, 0, 4);
-			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(1, 4);
-			text_edit->select(1, 0, 1, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
+
+			// Remove all text to right of caret.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(18);
+			text_edit->add_caret(0, 16);
+			text_edit->add_caret(0, 20);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0));
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(1);
-			args2.push_back(1);
-			lines_edited_args.push_front(args2);
-
-			// With selection should be a normal delete.
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "this is some tes\nthis is some test text.\n");
+			CHECK(text_edit->get_caret_count() == 1);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 16);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			// End of line should not do anything.
+			// Undo.
+			lines_edited_args = build_array(build_array(0, 0));
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is some test text.\nthis is some test text.\n");
+			CHECK(text_edit->get_caret_count() == 3);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 18);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 16);
+			CHECK_FALSE(text_edit->has_selection(2));
+			CHECK(text_edit->get_caret_line(2) == 0);
+			CHECK(text_edit->get_caret_column(2) == 20);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is some tes\nthis is some test text.\n");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 16);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Acts as a normal delete with selections.
+			text_edit->select(0, 0, 0, 4);
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 8, 1, 4, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+
+			SEND_GUI_ACTION("ui_text_delete_all_to_right");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == " is some tes\nthissome test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does nothing when caret is at end of line.
 			text_edit->set_caret_column(text_edit->get_line(0).length());
 			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
+			CHECK(text_edit->get_text() == " is some tes\nthissome test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == text_edit->get_line(0).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Does not work if not editable.
 			text_edit->set_caret_column(0);
 			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == " is some tes\nthissome test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
+			// Delete entire line.
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -2210,108 +4693,250 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_mid_grapheme_enabled(true);
 			CHECK(text_edit->is_caret_mid_grapheme_enabled());
 
-			text_edit->set_text("this ffi some test text.\n\nthis ffi some test text.\n");
-			text_edit->select(0, 0, 0, 4);
-			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(4);
-
-			text_edit->add_caret(2, 4);
-			text_edit->select(2, 0, 2, 4, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
+			text_edit->set_text("this is some test text.\n\nthis is some test text.\n");
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(2);
-			args2.push_back(2);
-			lines_edited_args.push_front(args2);
+			// Acts as a normal delete with selections.
+			text_edit->select(0, 8, 0, 15);
+			text_edit->add_caret(2, 6);
+			text_edit->select(2, 10, 2, 6, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0), build_array(2, 2));
 
-			// With selection should be a normal delete.
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.\n\n ffi some test text.\n");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "this is st text.\n\nthis ime test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 8);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 6);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			// With selection should be a normal delete.
-			((Array)lines_edited_args[0])[0] = 3;
-			((Array)lines_edited_args[1])[0] = 1;
+			// Removes newlines when at end of line.
 			text_edit->set_caret_column(text_edit->get_line(0).length());
 			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0), build_array(2, 1));
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
-			CHECK_FALSE(text_edit->has_selection());
-
+			CHECK(text_edit->get_text() == "this is st text.\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == text_edit->get_line(0).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
-			CHECK_FALSE(text_edit->has_selection(0));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[1])[0] = 0;
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
+			// Does not work if not editable.
 			text_edit->set_caret_column(0);
-			text_edit->set_caret_column(0, false, 1);
+			text_edit->set_caret_column(10, false, 1);
 			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "this is st text.\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 10);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
+			// FIXME: Remove after GH-77101 is fixed.
+			text_edit->start_action(TextEdit::ACTION_NONE);
+
+			// Delete to the end of the word right of the caret.
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
+
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " some test text.\n some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == " is st text.\nthis ime t text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 10);
 			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Undo.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "this is st text.\nthis ime test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 10);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is st text.\nthis ime t text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 10);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Delete one word with multiple carets.
+			text_edit->remove_secondary_carets();
+			text_edit->set_text("onelongword test");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(6);
+			text_edit->add_caret(0, 9);
+			text_edit->add_caret(0, 3);
+			lines_edited_args = build_array(build_array(0, 0));
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_text_delete_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "one test");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 3);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Removing newline effectively happens after removing text.
+			text_edit->set_text("test\nlines");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(2);
+			text_edit->add_caret(0, 4);
+
+			SEND_GUI_ACTION("ui_text_delete_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "telines");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			text_edit->remove_secondary_carets();
+
+			// Removing newline effectively happens after removing text, reverse caret order.
+			text_edit->set_text("test\nlines");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(0, 2);
+
+			SEND_GUI_ACTION("ui_text_delete_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_text() == "telines");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			text_edit->remove_secondary_carets();
+		}
+
+		SUBCASE("[TextEdit] ui_text_delete_word same line") {
+			text_edit->set_text("test longwordtest test");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+
+			// Multiple carets on the same line is handled.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(0);
+			text_edit->add_caret(0, 11);
+			text_edit->add_caret(0, 15);
+			text_edit->add_caret(0, 9);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+
+			SEND_GUI_ACTION("ui_text_delete_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == " long test");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0));
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test longwordtest test");
+			CHECK(text_edit->get_caret_count() == 4);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 11);
+			CHECK_FALSE(text_edit->has_selection(2));
+			CHECK(text_edit->get_caret_line(2) == 0);
+			CHECK(text_edit->get_caret_column(2) == 15);
+			CHECK_FALSE(text_edit->has_selection(3));
+			CHECK(text_edit->get_caret_line(3) == 0);
+			CHECK(text_edit->get_caret_column(3) == 9);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " long test");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
@@ -2320,192 +4945,337 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_mid_grapheme_enabled(true);
 			CHECK(text_edit->is_caret_mid_grapheme_enabled());
 
-			text_edit->set_text("this ffi some test text.\nthis ffi some test text.");
+			text_edit->set_text("this is some test text.\n\nthis is some test text.\n");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+
+			// Remove selected text when there are selections.
 			text_edit->select(0, 0, 0, 4);
-			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(4);
+			text_edit->add_caret(2, 2);
+			text_edit->select(2, 5, 2, 2, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(0, 0), build_array(2, 2));
 
-			text_edit->add_caret(1, 4);
-			text_edit->select(1, 0, 1, 4, 1);
+			SEND_GUI_ACTION("ui_text_delete");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == " is some test text.\n\nthis some test text.\n");
 			CHECK(text_edit->get_caret_count() == 2);
-
-			MessageQueue::get_singleton()->flush();
-
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
-			SIGNAL_DISCARD("caret_changed");
-
-			// For the second caret.
-			Array args2;
-			args2.push_back(1);
-			args2.push_back(1);
-			lines_edited_args.push_front(args2);
-
-			// With selection should be a normal delete.
-			SEND_GUI_ACTION("ui_text_delete");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 1);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			// With selection should be a normal delete.
-			lines_edited_args.remove_at(0);
-			((Array)lines_edited_args[0])[0] = 1;
-			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
-			text_edit->set_caret_column(text_edit->get_line(0).length());
+			// Undo remove selection.
+			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 5);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
+			// Redo remove selection.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test text.\n\nthis some test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Remove newline when at end of line.
+			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
+			lines_edited_args = build_array(build_array(1, 0), build_array(2, 1));
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text. ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 20);
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 19);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 20);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			// Caret should be removed due to column preservation.
-			CHECK(text_edit->get_caret_count() == 1);
-
-			// Lets add it back.
-			text_edit->set_caret_column(0);
-			text_edit->add_caret(0, 20);
-
-			((Array)lines_edited_args[0])[0] = 0;
-			lines_edited_args.push_back(args2);
-			((Array)lines_edited_args[1])[0] = 0;
-			((Array)lines_edited_args[1])[1] = 0;
+			// Undo remove newline.
+			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test text.\n\nthis some test text.\n");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 19);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 20);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
 
-			SIGNAL_DISCARD("text_set");
-			SIGNAL_DISCARD("text_changed");
-			SIGNAL_DISCARD("lines_edited_from");
+			// Redo remove newline.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 19);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 20);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does not work if not editable.
+			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(15, false, 1);
+			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text. ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 0);
-			CHECK(text_edit->get_caret_column(1) == 20);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
+			// FIXME: Remove after GH-77101 is fixed.
 			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
+
+			// Delete removes character to the right.
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "ffi some test text.ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "is some test text.\nthis some test ext.");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 0);
-			CHECK(text_edit->get_caret_column(1) == 19);
-			CHECK_FALSE(text_edit->has_selection(0));
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
-			SIGNAL_CHECK("text_changed", empty_signal_args);
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-
-			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
-
-			SEND_GUI_ACTION("ui_text_delete");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "fi some test text.fi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 0);
-			CHECK(text_edit->get_caret_column(1) == 18);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
+			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Delete another character without changing caret.
+			SEND_GUI_ACTION("ui_text_delete");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "s some test text.\nthis some test xt.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Undo both deletes.
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1), build_array(0, 0), build_array(1, 1));
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == " is some test text.\nthis some test text.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo both deletes.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "s some test text.\nthis some test xt.");
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 15);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Delete at end of last line does nothing.
+			text_edit->remove_secondary_carets();
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(18);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_text_delete");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "s some test text.\nthis some test xt.");
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 18);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_word_left") {
 			text_edit->set_text("\nthis is some test text.\nthis is some test text.");
 			text_edit->set_caret_line(1);
-			text_edit->set_caret_column(7);
-
-			text_edit->add_caret(2, 7);
-			CHECK(text_edit->get_caret_count() == 2);
+			text_edit->set_caret_column(15);
+			text_edit->add_caret(2, 10);
+			text_edit->select(1, 10, 1, 15);
+			text_edit->select(2, 15, 2, 10, 1);
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// Shift should select.
+			// Deselect to start of previous word when selection is right to left.
+			// Select to start of next word when selection is left to right.
 #ifdef MACOS_ENABLED
 			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
 #else
 			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 5);
-			CHECK(text_edit->get_selected_text(0) == "is");
+			CHECK(text_edit->get_caret_count() == 2);
+
 			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "me ");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 13);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 10);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
 
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 5);
-			CHECK(text_edit->get_selected_text(1) == "is");
 			CHECK(text_edit->has_selection(1));
-
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-
-			// Should still move caret with selection.
-			SEND_GUI_ACTION("ui_text_caret_word_left");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_selected_text(1) == "some te");
 			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_column(1) == 8);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 15);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(1));
 
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Normal word left.
+			// Select to start of word with shift.
+			text_edit->deselect();
+			text_edit->set_caret_column(7);
+			text_edit->set_caret_column(16, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+#ifdef MACOS_ENABLED
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
+#else
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+#endif
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 2);
+
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "is");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 5);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 7);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(0));
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "tes");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 13);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 16);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(1));
+
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Deselect and move caret to start of next word without shift.
 			SEND_GUI_ACTION("ui_text_caret_word_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 8);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Moves to end of previous line when at start of line. Does nothing at start of text.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(0, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_text_caret_word_left");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 23);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2515,249 +5285,417 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("\nthis is some test text.\nthis is some test text.");
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(7);
-			text_edit->select(1, 2, 1, 7);
-
-			text_edit->add_caret(2, 7);
-			text_edit->select(2, 2, 2, 7, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
+			text_edit->select(1, 3, 1, 7);
+			text_edit->add_caret(2, 3);
+			text_edit->select(2, 7, 2, 3, 1);
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// Normal left should deselect and place at selection start.
-			SEND_GUI_ACTION("ui_text_caret_left");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 2);
-			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 2);
-			CHECK_FALSE(text_edit->has_selection(1));
-
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-
-			// With shift should select.
+			// Remove one character from selection when selection is left to right.
+			// Add one character to selection when selection is right to left.
 			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 1);
-			CHECK(text_edit->get_selected_text(0) == "h");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "s i");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 6);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 3);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
 
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 1);
-			CHECK(text_edit->get_selected_text(1) == "h");
 			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "is is");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 7);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(1));
 
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// All ready at select left, should only deselect.
+			// Deselect and put caret at selection start without shift.
 			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 1);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 1);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 3);
 			CHECK_FALSE(text_edit->has_selection(1));
-
-			SIGNAL_CHECK_FALSE("caret_changed");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Normal left.
+			// Move caret one character to the left.
 			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 2);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 1);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Select one character to the left with shift and no existing selection.
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "h");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 1);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 2);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(0));
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "t");
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 1);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Left at col 0 should go up a line.
+			// Moves to end of previous line when at start of line. Does nothing at start of text.
+			text_edit->deselect();
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(0, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
 			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 23);
-			CHECK_FALSE(text_edit->has_selection(1));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Selects to end of previous line when at start of line.
+			text_edit->remove_secondary_carets();
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(0);
+			text_edit->select(1, 1, 1, 0);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "\nt");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 1);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Merge selections when they overlap.
+			text_edit->set_caret_line(1);
+			text_edit->set_caret_column(4);
+			text_edit->select(1, 6, 1, 4);
+			text_edit->add_caret(1, 8);
+			text_edit->select(1, 8, 1, 6, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			CHECK(text_edit->get_caret_count() == 2);
+
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "s is ");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 3);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 8);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(0));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_word_right") {
-			text_edit->set_text("this is some test text\n\nthis is some test text\n");
+			text_edit->set_text("this is some test text\n\nthis is some test text");
 			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(13);
-
-			text_edit->add_caret(2, 13);
-			CHECK(text_edit->get_caret_count() == 2);
-
+			text_edit->set_caret_column(15);
+			text_edit->add_caret(2, 10);
+			text_edit->select(0, 10, 0, 15);
+			text_edit->select(2, 15, 2, 10, 1);
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// Shift should select.
+			// Select to end of next word when selection is right to left.
+			// Deselect to end of previous word when selection is left to right.
 #ifdef MACOS_ENABLED
 			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
 #else
 			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 17);
-			CHECK(text_edit->get_selected_text(0) == "test");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "me test");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 17);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 10);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
 
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == " te");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 12);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 15);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(1));
+
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Select to end of word with shift.
+			text_edit->deselect();
+			text_edit->set_caret_column(13);
+			text_edit->set_caret_column(15, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+#ifdef MACOS_ENABLED
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
+#else
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+#endif
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "test");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 17);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 13);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "st");
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 17);
-			CHECK(text_edit->get_selected_text(1) == "test");
-			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 15);
+			CHECK(text_edit->is_caret_after_selection_origin(1));
 
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Should still move caret with selection.
+			// Deselect and move caret to end of next word without shift.
 			SEND_GUI_ACTION("ui_text_caret_word_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 22);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 22);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 22);
-			CHECK_FALSE(text_edit->has_selection(1));
-
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Normal word right.
+			// Moves to start of next line when at end of line. Does nothing at end of text.
 			SEND_GUI_ACTION("ui_text_caret_word_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 3);
-			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
 			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 22);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_right") {
-			text_edit->set_text("this is some test text\n\nthis is some test text\n");
+			text_edit->set_text("this is some test text\n\nthis is some test text");
 			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(16);
-			text_edit->select(0, 16, 0, 20);
-
-			text_edit->add_caret(2, 16);
-			text_edit->select(2, 16, 2, 20, 1);
-			CHECK(text_edit->get_caret_count() == 2);
-
+			text_edit->set_caret_column(19);
+			text_edit->select(0, 15, 0, 19);
+			text_edit->add_caret(2, 15);
+			text_edit->select(2, 19, 2, 15, 1);
 			MessageQueue::get_singleton()->flush();
-
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// Normal right should deselect and place at selection start.
-			SEND_GUI_ACTION("ui_text_caret_right");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 20);
-			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 20);
-			CHECK_FALSE(text_edit->has_selection(1));
-
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
-			SIGNAL_CHECK_FALSE("text_changed");
-			SIGNAL_CHECK_FALSE("lines_edited_from");
-
-			// With shift should select.
+			// Remove one character from selection when selection is right to left.
+			// Add one character to selection when selection is left to right.
 			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 21);
-			CHECK(text_edit->get_selected_text(0) == "x");
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "st te");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 20);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 15);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
 
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 21);
-			CHECK(text_edit->get_selected_text(1) == "x");
 			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "t t");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 16);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 19);
+			CHECK_FALSE(text_edit->is_caret_after_selection_origin(1));
 
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// All ready at select right, should only deselect.
+			// Deselect and put caret at selection end without shift.
 			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 21);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
-
-			CHECK(text_edit->get_caret_line(1) == 2);
-			CHECK(text_edit->get_caret_column(1) == 21);
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 20);
 			CHECK_FALSE(text_edit->has_selection(1));
-			SIGNAL_CHECK_FALSE("caret_changed");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 19);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Normal right.
+			// Move caret one character to the right.
 			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 22);
+			CHECK(text_edit->get_caret_count() == 2);
 			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 21);
+			CHECK_FALSE(text_edit->has_selection(1));
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 20);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Select one character to the right with shift and no existing selection.
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "t");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 22);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 21);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
+
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "x");
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 21);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 20);
+			CHECK(text_edit->is_caret_after_selection_origin(1));
+
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Moves to start of next line when at end of line. Does nothing at end of text.
+			text_edit->deselect();
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(22);
+			text_edit->set_caret_column(22, false, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_text_caret_right");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 2);
+			CHECK_FALSE(text_edit->has_selection(0));
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 22);
-			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			// Right at end col should go down a line.
-			SEND_GUI_ACTION("ui_text_caret_right");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection(0));
+			// Selects to start of next line when at end of line.
+			text_edit->remove_secondary_carets();
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(22);
+			text_edit->select(0, 21, 0, 22);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
 
-			CHECK(text_edit->get_caret_line(1) == 3);
-			CHECK(text_edit->get_caret_column(1) == 0);
-			CHECK_FALSE(text_edit->has_selection(1));
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "t\n");
+			CHECK(text_edit->get_caret_line(0) == 1);
+			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 21);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+
+			// Merge selections when they overlap.
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(4);
+			text_edit->select(0, 4, 0, 6);
+			text_edit->add_caret(0, 8);
+			text_edit->select(0, 6, 0, 8, 1);
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_DISCARD("caret_changed");
+			CHECK(text_edit->get_caret_count() == 2);
+
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == " is s");
+			CHECK(text_edit->get_caret_line(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 9);
+			CHECK(text_edit->get_selection_origin_line(0) == 0);
+			CHECK(text_edit->get_selection_origin_column(0) == 4);
+			CHECK(text_edit->is_caret_after_selection_origin(0));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2775,7 +5713,6 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 2);
 
 			MessageQueue::get_singleton()->flush();
-
 			CHECK(text_edit->is_line_wrapped(0));
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -3156,11 +6093,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			// For the second caret.
-			Array args2;
-			args2.push_back(1);
-			args2.push_back(1);
-			lines_edited_args.push_front(args2);
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
 
 			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3171,6 +6104,27 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
+			// Undo reverts both carets.
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "a\na");
+			CHECK(text_edit->get_caret_column() == 1);
+			CHECK(text_edit->get_caret_column(1) == 1);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", reverse_nested(lines_edited_args));
+
+			// Redo.
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "aA\naA");
+			CHECK(text_edit->get_caret_column() == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			// Does not work if not editable.
 			text_edit->set_editable(false);
 			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK_FALSE(text_edit->get_viewport()->is_input_handled()); // Should this be handled?
@@ -3182,8 +6136,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			lines_edited_args.push_back(lines_edited_args[1].duplicate());
-			lines_edited_args.push_front(args2.duplicate());
+			lines_edited_args = build_array(build_array(0, 0), build_array(0, 0), build_array(1, 1), build_array(1, 1));
 
 			text_edit->select(0, 0, 0, 1);
 			text_edit->select(1, 0, 1, 1, 1);
@@ -3220,8 +6173,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_overtype_mode_enabled(false);
 			CHECK_FALSE(text_edit->is_overtype_mode_enabled());
 
-			lines_edited_args.remove_at(0);
-			lines_edited_args.remove_at(1);
+			lines_edited_args = build_array(build_array(0, 0), build_array(1, 1));
 
 			SEND_GUI_KEY_EVENT(Key::TAB);
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3576,6 +6528,11 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	text_edit->set_caret_column(4);
 	CHECK(text_edit->get_word_under_caret() == "Lorem");
 
+	text_edit->set_caret_column(1);
+	text_edit->add_caret(0, 15);
+	CHECK(text_edit->get_word_under_caret() == "Lorem\ndolor");
+	text_edit->remove_secondary_carets();
+
 	// Should this work?
 	text_edit->set_caret_column(5);
 	CHECK(text_edit->get_word_under_caret() == "");
@@ -3616,18 +6573,20 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 	SIGNAL_DISCARD("caret_changed");
 
 	SUBCASE("[TextEdit] add remove caret") {
-		// Overlapping
+		// Overlapping.
 		CHECK(text_edit->add_caret(0, 0) == -1);
 		MessageQueue::get_singleton()->flush();
 		SIGNAL_CHECK_FALSE("caret_changed");
 
-		// Selection
-		text_edit->select(0, 0, 2, 4);
+		// Select.
+		text_edit->select(2, 4, 0, 0);
+
+		// Cannot add in selection.
 		CHECK(text_edit->add_caret(0, 0) == -1);
 		CHECK(text_edit->add_caret(2, 4) == -1);
 		CHECK(text_edit->add_caret(1, 2) == -1);
 
-		// Out of bounds
+		// Cannot add when out of bounds.
 		CHECK(text_edit->add_caret(-1, 0) == -1);
 		CHECK(text_edit->add_caret(5, 0) == -1);
 		CHECK(text_edit->add_caret(0, 100) == -1);
@@ -3670,23 +6629,276 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 		ERR_PRINT_ON;
 	}
 
-	SUBCASE("[TextEdit] caret index edit order") {
-		Vector<int> caret_index_get_order;
-		caret_index_get_order.push_back(1);
-		caret_index_get_order.push_back(0);
+	SUBCASE("[TextEdit] sort carets") {
+		Vector<int> sorted_carets = { 0, 1, 2 };
 
-		CHECK(text_edit->add_caret(1, 0));
-		CHECK(text_edit->get_caret_count() == 2);
-		CHECK(text_edit->get_caret_index_edit_order() == caret_index_get_order);
+		// Ascending order.
+		text_edit->remove_secondary_carets();
+		text_edit->add_caret(0, 1);
+		text_edit->add_caret(1, 0);
+		CHECK(text_edit->get_sorted_carets() == sorted_carets);
 
+		// Descending order.
+		sorted_carets = { 2, 1, 0 };
 		text_edit->remove_secondary_carets();
 		text_edit->set_caret_line(1);
-		CHECK(text_edit->add_caret(0, 0));
-		CHECK(text_edit->get_caret_count() == 2);
+		text_edit->add_caret(0, 1);
+		text_edit->add_caret(0, 0);
+		CHECK(text_edit->get_sorted_carets() == sorted_carets);
 
-		caret_index_get_order.write[0] = 0;
-		caret_index_get_order.write[1] = 1;
-		CHECK(text_edit->get_caret_index_edit_order() == caret_index_get_order);
+		// Mixed order.
+		sorted_carets = { 0, 2, 1, 3 };
+		text_edit->remove_secondary_carets();
+		text_edit->set_caret_line(0);
+		text_edit->add_caret(1, 0);
+		text_edit->add_caret(0, 1);
+		text_edit->add_caret(1, 1);
+		CHECK(text_edit->get_sorted_carets() == sorted_carets);
+
+		// Overlapping carets.
+		sorted_carets = { 0, 1, 3, 2 };
+		text_edit->remove_secondary_carets();
+		text_edit->add_caret(0, 1);
+		text_edit->add_caret(1, 2);
+		text_edit->add_caret(0, 2);
+		text_edit->set_caret_column(1, false, 3);
+		CHECK(text_edit->get_sorted_carets() == sorted_carets);
+
+		// Sorted by selection start.
+		sorted_carets = { 1, 0 };
+		text_edit->remove_secondary_carets();
+		text_edit->select(1, 3, 1, 5);
+		text_edit->add_caret(2, 0);
+		text_edit->select(1, 0, 2, 0, 1);
+		CHECK(text_edit->get_sorted_carets() == sorted_carets);
+	}
+
+	SUBCASE("[TextEdit] merge carets") {
+		text_edit->set_text("this is some text\nfor selection");
+		MessageQueue::get_singleton()->flush();
+
+		// Don't merge carets that are not overlapping.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(4);
+		text_edit->add_caret(0, 6);
+		text_edit->add_caret(1, 6);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 6);
+		CHECK(text_edit->get_caret_line(2) == 1);
+		CHECK(text_edit->get_caret_column(2) == 6);
+		text_edit->remove_secondary_carets();
+
+		// Don't merge when in a multicaret edit.
+		text_edit->begin_multicaret_edit();
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(4);
+		text_edit->add_caret(0, 4);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->is_in_mulitcaret_edit());
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 4);
+
+		// Merge overlapping carets. Merge at the end of the multicaret edit.
+		text_edit->end_multicaret_edit();
+		CHECK_FALSE(text_edit->is_in_mulitcaret_edit());
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+
+		// Don't merge selections that are not overlapping.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(4);
+		text_edit->add_caret(0, 2);
+		text_edit->add_caret(1, 4);
+		text_edit->select(0, 4, 1, 2, 0);
+		text_edit->select(0, 2, 0, 3, 1);
+		text_edit->select(1, 4, 1, 8, 2);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->has_selection(1));
+		CHECK(text_edit->has_selection(2));
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+
+		// Don't merge selections that are only touching.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(4);
+		text_edit->add_caret(1, 2);
+		text_edit->select(0, 4, 1, 2, 0);
+		text_edit->select(1, 2, 1, 5, 1);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->has_selection(1));
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+
+		// Merge carets into selection.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(3);
+		text_edit->add_caret(0, 2);
+		text_edit->add_caret(1, 4);
+		text_edit->add_caret(1, 8);
+		text_edit->add_caret(1, 10);
+		text_edit->select(0, 2, 1, 8, 0);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_from_line(0) == 0);
+		CHECK(text_edit->get_selection_from_column(0) == 2);
+		CHECK(text_edit->get_selection_to_line(0) == 1);
+		CHECK(text_edit->get_selection_to_column(0) == 8);
+		CHECK(text_edit->is_caret_after_selection_origin(0));
+		CHECK_FALSE(text_edit->has_selection(1));
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 10);
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+
+		// Merge partially overlapping selections.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(1);
+		text_edit->add_caret(0, 2);
+		text_edit->add_caret(0, 3);
+		text_edit->select(0, 2, 0, 6, 0);
+		text_edit->select(0, 4, 1, 3, 1);
+		text_edit->select(1, 0, 1, 5, 2);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_from_line(0) == 0);
+		CHECK(text_edit->get_selection_from_column(0) == 2);
+		CHECK(text_edit->get_selection_to_line(0) == 1);
+		CHECK(text_edit->get_selection_to_column(0) == 5);
+		CHECK(text_edit->is_caret_after_selection_origin(0));
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+
+		// Merge smaller overlapping selection into a bigger one.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(1);
+		text_edit->add_caret(0, 2);
+		text_edit->add_caret(0, 3);
+		text_edit->select(0, 2, 0, 6, 0);
+		text_edit->select(0, 8, 1, 3, 1);
+		text_edit->select(0, 2, 1, 5, 2);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_from_line(0) == 0);
+		CHECK(text_edit->get_selection_from_column(0) == 2);
+		CHECK(text_edit->get_selection_to_line(0) == 1);
+		CHECK(text_edit->get_selection_to_column(0) == 5);
+		CHECK(text_edit->is_caret_after_selection_origin(0));
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+
+		// Merge equal overlapping selections.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(1);
+		text_edit->add_caret(0, 2);
+		text_edit->select(0, 2, 1, 6, 0);
+		text_edit->select(0, 2, 1, 6, 1);
+		text_edit->merge_overlapping_carets();
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_from_line(0) == 0);
+		CHECK(text_edit->get_selection_from_column(0) == 2);
+		CHECK(text_edit->get_selection_to_line(0) == 1);
+		CHECK(text_edit->get_selection_to_column(0) == 6);
+		CHECK(text_edit->is_caret_after_selection_origin(0));
+	}
+
+	SUBCASE("[TextEdit] collapse carets") {
+		text_edit->set_text("this is some text\nfor selection");
+
+		// Collapse carets in range, dont affect other carets.
+		text_edit->add_caret(0, 9);
+		text_edit->add_caret(1, 0);
+		text_edit->add_caret(1, 2);
+		text_edit->add_caret(1, 6);
+		text_edit->begin_multicaret_edit();
+
+		text_edit->collapse_carets(0, 8, 1, 2);
+		CHECK(text_edit->get_caret_count() == 5);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 0);
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 8);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 8);
+		CHECK(text_edit->get_caret_line(3) == 1);
+		CHECK(text_edit->get_caret_column(3) == 2);
+		CHECK(text_edit->get_caret_line(4) == 1);
+		CHECK(text_edit->get_caret_column(4) == 6);
+		CHECK_FALSE(text_edit->multicaret_edit_ignore_caret(0));
+		CHECK(text_edit->multicaret_edit_ignore_caret(1));
+		CHECK(text_edit->multicaret_edit_ignore_caret(2));
+		CHECK_FALSE(text_edit->multicaret_edit_ignore_caret(3));
+		CHECK_FALSE(text_edit->multicaret_edit_ignore_caret(4));
+
+		// Collapsed carets get merged at the end of the edit.
+		text_edit->end_multicaret_edit();
+		CHECK(text_edit->get_caret_count() == 4);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 0);
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 8);
+		CHECK(text_edit->get_caret_line(2) == 1);
+		CHECK(text_edit->get_caret_column(2) == 2);
+		CHECK(text_edit->get_caret_line(3) == 1);
+		CHECK(text_edit->get_caret_column(3) == 6);
+		text_edit->remove_secondary_carets();
+
+		// Collapse inclusive.
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(3);
+		text_edit->add_caret(1, 2);
+		text_edit->collapse_carets(0, 3, 1, 2, true);
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line() == 0);
+		CHECK(text_edit->get_caret_column() == 3);
+		text_edit->remove_secondary_carets();
+
+		// Deselect if selection was encompassed.
+		text_edit->select(0, 5, 0, 7);
+		text_edit->collapse_carets(0, 3, 1, 2);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line() == 0);
+		CHECK(text_edit->get_caret_column() == 3);
+
+		// Clamp only caret end of selection.
+		text_edit->select(0, 1, 0, 7);
+		text_edit->collapse_carets(0, 3, 1, 2);
+		CHECK(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line() == 0);
+		CHECK(text_edit->get_caret_column() == 3);
+		CHECK(text_edit->get_selection_origin_line() == 0);
+		CHECK(text_edit->get_selection_origin_column() == 1);
+		text_edit->deselect();
+
+		// Clamp only selection origin end of selection.
+		text_edit->select(0, 7, 0, 1);
+		text_edit->collapse_carets(0, 3, 1, 2);
+		CHECK(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line() == 0);
+		CHECK(text_edit->get_caret_column() == 1);
+		CHECK(text_edit->get_selection_origin_line() == 0);
+		CHECK(text_edit->get_selection_origin_column() == 3);
+		text_edit->deselect();
 	}
 
 	SUBCASE("[TextEdit] add caret at carets") {
@@ -3694,36 +6906,320 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 		text_edit->set_caret_line(1);
 		text_edit->set_caret_column(9);
 
+		// Add caret below. Column will clamp.
 		text_edit->add_caret_at_carets(true);
 		CHECK(text_edit->get_caret_count() == 2);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 9);
 		CHECK(text_edit->get_caret_line(1) == 2);
 		CHECK(text_edit->get_caret_column(1) == 4);
 
+		// Cannot add below when at last line.
 		text_edit->add_caret_at_carets(true);
 		CHECK(text_edit->get_caret_count() == 2);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 9);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 4);
 
+		// Add caret above. Column will clamp.
 		text_edit->add_caret_at_carets(false);
 		CHECK(text_edit->get_caret_count() == 3);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 9);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 4);
 		CHECK(text_edit->get_caret_line(2) == 0);
 		CHECK(text_edit->get_caret_column(2) == 7);
 
+		// Cannot add above when at first line.
+		text_edit->add_caret_at_carets(false);
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 9);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 4);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 7);
+
+		// Cannot add below when at the last line for selection.
 		text_edit->remove_secondary_carets();
-		text_edit->set_caret_line(0);
-		text_edit->set_caret_column(4);
+		text_edit->select(2, 1, 2, 4);
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 2);
+		CHECK(text_edit->get_selection_origin_column(0) == 1);
+		CHECK(text_edit->get_caret_line(0) == 2);
+		CHECK(text_edit->get_caret_column(0) == 4);
+
+		// Cannot add above when at the first line for selection.
+		text_edit->select(0, 1, 0, 4);
+		text_edit->add_caret_at_carets(false);
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 0);
+		CHECK(text_edit->get_selection_origin_column(0) == 1);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+
+		// Add selection below.
 		text_edit->select(0, 0, 0, 4);
 		text_edit->add_caret_at_carets(true);
 		CHECK(text_edit->get_caret_count() == 2);
-		CHECK(text_edit->get_selection_from_line(1) == 1);
-		CHECK(text_edit->get_selection_to_line(1) == 1);
-		CHECK(text_edit->get_selection_from_column(1) == 0);
-		CHECK(text_edit->get_selection_to_column(1) == 3);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 0);
+		CHECK(text_edit->get_selection_origin_column(0) == 0);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->has_selection(1));
+		CHECK(text_edit->get_selection_origin_line(1) == 1);
+		CHECK(text_edit->get_selection_origin_column(1) == 0);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
 
+		// Add selection below again.
 		text_edit->add_caret_at_carets(true);
 		CHECK(text_edit->get_caret_count() == 3);
-		CHECK(text_edit->get_selection_from_line(2) == 2);
-		CHECK(text_edit->get_selection_to_line(2) == 2);
-		CHECK(text_edit->get_selection_from_column(2) == 0);
-		CHECK(text_edit->get_selection_to_column(2) == 4);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 0);
+		CHECK(text_edit->get_selection_origin_column(0) == 0);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->has_selection(1));
+		CHECK(text_edit->get_selection_origin_line(1) == 1);
+		CHECK(text_edit->get_selection_origin_column(1) == 0);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 3);
+		CHECK(text_edit->has_selection(2));
+		CHECK(text_edit->get_selection_origin_line(2) == 2);
+		CHECK(text_edit->get_selection_origin_column(2) == 0);
+		CHECK(text_edit->get_caret_line(2) == 2);
+		CHECK(text_edit->get_caret_column(2) == 4);
+
+		text_edit->set_text("\tthis is\nsome\n\ttest text");
+		MessageQueue::get_singleton()->flush();
+
+		// Last fit x is preserved when adding below.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(6);
+		text_edit->add_caret_at_carets(true);
+		text_edit->add_caret_at_carets(true);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 6);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 4);
+		CHECK(text_edit->get_caret_line(2) == 2);
+		CHECK(text_edit->get_caret_column(2) == 6);
+
+		// Last fit x is preserved when adding above.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(2);
+		text_edit->set_caret_column(9);
+		text_edit->add_caret_at_carets(false);
+		text_edit->add_caret_at_carets(false);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->get_caret_line(0) == 2);
+		CHECK(text_edit->get_caret_column(0) == 9);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 4);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 8);
+
+		// Last fit x is preserved when selection adding below.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->select(0, 8, 0, 5);
+		text_edit->add_caret_at_carets(true);
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 0);
+		CHECK(text_edit->get_selection_origin_column(0) == 8);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 5);
+		CHECK_FALSE(text_edit->has_selection(1));
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 4);
+		CHECK(text_edit->has_selection(2));
+		CHECK(text_edit->get_selection_origin_line(2) == 2);
+		CHECK(text_edit->get_selection_origin_column(2) == 7);
+		CHECK(text_edit->get_caret_line(2) == 2);
+		CHECK(text_edit->get_caret_column(2) == 5);
+
+		// Last fit x is preserved when selection adding above.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->select(2, 9, 2, 5);
+		text_edit->add_caret_at_carets(false);
+		text_edit->add_caret_at_carets(false);
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 2);
+		CHECK(text_edit->get_selection_origin_column(0) == 9);
+		CHECK(text_edit->get_caret_line(0) == 2);
+		CHECK(text_edit->get_caret_column(0) == 5);
+		CHECK_FALSE(text_edit->has_selection(1));
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 4);
+		CHECK(text_edit->has_selection(2));
+		CHECK(text_edit->get_selection_origin_line(2) == 0);
+		CHECK(text_edit->get_selection_origin_column(2) == 8);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 5);
+
+		// Selections are merged when they overlap.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->select(0, 1, 0, 5);
+		text_edit->add_caret(1, 0);
+		text_edit->select(1, 1, 1, 3, 1);
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 0);
+		CHECK(text_edit->get_selection_origin_column(0) == 1);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 5);
+		CHECK(text_edit->has_selection(1));
+		CHECK(text_edit->get_selection_origin_line(1) == 1);
+		CHECK(text_edit->get_selection_origin_column(1) == 1);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 4);
+		CHECK(text_edit->has_selection(2));
+		CHECK(text_edit->get_selection_origin_line(2) == 2);
+		CHECK(text_edit->get_selection_origin_column(2) == 0);
+		CHECK(text_edit->get_caret_line(2) == 2);
+		CHECK(text_edit->get_caret_column(2) == 3);
+
+		// Multiline selection.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(1);
+		text_edit->select(0, 3, 1, 1);
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->has_selection(0));
+		CHECK(text_edit->get_selection_origin_line(0) == 0);
+		CHECK(text_edit->get_selection_origin_column(0) == 3);
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 1);
+		CHECK(text_edit->has_selection(1));
+		CHECK(text_edit->get_selection_origin_line(1) == 1);
+		CHECK(text_edit->get_selection_origin_column(1) == 3);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 0);
+
+		text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
+		text_edit->set_size(Size2(50, 100));
+		// Line wraps: `\t,this, is\nso,me\n\t,test, ,text`.
+		CHECK(text_edit->is_line_wrapped(0));
+		MessageQueue::get_singleton()->flush();
+
+		// Add caret below on next line wrap.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(4);
+		text_edit->add_caret_at_carets(true);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 8);
+
+		// Add caret below from end of line wrap.
+		text_edit->add_caret_at_carets(true);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 8);
+		CHECK(text_edit->get_caret_line(2) == 1);
+		CHECK(text_edit->get_caret_column(2) == 1);
+
+		// Add caret below from last line and not last line wrap.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(2);
+		text_edit->set_caret_column(5);
+		text_edit->add_caret_at_carets(true);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_line(0) == 2);
+		CHECK(text_edit->get_caret_column(0) == 5);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 10);
+
+		// Cannot add caret below from last line last line wrap.
+		text_edit->add_caret_at_carets(true);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_line(0) == 2);
+		CHECK(text_edit->get_caret_column(0) == 5);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 10);
+
+		// Add caret above from not first line wrap.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(1);
+		text_edit->set_caret_column(4);
+		text_edit->add_caret_at_carets(false);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 1);
+
+		// Add caret above from first line wrap.
+		text_edit->add_caret_at_carets(false);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 1);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 8);
+
+		// Add caret above from first line and not first line wrap.
+		text_edit->add_caret_at_carets(false);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 4);
+		CHECK(text_edit->get_caret_line(0) == 1);
+		CHECK(text_edit->get_caret_column(0) == 4);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 1);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 8);
+		CHECK(text_edit->get_caret_line(3) == 0);
+		CHECK(text_edit->get_caret_column(3) == 4);
+
+		// Cannot add caret above from first line first line wrap.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(0);
+		text_edit->add_caret_at_carets(false);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 0);
 	}
 
 	memdelete(text_edit);
@@ -3992,7 +7488,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
-	// Wrap
+	// Wrap.
 	text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_total_visible_line_count() > total_visible_lines);
@@ -4242,7 +7738,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	// Typing and undo / redo should adjust viewport
+	// Typing and undo / redo should adjust viewport.
 	text_edit->set_caret_line(0);
 	text_edit->set_caret_column(0);
 	text_edit->set_line_as_first_visible(5);

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -136,6 +136,7 @@ int register_test_command(String p_command, TestFunc p_function);
 // Requires Message Queue and InputMap to be setup.
 // SEND_GUI_ACTION    - takes an input map key. e.g SEND_GUI_ACTION("ui_text_newline").
 // SEND_GUI_KEY_EVENT - takes a keycode set.   e.g SEND_GUI_KEY_EVENT(Key::A | KeyModifierMask::META).
+// SEND_GUI_KEY_UP_EVENT - takes a keycode set.   e.g SEND_GUI_KEY_UP_EVENT(Key::A | KeyModifierMask::META).
 // SEND_GUI_MOUSE_BUTTON_EVENT - takes a position, mouse button, mouse mask and modifiers e.g SEND_GUI_MOUSE_BUTTON_EVENT(Vector2(50, 50), MOUSE_BUTTON_NONE, MOUSE_BUTTON_NONE, Key::None);
 // SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT - takes a position, mouse button, mouse mask and modifiers e.g SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Vector2(50, 50), MOUSE_BUTTON_NONE, MOUSE_BUTTON_NONE, Key::None);
 // SEND_GUI_MOUSE_MOTION_EVENT - takes a position, mouse mask and modifiers e.g SEND_GUI_MOUSE_MOTION_EVENT(Vector2(50, 50), MouseButtonMask::LEFT, KeyModifierMask::META);
@@ -157,6 +158,14 @@ int register_test_command(String p_command, TestFunc p_function);
 	{                                                                        \
 		Ref<InputEventKey> event = InputEventKey::create_reference(m_input); \
 		event->set_pressed(true);                                            \
+		_SEND_DISPLAYSERVER_EVENT(event);                                    \
+		MessageQueue::get_singleton()->flush();                              \
+	}
+
+#define SEND_GUI_KEY_UP_EVENT(m_input)                                       \
+	{                                                                        \
+		Ref<InputEventKey> event = InputEventKey::create_reference(m_input); \
+		event->set_pressed(false);                                           \
 		_SEND_DISPLAYSERVER_EVENT(event);                                    \
 		MessageQueue::get_singleton()->flush();                              \
 	}


### PR DESCRIPTION
- related #73471
- fixes #86863 (all issues except some of [reload script](https://github.com/godotengine/godot/issues/86863#reload-scripts) and [goto line](https://github.com/godotengine/godot/issues/86863#goto-line))
- fixes #83410
- fixes #72797
- probably fixes #74400 (can't reproduce, related to other issues fixed)
- fixes #73202
- fixes #81535
- fixes #83826
- fixes https://github.com/godotengine/godot/issues/80378
- fixes #83589
- fixes https://github.com/godotengine/godot/issues/90462
- supersedes (can still cherry-pick) #84901 
- supersedes (can still cherry-pick) #81331
- supersedes #83451

Selection now goes from selection origin to the caret, so that the caret is always attached to the selection.

All TextEdit APIs now handle multiple carets. This should make it easier to use and use correctly.
If a method is called alone, it will merge overlapping carets. If it is called in a loop for multiple carets as part of a multicaret edit, the merge will happen afterwards to not affect caret indexes.

All text changes and caret changes now `queue_redraw()`.

<details>
<summary>Implementation details</summary>

General
- Added `remove_line_at()` and `insert_text()` in TextEdit to flesh out the API because methods now affects carets in different ways, so the way it is used and the context matters. 
	- For example: `set_line()` was often used to insert text, but this doesn't allow for much context of how the carets on that line should be affected.
- Moved `move_lines_up/down()`, `delete_lines()`, `duplicate_selection()`, and `delete_lines()` from `CodeEditor` to `CodeEdit` since the implementations changed so they can be tested, and based on this https://github.com/godotengine/godot/pull/66553#pullrequestreview-1598392668. 
- Made drag and drop text use a new caret instead of the main one so it won't interfere with any carets.
	- `get_caret_count()` and many other methods now ignores the drag caret if it exists, as it shouldn't be used as a regular caret in most cases.
	- I wanted it to not be part of the `carets` vector at all, but I also didn't want to copy lots of drawing and scrolling code.
- Added `_text_changed()`, `_caret_changed()`, and `_selection_changed()` to have one clear place after a change that will be called immediately. These are used to redraw, defer emit signals, and cancel drag and drop if needed.
	- A `selection_changed` signal should be easy to add now, if it is needed in the future.
- Added `_cancel_drag_and_drop_text()` to cancel the Viewport's drag and drop in certain circumstances.
	- Added `Viewport::gui_cancel_drag()` to support this, since I couldn't find an existing way of cancelling a drag and drop operation.
- Added `_unhide_carets()` because sometimes the TextEdit needs to unfold a line, and it can't just use unhide the line.
- Changed `_cut_internal()` to use `_copy_internal()` then just remove the selection/lines as it is much simpler.
- In `set_caret_line()` the `p_wrap_index` param now accepts `-1` to only clamp the column and not try to adjust it. In many cases `set_caret_column()` is called immediately afterward, so calculating the column so it lines up visually was unnecessary, and sometimes needed a workaround to avoid.
- Changed some MessageQueue calls to use callables, since I moved them around. (related #86301)
- Added `cancel_ime()` and `apply_ime()` for more control over the IME.
	- Added internally `_close_ime_window()`, `_update_ime_window_position()`, and `_update_ime_text()` to reduce code duplication and increase clarity.
	- We may want to make similar changes in LineEdit?
- Added `get/set_carets_state()` for the various `reload_text()` methods and for getting/setting the entire state.
- Updated some comments style. I didn't change the block comments that are used as headers, since they should probably be distinct from regular comments and I didn't know what style to change them to.
- Changed `GotoLineDialog::popup_find_line()` to use a `CodeTextEditor` instead of a `CodeEdit` so it can use the existing `goto_line()` functionality and not need to recreate it. 
	- GotoLineDialog should use a SpinBox or something, but that can be a separate PR.

TextEdit Multicaret
- Added `begin/end_multicaret_edit()` to be able to allow merging the carets when the edit is complete.
	- These should always come in pairs.
	- These can be nested, and is what allows for more complex editing to use regular APIs, and have both merge only once at the end of the edit.
- Added `queue_merge_carets()` to be used when merging should happen at the end of the multicaret edit.
- Added `multicaret_edit_ignore_caret()` that should be used when iterating over carets when editing them and text is removed. This will return true when the given caret would have been removed due to it merging with another caret, or it was just added. 
	- This allows multiple carets to be collapsed into one and delay the merging without affecting the edit.
- Added `collapse_carets()` to move all carets in a region of deleted text to one overlapping location and add to the ignore list. These will be merged at the end of the edit unless they are separated.
- Removed `get_caret_index_edit_order()`, because it is no longer needed since carets can be edited in any order.
- Added `get_sorted_carets()` to replace some functionality from `get_caret_index_edit_order`, but in the opposite order. It sorts by selection_from_line instead of selection_to_line, in ascending order (top of page to bottom).
- `get_sorted_carets()` is const and doesn't cache because it is usually only needed after a caret is moved which would invalidate the cache. I also use a Comparator so it should be faster, O(log(n)) instead of O(n^2). If there are still performance concerns, we can change it to use a cache.
- Added `get_line_ranges_from_carets()` to get a vector of all the lines that are part of a selection or have a caret on them. This is useful for many common editing tasks.
	- This was inspired by the removed methods in CodeTextEditor `_get_affected_lines_from/to()`, but more comprehensive.
- Removed `adjust_carets_after_edit()` because it is no longer needed now that carets are automatically handled. 
	- `_offset_carets_after()` is similar (though not the same) and is used internally for a similar purpose, to move all carets after some text was added/removed.
- Updated all code that operates on multiple carets.
	- `TextEdit::merge_overlapping_carets()`, `TextEdit::_new_line()`, `TextEdit::_do_backspace()`, `TextEdit::_delete()`, `TextEdit::insert_text_at_caret()`, `TextEdit::add_caret_at_carets()`, `TextEdit::adjust_carets_after_edit()`, `TextEdit::get_selected_text()`, `TextEdit::delete_selection()`, `TextEdit::_handle_unicode_input_internal()`, `TextEdit::_backspace_internal()`, `TextEdit::_cut_internal()`, `TextEdit::_copy_internal()`, `TextEdit::_paste_internal()`, `CodeEdit::_handle_unicode_input_internal()`, `CodeEdit::_backspace_internal()`, `CodeEdit::do_indent()`, `CodeEdit::indent_lines()`, `CodeEdit::unindent_lines()`, `CodeEdit::_new_line()`, `CodeEdit::create_code_region()`, `CodeEdit::confirm_code_completion()`, `CodeEdit::duplicate_lines()`, `TextEditor::_edit_option(EDIT_TOGGLE_FOLD_LINE)`, `ScriptTextEditor::_edit_option(EDIT_TOGGLE_FOLD_LINE)`, `ScriptTextEditor::_edit_option(DEBUG_TOGGLE_BREAKPOINT)`, `CodeTextEditor::convert_case()`, `CodeTextEditor::move_lines_up()`, `CodeTextEditor::move_lines_down()`, `CodeTextEditor::delete_lines()`, `CodeTextEditor::duplicate_selection()`, `CodeTextEditor::toggle_inline_comment()`, `CodeTextEditor::toggle_bookmark()`

TextEdit Selection
- Changed `select()` to now select from a 'selection origin' to the caret. Calling it will move the caret.
- `get_selection_from/to_line/column` still gives the start/end of the selection and can be used like before. Since these values are now calculated and its a common use case, they return the caret line/column if there is no active selection.
- Added `set_selection_origin_line/column()` to be able to set the origin of the selection directly, similar to `set_caret_line/column()`.
	- Added a `get_selection_origin_line/column()`. Deprecated `get_selection_line/column()` because the functionality is a bit different, and I wanted a more clear name. It didn't always return the origin of the selection, it was just used to setup the different selection modes.
	- These functions work even if there is no selection because it is sometimes needed to use or set it before starting a selection, like in `_pre_shift_selection()` or `add_caret_at_carets()`.
- Selections can now touch each other since when I was reworking on `merge_overlapping_carets()`, I used VSCode for reference and that is how it is done there. It is also useful in some scenarios.
- Changed `has_selection()`, `get_selected_text()`, and `deselect()` to be faster O(1) if the caret index is passed in instead of O(n). I didn't do this for all of them since there would be lots of copy pasted code.
- Added `is_selection_direction_right()` to be able to tell if the selection is left to right (top to bottom) or the reverse, since it now always has a direction.
- Removed `_post_shift_selection()` as it wasn't needed anymore.
- This comment in `_click_selection_held()` is no longer true: 
	- `Warning: is_mouse_button_pressed(MouseButton::LEFT) returns false for double+ clicks...`
	- I'm not sure when this changed but it does work for word and line mode.
- Added `selection_contains()`, `get_selection_at()`, and `is_line_col_in_range()` as helper functions to reduce duplicate code.

Tests
- Added clipboard and primary clipboard support to DisplayServerMock to be able to test cut, copy, paste, and paste primary
	- Removed those todos
- Added `build_array()` to TestTextEdit and TestCodeEdit to be able to easily create arrays, copied from `variant/test_array.h`.
	- These can be replaced with initializer lists after #86015.
- Updated comment style for CodeEditTests.
- Added `SEND_GUI_KEY_UP_EVENT` test macro, for some text drag tests where the key up event was needed.
- Added test cases for `insert text`, `remove text`, `remove line at`
- Improved/added tests in areas that had bugs or where I changed lots of code.
- Removed todo `// Add undo / redo tests?` line 1368 by adding undo redo tests for each input subcase. 
- Lots of `lines_edited_args` had to be changed since the order edits are done in are different, but this shouldn't be an issue.
- Added some comments to clarify some tests.
- Added `// FIXME: Remove after GH-77101 is fixed.` to some input tests, since a new action should not need to be started in between edits with different carets. related #77101.
- Removed `caret index edit order` tests, Added `sort carets` and `merge carets` tests.
- Added `text manipulation` test case with subcases `backspace`, `new line`,`move lines up`,`move lines down`,`delete lines`,`duplicate selection`,`duplicate lines`.

</details>