### PR TITLE
Allow configuring the maximum width for atlas import

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -898,6 +898,9 @@
 			If [code]true[/code], text resources are converted to a binary format on export. This decreases file sizes and speeds up loading slightly.
 			[b]Note:[/b] If [member editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to return the converted files in an exported project. Some file paths within the exported PCK will also change, such as [code]project.godot[/code] becoming [code]project.binary[/code]. If you rely on run-time loading of files present within the PCK, set [member editor/export/convert_text_resources_to_binary] to [code]false[/code].
 		</member>
+		<member name="editor/import/atlas_max_width" type="int" setter="" getter="" default="2048">
+			The maximum width to use when importing textures as an atlas. The value will be rounded to the nearest power of two when used. Use this to prevent imported textures from growing too large in the other direction.
+		</member>
 		<member name="editor/import/reimport_missing_imported_files" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="editor/import/use_multiple_threads" type="bool" setter="" getter="" default="true">

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -31,6 +31,7 @@
 #include "resource_importer_texture_atlas.h"
 
 #include "atlas_import_failed.xpm"
+#include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_saver.h"
@@ -276,9 +277,15 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 		idx++;
 	}
 
+	const int max_width = (int)GLOBAL_GET("editor/import/atlas_max_width");
+
 	//pack the charts
 	int atlas_width, atlas_height;
-	EditorAtlasPacker::chart_pack(charts, atlas_width, atlas_height);
+	EditorAtlasPacker::chart_pack(charts, atlas_width, atlas_height, max_width);
+
+	if (atlas_height > max_width * 2) {
+		WARN_PRINT(vformat(TTR("%s: Atlas texture significantly larger on one axis (%d), consider changing the `editor/import/atlas_max_width` Project Setting to allow a wider texture, making the result more even in size."), p_group_file, atlas_height));
+	}
 
 	//blit the atlas
 	Ref<Image> new_atlas = Image::create_empty(atlas_width, atlas_height, false, Image::FORMAT_RGBA8);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -272,6 +272,8 @@ void register_editor_types() {
 	GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
 	GLOBAL_DEF("editor/import/use_multiple_threads", true);
 
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/import/atlas_max_width", PROPERTY_HINT_RANGE, "128,8192,1,or_greater"), 2048);
+
 	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", true);
 
 	GLOBAL_DEF("editor/version_control/plugin_name", "");


### PR DESCRIPTION
Unsure about the best way of solving this, another option would be to improve the general size picking for the packer, but that becomes much more complex and I suspect it would have issues with optimization to adjust both axes

This feels like a decent enough basic improvement, and the current cap of `2048` is quite restrictive in some cases, but keeping it at that level by default to avoid unnecessary updates to existing projects

Will see about adding a warning in the importer to warn when the texture is above a certain size, and suggesting modifying this setting accordingly

Todo:
- [ ] Improve the documentation phrasing
- [x] Consider a warning

As discussed in:
* https://github.com/godotengine/godot/issues/87119

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
