### PR TITLE
[3.x] [C#] Fix `Encloses` failing on shared upper bound for `AABB` and `Rect2`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -91,11 +91,11 @@ namespace Godot
             Vector3 dstMax = with._position + with._size;
 
             return srcMin.x <= dstMin.x &&
-                   srcMax.x > dstMax.x &&
+                   srcMax.x >= dstMax.x &&
                    srcMin.y <= dstMin.y &&
-                   srcMax.y > dstMax.y &&
+                   srcMax.y >= dstMax.y &&
                    srcMin.z <= dstMin.z &&
-                   srcMax.z > dstMax.z;
+                   srcMax.z >= dstMax.z;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -112,8 +112,8 @@ namespace Godot
         public bool Encloses(Rect2 b)
         {
             return b._position.x >= _position.x && b._position.y >= _position.y &&
-               b._position.x + b._size.x < _position.x + _size.x &&
-               b._position.y + b._size.y < _position.y + _size.y;
+               b._position.x + b._size.x <= _position.x + _size.x &&
+               b._position.y + b._size.y <= _position.y + _size.y;
         }
 
         /// <summary>


### PR DESCRIPTION
3.x version of:
* https://github.com/godotengine/godot/pull/87264

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
