### PR TITLE
Add missing descriptions to remaining signals

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -301,7 +301,7 @@
 	<signals>
 		<signal name="begin_node_move">
 			<description>
-				Emitted at the beginning of a GraphNode movement.
+				Emitted at the beginning of a [GraphElement]'s movement.
 			</description>
 		</signal>
 		<signal name="connection_drag_ended">
@@ -344,13 +344,14 @@
 		</signal>
 		<signal name="copy_nodes_request">
 			<description>
-				Emitted when the user presses [kbd]Ctrl + C[/kbd].
+				Emitted when this [GraphEdit] captures a [code]ui_copy[/code] action ([kbd]Ctrl + C[/kbd] by default). In general, this signal indicates that the selected [GraphElement]s should be copied.
 			</description>
 		</signal>
 		<signal name="delete_nodes_request">
 			<param index="0" name="nodes" type="StringName[]" />
 			<description>
-				Emitted when attempting to remove a GraphNode from the GraphEdit. Provides a list of node names to be removed (all selected nodes, excluding nodes without closing button).
+				Emitted when this [GraphEdit] captures a [code]ui_graph_delete[/code] action ([kbd]Delete[/kbd] by default).
+				[param nodes] is an array of node names that should be removed. These usually include all selected nodes.
 			</description>
 		</signal>
 		<signal name="disconnection_request">
@@ -364,28 +365,29 @@
 		</signal>
 		<signal name="duplicate_nodes_request">
 			<description>
-				Emitted when a GraphNode is attempted to be duplicated in the GraphEdit.
+				Emitted when this [GraphEdit] captures a [code]ui_graph_duplicate[/code] action ([kbd]Ctrl + D[/kbd] by default). In general, this signal indicates that the selected [GraphElement]s should be duplicated.
 			</description>
 		</signal>
 		<signal name="end_node_move">
 			<description>
-				Emitted at the end of a GraphNode movement.
+				Emitted at the end of a [GraphElement]'s movement.
 			</description>
 		</signal>
 		<signal name="node_deselected">
 			<param index="0" name="node" type="Node" />
 			<description>
+				Emitted when the given [GraphElement] node is deselected.
 			</description>
 		</signal>
 		<signal name="node_selected">
 			<param index="0" name="node" type="Node" />
 			<description>
-				Emitted when a GraphNode is selected.
+				Emitted when the given [GraphElement] node is selected.
 			</description>
 		</signal>
 		<signal name="paste_nodes_request">
 			<description>
-				Emitted when the user presses [kbd]Ctrl + V[/kbd].
+				Emitted when this [GraphEdit] captures a [code]ui_paste[/code] action ([kbd]Ctrl + V[/kbd] by default). In general, this signal indicates that previously copied [GraphElement]s should be pasted.
 			</description>
 		</signal>
 		<signal name="popup_request">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -310,12 +310,14 @@
 			[b]Note:[/b] Unless this value is [code]1.0[/code], the key value in animation will not match the actual position value.
 		</member>
 		<member name="show_rest_only" type="bool" setter="set_show_rest_only" getter="is_show_rest_only" default="false">
+			If [code]true[/code], forces the bones in their default rest pose, regardless of their values. In the editor, this also prevents the bones from being edited.
 		</member>
 	</members>
 	<signals>
 		<signal name="bone_enabled_changed">
 			<param index="0" name="bone_idx" type="int" />
 			<description>
+				Emitted when the bone at [param bone_idx] is toggled with [method set_bone_enabled]. Use [method is_bone_enabled] to check the new value.
 			</description>
 		</signal>
 		<signal name="bone_pose_changed">
@@ -326,15 +328,19 @@
 		</signal>
 		<signal name="pose_updated">
 			<description>
+				Emitted when the pose is updated, after [constant NOTIFICATION_UPDATE_SKELETON] is received.
 			</description>
 		</signal>
 		<signal name="show_rest_only_changed">
 			<description>
+				Emitted when the value of [member show_rest_only] changes.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="NOTIFICATION_UPDATE_SKELETON" value="50">
+			Notification received when this skeleton's pose needs to be updated.
+			This notification is received [i]before[/i] the related [signal pose_updated] signal.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
This PR adds descriptions to signals which were previously missing one.
These are:
- **GraphEdit**'s `node_deselected` signal.
- **Skeleton3D**'s `bone_enabled_changed`, `pose_updated` and `show_rest_only_changed` signals.
     - And by extension, the `show_rest_only` property and the `NOTIFICATION_UPDATE_SKELETON` constant.


It also tweaks the descriptions of surrounding signals very slightly.

This also would make all signals in the class reference documented. 100%.