### PR TITLE
Optimize SceneTree's `change_scene_to_file` autocompletion

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1693,45 +1693,16 @@ void SceneTree::add_idle_callback(IdleCallback p_callback) {
 #ifdef TOOLS_ENABLED
 void SceneTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
-	if (pf == "change_scene_to_file") {
-		Ref<DirAccess> dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-		List<String> directories;
-		directories.push_back(dir_access->get_current_dir());
-
-		while (!directories.is_empty()) {
-			dir_access->change_dir(directories.back()->get());
-			directories.pop_back();
-
-			dir_access->list_dir_begin();
-			String filename = dir_access->get_next();
-
-			while (!filename.is_empty()) {
-				if (filename == "." || filename == "..") {
-					filename = dir_access->get_next();
-					continue;
-				}
-
-				if (dir_access->dir_exists(filename)) {
-					directories.push_back(dir_access->get_current_dir().path_join(filename));
-				} else if (filename.ends_with(".tscn") || filename.ends_with(".scn")) {
-					r_options->push_back("\"" + dir_access->get_current_dir().path_join(filename) + "\"");
-				}
-
-				filename = dir_access->get_next();
-			}
-		}
-	} else {
-		bool add_options = false;
-		if (p_idx == 0) {
-			add_options = pf == "get_nodes_in_group" || pf == "has_group" || pf == "get_first_node_in_group" || pf == "set_group" || pf == "notify_group" || pf == "call_group" || pf == "add_to_group";
-		} else if (p_idx == 1) {
-			add_options = pf == "set_group_flags" || pf == "call_group_flags" || pf == "notify_group_flags";
-		}
-		if (add_options) {
-			HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
-			for (const KeyValue<StringName, String> &E : global_groups) {
-				r_options->push_back(E.key.operator String().quote());
-			}
+	bool add_options = false;
+	if (p_idx == 0) {
+		add_options = pf == "get_nodes_in_group" || pf == "has_group" || pf == "get_first_node_in_group" || pf == "set_group" || pf == "notify_group" || pf == "call_group" || pf == "add_to_group";
+	} else if (p_idx == 1) {
+		add_options = pf == "set_group_flags" || pf == "call_group_flags" || pf == "notify_group_flags";
+	}
+	if (add_options) {
+		HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
+		for (const KeyValue<StringName, String> &E : global_groups) {
+			r_options->push_back(E.key.operator String().quote());
 		}
 	}
 	MainLoop::get_argument_options(p_function, p_idx, r_options);


### PR DESCRIPTION
As is currently, the autocompletion for the **SceneTree**'s `change_scene_to_file` is handled within `get_argument_options`. The implementation is done using a **DirAccess** and iterating through every file recursively, every time. It turns out this has a few problems:
- It is **EXTREMELY** slow, especially on larger projects.
    - At least on my machine, I have definitely seen it struggle.
- It does not account for the way files are imported.
   - Only file extensions are checked. This is not enough because a **PackedScene** could be imported in other ways, as well (such as `.glb` files).
- It does not respect the user's `"text_editor/completion/complete_file_paths"` Editor Setting.
- It's not scalable. This is not the only method that would benefit from file path autocompletion


This PR moves the autocompletion code **out** of the **SceneTree** and into the autocompletion code itself, recycling an existing function to go around all imported **PackedScene**s. This uses of the editor's own EditorFileSystem and is overall more performant.


In the future, this code snippet can even be further expanded with other similar methods.
