### PR TITLE
Revamp `godot.natvis` to improve VS debugging experience

### DIFF
--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -5,8 +5,40 @@
 			<Item Name="[size]">_cowdata._ptr ? (((const unsigned int *)(_cowdata._ptr))[-1]) : 0</Item>
 			<ArrayItems>
 				<Size>_cowdata._ptr ? (((const unsigned int *)(_cowdata._ptr))[-1]) : 0</Size>
-				<ValuePointer>_cowdata._ptr</ValuePointer>
+				<ValuePointer>($T1 *) _cowdata._ptr</ValuePointer>
 			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="Array">
+		<Expand>
+			<Item Name="[size]">_p->array._cowdata._ptr ? (((const unsigned int *)(_p->array._cowdata._ptr))[-1]) : 0</Item>
+			<ArrayItems>
+				<Size>_p->array._cowdata._ptr ? (((const unsigned int *)(_p->array._cowdata._ptr))[-1]) : 0</Size>
+				<ValuePointer>(Variant *) _p->array._cowdata._ptr</ValuePointer> 
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="TypedArray&lt;*&gt;">
+		<Expand>
+			<Item Name="[size]"> _p->array._cowdata._ptr ? (((const unsigned int *)(_p->array._cowdata._ptr))[-1]) : 0</Item>
+			<ArrayItems>
+				<Size>_p->array._cowdata._ptr ? (((const unsigned int *)(_p->array._cowdata._ptr))[-1]) : 0</Size>
+				<ValuePointer >(Variant *) _p->array._cowdata._ptr</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+  
+	<Type Name="Dictionary">
+		<Expand>
+			<Item Name="[size]">_p &amp;&amp; _p->variant_map.head_element ? _p->variant_map.num_elements : 0</Item>
+			<LinkedListItems>
+				<Size>_p &amp;&amp; _p->variant_map.head_element ? _p->variant_map.num_elements : 0</Size>
+				<HeadPointer>_p ? _p->variant_map.head_element : nullptr</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode Name="[{data.key}]">(*this),view(MapHelper)</ValueNode>
+			</LinkedListItems> 
 		</Expand>
 	</Type>
 
@@ -32,15 +64,77 @@
 		</Expand>
 	</Type>
 
-	<Type Name="HashMap&lt;*,*&gt;">
+	<Type Name="NodePath">
+		<DisplayString Condition="!data">[empty]</DisplayString>
+		<DisplayString Condition="!!data">{{[absolute] = {data->absolute} [path] = {data->path,view(NodePathHelper)} [subpath] = {data->subpath,view(NodePathHelper)}}}</DisplayString>
 		<Expand>
-			<Item Name="[size]">num_elements</Item>
+			<Item Name="[path]">data->path,view(NodePathHelper)</Item>
+			<Item Name="[subpath]">data->subpath,view(NodePathHelper)</Item>
+			<Item Name="[absolute]">data->absolute</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Vector&lt;StringName&gt;" IncludeView="NodePathHelper">
+		<Expand>
+			<ArrayItems>
+				<Size>_cowdata._ptr ? (((const unsigned int *)(_cowdata._ptr))[-1]) : 0</Size>
+				<ValuePointer>((StringName *)_cowdata._ptr),view(NodePathHelper)</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="StringName" IncludeView="NodePathHelper">
+		<DisplayString Condition="_data &amp;&amp; _data->cname">{_data->cname,s8b}</DisplayString>
+		<DisplayString Condition="_data &amp;&amp; !_data->cname">{_data->name,s32b}</DisplayString>
+		<DisplayString Condition="!_data">[empty]</DisplayString>
+		<StringView Condition="_data &amp;&amp; _data->cname">_data->cname,s8b</StringView>
+		<StringView Condition="_data &amp;&amp; !_data->cname">_data->name,s32b</StringView>
+	</Type>
+
+	<Type Name="HashMapElement&lt;*,*&gt;">
+		<DisplayString>{{Key = {($T1 *) &amp;data.key}  Value = {($T2 *) &amp;data.value}}}</DisplayString>
+		<Expand>
+			<Item Name="[key]">($T1 *) &amp;data.key</Item>
+			<Item Name="[value]">($T2 *) &amp;data.value</Item>
+		</Expand>
+	</Type>
+
+	<!-- elements displayed by index -->
+	<Type Name="HashMap&lt;*,*,*,*,*&gt;" Priority="Medium">
+		<Expand>
+			<Item Name="[size]">head_element ? num_elements : 0</Item>
 			<LinkedListItems>
-				<Size>num_elements</Size>
+				<Size>head_element ? num_elements : 0</Size>
 				<HeadPointer>head_element</HeadPointer>
 				<NextPointer>next</NextPointer>
-				<ValueNode>data</ValueNode>
+				<ValueNode>(*this)</ValueNode>
 			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<!-- elements by key:value -->
+	<!-- show elements by index by specifying "ShowElementsByIndex"-->
+	<Type Name="HashMap&lt;*,*,*,*,*&gt;" ExcludeView="ShowElementsByIndex" Priority="MediumHigh">
+		<Expand>
+			<Item Name="[size]">head_element ? num_elements : 0</Item>
+			<LinkedListItems>
+				<Size>head_element ? num_elements : 0</Size>
+				<HeadPointer>head_element</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode Name="[{data.key}]">(*this),view(MapHelper)</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<Type Name="KeyValue&lt;*,*&gt;" IncludeView="MapHelper">
+		<DisplayString>{value}</DisplayString>
+	</Type>
+
+	<Type Name="HashMapElement&lt;*,*&gt;" IncludeView="MapHelper">
+		<DisplayString>{data.value}</DisplayString>
+		<Expand>
+			<Item Name="[key]"  >($T1 *) &amp;data.key</Item>
+			<Item Name="[value]">($T2 *) &amp;data.value</Item>
 		</Expand>
 	</Type>
 
@@ -58,11 +152,6 @@
 		<DisplayString Condition="dynamic_cast&lt;CallableCustomMethodPointerBase*&gt;(key.custom)">{dynamic_cast&lt;CallableCustomMethodPointerBase*&gt;(key.custom)->text}</DisplayString>
 	</Type>
 
-	<!-- requires PR 64364
-	<Type Name="GDScriptThreadContext">
-		<DisplayString Condition="_is_main == true">main thread {_debug_thread_id}</DisplayString>
-	</Type>
-	-->
 
 	<Type Name="Variant">
 		<DisplayString Condition="type == Variant::NIL">nil</DisplayString>
@@ -82,22 +171,22 @@
 		<DisplayString Condition="type == Variant::PLANE">{*(Plane *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::QUATERNION">{*(Quaternion *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::COLOR">{*(Color *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::STRING_NAME">{*(StringName *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::NODE_PATH">{*(NodePath *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::RID">{*(::RID *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::OBJECT">{*(Object *)_data._mem}</DisplayString>
+		<DisplayString Condition="type == Variant::OBJECT">{*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj}</DisplayString>
 		<DisplayString Condition="type == Variant::DICTIONARY">{*(Dictionary *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::ARRAY">{*(Array *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<!-- broken, will show incorrect data
-		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*(PackedInt64Array *)_data._mem}</DisplayString>
-		-->
+		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type &lt; 0 || type >= Variant::VARIANT_MAX">[INVALID]</DisplayString>
 
 		<StringView Condition="type == Variant::STRING &amp;&amp; ((String *)(_data._mem))->_cowdata._ptr">((String *)(_data._mem))->_cowdata._ptr,s32</StringView>
 
@@ -116,20 +205,22 @@
 			<Item Name="[value]" Condition="type == Variant::PLANE">*(Plane *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::QUATERNION">*(Quaternion *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::COLOR">*(Color *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::STRING_NAME">*(StringName *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::NODE_PATH">*(NodePath *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::RID">*(::RID *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::OBJECT">*(Object *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::OBJECT">*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj</Item>
 			<Item Name="[value]" Condition="type == Variant::DICTIONARY">*(Dictionary *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::ARRAY">*(Array *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">*(PackedInt32Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*(PackedInt64Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">*(PackedFloat32Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">*(PackedFloat64Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">*(PackedStringArray *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">*(PackedVector2Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">*(PackedVector3Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">*(PackedColorArray *)_data._mem</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array</Item>		
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array</Item>
+
 		</Expand>
 	</Type>
 
@@ -148,10 +239,10 @@
 	</Type>
 
 	<Type Name="StringName">
-		<DisplayString Condition="_data &amp;&amp; _data->cname">{_data->cname}</DisplayString>
+		<DisplayString Condition="_data &amp;&amp; _data->cname">{_data->cname,na}</DisplayString>
 		<DisplayString Condition="_data &amp;&amp; !_data->cname">{_data->name,s32}</DisplayString>
 		<DisplayString Condition="!_data">[empty]</DisplayString>
-		<StringView Condition="_data &amp;&amp; _data->cname">_data->cname</StringView>
+		<StringView Condition="_data &amp;&amp; _data->cname">_data->cname,na</StringView>
 		<StringView Condition="_data &amp;&amp; !_data->cname">_data->name,s32</StringView>
 	</Type>
 


### PR DESCRIPTION
This updates the natvis files for godot substantially and makes debugging the Godot engine in Windows a lot more pleasant:

- Adds Array, TypedArray, Dictionary, and NodePath visualizers
- Displays HashMap entries by [key] = [value] by default, similar to the MS `std::map` visualizer
- Fixes bugs with Variant display for `Object` and all of the packed arrays
- StringName summary view no longer displays only memory address if cname is set