### PR TITLE
Fix inaccuracies in the report of leaked objects

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2222,8 +2222,9 @@ void ObjectDB::cleanup() {
 						extra_info = " - Resource path: " + String(resource_get_path->call(obj, nullptr, 0, call_error));
 					}
 
-					uint64_t id = uint64_t(i) | (uint64_t(object_slots[i].validator) << OBJECTDB_VALIDATOR_BITS) | (object_slots[i].is_ref_counted ? OBJECTDB_REFERENCE_BIT : 0);
-					print_line("Leaked instance: " + String(obj->get_class()) + ":" + itos(id) + extra_info);
+					uint64_t id = uint64_t(i) | (uint64_t(object_slots[i].validator) << OBJECTDB_SLOT_MAX_COUNT_BITS) | (object_slots[i].is_ref_counted ? OBJECTDB_REFERENCE_BIT : 0);
+					DEV_ASSERT(id == (uint64_t)obj->get_instance_id()); // We could just use the id from the object, but this check may help catching memory corruption catastrophes.
+					print_line("Leaked instance: " + String(obj->get_class()) + ":" + uitos(id) + extra_info);
 
 					count--;
 				}


### PR DESCRIPTION
Discovered while investigating #87196.

The reported object id was being reported wrongly, for a couple of reasons:
1. The id was being computed wrongly. We could get the id from the object, but I've decided to keep the computation, only fixed.
2. The id was printed as a signed integer, which was wrong for reference types, which have the MSB set.