### PR TITLE
Remove duplication of methods' code of class `Window` using an alias

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -211,6 +211,7 @@
 			<return type="void" />
 			<description>
 				Causes the window to grab focus, allowing it to receive user input.
+				[b]Note:[/b] Does the same thing as [method Window.move_to_foreground].
 			</description>
 		</method>
 		<method name="has_focus" qualifiers="const">
@@ -361,6 +362,7 @@
 			<return type="void" />
 			<description>
 				Moves the [Window] on top of other windows and focuses it.
+				[b]Note:[/b] Does the same thing as [method Window.grab_focus].
 			</description>
 		</method>
 		<method name="popup">

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -521,13 +521,7 @@ void Window::request_attention() {
 }
 
 void Window::move_to_foreground() {
-	ERR_MAIN_THREAD_GUARD;
-	if (embedder) {
-		embedder->_sub_window_grab_focus(this);
-
-	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-		DisplayServer::get_singleton()->window_move_to_foreground(window_id);
-	}
+	Window::grab_focus();
 }
 
 bool Window::can_draw() const {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -301,7 +301,7 @@ public:
 	bool is_maximize_allowed() const;
 
 	void request_attention();
-	void move_to_foreground();
+	_FORCE_INLINE_ void move_to_foreground();
 
 	virtual void set_visible(bool p_visible);
 	bool is_visible() const;


### PR DESCRIPTION
- Fixes #82936.
- Closes #83014.

This PR is an alternative fix to the issue linked above; what it does is it makes the `Window::move_to_foreground()` method an alias for the `Window::grab_focus()` method.

**Note**: I tried many different ways of making an alias in C++ - this version compiles, but I'm not sure if this is the best approach: ideally we'd like a situation where calling one method is internally a call of the other one.

Any suggestions for improvements are welcome.
