### PR TITLE
Add missing check when insert function `normal_roughness_compatibility`

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1340,7 +1340,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 					if (is_screen_texture && !texture_func_returns_data && actions.apply_luminance_multiplier) {
 						code = "(" + code + " * vec4(vec3(sc_luminance_multiplier), 1.0))";
 					}
-					if (is_normal_roughness_texture) {
+					if (is_normal_roughness_texture && !texture_func_returns_data) {
 						code = "normal_roughness_compatibility(" + code + ")";
 					}
 				} break;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87202

Without this check, the shader `ivec2 normal_roughness_size = textureSize(normal_roughness_buffer, 0);` compiles to 
`ivec2 m_normal_roughness_size=normal_roughness_compatibility(textureSize(sampler2D(normal_roughness_buffer, SAMPLER_LINEAR_WITH_MIPMAPS_REPEAT), 0));` and thus type mismatch and compile error.

Introduced in https://github.com/godotengine/godot/pull/86316/ , cc @clayjohn Any suggestions?

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
