### PR TITLE
Allow no tabs to be selected in TabBar and TabContainer

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -229,8 +229,11 @@
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
 			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
 		</member>
-		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="0">
-			Select tab at index [code]tab_idx[/code].
+		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="-1">
+			The index of the current selected tab. A value of [code]-1[/code] means that no tab is selected and can only be set when [member deselect_enabled] is [code]true[/code] or if all tabs are hidden or disabled.
+		</member>
+		<member name="deselect_enabled" type="bool" setter="set_deselect_enabled" getter="get_deselect_enabled" default="false">
+			If [code]true[/code], all tabs can be deselected so that no tab is selected. Click on the current tab to deselect it.
 		</member>
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -181,8 +181,13 @@
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
 			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
 		</member>
-		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="0">
+		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="-1">
 			The current tab index. When set, this index's [Control] node's [code]visible[/code] property is set to [code]true[/code] and all others are set to [code]false[/code].
+			A value of [code]-1[/code] means that no tab is selected.
+		</member>
+		<member name="deselect_enabled" type="bool" setter="set_deselect_enabled" getter="get_deselect_enabled" default="false">
+			If [code]true[/code], all tabs can be deselected so that no tab is selected. Click on the [member current_tab] to deselect it.
+			Only the tab header will be shown if no tabs are selected.
 		</member>
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -85,8 +85,8 @@ private:
 	bool buttons_visible = false;
 	bool missing_right = false;
 	Vector<Tab> tabs;
-	int current = 0;
-	int previous = 0;
+	int current = -1;
+	int previous = -1;
 	AlignmentMode tab_alignment = ALIGNMENT_LEFT;
 	bool clip_tabs = true;
 	int rb_hover = -1;
@@ -94,6 +94,7 @@ private:
 	bool tab_style_v_flip = false;
 
 	bool select_with_rmb = false;
+	bool deselect_enabled = false;
 
 	int cb_hover = -1;
 	bool cb_pressing = false;
@@ -146,6 +147,7 @@ private:
 	int get_tab_width(int p_idx) const;
 	Size2 _get_tab_icon_size(int p_idx) const;
 	void _ensure_no_over_offset();
+	bool _can_deselect() const;
 
 	void _update_hover();
 	void _update_cache(bool p_update_hover = true);
@@ -249,6 +251,9 @@ public:
 
 	void set_select_with_rmb(bool p_enabled);
 	bool get_select_with_rmb() const;
+
+	void set_deselect_enabled(bool p_enabled);
+	bool get_deselect_enabled() const;
 
 	void ensure_tab_visible(int p_idx);
 

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -56,7 +56,9 @@ private:
 	bool theme_changing = false;
 	Vector<Control *> children_removing;
 	bool drag_to_rearrange_enabled = false;
-	int setup_current_tab = -1;
+	// Set the default setup current tab to be an invalid index.
+	int setup_current_tab = -2;
+	bool updating_visibility = false;
 
 	struct ThemeCache {
 		int side_margin = 0;
@@ -108,6 +110,7 @@ private:
 	void _on_tab_selected(int p_tab);
 	void _on_tab_button_pressed(int p_tab);
 	void _on_active_tab_rearranged(int p_tab);
+	void _on_tab_visibility_changed(Control *p_child);
 
 	Variant _get_drag_data_fw(const Point2 &p_point, Control *p_from_control);
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control) const;
@@ -173,6 +176,9 @@ public:
 
 	bool select_previous_available();
 	bool select_next_available();
+
+	void set_deselect_enabled(bool p_enabled);
+	bool get_deselect_enabled() const;
 
 	Control *get_tab_control(int p_idx) const;
 	Control *get_current_tab_control() const;


### PR DESCRIPTION
- closes https://github.com/godotengine/godot-proposals/issues/8233
- related #21223
- fixes #74653
- fixes #73785
- fixes `remove_tab()` and `move_tabs()` not updating previous tab properly.
- related: https://github.com/godotengine/godot/issues/50930#issuecomment-1782019598

When TabContainer children visibility changes, that tab is marked as current and other tabs are deselected.

Adds deselect_enabled property to TabBar and TabContainer so that no tabs can be selected (disabled by default).
current_tab can now be -1 if this is enabled or there are no valid tabs.

Considerations:
- If there is only one child of a TabContainer and deselect_enabled is false, then the child cannot be hidden.
- This also prevents multiple TabContainer children from being visible at once.
- Changing visibility of TabContainer children changes the current tab, so when editing you need to make sure to switch to the tab you want to be the first selected tab before saving the scene.
