### PR TITLE
Fix renaming a node to the name of its siblings breaking NodePath

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1051,10 +1051,9 @@ void SceneTreeEditor::_rename_node(Node *p_node, const String &p_name) {
 		}
 	}
 
+	new_name = p_node->get_parent()->prevalidate_child_name(p_node, new_name);
 	if (new_name == p_node->get_name()) {
-		if (item->get_text(0).is_empty()) {
-			item->set_text(0, new_name);
-		}
+		item->set_text(0, new_name);
 		return;
 	}
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1214,6 +1214,11 @@ String Node::validate_child_name(Node *p_child) {
 	_generate_serial_child_name(p_child, name);
 	return name;
 }
+
+String Node::prevalidate_child_name(Node *p_child, StringName p_name) {
+	_generate_serial_child_name(p_child, p_name);
+	return p_name;
+}
 #endif
 
 String Node::adjust_name_casing(const String &p_name) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -614,6 +614,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);
+	String prevalidate_child_name(Node *p_child, StringName p_name);
 #endif
 	static String adjust_name_casing(const String &p_name);
 


### PR DESCRIPTION
rebase and updated version of #76575
Fix #76192
I also fix another issue where there was cases where node name was not visually updated because name was changed to an invalid node name which was automatically changed to a valid one which happens to be the previous name of the node which cancels renaming.
This issue was already present with invalid character and this PR added the same for renaming to the name of a sibling.

