### PR TITLE
Add descriptions to a few RenderingDevice's PipelineDynamicStateFlags

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -2142,8 +2142,10 @@
 			Represents the size of the [enum BlendOperation] enum.
 		</constant>
 		<constant name="DYNAMIC_STATE_LINE_WIDTH" value="1" enum="PipelineDynamicStateFlags" is_bitfield="true">
+			Allows dynamically changing the width of rendering lines.
 		</constant>
 		<constant name="DYNAMIC_STATE_DEPTH_BIAS" value="2" enum="PipelineDynamicStateFlags" is_bitfield="true">
+			Allows dynamically changing the depth bias.
 		</constant>
 		<constant name="DYNAMIC_STATE_BLEND_CONSTANTS" value="4" enum="PipelineDynamicStateFlags" is_bitfield="true">
 		</constant>


### PR DESCRIPTION
This PR fills the descriptions of the **RenderingDevice**'s **DYNAMIC_STATE_LINE_WIDTH** and **DYNAMIC_STATE_DEPTH_BIAS**.

I wish I had the knowledge to fill all of them, but these two are the only two [I can write down with some confidence](https://chat.godotengine.org/channel/rendering?msg=wXQu6vL22B44RXk5N). Help to do this would be great.
