### PR TITLE
Add autocompletion for TranslationServer

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -983,6 +983,29 @@ bool TranslationServer::is_placeholder(String &p_message, int p_index) const {
 					p_message[p_index + 1] == 'o' || p_message[p_index + 1] == 'x' || p_message[p_index + 1] == 'X' || p_message[p_index + 1] == 'f');
 }
 
+#ifdef TOOLS_ENABLED
+void TranslationServer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	if (p_idx == 0) {
+		HashMap<String, String> *target_hash_map = nullptr;
+		if (pf == "get_language_name") {
+			target_hash_map = &language_map;
+		} else if (pf == "get_script_name") {
+			target_hash_map = &script_map;
+		} else if (pf == "get_country_name") {
+			target_hash_map = &country_name_map;
+		}
+
+		if (target_hash_map) {
+			for (const KeyValue<String, String> &E : *target_hash_map) {
+				r_options->push_back(E.key.quote());
+			}
+		}
+	}
+	Object::get_argument_options(p_function, p_idx, r_options);
+}
+#endif // TOOLS_ENABLED
+
 void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_locale", "locale"), &TranslationServer::set_locale);
 	ClassDB::bind_method(D_METHOD("get_locale"), &TranslationServer::get_locale);

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -185,6 +185,10 @@ public:
 
 	void load_translations();
 
+#ifdef TOOLS_ENABLED
+	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif // TOOLS_ENABLED
+
 	TranslationServer();
 };
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/86893, https://github.com/godotengine/godot/pull/86753, https://github.com/godotengine/godot/pull/86747, https://github.com/godotengine/godot/pull/86758,  https://github.com/godotengine/godot/pull/86764, <sub>_breathes in_</sub> https://github.com/godotengine/godot/pull/86777, and https://github.com/godotengine/godot/pull/86798

This PR adds autocompletion for TranslationServer's `get_language_name`, `get_script_name` and `get_country_name`.

| get_language_name | get_script_name | get_country_name |
|--- | --- | --- |
| ![image](https://github.com/godotengine/godot/assets/66727710/a71a4f56-fb62-4067-8288-208ce2990789) |![image](https://github.com/godotengine/godot/assets/66727710/e674e867-9e35-4202-bfac-4b5f4349b7c8) | ![image](https://github.com/godotengine/godot/assets/66727710/728b9f9a-793a-48ef-83f5-cc78032990d8) |

I originally was not sure whether or not to do this, since each one of these options has very few characters and there is **a lot** of them. I then realised it could be nice to know that what you're writing is actually on the list, when using constant Strings?