### PR TITLE
Fix reloading current scene forgetting path

### DIFF
--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -273,12 +273,13 @@ void EditorRunBar::play_main_scene(bool p_from_native) {
 }
 
 void EditorRunBar::play_current_scene(bool p_reload) {
+	String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
+
 	EditorNode::get_singleton()->save_default_environment();
 	stop_playing();
 
 	current_mode = RunMode::RUN_CURRENT;
 	if (p_reload) {
-		String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
 		_run_scene(last_current_scene);
 	} else {
 		_run_scene();


### PR DESCRIPTION
Scene was stopped before running which cleared the last run scene, forcing it to run the currently edited scene instead

* Fixes: https://github.com/godotengine/godot/issues/87163

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
