### PR TITLE
Add missing descriptions to PrimitiveMesh and SoftBody3D

### DIFF
--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -12,6 +12,7 @@
 		<method name="_create_mesh_array" qualifiers="virtual const">
 			<return type="Array" />
 			<description>
+				Override this method to customize how this primitive mesh should be generated. Should return an [Array] where each element is another Array of values required for the mesh (see the [enum Mesh.ArrayType] constants).
 			</description>
 		</method>
 		<method name="get_mesh_arrays" qualifiers="const">

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -41,6 +41,7 @@
 		<method name="get_physics_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
+				Returns the internal [RID] used by the [PhysicsServer3D] for this body.
 			</description>
 		</method>
 		<method name="get_point_transform">
@@ -100,11 +101,14 @@
 			[b]Note:[/b] Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="damping_coefficient" type="float" setter="set_damping_coefficient" getter="get_damping_coefficient" default="0.01">
+			The body's damping coefficient. Higher values will slow down the body more noticeably when forces are applied.
 		</member>
 		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="SoftBody3D.DisableMode" default="0">
 			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
 		</member>
 		<member name="drag_coefficient" type="float" setter="set_drag_coefficient" getter="get_drag_coefficient" default="0.0">
+			The body's drag coefficient. Higher values increase this body's air resistance.
+			[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
 		</member>
 		<member name="linear_stiffness" type="float" setter="set_linear_stiffness" getter="get_linear_stiffness" default="0.5">
 			Higher values will result in a stiffer body, while lower values will increase the body's ability to bend. The value can be between [code]0.0[/code] and [code]1.0[/code] (inclusive).
@@ -113,6 +117,7 @@
 			[NodePath] to a [CollisionObject3D] this SoftBody3D should avoid clipping.
 		</member>
 		<member name="pressure_coefficient" type="float" setter="set_pressure_coefficient" getter="get_pressure_coefficient" default="0.0">
+			The pressure coefficient of this soft body. Simulate pressure build-up from inside this body. Higher values increase the strength of this effect.
 		</member>
 		<member name="ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">
 			If [code]true[/code], the [SoftBody3D] will respond to [RayCast3D]s.


### PR DESCRIPTION
This PR ...💤💤...
... This brings them to 100% completion.


Pressure coefficient source: https://arxiv.org/ftp/physics/papers/0407/0407003.pdf

May require the insight from the Physics team for the missing SoftBody3D descriptions.