### PR TITLE
Add `CanvasItem::get_canvas_layer_node()`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -411,6 +411,12 @@
 				Returns the canvas item RID used by [RenderingServer] for this item.
 			</description>
 		</method>
+		<method name="get_canvas_layer_node" qualifiers="const">
+			<return type="CanvasLayer" />
+			<description>
+				Returns the [CanvasLayer] that contains this node, or [code]null[/code] if the node is not in any [CanvasLayer].
+			</description>
+		</method>
 		<method name="get_canvas_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<description>

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1169,6 +1169,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_local_mouse_position"), &CanvasItem::get_local_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_global_mouse_position"), &CanvasItem::get_global_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasItem::get_canvas);
+	ClassDB::bind_method(D_METHOD("get_canvas_layer_node"), &CanvasItem::get_canvas_layer_node);
 	ClassDB::bind_method(D_METHOD("get_world_2d"), &CanvasItem::get_world_2d);
 	//ClassDB::bind_method(D_METHOD("get_viewport"),&CanvasItem::get_viewport);
 
@@ -1323,6 +1324,11 @@ int CanvasItem::get_canvas_layer() const {
 	} else {
 		return 0;
 	}
+}
+
+CanvasLayer *CanvasItem::get_canvas_layer_node() const {
+	ERR_READ_THREAD_GUARD_V(nullptr);
+	return canvas_layer;
 }
 
 void CanvasItem::set_visibility_layer(uint32_t p_visibility_layer) {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -363,6 +363,7 @@ public:
 	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); };
 
 	int get_canvas_layer() const;
+	CanvasLayer *get_canvas_layer_node() const;
 
 	CanvasItem();
 	~CanvasItem();


### PR DESCRIPTION
* Added `CanvasLayer::get_canvas_layer_node`, which returns the CanvasLayer node the CanvasItem is in. Returns `nullptr` when the CanvasItem is not in a CanvasLayer node.

Fix godotengine/godot-proposals#8863