### PR TITLE
Shaders: Allow trailing commas in function calls

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3176,7 +3176,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 				}
 
 				if (!fail) {
-					// When running tests, we might not have a proper rendering server to check low-endness with
+					// When running tests, we might not have a proper rendering server to check low-endness with.
 					RenderingServer *rendering_server = RenderingServer::get_singleton();
 					if (rendering_server != nullptr && rendering_server->is_low_end()) {
 						if (builtin_func_defs[idx].high_end) {
@@ -3639,7 +3639,7 @@ bool ShaderLanguage::_parse_function_arguments(BlockNode *p_block, const Functio
 		// if so, it must be a argument-list-trailing comma.
 		if (_peek_token().type == TK_PARENTHESIS_CLOSE) {
 			// Swallow the closing parenthesis and return.
-			ERR_FAIL_COND_V(_get_token().type != TK_PARENTHESIS_CLOSE, false);
+			_get_token();
 			break;
 		}
 	}

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -883,7 +883,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 #undef GETCHAR
 }
 
-bool ShaderLanguage::_lookup_next(Token &r_tk) {
+bool ShaderLanguage::_lookup_next_for_completion(Token &r_tk) {
 	TkPos pre_pos = _get_tkpos();
 	int line = pre_pos.tk_line;
 	_get_token();
@@ -6939,7 +6939,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			}
 
 #ifdef DEBUG_ENABLED
-			if (is_const && _lookup_next(next)) {
+			if (is_const && _lookup_next_for_completion(next)) {
 				if (is_token_precision(next.type)) {
 					keyword_completion_context = CF_UNSPECIFIED;
 				}
@@ -8337,7 +8337,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 			case TK_GLOBAL: {
 #ifdef DEBUG_ENABLED
 				keyword_completion_context = CF_UNIFORM_KEYWORD;
-				if (_lookup_next(next)) {
+				if (_lookup_next_for_completion(next)) {
 					if (next.type == TK_UNIFORM) {
 						keyword_completion_context ^= CF_UNIFORM_KEYWORD;
 					}
@@ -8355,7 +8355,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				if (tk.type == TK_INSTANCE) {
 #ifdef DEBUG_ENABLED
 					keyword_completion_context = CF_UNIFORM_KEYWORD;
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (next.type == TK_UNIFORM) {
 							keyword_completion_context ^= CF_UNIFORM_KEYWORD;
 						}
@@ -8407,7 +8407,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					datatype_flag = CF_VARYING_TYPE;
 					keyword_completion_context = CF_INTERPOLATION_QUALIFIER | CF_PRECISION_MODIFIER | datatype_flag;
 
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (is_token_interpolation(next.type)) {
 							keyword_completion_context ^= (CF_INTERPOLATION_QUALIFIER | datatype_flag);
 						} else if (is_token_precision(next.type)) {
@@ -8420,7 +8420,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					datatype_flag = CF_UNIFORM_TYPE;
 					keyword_completion_context = CF_PRECISION_MODIFIER | datatype_flag;
 
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (is_token_precision(next.type)) {
 							keyword_completion_context ^= (CF_PRECISION_MODIFIER | datatype_flag);
 						} else if (is_token_datatype(next.type)) {
@@ -8445,7 +8445,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					if (keyword_completion_context & CF_INTERPOLATION_QUALIFIER) {
 						keyword_completion_context ^= CF_INTERPOLATION_QUALIFIER;
 					}
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (is_token_precision(next.type)) {
 							keyword_completion_context ^= CF_PRECISION_MODIFIER;
 						} else if (is_token_datatype(next.type)) {
@@ -8468,7 +8468,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					if (keyword_completion_context & CF_PRECISION_MODIFIER) {
 						keyword_completion_context ^= CF_PRECISION_MODIFIER;
 					}
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (is_token_datatype(next.type)) {
 							keyword_completion_context = CF_UNSPECIFIED;
 						}
@@ -9110,7 +9110,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					struct_name = tk.text;
 				} else {
 #ifdef DEBUG_ENABLED
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (next.type == TK_UNIFORM) {
 							keyword_completion_context = CF_UNIFORM_QUALIFIER;
 						}
@@ -9529,7 +9529,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 #ifdef DEBUG_ENABLED
 					keyword_completion_context = CF_CONST_KEYWORD | CF_FUNC_DECL_PARAM_SPEC | CF_PRECISION_MODIFIER | CF_FUNC_DECL_PARAM_TYPE; // eg. const in mediump float
 
-					if (_lookup_next(next)) {
+					if (_lookup_next_for_completion(next)) {
 						if (next.type == TK_CONST) {
 							keyword_completion_context = CF_UNSPECIFIED;
 						} else if (is_token_arg_qual(next.type)) {
@@ -9551,7 +9551,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							keyword_completion_context ^= CF_CONST_KEYWORD;
 						}
 
-						if (_lookup_next(next)) {
+						if (_lookup_next_for_completion(next)) {
 							if (is_token_arg_qual(next.type)) {
 								keyword_completion_context = CF_UNSPECIFIED;
 							} else if (is_token_precision(next.type)) {
@@ -9597,7 +9597,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							keyword_completion_context ^= CF_FUNC_DECL_PARAM_SPEC;
 						}
 
-						if (_lookup_next(next)) {
+						if (_lookup_next_for_completion(next)) {
 							if (is_token_precision(next.type)) {
 								keyword_completion_context = CF_FUNC_DECL_PARAM_TYPE;
 							} else if (is_token_datatype(next.type)) {
@@ -9630,7 +9630,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							keyword_completion_context ^= CF_PRECISION_MODIFIER;
 						}
 
-						if (_lookup_next(next)) {
+						if (_lookup_next_for_completion(next)) {
 							if (is_token_datatype(next.type)) {
 								keyword_completion_context = CF_UNSPECIFIED;
 							}

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -394,6 +394,9 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 	{ TK_ERROR, nullptr, CF_UNSPECIFIED, {}, {} }
 };
 
+/**
+ * Parse the next token from the code and advance the cursor.
+ */
 ShaderLanguage::Token ShaderLanguage::_get_token() {
 #define GETCHAR(m_idx) (((char_idx + m_idx) < code.length()) ? code[char_idx + m_idx] : char32_t(0))
 
@@ -894,6 +897,17 @@ bool ShaderLanguage::_lookup_next_for_completion(Token &r_tk) {
 		return true;
 	}
 	return false;
+}
+
+/**
+ * Parse the next token, then rewind the tokenizer state
+ * so it looks as if the token was never parsed.
+ */
+ShaderLanguage::Token ShaderLanguage::_peek_token() {
+	TkPos pre_pos = _get_tkpos();
+	Token tok = _get_token();
+	_set_tkpos(pre_pos);
+	return tok;
 }
 
 String ShaderLanguage::token_debug(const String &p_code) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1011,6 +1011,7 @@ private:
 
 	Token _make_token(TokenType p_type, const StringName &p_text = StringName());
 	Token _get_token();
+	Token _peek_token();
 	bool _lookup_next_for_completion(Token &r_tk);
 
 	ShaderNode *shader = nullptr;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1011,7 +1011,7 @@ private:
 
 	Token _make_token(TokenType p_type, const StringName &p_text = StringName());
 	Token _get_token();
-	bool _lookup_next(Token &r_tk);
+	bool _lookup_next_for_completion(Token &r_tk);
 
 	ShaderNode *shader = nullptr;
 

--- a/tests/servers/rendering/test_shader_language.h
+++ b/tests/servers/rendering/test_shader_language.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  test_shader_language.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_SHADER_LANGUAGE_H
+#define TEST_SHADER_LANGUAGE_H
+
+#include "servers/rendering/shader_language.h"
+
+#include "tests/test_macros.h"
+
+#include <servers/rendering/shader_types.h>
+
+#include <cctype>
+
+namespace TestShaderLanguage {
+
+TEST_CASE("[ShaderLanguage] Function call trailing commas") {
+	String code(
+			"shader_type canvas_item;\n"
+			"void fragment() {\n"
+			"  clamp(\n"
+			"    5.0,\n"
+			"    0.0,\n"
+			"    1.0,\n"
+			"  );\n"
+			"}\n");
+	ShaderLanguage sl;
+	sl.set_warning_flags(0);
+	ShaderLanguage::ShaderCompileInfo comp_info;
+	comp_info.functions = ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(RenderingServer::SHADER_CANVAS_ITEM));
+	comp_info.render_modes = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(RenderingServer::SHADER_CANVAS_ITEM));
+	comp_info.shader_types = ShaderTypes::get_singleton()->get_types();
+	Error last_compile_result = sl.compile(code, comp_info);
+	CHECK_NE(last_compile_result, OK);
+	CHECK_EQ(sl.get_error_text(), "Expected expression, found: 'PARENTHESIS_CLOSE'.");
+}
+
+} // namespace TestShaderLanguage
+
+#endif // TEST_SHADER_LANGUAGE_H

--- a/tests/servers/rendering/test_shader_language.h
+++ b/tests/servers/rendering/test_shader_language.h
@@ -58,8 +58,7 @@ TEST_CASE("[ShaderLanguage] Function call trailing commas") {
 	comp_info.render_modes = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(RenderingServer::SHADER_CANVAS_ITEM));
 	comp_info.shader_types = ShaderTypes::get_singleton()->get_types();
 	Error last_compile_result = sl.compile(code, comp_info);
-	CHECK_NE(last_compile_result, OK);
-	CHECK_EQ(sl.get_error_text(), "Expected expression, found: 'PARENTHESIS_CLOSE'.");
+	CHECK_EQ(last_compile_result, OK);
 }
 
 } // namespace TestShaderLanguage

--- a/tests/servers/rendering/test_shader_language.h
+++ b/tests/servers/rendering/test_shader_language.h
@@ -37,8 +37,6 @@
 
 #include <servers/rendering/shader_types.h>
 
-#include <cctype>
-
 namespace TestShaderLanguage {
 
 TEST_CASE("[ShaderLanguage] Function call trailing commas") {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -120,6 +120,7 @@
 #include "tests/scene/test_viewport.h"
 #include "tests/scene/test_visual_shader.h"
 #include "tests/scene/test_window.h"
+#include "tests/servers/rendering/test_shader_language.h"
 #include "tests/servers/rendering/test_shader_preprocessor.h"
 #include "tests/servers/test_navigation_server_2d.h"
 #include "tests/servers/test_navigation_server_3d.h"


### PR DESCRIPTION
This PR implements https://github.com/godotengine/godot-proposals/issues/8840: allowing trailing commas in shader call function call argument lists like
```glsl
vec3 fadeInTex = clamp(
  mix(-1.0, 2.0, fadeIn) + texture(fade_in_bias, UV).rgb, 
  0.0, 
  1.0,
);
```

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8840*
