### PR TITLE
Add color in built-in documentation for overridden properties

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -134,6 +134,7 @@ class EditorHelp : public VBoxContainer {
 		Color value_color;
 		Color qualifier_color;
 		Color type_color;
+		Color override_color;
 
 		Ref<Font> doc_font;
 		Ref<Font> doc_bold_font;
@@ -197,6 +198,16 @@ class EditorHelp : public VBoxContainer {
 	static void _gen_doc_thread(void *p_udata);
 	static void _gen_extensions_docs();
 	static void _compute_doc_version_hash();
+
+	struct PropertyCompare {
+		_FORCE_INLINE_ bool operator()(const DocData::PropertyDoc &p_l, const DocData::PropertyDoc &p_r) const {
+			// Sort overridden properties above all else.
+			if (p_l.overridden == p_r.overridden) {
+				return p_l.name.naturalcasecmp_to(p_r.name) < 0;
+			}
+			return p_l.overridden;
+		}
+	};
 
 protected:
 	virtual void _update_theme_item_cache() override;

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -2006,6 +2006,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_color("value_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
 		p_theme->set_color("qualifier_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.8));
 		p_theme->set_color("type_color", "EditorHelp", p_config.accent_color.lerp(p_config.font_color, 0.5));
+		p_theme->set_color("override_color", "EditorHelp", p_config.warning_color);
 		p_theme->set_color("selection_color", "EditorHelp", p_config.selection_color);
 		p_theme->set_color("link_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color, 0.8));
 		p_theme->set_color("code_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color, 0.6));


### PR DESCRIPTION
Should mitigate https://github.com/godotengine/godot/issues/84796 to an extent, and perhaps supersedes https://github.com/godotengine/godot/pull/84939?

The name is pretty self-explanatory.
It uses the warning color. This is used pretty consistently for other "inheritance"-related concepts in the editor, so I think it makes sense.

| . | . |
| --- |-- |
| ![image](https://github.com/godotengine/godot/assets/66727710/5c34117b-1b10-4e23-b103-f591fad447a1) | ![image](https://github.com/godotengine/godot/assets/66727710/181fce6d-a853-40e4-a63b-f7f2f2e01f00)

I was also asked for a bit of padding between overridden and normal properties, although... I still don't like the way it looks, but hey, it works.
