### PR TITLE
Fix build failing with PIX enabled

### DIFF
--- a/drivers/d3d12/d3d12_context.cpp
+++ b/drivers/d3d12/d3d12_context.cpp
@@ -65,17 +65,6 @@ extern "C" {
 char godot_nir_arch_name[32];
 }
 
-#ifdef PIX_ENABLED
-#if defined(__GNUC__)
-#define _MSC_VER 1800
-#endif
-#define USE_PIX
-#include "WinPixEventRuntime/pix3.h"
-#if defined(__GNUC__)
-#undef _MSC_VER
-#endif
-#endif
-
 #define D3D12_DEBUG_LAYER_BREAK_ON_ERROR 0
 
 void D3D12Context::_debug_message_func(

--- a/drivers/d3d12/d3d12_context.h
+++ b/drivers/d3d12/d3d12_context.h
@@ -63,6 +63,17 @@
 
 using Microsoft::WRL::ComPtr;
 
+#ifdef PIX_ENABLED
+#if defined(__GNUC__)
+#define _MSC_VER 1800
+#endif
+#define USE_PIX
+#include "WinPixEventRuntime/pix3.h"
+#if defined(__GNUC__)
+#undef _MSC_VER
+#endif
+#endif
+
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
 class D3D12Context : public ApiContextRD {


### PR DESCRIPTION
After the refactor to RDD, the driver needs to see the PIX headers (in addition to the contex).

@bruvzg, any MinGW implications?