### PR TITLE
Add `window_size_changed` signal

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -765,6 +765,11 @@
 			<description>
 				Emitted when the [Window] is currently focused and receives any input, passing the received event as an argument. The event's position, if present, is in the embedder's coordinate system.
 			</description>
+		<signal name="window_size_changed">
+			<description>
+				Emitted when [Window] size is changed.
+			</description>
+		</signal>
 		</signal>
 	</signals>
 	<constants>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -765,11 +765,11 @@
 			<description>
 				Emitted when the [Window] is currently focused and receives any input, passing the received event as an argument. The event's position, if present, is in the embedder's coordinate system.
 			</description>
+		</signal>
 		<signal name="window_size_changed">
 			<description>
 				Emitted when [Window] size is changed.
 			</description>
-		</signal>
 		</signal>
 	</signals>
 	<constants>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1163,6 +1163,7 @@ void Window::_update_viewport_size() {
 	if (old_size != size) {
 		old_size = size;
 		notification(NOTIFICATION_WM_SIZE_CHANGED);
+		emit_signal(SNAME("window_size_changed"));
 	}
 
 	if (embedder) {
@@ -2926,6 +2927,7 @@ void Window::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("theme_changed"));
 	ADD_SIGNAL(MethodInfo("dpi_changed"));
 	ADD_SIGNAL(MethodInfo("titlebar_changed"));
+	ADD_SIGNAL(MethodInfo("window_size_changed"));
 
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_THEME_CHANGED);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Towards https://github.com/godotengine/godot-proposals/issues/8788

This PR adds a new signal to the `Window` class called `window_size_changed`. The signal is emitted whenever the window size is changed, either in code or using UI.

The PR is inspired by https://github.com/godotengine/godot/issues/79336 and my issues with `Viewport.size_changed` signal while using either `Window.ContentScaleMode.CONTENT_SCALE_MODE_VIEWPORT` or `Window.ContentScaleMode.CONTENT_SCALE_MODE_CANVAS_ITEMS`. The `Viewport.size_changed` signal, which `Window` class inherits, is not emitted with the scaling mode set. It works as expected when scaling is disabled. This is not indicated in the engine documentation. There is no alternative to the signal, leaving users with only the `NOTIFICATION_WM_SIZE_CHANGED` to subscribe to, and in a pretty obscure way as showcased in <https://github.com/godotengine/godot/issues/79336#issuecomment-1631627181> (patching the root node script).

To better explain:

| enum | `ContentScaleMode` | `Window.size_changed` emitted | `Window.window_size_changed` emitted - added by this PR |
|------|--------------------|-------------------------------|---|
|    0 | CONTENT_SCALE_MODE_DISABLED | yes 💚  | yes 💚  |
|    1 | CONTENT_SCALE_MODE_CANVAS_ITEMS | no ❌   | yes 💚  |
|    2 | CONTENT_SCALE_MODE_VIEWPORT | no ❌ |  yes 💚  |

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/8788