### PR TITLE
Capitalize OIDN in editor settings and properties

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -224,6 +224,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	//capitalize_string_remaps["msec"] = "(msec)"; // Unit.
 	capitalize_string_remaps["navmesh"] = "NavMesh";
 	capitalize_string_remaps["nfc"] = "NFC";
+	capitalize_string_remaps["oidn"] = "OIDN";
 	capitalize_string_remaps["ok"] = "OK";
 	capitalize_string_remaps["opengl"] = "OpenGL";
 	capitalize_string_remaps["opentype"] = "OpenType";


### PR DESCRIPTION
Fixes the name of OIDN not being properly capitalized in the editor settings:

<img width="281" alt="godot windows editor dev x86_64_2024-01-12_13-17-01" src="https://github.com/godotengine/godot/assets/11782833/b7397269-9c44-400f-a6a9-b916f379b945">

<img width="260" alt="godot windows editor dev x86_64_2024-01-12_13-45-57" src="https://github.com/godotengine/godot/assets/11782833/91fee652-5eaf-4783-ba4d-45471684617c">

----

While looking for other easy pickings I also noticed that we have a problem with `path3d` being turned into `Path 3d`. This is because the `3d` to `3D` conversion is only done on individual bits in names, but the conversion of the node name into two words is a separate code path.

<img width="143" alt="godot windows editor dev x86_64_2024-01-12_13-44-33" src="https://github.com/godotengine/godot/assets/11782833/55fae527-43af-4708-87d5-aaee24c83f1b">


We could add `path3d` explicitly to the list, but this feels counter-productive. I didn't risk it trying to make a quick fix after looking at it for a bit, but it's something we should eventually correct.