### PR TITLE
Handle clickable `[url]` tags in `print_rich()` editor output log

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -877,6 +877,7 @@
 				[/codeblocks]
 				[b]Note:[/b] Consider using [method push_error] and [method push_warning] to print error and warning messages instead of [method print] or [method print_rich]. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed.
 				[b]Note:[/b] On Windows, only Windows 10 and later correctly displays ANSI escape codes in standard output.
+				[b]Note:[/b] Output displayed in the editor supports clickable [code skip-lint][url=address]text[/url][/code] tags. The [code skip-lint][url][/code] tag's [code]address[/code] value is handled by [method OS.shell_open] when clicked.
 			</description>
 		</method>
 		<method name="print_verbose" qualifiers="vararg">

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -192,6 +192,10 @@ void EditorLog::_load_state() {
 	is_loading_state = false;
 }
 
+void EditorLog::_meta_clicked(const String &p_meta) {
+	OS::get_singleton()->shell_open(p_meta);
+}
+
 void EditorLog::_clear_request() {
 	log->clear();
 	messages.clear();
@@ -407,6 +411,7 @@ EditorLog::EditorLog() {
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
 	log->set_deselect_on_focus_loss_enabled(false);
+	log->connect("meta_clicked", callable_mp(this, &EditorLog::_meta_clicked));
 	vb_left->add_child(log);
 
 	// Search box

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -157,6 +157,7 @@ private:
 	Thread::ID current;
 
 	//void _dragged(const Point2& p_ofs);
+	void _meta_clicked(const String &p_meta);
 	void _clear_request();
 	void _copy_request();
 	static void _undo_redo_cbk(void *p_self, const String &p_name);


### PR DESCRIPTION
Since this uses `OS.shell_open()`, this allows the use of any standard URL including `file://` paths, `mailto:`, custom protocols set up by the user, etc.

- This closes https://github.com/godotengine/godot-proposals/issues/8879.

**Testing project:** [test_editor_print_rich_meta.zip](https://github.com/godotengine/godot/files/13939392/test_editor_print_rich_meta.zip)
