### PR TITLE
[MP] Fix spawned nodes not working after reset

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -189,9 +189,6 @@ void SceneReplicationInterface::_node_ready(const ObjectID &p_oid) {
 
 		spawned_nodes.insert(oid);
 		if (_has_authority(spawner)) {
-			if (tobj.net_id == 0) {
-				tobj.net_id = ++last_net_id;
-			}
 			_update_spawn_visibility(0, oid);
 		}
 	}
@@ -472,9 +469,13 @@ Error SceneReplicationInterface::_make_spawn_packet(Node *p_node, MultiplayerSpa
 	ERR_FAIL_COND_V(!multiplayer || !p_node || !p_spawner, ERR_BUG);
 
 	const ObjectID oid = p_node->get_instance_id();
-	const TrackedNode *tnode = tracked_nodes.getptr(oid);
+	TrackedNode *tnode = tracked_nodes.getptr(oid);
 	ERR_FAIL_NULL_V(tnode, ERR_INVALID_PARAMETER);
 
+	if (tnode->net_id == 0) {
+		// Ensure the node has an ID.
+		tnode->net_id = ++last_net_id;
+	}
 	uint32_t nid = tnode->net_id;
 	ERR_FAIL_COND_V(!nid, ERR_UNCONFIGURED);
 


### PR DESCRIPTION
Ensures that spawnable nodes (i.e. spawned nodes over which the local instance has authority) always have a network ID, since they may lose it after the multiplayer is reset (e.g. when changing the multiplayer peer).

Fixes #87184