### PR TITLE
Expose the property clipboard

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -53,6 +53,12 @@
 				Returns the object currently selected in this inspector.
 			</description>
 		</method>
+		<method name="get_property_clipboard" qualifiers="static">
+			<return type="Variant" />
+			<description>
+				Gets the value currently in the property clipboard.
+			</description>
+		</method>
 		<method name="get_selected_path" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -70,6 +76,13 @@
 			<param index="6" name="wide" type="bool" default="false" />
 			<description>
 				Creates a property editor that can be used by plugin UI to edit the specified property of an [param object].
+			</description>
+		</method>
+		<method name="set_property_clipboard" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="value" type="Variant" />
+			<description>
+				Sets the property clipboard's content to the given value.
 			</description>
 		</method>
 	</methods>

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -6329,6 +6329,19 @@ void EditorInspector::set_property_clipboard(EditorInspector::PropertyClipboard:
 	property_clipboard.value = p_value;
 }
 
+void EditorInspector::set_property_clipboard_property_value(const Variant &p_value) {
+	property_clipboard.type = EditorInspector::PropertyClipboard::Type::PROPERTY;
+	property_clipboard.value = p_value;
+}
+
+Variant EditorInspector::get_property_clipboard_property_value() {
+	if (get_property_clipboard_type() == EditorInspector::PropertyClipboard::Type::PROPERTY) {
+		return get_property_clipboard_value();
+	} else {
+		return Variant();
+	}
+}
+
 void EditorInspector::_show_add_meta_dialog() {
 	if (!add_meta_dialog) {
 		add_meta_dialog = memnew(AddMetadataDialog());
@@ -6388,6 +6401,9 @@ void EditorInspector::_bind_methods() {
 
 	ClassDB::bind_static_method("EditorInspector", D_METHOD("instantiate_property_editor", "object", "type", "path", "hint", "hint_text", "usage", "wide"), &EditorInspector::instantiate_property_editor, DEFVAL(false));
 	ClassDB::bind_static_method("EditorInspector", D_METHOD("create_default_inspector", "filter_line_edit"), &EditorInspector::create_default_inspector, DEFVAL(Variant()));
+
+	ClassDB::bind_static_method("EditorInspector", D_METHOD("set_property_clipboard", "value"), &EditorInspector::set_property_clipboard_property_value);
+	ClassDB::bind_static_method("EditorInspector", "get_property_clipboard", &EditorInspector::get_property_clipboard_property_value);
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -928,6 +928,9 @@ public:
 	static PropertyClipboard::Type get_property_clipboard_type() { return property_clipboard.type; }
 	static Variant get_property_clipboard_value() { return property_clipboard.value; }
 
+	static void set_property_clipboard_property_value(const Variant &p_value);
+	static Variant get_property_clipboard_property_value();
+
 	static EditorInspector *create_default_inspector(LineEdit *p_filter_line_edit = nullptr);
 
 	bool is_main_editor_inspector() const;


### PR DESCRIPTION
Closes godotengine/godot-proposals#8745

Exposes the `get_property_clipboard()` and `set_property_clipboard()` methods on `EditorInspector` to the ClassDB, allowing use from GDScript and GDExtension.

Now that the editor plugin that inspired this proposal has been published in the asset library, I had the time to go and implement this. This will allow Vector2/3/4's calculated in the add-on to be copied and pasted directly into properties in the inspector. Here is a quick demo of this in action:


https://github.com/godotengine/godot/assets/61520531/71b1d54c-6ae5-4c55-ab25-33b7e2483219

