### PR TITLE
Android: Disable automatic permissions request

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -91,6 +91,10 @@ open class GodotEditor : GodotActivity() {
 	private val commandLineParams = ArrayList<String>()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
+		// We exclude certain permissions from the set we request at startup, as they'll be
+		// requested on demand based on use-cases.
+		PermissionsUtil.requestManifestPermissions(this, setOf(Manifest.permission.RECORD_AUDIO))
+
 		val params = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
 		Log.d(TAG, "Received parameters ${params.contentToString()}")
 		updateCommandLineParams(params)

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
@@ -30,7 +30,6 @@
 
 package org.godotengine.godot
 
-import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -65,10 +64,6 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 		private set
 
 	override fun onCreate(savedInstanceState: Bundle?) {
-		// We exclude certain permissions from the set we request at startup, as they'll be
-		// requested on demand based on use-cases.
-		PermissionsUtil.requestManifestPermissions(this, setOf(Manifest.permission.RECORD_AUDIO))
-
 		super.onCreate(savedInstanceState)
 		setContentView(R.layout.godot_app_layout)
 
@@ -156,7 +151,8 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 		super.onRequestPermissionsResult(requestCode, permissions, grantResults)
 		godotFragment?.onRequestPermissionsResult(requestCode, permissions, grantResults)
 
-		if (requestCode == PermissionsUtil.REQUEST_ALL_PERMISSION_REQ_CODE) {
+		// Logging the result of permission requests
+		if (requestCode == PermissionsUtil.REQUEST_ALL_PERMISSION_REQ_CODE || requestCode == PermissionsUtil.REQUEST_SINGLE_PERMISSION_REQ_CODE) {
 			Log.d(TAG, "Received permissions request result..")
 			for (i in permissions.indices) {
 				val permissionGranted = grantResults[i] == PackageManager.PERMISSION_GRANTED

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
@@ -56,9 +56,9 @@ import java.util.Set;
 public final class PermissionsUtil {
 	private static final String TAG = PermissionsUtil.class.getSimpleName();
 
-	static final int REQUEST_RECORD_AUDIO_PERMISSION = 1;
-	static final int REQUEST_CAMERA_PERMISSION = 2;
-	static final int REQUEST_VIBRATE_PERMISSION = 3;
+	public static final int REQUEST_RECORD_AUDIO_PERMISSION = 1;
+	public static final int REQUEST_CAMERA_PERMISSION = 2;
+	public static final int REQUEST_VIBRATE_PERMISSION = 3;
 	public static final int REQUEST_ALL_PERMISSION_REQ_CODE = 1001;
 	public static final int REQUEST_SINGLE_PERMISSION_REQ_CODE = 1002;
 	public static final int REQUEST_MANAGE_EXTERNAL_STORAGE_REQ_CODE = 2002;
@@ -70,7 +70,7 @@ public final class PermissionsUtil {
 	 * Request a dangerous permission. name must be specified in <a href="https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/res/AndroidManifest.xml">this</a>
 	 * @param permissionName the name of the requested permission.
 	 * @param activity the caller activity for this method.
-	 * @return true/false. "true" if permission was granted otherwise returns "false".
+	 * @return true/false. "true" if permission is already granted, "false" if a permission request was dispatched.
 	 */
 	public static boolean requestPermission(String permissionName, Activity activity) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -124,7 +124,7 @@ public final class PermissionsUtil {
 	/**
 	 * Request dangerous permissions which are defined in the Android manifest file from the user.
 	 * @param activity the caller activity for this method.
-	 * @return true/false. "true" if all permissions were granted otherwise returns "false".
+	 * @return true/false. "true" if all permissions were already granted, returns "false" if permissions requests were dispatched.
 	 */
 	public static boolean requestManifestPermissions(Activity activity) {
 		return requestManifestPermissions(activity, null);
@@ -134,7 +134,7 @@ public final class PermissionsUtil {
 	 * Request dangerous permissions which are defined in the Android manifest file from the user.
 	 * @param activity the caller activity for this method.
 	 * @param excludes Set of permissions to exclude from the request
-	 * @return true/false. "true" if all permissions were granted otherwise returns "false".
+	 * @return true/false. "true" if all permissions were already granted, returns "false" if permissions requests were dispatched.
 	 */
 	public static boolean requestManifestPermissions(Activity activity, @Nullable Set<String> excludes) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -235,7 +235,7 @@ public final class PermissionsUtil {
 	/**
 	 * Check if the given permission is in the AndroidManifest.xml file.
 	 * @param context the caller context for this method.
-	 * @param permission the permession to look for in the manifest file.
+	 * @param permission the permission to look for in the manifest file.
 	 * @return "true" if the permission is in the manifest file of the activity, "false" otherwise.
 	 */
 	public static boolean hasManifestPermission(Context context, String permission) {


### PR DESCRIPTION
The feature was added in Godot 4.2, but it goes against recommended best practices for permissions request, as such it's being reverted. In its place, developers now have to explicitly request the permissions they need to access.

Fixes https://github.com/godotengine/godot/issues/87043
Fixes https://github.com/m4gr3d/Godot-Android-Samples/issues/14

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
