### PR TITLE
Remove 2D transform snapping to rely instead on the GPU

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -248,9 +248,6 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	}
 
 	Transform2D xform = ci->xform;
-	if (snapping_2d_transforms_to_pixel) {
-		xform.columns[2] = xform.columns[2].floor();
-	}
 	xform = p_transform * xform;
 
 	Rect2 global_rect = xform.xform(rect);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -43,19 +43,11 @@ static Transform2D _canvas_get_transform(RendererViewport::Viewport *p_viewport,
 	float scale = 1.0;
 	if (p_viewport->canvas_map.has(p_canvas->parent)) {
 		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
-		if (p_viewport->snap_2d_transforms_to_pixel) {
-			c_xform.columns[2] = c_xform.columns[2].floor();
-		}
 		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
 	}
 
 	Transform2D c_xform = p_canvas_data->transform;
-
-	if (p_viewport->snap_2d_transforms_to_pixel) {
-		c_xform.columns[2] = c_xform.columns[2].floor();
-	}
-
 	xf = xf * c_xform;
 
 	if (scale != 1.0 && !RSG::canvas->disable_scale) {


### PR DESCRIPTION
More or less applies #46657 to the `master` branch (4.x). It fixed issues on 3.x, but wasn't forward-ported in 4.x.

This PR removes the need of rounding brought by #84380. As the GPU is doing the rounding, we don't have to floor the transform values on the DisplayServer side.

## Comparison
### Merlin: Scale of the Magic
Using the open-source pixel perfect game [Merlin: Scale of the Magic](https://github.com/nicolasbize/Scalazard) by @nicolasbize.

#### w/o this PR
https://github.com/godotengine/godot/assets/270928/426c4009-8b45-476e-9a47-d5080baa9aaa

#### w/ this PR
https://github.com/godotengine/godot/assets/270928/7b62d896-ff5f-4a72-ade2-eb84135d5d90

### #56793

#### w/o this PR
![image](https://github.com/godotengine/godot/assets/270928/d3dc163a-0f0c-4787-b9a4-43e2e262d35d)

#### w/ this PR
![image](https://github.com/godotengine/godot/assets/270928/7c7885c3-4322-4167-908e-c61f8965226c)

## Relates to
Supersedes #84380.
Fixes #56793.
Fixes #84632.
