### PR TITLE
Fix a possible crash when importing an OGG file with zero-length packets

### DIFF
--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -212,11 +212,13 @@ Ref<AudioStreamOggVorbis> ResourceImporterOggVorbis::load_from_buffer(const Vect
 				granule_pos = packet.granulepos;
 			}
 
-			PackedByteArray data;
-			data.resize(packet.bytes);
-			memcpy(data.ptrw(), packet.packet, packet.bytes);
-			sorted_packets[granule_pos].push_back(data);
-			packet_count++;
+			if (packet.bytes > 0) {
+				PackedByteArray data;
+				data.resize(packet.bytes);
+				memcpy(data.ptrw(), packet.packet, packet.bytes);
+				sorted_packets[granule_pos].push_back(data);
+				packet_count++;
+			}
 		}
 		Vector<Vector<uint8_t>> packet_data;
 		for (const KeyValue<uint64_t, Vector<Vector<uint8_t>>> &pair : sorted_packets) {
@@ -224,7 +226,7 @@ Ref<AudioStreamOggVorbis> ResourceImporterOggVorbis::load_from_buffer(const Vect
 				packet_data.push_back(packets);
 			}
 		}
-		if (initialized_stream) {
+		if (initialized_stream && packet_data.size() > 0) {
 			ogg_packet_sequence->push_page(ogg_page_granulepos(&page), packet_data);
 		}
 	}


### PR DESCRIPTION
Fixes #87076.
Supersedes #87233.

A zero-length `memcpy` into a null pointer itself does not fail but apparently causes an optimizing gcc (production build) to generate incorrect code further down the line because it then assumes the pointer to be non-null and skips any conditionals referencing that pointer.

~Keeping this as a draft until someone with a gcc build pipeline can verify this fix.~

_Edit:_ Might also fix #84712 since that's the file I used to track down the crash. Not sure about those non-monotonous timestamps reported by ffmpeg, but that file imports and plays fine for me in the Godot 4.3 dev 1 release build if I just skip processing the zero-length packet in the debugger.

_Edit 2_: Thank you @RichTeaMan for building this with gcc and verifying that it fixes the crash. As for the numerous errors and warnings, I've now changed the importer to completely strip zero-length packets and pages that contain no packets from the `OggPacketSequence`. This makes it conform better to the assumptions that `AudioStreamPlaybackOggVorbis` makes (such as "after I successfully move to the next packet, I have new data that I can decode"). With this change in place, I don't get any more warnings or errors when importing and playing the `OST.ogg` file from #84712.