### PR TITLE
Enable content clipping for LineEdit, add TextServer option to clamp glyph offsets.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1007,6 +1007,9 @@
 			Font anti-aliasing mode for the default project font. See [member FontFile.antialiasing].
 			[b]Note:[/b] This setting does not affect custom [Font]s used within the project. Use the [b]Import[/b] dock for that instead (see [member ResourceImporterDynamicFont.antialiasing]).
 		</member>
+		<member name="gui/theme/default_font_clamp_glyph_offset" type="int" setter="" getter="" default="0.0">
+			Sets default value for glyph offset clamping. Value is a fraction of font height. If set to zero or negative value, no clamping is done.
+		</member>
 		<member name="gui/theme/default_font_generate_mipmaps" type="bool" setter="" getter="" default="false">
 			If set to [code]true[/code], the default font will have mipmaps generated. This prevents text from looking grainy when a [Control] is scaled down, or when a [Label3D] is viewed from a long distance (if [member Label3D.texture_filter] is set to a mode that displays mipmaps).
 			Enabling [member gui/theme/default_font_generate_mipmaps] increases font generation time and memory usage. Only enable this setting if you actually need it.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="clamp_glyph_offsets">
+			<return type="void" />
+			<param index="0" name="limit" type="float" />
+			<description>
+				Sets default value for glyph offset clamping. Value is a fraction of font height. If set to zero or negative value, no clamping is done. Default value is zero.
+			</description>
+		</method>
 		<method name="create_font">
 			<return type="RID" />
 			<description>
@@ -1184,6 +1191,14 @@
 			<param index="6" name="meta" type="Variant" default="null" />
 			<description>
 				Adds text span and font to draw it to the text buffer.
+			</description>
+		</method>
+		<method name="shaped_text_clamp_glyph_offsets">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="limit" type="float" />
+			<description>
+				Sets value for glyph offset clamping. Value is a fraction of font height. If set to zero or negative value, default value is used.
 			</description>
 		</method>
 		<method name="shaped_text_clear">

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_clamp_glyph_offsets" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="limit" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_cleanup" qualifiers="virtual">
 			<return type="void" />
 			<description>
@@ -1019,6 +1025,13 @@
 			<param index="4" name="opentype_features" type="Dictionary" />
 			<param index="5" name="language" type="String" />
 			<param index="6" name="meta" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_shaped_text_clamp_glyph_offsets" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="limit" type="float" />
 			<description>
 			</description>
 		</method>

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -494,6 +494,7 @@ class TextServerAdvanced : public TextServerExtension {
 
 		bool preserve_invalid = true; // Draw hex code box instead of missing characters.
 		bool preserve_control = false; // Draw control characters.
+		double clamp_offset = 0.0;
 
 		double ascent = 0.0; // Ascent for horizontal layout, 1/2 of width for vertical.
 		double descent = 0.0; // Descent for horizontal layout, 1/2 of width for vertical.
@@ -547,6 +548,7 @@ class TextServerAdvanced : public TextServerExtension {
 	mutable RID_PtrOwner<FontAdvancedLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontAdvanced> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
+	double clamp_offset = 0.0;
 
 	_FORCE_INLINE_ FontAdvanced *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
@@ -958,6 +960,9 @@ public:
 
 	MODBIND1RC(Array, shaped_text_get_objects, const RID &);
 	MODBIND2RC(Rect2, shaped_text_get_object_rect, const RID &, const Variant &);
+
+	MODBIND2(shaped_text_clamp_glyph_offsets, const RID &, double);
+	MODBIND1(clamp_glyph_offsets, double);
 
 	MODBIND1RC(Size2, shaped_text_get_size, const RID &);
 	MODBIND1RC(double, shaped_text_get_ascent, const RID &);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -4271,6 +4271,14 @@ Rect2 TextServerFallback::_shaped_text_get_object_rect(const RID &p_shaped, cons
 	return sd->objects[p_key].rect;
 }
 
+void TextServerFallback::_shaped_text_clamp_glyph_offsets(const RID &p_shaped, double p_limit) {
+	// Glyph offsets aren't supported, there's nothing to clamp.
+}
+
+void TextServerFallback::_clamp_glyph_offsets(double p_limit) {
+	// Glyph offsets aren't supported, there's nothing to clamp.
+}
+
 Size2 TextServerFallback::_shaped_text_get_size(const RID &p_shaped) const {
 	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V(sd, Size2());

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -827,6 +827,9 @@ public:
 	MODBIND1RC(Array, shaped_text_get_objects, const RID &);
 	MODBIND2RC(Rect2, shaped_text_get_object_rect, const RID &, const Variant &);
 
+	MODBIND2(shaped_text_clamp_glyph_offsets, const RID &, double);
+	MODBIND1(clamp_glyph_offsets, double);
+
 	MODBIND1RC(Size2, shaped_text_get_size, const RID &);
 	MODBIND1RC(double, shaped_text_get_ascent, const RID &);
 	MODBIND1RC(double, shaped_text_get_descent, const RID &);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -101,6 +101,7 @@ private:
 	String ime_text;
 	Point2 ime_selection;
 
+	RID canvas_item_text;
 	RID text_rid;
 	float full_width = 0.0;
 

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -52,9 +52,11 @@ void ThemeDB::initialize_theme() {
 	String project_theme_path = GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
 	String project_font_path = GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.otf,*.ttf,*.woff,*.woff2,*.fnt,*.font,*.pfb,*.pfm", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
 
+	float clamp_glyph_offset = (float)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_clamp_glyph_offset", PROPERTY_HINT_RANGE, "0.0,10.0,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), 0.0);
 	TextServer::FontAntialiasing font_antialiasing = (TextServer::FontAntialiasing)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_antialiasing", PROPERTY_HINT_ENUM, "None,Grayscale,LCD Subpixel", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), 1);
 	TextServer::Hinting font_hinting = (TextServer::Hinting)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), TextServer::HINTING_LIGHT);
 	TextServer::SubpixelPositioning font_subpixel_positioning = (TextServer::SubpixelPositioning)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), TextServer::SUBPIXEL_POSITIONING_AUTO);
+	TS->clamp_glyph_offsets(clamp_glyph_offset);
 
 	const bool font_msdf = GLOBAL_DEF_RST("gui/theme/default_font_multichannel_signed_distance_field", false);
 	const bool font_generate_mipmaps = GLOBAL_DEF_RST("gui/theme/default_font_generate_mipmaps", false);

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -294,6 +294,9 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shaped_text_get_objects, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_object_rect, "shaped", "key");
 
+	GDVIRTUAL_BIND(_shaped_text_clamp_glyph_offsets, "shaped", "limit");
+	GDVIRTUAL_BIND(_clamp_glyph_offsets, "limit");
+
 	GDVIRTUAL_BIND(_shaped_text_get_size, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_ascent, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_descent, "shaped");
@@ -1282,6 +1285,14 @@ Rect2 TextServerExtension::shaped_text_get_object_rect(const RID &p_shaped, cons
 	Rect2 ret;
 	GDVIRTUAL_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret);
 	return ret;
+}
+
+void TextServerExtension::shaped_text_clamp_glyph_offsets(const RID &p_shaped, double p_limit) {
+	GDVIRTUAL_CALL(_shaped_text_clamp_glyph_offsets, p_shaped, p_limit);
+}
+
+void TextServerExtension::clamp_glyph_offsets(double p_limit) {
+	GDVIRTUAL_CALL(_clamp_glyph_offsets, p_limit);
 }
 
 Size2 TextServerExtension::shaped_text_get_size(const RID &p_shaped) const {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -489,6 +489,11 @@ public:
 	GDVIRTUAL1RC(Array, _shaped_text_get_objects, RID);
 	GDVIRTUAL2RC(Rect2, _shaped_text_get_object_rect, RID, const Variant &);
 
+	virtual void shaped_text_clamp_glyph_offsets(const RID &p_shaped, double p_limit) override;
+	virtual void clamp_glyph_offsets(double p_limit) override;
+	GDVIRTUAL2(_shaped_text_clamp_glyph_offsets, RID, double);
+	GDVIRTUAL1(_clamp_glyph_offsets, double);
+
 	virtual Size2 shaped_text_get_size(const RID &p_shaped) const override;
 	virtual double shaped_text_get_ascent(const RID &p_shaped) const override;
 	virtual double shaped_text_get_descent(const RID &p_shaped) const override;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -444,6 +444,9 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shaped_text_get_objects", "shaped"), &TextServer::shaped_text_get_objects);
 	ClassDB::bind_method(D_METHOD("shaped_text_get_object_rect", "shaped", "key"), &TextServer::shaped_text_get_object_rect);
 
+	ClassDB::bind_method(D_METHOD("shaped_text_clamp_glyph_offsets", "shaped", "limit"), &TextServer::shaped_text_clamp_glyph_offsets);
+	ClassDB::bind_method(D_METHOD("clamp_glyph_offsets", "limit"), &TextServer::clamp_glyph_offsets);
+
 	ClassDB::bind_method(D_METHOD("shaped_text_get_size", "shaped"), &TextServer::shaped_text_get_size);
 	ClassDB::bind_method(D_METHOD("shaped_text_get_ascent", "shaped"), &TextServer::shaped_text_get_ascent);
 	ClassDB::bind_method(D_METHOD("shaped_text_get_descent", "shaped"), &TextServer::shaped_text_get_descent);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -496,6 +496,9 @@ public:
 	virtual double shaped_text_get_underline_position(const RID &p_shaped) const = 0;
 	virtual double shaped_text_get_underline_thickness(const RID &p_shaped) const = 0;
 
+	virtual void shaped_text_clamp_glyph_offsets(const RID &p_shaped, double p_limit) = 0;
+	virtual void clamp_glyph_offsets(double p_limit) = 0;
+
 	virtual Direction shaped_text_get_dominant_direction_in_range(const RID &p_shaped, int64_t p_start, int64_t p_end) const;
 
 	virtual CaretInfo shaped_text_get_carets(const RID &p_shaped, int64_t p_position) const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87016
Fixes https://github.com/godotengine/godot-proposals/issues/8860

- Enable content clipping for `LineEdit` (via separate canvas item for the text).
- Add `TextServer` option to clamp glyph offsets (global default, editor setting, and API for overriding it in the custom drawing).

| Before | After (no clamping) | After (with clamping set to `1.0`) |
| --- | --- | --- |
| <img width="419" alt="Screenshot 2024-01-10 at 10 42 53" src="https://github.com/godotengine/godot/assets/7645683/a8e202c1-117f-4940-8c76-713ab5dcef39"> | <img width="419" alt="Screenshot 2024-01-10 at 11 16 59" src="https://github.com/godotengine/godot/assets/7645683/ad76a0ef-2e84-49a0-9d35-8de8b54ead51"> | <img width="419" alt="Screenshot 2024-01-10 at 11 34 11" src="https://github.com/godotengine/godot/assets/7645683/166b82cf-a568-478e-8870-bbabac4da4e7"> |
