### PR TITLE
SCons: Silence redundant MSVC output

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -186,6 +186,7 @@ def get_opts():
         BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
         BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False),
         BoolVariable("incremental_link", "Use MSVC incremental linking. May increase or decrease build times.", False),
+        BoolVariable("silence_msvc", "Silence MSVC's stdout. Decreases output log bloat by roughly half.", True),
         ("angle_libs", "Path to the ANGLE static libraries", ""),
         # Direct3D 12 support.
         ("mesa_libs", "Path to the MESA/NIR static libraries (required for D3D12)", ""),
@@ -357,6 +358,20 @@ def configure_msvc(env, vcvars_msvc_config):
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
 
     ## Compile/link flags
+
+    env["MAXLINELENGTH"] = 8192  # Windows Vista and beyond, so always applicable.
+
+    if env["silence_msvc"]:
+        env.Prepend(CCFLAGS=[">", "NUL"])
+        env.Prepend(LINKFLAGS=[">", "NUL"])
+
+        # "> NUL" fails if using a tempfile, circumvent by removing the argument altogether.
+        old_esc_func = env["TEMPFILEARGESCFUNC"]
+
+        def trim_nul(arg):
+            return "" if arg in [">", "NUL"] else old_esc_func(arg)
+
+        env["TEMPFILEARGESCFUNC"] = trim_nul
 
     if env["debug_crt"]:
         # Always use dynamic runtime, static debug CRT breaks thread_local.


### PR DESCRIPTION
"Closes" #72246. Technically, that issue is already closed & marked as "not planned", as this is actually an msvc bug[^1]. Nonetheless, I've figured out a workaround for the majority of the issues caused by this: redirecting the `stdout` to `NULL` where supported. This works like a charm when compiling objects and resources, effectively reducing output bloat by half! ~~I haven't found a workaround for the linker, but there's only ever less than a handful of files linked in a given build, so it's much less of a concern.~~ In practice, the output logs are significantly cleaner & much more closely resemble `gcc`/`clang`, and preserving `stderr` allows potential errors to still be caught and logged as before

Before:
```
[  9%] Compiling thirdparty\libvorbis\sharedbook.c ...
mapping0.c
[  9%] Compiling thirdparty\libvorbis\smallft.c ...
mdct.c
[  9%] Compiling thirdparty\libvorbis\synthesis.c ...
psy.c
registry.c
sharedbook.c
res0.c
smallft.c
synthesis.c
[  9%] Compiling modules\msdfgen\register_types.cpp ...
[  9%] Compiling thirdparty\libvorbis\vorbisfile.c ...
[  9%] Compiling thirdparty\libvorbis\window.c ...
```

After:
```
[  9%] Compiling thirdparty\libvorbis\res0.c ...
[  9%] Compiling thirdparty\libvorbis\sharedbook.c ...
[  9%] Compiling thirdparty\libvorbis\smallft.c ...
[  9%] Compiling thirdparty\libvorbis\synthesis.c ...
[  9%] Compiling modules\theora\video_stream_theora.cpp ...
[  9%] Compiling modules\theora\register_types.cpp ...
[  9%] Compiling modules\msdfgen\register_types.cpp ...
[  9%] Compiling thirdparty\libvorbis\vorbisfile.c ...
[  9%] Compiling thirdparty\libvorbis\window.c ...
[ 10%] Compiling thirdparty\astcenc\astcenc_averages_and_directions.cpp ...
[ 10%] Compiling thirdparty\astcenc\astcenc_block_sizes.cpp ...
[ 10%] Compiling thirdparty\astcenc\astcenc_color_quantize.cpp ...
[ 10%] Compiling thirdparty\astcenc\astcenc_color_unquantize.cpp ...
[ 10%] Compiling thirdparty\astcenc\astcenc_compress_symbolic.cpp ...
```

[^1]: https://developercommunity.visualstudio.com/t/allow-having-clexe-not-print-the-compiled-source-f/717761 