### PR TITLE
Fix sprite crunch at half-pixels (redux)

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -425,6 +425,20 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 
 	PushConstant push_constant;
 	Transform2D base_transform = p_canvas_transform_inverse * p_item->final_transform;
+
+	// Make sure to round nearest filtered textures to avoid sprite "crunching".
+	// We don't round linear filtered textures because it would look identical to nearest filtering.
+	switch (p_item->texture_filter) {
+		case RS::CanvasItemTextureFilter::CANVAS_ITEM_TEXTURE_FILTER_NEAREST:
+		case RS::CanvasItemTextureFilter::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS:
+		case RS::CanvasItemTextureFilter::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
+			base_transform.set_origin(base_transform.get_origin().round());
+		} break;
+		default: {
+			// Do nothing.
+		}
+	}
+
 	Transform2D draw_transform;
 	_update_transform_2d_to_mat2x3(base_transform, push_constant.world);
 


### PR DESCRIPTION
Seems that #84380 doesn't fix every issues about sprite crunching.

## Comparison
### #84380
Here's #84380's rendering of [Godot-Tutorial-SmoothCamera](https://github.com/RPicster/Godot-Collected-Thingies/tree/master/Godot-Tutorial-SmoothCamera) ported to Godot 4.3.

Notice that we lose the eyes sometimes, and that there's some cropping artifacts.

https://github.com/godotengine/godot/assets/270928/2344922d-ec3b-49ad-a78e-049b59917962

### This PR
Here's this PR's rendering of the same project:

https://github.com/godotengine/godot/assets/270928/b2fe6f40-fc0e-4c4f-9d96-122bfff80728

## Open question
Relates to the comment by @clayjohn in https://github.com/godotengine/godot/pull/86670#issuecomment-1879187086
Do we really want to make this logic dependant of ProjectsSettings for snapping 2D?

If we do:
- nearest textures will be broken when non snapped;
- linear textures will not ever be "blurred" when snapped.

## Relates to
Supersedes #86670.
Fixes #84632.