### PR TITLE
Add missing descriptions for SliderJoint3D's `param` methods

### DIFF
--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -13,6 +13,7 @@
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
 			<description>
+				Returns the value of the given parameter (see [enum Param] constants).
 			</description>
 		</method>
 		<method name="set_param">
@@ -20,6 +21,7 @@
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
 			<param index="1" name="value" type="float" />
 			<description>
+				Assigns [param value] to the given parameter (see [enum Param] constants).
 			</description>
 		</method>
 	</methods>
@@ -96,70 +98,70 @@
 	</members>
 	<constants>
 		<constant name="PARAM_LINEAR_LIMIT_UPPER" value="0" enum="Param">
-			The maximum difference between the pivot points on their X axis before damping happens.
+			Constant for accessing [member linear_limit/upper_distance]. The maximum difference between the pivot points on their X axis before damping happens.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_LOWER" value="1" enum="Param">
-			The minimum difference between the pivot points on their X axis before damping happens.
+			Constant for accessing [member linear_limit/lower_distance]. The minimum difference between the pivot points on their X axis before damping happens.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_SOFTNESS" value="2" enum="Param">
-			A factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement.
+			Constant for accessing [member linear_limit/softness]. A factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_RESTITUTION" value="3" enum="Param">
-			The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost.
+			Constant for accessing [member linear_limit/restitution]. The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_DAMPING" value="4" enum="Param">
-			The amount of damping once the slider limits are surpassed.
+			Constant for accessing [member linear_limit/damping]. The amount of damping once the slider limits are surpassed.
 		</constant>
 		<constant name="PARAM_LINEAR_MOTION_SOFTNESS" value="5" enum="Param">
-			A factor applied to the movement across the slider axis as long as the slider is in the limits. The lower, the slower the movement.
+			Constant for accessing [member linear_motion/softness]. A factor applied to the movement across the slider axis as long as the slider is in the limits. The lower, the slower the movement.
 		</constant>
 		<constant name="PARAM_LINEAR_MOTION_RESTITUTION" value="6" enum="Param">
-			The amount of restitution inside the slider limits.
+			Constant for accessing [member linear_motion/restitution]. The amount of restitution inside the slider limits.
 		</constant>
 		<constant name="PARAM_LINEAR_MOTION_DAMPING" value="7" enum="Param">
-			The amount of damping inside the slider limits.
+			Constant for accessing [member linear_motion/damping]. The amount of damping inside the slider limits.
 		</constant>
 		<constant name="PARAM_LINEAR_ORTHOGONAL_SOFTNESS" value="8" enum="Param">
-			A factor applied to the movement across axes orthogonal to the slider.
+			Constant for accessing [member linear_ortho/softness]. A factor applied to the movement across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_LINEAR_ORTHOGONAL_RESTITUTION" value="9" enum="Param">
-			The amount of restitution when movement is across axes orthogonal to the slider.
+			Constant for accessing [member linear_motion/restitution]. The amount of restitution when movement is across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_LINEAR_ORTHOGONAL_DAMPING" value="10" enum="Param">
-			The amount of damping when movement is across axes orthogonal to the slider.
+			Constant for accessing [member linear_motion/damping]. The amount of damping when movement is across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_ANGULAR_LIMIT_UPPER" value="11" enum="Param">
-			The upper limit of rotation in the slider.
+			Constant for accessing [member angular_limit/upper_angle]. The upper limit of rotation in the slider.
 		</constant>
 		<constant name="PARAM_ANGULAR_LIMIT_LOWER" value="12" enum="Param">
-			The lower limit of rotation in the slider.
+			Constant for accessing [member angular_limit/lower_angle]. The lower limit of rotation in the slider.
 		</constant>
 		<constant name="PARAM_ANGULAR_LIMIT_SOFTNESS" value="13" enum="Param">
-			A factor applied to the all rotation once the limit is surpassed.
+			Constant for accessing [member angular_limit/softness]. A factor applied to the all rotation once the limit is surpassed.
 		</constant>
 		<constant name="PARAM_ANGULAR_LIMIT_RESTITUTION" value="14" enum="Param">
-			The amount of restitution of the rotation when the limit is surpassed.
+			Constant for accessing [member angular_limit/restitution]. The amount of restitution of the rotation when the limit is surpassed.
 		</constant>
 		<constant name="PARAM_ANGULAR_LIMIT_DAMPING" value="15" enum="Param">
-			The amount of damping of the rotation when the limit is surpassed.
+			Constant for accessing [member angular_limit/damping]. The amount of damping of the rotation when the limit is surpassed.
 		</constant>
 		<constant name="PARAM_ANGULAR_MOTION_SOFTNESS" value="16" enum="Param">
-			A factor applied to the all rotation in the limits.
+			Constant for accessing [member angular_motion/softness]. A factor applied to the all rotation in the limits.
 		</constant>
 		<constant name="PARAM_ANGULAR_MOTION_RESTITUTION" value="17" enum="Param">
-			The amount of restitution of the rotation in the limits.
+			Constant for accessing [member angular_motion/restitution]. The amount of restitution of the rotation in the limits.
 		</constant>
 		<constant name="PARAM_ANGULAR_MOTION_DAMPING" value="18" enum="Param">
-			The amount of damping of the rotation in the limits.
+			Constant for accessing [member angular_motion/damping]. The amount of damping of the rotation in the limits.
 		</constant>
 		<constant name="PARAM_ANGULAR_ORTHOGONAL_SOFTNESS" value="19" enum="Param">
-			A factor applied to the all rotation across axes orthogonal to the slider.
+			Constant for accessing [member angular_ortho/softness]. A factor applied to the all rotation across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_ANGULAR_ORTHOGONAL_RESTITUTION" value="20" enum="Param">
-			The amount of restitution of the rotation across axes orthogonal to the slider.
+			Constant for accessing [member angular_ortho/restitution]. The amount of restitution of the rotation across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_ANGULAR_ORTHOGONAL_DAMPING" value="21" enum="Param">
-			The amount of damping of the rotation across axes orthogonal to the slider.
+			Constant for accessing [member angular_ortho/damping]. The amount of damping of the rotation across axes orthogonal to the slider.
 		</constant>
 		<constant name="PARAM_MAX" value="22" enum="Param">
 			Represents the size of the [enum Param] enum.


### PR DESCRIPTION
...

This PR adds missing descriptions for **SliderJoint3D**'s `set_param` and `get_param`, thus fully completing them.
It also links back to the corresponding properties in the constants' descriptions, akin to how the **Light3D** class reference does it.