### PR TITLE
[Shaders] Disallow trailing commas in function declarations

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10881,7 +10881,13 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 					if (tk.type == TK_COMMA) {
 						tk = _get_token();
-						//do none and go on
+#ifdef DISABLE_DEPRECATED
+						// Disallow trailing comma.
+						if (tk.type == TK_PARENTHESIS_CLOSE) {
+							_set_error(RTR("Expected a valid data type for argument. Trailing commas are not allowed."));
+							return ERR_PARSE_ERROR;
+						}
+#endif
 					} else if (tk.type != TK_PARENTHESIS_CLOSE) {
 						_set_expected_error(",", ")");
 						return ERR_PARSE_ERROR;


### PR DESCRIPTION
Might not be the most elegant fix, but not very familiar with this code, if someone has a cleaner idea for doing this I'd appreciate suggestions. Added it with deprecation to avoid breaking existing shaders, though I'm not sure that's necessary

I was considering enclosing the whole `while` loop in a block to check closing paren at the start, which would make catching this easier, but want to avoid noise in the blame if I can, having to indent the whole thing.

For reasoning, see the discussion in:
* https://github.com/godotengine/godot-proposals/issues/8840

Alternative to:
* https://github.com/godotengine/godot/pull/86991

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
