### PR TITLE
Include `animation.length` in Animation example

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -8,21 +8,23 @@
 		[codeblocks]
 		[gdscript]
 		# This creates an animation that makes the node "Enemy" move to the right by
-		# 100 pixels in 0.5 seconds.
+		# 100 pixels in 2.0 seconds.
 		var animation = Animation.new()
 		var track_index = animation.add_track(Animation.TYPE_VALUE)
 		animation.track_set_path(track_index, "Enemy:position:x")
 		animation.track_insert_key(track_index, 0.0, 0)
-		animation.track_insert_key(track_index, 0.5, 100)
+		animation.track_insert_key(track_index, 2.0, 100)
+		animation.length = 2.0
 		[/gdscript]
 		[csharp]
 		// This creates an animation that makes the node "Enemy" move to the right by
-		// 100 pixels in 0.5 seconds.
+		// 100 pixels in 2.0 seconds.
 		var animation = new Animation();
 		int trackIndex = animation.AddTrack(Animation.TrackType.Value);
 		animation.TrackSetPath(trackIndex, "Enemy:position:x");
 		animation.TrackInsertKey(trackIndex, 0.0f, 0);
-		animation.TrackInsertKey(trackIndex, 0.5f, 100);
+		animation.TrackInsertKey(trackIndex, 2.0f, 100);
+		animation.Length = 2.0f;
 		[/csharp]
 		[/codeblocks]
 		Animations are just data containers, and must be added to nodes such as an [AnimationPlayer] to be played back. Animation tracks have different types, each with its own set of dedicated methods. Check [enum TrackType] to see available types.


### PR DESCRIPTION
The length of an Animation isn't automatically set by adding keys, and it must be set manually. The existing example only has keys up to 0.5s, so the default value of 1.0s may be acceptable. However, this results in unexpected behavior for anyone who makes an animation longer than 1.0s. Include animation.length in the example because it's important.

Also, increase the key position to 2.0s so it won't be confusing that the assignment is somewhat redundant.
