### PR TITLE
Switch between global and local transforms when top level is toggled in a Node3D

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -737,7 +737,7 @@ void Node3D::set_as_top_level(bool p_enabled) {
 	if (data.top_level == p_enabled) {
 		return;
 	}
-	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+	if (is_inside_tree()) {
 		if (p_enabled) {
 			set_transform(get_global_transform());
 		} else if (data.parent) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Required, but does not fully fix: #86861 due to how AABBs bounds are calculated.

Currently when you toggle top level, the transform values remain relative to the origin of the parent. This PR fixes this and will now toggle between global and local transforms.

The code that has been modified has been in Godot since the beginning, and I can't think of any reason why it's needed now. I'm assuming this is an artifact of some work around to something that existed a decade ago, and since 3D has been majorly reworked is no longer required. 

https://github.com/godotengine/godot/assets/105675984/881b8d07-ae4e-482a-9e6e-6917c32bcef7





