### PR TITLE
Fix ZIPPacker storing file permissions unexpectedly

### DIFF
--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -88,7 +88,7 @@ Error ZIPPacker::start_file(const String &p_path) {
 			Z_DEFAULT_STRATEGY,
 			nullptr,
 			0,
-			0x0314, // "version made by", 0x03 - Unix, 0x14 - ZIP specification version 2.0, required to store Unix file permissions.
+			0, // "version made by", indicates the compatibility of the file attribute information (the `external_fa` field above).
 			1 << 11); // Bit 11 is the language encoding flag. When set, filename and comment fields must be encoded using UTF-8.
 	return err == ZIP_OK ? OK : FAILED;
 }


### PR DESCRIPTION
Fixes #86967

The "version made by" parameter indicates the compatibility of the file attribute information. Since 0 is stored in the related file attribute field, using `0x0314` as "version made by" is effectly saying "I want the file's UNIX file permission to be 0".

`ZIPPacker` does not support specifying file permissions, so it's safe to use 0 as "version made by", ignoring the file attribute information field.