### PR TITLE
Fix 2D normals for transposed texture

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -587,6 +587,9 @@ void main() {
 
 	if (normal_used || (using_light && bool(read_draw_data_flags & FLAGS_DEFAULT_NORMAL_MAP_USED))) {
 		normal.xy = texture(normal_texture, uv).xy * vec2(2.0, -2.0) - vec2(1.0, -1.0);
+		if (bool(read_draw_data_flags & FLAGS_TRANSPOSE_RECT)) {
+			normal.xy = normal.yx;
+		}
 		if (bool(read_draw_data_flags & FLAGS_FLIP_H)) {
 			normal.x = -normal.x;
 		}

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -516,6 +516,9 @@ void main() {
 
 	if (normal_used || (using_light && bool(draw_data.flags & FLAGS_DEFAULT_NORMAL_MAP_USED))) {
 		normal.xy = texture(sampler2D(normal_texture, texture_sampler), uv).xy * vec2(2.0, -2.0) - vec2(1.0, -1.0);
+		if (bool(draw_data.flags & FLAGS_TRANSPOSE_RECT)) {
+			normal.xy = normal.yx;
+		}
 		if (bool(draw_data.flags & FLAGS_FLIP_H)) {
 			normal.x = -normal.x;
 		}


### PR DESCRIPTION
Fixes #87157.

| Before<br>v4.3.dev2.official [352434668]| After<br>(this PR)|
|--------|--------|
|![bP9ynTQLKj](https://github.com/godotengine/godot/assets/9283098/c8a877a8-9f2d-4168-badc-a512f70daaf7)|![godot windows editor dev x86_64_NUgdIIcntX](https://github.com/godotengine/godot/assets/9283098/4b1823d7-a33e-451b-8f13-7c5f4c986632)|

Shader used:
```glsl
shader_type canvas_item;
void fragment() {
	COLOR = vec4(NORMAL.xy * vec2(0.5, -0.5) + vec2(0.5), 1.0, 1.0);
}
```