### PR TITLE
Use ETC2 compression for grayscale images

### DIFF
--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -40,7 +40,7 @@
 EtcpakType _determine_etc_type(Image::UsedChannels p_channels) {
 	switch (p_channels) {
 		case Image::USED_CHANNELS_L:
-			return EtcpakType::ETCPAK_TYPE_ETC1;
+			return EtcpakType::ETCPAK_TYPE_ETC2;
 		case Image::USED_CHANNELS_LA:
 			return EtcpakType::ETCPAK_TYPE_ETC2_ALPHA;
 		case Image::USED_CHANNELS_R:


### PR DESCRIPTION
Sets the default compression type for grayscale textures to the higher-quality ETC2 format instead of ETC1.

Textures can still be explicitly compressed as ETC1 by using `Image`'s `compress` function, although [this PR](https://github.com/godotengine/godot/pull/84913#issue-1993603194) mentions that the ETC1 format is no longer used by Godot, so should compression support for it be removed entirely?

MRP for testing: [etc1grayscale.zip](https://github.com/godotengine/godot/files/13927998/etc1grayscale.zip)