### PR TITLE
Properly change GridMap floors while selecting

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -60,10 +60,18 @@ void GridMapEditor::_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPTION_PREV_LEVEL: {
 			floor->set_value(floor->get_value() - 1);
+			if (selection.active && input_action == INPUT_SELECT) {
+				selection.current[edit_axis]--;
+				_validate_selection();
+			}
 		} break;
 
 		case MENU_OPTION_NEXT_LEVEL: {
 			floor->set_value(floor->get_value() + 1);
+			if (selection.active && input_action == INPUT_SELECT) {
+				selection.current[edit_axis]++;
+				_validate_selection();
+			}
 		} break;
 
 		case MENU_OPTION_X_AXIS:
@@ -753,19 +761,6 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 						_menu_option(options->get_popup()->get_item_id(i));
 						return EditorPlugin::AFTER_GUI_INPUT_STOP;
 					}
-				}
-			}
-
-			if (k->is_shift_pressed() && selection.active && input_action != INPUT_PASTE) {
-				if (k->get_keycode() == (Key)options->get_popup()->get_item_accelerator(options->get_popup()->get_item_index(MENU_OPTION_PREV_LEVEL))) {
-					selection.click[edit_axis]--;
-					_validate_selection();
-					return EditorPlugin::AFTER_GUI_INPUT_STOP;
-				}
-				if (k->get_keycode() == (Key)options->get_popup()->get_item_accelerator(options->get_popup()->get_item_index(MENU_OPTION_NEXT_LEVEL))) {
-					selection.click[edit_axis]++;
-					_validate_selection();
-					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #87107

https://github.com/godotengine/godot/assets/2223172/0f4074c5-1d22-4453-8f88-2f649e12d6a5

Note that behavior is still different than in the previous versions. You need to release Shift to use E and Q, also it changes the current selection position, instead of the origin like it did previously.