### PR TITLE
Allow Angle backend selection, add initial iOS Angle support.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2370,6 +2370,18 @@
 		<member name="rendering/environment/volumetric_fog/volume_size" type="int" setter="" getter="" default="64">
 			Base size used to determine size of froxel buffer in the camera X-axis and Y-axis. The final size is scaled by the aspect ratio of the screen, so actual values may differ from what is set. Set a larger size for more detailed fog, set a smaller size for better performance.
 		</member>
+		<member name="rendering/gl_compatibility/angle_backend" type="String" setter="" getter="">
+			Angle render backend.
+		</member>
+		<member name="rendering/gl_compatibility/angle_backend.ios" type="String" setter="" getter="">
+			iOS override for [member rendering/gl_compatibility/angle_backend].
+		</member>
+		<member name="rendering/gl_compatibility/angle_backend.macos" type="String" setter="" getter="">
+			macOS override for [member rendering/gl_compatibility/angle_backend].
+		</member>
+		<member name="rendering/gl_compatibility/angle_backend.windows" type="String" setter="" getter="">
+			Windows override for [member rendering/gl_compatibility/angle_backend].
+		</member>
 		<member name="rendering/gl_compatibility/driver" type="String" setter="" getter="">
 			Sets the driver to be used by the renderer when using the Compatibility renderer. This property can not be edited directly, instead, set the driver using the platform-specific overrides.
 		</member>

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -2,7 +2,7 @@
 
 Import("env")
 
-if env["platform"] in ["macos", "windows", "linuxbsd"]:
+if env["platform"] in ["ios", "macos", "windows", "linuxbsd"]:
     # Thirdparty source files
     thirdparty_dir = "#thirdparty/glad/"
     thirdparty_sources = ["gl.c"]

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -289,7 +289,9 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 #else
 		// On Desktop and mobile we map the memory without synchronizing for maximum speed.
 		void *ubo = glMapBufferRange(GL_UNIFORM_BUFFER, 0, sizeof(LightUniform) * light_count, GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-		memcpy(ubo, state.light_uniforms, sizeof(LightUniform) * light_count);
+		if (ubo) {
+			memcpy(ubo, state.light_uniforms, sizeof(LightUniform) * light_count);
+		}
 		glUnmapBuffer(GL_UNIFORM_BUFFER);
 #endif
 
@@ -648,7 +650,9 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 #else
 	// On Desktop and mobile we map the memory without synchronizing for maximum speed.
 	void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-	memcpy(buffer, state.instance_data_array, index * sizeof(InstanceData));
+	if (buffer) {
+		memcpy(buffer, state.instance_data_array, index * sizeof(InstanceData));
+	}
 	glUnmapBuffer(GL_ARRAY_BUFFER);
 #endif
 
@@ -1506,7 +1510,9 @@ void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broke
 #else
 		// On Desktop and mobile we map the memory without synchronizing for maximum speed.
 		void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), r_index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-		memcpy(buffer, state.instance_data_array, r_index * sizeof(InstanceData));
+		if (buffer) {
+			memcpy(buffer, state.instance_data_array, r_index * sizeof(InstanceData));
+		}
 		glUnmapBuffer(GL_ARRAY_BUFFER);
 #endif
 		_allocate_instance_buffer();

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -83,6 +83,7 @@
 #endif
 
 bool RasterizerGLES3::gles_over_gl = true;
+bool RasterizerGLES3::use_egl = true;
 
 void RasterizerGLES3::begin_frame(double frame_step) {
 	frame++;
@@ -231,9 +232,9 @@ RasterizerGLES3::RasterizerGLES3() {
 	// version global to see if it loaded for now though, otherwise we fall back to
 	// the generic loader below.
 #if defined(EGL_STATIC)
-	bool has_egl = true;
+	bool has_egl = use_egl;
 #else
-	bool has_egl = (eglGetProcAddress != nullptr);
+	bool has_egl = use_egl && (eglGetProcAddress != nullptr);
 #endif
 
 	if (gles_over_gl) {
@@ -262,6 +263,7 @@ RasterizerGLES3::RasterizerGLES3() {
 	// or we need to actually test for this situation before constructing this.
 	ERR_FAIL_COND_MSG(!glad_loaded, "Error initializing GLAD.");
 
+#ifdef CAN_DEBUG
 	if (gles_over_gl) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			if (GLAD_GL_ARB_debug_output) {
@@ -273,6 +275,7 @@ RasterizerGLES3::RasterizerGLES3() {
 			}
 		}
 	}
+#endif // CAN_DEBUG
 #endif // GLAD_ENABLED
 
 	// For debugging

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -55,6 +55,7 @@ private:
 	double time_total = 0.0;
 
 	static bool gles_over_gl;
+	static bool use_egl;
 
 protected:
 	GLES3::Config *config = nullptr;
@@ -105,8 +106,9 @@ public:
 	static bool is_gles_over_gl() { return gles_over_gl; }
 	static void clear_depth(float p_depth);
 
-	static void make_current(bool p_gles_over_gl) {
+	static void make_current(bool p_gles_over_gl, bool p_use_egl = true) {
 		gles_over_gl = p_gles_over_gl;
+		use_egl = p_use_egl;
 		_create_func = _create_current;
 		low_end = true;
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1804,13 +1804,18 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.linuxbsd", PROPERTY_HINT_ENUM, driver_hints_egl), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.web", PROPERTY_HINT_ENUM, driver_hints), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.android", PROPERTY_HINT_ENUM, driver_hints), default_driver);
-		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.ios", PROPERTY_HINT_ENUM, driver_hints), default_driver);
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.ios", PROPERTY_HINT_ENUM, driver_hints_angle), default_driver);
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.macos", PROPERTY_HINT_ENUM, driver_hints_angle), default_driver);
 
 		GLOBAL_DEF_RST("rendering/gl_compatibility/nvidia_disable_threaded_optimization", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_angle", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_native", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_gles", true);
+
+		GLOBAL_DEF_RST_NOVAL("rendering/gl_compatibility/angle_backend", "default");
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/angle_backend.windows", PROPERTY_HINT_ENUM, "dx11,opengl"), "dx11");
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/angle_backend.ios", PROPERTY_HINT_ENUM, "metal,opengl"), "metal");
+		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/angle_backend.macos", PROPERTY_HINT_ENUM, "metal,opengl"), "metal");
 
 		Array device_blocklist;
 

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		1FF8DBB11FBA9DE1009DE660 /* dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */; };
 		D07CD44E1C5D589C00B7FB28 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D07CD44D1C5D589C00B7FB28 /* Images.xcassets */; };
 		9039D3BE24C093AC0020482C /* MoltenVK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9039D3BD24C093AC0020482C /* MoltenVK.xcframework */; };
+		9039D3BE24C093AC00204830 /* libANGLE.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9039D3BD24C093AC00204830 /* libANGLE.xcframework */; };
+		9039D3BE24C093AC00204831 /* libEGL.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9039D3BD24C093AC00204831 /* libEGL.xcframework */; };
+		9039D3BE24C093AC00204832 /* libGLES.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9039D3BD24C093AC00204832 /* libGLES.xcframework */; };
 		D0BCFE4618AEBDA2004A7AAE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE4418AEBDA2004A7AAE /* InfoPlist.strings */; };
 		D0BCFE7818AEBFEB004A7AAE /* $binary.pck in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE7718AEBFEB004A7AAE /* $binary.pck */; };
 		$pbx_launch_screen_build_reference
@@ -41,6 +44,9 @@
 		1FF4C1881F584E6300A41E41 /* $binary.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "$binary.entitlements"; sourceTree = "<group>"; };
 		1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dummy.cpp; sourceTree = "<group>"; };
 		9039D3BD24C093AC0020482C /* MoltenVK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MoltenVK; path = MoltenVK.xcframework; sourceTree = "<group>"; };
+		9039D3BD24C093AC00204830 /* libANGLE.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MoltenVK; path = libANGLE.xcframework; sourceTree = "<group>"; };
+		9039D3BD24C093AC00204831 /* libEGL.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MoltenVK; path = libEGL.xcframework; sourceTree = "<group>"; };
+		9039D3BD24C093AC00204832 /* libGLES.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MoltenVK; path = libGLES.xcframework; sourceTree = "<group>"; };
 		D07CD44D1C5D589C00B7FB28 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "$binary.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BCFE4318AEBDA2004A7AAE /* $binary-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "$binary-Info.plist"; sourceTree = "<group>"; };
@@ -58,6 +64,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				9039D3BE24C093AC0020482C /* MoltenVK.xcframework in Frameworks */,
+				9039D3BE24C093AC00204830 /* libANGLE.xcframework in Frameworks */,
+				9039D3BE24C093AC00204831 /* libEGL.xcframework in Frameworks */,
+				9039D3BE24C093AC00204832 /* libGLES.xcframework in Frameworks */,
 				DEADBEEF2F582BE20003B888 /* $binary.xcframework */,
 				$modules_buildphase
 				$additional_pbx_frameworks_build
@@ -91,6 +100,9 @@
 			isa = PBXGroup;
 			children = (
 				9039D3BD24C093AC0020482C /* MoltenVK.xcframework */,
+				9039D3BD24C093AC00204830 /* libANGLE.xcframework */,
+				9039D3BD24C093AC00204831 /* libEGL.xcframework */,
+				9039D3BD24C093AC00204832 /* libGLES.xcframework */,
 				DEADBEEF1F582BE20003B888 /* $binary.xcframework */,
 				$modules_buildgrp
 				$additional_pbx_frameworks_refs

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -15,6 +15,7 @@ ios_lib = [
     "godot_view.mm",
     "tts_ios.mm",
     "display_layer.mm",
+    "gl_manager_ios_angle.mm",
     "godot_app_delegate.m",
     "godot_view_renderer.mm",
     "device_metrics.m",

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -31,6 +31,7 @@ def get_opts():
         ("IOS_SDK_PATH", "Path to the iOS SDK", ""),
         BoolVariable("ios_simulator", "Build for iOS Simulator", False),
         ("ios_triple", "Triple for ios toolchain", ""),
+        ("angle_libs", "Path to the ANGLE static libraries", ""),
     ]
 
 
@@ -156,6 +157,10 @@ def configure(env: "Environment"):
 
     if env["opengl3"]:
         env.Append(CPPDEFINES=["GLES3_ENABLED", "GLES_SILENCE_DEPRECATION"])
+        if env["angle_libs"] != "":
+            env.AppendUnique(CPPDEFINES=["EGL_STATIC"])
+        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+
         env.Prepend(
             CPPPATH=[
                 "$IOS_SDK_PATH/System/Library/Frameworks/OpenGLES.framework/Headers",

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -50,6 +50,10 @@
 #endif // RD_ENABLED
 
 #if defined(GLES3_ENABLED)
+#include "gl_manager_ios_angle.h"
+#endif // GLES3_ENABLED
+
+#if defined(GLES3_ENABLED)
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif // GLES3_ENABLED
 
@@ -64,6 +68,9 @@ class DisplayServerIOS : public DisplayServer {
 #if defined(RD_ENABLED)
 	ApiContextRD *context_rd = nullptr;
 	RenderingDevice *rendering_device = nullptr;
+#endif
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+	GLManagerANGLE_IOS *gl_manager_angle = nullptr;
 #endif
 
 	id tts = nullptr;
@@ -130,6 +137,22 @@ public:
 	void update_gyroscope(float p_x, float p_y, float p_z);
 
 	// MARK: -
+
+	void window_make_current() {
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+		if (gl_manager_angle) {
+			gl_manager_angle->window_make_current(MAIN_WINDOW_ID);
+		}
+#endif
+	}
+
+	void window_release_current() {
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+		if (gl_manager_angle) {
+			gl_manager_angle->release_current();
+		}
+#endif
+	}
 
 	virtual bool has_feature(Feature p_feature) const override;
 	virtual String get_name() const override;
@@ -227,7 +250,13 @@ public:
 	virtual bool screen_is_kept_on() const override;
 
 	void resize_window(CGSize size);
-	virtual void swap_buffers() override {}
+	virtual void swap_buffers() override {
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+		if (gl_manager_angle) {
+			gl_manager_angle->swap_buffers();
+		}
+#endif
+	}
 };
 
 #endif // DISPLAY_SERVER_IOS_H

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -62,11 +62,11 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 		tts = [[TTS_IOS alloc] init];
 	}
 
+	CALayer *layer = nullptr;
+
 #if defined(RD_ENABLED)
 	context_rd = nullptr;
 	rendering_device = nullptr;
-
-	CALayer *layer = nullptr;
 
 	union {
 #ifdef VULKAN_ENABLED
@@ -108,16 +108,44 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 #endif
 
 #if defined(GLES3_ENABLED)
+#if defined(EGL_ENABLED)
+	if (rendering_driver == "opengl3_angle") {
+		layer = [AppDelegate.viewController.godotView initializeRenderingForDriver:@"opengl3_angle"];
+		if (!layer) {
+			ERR_FAIL_MSG("Failed to create iOS OpenGLES/ANGLE rendering layer.");
+		}
+		gl_manager_angle = memnew(GLManagerANGLE_IOS);
+		if (gl_manager_angle->initialize() != OK || gl_manager_angle->open_display(nullptr) != OK) {
+			memdelete(gl_manager_angle);
+			gl_manager_angle = nullptr;
+			bool fallback = GLOBAL_GET("rendering/gl_compatibility/fallback_to_native");
+			if (fallback) {
+				WARN_PRINT("Your video card drivers seem not to support the required Metal version, switching to native OpenGL.");
+				rendering_driver = "opengl3";
+			} else {
+				r_error = ERR_UNAVAILABLE;
+				ERR_FAIL_MSG("Could not initialize ANGLE OpenGL.");
+			}
+		} else {
+			Size2i size = Size2i(layer.bounds.size.width, layer.bounds.size.height) * screen_get_max_scale();
+			Error err = gl_manager_angle->window_create(MAIN_WINDOW_ID, nullptr, (__bridge void *)layer, size.width, size.height);
+			ERR_FAIL_COND_MSG(err != OK, "Can't create an OpenGL context.");
+		}
+	}
+#endif // EGL_ENABLED
+
 	if (rendering_driver == "opengl3") {
-		CALayer *layer = [AppDelegate.viewController.godotView initializeRenderingForDriver:@"opengl3"];
+		layer = [AppDelegate.viewController.godotView initializeRenderingForDriver:@"opengl3"];
 
 		if (!layer) {
 			ERR_FAIL_MSG("Failed to create iOS OpenGLES rendering layer.");
 		}
-
-		RasterizerGLES3::make_current(false);
 	}
-#endif
+
+	if (rendering_driver == "opengl3" || rendering_driver == "opengl3_angle") {
+		RasterizerGLES3::make_current(false, rendering_driver == "opengl3_angle");
+	}
+#endif // GLES3_ENABLED
 
 	bool keep_screen_on = bool(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 	screen_set_keep_on(keep_screen_on);
@@ -141,6 +169,13 @@ DisplayServerIOS::~DisplayServerIOS() {
 		context_rd = nullptr;
 	}
 #endif
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->window_destroy(MAIN_WINDOW_ID);
+		memdelete(gl_manager_angle);
+		gl_manager_angle = nullptr;
+	}
+#endif
 }
 
 DisplayServer *DisplayServerIOS::create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
@@ -155,6 +190,7 @@ Vector<String> DisplayServerIOS::get_rendering_drivers_func() {
 #endif
 #if defined(GLES3_ENABLED)
 	drivers.push_back("opengl3");
+	drivers.push_back("opengl3_angle");
 #endif
 
 	return drivers;
@@ -489,6 +525,14 @@ int64_t DisplayServerIOS::window_get_native_handle(HandleType p_handle_type, Win
 		case WINDOW_VIEW: {
 			return (int64_t)AppDelegate.viewController.godotView;
 		}
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+		case OPENGL_CONTEXT: {
+			if (gl_manager_angle) {
+				return (int64_t)gl_manager_angle->get_context(p_window);
+			}
+			return 0;
+		}
+#endif
 		default: {
 			return 0;
 		}
@@ -715,7 +759,11 @@ void DisplayServerIOS::resize_window(CGSize viewSize) {
 		context_rd->window_resize(MAIN_WINDOW_ID, size.x, size.y);
 	}
 #endif
-
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->window_resize(MAIN_WINDOW_ID, size.x, size.y);
+	}
+#endif
 	Variant resize_rect = Rect2i(Point2i(), size);
 	_window_callback(window_resize_callback, resize_rect);
 }
@@ -727,6 +775,11 @@ void DisplayServerIOS::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mo
 		context_rd->set_vsync_mode(p_window, p_vsync_mode);
 	}
 #endif
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+	if (gl_manager_angle) {
+		gl_manager_angle->set_use_vsync(p_vsync_mode != DisplayServer::VSYNC_DISABLED);
+	}
+#endif
 }
 
 DisplayServer::VSyncMode DisplayServerIOS::window_get_vsync_mode(WindowID p_window) const {
@@ -734,6 +787,11 @@ DisplayServer::VSyncMode DisplayServerIOS::window_get_vsync_mode(WindowID p_wind
 #if defined(RD_ENABLED)
 	if (context_rd) {
 		return context_rd->get_vsync_mode(p_window);
+	}
+#endif
+#if defined(GLES3_ENABLED) && defined(EGL_ENABLED)
+	if (gl_manager_angle) {
+		return (gl_manager_angle->is_using_vsync() ? DisplayServer::VSyncMode::VSYNC_ENABLED : DisplayServer::VSyncMode::VSYNC_DISABLED);
 	}
 #endif
 	return DisplayServer::VSYNC_ENABLED;

--- a/platform/ios/gl_manager_ios_angle.h
+++ b/platform/ios/gl_manager_ios_angle.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gl_manager_windows_angle.cpp                                          */
+/*  gl_manager_ios_angle.h                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,51 +28,34 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "core/config/project_settings.h"
+#ifndef GL_MANAGER_IOS_ANGLE_H
+#define GL_MANAGER_IOS_ANGLE_H
 
-#include "gl_manager_windows_angle.h"
+#if defined(IOS_ENABLED) && defined(GLES3_ENABLED) && defined(EGL_ENABLED)
 
-#if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
+#include "core/error/error_list.h"
+#include "core/os/os.h"
+#include "core/templates/local_vector.h"
+#include "drivers/egl/egl_manager.h"
+#include "servers/display_server.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <CoreVideo/CoreVideo.h>
 
-#include <EGL/eglext_angle.h>
+class GLManagerANGLE_IOS : public EGLManager {
+private:
+	virtual const char *_get_platform_extension_name() const override;
+	virtual EGLenum _get_platform_extension_enum() const override;
+	virtual EGLenum _get_platform_api_enum() const override;
+	virtual Vector<EGLAttrib> _get_platform_display_attributes() const override;
+	virtual Vector<EGLint> _get_platform_context_attribs() const override;
 
-const char *GLManagerANGLE_Windows::_get_platform_extension_name() const {
-	return "EGL_ANGLE_platform_angle";
-}
+public:
+	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height) {}
 
-EGLenum GLManagerANGLE_Windows::_get_platform_extension_enum() const {
-	return EGL_PLATFORM_ANGLE_ANGLE;
-}
+	GLManagerANGLE_IOS() {}
+	~GLManagerANGLE_IOS() {}
+};
 
-Vector<EGLAttrib> GLManagerANGLE_Windows::_get_platform_display_attributes() const {
-	const String &backend = GLOBAL_GET("rendering/gl_compatibility/angle_backend");
+#endif // IOS_ENABLED && GLES3_ENABLED && EGL_ENABLED
 
-	Vector<EGLAttrib> ret;
-	ret.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
-	if (backend.to_lower() == "dx11" || backend.to_lower() == "default") {
-		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE);
-	} else {
-		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
-	}
-	ret.push_back(EGL_NONE);
-
-	return ret;
-}
-
-EGLenum GLManagerANGLE_Windows::_get_platform_api_enum() const {
-	return EGL_OPENGL_ES_API;
-}
-
-Vector<EGLint> GLManagerANGLE_Windows::_get_platform_context_attribs() const {
-	Vector<EGLint> ret;
-	ret.push_back(EGL_CONTEXT_CLIENT_VERSION);
-	ret.push_back(3);
-	ret.push_back(EGL_NONE);
-
-	return ret;
-}
-
-#endif // WINDOWS_ENABLED && GLES3_ENABLED
+#endif // GL_MANAGER_IOS_ANGLE_H

--- a/platform/ios/gl_manager_ios_angle.mm
+++ b/platform/ios/gl_manager_ios_angle.mm
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gl_manager_windows_angle.cpp                                          */
+/*  gl_manager_ios_angle.mm                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,30 +30,30 @@
 
 #include "core/config/project_settings.h"
 
-#include "gl_manager_windows_angle.h"
+#include "gl_manager_ios_angle.h"
 
-#if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
+#if defined(IOS_ENABLED) && defined(GLES3_ENABLED) && defined(EGL_ENABLED)
 
 #include <stdio.h>
 #include <stdlib.h>
 
 #include <EGL/eglext_angle.h>
 
-const char *GLManagerANGLE_Windows::_get_platform_extension_name() const {
+const char *GLManagerANGLE_IOS::_get_platform_extension_name() const {
 	return "EGL_ANGLE_platform_angle";
 }
 
-EGLenum GLManagerANGLE_Windows::_get_platform_extension_enum() const {
+EGLenum GLManagerANGLE_IOS::_get_platform_extension_enum() const {
 	return EGL_PLATFORM_ANGLE_ANGLE;
 }
 
-Vector<EGLAttrib> GLManagerANGLE_Windows::_get_platform_display_attributes() const {
+Vector<EGLAttrib> GLManagerANGLE_IOS::_get_platform_display_attributes() const {
 	const String &backend = GLOBAL_GET("rendering/gl_compatibility/angle_backend");
 
 	Vector<EGLAttrib> ret;
 	ret.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
-	if (backend.to_lower() == "dx11" || backend.to_lower() == "default") {
-		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE);
+	if (backend.to_lower() == "metal" || backend.to_lower() == "default") {
+		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE);
 	} else {
 		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
 	}
@@ -62,11 +62,11 @@ Vector<EGLAttrib> GLManagerANGLE_Windows::_get_platform_display_attributes() con
 	return ret;
 }
 
-EGLenum GLManagerANGLE_Windows::_get_platform_api_enum() const {
+EGLenum GLManagerANGLE_IOS::_get_platform_api_enum() const {
 	return EGL_OPENGL_ES_API;
 }
 
-Vector<EGLint> GLManagerANGLE_Windows::_get_platform_context_attribs() const {
+Vector<EGLint> GLManagerANGLE_IOS::_get_platform_context_attribs() const {
 	Vector<EGLint> ret;
 	ret.push_back(EGL_CONTEXT_CLIENT_VERSION);
 	ret.push_back(3);
@@ -75,4 +75,4 @@ Vector<EGLint> GLManagerANGLE_Windows::_get_platform_context_attribs() const {
 	return ret;
 }
 
-#endif // WINDOWS_ENABLED && GLES3_ENABLED
+#endif // IOS_ENABLED && GLES3_ENABLED && EGL_ENABLED

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -71,7 +71,7 @@ static const float earth_gravity = 9.80665;
 
 	CALayer<DisplayLayer> *layer;
 
-	if ([driverName isEqualToString:@"vulkan"]) {
+	if ([driverName isEqualToString:@"vulkan"] || [driverName isEqualToString:@"opengl3_angle"]) {
 #if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
 		if (@available(iOS 13, *)) {
 			layer = [GodotMetalLayer layer];

--- a/platform/ios/platform_gl.h
+++ b/platform/ios/platform_gl.h
@@ -35,6 +35,14 @@
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
-#include <ES3/gl.h>
+#ifdef EGL_STATIC
+#define KHRONOS_STATIC 1
+#include "thirdparty/angle/include/EGL/egl.h"
+#include "thirdparty/angle/include/EGL/eglext.h"
+#undef KHRONOS_STATIC
+#else
+#include "thirdparty/glad/glad/egl.h"
+#endif
+#include "thirdparty/glad/glad/gl.h"
 
 #endif // PLATFORM_GL_H

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -788,6 +788,9 @@ void DisplayServerMacOS::window_destroy(WindowID p_window) {
 	if (gl_manager_legacy) {
 		gl_manager_legacy->window_destroy(p_window);
 	}
+	if (gl_manager_angle) {
+		gl_manager_angle->window_destroy(p_window);
+	}
 #endif
 #ifdef RD_ENABLED
 	if (context_rd) {

--- a/platform/macos/gl_manager_macos_angle.mm
+++ b/platform/macos/gl_manager_macos_angle.mm
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "core/config/project_settings.h"
+
 #include "gl_manager_macos_angle.h"
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
@@ -46,9 +48,15 @@ EGLenum GLManagerANGLE_MacOS::_get_platform_extension_enum() const {
 }
 
 Vector<EGLAttrib> GLManagerANGLE_MacOS::_get_platform_display_attributes() const {
+	const String &backend = GLOBAL_GET("rendering/gl_compatibility/angle_backend");
+
 	Vector<EGLAttrib> ret;
 	ret.push_back(EGL_PLATFORM_ANGLE_TYPE_ANGLE);
-	ret.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
+	if (backend.to_lower() == "metal" || backend.to_lower() == "default") {
+		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE);
+	} else {
+		ret.push_back(EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE);
+	}
 	ret.push_back(EGL_NONE);
 
 	return ret;

--- a/thirdparty/glad/gl.c
+++ b/thirdparty/glad/gl.c
@@ -2663,7 +2663,7 @@ static void* _glad_GL_loader_handle = NULL;
 static void* glad_gles2_dlopen_handle(void) {
 #if GLAD_PLATFORM_EMSCRIPTEN
 #elif GLAD_PLATFORM_APPLE
-    static const char *NAMES[] = {"libGLESv2.dylib"};
+    static const char *NAMES[] = {"/System/Library/Frameworks/OpenGLES.framework/OpenGLES", "libGLESv2.dylib"};
 #elif GLAD_PLATFORM_WIN32
     static const char *NAMES[] = {"GLESv2.dll", "libGLESv2.dll"};
 #else
@@ -2708,10 +2708,6 @@ int gladLoaderLoadGLES2(void) {
     userptr.get_proc_address_ptr = emscripten_GetProcAddress;
     version = gladLoadGLES2UserPtr(glad_gles2_get_proc, &userptr);
 #else
-    if (eglGetProcAddress == NULL) {
-        return 0;
-    }
-
     did_load = _glad_GL_loader_handle == NULL;
     handle = glad_gles2_dlopen_handle();
     if (handle != NULL) {

--- a/thirdparty/glad/patches/patch_ios.diff
+++ b/thirdparty/glad/patches/patch_ios.diff
@@ -1,0 +1,24 @@
+diff --git a/thirdparty/glad/gl.c b/thirdparty/glad/gl.c
+index ee0cc188fc..d055d2636c 100644
+--- a/thirdparty/glad/gl.c
++++ b/thirdparty/glad/gl.c
+@@ -2663,7 +2663,7 @@ static void* _glad_GL_loader_handle = NULL;
+ static void* glad_gles2_dlopen_handle(void) {
+ #if GLAD_PLATFORM_EMSCRIPTEN
+ #elif GLAD_PLATFORM_APPLE
+-    static const char *NAMES[] = {"libGLESv2.dylib"};
++    static const char *NAMES[] = {"/System/Library/Frameworks/OpenGLES.framework/OpenGLES", "libGLESv2.dylib"};
+ #elif GLAD_PLATFORM_WIN32
+     static const char *NAMES[] = {"GLESv2.dll", "libGLESv2.dll"};
+ #else
+@@ -2708,10 +2708,6 @@ int gladLoaderLoadGLES2(void) {
+     userptr.get_proc_address_ptr = emscripten_GetProcAddress;
+     version = gladLoadGLES2UserPtr(glad_gles2_get_proc, &userptr);
+ #else
+-    if (eglGetProcAddress == NULL) {
+-        return 0;
+-    }
+-
+     did_load = _glad_GL_loader_handle == NULL;
+     handle = glad_gles2_dlopen_handle();
+     if (handle != NULL) {


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot-angle-static/pull/3 (include workaround for massive leaks on macOS and iOS build config).

- Adds project setting to select Angle backend (for all supported platforms).
- Makes Angle over Metal usable on macOS (slow line drawing is still the issue).
- Adds support for iOS build.
