### PR TITLE
[3.x] Linux: Fix arm32 build for OIDN and Embree

### DIFF
--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -7,7 +7,7 @@ def can_build(env, platform):
     # Note: oneDNN doesn't support ARM64, OIDN needs updating to the latest version
     supported_platform = platform in ["x11", "osx", "windows", "server"]
     supported_arch = env["bits"] == "64"
-    if env["arch"] == "arm64":
+    if env["arch"].startswith("arm"):
         supported_arch = False
     if env["arch"].startswith("ppc"):
         supported_arch = False

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -3,7 +3,7 @@ def can_build(env, platform):
         return False
 
     # Depends on Embree library, which only supports x86_64 and aarch64.
-    if env["arch"].startswith("rv") or env["arch"].startswith("ppc"):
+    if env["arch"] in ["arm", "arm32"] or env["arch"].startswith("rv") or env["arch"].startswith("ppc"):
         return False
 
     if platform == "android":


### PR DESCRIPTION
Still paying the cost of not having refactored all architecture handling in the 3.x branch so we have this broken hybrid of arch/bits which is unreliable.

Sunken cost fallacy says it's not time to do this refactoring now, so let's hack more.