### PR TITLE
Add documentation to PhysicsServer2DExtension

### DIFF
--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -17,6 +17,7 @@
 			<param index="2" name="transform" type="Transform2D" />
 			<param index="3" name="disabled" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_add_shape].
 			</description>
 		</method>
 		<method name="_area_attach_canvas_instance_id" qualifiers="virtual">
@@ -24,6 +25,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_attach_canvas_instance_id].
 			</description>
 		</method>
 		<method name="_area_attach_object_instance_id" qualifiers="virtual">
@@ -31,41 +33,48 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_attach_object_instance_id].
 			</description>
 		</method>
 		<method name="_area_clear_shapes" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_clear_shapes].
 			</description>
 		</method>
 		<method name="_area_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_create].
 			</description>
 		</method>
 		<method name="_area_get_canvas_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_canvas_instance_id].
 			</description>
 		</method>
 		<method name="_area_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_collision_layer].
 			</description>
 		</method>
 		<method name="_area_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_collision_mask].
 			</description>
 		</method>
 		<method name="_area_get_object_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_object_instance_id].
 			</description>
 		</method>
 		<method name="_area_get_param" qualifiers="virtual const">
@@ -73,6 +82,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_param].
 			</description>
 		</method>
 		<method name="_area_get_shape" qualifiers="virtual const">
@@ -80,12 +90,14 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_shape].
 			</description>
 		</method>
 		<method name="_area_get_shape_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_shape_count].
 			</description>
 		</method>
 		<method name="_area_get_shape_transform" qualifiers="virtual const">
@@ -93,18 +105,21 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_shape_transform].
 			</description>
 		</method>
 		<method name="_area_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_space].
 			</description>
 		</method>
 		<method name="_area_get_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_get_transform].
 			</description>
 		</method>
 		<method name="_area_remove_shape" qualifiers="virtual">
@@ -112,6 +127,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_remove_shape].
 			</description>
 		</method>
 		<method name="_area_set_area_monitor_callback" qualifiers="virtual">
@@ -119,6 +135,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_area_monitor_callback].
 			</description>
 		</method>
 		<method name="_area_set_collision_layer" qualifiers="virtual">
@@ -126,6 +143,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_collision_layer].
 			</description>
 		</method>
 		<method name="_area_set_collision_mask" qualifiers="virtual">
@@ -133,6 +151,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_collision_mask].
 			</description>
 		</method>
 		<method name="_area_set_monitor_callback" qualifiers="virtual">
@@ -140,6 +159,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_monitor_callback].
 			</description>
 		</method>
 		<method name="_area_set_monitorable" qualifiers="virtual">
@@ -147,6 +167,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_monitorable].
 			</description>
 		</method>
 		<method name="_area_set_param" qualifiers="virtual">
@@ -155,6 +176,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<param index="2" name="value" type="Variant" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_param].
 			</description>
 		</method>
 		<method name="_area_set_pickable" qualifiers="virtual">
@@ -162,6 +184,8 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="pickable" type="bool" />
 			<description>
+				If set to [code]true[/code], allows the area with the given [RID] to detect mouse inputs when the mouse cursor is hovering on it.
+				Overridable version of [PhysicsServer2D]'s internal [code]area_set_pickable[/code] method. Corresponds to [member PhysicsBody2D.input_pickable].
 			</description>
 		</method>
 		<method name="_area_set_shape" qualifiers="virtual">
@@ -170,6 +194,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_shape].
 			</description>
 		</method>
 		<method name="_area_set_shape_disabled" qualifiers="virtual">
@@ -178,6 +203,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_shape_disabled].
 			</description>
 		</method>
 		<method name="_area_set_shape_transform" qualifiers="virtual">
@@ -186,6 +212,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_shape_transform].
 			</description>
 		</method>
 		<method name="_area_set_space" qualifiers="virtual">
@@ -193,6 +220,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_space].
 			</description>
 		</method>
 		<method name="_area_set_transform" qualifiers="virtual">
@@ -200,6 +228,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
+				Overridable version of [method PhysicsServer2D.area_set_transform].
 			</description>
 		</method>
 		<method name="_body_add_collision_exception" qualifiers="virtual">
@@ -207,6 +236,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_add_collision_exception].
 			</description>
 		</method>
 		<method name="_body_add_constant_central_force" qualifiers="virtual">
@@ -214,6 +244,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_add_constant_central_force].
 			</description>
 		</method>
 		<method name="_body_add_constant_force" qualifiers="virtual">
@@ -222,6 +253,7 @@
 			<param index="1" name="force" type="Vector2" />
 			<param index="2" name="position" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_add_constant_force].
 			</description>
 		</method>
 		<method name="_body_add_constant_torque" qualifiers="virtual">
@@ -229,6 +261,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_add_constant_torque].
 			</description>
 		</method>
 		<method name="_body_add_shape" qualifiers="virtual">
@@ -238,6 +271,7 @@
 			<param index="2" name="transform" type="Transform2D" />
 			<param index="3" name="disabled" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_add_shape].
 			</description>
 		</method>
 		<method name="_body_apply_central_force" qualifiers="virtual">
@@ -245,6 +279,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_apply_central_force].
 			</description>
 		</method>
 		<method name="_body_apply_central_impulse" qualifiers="virtual">
@@ -252,6 +287,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_apply_central_impulse].
 			</description>
 		</method>
 		<method name="_body_apply_force" qualifiers="virtual">
@@ -260,6 +296,7 @@
 			<param index="1" name="force" type="Vector2" />
 			<param index="2" name="position" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_apply_force].
 			</description>
 		</method>
 		<method name="_body_apply_impulse" qualifiers="virtual">
@@ -268,6 +305,7 @@
 			<param index="1" name="impulse" type="Vector2" />
 			<param index="2" name="position" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_apply_impulse].
 			</description>
 		</method>
 		<method name="_body_apply_torque" qualifiers="virtual">
@@ -275,6 +313,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_apply_torque].
 			</description>
 		</method>
 		<method name="_body_apply_torque_impulse" qualifiers="virtual">
@@ -282,6 +321,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_apply_torque_impulse].
 			</description>
 		</method>
 		<method name="_body_attach_canvas_instance_id" qualifiers="virtual">
@@ -289,6 +329,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_attach_canvas_instance_id].
 			</description>
 		</method>
 		<method name="_body_attach_object_instance_id" qualifiers="virtual">
@@ -296,12 +337,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_attach_object_instance_id].
 			</description>
 		</method>
 		<method name="_body_clear_shapes" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_clear_shapes].
 			</description>
 		</method>
 		<method name="_body_collide_shape" qualifiers="virtual">
@@ -315,89 +358,107 @@
 			<param index="6" name="result_max" type="int" />
 			<param index="7" name="result_count" type="int32_t*" />
 			<description>
+				Given a [param body], a [param shape], and their respective parameters, this method should return [code]true[/code] if a collision between the two would occur, with additional details passed in [param results].
+				Overridable version of [PhysicsServer2D]'s internal [code]shape_collide[/code] method. Corresponds to [method PhysicsDirectSpaceState2D.collide_shape].
 			</description>
 		</method>
 		<method name="_body_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_create].
 			</description>
 		</method>
 		<method name="_body_get_canvas_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_canvas_instance_id].
 			</description>
 		</method>
 		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Returns the [RID]s of all bodies added as collision exceptions for the given [param body]. See also [method _body_add_collision_exception] and [method _body_remove_collision_exception].
+				Overridable version of [PhysicsServer2D]'s internal [code]body_get_collision_exceptions[/code] method. Corresponds to [method PhysicsBody2D.get_collision_exceptions].
 			</description>
 		</method>
 		<method name="_body_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_collision_layer].
 			</description>
 		</method>
 		<method name="_body_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_collision_mask].
 			</description>
 		</method>
 		<method name="_body_get_collision_priority" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_collision_priority].
 			</description>
 		</method>
 		<method name="_body_get_constant_force" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_constant_force].
 			</description>
 		</method>
 		<method name="_body_get_constant_torque" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_constant_torque].
 			</description>
 		</method>
 		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [PhysicsServer2D]'s internal [code]body_get_contacts_reported_depth_threshold[/code] method.
+				[b]Note:[/b] This method is currently unused by Godot's default physics implementation.
 			</description>
 		</method>
 		<method name="_body_get_continuous_collision_detection_mode" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.CCDMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_continuous_collision_detection_mode].
 			</description>
 		</method>
 		<method name="_body_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectBodyState2D" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_direct_state].
 			</description>
 		</method>
 		<method name="_body_get_max_contacts_reported" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_max_contacts_reported].
 			</description>
 		</method>
 		<method name="_body_get_mode" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.BodyMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_mode].
 			</description>
 		</method>
 		<method name="_body_get_object_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_object_instance_id].
 			</description>
 		</method>
 		<method name="_body_get_param" qualifiers="virtual const">
@@ -405,6 +466,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_param].
 			</description>
 		</method>
 		<method name="_body_get_shape" qualifiers="virtual const">
@@ -412,12 +474,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_shape].
 			</description>
 		</method>
 		<method name="_body_get_shape_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_shape_count].
 			</description>
 		</method>
 		<method name="_body_get_shape_transform" qualifiers="virtual const">
@@ -425,12 +489,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_shape_transform].
 			</description>
 		</method>
 		<method name="_body_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_space].
 			</description>
 		</method>
 		<method name="_body_get_state" qualifiers="virtual const">
@@ -438,12 +504,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_get_state].
 			</description>
 		</method>
 		<method name="_body_is_omitting_force_integration" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_is_omitting_force_integration].
 			</description>
 		</method>
 		<method name="_body_remove_collision_exception" qualifiers="virtual">
@@ -451,6 +519,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_remove_collision_exception].
 			</description>
 		</method>
 		<method name="_body_remove_shape" qualifiers="virtual">
@@ -458,12 +527,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_remove_shape].
 			</description>
 		</method>
 		<method name="_body_reset_mass_properties" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_reset_mass_properties].
 			</description>
 		</method>
 		<method name="_body_set_axis_velocity" qualifiers="virtual">
@@ -471,6 +542,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis_velocity" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_axis_velocity].
 			</description>
 		</method>
 		<method name="_body_set_collision_layer" qualifiers="virtual">
@@ -478,6 +550,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_collision_layer].
 			</description>
 		</method>
 		<method name="_body_set_collision_mask" qualifiers="virtual">
@@ -485,6 +558,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_collision_mask].
 			</description>
 		</method>
 		<method name="_body_set_collision_priority" qualifiers="virtual">
@@ -492,6 +566,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="priority" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_collision_priority].
 			</description>
 		</method>
 		<method name="_body_set_constant_force" qualifiers="virtual">
@@ -499,6 +574,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_constant_force].
 			</description>
 		</method>
 		<method name="_body_set_constant_torque" qualifiers="virtual">
@@ -506,6 +582,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_constant_torque].
 			</description>
 		</method>
 		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
@@ -513,6 +590,8 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="threshold" type="float" />
 			<description>
+				Overridable version of [PhysicsServer2D]'s internal [code]body_set_contacts_reported_depth_threshold[/code] method.
+				[b]Note:[/b] This method is currently unused by Godot's default physics implementation.
 			</description>
 		</method>
 		<method name="_body_set_continuous_collision_detection_mode" qualifiers="virtual">
@@ -520,6 +599,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.CCDMode" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_continuous_collision_detection_mode].
 			</description>
 		</method>
 		<method name="_body_set_force_integration_callback" qualifiers="virtual">
@@ -528,6 +608,7 @@
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="userdata" type="Variant" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_force_integration_callback].
 			</description>
 		</method>
 		<method name="_body_set_max_contacts_reported" qualifiers="virtual">
@@ -535,6 +616,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="amount" type="int" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_max_contacts_reported].
 			</description>
 		</method>
 		<method name="_body_set_mode" qualifiers="virtual">
@@ -542,6 +624,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.BodyMode" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_mode].
 			</description>
 		</method>
 		<method name="_body_set_omit_force_integration" qualifiers="virtual">
@@ -549,6 +632,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_omit_force_integration].
 			</description>
 		</method>
 		<method name="_body_set_param" qualifiers="virtual">
@@ -557,6 +641,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<param index="2" name="value" type="Variant" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_param].
 			</description>
 		</method>
 		<method name="_body_set_pickable" qualifiers="virtual">
@@ -564,6 +649,8 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="pickable" type="bool" />
 			<description>
+				If set to [code]true[/code], allows the body with the given [RID] to detect mouse inputs when the mouse cursor is hovering on it.
+				Overridable version of [PhysicsServer2D]'s internal [code]body_set_pickable[/code] method. Corresponds to [member PhysicsBody2D.input_pickable].
 			</description>
 		</method>
 		<method name="_body_set_shape" qualifiers="virtual">
@@ -572,6 +659,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_shape].
 			</description>
 		</method>
 		<method name="_body_set_shape_as_one_way_collision" qualifiers="virtual">
@@ -581,6 +669,7 @@
 			<param index="2" name="enable" type="bool" />
 			<param index="3" name="margin" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_shape_as_one_way_collision].
 			</description>
 		</method>
 		<method name="_body_set_shape_disabled" qualifiers="virtual">
@@ -589,6 +678,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_shape_disabled].
 			</description>
 		</method>
 		<method name="_body_set_shape_transform" qualifiers="virtual">
@@ -597,6 +687,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_shape_transform].
 			</description>
 		</method>
 		<method name="_body_set_space" qualifiers="virtual">
@@ -604,6 +695,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_space].
 			</description>
 		</method>
 		<method name="_body_set_state" qualifiers="virtual">
@@ -612,6 +704,7 @@
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<param index="2" name="value" type="Variant" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_set_state].
 			</description>
 		</method>
 		<method name="_body_set_state_sync_callback" qualifiers="virtual">
@@ -619,6 +712,8 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
+				Assigns the [param body] to call the given [param callable] during the synchronization phase of the loop, before [method _step] is called. See also [method _sync].
+				Overridable version of [PhysicsServer2D]'s internal [code]body_set_state_sync_callback[/code] method.
 			</description>
 		</method>
 		<method name="_body_test_motion" qualifiers="virtual const">
@@ -631,26 +726,31 @@
 			<param index="5" name="recovery_as_collision" type="bool" />
 			<param index="6" name="result" type="PhysicsServer2DExtensionMotionResult*" />
 			<description>
+				Overridable version of [method PhysicsServer2D.body_test_motion]. Unlike the exposed implementation, this method does not receive all of the arguments inside a [PhysicsTestMotionParameters2D].
 			</description>
 		</method>
 		<method name="_capsule_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.capsule_shape_create].
 			</description>
 		</method>
 		<method name="_circle_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.circle_shape_create].
 			</description>
 		</method>
 		<method name="_concave_polygon_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.concave_polygon_shape_create].
 			</description>
 		</method>
 		<method name="_convex_polygon_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.convex_polygon_shape_create].
 			</description>
 		</method>
 		<method name="_damped_spring_joint_get_param" qualifiers="virtual const">
@@ -658,6 +758,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<description>
+				Overridable version of [method PhysicsServer2D.damped_spring_joint_get_param].
 			</description>
 		</method>
 		<method name="_damped_spring_joint_set_param" qualifiers="virtual">
@@ -666,54 +767,69 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<param index="2" name="value" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.damped_spring_joint_set_param].
 			</description>
 		</method>
 		<method name="_end_sync" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Called to indicate that the physics server has stopped synchronizing. It is in the loop's iteration/physics phase, and can access physics objects even if running on a separate thread. See also [method _sync].
+				Overridable version of [PhysicsServer2D]'s internal [code]end_sync[/code] method.
 			</description>
 		</method>
 		<method name="_finish" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Called when the main loop finalizes to shut down the physics server. See also [method MainLoop._finalize] and [method _init].
+				Overridable version of [PhysicsServer2D]'s internal [code]finish[/code] method.
 			</description>
 		</method>
 		<method name="_flush_queries" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Called every physics step before [method _step] to process all remaining queries.
+				Overridable version of [PhysicsServer2D]'s internal [code]flush_queries[/code] method.
 			</description>
 		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.free_rid].
 			</description>
 		</method>
 		<method name="_get_process_info" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
 			<description>
+				Overridable version of [method PhysicsServer2D.get_process_info].
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Called when the main loop is initialized and creates a new instance of this physics server. See also [method MainLoop._initialize] and [method _finish].
+				Overridable version of [PhysicsServer2D]'s internal [code]init[/code] method.
 			</description>
 		</method>
 		<method name="_is_flushing_queries" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
+				Overridable method that should return [code]true[/code] when the physics server is processing queries. See also [method _flush_queries].
+				Overridable version of [PhysicsServer2D]'s internal [code]is_flushing_queries[/code] method.
 			</description>
 		</method>
 		<method name="_joint_clear" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_clear].
 			</description>
 		</method>
 		<method name="_joint_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_create].
 			</description>
 		</method>
 		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual">
@@ -721,6 +837,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="disable" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_disable_collisions_between_bodies].
 			</description>
 		</method>
 		<method name="_joint_get_param" qualifiers="virtual const">
@@ -728,18 +845,21 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_get_param].
 			</description>
 		</method>
 		<method name="_joint_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.JointType" />
 			<param index="0" name="joint" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_get_type].
 			</description>
 		</method>
 		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_is_disabled_collisions_between_bodies].
 			</description>
 		</method>
 		<method name="_joint_make_damped_spring" qualifiers="virtual">
@@ -750,6 +870,7 @@
 			<param index="3" name="body_a" type="RID" />
 			<param index="4" name="body_b" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_make_damped_spring].
 			</description>
 		</method>
 		<method name="_joint_make_groove" qualifiers="virtual">
@@ -761,6 +882,7 @@
 			<param index="4" name="body_a" type="RID" />
 			<param index="5" name="body_b" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_make_groove].
 			</description>
 		</method>
 		<method name="_joint_make_pin" qualifiers="virtual">
@@ -770,6 +892,7 @@
 			<param index="2" name="body_a" type="RID" />
 			<param index="3" name="body_b" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_make_pin].
 			</description>
 		</method>
 		<method name="_joint_set_param" qualifiers="virtual">
@@ -778,6 +901,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.joint_set_param].
 			</description>
 		</method>
 		<method name="_pin_joint_get_flag" qualifiers="virtual const">
@@ -785,6 +909,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer2D.PinJointFlag" />
 			<description>
+				Overridable version of [method PhysicsServer2D.pin_joint_get_flag].
 			</description>
 		</method>
 		<method name="_pin_joint_get_param" qualifiers="virtual const">
@@ -792,6 +917,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
 			<description>
+				Overridable version of [method PhysicsServer2D.pin_joint_get_param].
 			</description>
 		</method>
 		<method name="_pin_joint_set_flag" qualifiers="virtual">
@@ -800,6 +926,7 @@
 			<param index="1" name="flag" type="int" enum="PhysicsServer2D.PinJointFlag" />
 			<param index="2" name="enabled" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.pin_joint_set_flag].
 			</description>
 		</method>
 		<method name="_pin_joint_set_param" qualifiers="virtual">
@@ -808,27 +935,32 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.pin_joint_set_param].
 			</description>
 		</method>
 		<method name="_rectangle_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.rectangle_shape_create].
 			</description>
 		</method>
 		<method name="_segment_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.segment_shape_create].
 			</description>
 		</method>
 		<method name="_separation_ray_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.separation_ray_shape_create].
 			</description>
 		</method>
 		<method name="_set_active" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.set_active].
 			</description>
 		</method>
 		<method name="_shape_collide" qualifiers="virtual">
@@ -843,24 +975,30 @@
 			<param index="7" name="result_max" type="int" />
 			<param index="8" name="result_count" type="int32_t*" />
 			<description>
+				Given two shapes and their parameters, should return [code]true[/code] if a collision between the two would occur, with additional details passed in [param results].
+				Overridable version of [PhysicsServer2D]'s internal [code]shape_collide[/code] method. Corresponds to [method PhysicsDirectSpaceState2D.collide_shape].
 			</description>
 		</method>
 		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
 			<description>
+				Should return the custom solver bias of the given [param shape], which defines how much bodies are forced to separate on contact when this shape is involved.
+				Overridable version of [PhysicsServer2D]'s internal [code]shape_get_custom_solver_bias[/code] method. Corresponds to [member Shape2D.custom_solver_bias].
 			</description>
 		</method>
 		<method name="_shape_get_data" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.shape_get_data].
 			</description>
 		</method>
 		<method name="_shape_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.shape_get_type].
 			</description>
 		</method>
 		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
@@ -868,6 +1006,8 @@
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="bias" type="float" />
 			<description>
+				Should set the custom solver bias for the given [param shape]. It defines how much bodies are forced to separate on contact.
+				Overridable version of [PhysicsServer2D]'s internal [code]shape_get_custom_solver_bias[/code] method. Corresponds to [member Shape2D.custom_solver_bias].
 			</description>
 		</method>
 		<method name="_shape_set_data" qualifiers="virtual">
@@ -875,29 +1015,36 @@
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
 			<description>
+				Overridable version of [method PhysicsServer2D.shape_set_data].
 			</description>
 		</method>
 		<method name="_space_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.space_create].
 			</description>
 		</method>
 		<method name="_space_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
 			<description>
+				Should return how many contacts have occurred during the last physics step in the given [param space]. See also [method _space_get_contacts] and [method _space_set_debug_contacts].
+				Overridable version of [PhysicsServer2D]'s internal [code]space_get_contact_count[/code] method.
 			</description>
 		</method>
 		<method name="_space_get_contacts" qualifiers="virtual const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="space" type="RID" />
 			<description>
+				Should return the positions of all contacts that have occurred during the last physics step in the given [param space]. See also [method _space_get_contact_count] and [method _space_set_debug_contacts].
+				Overridable version of [PhysicsServer2D]'s internal [code]space_get_contacts[/code] method.
 			</description>
 		</method>
 		<method name="_space_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectSpaceState2D" />
 			<param index="0" name="space" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.space_get_direct_state].
 			</description>
 		</method>
 		<method name="_space_get_param" qualifiers="virtual const">
@@ -905,12 +1052,14 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<description>
+				Overridable version of [method PhysicsServer2D.space_get_param].
 			</description>
 		</method>
 		<method name="_space_is_active" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="space" type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.space_is_active].
 			</description>
 		</method>
 		<method name="_space_set_active" qualifiers="virtual">
@@ -918,6 +1067,7 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
 			<description>
+				Overridable version of [method PhysicsServer2D.space_set_active].
 			</description>
 		</method>
 		<method name="_space_set_debug_contacts" qualifiers="virtual">
@@ -925,6 +1075,8 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="max_contacts" type="int" />
 			<description>
+				Used internally to allow the given [param space] to store contact points, up to [param max_contacts]. This is automatically set for the main [World2D]'s space when [member SceneTree.debug_collisions_hint] is [code]true[/code], or by checking "Visible Collision Shapes" in the editor. Only works in debug builds.
+				Overridable version of [PhysicsServer2D]'s internal [code]space_set_debug_contacts[/code] method.
 			</description>
 		</method>
 		<method name="_space_set_param" qualifiers="virtual">
@@ -933,34 +1085,42 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
 			<description>
+				Overridable version of [method PhysicsServer2D.space_set_param].
 			</description>
 		</method>
 		<method name="_step" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="step" type="float" />
 			<description>
+				Called every physics step to process the physics simulation. [param step] is the time elapsed since the last physics step, in seconds. It is usually the same as [method Node.get_physics_process_delta_time].
+				Overridable version of [PhysicsServer2D]'s internal [code skip-lint]step[/code] method.
 			</description>
 		</method>
 		<method name="_sync" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Called to indicate that the physics server is synchronizing and cannot access physics states if running on a separate thread. See also [method _end_sync].
+				Overridable version of [PhysicsServer2D]'s internal [code]sync[/code] method.
 			</description>
 		</method>
 		<method name="_world_boundary_shape_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Overridable version of [method PhysicsServer2D.world_boundary_shape_create].
 			</description>
 		</method>
 		<method name="body_test_motion_is_excluding_body" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Returns [code]true[/code] if the body with the given [RID] is being excluded from [method _body_test_motion]. See also [method Object.get_instance_id].
 			</description>
 		</method>
 		<method name="body_test_motion_is_excluding_object" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="object" type="int" />
 			<description>
+				Returns [code]true[/code] if the object with the given instance ID is being excluded from [method _body_test_motion]. See also [method Object.get_instance_id].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Oh goodness me.

This PR... This PR fills in the class reference of **PhysicsServer2DExtension**.

A grand majority of these methods link to the **PhysicsServer2D** equivalents. The reasons for this are as follow:
- Curating whole new descriptions with the assumption that that they are overridable now is not something I would wish for to my dearest enemy. It could be my job and I wouldn't do it, at least not all at once.
- Copying the descriptions between the two word-by-word would mean having to maintain **two** copies of the same identical description.
- This documentation is tailored towards advanced users, even more "advanced" than those that would read **PhysicsServer2D**'s class reference. They should roughly know what they're doing already.
     - Most of this documentation basically behaves like a quality of life "click here to read more". 

Not all of them point back to **PhysicsServer2D**. Some have been described from scratch, because there's no equivalent of them exposed to the scripting languages.

Could use the feedback of physics-savvy maintainers, but I somehow have the confidence that the new descriptions are accurate enough.