### PR TITLE
Fix export window size getting epic proportions

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1276,7 +1276,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	server_strip_message = memnew(Label);
 	server_strip_message->set_visible(false);
-	server_strip_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	server_strip_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	resources_vb->add_child(server_strip_message);
 
 	{


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85551

Not sure why, but the smart autowrap on the seemingly harmless label `server_strip_message` gives the export window a crazy height when`Export Mode` is set to `Export as dedicated server` , making it impossible to access the buttons to export your project when in `Single Window Mode`.
That label is only supposed to hold some information text, listing the resources that will be stripped from the server export.

For some reason changing the autowrap mode to something else fixes the issue. So I switched it to `AUTOWRAP_WORD` here, which should look quite similar to what's intended.

Might be a `TextServer` issue, but I have not looked into that.