### PR TITLE
Fix `LineEdit` caret rendering/positioning on Undo.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1228,9 +1228,10 @@ void LineEdit::undo() {
 	TextOperation op = undo_stack_pos->get();
 	text = op.text;
 	scroll_offset = op.scroll_offset;
-	set_caret_column(op.caret_column);
 
 	_shape();
+	set_caret_column(op.caret_column);
+
 	_emit_text_change();
 }
 
@@ -1252,9 +1253,10 @@ void LineEdit::redo() {
 	TextOperation op = undo_stack_pos->get();
 	text = op.text;
 	scroll_offset = op.scroll_offset;
-	set_caret_column(op.caret_column);
 
 	_shape();
+	set_caret_column(op.caret_column);
+
 	_emit_text_change();
 }
 


### PR DESCRIPTION
Fixes  #67169.

This fixes the circumstance where undoing deleted text in `LineEdit` could lead to caret appearing outside of the box. (This bug has become even easier to reproduce with recent PR https://github.com/godotengine/godot/pull/86732 , though repo steps are the same )

The reason for this appears to be that in the `undo()` function, the `set_caret_column()` was called before the `_shape()` function. However, it seems the `_shape()` function needs to be called first (as it is in other parts of the `LineEdit.cpp`) as otherwise the `get_caret_pixel_pos()` that `set_caret_column()` uses gives an incorrect value (that the caret is at 0, 0).

I've reordered these functions in both `undo()` and `redo()` and the bug now appears fixed with the caret behaving appropriately when undoing.