### PR TITLE
Add missing documentation to Viewport

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -347,12 +347,17 @@
 			Sets the screen-space antialiasing method used. Screen-space antialiasing works by selectively blurring edges in a post-process shader. It differs from MSAA which takes multiple coverage samples while rendering objects. Screen-space AA methods are typically faster than MSAA and will smooth out specular aliasing, but tend to make scenes appear blurry.
 		</member>
 		<member name="sdf_oversize" type="int" setter="set_sdf_oversize" getter="get_sdf_oversize" enum="Viewport.SDFOversize" default="1">
+			Controls how much of the original viewport's size should be covered by the 2D signed distance field. This SDF can be sampled in [CanvasItem] shaders and is also used for [GPUParticles2D] collision. Higher values allow portions of occluders located outside the viewport to still be taken into account in the generated signed distance field, at the cost of performance. If you notice particles falling through [LightOccluder2D]s as the occluders leave the viewport, increase this setting.
+			The percentage is added on each axis and on both sides. For example, with the default [constant SDF_OVERSIZE_120_PERCENT], the signed distance field will cover 20% of the viewport's size outside the viewport on each side (top, right, bottom, left).
 		</member>
 		<member name="sdf_scale" type="int" setter="set_sdf_scale" getter="get_sdf_scale" enum="Viewport.SDFScale" default="1">
+			The resolution scale to use for the 2D signed distance field. Higher values lead to a more precise and more stable signed distance field as the camera moves, at the cost of performance.
 		</member>
 		<member name="snap_2d_transforms_to_pixel" type="bool" setter="set_snap_2d_transforms_to_pixel" getter="is_snap_2d_transforms_to_pixel_enabled" default="false">
+			If [code]true[/code], [CanvasItem] nodes will internally snap to full pixels. Their position can still be sub-pixel, but the decimals will not have effect. This can lead to a crisper appearance at the cost of less smooth movement, especially when [Camera2D] smoothing is enabled.
 		</member>
 		<member name="snap_2d_vertices_to_pixel" type="bool" setter="set_snap_2d_vertices_to_pixel" getter="is_snap_2d_vertices_to_pixel_enabled" default="false">
+			If [code]true[/code], vertices of [CanvasItem] nodes will snap to full pixels. Only affects the final vertex positions, not the transforms. This can lead to a crisper appearance at the cost of less smooth movement, especially when [Camera2D] smoothing is enabled.
 		</member>
 		<member name="texture_mipmap_bias" type="float" setter="set_texture_mipmap_bias" getter="get_texture_mipmap_bias" default="0.0">
 			Affects the final texture sharpness by reading from a lower or higher mipmap (also called "texture LOD bias"). Negative values make mipmapped textures sharper but grainier when viewed at a distance, while positive values make mipmapped textures blurrier (even when up close).
@@ -515,14 +520,16 @@
 			Objects are displayed without light information.
 		</constant>
 		<constant name="DEBUG_DRAW_LIGHTING" value="2" enum="DebugDraw">
+			Objects are displayed without textures and only with lighting information.
 		</constant>
 		<constant name="DEBUG_DRAW_OVERDRAW" value="3" enum="DebugDraw">
 			Objects are displayed semi-transparent with additive blending so you can see where they are drawing over top of one another. A higher overdraw means you are wasting performance on drawing pixels that are being hidden behind others.
 		</constant>
 		<constant name="DEBUG_DRAW_WIREFRAME" value="4" enum="DebugDraw">
-			Objects are displayed in wireframe style.
+			Objects are displayed as wireframe models.
 		</constant>
 		<constant name="DEBUG_DRAW_NORMAL_BUFFER" value="5" enum="DebugDraw">
+			Objects are displayed without lighting information and their textures replaced by normal mapping.
 		</constant>
 		<constant name="DEBUG_DRAW_VOXEL_GI_ALBEDO" value="6" enum="DebugDraw">
 			Objects are displayed with only the albedo value from [VoxelGI]s.
@@ -540,6 +547,7 @@
 			Draws the shadow atlas that stores shadows from [DirectionalLight3D]s in the upper left quadrant of the [Viewport].
 		</constant>
 		<constant name="DEBUG_DRAW_SCENE_LUMINANCE" value="11" enum="DebugDraw">
+			Draws the scene luminance buffer (if available) in the upper left quadrant of the [Viewport].
 		</constant>
 		<constant name="DEBUG_DRAW_SSAO" value="12" enum="DebugDraw">
 			Draws the screen-space ambient occlusion texture instead of the scene so that you can clearly see how it is affecting objects. In order for this display mode to work, you must have [member Environment.ssao_enabled] set in your [WorldEnvironment].
@@ -554,24 +562,36 @@
 			Draws the decal atlas used by [Decal]s and light projector textures in the upper left quadrant of the [Viewport].
 		</constant>
 		<constant name="DEBUG_DRAW_SDFGI" value="16" enum="DebugDraw">
+			Draws the cascades used to render signed distance field global illumination (SDFGI).
+			Does nothing if the current environment's [member Environment.sdfgi_enabled] is [code]false[/code] or SDFGI is not supported on the platform.
 		</constant>
 		<constant name="DEBUG_DRAW_SDFGI_PROBES" value="17" enum="DebugDraw">
+			Draws the probes used for signed distance field global illumination (SDFGI).
+			Does nothing if the current environment's [member Environment.sdfgi_enabled] is [code]false[/code] or SDFGI is not supported on the platform.
 		</constant>
 		<constant name="DEBUG_DRAW_GI_BUFFER" value="18" enum="DebugDraw">
+			Draws the buffer used for global illumination (GI).
 		</constant>
 		<constant name="DEBUG_DRAW_DISABLE_LOD" value="19" enum="DebugDraw">
+			Draws all of the objects at their highest polycount, without low level of detail (LOD).
 		</constant>
 		<constant name="DEBUG_DRAW_CLUSTER_OMNI_LIGHTS" value="20" enum="DebugDraw">
+			Draws the cluster used by [OmniLight3D] nodes to optimize light rendering.
 		</constant>
 		<constant name="DEBUG_DRAW_CLUSTER_SPOT_LIGHTS" value="21" enum="DebugDraw">
+			Draws the cluster used by [SpotLight3D] nodes to optimize light rendering.
 		</constant>
 		<constant name="DEBUG_DRAW_CLUSTER_DECALS" value="22" enum="DebugDraw">
+			Draws the cluster used by [Decal] nodes to optimize decal rendering.
 		</constant>
 		<constant name="DEBUG_DRAW_CLUSTER_REFLECTION_PROBES" value="23" enum="DebugDraw">
+			Draws the cluster used by [ReflectionProbe] nodes to optimize decal rendering.
 		</constant>
 		<constant name="DEBUG_DRAW_OCCLUDERS" value="24" enum="DebugDraw">
+			Draws the buffer used for occlusion culling.
 		</constant>
 		<constant name="DEBUG_DRAW_MOTION_VECTORS" value="25" enum="DebugDraw">
+			Draws vector lines over the viewport to indicate the movement of pixels between frames.
 		</constant>
 		<constant name="DEBUG_DRAW_INTERNAL_BUFFER" value="26" enum="DebugDraw">
 			Draws the internal resolution buffer of the scene before post-processing is applied.
@@ -591,7 +611,7 @@
 			Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
 		</constant>
 		<constant name="DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_MAX" value="4" enum="DefaultCanvasItemTextureFilter">
-			Max value for [enum DefaultCanvasItemTextureFilter] enum.
+			Represents the size of the [enum DefaultCanvasItemTextureFilter] enum.
 		</constant>
 		<constant name="DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_DISABLED" value="0" enum="DefaultCanvasItemTextureRepeat">
 			Disables textures repeating. Instead, when reading UVs outside the 0-1 range, the value will be clamped to the edge of the texture, resulting in a stretched out look at the borders of the texture.
@@ -603,34 +623,43 @@
 			Flip the texture when repeating so that the edge lines up instead of abruptly changing.
 		</constant>
 		<constant name="DEFAULT_CANVAS_ITEM_TEXTURE_REPEAT_MAX" value="3" enum="DefaultCanvasItemTextureRepeat">
-			Max value for [enum DefaultCanvasItemTextureRepeat] enum.
+			Represents the size of the [enum DefaultCanvasItemTextureRepeat] enum.
 		</constant>
 		<constant name="SDF_OVERSIZE_100_PERCENT" value="0" enum="SDFOversize">
+			The signed distance field only covers the viewport's own rectangle.
 		</constant>
 		<constant name="SDF_OVERSIZE_120_PERCENT" value="1" enum="SDFOversize">
+			The signed distance field is expanded to cover 20% of the viewport's size around the borders.
 		</constant>
 		<constant name="SDF_OVERSIZE_150_PERCENT" value="2" enum="SDFOversize">
+			The signed distance field is expanded to cover 50% of the viewport's size around the borders.
 		</constant>
 		<constant name="SDF_OVERSIZE_200_PERCENT" value="3" enum="SDFOversize">
+			The signed distance field is expanded to cover 100% (double) of the viewport's size around the borders.
 		</constant>
 		<constant name="SDF_OVERSIZE_MAX" value="4" enum="SDFOversize">
+			Represents the size of the [enum SDFOversize] enum.
 		</constant>
 		<constant name="SDF_SCALE_100_PERCENT" value="0" enum="SDFScale">
+			The signed distance field is rendered at full resolution.
 		</constant>
 		<constant name="SDF_SCALE_50_PERCENT" value="1" enum="SDFScale">
+			The signed distance field is rendered at half the resolution of this viewport.
 		</constant>
 		<constant name="SDF_SCALE_25_PERCENT" value="2" enum="SDFScale">
+			The signed distance field is rendered at a quarter the resolution of this viewport.
 		</constant>
 		<constant name="SDF_SCALE_MAX" value="3" enum="SDFScale">
+			Represents the size of the [enum SDFScale] enum.
 		</constant>
 		<constant name="VRS_DISABLED" value="0" enum="VRSMode">
-			VRS is disabled.
+			Variable Rate Shading is disabled.
 		</constant>
 		<constant name="VRS_TEXTURE" value="1" enum="VRSMode">
-			VRS uses a texture. Note, for stereoscopic use a texture atlas with a texture for each view.
+			Variable Rate Shading uses a texture. Note, for stereoscopic use a texture atlas with a texture for each view.
 		</constant>
 		<constant name="VRS_XR" value="2" enum="VRSMode">
-			VRS texture is supplied by the primary [XRInterface].
+			Variable Rate Shading's texture is supplied by the primary [XRInterface].
 		</constant>
 		<constant name="VRS_MAX" value="3" enum="VRSMode">
 			Represents the size of the [enum VRSMode] enum.


### PR DESCRIPTION
This PR fills all of the class reference's descriptions that have been missing from **Viewport**. It also tweaks existing descriptions very slightly.

In particular, the descriptions for `sdf_oversize`, `sdf_scale`, `snap_2d_transforms_to_pixel`, and `snap_2d_vertices_to_pixel` have almost been copied word-for-word from the equivalent Project Settings.

I could have rewritten them outright, but the time I spend on these is directly proportional to how long it will take for them to be reviewed and merged.