### PR TITLE
Add rendering layer mask to GridMap

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -103,6 +103,13 @@
 				This function considers a discretization of rotations into 24 points on unit sphere, lying along the vectors (x,y,z) with each component being either -1, 0, or 1, and returns the index (in the range from 0 to 23) of the point best representing the orientation of the object. For further details, refer to the Godot source code.
 			</description>
 		</method>
+		<method name="get_rendering_layer_mask_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member rendering_layers] is enabled, given a [param layer_number] between 1 and 20.
+			</description>
+		</method>
 		<method name="get_used_cells" qualifiers="const">
 			<return type="Vector3i[]" />
 			<description>
@@ -179,6 +186,14 @@
 				Sets the [RID] of the navigation map this GridMap node should use for its cell baked navigation meshes.
 			</description>
 		</method>
+		<method name="set_rendering_layer_mask_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [param value], enables or disables the specified layer in the [member rendering_layers], given a [param layer_number] between 1 and 20.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="bake_navigation" type="bool" setter="set_bake_navigation" getter="is_baking_navigation" default="false">
@@ -219,6 +234,10 @@
 		</member>
 		<member name="physics_material" type="PhysicsMaterial" setter="set_physics_material" getter="get_physics_material">
 			Overrides the default friction and bounce physics properties for the whole [GridMap].
+		</member>
+		<member name="rendering_layers" type="int" setter="set_rendering_layer_mask" getter="get_rendering_layer_mask" default="1">
+			The render layer(s) this [GridMap] is drawn on.
+			This object will only be visible for [Camera3D]s whose cull mask includes any of the render layers this [GridMap] is set to.
 		</member>
 	</members>
 	<signals>

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -80,6 +80,7 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 			if (is_inside_tree()) {
 				RS::get_singleton()->instance_set_scenario(bm.instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(bm.instance, get_global_transform());
+				RS::get_singleton()->instance_set_layer_mask(bm.instance, get_rendering_layer_mask());
 			}
 			baked_meshes.push_back(bm);
 		}
@@ -255,6 +256,33 @@ RID GridMap::get_navigation_map() const {
 		return get_world_3d()->get_navigation_map();
 	}
 	return RID();
+}
+
+void GridMap::set_rendering_layer_mask(uint32_t p_mask) {
+	rendering_layers = p_mask;
+	_update_visibility();
+}
+
+uint32_t GridMap::get_rendering_layer_mask() const {
+	return rendering_layers;
+}
+
+void GridMap::set_rendering_layer_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Render layer number must be between 1 and 20 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
+	uint32_t mask = get_rendering_layer_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_rendering_layer_mask(mask);
+}
+
+bool GridMap::get_rendering_layer_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
+	return rendering_layers & (1 << (p_layer_number - 1));
 }
 
 void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {
@@ -715,6 +743,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			if (is_inside_tree()) {
 				RS::get_singleton()->instance_set_scenario(instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(instance, get_global_transform());
+				RS::get_singleton()->instance_set_layer_mask(instance, get_rendering_layer_mask());
 			}
 
 			mmi.multimesh = mm;
@@ -763,6 +792,7 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
 		RS::get_singleton()->instance_set_scenario(g.multimesh_instances[i].instance, get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_transform(g.multimesh_instances[i].instance, get_global_transform());
+		RS::get_singleton()->instance_set_layer_mask(g.multimesh_instances[i].instance, get_rendering_layer_mask());
 	}
 
 	if (bake_navigation && mesh_library.is_valid()) {
@@ -904,6 +934,7 @@ void GridMap::_notification(int p_what) {
 			for (int i = 0; i < baked_meshes.size(); i++) {
 				RS::get_singleton()->instance_set_scenario(baked_meshes[i].instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(baked_meshes[i].instance, get_global_transform());
+				RS::get_singleton()->instance_set_layer_mask(baked_meshes[i].instance, get_rendering_layer_mask());
 			}
 		} break;
 
@@ -962,11 +993,13 @@ void GridMap::_update_visibility() {
 		for (int i = 0; i < octant->multimesh_instances.size(); i++) {
 			const Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
 			RS::get_singleton()->instance_set_visible(mi.instance, is_visible_in_tree());
+			RS::get_singleton()->instance_set_layer_mask(mi.instance, get_rendering_layer_mask());
 		}
 	}
 
 	for (int i = 0; i < baked_meshes.size(); i++) {
 		RS::get_singleton()->instance_set_visible(baked_meshes[i].instance, is_visible_in_tree());
+		RS::get_singleton()->instance_set_layer_mask(baked_meshes[i].instance, get_rendering_layer_mask());
 	}
 }
 
@@ -1060,6 +1093,11 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_navigation_map", "navigation_map"), &GridMap::set_navigation_map);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &GridMap::get_navigation_map);
 
+	ClassDB::bind_method(D_METHOD("set_rendering_layer_mask", "mask"), &GridMap::set_rendering_layer_mask);
+	ClassDB::bind_method(D_METHOD("get_rendering_layer_mask"), &GridMap::get_rendering_layer_mask);
+	ClassDB::bind_method(D_METHOD("set_rendering_layer_mask_value", "layer_number", "value"), &GridMap::set_rendering_layer_mask_value);
+	ClassDB::bind_method(D_METHOD("get_rendering_layer_mask_value", "layer_number"), &GridMap::get_rendering_layer_mask_value);
+
 	ClassDB::bind_method(D_METHOD("set_mesh_library", "mesh_library"), &GridMap::set_mesh_library);
 	ClassDB::bind_method(D_METHOD("get_mesh_library"), &GridMap::get_mesh_library);
 
@@ -1121,6 +1159,8 @@ void GridMap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_priority"), "set_collision_priority", "get_collision_priority");
 	ADD_GROUP("Navigation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_navigation"), "set_bake_navigation", "is_baking_navigation");
+	ADD_GROUP("Rendering", "rendering_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rendering_layers", PROPERTY_HINT_LAYERS_3D_RENDER), "set_rendering_layer_mask", "get_rendering_layer_mask");
 
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
@@ -1288,6 +1328,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		if (is_inside_tree()) {
 			RS::get_singleton()->instance_set_scenario(bm.instance, get_world_3d()->get_scenario());
 			RS::get_singleton()->instance_set_transform(bm.instance, get_global_transform());
+			RS::get_singleton()->instance_set_layer_mask(bm.instance, get_rendering_layer_mask());
 		}
 
 		if (p_gen_lightmap_uv) {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -151,6 +151,7 @@ class GridMap : public Node3D {
 
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
+	uint32_t rendering_layers = 1;
 	real_t collision_priority = 1.0;
 	Ref<PhysicsMaterial> physics_material;
 	bool bake_navigation = false;
@@ -256,6 +257,12 @@ public:
 
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;
+
+	void set_rendering_layer_mask(uint32_t p_mask);
+	uint32_t get_rendering_layer_mask() const;
+
+	void set_rendering_layer_mask_value(int p_layer_number, bool p_enable);
+	bool get_rendering_layer_mask_value(int p_layer_number) const;
 
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);
 	Ref<MeshLibrary> get_mesh_library() const;


### PR DESCRIPTION
This PR adds support for rendering layers to GridMap. It is mostly a straight-up copy of the code from VisualInstance3D. Perhaps it would be better to inherit from VisualInstance3D, but since GridMap handles collision and navigation also, I assumed that was the reason it didn't already.

Solves https://github.com/godotengine/godot/issues/40245