### PR TITLE
ThorVG: update from v0.12.0 to v0.12.1

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -861,7 +861,7 @@ instead of `miniz.h` as an external dependency.
 ## thorvg
 
 - Upstream: https://github.com/thorvg/thorvg
-- Version: 0.12.0 (25ea242d3867ed66807714f5a52d080984d3c8cc, 2024)
+- Version: 0.12.1 (d761e3c5622c0ffba2e5bb40da05751e2451e495, 2024)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -9,5 +9,5 @@
 // For internal debugging:
 //#define THORVG_LOG_ENABLED
 
-#define THORVG_VERSION_STRING "0.12.0"
+#define THORVG_VERSION_STRING "0.12.1"
 #endif

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp
@@ -3732,10 +3732,8 @@ bool SvgLoader::read()
 {
     if (!content || size == 0) return false;
 
-    if (!LoadModule::read()) return true;
-
     //the loading has been already completed in header()
-    if (root) return true;
+    if (root || !LoadModule::read()) return true;
 
     TaskScheduler::request(this);
 

--- a/thirdparty/thorvg/src/loaders/svg/tvgXmlParser.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgXmlParser.cpp
@@ -171,10 +171,11 @@ static const char* _simpleXmlFindStartTag(const char* itr, const char* itrEnd)
 
 static const char* _simpleXmlFindEndTag(const char* itr, const char* itrEnd)
 {
-    bool insideQuote = false;
+    bool insideQuote[2] = {false, false}; // 0: ", 1: '
     for (; itr < itrEnd; itr++) {
-        if (*itr == '"') insideQuote = !insideQuote;
-        if (!insideQuote) {
+        if (*itr == '"' && !insideQuote[1]) insideQuote[0] = !insideQuote[0];
+        if (*itr == '\'' && !insideQuote[0]) insideQuote[1] = !insideQuote[1];
+        if (!insideQuote[0] && !insideQuote[1]) {
             if ((*itr == '>') || (*itr == '<'))
                 return itr;
         }

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -77,7 +77,7 @@ void mpoolRetDashOutline(SwMpool* mpool, unsigned idx)
 }
 
 
-SwMpool* mpoolInit(unsigned threads)
+SwMpool* mpoolInit(uint32_t threads)
 {
     auto allocSize = threads + 1;
 

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -821,8 +821,8 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const 
 
 static AASpans* _AASpans(float ymin, float ymax, const SwImage* image, const SwBBox* region)
 {
-    auto yStart = static_cast<int32_t>(ymin);
-    auto yEnd = static_cast<int32_t>(ymax);
+    auto yStart = static_cast<int>(ymin);
+    auto yEnd = static_cast<int>(ymax);
 
     if (!_arrange(image, region, yStart, yEnd)) return nullptr;
 
@@ -1108,8 +1108,7 @@ static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const
 
     float ys = FLT_MAX, ye = -1.0f;
     for (int i = 0; i < 4; i++) {
-        mathMultiply(&vertices[i].pt, transform);
-
+        if (transform) mathMultiply(&vertices[i].pt, transform);
         if (vertices[i].pt.y < ys) ys = vertices[i].pt.y;
         if (vertices[i].pt.y > ye) ye = vertices[i].pt.y;
     }

--- a/thirdparty/thorvg/src/renderer/tvgShape.cpp
+++ b/thirdparty/thorvg/src/renderer/tvgShape.cpp
@@ -130,11 +130,11 @@ Result Shape::appendCircle(float cx, float cy, float rx, float ry) noexcept
     auto ryKappa = ry * PATH_KAPPA;
 
     pImpl->grow(6, 13);
-    pImpl->moveTo(cx, cy - ry);
-    pImpl->cubicTo(cx + rxKappa, cy - ry, cx + rx, cy - ryKappa, cx + rx, cy);
+    pImpl->moveTo(cx + rx, cy);
     pImpl->cubicTo(cx + rx, cy + ryKappa, cx + rxKappa, cy + ry, cx, cy + ry);
     pImpl->cubicTo(cx - rxKappa, cy + ry, cx - rx, cy + ryKappa, cx - rx, cy);
     pImpl->cubicTo(cx - rx, cy - ryKappa, cx - rxKappa, cy - ry, cx, cy - ry);
+    pImpl->cubicTo(cx + rxKappa, cy - ry, cx + rx, cy - ryKappa, cx + rx, cy);
     pImpl->close();
 
     return Result::Success;

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION=0.12.0
+VERSION=0.12.1
 
 cd thirdparty/thorvg/ || true
 rm -rf AUTHORS LICENSE inc/ src/ *.zip *.tar.gz tmp/


### PR DESCRIPTION
https://github.com/thorvg/thorvg/releases/tag/v0.12.1

Godot-related SVG bug fixes:

+ [SVG] XML parser workaround for quote checks within quotes. thorvg/thorvg#1892

Fixes »dancing errors« with such SVG images inside the project folder:

![Screenshot from 2024-01-12 08-45-09](https://github.com/godotengine/godot/assets/4047289/41b325fe-9f16-4cb0-bb17-fb1e2cd1d5d7)
