### PR TITLE
Add parameter `animation_override` to `AnimationNodeAnimation`

### DIFF
--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -38,6 +38,7 @@ class AnimationNodeAnimation : public AnimationRootNode {
 
 	StringName animation;
 	StringName time = "time";
+	StringName animation_override = "animation_override";
 
 	uint64_t last_version = 0;
 	bool skip = false;


### PR DESCRIPTION
Add a parameter to override the animation of  `AnimationNodeAnimation`. We can now change different animation for each `AnimationNodeAnimation` in each `AnimationTree` node while reuse animation tree resources.

#### A simple demo is attached: [animation-test.zip](https://github.com/godotengine/godot/files/13920717/animation-test.zip)
#### Demo gif preview: 
![animation override test](https://github.com/godotengine/godot/assets/40318251/4137d1fb-e6b6-491b-8bd9-72157debd91e)
#### Related issue: https://github.com/godotengine/godot-proposals/issues/8818

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8818*