### PR TITLE
Clear drag preview nodes on `NOTIFICATION_DRAG_END`

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6027,6 +6027,10 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("mouse_exited", callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
 		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			_remove_preview();
+		} break;
 	}
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3017,6 +3017,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 			// Clear preview material when dropped outside applicable object.
 			if (spatial_editor->get_preview_material().is_valid() && !is_drag_successful()) {
 				_remove_preview_material();
+			} else {
+				_remove_preview_node();
 			}
 		} break;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This didn't really work before. It took seconds for the preview node to actually delete when 'ui_cancel' was pressed before dropping, and there are certain situations where you could keep the preview node in the viewport indefinitely, such as panning around.

2D Before:

https://github.com/godotengine/godot/assets/105675984/55fd767b-a051-4190-949f-d15553afc8f0

2D After: 

https://github.com/godotengine/godot/assets/105675984/c69ace89-0fa1-465e-8339-bff237f06469

3D Before: 

https://github.com/godotengine/godot/assets/105675984/36629cb5-7632-4bfb-97ef-bd810efa1ae9

3D After: 

https://github.com/godotengine/godot/assets/105675984/28172689-d56c-47a1-9ace-eca004a5dc75





