### PR TITLE
Add renaming of PDB files to avoid blocking them

### DIFF
--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -47,9 +47,6 @@ class GDExtension : public Resource {
 
 	void *library = nullptr; // pointer if valid,
 	String library_path;
-#if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
-	String temp_lib_path;
-#endif
 	bool reloadable = false;
 
 	struct Extension {
@@ -129,10 +126,6 @@ public:
 
 	Error open_library(const String &p_path, const String &p_entry_symbol);
 	void close_library();
-
-#if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
-	String get_temp_library_path() const { return temp_lib_path; }
-#endif
 
 	enum InitializationLevel {
 		INITIALIZATION_LEVEL_CORE = GDEXTENSION_INITIALIZATION_CORE,

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -153,7 +153,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
-	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) { return ERR_UNAVAILABLE; }
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) { return ERR_UNAVAILABLE; }
 	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; }
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) { return ERR_UNAVAILABLE; }
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -741,7 +741,7 @@ String OS_Unix::get_locale() const {
 	return locale;
 }
 
-Error OS_Unix::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Unix::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path, bool p_generate_temp_files) {
 	String path = p_path;
 
 	if (FileAccess::exists(path) && path.is_relative_path()) {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -55,7 +55,7 @@ public:
 
 	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
-	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -162,7 +162,7 @@ Vector<String> OS_Android::get_granted_permissions() const {
 	return godot_java->get_granted_permissions();
 }
 
-Error OS_Android::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Android::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path, bool p_generate_temp_files) {
 	String path = p_path;
 	bool so_file_exists = true;
 	if (!FileAccess::exists(path)) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -113,7 +113,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title) override;
 
-	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) override;
 
 	virtual String get_name() const override;
 	virtual String get_distribution_name() const override;

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -103,7 +103,7 @@ public:
 	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;
 	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const override;
 
-	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;
 

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -219,7 +219,7 @@ _FORCE_INLINE_ String OS_IOS::get_framework_executable(const String &p_path) {
 	return p_path;
 }
 
-Error OS_IOS::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_IOS::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path, bool p_generate_temp_files) {
 	if (p_path.length() == 0) {
 		// Static xcframework.
 		p_library_handle = RTLD_SELF;

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -85,7 +85,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
-	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) override;
 
 	virtual MainLoop *get_main_loop() const override;
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -217,7 +217,7 @@ _FORCE_INLINE_ String OS_MacOS::get_framework_executable(const String &p_path) {
 	return p_path;
 }
 
-Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path, bool p_generate_temp_files) {
 	String path = get_framework_executable(p_path);
 
 	if (!FileAccess::exists(path)) {

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -243,7 +243,7 @@ bool OS_Web::is_userfs_persistent() const {
 	return idb_available;
 }
 
-Error OS_Web::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Web::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path, bool p_generate_temp_files) {
 	String path = p_path.get_file();
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);
 	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, dlerror()));

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -108,7 +108,7 @@ public:
 
 	void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
-	Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) override;
 
 	void resume_audio();
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -17,6 +17,7 @@ common_win = [
     "joypad_windows.cpp",
     "tts_windows.cpp",
     "windows_terminal_logger.cpp",
+    "windows_utils.cpp",
     "native_menu_windows.cpp",
     "gl_manager_windows_native.cpp",
     "gl_manager_windows_angle.cpp",

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -34,6 +34,7 @@
 #include "joypad_windows.h"
 #include "lang_table.h"
 #include "windows_terminal_logger.h"
+#include "windows_utils.h"
 
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
@@ -269,6 +270,10 @@ void OS_Windows::finalize() {
 }
 
 void OS_Windows::finalize_core() {
+	while (!temp_libraries.is_empty()) {
+		_remove_temp_library(temp_libraries.last()->key);
+	}
+
 	FileAccessWindows::finalize();
 
 	timeEndPeriod(1);
@@ -354,7 +359,7 @@ void debug_dynamic_library_check_dependencies(const String &p_root_path, const S
 }
 #endif
 
-Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
+Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path, bool p_generate_temp_files) {
 	String path = p_path.replace("/", "\\");
 
 	if (!FileAccess::exists(path)) {
@@ -363,6 +368,35 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 	}
 
 	ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
+
+	// Here we want a copy to be loaded.
+	// This is so the original file isn't locked and can be updated by a compiler.
+	if (p_generate_temp_files) {
+		// Copy the file to the same directory as the original with a prefix in the name.
+		// This is so relative path to dependencies are satisfied.
+		String copy_path = path.get_base_dir().path_join("~" + path.get_file());
+
+		// If there's a left-over copy (possibly from a crash) then delete it first.
+		if (FileAccess::exists(copy_path)) {
+			DirAccess::remove_absolute(copy_path);
+		}
+
+		Error copy_err = DirAccess::copy_absolute(path, copy_path);
+		if (copy_err) {
+			ERR_PRINT("Error copying library: " + path);
+			return ERR_CANT_CREATE;
+		}
+
+		FileAccess::set_hidden_attribute(copy_path, true);
+
+		// Save the copied path so it can be deleted later.
+		path = copy_path;
+
+		Error pdb_err = WindowsUtils::copy_and_rename_pdb(path);
+		if (pdb_err != OK && pdb_err != ERR_SKIP) {
+			WARN_PRINT(vformat("Failed to rename the PDB file. The original PDB file for '%s' will be loaded.", path));
+		}
+	}
 
 	typedef DLL_DIRECTORY_COOKIE(WINAPI * PAddDllDirectory)(PCWSTR);
 	typedef BOOL(WINAPI * PRemoveDllDirectory)(DLL_DIRECTORY_COOKIE);
@@ -378,8 +412,12 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 	}
 
 	p_library_handle = (void *)LoadLibraryExW((LPCWSTR)(path.utf16().get_data()), nullptr, (p_also_set_library_path && has_dll_directory_api) ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0);
-#ifdef DEBUG_ENABLED
 	if (!p_library_handle) {
+		if (p_generate_temp_files) {
+			DirAccess::remove_absolute(path);
+		}
+
+#ifdef DEBUG_ENABLED
 		DWORD err_code = GetLastError();
 
 		HashSet<String> checekd_libs;
@@ -397,8 +435,10 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 		} else {
 			ERR_FAIL_V_MSG(ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, format_error_message(err_code)));
 		}
+#endif
 	}
-#else
+
+#ifndef DEBUG_ENABLED
 	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, vformat("Can't open dynamic library: %s. Error: %s.", p_path, format_error_message(GetLastError())));
 #endif
 
@@ -410,6 +450,10 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 		*r_resolved_path = path;
 	}
 
+	if (p_generate_temp_files) {
+		temp_libraries[p_library_handle] = path;
+	}
+
 	return OK;
 }
 
@@ -417,7 +461,20 @@ Error OS_Windows::close_dynamic_library(void *p_library_handle) {
 	if (!FreeLibrary((HMODULE)p_library_handle)) {
 		return FAILED;
 	}
+
+	// Delete temporary copy of library if it exists.
+	_remove_temp_library(p_library_handle);
+
 	return OK;
+}
+
+void OS_Windows::_remove_temp_library(void *p_library_handle) {
+	if (temp_libraries.has(p_library_handle)) {
+		String path = temp_libraries[p_library_handle];
+		DirAccess::remove_absolute(path);
+		WindowsUtils::remove_temp_pdbs(path);
+		temp_libraries.erase(p_library_handle);
+	}
 }
 
 Error OS_Windows::get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -127,6 +127,9 @@ class OS_Windows : public OS {
 	bool dwrite_init = false;
 	bool dwrite2_init = false;
 
+	HashMap<void *, String> temp_libraries;
+
+	void _remove_temp_library(void *p_library_handle);
 	String _get_default_fontname(const String &p_font_name) const;
 	DWRITE_FONT_WEIGHT _weight_to_dw(int p_weight) const;
 	DWRITE_FONT_STRETCH _stretch_to_dw(int p_stretch) const;
@@ -155,7 +158,7 @@ public:
 
 	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
-	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
+	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr, bool p_generate_temp_files = false) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;
 

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -1,0 +1,280 @@
+/**************************************************************************/
+/*  windows_utils.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "windows_utils.h"
+
+#ifdef WINDOWS_ENABLED
+
+#include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef FAILED // Overrides Error::FAILED
+
+// dbghelp is linked only in DEBUG_ENABLED builds.
+#ifdef DEBUG_ENABLED
+#include <dbghelp.h>
+#endif
+#include <winnt.h>
+
+HashMap<String, Vector<String>> WindowsUtils::temp_pdbs;
+
+Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
+#ifdef DEBUG_ENABLED
+	// 1000 ought to be enough for anybody, in case the debugger does not unblock previous PDBs.
+	// Usually no more than 2 will be used.
+	const int max_pdb_names = 1000;
+
+	struct PDBResourceInfo {
+		uint32_t address = 0;
+		String path;
+	} pdb_info;
+
+	// Open and read the PDB information if available.
+	{
+		ULONG dbg_info_size = 0;
+		DWORD dbg_info_position = 0;
+
+		{
+			// The custom LoadLibraryExW is used instead of open_dynamic_library
+			// to avoid loading the original PDB into the debugger.
+			HMODULE library_ptr = LoadLibraryExW((LPCWSTR)(p_dll_path.utf16().get_data()), NULL, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
+
+			ERR_FAIL_NULL_V_MSG(library_ptr, ERR_FILE_CANT_OPEN, vformat("Failed to load library '%s'.", p_dll_path));
+
+			IMAGE_DEBUG_DIRECTORY *dbg_dir = (IMAGE_DEBUG_DIRECTORY *)ImageDirectoryEntryToDataEx(library_ptr, FALSE, IMAGE_DIRECTORY_ENTRY_DEBUG, &dbg_info_size, NULL);
+
+			bool has_debug = dbg_dir && dbg_dir->Type == IMAGE_DEBUG_TYPE_CODEVIEW;
+			if (has_debug) {
+				dbg_info_position = dbg_dir->PointerToRawData;
+				dbg_info_size = dbg_dir->SizeOfData;
+			}
+
+			ERR_FAIL_COND_V_MSG(!FreeLibrary((HMODULE)library_ptr), FAILED, vformat("Failed to free library '%s'.", p_dll_path));
+
+			if (!has_debug) {
+				// Skip with no debugging symbols.
+				return ERR_SKIP;
+			}
+		}
+
+		struct CV_HEADER {
+			DWORD Signature;
+			DWORD Offset;
+		};
+
+		const DWORD nb10_magic = '01BN';
+		struct CV_INFO_PDB20 {
+			CV_HEADER CvHeader; // CvHeader.Signature = "NB10"
+			DWORD Signature;
+			DWORD Age;
+			BYTE PdbFileName[1];
+		};
+
+		const DWORD rsds_magic = 'SDSR';
+		struct CV_INFO_PDB70 {
+			DWORD Signature; // "RSDS"
+			BYTE Guid[16];
+			DWORD Age;
+			BYTE PdbFileName[1];
+		};
+
+		Vector<uint8_t> dll_data;
+
+		{
+			Error err = OK;
+			Ref<FileAccess> file = FileAccess::open(p_dll_path, FileAccess::READ, &err);
+			ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to read library '%s'.", p_dll_path));
+
+			file->seek(dbg_info_position);
+			dll_data = file->get_buffer(dbg_info_size);
+			ERR_FAIL_COND_V_MSG(file->get_error() != OK, file->get_error(), vformat("Failed to read data from library '%s'.", p_dll_path));
+		}
+
+		const char *raw_pdb_path = nullptr;
+		int raw_pdb_offset = 0;
+		DWORD *pdb_info_signature = (DWORD *)dll_data.ptr();
+
+		if (*pdb_info_signature == rsds_magic) {
+			raw_pdb_path = (const char *)(((CV_INFO_PDB70 *)pdb_info_signature)->PdbFileName);
+			raw_pdb_offset = offsetof(CV_INFO_PDB70, PdbFileName);
+		} else if (*pdb_info_signature == nb10_magic) {
+			// Not even sure if this format still exists anywhere...
+			raw_pdb_path = (const char *)(((CV_INFO_PDB20 *)pdb_info_signature)->PdbFileName);
+			raw_pdb_offset = offsetof(CV_INFO_PDB20, PdbFileName);
+		} else {
+			ERR_FAIL_V_MSG(FAILED, vformat("Unknown PDB format in '%s'.", p_dll_path));
+		}
+
+		String utf_path;
+		Error err = utf_path.parse_utf8(raw_pdb_path);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to read PDB path from '%s'.", p_dll_path));
+
+		pdb_info.path = utf_path;
+		pdb_info.address = dbg_info_position + raw_pdb_offset;
+	}
+
+	String dll_base_dir = p_dll_path.get_base_dir();
+	String copy_pdb_path = pdb_info.path;
+
+	// Attempting to find the PDB by absolute and relative paths.
+	if (copy_pdb_path.is_relative_path()) {
+		copy_pdb_path = dll_base_dir.path_join(copy_pdb_path);
+		if (!FileAccess::exists(copy_pdb_path)) {
+			copy_pdb_path = dll_base_dir.path_join(copy_pdb_path.get_file());
+		}
+	} else if (!FileAccess::exists(copy_pdb_path)) {
+		copy_pdb_path = dll_base_dir.path_join(copy_pdb_path.get_file());
+	}
+	ERR_FAIL_COND_V_MSG(!FileAccess::exists(copy_pdb_path), FAILED, vformat("File '%s' does not exist.", copy_pdb_path));
+
+	String new_pdb_base_name = p_dll_path.get_file().get_basename() + "_";
+
+	// Checking the available space for the updated string
+	// and trying to shorten it if there is not much space.
+	{
+		// e.g. 999.pdb
+		const uint8_t suffix_size = String::num_characters((int64_t)max_pdb_names - 1) + 4;
+		// e.g. ~lib_ + 1 for the \0
+		const uint8_t min_base_size = 5 + 1;
+		int original_path_size = pdb_info.path.utf8().length();
+		CharString utf8_name = new_pdb_base_name.utf8();
+		int new_expected_buffer_size = utf8_name.length() + suffix_size;
+
+		// Since we have limited space inside the DLL to patch the path to the PDB,
+		// it is necessary to limit the size based on the number of bytes occupied by the string.
+		if (new_expected_buffer_size > original_path_size) {
+			ERR_FAIL_COND_V_MSG(original_path_size < min_base_size + suffix_size, FAILED, vformat("The original PDB path size in bytes is too small: '%s'. Expected size: %d or more bytes, but available %d.", pdb_info.path, min_base_size + suffix_size, original_path_size));
+
+			utf8_name.resize(original_path_size - suffix_size + 1); // +1 for the \0
+			utf8_name[utf8_name.size() - 1] = '\0';
+			new_pdb_base_name.parse_utf8(utf8_name);
+			new_pdb_base_name[new_pdb_base_name.length() - 1] = '_'; // Restore the last '_'
+			WARN_PRINT(vformat("The original path size of '%s' in bytes was too small to fit the new name, so it was shortened to '%s%d.pdb'.", pdb_info.path, new_pdb_base_name, max_pdb_names - 1));
+		}
+	}
+
+	// Delete old PDB files.
+	for (const String &file : DirAccess::get_files_at(dll_base_dir)) {
+		if (file.begins_with(new_pdb_base_name) && file.ends_with(".pdb")) {
+			String path = dll_base_dir.path_join(file);
+
+			// Just try to delete without showing any errors.
+			Error err = DirAccess::remove_absolute(path);
+			if (err == OK && temp_pdbs[p_dll_path].has(path)) {
+				temp_pdbs[p_dll_path].erase(path);
+			}
+		}
+	}
+
+	// Try to copy PDB with new name and patch DLL.
+	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	for (int i = 0; i < max_pdb_names; i++) {
+		String new_pdb_name = vformat("%s%d.pdb", new_pdb_base_name, i);
+		String new_pdb_path = dll_base_dir.path_join(new_pdb_name);
+		Error err = OK;
+
+		Ref<FileAccess> test_pdb_is_locked = FileAccess::open(new_pdb_path, FileAccess::READ_WRITE, &err);
+		if (err == ERR_FILE_CANT_OPEN) {
+			// If the file is blocked, continue searching.
+			continue;
+		} else if (err != OK && err != ERR_FILE_NOT_FOUND) {
+			ERR_FAIL_V_MSG(err, vformat("Failed to open '%s' to check if it is locked.", new_pdb_path));
+		}
+
+		err = d->copy(copy_pdb_path, new_pdb_path);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to copy PDB from '%s' to '%s'.", copy_pdb_path, new_pdb_path));
+		temp_pdbs[p_dll_path].append(new_pdb_path);
+
+		Ref<FileAccess> file = FileAccess::open(p_dll_path, FileAccess::READ_WRITE, &err);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to open '%s' to patch the PDB path.", p_dll_path));
+
+		int original_path_size = pdb_info.path.utf8().length();
+		// Double-check file bounds.
+		ERR_FAIL_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
+
+		Vector<uint8_t> u8 = new_pdb_name.to_utf8_buffer();
+		file->seek(pdb_info.address);
+		file->store_buffer(u8);
+
+		// Terminate string and fill the remaining part of the original string with the '\0'.
+		// Can be replaced by file->store_8('\0');
+		Vector<uint8_t> padding_buffer;
+		padding_buffer.resize((int64_t)original_path_size - u8.size());
+		padding_buffer.fill('\0');
+		file->store_buffer(padding_buffer);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to write a new PDB path to '%s'.", p_dll_path));
+
+		return OK;
+	}
+
+	ERR_FAIL_V_MSG(FAILED, vformat("Failed to find an unblocked PDB name for '%s' among %d files.", p_dll_path, max_pdb_names));
+#else
+	WARN_PRINT_ONCE("Renaming PDB files is only available in debug builds. If your libraries use PDB files, then the original ones will be used.");
+	return ERR_SKIP;
+#endif
+}
+
+void WindowsUtils::remove_temp_pdbs(const String &p_dll_path) {
+#ifdef DEBUG_ENABLED
+	if (temp_pdbs.has(p_dll_path)) {
+		Vector<String> removed;
+		int failed = 0;
+		const int failed_limit = 10;
+		for (const String &pdb : temp_pdbs[p_dll_path]) {
+			if (FileAccess::exists(pdb)) {
+				Error err = DirAccess::remove_absolute(pdb);
+				if (err == OK) {
+					removed.append(pdb);
+				} else {
+					failed++;
+					if (failed <= failed_limit) {
+						print_verbose("Failed to remove temp PDB: " + pdb);
+					}
+				}
+			} else {
+				removed.append(pdb);
+			}
+		}
+
+		if (failed > failed_limit) {
+			print_verbose(vformat("And %d more PDB files could not be removed....", failed - failed_limit));
+		}
+
+		for (const String &pdb : removed) {
+			temp_pdbs[p_dll_path].erase(pdb);
+		}
+	}
+#endif
+}
+
+#endif // WINDOWS_ENABLED

--- a/platform/windows/windows_utils.h
+++ b/platform/windows/windows_utils.h
@@ -1,0 +1,49 @@
+/**************************************************************************/
+/*  windows_utils.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef WINDOWS_UTILS_H
+#define WINDOWS_UTILS_H
+
+#ifdef WINDOWS_ENABLED
+
+#include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
+
+class WindowsUtils {
+	static HashMap<String, Vector<String>> temp_pdbs;
+
+public:
+	static Error copy_and_rename_pdb(const String &p_dll_path);
+	static void remove_temp_pdbs(const String &p_dll_path);
+};
+
+#endif // WINDOWS_ENABLED
+
+#endif // WINDOWS_UTILS_H


### PR DESCRIPTION
Fixes #82536
Supersedes https://github.com/godotengine/godot-cpp/pull/1331

In this implementation, I patch the copied ~DLL by replacing the PDB path in it with a new non-blocked path. Actually, all that is left of the PDB path is the file name, so that the new name almost never goes beyond the existing `CODEVIEW` entry.

Strangely, while I was testing this implementation the debugger did not block more than one PDB file, whereas in python/scons implementation PDBs were blocked until the debugger was restarted. If PDBs will be blocked until the debugger is restarted, 1000 copies of the PDB can be created.
I also noticed that `vscode` and `vs` load debug symbols with no problem, but `vs` doesn't update the breakpoints state and they have to be manually recreated.

If the DLL is renamed, then the PDB too, and previously created copies of it will not be deleted automatically.
Also, if a version without debug symbols is built, past previous will not be deleted.

Tested only with `godot-cpp` and `msvc`.
