### PR TITLE
Rename camera `near` and `far` private members to avoid conflict with `Windows.h` defines

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -45,14 +45,14 @@ void Camera3D::_update_camera_mode() {
 	force_change = true;
 	switch (mode) {
 		case PROJECTION_PERSPECTIVE: {
-			set_perspective(fov, near, far);
+			set_perspective(fov, _near, _far);
 
 		} break;
 		case PROJECTION_ORTHOGONAL: {
-			set_orthogonal(size, near, far);
+			set_orthogonal(size, _near, _far);
 		} break;
 		case PROJECTION_FRUSTUM: {
-			set_frustum(size, frustum_offset, near, far);
+			set_frustum(size, frustum_offset, _near, _far);
 		} break;
 	}
 }
@@ -175,13 +175,13 @@ Projection Camera3D::_get_camera_projection(real_t p_near) const {
 
 	switch (mode) {
 		case PROJECTION_PERSPECTIVE: {
-			cm.set_perspective(fov, viewport_size.aspect(), p_near, far, keep_aspect == KEEP_WIDTH);
+			cm.set_perspective(fov, viewport_size.aspect(), p_near, _far, keep_aspect == KEEP_WIDTH);
 		} break;
 		case PROJECTION_ORTHOGONAL: {
-			cm.set_orthogonal(size, viewport_size.aspect(), p_near, far, keep_aspect == KEEP_WIDTH);
+			cm.set_orthogonal(size, viewport_size.aspect(), p_near, _far, keep_aspect == KEEP_WIDTH);
 		} break;
 		case PROJECTION_FRUSTUM: {
-			cm.set_frustum(size, viewport_size.aspect(), frustum_offset, p_near, far);
+			cm.set_frustum(size, viewport_size.aspect(), frustum_offset, p_near, _far);
 		} break;
 	}
 
@@ -190,54 +190,54 @@ Projection Camera3D::_get_camera_projection(real_t p_near) const {
 
 Projection Camera3D::get_camera_projection() const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Projection(), "Camera is not inside the scene tree.");
-	return _get_camera_projection(near);
+	return _get_camera_projection(_near);
 }
 
 void Camera3D::set_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far) {
-	if (!force_change && fov == p_fovy_degrees && p_z_near == near && p_z_far == far && mode == PROJECTION_PERSPECTIVE) {
+	if (!force_change && fov == p_fovy_degrees && p_z_near == _near && p_z_far == _far && mode == PROJECTION_PERSPECTIVE) {
 		return;
 	}
 
 	fov = p_fovy_degrees;
-	near = p_z_near;
-	far = p_z_far;
+	_near = p_z_near;
+	_far = p_z_far;
 	mode = PROJECTION_PERSPECTIVE;
 
-	RenderingServer::get_singleton()->camera_set_perspective(camera, fov, near, far);
+	RenderingServer::get_singleton()->camera_set_perspective(camera, fov, _near, _far);
 	update_gizmos();
 	force_change = false;
 }
 
 void Camera3D::set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far) {
-	if (!force_change && size == p_size && p_z_near == near && p_z_far == far && mode == PROJECTION_ORTHOGONAL) {
+	if (!force_change && size == p_size && p_z_near == _near && p_z_far == _far && mode == PROJECTION_ORTHOGONAL) {
 		return;
 	}
 
 	size = p_size;
 
-	near = p_z_near;
-	far = p_z_far;
+	_near = p_z_near;
+	_far = p_z_far;
 	mode = PROJECTION_ORTHOGONAL;
 	force_change = false;
 
-	RenderingServer::get_singleton()->camera_set_orthogonal(camera, size, near, far);
+	RenderingServer::get_singleton()->camera_set_orthogonal(camera, size, _near, _far);
 	update_gizmos();
 }
 
 void Camera3D::set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far) {
-	if (!force_change && size == p_size && frustum_offset == p_offset && p_z_near == near && p_z_far == far && mode == PROJECTION_FRUSTUM) {
+	if (!force_change && size == p_size && frustum_offset == p_offset && p_z_near == _near && p_z_far == _far && mode == PROJECTION_FRUSTUM) {
 		return;
 	}
 
 	size = p_size;
 	frustum_offset = p_offset;
 
-	near = p_z_near;
-	far = p_z_far;
+	_near = p_z_near;
+	_far = p_z_far;
 	mode = PROJECTION_FRUSTUM;
 	force_change = false;
 
-	RenderingServer::get_singleton()->camera_set_frustum(camera, size, frustum_offset, near, far);
+	RenderingServer::get_singleton()->camera_set_frustum(camera, size, frustum_offset, _near, _far);
 	update_gizmos();
 }
 
@@ -309,9 +309,9 @@ Vector3 Camera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	if (mode == PROJECTION_ORTHOGONAL) {
 		ray = Vector3(0, 0, -1);
 	} else {
-		Projection cm = _get_camera_projection(near);
+		Projection cm = _get_camera_projection(_near);
 		Vector2 screen_he = cm.get_viewport_half_extents();
-		ray = Vector3(((cpos.x / viewport_size.width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (cpos.y / viewport_size.height)) * 2.0 - 1.0) * screen_he.y, -near).normalized();
+		ray = Vector3(((cpos.x / viewport_size.width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (cpos.y / viewport_size.height)) * 2.0 - 1.0) * screen_he.y, -_near).normalized();
 	}
 
 	return ray;
@@ -338,7 +338,7 @@ Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 		Vector3 ray;
 		ray.x = pos.x * (hsize)-hsize / 2;
 		ray.y = (1.0 - pos.y) * (vsize)-vsize / 2;
-		ray.z = -near;
+		ray.z = -_near;
 		ray = get_camera_transform().xform(ray);
 		return ray;
 	} else {
@@ -349,13 +349,13 @@ Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 bool Camera3D::is_position_behind(const Vector3 &p_pos) const {
 	Transform3D t = get_global_transform();
 	Vector3 eyedir = -t.basis.get_column(2).normalized();
-	return eyedir.dot(p_pos - t.origin) < near;
+	return eyedir.dot(p_pos - t.origin) < _near;
 }
 
 Vector<Vector3> Camera3D::get_near_plane_points() const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector<Vector3>(), "Camera is not inside scene.");
 
-	Projection cm = _get_camera_projection(near);
+	Projection cm = _get_camera_projection(_near);
 
 	Vector3 endpoints[8];
 	cm.get_endpoints(Transform3D(), endpoints);
@@ -375,7 +375,7 @@ Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
-	Projection cm = _get_camera_projection(near);
+	Projection cm = _get_camera_projection(_near);
 
 	Plane p(get_camera_transform().xform_inv(p_pos), 1.0);
 
@@ -459,8 +459,8 @@ void Camera3D::_attributes_changed() {
 	ERR_FAIL_NULL(physical_attributes);
 
 	fov = physical_attributes->get_fov();
-	near = physical_attributes->get_near();
-	far = physical_attributes->get_far();
+	_near = physical_attributes->get_near();
+	_far = physical_attributes->get_far();
 	keep_aspect = KEEP_HEIGHT;
 	_update_camera_mode();
 }
@@ -583,7 +583,7 @@ real_t Camera3D::get_size() const {
 }
 
 real_t Camera3D::get_near() const {
-	return near;
+	return _near;
 }
 
 Vector2 Camera3D::get_frustum_offset() const {
@@ -591,7 +591,7 @@ Vector2 Camera3D::get_frustum_offset() const {
 }
 
 real_t Camera3D::get_far() const {
-	return far;
+	return _far;
 }
 
 Camera3D::ProjectionType Camera3D::get_projection() const {
@@ -611,7 +611,7 @@ void Camera3D::set_size(real_t p_size) {
 }
 
 void Camera3D::set_near(real_t p_near) {
-	near = p_near;
+	_near = p_near;
 	_update_camera_mode();
 }
 
@@ -621,7 +621,7 @@ void Camera3D::set_frustum_offset(Vector2 p_offset) {
 }
 
 void Camera3D::set_far(real_t p_far) {
-	far = p_far;
+	_far = p_far;
 	_update_camera_mode();
 }
 
@@ -656,7 +656,7 @@ bool Camera3D::get_cull_mask_value(int p_layer_number) const {
 Vector<Plane> Camera3D::get_frustum() const {
 	ERR_FAIL_COND_V(!is_inside_world(), Vector<Plane>());
 
-	Projection cm = _get_camera_projection(near);
+	Projection cm = _get_camera_projection(_near);
 
 	return cm.get_projection_planes(get_camera_transform());
 }

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -36,11 +36,6 @@
 #include "scene/resources/camera_attributes.h"
 #include "scene/resources/environment.h"
 
-#ifdef MINGW_ENABLED
-#undef near
-#undef far
-#endif
-
 class Camera3D : public Node3D {
 	GDCLASS(Camera3D, Node3D);
 
@@ -72,8 +67,9 @@ private:
 	real_t fov = 75.0;
 	real_t size = 1.0;
 	Vector2 frustum_offset;
-	real_t near = 0.05;
-	real_t far = 4000.0;
+	// _ prefix to avoid conflict with Windows defines.
+	real_t _near = 0.05;
+	real_t _far = 4000.0;
 	real_t v_offset = 0.0;
 	real_t h_offset = 0.0;
 	KeepAspect keep_aspect = KEEP_HEIGHT;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -885,7 +885,7 @@ void Viewport::_process_picking() {
 			if (camera_3d) {
 				Vector3 from = camera_3d->project_ray_origin(pos);
 				Vector3 dir = camera_3d->project_ray_normal(pos);
-				real_t far = camera_3d->far;
+				real_t far = camera_3d->get_far();
 
 				PhysicsDirectSpaceState3D *space = PhysicsServer3D::get_singleton()->space_get_direct_state(find_world_3d()->get_space());
 				if (space) {


### PR DESCRIPTION
Sadly `Windows.h` defines macros for both `near` and `far` so naming variables like this, especially in header files is causing a lot of issues. As soon as any file includes `Windows.h` before `camera_3d.h` your build will simply fail. While `camera_3d.h` does already include undefs for mingw builds this is insufficient as those macros are used in other parts of the windows headers as well.

This PR simply renames `Camera3D::far` and `Camera3D::near` to `Camera3D::camera_far` and `Camera3D::camera_near` to avoid this issue alltogether. Since all public methods stay the same this shouldn't cause any downstream issues.
