### PR TITLE
Fix deadlock in `RemoteDebugger::debug`

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -435,9 +435,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 		messages.insert(Thread::get_caller_id(), List<Message>());
 	}
 
-	mutex.lock();
 	while (is_peer_connected()) {
-		mutex.unlock();
 		flush_output();
 
 		_poll_messages();


### PR DESCRIPTION
This raw `mutex.lock` will cause a deadlock in the debugger if the peer is not connected. Additionally, calling `mutex.unlock` if the mutex is not held by the current thread is undefined behavior. This is causing deadlocks for me when a different thread than the MainThread enters this loop due to eg an error in a GDScript thread as the microsoft inplementation will decrease the lock counter of the recursive mutex below 0 causing the mutex to appear as locked.

Not sure why this `mutex.lock` is here in the first place as every additional iteration won't relock the mutex. If this lock is indeed needed the loop needs to be converted to `while(true)` and the check placed inside but in my testing I didn't find any issues with completely removing this.
