### PR TITLE
Add `tests/python_build` to clang-format pre-commit hook ignore list

### DIFF
--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -140,6 +140,9 @@ do
     if grep -q "\-so_wrap." <<< $file; then
         continue;
     fi
+    if grep -q "tests/python_build" <<< $file; then
+          continue;
+    fi
 
     # ignore file if we do check for file extensions and the file
     # does not match any of the extensions specified in $FILE_EXTS


### PR DESCRIPTION
It had been ignored by misc/scripts/clang_format.sh since 388d35b74d8919b251faae9e24af50476f12b1a2 but not the hook; running the hook on all files yields changes in GLSL files in that directory.
