### PR TITLE
Fix Dummy audio driver initialization issue on WASAPI output device initialization failure

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -557,12 +557,10 @@ Error AudioDriverWASAPI::init() {
 
 	target_latency_ms = Engine::get_singleton()->get_audio_output_latency();
 
-	Error err = init_output_device();
-	if (err != OK) {
-		ERR_PRINT("WASAPI: init_output_device error");
-	}
-
 	exit_thread.clear();
+
+	Error err = init_output_device();
+	ERR_FAIL_COND_V_MSG(err != OK, err, "WASAPI: init_output_device error.");
 
 	thread.start(thread_func, this);
 


### PR DESCRIPTION
`AudioDriverWASAPI::init` consistently returns `Error::OK`, even when encountering a failure during the initialization of the output device. This behaviour blocks the dummy driver from initializing in `AudioDriverManager::initialize`. Fixes #71640.
