### PR TITLE
Add miscellaneous documentation to some classes

### DIFF
--- a/doc/classes/EditorExportPlatformPC.xml
+++ b/doc/classes/EditorExportPlatformPC.xml
@@ -4,7 +4,10 @@
 		Base class for the desktop platform exporter (Windows and Linux/BSD).
 	</brief_description>
 	<description>
+		The base class for the desktop platform exporters. These include Windows and Linux/BSD, but not macOS. See the classes inheriting this one for more details.
 	</description>
 	<tutorials>
+		<link title="Exporting for Windows">$DOCS_URL/tutorials/export/exporting_for_windows.html</link>
+		<link title="Exporting for Linux">$DOCS_URL/tutorials/export/exporting_for_linux.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/JSONRPC.xml
+++ b/doc/classes/JSONRPC.xml
@@ -79,15 +79,19 @@
 	</methods>
 	<constants>
 		<constant name="PARSE_ERROR" value="-32700" enum="ErrorCode">
+			The request could not be parsed as it was not valid by JSON standard ([method JSON.parse] failed).
 		</constant>
 		<constant name="INVALID_REQUEST" value="-32600" enum="ErrorCode">
+			A method call was requested but the request's format is not valid.
 		</constant>
 		<constant name="METHOD_NOT_FOUND" value="-32601" enum="ErrorCode">
 			A method call was requested but no function of that name existed in the JSONRPC subclass.
 		</constant>
 		<constant name="INVALID_PARAMS" value="-32602" enum="ErrorCode">
+			A method call was requested but the given method parameters are not valid. Not used by the built-in JSONRPC.
 		</constant>
 		<constant name="INTERNAL_ERROR" value="-32603" enum="ErrorCode">
+			An internal error occurred while processing the request. Not used by the built-in JSONRPC.
 		</constant>
 	</constants>
 </class>

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -590,6 +590,7 @@
 			Application version visible to the user. Falls back to [member ProjectSettings.application/config/version] if left empty.
 		</member>
 		<member name="xr_features/xr_mode" type="int" setter="" getter="">
+			The extended reality (XR) mode for this application.
 		</member>
 	</members>
 </class>

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -4,6 +4,7 @@
 		Exporter for Windows.
 	</brief_description>
 	<description>
+		The Windows exporter customizes how a Windows build is handled. In the editor's "Export" window, it is created when adding a new "Windows" preset.
 	</description>
 	<tutorials>
 		<link title="Exporting for Windows">$DOCS_URL/tutorials/export/exporting_for_windows.html</link>


### PR DESCRIPTION
This PR adds descriptions for:
- **EditorExportPlatformPC** itself;
- **EditorExportPlatformWindows** itself;
- **EditorExportPlatformAndroid**'s `xr_features/xr_mode`.
- The **JSONRPC** constants;

I originally wanted to keep this private until I had something more complete, but it's better to create a PR than accidentally losing a bit of work.
And besides, it seems like a bad description is better than no description at all.