### PR TITLE
[C#] Fix `Encloses` failing on shared upper bound for `AABB` and `Rect2(I)`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -98,11 +98,11 @@ namespace Godot
             Vector3 dstMax = with._position + with._size;
 
             return srcMin.X <= dstMin.X &&
-                   srcMax.X > dstMax.X &&
+                   srcMax.X >= dstMax.X &&
                    srcMin.Y <= dstMin.Y &&
-                   srcMax.Y > dstMax.Y &&
+                   srcMax.Y >= dstMax.Y &&
                    srcMin.Z <= dstMin.Z &&
-                   srcMax.Z > dstMax.Z;
+                   srcMax.Z >= dstMax.Z;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -123,8 +123,8 @@ namespace Godot
         public readonly bool Encloses(Rect2 b)
         {
             return b._position.X >= _position.X && b._position.Y >= _position.Y &&
-               b._position.X + b._size.X < _position.X + _size.X &&
-               b._position.Y + b._size.Y < _position.Y + _size.Y;
+               b._position.X + b._size.X <= _position.X + _size.X &&
+               b._position.Y + b._size.Y <= _position.Y + _size.Y;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
@@ -113,8 +113,8 @@ namespace Godot
         public readonly bool Encloses(Rect2I b)
         {
             return b._position.X >= _position.X && b._position.Y >= _position.Y &&
-               b._position.X + b._size.X < _position.X + _size.X &&
-               b._position.Y + b._size.Y < _position.Y + _size.Y;
+               b._position.X + b._size.X <= _position.X + _size.X &&
+               b._position.Y + b._size.Y <= _position.Y + _size.Y;
         }
 
         /// <summary>


### PR DESCRIPTION
C# version of:
* https://github.com/godotengine/godot/pull/87118
* https://github.com/godotengine/godot/pull/32478
* https://github.com/godotengine/godot/pull/57469

3.x version:
* #87265

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
