### PR TITLE
Add support for search shortcut to all docks

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -783,6 +783,9 @@ void GroupsEditor::_groups_gui_input(Ref<InputEvent> p_event) {
 			_menu_id_pressed(DELETE_GROUP);
 		} else if (ED_IS_SHORTCUT("groups_editor/rename", p_event)) {
 			_menu_id_pressed(RENAME_GROUP);
+		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
+			filter->grab_focus();
+			filter->select_all();
 		} else {
 			return;
 		}

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -614,6 +614,26 @@ void InspectorDock::apply_script_properties(Object *p_object) {
 	stored_properties.clear();
 }
 
+void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventKey> key = p_event;
+
+	if (key.is_null() || !key->is_pressed() || key->is_echo()) {
+		return;
+	}
+
+	if (!is_visible() || !inspector->get_rect().has_point(inspector->get_local_mouse_position())) {
+		return;
+	}
+
+	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
+		search->grab_focus();
+		search->select_all();
+		accept_event();
+	}
+}
+
 InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	singleton = this;
 	set_name("Inspector");
@@ -770,6 +790,8 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector->set_use_filter(true); // TODO: check me
 
 	inspector->connect("resource_selected", callable_mp(this, &InspectorDock::_resource_selected));
+
+	set_process_shortcut_input(true);
 }
 
 InspectorDock::~InspectorDock() {

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -133,6 +133,8 @@ class InspectorDock : public VBoxContainer {
 	void _select_history(int p_idx);
 	void _prepare_history();
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 private:
 	static InspectorDock *singleton;
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -162,6 +162,20 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	accept_event();
 }
 
+void SceneTreeDock::_scene_tree_gui_input(Ref<InputEvent> p_event) {
+	Ref<InputEventKey> key = p_event;
+
+	if (key.is_null() || !key->is_pressed() || key->is_echo()) {
+		return;
+	}
+
+	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
+		filter->grab_focus();
+		filter->select_all();
+		accept_event();
+	}
+}
+
 void SceneTreeDock::instantiate(const String &p_file) {
 	Vector<String> scenes;
 	scenes.push_back(p_file);
@@ -4226,6 +4240,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	scene_tree->connect("script_dropped", callable_mp(this, &SceneTreeDock::_script_dropped));
 	scene_tree->connect("nodes_dragged", callable_mp(this, &SceneTreeDock::_nodes_drag_begin));
 
+	scene_tree->get_scene_tree()->connect("gui_input", callable_mp(this, &SceneTreeDock::_scene_tree_gui_input));
 	scene_tree->get_scene_tree()->connect("item_icon_double_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
 
 	editor_selection->connect("selection_changed", callable_mp(this, &SceneTreeDock::_selection_changed));

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -235,6 +235,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _nodes_drag_begin();
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+	void _scene_tree_gui_input(Ref<InputEvent> p_event);
 
 	void _new_scene_from(String p_file);
 	void _set_node_owner_recursive(Node *p_node, Node *p_owner, const HashMap<const Node *, Node *> &p_inverse_duplimap);


### PR DESCRIPTION
Adds support for Ctrl+F to scene, inspector and node docks, see https://github.com/godotengine/godot-proposals/discussions/8845

https://github.com/godotengine/godot/assets/60579014/19d7b72c-75be-4225-8579-ff5aaf007a9d

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/discussions/8845