### PR TITLE
Fix MultiMesh resource loading when using CACHE_MODE_REPLACE

### DIFF
--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -219,6 +219,8 @@ void MultiMesh::set_instance_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
 	RenderingServer::get_singleton()->multimesh_allocate_data(multimesh, p_count, RS::MultimeshTransformFormat(transform_format), use_colors, use_custom_data);
 	instance_count = p_count;
+
+	notify_property_list_changed();
 }
 
 int MultiMesh::get_instance_count() const {
@@ -278,7 +280,6 @@ RID MultiMesh::get_rid() const {
 }
 
 void MultiMesh::set_use_colors(bool p_enable) {
-	ERR_FAIL_COND(instance_count > 0);
 	use_colors = p_enable;
 }
 
@@ -287,7 +288,6 @@ bool MultiMesh::is_using_colors() const {
 }
 
 void MultiMesh::set_use_custom_data(bool p_enable) {
-	ERR_FAIL_COND(instance_count > 0);
 	use_custom_data = p_enable;
 }
 
@@ -296,7 +296,6 @@ bool MultiMesh::is_using_custom_data() const {
 }
 
 void MultiMesh::set_transform_format(TransformFormat p_transform_format) {
-	ERR_FAIL_COND(instance_count > 0);
 	transform_format = p_transform_format;
 }
 
@@ -358,6 +357,14 @@ void MultiMesh::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(TRANSFORM_2D);
 	BIND_ENUM_CONSTANT(TRANSFORM_3D);
+}
+
+void MultiMesh::_validate_property(PropertyInfo &p_property) const {
+	if (instance_count > 0) {
+		if (p_property.name == "transform_format" || p_property.name == "use_colors" || p_property.name == "use_custom_data") {
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
+		}
+	}
 }
 
 MultiMesh::MultiMesh() {

--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -55,6 +55,7 @@ private:
 
 protected:
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED
 	// Kept for compatibility from 3.x to 4.0.


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/87166, or at least the loading error part. I couldn't repro the scene corruption, so this might either fix that or it is an unrelated issue caused by something else.

MultiMesh is a bit unusual resource as the properties must updated in specific order for things to work. That is, property `instance_count` must be updated after some others. This is [documented](https://docs.godotengine.org/en/latest/classes/class_multimesh.html#class-multimesh-property-instance-count), but a bit clumsy. This calling order applies when loading a saved MultiMesh resource, too. Things work most of the time, but when the editor loads the resource using `ResourceFormatLoader::CACHE_MODE_REPLACE` the error checks in some property updates get in the way because the property setter calls are now coming in "wrong" order because the previous load already updated some properties. This can result in an incorrectly configured MultiMesh.

This PR simply removes the error macros from some property setters. Things work perfectly fine without them, although the error messages can give some useful hints to check the class documentation when accessing the API programmatically. For the editor UI, I added `_validate_property()` to disable some fields in the editor if `instance_count` is not 0 (previously, if you tried to edit these properties the error macros triggered, now the fields are disabled). The overall behavior of MultiMesh could be improved in the future, but this fixes the loading issue.