### PR TITLE
[MP] Fix remote net ID cleanup

### DIFF
--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -49,11 +49,11 @@ void MultiplayerSynchronizer::_stop() {
 	}
 #endif
 	root_node_cache = ObjectID();
-	reset();
 	Node *node = is_inside_tree() ? get_node_or_null(root_path) : nullptr;
 	if (node) {
 		get_multiplayer()->object_configuration_remove(node, this);
 	}
+	reset();
 }
 
 void MultiplayerSynchronizer::_start() {

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -249,6 +249,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		uint32_t net_id = pending_sync_net_ids[0];
 		pending_sync_net_ids.pop_front();
 		peers_info[pending_spawn_remote].recv_sync_ids[net_id] = sync->get_instance_id();
+		sync->set_net_id(net_id);
 
 		// Try to apply spawn state (before ready).
 		if (pending_buffer_size > 0) {


### PR DESCRIPTION
Synchronizers for spawned nodes were not correctly keeping track of the net ID assigned by the remote, preventing the replication from performing the proper cleanup.

This resulted in errors being thrown when sync messages were received after despawn (which is possible due to their unreliable nature).

Fixes #86146
