### PR TITLE
C#: Enable default items for `GodotSharp` & `GodotSharpEditor`

### DIFF
--- a/misc/scripts/dotnet_format.sh
+++ b/misc/scripts/dotnet_format.sh
@@ -5,12 +5,8 @@
 
 set -uo pipefail
 
-# Create dummy generated files.
+# Create dummy generated file.
 echo "<Project />" > modules/mono/SdkPackageVersions.props
-mkdir -p modules/mono/glue/GodotSharp/GodotSharp/Generated
-echo "<Project />" > modules/mono/glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props
-mkdir -p modules/mono/glue/GodotSharp/GodotSharpEditor/Generated
-echo "<Project />" > modules/mono/glue/GodotSharp/GodotSharpEditor/Generated/GeneratedIncludes.props
 
 # Loops through all C# projects tracked by Git.
 git ls-files -- '*.csproj' \

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1108,13 +1108,19 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 	}
 
 	da->change_dir(p_proj_dir);
-	da->make_dir("Generated");
-	da->make_dir("Generated/GodotObjects");
+	da->make_dir_recursive("Generated/GodotObjects");
 
-	String base_gen_dir = path::join(p_proj_dir, "Generated");
-	String godot_objects_gen_dir = path::join(base_gen_dir, "GodotObjects");
+	da->change_dir("Generated");
+	String base_gen_dir = da->get_current_dir();
+	for (const String &file : da->get_files()) {
+		da->remove(file);
+	}
 
-	Vector<String> compile_items;
+	da->change_dir("GodotObjects");
+	String godot_objects_gen_dir = da->get_current_dir();
+	for (const String &file : da->get_files()) {
+		da->remove(file);
+	}
 
 	// Generate source file for global scope constants and enums
 	{
@@ -1125,8 +1131,6 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		if (save_err != OK) {
 			return save_err;
 		}
-
-		compile_items.push_back(output_file);
 	}
 
 	// Generate source file for array extensions
@@ -1138,8 +1142,6 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		if (save_err != OK) {
 			return save_err;
 		}
-
-		compile_items.push_back(output_file);
 	}
 
 	for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
@@ -1159,8 +1161,6 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		if (err != OK) {
 			return err;
 		}
-
-		compile_items.push_back(output_file);
 	}
 
 	// Generate native calls
@@ -1203,29 +1203,6 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		return err;
 	}
 
-	compile_items.push_back(internal_methods_file);
-
-	// Generate GeneratedIncludes.props
-
-	StringBuilder includes_props_content;
-	includes_props_content.append("<Project>\n"
-								  "  <ItemGroup>\n");
-
-	for (int i = 0; i < compile_items.size(); i++) {
-		String include = path::relative_to(compile_items[i], p_proj_dir).replace("/", "\\");
-		includes_props_content.append("    <Compile Include=\"" + include + "\" />\n");
-	}
-
-	includes_props_content.append("  </ItemGroup>\n"
-								  "</Project>\n");
-
-	String includes_props_file = path::join(base_gen_dir, "GeneratedIncludes.props");
-
-	err = _save_file(includes_props_file, includes_props_content);
-	if (err != OK) {
-		return err;
-	}
-
 	return OK;
 }
 
@@ -1241,13 +1218,19 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 	}
 
 	da->change_dir(p_proj_dir);
-	da->make_dir("Generated");
-	da->make_dir("Generated/GodotObjects");
+	da->make_dir_recursive("Generated/GodotObjects");
 
-	String base_gen_dir = path::join(p_proj_dir, "Generated");
-	String godot_objects_gen_dir = path::join(base_gen_dir, "GodotObjects");
+	da->change_dir("Generated");
+	String base_gen_dir = da->get_current_dir();
+	for (const String &file : da->get_files()) {
+		da->remove(file);
+	}
 
-	Vector<String> compile_items;
+	da->change_dir("GodotObjects");
+	String godot_objects_gen_dir = da->get_current_dir();
+	for (const String &file : da->get_files()) {
+		da->remove(file);
+	}
 
 	for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
 		const TypeInterface &itype = E.value;
@@ -1266,8 +1249,6 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		if (err != OK) {
 			return err;
 		}
-
-		compile_items.push_back(output_file);
 	}
 
 	// Generate native calls
@@ -1308,29 +1289,6 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 	String internal_methods_file = path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS_EDITOR ".cs");
 
 	Error err = _save_file(internal_methods_file, cs_icalls_content);
-	if (err != OK) {
-		return err;
-	}
-
-	compile_items.push_back(internal_methods_file);
-
-	// Generate GeneratedIncludes.props
-
-	StringBuilder includes_props_content;
-	includes_props_content.append("<Project>\n"
-								  "  <ItemGroup>\n");
-
-	for (int i = 0; i < compile_items.size(); i++) {
-		String include = path::relative_to(compile_items[i], p_proj_dir).replace("/", "\\");
-		includes_props_content.append("    <Compile Include=\"" + include + "\" />\n");
-	}
-
-	includes_props_content.append("  </ItemGroup>\n"
-								  "</Project>\n");
-
-	String includes_props_file = path::join(base_gen_dir, "GeneratedIncludes.props");
-
-	err = _save_file(includes_props_file, includes_props_content);
 	if (err != OK) {
 		return err;
 	}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Godot</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
-    <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>10</LangVersion>
 
@@ -44,103 +43,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Godot.SourceGenerators.Internal\Godot.SourceGenerators.Internal.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <!-- Sources -->
-  <ItemGroup>
-    <Compile Include="Core\Aabb.cs" />
-    <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
-    <Compile Include="Core\Bridge\MethodInfo.cs" />
-    <Compile Include="Core\Callable.generics.cs" />
-    <Compile Include="Core\CustomGCHandle.cs" />
-    <Compile Include="Core\Array.cs" />
-    <Compile Include="Core\Attributes\AssemblyHasScriptsAttribute.cs" />
-    <Compile Include="Core\Attributes\ExportAttribute.cs" />
-    <Compile Include="Core\Attributes\ExportCategoryAttribute.cs" />
-    <Compile Include="Core\Attributes\ExportGroupAttribute.cs" />
-    <Compile Include="Core\Attributes\ExportSubgroupAttribute.cs" />
-    <Compile Include="Core\Attributes\GlobalClassAttribute.cs" />
-    <Compile Include="Core\Attributes\GodotClassNameAttribute.cs" />
-    <Compile Include="Core\Attributes\IconAttribute.cs" />
-    <Compile Include="Core\Attributes\MustBeVariantAttribute.cs" />
-    <Compile Include="Core\Attributes\RpcAttribute.cs" />
-    <Compile Include="Core\Attributes\ScriptPathAttribute.cs" />
-    <Compile Include="Core\Attributes\SignalAttribute.cs" />
-    <Compile Include="Core\Attributes\ToolAttribute.cs" />
-    <Compile Include="Core\Basis.cs" />
-    <Compile Include="Core\Bridge\CSharpInstanceBridge.cs" />
-    <Compile Include="Core\Bridge\GCHandleBridge.cs" />
-    <Compile Include="Core\Bridge\AlcReloadCfg.cs" />
-    <Compile Include="Core\Bridge\ManagedCallbacks.cs" />
-    <Compile Include="Core\Bridge\PropertyInfo.cs" />
-    <Compile Include="Core\Bridge\ScriptManagerBridge.cs" />
-    <Compile Include="Core\Bridge\ScriptManagerBridge.types.cs" />
-    <Compile Include="Core\Callable.cs" />
-    <Compile Include="Core\Color.cs" />
-    <Compile Include="Core\Colors.cs" />
-    <Compile Include="Core\DebuggingUtils.cs" />
-    <Compile Include="Core\DelegateUtils.cs" />
-    <Compile Include="Core\Dictionary.cs" />
-    <Compile Include="Core\Dispatcher.cs" />
-    <Compile Include="Core\Extensions\GodotObjectExtensions.cs" />
-    <Compile Include="Core\Extensions\NodeExtensions.cs" />
-    <Compile Include="Core\Extensions\PackedSceneExtensions.cs" />
-    <Compile Include="Core\Extensions\ResourceLoaderExtensions.cs" />
-    <Compile Include="Core\GD.cs" />
-    <Compile Include="Core\GodotObject.base.cs" />
-    <Compile Include="Core\GodotObject.exceptions.cs" />
-    <Compile Include="Core\GodotSynchronizationContext.cs" />
-    <Compile Include="Core\GodotTaskScheduler.cs" />
-    <Compile Include="Core\GodotTraceListener.cs" />
-    <Compile Include="Core\GodotUnhandledExceptionEvent.cs" />
-    <Compile Include="Core\DisposablesTracker.cs" />
-    <Compile Include="Core\Interfaces\IAwaitable.cs" />
-    <Compile Include="Core\Interfaces\IAwaiter.cs" />
-    <Compile Include="Core\Interfaces\ISerializationListener.cs" />
-    <Compile Include="Core\Mathf.cs" />
-    <Compile Include="Core\MathfEx.cs" />
-    <Compile Include="Core\NativeInterop\CustomUnsafe.cs" />
-    <Compile Include="Core\NativeInterop\ExceptionUtils.cs" />
-    <Compile Include="Core\NativeInterop\GodotDllImportResolver.cs" />
-    <Compile Include="Core\NativeInterop\InteropUtils.cs" />
-    <Compile Include="Core\NativeInterop\NativeFuncs.extended.cs" />
-    <Compile Include="Core\NativeInterop\NativeVariantPtrArgs.cs" />
-    <Compile Include="Core\NativeInterop\VariantUtils.cs" />
-    <Compile Include="Core\NativeInterop\VariantUtils.generic.cs" />
-    <Compile Include="Core\NodePath.cs" />
-    <Compile Include="Core\Plane.cs" />
-    <Compile Include="Core\Projection.cs" />
-    <Compile Include="Core\Quaternion.cs" />
-    <Compile Include="Core\Rect2.cs" />
-    <Compile Include="Core\Rect2I.cs" />
-    <Compile Include="Core\ReflectionUtils.cs" />
-    <Compile Include="Core\Rid.cs" />
-    <Compile Include="Core\NativeInterop\NativeFuncs.cs" />
-    <Compile Include="Core\NativeInterop\InteropStructs.cs" />
-    <Compile Include="Core\NativeInterop\Marshaling.cs" />
-    <Compile Include="Core\Signal.cs" />
-    <Compile Include="Core\SignalAwaiter.cs" />
-    <Compile Include="Core\StringExtensions.cs" />
-    <Compile Include="Core\StringName.cs" />
-    <Compile Include="Core\Transform2D.cs" />
-    <Compile Include="Core\Transform3D.cs" />
-    <Compile Include="Core\Variant.cs" />
-    <Compile Include="Core\Vector2.cs" />
-    <Compile Include="Core\Vector2I.cs" />
-    <Compile Include="Core\Vector3.cs" />
-    <Compile Include="Core\Vector3I.cs" />
-    <Compile Include="Core\Vector4.cs" />
-    <Compile Include="Core\Vector4I.cs" />
-    <Compile Include="GlobalUsings.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <!-- Compat Sources -->
-  <ItemGroup>
-    <Compile Include="Compat.cs" />
-  </ItemGroup>
-  <!--
-  We import a props file with auto-generated includes. This works well with Rider.
-  However, Visual Studio and MonoDevelop won't list them in the solution explorer.
-  We can't use wildcards as there may be undesired old files still hanging around.
-  Fortunately code completion, go to definition and such still work.
-  -->
-  <Import Project="Generated\GeneratedIncludes.props" />
 </Project>

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Godot</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
-    <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
@@ -34,15 +33,4 @@
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
-  <!-- Compat Sources -->
-  <ItemGroup>
-    <Compile Include="Compat.cs" />
-  </ItemGroup>
-  <!--
-  We import a props file with auto-generated includes. This works well with Rider.
-  However, Visual Studio and MonoDevelop won't list them in the solution explorer.
-  We can't use wildcards as there may be undesired old files still hanging around.
-  Fortunately code completion, go to definition and such still work.
-  -->
-  <Import Project="Generated\GeneratedIncludes.props" />
 </Project>


### PR DESCRIPTION
`bindings_generator.cpp` will now account for potentially unwanted, older versions of files by clearing the generated folder (and subfolders) prior to building glue. This cleans up the `GodotSharp` and `GodotSharpEditor` project files by quite a lot, as they can now safely auto-include their contents like the rest of the repo. `GeneratedIncludes.props` is no longer required and has consequently been removed from the generation process; as such, `dotnet_format.sh` was adjusted to no longer create them as dummy files.