### PR TITLE
Do not commit transforms and handles if no changes were made

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -291,6 +291,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 					const PosVertex closest = closest_point(gpoint);
 					if (closest.valid()) {
+						original_mouse_pos = gpoint;
 						pre_move_edit = _get_polygon(closest.polygon);
 						edited_point = PosVertex(closest, xform.affine_inverse().xform(closest.pos));
 						selected_point = closest;
@@ -327,15 +328,15 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 					}
 				} else {
 					if (edited_point.valid()) {
-						//apply
+						if (original_mouse_pos != gpoint) {
+							Vector<Vector2> vertices = _get_polygon(edited_point.polygon);
+							ERR_FAIL_INDEX_V(edited_point.vertex, vertices.size(), false);
+							vertices.write[edited_point.vertex] = edited_point.pos - _get_offset(edited_point.polygon);
 
-						Vector<Vector2> vertices = _get_polygon(edited_point.polygon);
-						ERR_FAIL_INDEX_V(edited_point.vertex, vertices.size(), false);
-						vertices.write[edited_point.vertex] = edited_point.pos - _get_offset(edited_point.polygon);
-
-						undo_redo->create_action(TTR("Edit Polygon"));
-						_action_set_polygon(edited_point.polygon, pre_move_edit, vertices);
-						_commit_action();
+							undo_redo->create_action(TTR("Edit Polygon"));
+							_action_set_polygon(edited_point.polygon, pre_move_edit, vertices);
+							_commit_action();
+						}
 
 						edited_point = PosVertex();
 						return true;

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -79,6 +79,7 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 	Vertex hover_point; // point under mouse cursor
 	Vertex selected_point; // currently selected
 	PosVertex edge_point; // adding an edge point?
+	Vector2 original_mouse_pos;
 
 	Vector<Vector2> pre_move_edit;
 	Vector<Vector2> wip;

--- a/editor/plugins/cast_2d_editor_plugin.cpp
+++ b/editor/plugins/cast_2d_editor_plugin.cpp
@@ -65,10 +65,13 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		Vector2 target_position = node->get("target_position");
 
+		Vector2 gpoint = mb->get_position();
+
 		if (mb->is_pressed()) {
-			if (xform.xform(target_position).distance_to(mb->get_position()) < 8) {
+			if (xform.xform(target_position).distance_to(gpoint) < 8) {
 				pressed = true;
 				original_target_position = target_position;
+				original_mouse_pos = gpoint;
 
 				return true;
 			} else {
@@ -77,16 +80,17 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 				return false;
 			}
 		} else if (pressed) {
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action(TTR("Set Target Position"));
-			undo_redo->add_do_property(node, "target_position", target_position);
-			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-			undo_redo->add_undo_property(node, "target_position", original_target_position);
-			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
-			undo_redo->commit_action();
+			if (original_mouse_pos != gpoint) {
+				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+				undo_redo->create_action(TTR("Set Target Position"));
+				undo_redo->add_do_property(node, "target_position", target_position);
+				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+				undo_redo->add_undo_property(node, "target_position", original_target_position);
+				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+				undo_redo->commit_action();
+			}
 
 			pressed = false;
-
 			return true;
 		}
 	}

--- a/editor/plugins/cast_2d_editor_plugin.h
+++ b/editor/plugins/cast_2d_editor_plugin.h
@@ -44,6 +44,7 @@ class Cast2DEditor : public Control {
 
 	bool pressed = false;
 	Point2 original_target_position;
+	Vector2 original_mouse_pos;
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -326,6 +326,7 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 					return false;
 				}
 
+				original_mouse_pos = gpoint;
 				original_point = handles[edit_handle];
 				original = get_handle_value(edit_handle);
 				original_transform = node->get_global_transform();
@@ -336,7 +337,9 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 
 			} else {
 				if (pressed) {
-					commit_handle(edit_handle, original);
+					if (original_mouse_pos != gpoint) {
+						commit_handle(edit_handle, original);
+					}
 
 					edit_handle = -1;
 					pressed = false;

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -74,6 +74,7 @@ class CollisionShape2DEditor : public Control {
 	Transform2D original_transform;
 	Vector2 original_point;
 	Point2 last_point;
+	Vector2 original_mouse_pos;
 
 	Ref<Shape2D> current_shape;
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1870,7 +1870,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					surface->queue_redraw();
 				} else {
 					if (_edit.gizmo.is_valid()) {
-						_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
+						if (_edit.original_mouse_pos != _edit.mouse_pos) {
+							_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
+						}
 						_edit.gizmo = Ref<EditorNode3DGizmo>();
 						break;
 					}
@@ -1904,7 +1906,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 							se->gizmo->commit_subgizmos(ids, restore, false);
 						} else {
-							commit_transform();
+							if (_edit.original_mouse_pos != _edit.mouse_pos) {
+								commit_transform();
+							}
 						}
 						_edit.mode = TRANSFORM_NONE;
 						set_message("");

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -86,6 +86,8 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		if (mb->is_pressed() && action == ACTION_NONE) {
 			Ref<Curve2D> curve = node->get_curve();
 
+			original_mouse_pos = gpoint;
+
 			for (int i = 0; i < curve->get_point_count(); i++) {
 				real_t dist_to_p = gpoint.distance_to(xform.xform(curve->get_point_position(i)));
 				real_t dist_to_p_out = gpoint.distance_to(xform.xform(curve->get_point_position(i) + curve->get_point_out(i)));
@@ -224,45 +226,48 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 				case ACTION_MOVING_POINT:
 				case ACTION_MOVING_NEW_POINT: {
-					if (action == ACTION_MOVING_POINT) {
-						undo_redo->create_action(TTR("Move Point in Curve"));
-						undo_redo->add_undo_method(curve.ptr(), "set_point_position", action_point, moving_from);
+					if (original_mouse_pos != gpoint) {
+						if (action == ACTION_MOVING_POINT) {
+							undo_redo->create_action(TTR("Move Point in Curve"));
+							undo_redo->add_undo_method(curve.ptr(), "set_point_position", action_point, moving_from);
+						}
+						undo_redo->add_do_method(curve.ptr(), "set_point_position", action_point, cpoint);
+						undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+						undo_redo->commit_action(false);
 					}
-					undo_redo->add_do_method(curve.ptr(), "set_point_position", action_point, cpoint);
-					undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-					undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
-					undo_redo->commit_action(false);
-
 				} break;
 
 				case ACTION_MOVING_IN: {
-					undo_redo->create_action(TTR("Move In-Control in Curve"));
-					undo_redo->add_do_method(curve.ptr(), "set_point_in", action_point, new_pos);
-					undo_redo->add_undo_method(curve.ptr(), "set_point_in", action_point, moving_from);
+					if (original_mouse_pos != gpoint) {
+						undo_redo->create_action(TTR("Move In-Control in Curve"));
+						undo_redo->add_do_method(curve.ptr(), "set_point_in", action_point, new_pos);
+						undo_redo->add_undo_method(curve.ptr(), "set_point_in", action_point, moving_from);
 
-					if (mirror_handle_angle) {
-						undo_redo->add_do_method(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_out_length));
-						undo_redo->add_undo_method(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_out_length));
+						if (mirror_handle_angle) {
+							undo_redo->add_do_method(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_out_length));
+							undo_redo->add_undo_method(curve.ptr(), "set_point_out", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_out_length));
+						}
+						undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+						undo_redo->commit_action();
 					}
-					undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-					undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
-					undo_redo->commit_action();
-
 				} break;
 
 				case ACTION_MOVING_OUT: {
-					undo_redo->create_action(TTR("Move Out-Control in Curve"));
-					undo_redo->add_do_method(curve.ptr(), "set_point_out", action_point, new_pos);
-					undo_redo->add_undo_method(curve.ptr(), "set_point_out", action_point, moving_from);
+					if (original_mouse_pos != gpoint) {
+						undo_redo->create_action(TTR("Move Out-Control in Curve"));
+						undo_redo->add_do_method(curve.ptr(), "set_point_out", action_point, new_pos);
+						undo_redo->add_undo_method(curve.ptr(), "set_point_out", action_point, moving_from);
 
-					if (mirror_handle_angle) {
-						undo_redo->add_do_method(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_in_length));
-						undo_redo->add_undo_method(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_in_length));
+						if (mirror_handle_angle) {
+							undo_redo->add_do_method(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -new_pos : (-new_pos.normalized() * orig_in_length));
+							undo_redo->add_undo_method(curve.ptr(), "set_point_in", action_point, mirror_handle_length ? -moving_from : (-moving_from.normalized() * orig_in_length));
+						}
+						undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+						undo_redo->commit_action();
 					}
-					undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-					undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
-					undo_redo->commit_action();
-
 				} break;
 			}
 

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -92,6 +92,7 @@ class Path2DEditor : public HBoxContainer {
 	float orig_in_length = 0.0f;
 	float orig_out_length = 0.0f;
 	Vector2 edge_point;
+	Vector2 original_mouse_pos;
 
 	void _mode_selected(int p_mode);
 	void _handle_option_pressed(int p_option);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Currently left clicking without moving the mouse will commit a transform and handles unnecessarily flooding the output and history with transform messages. This PR checks that the mouse was moved, meaning a changed was made, before committing. 

![image](https://github.com/godotengine/godot/assets/105675984/76faad21-2a13-45c3-a5ec-d54c1605b2ff)

![image](https://github.com/godotengine/godot/assets/105675984/6a00a38f-7b2e-4a95-865a-96c3300b7e98)


![image](https://github.com/godotengine/godot/assets/105675984/3e7db056-1fa2-4888-a07c-d841cb4f2c9c)
