### PR TITLE
Simplify script paths to ensure proper resource path checks

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -330,7 +330,7 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 
 	tokenizer.set_source_code(source);
 	tokenizer.set_cursor_position(cursor_line, cursor_column);
-	script_path = p_script_path;
+	script_path = p_script_path.simplify_path();
 	current = tokenizer.scan();
 	// Avoid error or newline as the first token.
 	// The latter can mess with the parser when opening files filled exclusively with comments and newlines.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87094.

Prevents script paths that could have partial dirs in them (e.g. `res://./addons/<...>` or `res://folder1/../folder2/<...>`) by simplifying them.

This issue manifested on a very specific case (https://github.com/godotengine/godot/issues/87094) of an addon with warnings, treating warnings as errors, and a script being supplied through the CLI interface with a preceding `./`. It caused the script path to become `res://./addons/...`, which then fails this check and erroneously lets the warning be issued:
https://github.com/godotengine/godot/blob/26b1fd0d842fa3c2f090ead47e8ea7cd2d6515e1/modules/gdscript/gdscript_parser.cpp#L184-L186

If applying this fix to the `script_path` is risky, I can move it to this check instead.