### PR TITLE
Fix some `TileMap` debug drawing truncating to ints

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1869,7 +1869,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_unscaled_draw() {
 		for (int i = 0; i < tile_set_atlas_source->get_tiles_count(); i++) {
 			Vector2i coords = tile_set_atlas_source->get_tile_id(i);
 			Rect2i texture_region = tile_set_atlas_source->get_tile_texture_region(coords);
-			Vector2i position = texture_region.get_center() + tile_set_atlas_source->get_tile_data(coords, 0)->get_texture_origin();
+			Vector2 position = ((Rect2)texture_region).get_center() + tile_set_atlas_source->get_tile_data(coords, 0)->get_texture_origin();
 
 			Transform2D xform = tile_atlas_control->get_parent_control()->get_transform();
 			xform.translate_local(position);
@@ -1892,7 +1892,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_unscaled_draw() {
 					continue;
 				}
 				Rect2i texture_region = tile_set_atlas_source->get_tile_texture_region(E.tile);
-				Vector2i position = texture_region.get_center() + tile_set_atlas_source->get_tile_data(E.tile, 0)->get_texture_origin();
+				Vector2 position = ((Rect2)texture_region).get_center() + tile_set_atlas_source->get_tile_data(E.tile, 0)->get_texture_origin();
 
 				Transform2D xform = tile_atlas_control->get_parent_control()->get_transform();
 				xform.translate_local(position);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -634,7 +634,7 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 }
 
 #ifdef DEBUG_ENABLED
-void TileMapLayer::_rendering_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data) {
+void TileMapLayer::_rendering_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data) {
 	const Ref<TileSet> &tile_set = tile_map_node->get_tileset();
 	ERR_FAIL_COND(!tile_set.is_valid());
 
@@ -898,7 +898,7 @@ void TileMapLayer::_physics_update_cell(CellData &r_cell_data) {
 }
 
 #ifdef DEBUG_ENABLED
-void TileMapLayer::_physics_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data) {
+void TileMapLayer::_physics_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data) {
 	// Draw the debug collision shapes.
 	const Ref<TileSet> &tile_set = tile_map_node->get_tileset();
 	ERR_FAIL_COND(!tile_set.is_valid());
@@ -1117,7 +1117,7 @@ void TileMapLayer::_navigation_update_cell(CellData &r_cell_data) {
 }
 
 #ifdef DEBUG_ENABLED
-void TileMapLayer::_navigation_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data) {
+void TileMapLayer::_navigation_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data) {
 	// Draw the debug collision shapes.
 	bool show_navigation = false;
 	switch (tile_map_node->get_navigation_visibility_mode()) {
@@ -1302,7 +1302,7 @@ void TileMapLayer::_scenes_update_cell(CellData &r_cell_data) {
 }
 
 #ifdef DEBUG_ENABLED
-void TileMapLayer::_scenes_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data) {
+void TileMapLayer::_scenes_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data) {
 	const Ref<TileSet> &tile_set = tile_map_node->get_tileset();
 	ERR_FAIL_COND(!tile_set.is_valid());
 

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -300,7 +300,7 @@ private:
 	void _rendering_occluders_clear_cell(CellData &r_cell_data);
 	void _rendering_occluders_update_cell(CellData &r_cell_data);
 #ifdef DEBUG_ENABLED
-	void _rendering_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data);
+	void _rendering_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data);
 #endif // DEBUG_ENABLED
 
 	HashMap<RID, Vector2i> bodies_coords; // Mapping for RID to coords.
@@ -310,7 +310,7 @@ private:
 	void _physics_clear_cell(CellData &r_cell_data);
 	void _physics_update_cell(CellData &r_cell_data);
 #ifdef DEBUG_ENABLED
-	void _physics_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data);
+	void _physics_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data);
 #endif // DEBUG_ENABLED
 
 	bool _navigation_was_cleaned_up = false;
@@ -318,7 +318,7 @@ private:
 	void _navigation_clear_cell(CellData &r_cell_data);
 	void _navigation_update_cell(CellData &r_cell_data);
 #ifdef DEBUG_ENABLED
-	void _navigation_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data);
+	void _navigation_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data);
 #endif // DEBUG_ENABLED
 
 	bool _scenes_was_cleaned_up = false;
@@ -326,7 +326,7 @@ private:
 	void _scenes_clear_cell(CellData &r_cell_data);
 	void _scenes_update_cell(CellData &r_cell_data);
 #ifdef DEBUG_ENABLED
-	void _scenes_draw_cell_debug(const RID &p_canvas_item, const Vector2i &p_quadrant_pos, const CellData &r_cell_data);
+	void _scenes_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data);
 #endif // DEBUG_ENABLED
 
 	// Terrains.


### PR DESCRIPTION
Fixes part of #87138 (besides the incorrect generation of the navigation polygon (see https://github.com/godotengine/godot/issues/87138#issuecomment-1890810824)).



- `quadrant_pos` was correctly calculated as `Vector2` but it was converted to `Vector2i` when passing to `_X_draw_cell_debug` methods:
https://github.com/godotengine/godot/blob/26b1fd0d842fa3c2f090ead47e8ea7cd2d6515e1/scene/2d/tile_map_layer.cpp#L126-L136

- `Rect2i::get_center` returning `Vector2i` instead of `Vector2` strikes again. This time making the offset for the texture region center being calculated incorrectly.
Still no idea why this method works like that. For me it's like if `Vector2i::length` would be returning `int` instead of `float` etc. :upside_down_face: Maybe we could/should add something like `Rect2i::get_centerf`? :thinking: (assuming `Rect2i::get_center` can't be changed because of compat)


|debug drawing| Before<br>(v4.3.dev1.official [9d1cbab1c])| After<br>(this PR) |
|-|--------|--------|
|Physics<br>- rendering offsets fixed|![Godot_v4 3-dev1_win64_m0yNeSm9AH](https://github.com/godotengine/godot/assets/9283098/e9aabb7e-2939-4a3a-9226-4e4d146fa0ef)|![AUAudD4WTr](https://github.com/godotengine/godot/assets/9283098/27771852-24aa-4505-a1fd-2639b78686c1)|
|Navigation<br>- rendering offsets fixed<br>- still incorrect polygon generated|![TJOynU8MBc](https://github.com/godotengine/godot/assets/9283098/494dfc1b-c78f-4b91-927b-759a4fe0a7c0)|![WapiwxvbWN](https://github.com/godotengine/godot/assets/9283098/6e28b36e-fc25-4248-a9fd-18c7c86b5ecf)|

Haven't tested this thoroughly so not sure if maybe something else got broken/revealed incorrect offset calculation or something like that.