### PR TITLE
[Core] Fix `AABB.encloses` failing on shared upper bound

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -200,11 +200,11 @@ inline bool AABB::encloses(const AABB &p_aabb) const {
 
 	return (
 			(src_min.x <= dst_min.x) &&
-			(src_max.x > dst_max.x) &&
+			(src_max.x >= dst_max.x) &&
 			(src_min.y <= dst_min.y) &&
-			(src_max.y > dst_max.y) &&
+			(src_max.y >= dst_max.y) &&
 			(src_min.z <= dst_min.z) &&
-			(src_max.z > dst_max.z));
+			(src_max.z >= dst_max.z));
 }
 
 Vector3 AABB::get_support(const Vector3 &p_normal) const {

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -228,7 +228,16 @@ TEST_CASE("[AABB] Merging") {
 TEST_CASE("[AABB] Encloses") {
 	const AABB aabb_big = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 
+	CHECK_MESSAGE(
+			aabb_big.encloses(aabb_big),
+			"encloses() with itself should return the expected result.");
+
 	AABB aabb_small = AABB(Vector3(-1.5, 2, -2.5), Vector3(1, 1, 1));
+	CHECK_MESSAGE(
+			aabb_big.encloses(aabb_small),
+			"encloses() with fully contained AABB (touching the edge) should return the expected result.");
+
+	aabb_small = AABB(Vector3(1.5, 6, 2.5), Vector3(1, 1, 1));
 	CHECK_MESSAGE(
 			aabb_big.encloses(aabb_small),
 			"encloses() with fully contained AABB (touching the edge) should return the expected result.");


### PR DESCRIPTION
This differs from `Rect2(i)` and was fixed for those classes in the past

See:
* https://github.com/godotengine/godot/pull/32478
* https://github.com/godotengine/godot/pull/57469

Which fixed this for those types, makes sense to me to have parity between the two, and it doesn't make sense to only allow it on one side, or fail to enclose yourself. I'd also say that the following should be equivalent: `a.encloses(b)` and `a.intersection(b) == b`

Essentially: Either it should be true only when *no* sides touch, or it should allow any side to touch, an alternative would be to add an `encloses_inclusive` or some other wording that does what this does, and change all the checks for the `encloses` to be strict

(Will open a godot-cpp equivalent if this gets approved)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
