### PR TITLE
Give EXR saving methods a default value of false like the bindings

### DIFF
--- a/core/io/image.h
+++ b/core/io/image.h
@@ -313,8 +313,8 @@ public:
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
-	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale) const;
-	Error save_exr(const String &p_path, bool p_grayscale) const;
+	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false) const;
+	Error save_exr(const String &p_path, bool p_grayscale = false) const;
 	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 


### PR DESCRIPTION
The bindings already had a default value of false, but this was missing internally:

```cpp
ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
ClassDB::bind_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::save_exr_to_buffer, DEFVAL(false));
```