### PR TITLE
Implement consistent functionality for select, copy, paste, and duplicate in AnimationPlayer

### DIFF
--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -42,6 +42,8 @@ class AnimationBezierTrackEdit : public Control {
 	enum {
 		MENU_KEY_INSERT,
 		MENU_KEY_DUPLICATE,
+		MENU_KEY_COPY,
+		MENU_KEY_PASTE,
 		MENU_KEY_DELETE,
 		MENU_KEY_SET_HANDLE_FREE,
 		MENU_KEY_SET_HANDLE_LINEAR,
@@ -139,6 +141,7 @@ class AnimationBezierTrackEdit : public Control {
 	void _clear_selection();
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);
 	void _select_at_anim(const Ref<Animation> &p_anim, int p_track, real_t p_pos);
+	bool _try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable);
 	void _change_selected_keys_handle_mode(Animation::HandleMode p_mode, bool p_auto = false);
 
 	Vector2 menu_insert_key;
@@ -190,6 +193,9 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static Array make_default_bezier_key(float p_value);
+	static float get_bezier_key_value(Array p_bezier_key_array);
+
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
 	Ref<Animation> get_animation() const;
@@ -205,7 +211,9 @@ public:
 	void set_play_position(real_t p_pos);
 	void update_play_position();
 
-	void duplicate_selection();
+	void duplicate_selected_keys(real_t p_ofs);
+	void copy_selected_keys();
+	void paste_keys(real_t p_ofs);
 	void delete_selection();
 
 	void _bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -230,6 +230,8 @@ class AnimationTrackEdit : public Control {
 		MENU_LOOP_CLAMP,
 		MENU_KEY_INSERT,
 		MENU_KEY_DUPLICATE,
+		MENU_KEY_COPY,
+		MENU_KEY_PASTE,
 		MENU_KEY_ADD_RESET,
 		MENU_KEY_DELETE,
 		MENU_USE_BLEND_ENABLED,
@@ -275,6 +277,7 @@ class AnimationTrackEdit : public Control {
 	void _path_submitted(const String &p_text);
 	void _play_position_draw();
 	bool _is_value_key_valid(const Variant &p_key_value, Variant::Type &r_valid_type) const;
+	bool _try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable);
 
 	Ref<Texture2D> _get_key_type_icon() const;
 
@@ -375,6 +378,7 @@ public:
 class AnimationTrackEditor : public VBoxContainer {
 	GDCLASS(AnimationTrackEditor, VBoxContainer);
 	friend class AnimationTimelineEdit;
+	friend class AnimationBezierTrackEdit;
 
 	Ref<Animation> animation;
 	bool read_only = false;
@@ -570,7 +574,13 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _cleanup_animation(Ref<Animation> p_animation);
 
-	void _anim_duplicate_keys(bool transpose);
+	void _anim_duplicate_keys(float p_ofs, int p_track);
+
+	void _anim_copy_keys();
+
+	bool _is_track_compatible(int p_target_track_idx, Variant::Type p_source_value_type, Animation::TrackType p_source_track_type);
+
+	void _anim_paste_keys(float p_ofs, int p_track);
 
 	void _view_group_toggle();
 	Button *view_group = nullptr;
@@ -600,8 +610,23 @@ class AnimationTrackEditor : public VBoxContainer {
 		Vector<Key> keys;
 	};
 
-	Vector<TrackClipboard> track_clipboard;
+	struct KeyClipboard {
+		int top_track;
 
+		struct Key {
+			Animation::TrackType track_type;
+			int track;
+			float time = 0;
+			float transition = 0;
+			Variant value;
+		};
+		Vector<Key> keys;
+	};
+
+	Vector<TrackClipboard> track_clipboard;
+	KeyClipboard key_clipboard;
+
+	void _set_key_clipboard(int p_top_track, float p_top_time, RBMap<SelectedKey, KeyInfo> &p_keymap);
 	void _insert_animation_key(NodePath p_path, const Variant &p_value);
 
 	void _pick_track_filter_text_changed(const String &p_newtext);
@@ -622,13 +647,14 @@ public:
 		EDIT_COPY_TRACKS,
 		EDIT_COPY_TRACKS_CONFIRM,
 		EDIT_PASTE_TRACKS,
+		EDIT_COPY_KEYS,
+		EDIT_PASTE_KEYS,
 		EDIT_SCALE_SELECTION,
 		EDIT_SCALE_FROM_CURSOR,
 		EDIT_SCALE_CONFIRM,
 		EDIT_EASE_SELECTION,
 		EDIT_EASE_CONFIRM,
-		EDIT_DUPLICATE_SELECTION,
-		EDIT_DUPLICATE_TRANSPOSED,
+		EDIT_DUPLICATE_SELECTED_KEYS,
 		EDIT_ADD_RESET_KEY,
 		EDIT_DELETE_SELECTION,
 		EDIT_GOTO_NEXT_STEP,
@@ -672,6 +698,7 @@ public:
 
 	bool is_key_selected(int p_track, int p_key) const;
 	bool is_selection_active() const;
+	bool is_key_clipboard_active() const;
 	bool is_moving_selection() const;
 	bool is_snap_enabled() const;
 	float get_moving_selection_offset() const;


### PR DESCRIPTION
This PR seeks to implement the copying and pasting of keyframes ([#3419](https://github.com/godotengine/godot-proposals/issues/3419)), but to do so consistently, also modifies the behavior of selection and duplication of keyframes.
My idea is, to separate this PR into three individual commits. As there are really many inconsistencies in the AnimationPlayerEditor, I would like to tackle all that are relevant for copy-pasting in the same PR, as I am touching a lot of the AnimationTrackEditor code anyway. The commits would do the following:

## **1. Modify selection behavior**
for copy, paste, and duplicate to work efficiently, the user needs to be able to select the track they want to paste on individually from the keyframes. Previously, clicking on a track would always deselect all keyframes. With this change, holding CTRL or Shift while clicking will not deselect the keyframes anymore. This is consistent with selection in other areas, for example, the scene tree. 
![KeyframeCTRLSelection](https://github.com/godotengine/godot/assets/53947784/04aebd02-33b2-4c5d-82b2-a6bc95380cac)

Previously, you had to awkwardly select a keyframe on the track you wanted to select and deselect it again, and if there was no keyframe on that track you first had to insert one — bad UX.


## **2.  Implement Copy and Paste of Keyframes in AnimationTrackEditor and AnimationBezierEditor**
The bulk of this PR. The implementation adds a clipboard to the AnimationTrackEditor, where a list of keys can be stored. Then, it adds a right-click menu action ("Copy Key(s)") and a shortcut (CTRL+C), that takes the current selection of keys and adds them to the clipboard. With another menu action ("Paste Key(s)") that is only visible when the clipboard is not empty, or shortcut (CTRL+V),  the keys then get added to the currently selected tracks. This behavior works in tandem between the regular AnimationTrackEditor and the AnimationBezierEditor, i.e. keys can be copied in one and pasted in the other. 

![CopyPaste](https://github.com/godotengine/godot/assets/53947784/25578121-06c7-4a99-a1da-18f04e097af1)

*2a. Copy-Pasting from different tracks*
1) The implementation follows the behavior set by "duplicate transposed" and takes the lowest track index *top* (the uppermost track) of the copied keys as a reference. Upon pasting, the program will attempt to insert the keys from the uppermost track on the currently selected track (index *s*), any other key at track index *top+x* will be attempted to be pasted on track *s+x*. While this behavior is intuitive in the default case, we should discuss if there is a need for pasting all keys from different tracks on the same track, and if this additional "Paste on same track" should then have the shortcut CTRL+SHIFT+V. I argue against this being the default case, and having the former action be "Paste transposed", as "Duplicate transposed" already [proved to be an obscure and unintuitive description](https://github.com/godotengine/godot/issues/55713).
2) Now this leaves us with a problem, that currently also exists for duplicate functionality: Track display order can be different between the list and the group (default) view. When some track in the list view is moved, and this is not reflected in the group view, the behavior for copy-paste and duplicate becomes incomprehensible from a group-view user's perspective, when he pastes keys from different tracks on a track that was not the *top* track. My proposed solutions would be:
    a: show a warning when keys from multiple tracks are copied/duplicated if this is the case OR
    b: keep a separate track index list for the group view, and use the respective indexing in the current view (more complex)
No matter the solution, the user will still be confused when he copies frames, moves/deletes a track in between and then pastes. I think this is a problem that cannot be solved, and the only possible countermeasure could be invalidating the clipboard on these actions, but I'm happy to hear your suggestions and will then implement accordingly.

*2b. Cross-Track Compatibility*
To make matters as intuitive as possible, you can copy-paste property keys across tracks that modify the same type. You can also copy-paste Vector3 keys across track types that accept a Vector3, and you can copy-paste keys across float property and bezier tracks. I.e. this is handled the following way:
Pasting keyframes can be performed under the following conditions (target track is the track where the keys are pasted on):
1) if the target track is a property track, the type of the copied key's value is the same as the property (most common use-case)
2) if the target tack is a property track modifying a VECTOR3, and the copied key was on a POSITION or SCALE track 
3) if the target track is a property track modifying a QUATERNION and the copied key was a ROTATION track
4) if the target track is a property track modifying a FLOAT and the copied key is a bezier key, in that case the handles are discarded and only the value is copied
5) if the target track is a POSITION or SCALE track and the copied key's value is a VECTOR3
6) if the target track is a ROTATION track and the copied key's value is a QUATERNION
7) otherwise only if the target track type is the same than the copied key's track type (for Animation Tracks, Method Call tracks, Blend Shape Tracks (**not tested! I don't know how to use them**), etc.)

**All other paste attempts are denied**, and will prompt the user with the error (popping up from the notification bar) "Paste failed: Not all animation keys were compatible with their target tracks". For now, I do not see the need of a float->int, Vector2->Vector3 conversion when copying, as this would also complicate matters more and would require a lot more warnings/errors. 


## **3. Adjust behavior of Duplicate actions** 

*3a. Merge Duplicate Transposed Behavior*
in response to #55713. 

*3b. Apply same Cross-Track Compatibility rules for Duplicate as in 2b*
Currently, it looks like the editor just casts what he can, or inserts a default keyframe when using Duplicate Transposed. This is unintuitive but also dangerous in my opinion.

*3c. Adjust naming*
It should be named "Duplicate selected keys", as you can select both track and keys.

*3d. Fix undo not restoring selection in BezierEditor*

## **4. Behavior of Right-Clicking**

*4a. Selection*
Hovering over a key and right-clicking should select the key (to be consistent with e.g. the scene tree). This saves an extra click when copying a key.

*4b. Right-click action positions*
Right-click->Insert Key inserts the key at the current mouse position. I think duplicating, and pasting should do the same. Only when using shortcuts, the keys should be placed at the play position. This can also speed up workflows, as pasting/duplicating would not require moving the play position all the time.

