### PR TITLE
Fix a possible crash when unreferencing an empty CowData<T>

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -113,7 +113,7 @@ private:
 		return *out;
 	}
 
-	void _unref(void *p_data);
+	void _unref();
 	void _ref(const CowData *p_from);
 	void _ref(const CowData &p_from);
 	uint32_t _copy_on_write();
@@ -195,8 +195,8 @@ public:
 };
 
 template <class T>
-void CowData<T>::_unref(void *p_data) {
-	if (!p_data) {
+void CowData<T>::_unref() {
+	if (!_ptr) {
 		return;
 	}
 
@@ -218,7 +218,7 @@ void CowData<T>::_unref(void *p_data) {
 	}
 
 	// free mem
-	Memory::free_static((uint8_t *)p_data, true);
+	Memory::free_static((uint8_t *)_ptr, true);
 }
 
 template <class T>
@@ -251,7 +251,7 @@ uint32_t CowData<T>::_copy_on_write() {
 			}
 		}
 
-		_unref(_ptr);
+		_unref();
 		_ptr = _data;
 
 		rc = 1;
@@ -272,7 +272,7 @@ Error CowData<T>::resize(int p_size) {
 
 	if (p_size == 0) {
 		// wants to clean up
-		_unref(_ptr);
+		_unref();
 		_ptr = nullptr;
 		return OK;
 	}
@@ -398,7 +398,7 @@ void CowData<T>::_ref(const CowData &p_from) {
 		return; // self assign, do nothing.
 	}
 
-	_unref(_ptr);
+	_unref();
 	_ptr = nullptr;
 
 	if (!p_from._ptr) {
@@ -412,7 +412,7 @@ void CowData<T>::_ref(const CowData &p_from) {
 
 template <class T>
 CowData<T>::~CowData() {
-	_unref(_ptr);
+	_unref();
 }
 
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
Fixes #87076.

`CowData<T>::_unref()` was implemented like this:
```c++
template <class T>
void CowData<T>::_unref(void *p_data) {
	if (!p_data) {
		return;
	}

	SafeNumeric<uint32_t> *refc = _get_refcount();

	if (refc->decrement() > 0) {
		return; // still in use
	}
	// clean up

	if (!std::is_trivially_destructible<T>::value) {
		uint32_t *count = _get_size();
		T *data = (T *)(count + 1);

		for (uint32_t i = 0; i < *count; ++i) {
			// call destructors
			data[i].~T();
		}
	}

	// free mem
	Memory::free_static((uint8_t *)p_data, true);
}

_FORCE_INLINE_ SafeNumeric<uint32_t> *_get_refcount() const {
	if (!_ptr) {
		return nullptr;
	}

	return reinterpret_cast<SafeNumeric<uint32_t> *>(_ptr) - 2;
}
```

On the surface, `if (!p_data)` doesn't do anything because `Memory::free_static()` uses its own null check and the parameter is otherwise unused, so in the release builds of Godot 4.2.1 and 4.3 dev 1 (and most likely others), there is at least one occasion where this check is optimized out by the compiler. However, the method assumes that `p_data == this->_ptr`, so that `if (!p_data)` is an implicit check for `if (this->_ptr != nullptr)`. If the compiler, unaware of this assumption, removes the `if (!p_data)`, then `if (refc->decrement() > 0)` dereferences a null pointer whenever `this->_ptr` is null.

The `p_data` parameter makes it possible to decrement the reference count of the internal pointer but then free a different pointer should that reference count reach zero. I'm not sure what the original use case for this was, especially since the method may crash should you pass in anything other than `this->ptr`. In the current code, the method is only ever called as `_unref(_ptr)`.

I removed the `p_data` parameter and made the method explicitly operate on `this->_ptr`. This should prevent the compiler from optimizing the check out although I don't know how to create an official release build, so I can't check the generated code.

Since `CowData<T>` is the internal data structure used in `String` and `Vector<T>`, this change affects basically the whole engine. Hopefully in a good way.