### PR TITLE
Add bone update option to OpenXRHand to allow preserving original hand scale

### DIFF
--- a/modules/openxr/doc_classes/OpenXRHand.xml
+++ b/modules/openxr/doc_classes/OpenXRHand.xml
@@ -7,10 +7,14 @@
 		This node enables OpenXR's hand tracking functionality. The node should be a child node of an [XROrigin3D] node, tracking will update its position to the player's tracked hand Palm joint location (the center of the middle finger's metacarpal bone). This node also updates the skeleton of a properly skinned hand or avatar model.
 		If the skeleton is a hand (one of the hand bones is the root node of the skeleton), then the skeleton will be placed relative to the hand palm location and the hand mesh and skeleton should be children of the OpenXRHand node.
 		If the hand bones are part of a full skeleton, then the root of the hand will keep its location with the assumption that IK is used to position the hand and arm.
+		By default the skeleton hand bones are repositioned to match the size of the tracked hand. To preserve the modeled bone sizes change [member bone_update] to apply rotation only.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="bone_update" type="int" setter="set_bone_update" getter="get_bone_update" enum="OpenXRHand.BoneUpdate" default="0">
+			Specify the type of updates to perform on the bone.
+		</member>
 		<member name="hand" type="int" setter="set_hand" getter="get_hand" enum="OpenXRHand.Hands" default="0">
 			Specifies whether this node tracks the left or right hand of the player.
 		</member>
@@ -51,6 +55,15 @@
 		</constant>
 		<constant name="SKELETON_RIG_MAX" value="2" enum="SkeletonRig">
 			Maximum supported hands.
+		</constant>
+		<constant name="BONE_UPDATE_FULL" value="0" enum="BoneUpdate">
+			The skeletons bones are fully updated (both position and rotation) to match the tracked bones.
+		</constant>
+		<constant name="BONE_UPDATE_ROTATION_ONLY" value="1" enum="BoneUpdate">
+			The skeletons bones are only rotated to align with the tracked bones, preserving bone length.
+		</constant>
+		<constant name="BONE_UPDATE_MAX" value="2" enum="BoneUpdate">
+			Maximum supported bone update mode.
 		</constant>
 	</constants>
 </class>

--- a/modules/openxr/scene/openxr_hand.h
+++ b/modules/openxr/scene/openxr_hand.h
@@ -61,6 +61,12 @@ public:
 		SKELETON_RIG_MAX
 	};
 
+	enum BoneUpdate {
+		BONE_UPDATE_FULL,
+		BONE_UPDATE_ROTATION_ONLY,
+		BONE_UPDATE_MAX
+	};
+
 private:
 	struct JointData {
 		int bone = -1;
@@ -74,6 +80,7 @@ private:
 	MotionRange motion_range = MOTION_RANGE_UNOBSTRUCTED;
 	NodePath hand_skeleton;
 	SkeletonRig skeleton_rig = SKELETON_RIG_OPENXR;
+	BoneUpdate bone_update = BONE_UPDATE_FULL;
 
 	JointData joints[XR_HAND_JOINT_COUNT_EXT];
 
@@ -101,11 +108,15 @@ public:
 	void set_skeleton_rig(SkeletonRig p_skeleton_rig);
 	SkeletonRig get_skeleton_rig() const;
 
+	void set_bone_update(BoneUpdate p_bone_update);
+	BoneUpdate get_bone_update() const;
+
 	void _notification(int p_what);
 };
 
 VARIANT_ENUM_CAST(OpenXRHand::Hands)
 VARIANT_ENUM_CAST(OpenXRHand::MotionRange)
 VARIANT_ENUM_CAST(OpenXRHand::SkeletonRig)
+VARIANT_ENUM_CAST(OpenXRHand::BoneUpdate)
 
 #endif // OPENXR_HAND_H


### PR DESCRIPTION
This pull request adds an option to OpenXRHand to select the type of bone updates to perform.
![image](https://github.com/godotengine/godot/assets/1863707/ba3ffd46-1613-4bce-ae37-3268c2e3cc2d)

The supported options are:
- Full (default) which works the same as today applying both position and rotation of the tracked hand
- Rotation Only which only rotates the bones preserving their relative position and length

The Rotation mode is useful if the hand model is not weighted to support re-scaling to the users hands; or the hand is scaled to non-human sizes.

With "Full" the following hand model gets damaged (the fingers get pushed into the palm):
![image](https://github.com/godotengine/godot/assets/1863707/9d5d325f-6d17-4b01-8d35-a1119cd3825d)

Switching to "Rotation Only" preserves the bone lengths - and the mesh integrity:
![image](https://github.com/godotengine/godot/assets/1863707/c8ccb906-1377-47bc-a8d0-fc7327da24b7)

