### PR TITLE
Add per-bone meta to Skeleton3D

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -99,6 +99,21 @@
 				Returns the global rest transform for [param bone_idx].
 			</description>
 		</method>
+		<method name="get_bone_meta" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="bone_idx" type="int" />
+			<param index="1" name="key" type="StringName" />
+			<description>
+				Returns bone metadata for [param bone_idx] with [param key].
+			</description>
+		</method>
+		<method name="get_bone_meta_list" qualifiers="const">
+			<return type="StringName[]" />
+			<param index="0" name="bone_idx" type="int" />
+			<description>
+				Returns a list of all metadata keys for [param bone_idx].
+			</description>
+		</method>
 		<method name="get_bone_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="bone_idx" type="int" />
@@ -169,6 +184,14 @@
 				Returns the number of times the bone hierarchy has changed within this skeleton, including renames.
 				The Skeleton version is not serialized: only use within a single instance of Skeleton3D.
 				Use for invalidating caches in IK solvers and other nodes which process bones.
+			</description>
+		</method>
+		<method name="has_bone_meta" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="bone_idx" type="int" />
+			<param index="1" name="key" type="StringName" />
+			<description>
+				Returns whether there exists any bone metadata for [param bone_idx] with key [param key].
 			</description>
 		</method>
 		<method name="is_bone_enabled" qualifiers="const">
@@ -261,6 +284,15 @@
 				Sets the global pose transform, [param pose], for the bone at [param bone_idx].
 				[param amount] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
 				[b]Note:[/b] The pose transform needs to be a global pose! To convert a world transform from a [Node3D] to a global bone pose, multiply the [method Transform3D.affine_inverse] of the node's [member Node3D.global_transform] by the desired world transform.
+			</description>
+		</method>
+		<method name="set_bone_meta">
+			<return type="void" />
+			<param index="0" name="bone_idx" type="int" />
+			<param index="1" name="key" type="StringName" />
+			<param index="2" name="value" type="Variant" />
+			<description>
+				Sets bone metadata for [param bone_idx], will set the [param key] meta to [param value].
 			</description>
 		</method>
 		<method name="set_bone_name">

--- a/editor/add_metadata_dialog.cpp
+++ b/editor/add_metadata_dialog.cpp
@@ -1,0 +1,118 @@
+/**************************************************************************/
+/*  add_metadata_dialog.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "add_metadata_dialog.h"
+
+AddMetadataDialog::AddMetadataDialog() {
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	add_child(vbc);
+
+	HBoxContainer *hbc = memnew(HBoxContainer);
+	vbc->add_child(hbc);
+	hbc->add_child(memnew(Label(TTR("Name:"))));
+
+	add_meta_name = memnew(LineEdit);
+	add_meta_name->set_custom_minimum_size(Size2(200 * EDSCALE, 1));
+	hbc->add_child(add_meta_name);
+	hbc->add_child(memnew(Label(TTR("Type:"))));
+
+	add_meta_type = memnew(OptionButton);
+
+	hbc->add_child(add_meta_type);
+
+	Control *spacing = memnew(Control);
+	vbc->add_child(spacing);
+	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
+
+	set_ok_button_text(TTR("Add"));
+	register_text_enter(add_meta_name);
+
+	validation_panel = memnew(EditorValidationPanel);
+	vbc->add_child(validation_panel);
+	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name is valid."));
+	validation_panel->set_update_callback(callable_mp(this, &AddMetadataDialog::_check_meta_name));
+	validation_panel->set_accept_button(get_ok_button());
+
+	add_meta_name->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+}
+
+void AddMetadataDialog::_complete_init(const StringName &p_title) {
+	add_meta_name->grab_focus();
+	add_meta_name->set_text("");
+	validation_panel->update();
+
+	set_title(vformat(TTR("Add Metadata Property for \"%s\""), p_title));
+
+	// Skip if we already completed the initialization.
+	if (add_meta_type->get_item_count()) {
+		return;
+	}
+
+	// Theme icons can be retrieved only the Window has been initialized.
+	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+		if (i == Variant::NIL || i == Variant::RID || i == Variant::CALLABLE || i == Variant::SIGNAL) {
+			continue; //not editable by inspector.
+		}
+		String type = i == Variant::OBJECT ? String("Resource") : Variant::get_type_name(Variant::Type(i));
+
+		add_meta_type->add_icon_item(get_editor_theme_icon(type), type, i);
+	}
+}
+
+void AddMetadataDialog::open(const StringName p_title, List<StringName> &p_existing_metas) {
+	this->_existing_metas = p_existing_metas;
+	_complete_init(p_title);
+	popup_centered();
+}
+
+StringName AddMetadataDialog::get_meta_name() {
+	return add_meta_name->get_text();
+}
+
+Variant AddMetadataDialog::get_meta_defval() {
+	Variant defval;
+	Callable::CallError ce;
+	Variant::construct(Variant::Type(add_meta_type->get_selected_id()), defval, nullptr, 0, ce);
+	return defval;
+}
+
+void AddMetadataDialog::_check_meta_name() {
+	const String meta_name = add_meta_name->get_text();
+
+	if (meta_name.is_empty()) {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
+	} else if (!meta_name.is_valid_ascii_identifier()) {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
+	} else if (_existing_metas.find(meta_name)) {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);
+	} else if (meta_name[0] == '_') {
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Names starting with _ are reserved for editor-only metadata."), EditorValidationPanel::MSG_ERROR);
+	}
+}

--- a/editor/add_metadata_dialog.h
+++ b/editor/add_metadata_dialog.h
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  add_metadata_dialog.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef ADD_METADATA_DIALOG_H
+#define ADD_METADATA_DIALOG_H
+
+#include "core/object/callable_method_pointer.h"
+#include "editor/editor_help.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/gui/editor_validation_panel.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/button.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/tree.h"
+
+class AddMetadataDialog : public ConfirmationDialog {
+	GDCLASS(AddMetadataDialog, ConfirmationDialog);
+
+public:
+	AddMetadataDialog();
+	void open(const StringName p_title, List<StringName> &p_existing_metas);
+
+	StringName get_meta_name();
+	Variant get_meta_defval();
+
+private:
+	List<StringName> _existing_metas;
+
+	void _check_meta_name();
+	void _complete_init(const StringName &p_label);
+
+	LineEdit *add_meta_name = nullptr;
+	OptionButton *add_meta_type = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
+};
+#endif // ADD_METADATA_DIALOG_H

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_INSPECTOR_H
 #define EDITOR_INSPECTOR_H
 
+#include "editor/add_metadata_dialog.h"
 #include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/scroll_container.h"
@@ -575,14 +576,13 @@ class EditorInspector : public ScrollContainer {
 
 	bool _is_property_disabled_by_feature_profile(const StringName &p_property);
 
-	ConfirmationDialog *add_meta_dialog = nullptr;
+	AddMetadataDialog *add_meta_dialog = nullptr;
 	LineEdit *add_meta_name = nullptr;
 	OptionButton *add_meta_type = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 
 	void _add_meta_confirm();
 	void _show_add_meta_dialog();
-	void _check_meta_name();
 
 protected:
 	static void _bind_methods();

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef SKELETON_3D_EDITOR_PLUGIN_H
 #define SKELETON_3D_EDITOR_PLUGIN_H
 
+#include "editor/add_metadata_dialog.h"
 #include "editor/editor_properties.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/plugins/editor_plugin.h"
@@ -50,8 +51,8 @@ class Tree;
 class TreeItem;
 class VSeparator;
 
-class BoneTransformEditor : public VBoxContainer {
-	GDCLASS(BoneTransformEditor, VBoxContainer);
+class BonePropertiesEditor : public VBoxContainer {
+	GDCLASS(BonePropertiesEditor, VBoxContainer);
 
 	EditorInspectorSection *section = nullptr;
 
@@ -62,6 +63,10 @@ class BoneTransformEditor : public VBoxContainer {
 
 	EditorInspectorSection *rest_section = nullptr;
 	EditorPropertyTransform3D *rest_matrix = nullptr;
+
+	EditorInspectorSection *meta_section = nullptr;
+	AddMetadataDialog *add_meta_dialog = nullptr;
+	Button *add_metadata_button = nullptr;
 
 	Rect2 background_rects[5];
 
@@ -79,11 +84,18 @@ class BoneTransformEditor : public VBoxContainer {
 
 	void _property_keyed(const String &p_path, bool p_advance);
 
+	void _meta_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
+	void _meta_deleted(const String &p_property);
+	void _show_add_meta_dialog();
+	void _add_meta_confirm();
+
+	HashMap<StringName, EditorProperty *> meta_editors;
+
 protected:
 	void _notification(int p_what);
 
 public:
-	BoneTransformEditor(Skeleton3D *p_skeleton);
+	BonePropertiesEditor(Skeleton3D *p_skeleton);
 
 	// Which transform target to modify.
 	void set_target(const String &p_prop);
@@ -123,8 +135,8 @@ class Skeleton3DEditor : public VBoxContainer {
 	};
 
 	Tree *joint_tree = nullptr;
-	BoneTransformEditor *rest_editor = nullptr;
-	BoneTransformEditor *pose_editor = nullptr;
+	BonePropertiesEditor *rest_editor = nullptr;
+	BonePropertiesEditor *pose_editor = nullptr;
 
 	HBoxContainer *topmenu_bar = nullptr;
 	MenuButton *skeleton_options = nullptr;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5534,6 +5534,10 @@ void GLTFDocument::_convert_skeleton_to_gltf(Skeleton3D *p_skeleton3d, Ref<GLTFS
 		joint_node->set_name(_gen_unique_name(p_state, skeleton->get_bone_name(bone_i)));
 		joint_node->transform = skeleton->get_bone_pose(bone_i);
 		joint_node->joint = true;
+
+		if (p_skeleton3d->has_bone_meta(bone_i, "extras")) {
+			joint_node->set_meta("extras", p_skeleton3d->get_bone_meta(bone_i, "extras"));
+		}
 		GLTFNodeIndex current_node_i = p_state->nodes.size();
 		p_state->scene_nodes.insert(current_node_i, skeleton);
 		p_state->nodes.push_back(joint_node);

--- a/modules/gltf/skin_tool.cpp
+++ b/modules/gltf/skin_tool.cpp
@@ -602,6 +602,11 @@ Error SkinTool::_create_skeletons(
 			skeleton->set_bone_pose_rotation(bone_index, node->transform.basis.get_rotation_quaternion());
 			skeleton->set_bone_pose_scale(bone_index, node->transform.basis.get_scale());
 
+			// Store bone-level GLTF extras in skeleton per bone meta.
+			if (node->has_meta("extras")) {
+				skeleton->set_bone_meta(bone_index, "extras", node->get_meta("extras"));
+			}
+
 			if (node->parent >= 0 && nodes[node->parent]->skeleton == skel_i) {
 				const int bone_parent = skeleton->find_bone(nodes[node->parent]->get_name());
 				ERR_FAIL_COND_V(bone_parent < 0, FAILED);

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -116,6 +116,8 @@ private:
 			}
 		}
 
+		HashMap<StringName, Variant> metadata;
+
 #ifndef DISABLE_DEPRECATED
 		Transform3D pose_global_no_override;
 		real_t global_pose_override_amount = 0.0;
@@ -193,6 +195,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
+	TypedArray<StringName> _get_bone_meta_list_bind(int p_bone) const;
 	static void _bind_methods();
 
 	virtual void add_child_notify(Node *p_child) override;
@@ -237,6 +240,12 @@ public:
 
 	void set_motion_scale(float p_motion_scale);
 	float get_motion_scale() const;
+
+	// bone metadata
+	Variant get_bone_meta(int p_bone, const StringName &p_key) const;
+	void get_bone_meta_list(int p_bone, List<StringName> *p_list) const;
+	bool has_bone_meta(int p_bone, const StringName &p_key) const;
+	void set_bone_meta(int p_bone, const StringName &p_key, const Variant &p_value);
 
 	// Posing API
 	Transform3D get_bone_pose(int p_bone) const;

--- a/tests/scene/test_skeleton_3d.h
+++ b/tests/scene/test_skeleton_3d.h
@@ -1,0 +1,78 @@
+/**************************************************************************/
+/*  test_skeleton_3d.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_SKELETON_3D_H
+#define TEST_SKELETON_3D_H
+
+#include "tests/test_macros.h"
+
+#include "scene/3d/skeleton_3d.h"
+
+namespace TestSkeleton3D {
+
+TEST_CASE("[Skeleton3D] Test per-bone meta") {
+	Skeleton3D *skeleton = memnew(Skeleton3D);
+	skeleton->add_bone("root");
+	skeleton->set_bone_rest(0, Transform3D());
+
+	// Adding meta to bone.
+	skeleton->set_bone_meta(0, "key1", "value1");
+	skeleton->set_bone_meta(0, "key2", 12345);
+	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == "value1", "Bone meta missing.");
+	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key2") == Variant(12345), "Bone meta missing.");
+
+	// Rename bone and check if meta persists.
+	skeleton->set_bone_name(0, "renamed_root");
+	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == "value1", "Bone meta missing.");
+	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key2") == Variant(12345), "Bone meta missing.");
+
+	// Retrieve list of keys.
+	List<StringName> keys;
+	skeleton->get_bone_meta_list(0, &keys);
+	CHECK_MESSAGE(keys.size() == 2, "Wrong number of bone meta keys.");
+	CHECK_MESSAGE(keys.find("key1"), "key1 not found in bone meta list");
+	CHECK_MESSAGE(keys.find("key2"), "key2 not found in bone meta list");
+
+	// Removing meta.
+	skeleton->set_bone_meta(0, "key1", Variant());
+	skeleton->set_bone_meta(0, "key2", Variant());
+	CHECK_MESSAGE(!skeleton->has_bone_meta(0, "key1"), "Bone meta key1 should be deleted.");
+	CHECK_MESSAGE(!skeleton->has_bone_meta(0, "key2"), "Bone meta key2 should be deleted.");
+	List<StringName> should_be_empty_keys;
+	skeleton->get_bone_meta_list(0, &should_be_empty_keys);
+	CHECK_MESSAGE(should_be_empty_keys.size() == 0, "Wrong number of bone meta keys.");
+
+	// Deleting non-existing key should succeed.
+	skeleton->set_bone_meta(0, "non-existing-key", Variant());
+	memdelete(skeleton);
+}
+} // namespace TestSkeleton3D
+
+#endif // TEST_SKELETON_3D_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -160,6 +160,7 @@
 #include "tests/scene/test_path_3d.h"
 #include "tests/scene/test_path_follow_3d.h"
 #include "tests/scene/test_primitives.h"
+#include "tests/scene/test_skeleton_3d.h"
 #endif // _3D_DISABLED
 
 #include "modules/modules_tests.gen.h"


### PR DESCRIPTION
- Bones are not represented as `Node`s and don't inherit get/set meta functionality from `Object`, so the skeleton has to carry the meta information similarly to how other per-bone properties are handled.
- Adds support for GLTF import/export

This was split off of https://github.com/godotengine/godot/pull/86183 which only deals with import/export of metadata for nodes, meshes and materials - all of which do inherit from Object and therefore support metadata already.

Supporting the same for bones requires changes to `Skeleton3D` datastructure, so it's better to have the discussion separate.

![image](https://github.com/user-attachments/assets/b1d0749a-5493-4560-953b-d293bab85fd3)

