### PR TITLE
[Shaders] Allow trailing comma in initializer lists

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4876,6 +4876,15 @@ ShaderLanguage::Node *ShaderLanguage::_parse_array_constructor(BlockNode *p_bloc
 			tk = _get_token();
 			if (tk.type == TK_COMMA) {
 				an->initializer.push_back(n);
+
+				if (auto_size) {
+					TkPos prev_pos = _get_tkpos();
+					tk = _get_token();
+					if (tk.type == TK_CURLY_BRACKET_CLOSE) {
+						break;
+					}
+					_set_tkpos(prev_pos);
+				}
 			} else if (!auto_size && tk.type == TK_PARENTHESIS_CLOSE) {
 				an->initializer.push_back(n);
 				break;
@@ -4998,6 +5007,15 @@ ShaderLanguage::Node *ShaderLanguage::_parse_array_constructor(BlockNode *p_bloc
 			tk = _get_token();
 			if (tk.type == TK_COMMA) {
 				an->initializer.push_back(n);
+
+				if (auto_size) {
+					prev_pos = _get_tkpos();
+					tk = _get_token();
+					if (tk.type == TK_CURLY_BRACKET_CLOSE) {
+						break;
+					}
+					_set_tkpos(prev_pos);
+				}
 			} else if (!auto_size && tk.type == TK_PARENTHESIS_CLOSE) {
 				an->initializer.push_back(n);
 				break;
@@ -7252,6 +7270,16 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 									tk = _get_token();
 									if (tk.type == TK_COMMA) {
 										decl.initializer.push_back(n);
+
+										if (curly) {
+											prev_pos = _get_tkpos();
+											tk = _get_token();
+											if (tk.type == TK_CURLY_BRACKET_CLOSE) {
+												break;
+											}
+											_set_tkpos(prev_pos);
+										}
+
 										continue;
 									} else if (!curly && tk.type == TK_PARENTHESIS_CLOSE) {
 										decl.initializer.push_back(n);
@@ -9360,6 +9388,16 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 										tk = _get_token();
 										if (tk.type == TK_COMMA) {
 											decl.initializer.push_back(n);
+
+											if (curly) {
+												prev_pos = _get_tkpos();
+												tk = _get_token();
+												if (tk.type == TK_CURLY_BRACKET_CLOSE) {
+													break;
+												}
+												_set_tkpos(prev_pos);
+											}
+
 											continue;
 										} else if (!curly && tk.type == TK_PARENTHESIS_CLOSE) {
 											decl.initializer.push_back(n);


### PR DESCRIPTION
GLSL allows trailing comma in array constructors, and so does many languages, this brings Godot shaders to parity with that

I believe I have caught every case, but might have missed some, as this is quite complex code, it works for both declarations in global, function, and argument scope, so believe I've caught everything

Edit: To clarify this is the curly braces style initialization by initializer list, as supported from version 4.2, not the parenthesis form, i.e. `float my_arr[3] = { 1.0, 2.0, 3.0, };` not `float my_array[3] = float[3](1.0, 2.0, 3.0);`

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
