### PR TITLE
Make `get_id_path` return empty when first point is disabled

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -481,6 +481,10 @@ Vector<int64_t> AStar3D::get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_
 		return ret;
 	}
 
+	if (!a->enabled) {
+		return Vector<int64_t>();
+	}
+
 	Point *begin_point = a;
 	Point *end_point = b;
 
@@ -762,6 +766,10 @@ Vector<int64_t> AStar2D::get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_
 		Vector<int64_t> ret;
 		ret.push_back(a->id);
 		return ret;
+	}
+
+	if (!a->enabled) {
+		return Vector<int64_t>();
 	}
 
 	AStar3D::Point *begin_point = a;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86866

This should be discussed more, at least this pr breaks compatibility and might not suit for other's understanding of how A* should work. If this change is not good, I will drop this commit and update the doc instead.

Also I find that AStarGrid2D doesn't have similiar methods for enable and disable single point, I guess it is intended because it deals with region rather than point?


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
