### PR TITLE
Fix position and basis of 3D Scenes instantiated via drag and drop

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4371,7 +4371,8 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		}
 
 		Transform3D new_tf = node3d->get_transform();
-		new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos);
+		new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos + node3d->get_position());
+		new_tf.basis = parent_tf.affine_inverse().basis * new_tf.basis;
 
 		undo_redo->add_do_method(instantiated_scene, "set_transform", new_tf);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #84424

Supersedes #84438

https://github.com/godotengine/godot/assets/105675984/2029b533-d1c1-4088-a2c2-f85fbdb4e89c

![image](https://github.com/godotengine/godot/assets/105675984/1fdad442-93f9-4675-8c8d-744886846a45)


