### PR TITLE
Fix Windows editor reload when a GDExtension lacks `FreeLibrary` support

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -536,6 +536,16 @@ List<String> OS::get_restart_on_exit_arguments() const {
 	return restart_commandline;
 }
 
+Error OS::kill_previous_editor_and_wait(const ProcessID &p_pid) {
+	// On most platforms, kill waits for the process to exit. On Windows, it
+	// doesn't, and needs to be overridden for this case specifically.
+	return kill(p_pid);
+}
+
+bool OS::is_restart_responsible_for_exit() const {
+	return false;
+}
+
 PackedStringArray OS::get_connected_midi_inputs() {
 	if (MIDIDriver::get_singleton()) {
 		return MIDIDriver::get_singleton()->get_connected_inputs();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -95,6 +95,8 @@ public:
 		RENDER_SEPARATE_THREAD
 	};
 
+	typedef int64_t ProcessID;
+
 protected:
 	friend class Main;
 	// Needed by tests to setup command-line args.
@@ -124,9 +126,10 @@ protected:
 
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
-public:
-	typedef int64_t ProcessID;
+	virtual Error kill_previous_editor_and_wait(const ProcessID &p_pid);
+	virtual bool is_restart_responsible_for_exit() const;
 
+public:
 	static OS *get_singleton();
 
 	String get_current_rendering_driver_name() const { return _current_rendering_driver_name; }
@@ -301,7 +304,7 @@ public:
 
 	void set_restart_on_exit(bool p_restart, const List<String> &p_restart_arguments);
 	bool is_restart_on_exit_set() const;
-	List<String> get_restart_on_exit_arguments() const;
+	virtual List<String> get_restart_on_exit_arguments() const;
 
 	virtual bool request_permission(const String &p_name) { return true; }
 	virtual bool request_permissions() { return true; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -179,6 +179,7 @@ static OS::ProcessID editor_pid = 0;
 static bool found_project = false;
 static bool auto_build_solutions = false;
 static String debug_server_uri;
+static OS::ProcessID kill_previous_editor_pid = 0;
 #ifndef DISABLE_DEPRECATED
 static int converter_max_kb_file = 4 * 1024; // 4MB
 static int converter_max_line_length = 100000;
@@ -523,6 +524,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --gdscript-docs <path>            Rather than dumping the engine API, generate API reference from the inline documentation in the GDScript files found in <path> (used with --doctool).\n");
 #endif
 	OS::get_singleton()->print("  --build-solutions                 Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
+	OS::get_singleton()->print("  --kill-previous-editor-pid <pid>  Kill the process identified by <pid> before initialization. Used internally by 'Reload Current Project' on Windows.\n");
 	OS::get_singleton()->print("  --dump-gdextension-interface      Generate GDExtension header file 'gdextension_interface.h' in the current folder. This file is the base file required to implement a GDExtension.\n");
 	OS::get_singleton()->print("  --dump-extension-api              Generate JSON dump of the Godot API for GDExtension bindings named 'extension_api.json' in the current folder.\n");
 	OS::get_singleton()->print("  --dump-extension-api-with-docs    Generate JSON dump of the Godot API like the previous option, but including documentation.\n");
@@ -1241,6 +1243,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			auto_build_solutions = true;
 			editor = true;
 			cmdline_tool = true;
+		} else if (I->get() == "--kill-previous-editor-pid") {
+			if (I->next()) {
+				kill_previous_editor_pid = I->next()->get().to_int();
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing kill-previous-editor-pid PID argument, aborting.\n");
+				goto error;
+			}
 		} else if (I->get() == "--dump-gdextension-interface") {
 			// Register as an editor instance to use low-end fallback if relevant.
 			editor = true;
@@ -1577,6 +1587,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->print(
 				"Error: Command line arguments implied opening both editor and project manager, which is not possible. Aborting.\n");
 		goto error;
+	}
+#endif
+
+#ifdef TOOLS_ENABLED
+	if (kill_previous_editor_pid) {
+		// Ignore error result. The internal prints are sufficient, and this is
+		// just a best effort for a Windows GDExtension corner case.
+		OS::get_singleton()->kill_previous_editor_and_wait(kill_previous_editor_pid);
 	}
 #endif
 
@@ -4026,7 +4044,8 @@ void Main::cleanup(bool p_force) {
 		//attempt to restart with arguments
 		List<String> args = OS::get_singleton()->get_restart_on_exit_arguments();
 		OS::get_singleton()->create_instance(args);
-		OS::get_singleton()->set_restart_on_exit(false, List<String>()); //clear list (uses memory)
+		// Clear list (uses memory) but leave the boolean true.
+		OS::get_singleton()->set_restart_on_exit(true, List<String>());
 	}
 
 	// Now should be safe to delete MessageQueue (famous last words).
@@ -4042,4 +4061,9 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->benchmark_dump();
 
 	OS::get_singleton()->finalize_core();
+
+	if (OS::get_singleton()->is_restart_responsible_for_exit()) {
+		// Wait for 10 seconds to let the new instance kill the current one.
+		OS::get_singleton()->delay_usec(10 * 1000 * 1000);
+	}
 }

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -149,6 +149,9 @@ protected:
 	virtual void finalize_core() override;
 	virtual String get_stdin_string() override;
 
+	virtual Error kill_previous_editor_and_wait(const ProcessID &p_pid) override;
+	virtual bool is_restart_responsible_for_exit() const override;
+
 	String _quote_command_line_argument(const String &p_text) const;
 
 	struct ProcessInfo {
@@ -219,6 +222,8 @@ public:
 	virtual String get_user_data_dir() const override;
 
 	virtual String get_unique_id() const override;
+
+	virtual List<String> get_restart_on_exit_arguments() const override;
 
 	virtual Error shell_open(String p_uri) override;
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder) override;


### PR DESCRIPTION
* For https://github.com/godotengine/godot-proposals/issues/8772
* Implements the idea I mentioned in [a comment](https://github.com/godotengine/godot-proposals/issues/8772#issuecomment-1890778324), but with a bit more polish.

As far as I can tell, this functionality is only useful on Windows, and only to address that issue/proposal. For now though, I didn't write the PR to go out of its way to make it not work on other OSes or in other situations.

About this:

> 	// Kill the previous editor process and wait for it to stop. The OS::kill
>	// method sends the kill signal without waiting, so it can't be used here.

I could change `kill` on Windows to wait for the process to terminate, but for compatibility reasons and the potential for a perf hit when it isn't necessary to wait, I decided not to do that in this PR for now.

I've only tested this on my local Windows 10 machine with a trivial GDExtension written in Go (cgo).