### PR TITLE
Add missing descriptions for Image's documentation

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -19,6 +19,7 @@
 			<param index="1" name="contrast" type="float" />
 			<param index="2" name="saturation" type="float" />
 			<description>
+				Adjusts this image's [param brightness], [param contrast], and [param saturation] by the given values. Does not work if the image is compressed (see [method is_compressed]).
 			</description>
 		</method>
 		<method name="blend_rect">
@@ -163,6 +164,7 @@
 			<return type="int" enum="Image.UsedChannels" />
 			<param index="0" name="source" type="int" enum="Image.CompressSource" default="0" />
 			<description>
+				Returns the color channels used by this image, as one of the [enum UsedChannels] constants. If the image is compressed, the original [param source] must be specified.
 			</description>
 		</method>
 		<method name="fill">
@@ -612,6 +614,7 @@
 			OpenGL texture format [code]RGBA[/code] with four components, each with a bitdepth of 4.
 		</constant>
 		<constant name="FORMAT_RGB565" value="7" enum="Format">
+			OpenGL texture format [code]RGB[/code] with three components. Red and blue have a bitdepth of 5, and green has a bitdepth of 6.
 		</constant>
 		<constant name="FORMAT_RF" value="8" enum="Format">
 			OpenGL texture format [code]GL_R32F[/code] where there's one component, a 32-bit floating-point value.
@@ -696,8 +699,10 @@
 			[b]Note:[/b] When creating an [ImageTexture], an sRGB to linear color space conversion is performed.
 		</constant>
 		<constant name="FORMAT_ETC2_RA_AS_RG" value="33" enum="Format">
+			[url=https://en.wikipedia.org/wiki/Ericsson_Texture_Compression#ETC2_and_EAC]Ericsson Texture Compression format 2[/url] ([code]RGBA8[/code] variant), which compresses RA data and interprets it as two channels (red and green). See also [constant FORMAT_ETC2_RGBA8].
 		</constant>
 		<constant name="FORMAT_DXT5_RA_AS_RG" value="34" enum="Format">
+			The [url=https://en.wikipedia.org/wiki/S3_Texture_Compression]S3TC[/url] texture format also known as Block Compression 3 or BC3, which compresses RA data and interprets it as two channels (red and green). See also [constant FORMAT_DXT5].
 		</constant>
 		<constant name="FORMAT_ASTC_4x4" value="35" enum="Format">
 			[url=https://en.wikipedia.org/wiki/Adaptive_scalable_texture_compression]Adaptive Scalable Texture Compression[/url]. This implements the 4x4 (high quality) mode.
@@ -761,16 +766,22 @@
 			Represents the size of the [enum CompressMode] enum.
 		</constant>
 		<constant name="USED_CHANNELS_L" value="0" enum="UsedChannels">
+			The image only uses one channel for luminance (grayscale).
 		</constant>
 		<constant name="USED_CHANNELS_LA" value="1" enum="UsedChannels">
+			The image uses two channels for luminance and alpha, respectively.
 		</constant>
 		<constant name="USED_CHANNELS_R" value="2" enum="UsedChannels">
+			The image only uses the red channel.
 		</constant>
 		<constant name="USED_CHANNELS_RG" value="3" enum="UsedChannels">
+			The image uses two channels for red and green.
 		</constant>
 		<constant name="USED_CHANNELS_RGB" value="4" enum="UsedChannels">
+			The image uses three channels for red, green, and blue.
 		</constant>
 		<constant name="USED_CHANNELS_RGBA" value="5" enum="UsedChannels">
+			The image uses four channels for red, green, blue, and alpha.
 		</constant>
 		<constant name="COMPRESS_SOURCE_GENERIC" value="0" enum="CompressSource">
 			Source texture (before compression) is a regular texture. Default for all textures.


### PR DESCRIPTION
This PR adds missing descriptions to **Image**'s methods and constants, filling them in.

The only ones I have doubts about are **FORMAT_ETC2_RA_AS_RG** and **FORMAT_DXT5_RA_AS_RG**, and code is not exactly clear unless you're savvy enough.
...

Uhm... Yeah, that's all.