### PR TITLE
C#: Fix debug crashes due to check released pointers over weak ones

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1856,10 +1856,8 @@ void CSharpInstance::mono_object_disposed(GCHandleIntPtr p_gchandle_to_free) {
 }
 
 void CSharpInstance::mono_object_disposed_baseref(GCHandleIntPtr p_gchandle_to_free, bool p_is_finalizer, bool &r_delete_owner, bool &r_remove_script_instance) {
-#ifdef DEBUG_ENABLED
-	CRASH_COND(!base_ref_counted);
-	CRASH_COND(!gchandle.is_weak() && gchandle.is_released());
-#endif
+	DEV_ASSERT(base_ref_counted);
+	DEV_ASSERT(gchandle.is_weak() || !gchandle.is_released());
 
 	// Must make sure event signals are not left dangling
 	disconnect_event_signals();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1858,7 +1858,7 @@ void CSharpInstance::mono_object_disposed(GCHandleIntPtr p_gchandle_to_free) {
 void CSharpInstance::mono_object_disposed_baseref(GCHandleIntPtr p_gchandle_to_free, bool p_is_finalizer, bool &r_delete_owner, bool &r_remove_script_instance) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND(!base_ref_counted);
-	CRASH_COND(gchandle.is_released());
+	CRASH_COND(!gchandle.is_weak() && gchandle.is_released());
 #endif
 
 	// Must make sure event signals are not left dangling

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1856,8 +1856,10 @@ void CSharpInstance::mono_object_disposed(GCHandleIntPtr p_gchandle_to_free) {
 }
 
 void CSharpInstance::mono_object_disposed_baseref(GCHandleIntPtr p_gchandle_to_free, bool p_is_finalizer, bool &r_delete_owner, bool &r_remove_script_instance) {
-	DEV_ASSERT(base_ref_counted);
-	DEV_ASSERT(gchandle.is_weak() || !gchandle.is_released());
+#ifdef DEBUG_ENABLED
+	CRASH_COND(!base_ref_counted);
+	CRASH_COND(!gchandle.is_weak() && gchandle.is_released());
+#endif
 
 	// Must make sure event signals are not left dangling
 	disconnect_event_signals();


### PR DESCRIPTION
fixes debug crashes described in https://github.com/godotengine/godot/issues/83762#issuecomment-1885147082, which `CRASH_COND` check released pointers over weak ones that might be released by CLR.
