### PR TITLE
Make CharacterBody properties public

### DIFF
--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -362,44 +362,6 @@ public:
 	int get_slide_collision_count() const;
 	PhysicsServer2D::MotionResult get_slide_collision(int p_bounce) const;
 
-	CharacterBody2D();
-	~CharacterBody2D();
-
-private:
-	real_t margin = 0.08;
-	MotionMode motion_mode = MOTION_MODE_GROUNDED;
-	PlatformOnLeave platform_on_leave = PLATFORM_ON_LEAVE_ADD_VELOCITY;
-
-	bool floor_constant_speed = false;
-	bool floor_stop_on_slope = true;
-	bool floor_block_on_wall = true;
-	bool slide_on_ceiling = true;
-	int max_slides = 4;
-	int platform_layer = 0;
-	real_t floor_max_angle = Math::deg_to_rad((real_t)45.0);
-	real_t floor_snap_length = 1;
-	real_t wall_min_slide_angle = Math::deg_to_rad((real_t)15.0);
-	Vector2 up_direction = Vector2(0.0, -1.0);
-	uint32_t platform_floor_layers = UINT32_MAX;
-	uint32_t platform_wall_layers = 0;
-	Vector2 velocity;
-
-	Vector2 floor_normal;
-	Vector2 platform_velocity;
-	Vector2 wall_normal;
-	Vector2 last_motion;
-	Vector2 previous_position;
-	Vector2 real_velocity;
-
-	RID platform_rid;
-	ObjectID platform_object_id;
-	bool on_floor = false;
-	bool on_ceiling = false;
-	bool on_wall = false;
-
-	Vector<PhysicsServer2D::MotionResult> motion_results;
-	Vector<Ref<KinematicCollision2D>> slide_colliders;
-
 	void set_safe_margin(real_t p_margin);
 	real_t get_safe_margin() const;
 
@@ -438,6 +400,44 @@ private:
 
 	void set_platform_on_leave(PlatformOnLeave p_on_leave_velocity);
 	PlatformOnLeave get_platform_on_leave() const;
+
+	CharacterBody2D();
+	~CharacterBody2D();
+
+private:
+	real_t margin = 0.08;
+	MotionMode motion_mode = MOTION_MODE_GROUNDED;
+	PlatformOnLeave platform_on_leave = PLATFORM_ON_LEAVE_ADD_VELOCITY;
+
+	bool floor_constant_speed = false;
+	bool floor_stop_on_slope = true;
+	bool floor_block_on_wall = true;
+	bool slide_on_ceiling = true;
+	int max_slides = 4;
+	int platform_layer = 0;
+	real_t floor_max_angle = Math::deg_to_rad((real_t)45.0);
+	real_t floor_snap_length = 1;
+	real_t wall_min_slide_angle = Math::deg_to_rad((real_t)15.0);
+	Vector2 up_direction = Vector2(0.0, -1.0);
+	uint32_t platform_floor_layers = UINT32_MAX;
+	uint32_t platform_wall_layers = 0;
+	Vector2 velocity;
+
+	Vector2 floor_normal;
+	Vector2 platform_velocity;
+	Vector2 wall_normal;
+	Vector2 last_motion;
+	Vector2 previous_position;
+	Vector2 real_velocity;
+
+	RID platform_rid;
+	ObjectID platform_object_id;
+	bool on_floor = false;
+	bool on_ceiling = false;
+	bool on_wall = false;
+
+	Vector<PhysicsServer2D::MotionResult> motion_results;
+	Vector<Ref<KinematicCollision2D>> slide_colliders;
 
 	void _move_and_slide_floating(double p_delta);
 	void _move_and_slide_grounded(double p_delta, bool p_was_on_floor);

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -381,6 +381,45 @@ public:
 	int get_slide_collision_count() const;
 	PhysicsServer3D::MotionResult get_slide_collision(int p_bounce) const;
 
+	void set_safe_margin(real_t p_margin);
+	real_t get_safe_margin() const;
+
+	bool is_floor_stop_on_slope_enabled() const;
+	void set_floor_stop_on_slope_enabled(bool p_enabled);
+
+	bool is_floor_constant_speed_enabled() const;
+	void set_floor_constant_speed_enabled(bool p_enabled);
+
+	bool is_floor_block_on_wall_enabled() const;
+	void set_floor_block_on_wall_enabled(bool p_enabled);
+
+	bool is_slide_on_ceiling_enabled() const;
+	void set_slide_on_ceiling_enabled(bool p_enabled);
+
+	int get_max_slides() const;
+	void set_max_slides(int p_max_slides);
+
+	real_t get_floor_max_angle() const;
+	void set_floor_max_angle(real_t p_radians);
+
+	real_t get_floor_snap_length();
+	void set_floor_snap_length(real_t p_floor_snap_length);
+
+	real_t get_wall_min_slide_angle() const;
+	void set_wall_min_slide_angle(real_t p_radians);
+
+	uint32_t get_platform_floor_layers() const;
+	void set_platform_floor_layers(const uint32_t p_exclude_layer);
+
+	uint32_t get_platform_wall_layers() const;
+	void set_platform_wall_layers(const uint32_t p_exclude_layer);
+
+	void set_motion_mode(MotionMode p_mode);
+	MotionMode get_motion_mode() const;
+
+	void set_platform_on_leave(PlatformOnLeave p_on_leave_velocity);
+	PlatformOnLeave get_platform_on_leave() const;
+
 	CharacterBody3D();
 	~CharacterBody3D();
 
@@ -434,45 +473,6 @@ private:
 
 	Vector<PhysicsServer3D::MotionResult> motion_results;
 	Vector<Ref<KinematicCollision3D>> slide_colliders;
-
-	void set_safe_margin(real_t p_margin);
-	real_t get_safe_margin() const;
-
-	bool is_floor_stop_on_slope_enabled() const;
-	void set_floor_stop_on_slope_enabled(bool p_enabled);
-
-	bool is_floor_constant_speed_enabled() const;
-	void set_floor_constant_speed_enabled(bool p_enabled);
-
-	bool is_floor_block_on_wall_enabled() const;
-	void set_floor_block_on_wall_enabled(bool p_enabled);
-
-	bool is_slide_on_ceiling_enabled() const;
-	void set_slide_on_ceiling_enabled(bool p_enabled);
-
-	int get_max_slides() const;
-	void set_max_slides(int p_max_slides);
-
-	real_t get_floor_max_angle() const;
-	void set_floor_max_angle(real_t p_radians);
-
-	real_t get_floor_snap_length();
-	void set_floor_snap_length(real_t p_floor_snap_length);
-
-	real_t get_wall_min_slide_angle() const;
-	void set_wall_min_slide_angle(real_t p_radians);
-
-	uint32_t get_platform_floor_layers() const;
-	void set_platform_floor_layers(const uint32_t p_exclude_layer);
-
-	uint32_t get_platform_wall_layers() const;
-	void set_platform_wall_layers(const uint32_t p_exclude_layer);
-
-	void set_motion_mode(MotionMode p_mode);
-	MotionMode get_motion_mode() const;
-
-	void set_platform_on_leave(PlatformOnLeave p_on_leave_velocity);
-	PlatformOnLeave get_platform_on_leave() const;
 
 	void _move_and_slide_floating(double p_delta);
 	void _move_and_slide_grounded(double p_delta, bool p_was_on_floor);


### PR DESCRIPTION
For some reason the get and set methods for most of the properties in `CharacterBody3D` are marked as private in C++ even though they are all exposed to GDScript. This PR simply marks those methods public in C++ as well so its possible to call them.
