### PR TITLE
Add support for default arguments in utility functions

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -578,14 +578,19 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			bool vararg = Variant::is_utility_function_vararg(name);
 			func["is_vararg"] = Variant::is_utility_function_vararg(name);
 			func["hash"] = Variant::get_utility_function_hash(name);
+
 			Array arguments;
-			int argcount = Variant::get_utility_function_argument_count(name);
-			for (int i = 0; i < argcount; i++) {
+			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(name);
+			for (int i = 0; i < Variant::get_utility_function_argument_count(name); i++) {
 				Dictionary arg;
 				String argname = vararg ? "arg" + itos(i + 1) : Variant::get_utility_function_argument_name(name, i);
 				arg["name"] = argname;
 				arg["type"] = get_builtin_or_variant_type_name(Variant::get_utility_function_argument_type(name, i));
-				//no default value support in utility functions
+
+				const int dargidx = Variant::get_utility_function_default_argument_index(name, i);
+				if (dargidx >= 0) {
+					arg["default_value"] = def_args[dargidx].get_construct_string();
+				}
 				arguments.push_back(arg);
 			}
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -751,6 +751,8 @@ public:
 	static int get_utility_function_argument_count(const StringName &p_name);
 	static Variant::Type get_utility_function_argument_type(const StringName &p_name, int p_arg);
 	static String get_utility_function_argument_name(const StringName &p_name, int p_arg);
+	static Vector<Variant> get_utility_function_default_arguments(const StringName &p_name);
+	static int get_utility_function_default_argument_index(const StringName &p_name, int p_arg);
 	static bool has_utility_function_return_value(const StringName &p_name);
 	static Variant::Type get_utility_function_return_type(const StringName &p_name);
 	static bool is_utility_function_vararg(const StringName &p_name);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1227,47 +1227,19 @@ bool VariantUtilityFunctions::is_same(const Variant &p_a, const Variant &p_b) {
 	return p_a.identity_compare(p_b);
 }
 
-#ifdef DEBUG_METHODS_ENABLED
-#define VCALLR *ret = p_func(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...)
-#define VCALL p_func(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...)
-#else
-#define VCALLR *ret = p_func(VariantCaster<P>::cast(*p_args[Is])...)
-#define VCALL p_func(VariantCaster<P>::cast(*p_args[Is])...)
-#endif
-
-template <class R, class... P, size_t... Is>
-static _FORCE_INLINE_ void call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
-	r_error.error = Callable::CallError::CALL_OK;
-	VCALLR;
-	(void)p_args; // avoid gcc warning
-	(void)r_error;
-}
-
-template <class R, class... P, size_t... Is>
-static _FORCE_INLINE_ void validated_call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, IndexSequence<Is...>) {
-	*ret = p_func(VariantCaster<P>::cast(*p_args[Is])...);
-	(void)p_args;
-}
-
-template <class R, class... P, size_t... Is>
-static _FORCE_INLINE_ void ptr_call_helperpr(R (*p_func)(P...), void *ret, const void **p_args, IndexSequence<Is...>) {
-	PtrToArg<R>::encode(p_func(PtrToArg<P>::convert(p_args[Is])...), ret);
-	(void)p_args;
-}
-
 template <class R, class... P>
-static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error) {
-	call_helperpr(p_func, ret, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
+	call_with_variant_args_static_ret_dv(p_func, p_args, p_argcount, *ret, r_error, p_defvals);
 }
 
 template <class R, class... P>
 static _FORCE_INLINE_ void validated_call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args) {
-	validated_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_static_method_ret(p_func, p_args, ret);
 }
 
 template <class R, class... P>
 static _FORCE_INLINE_ void ptr_call_helperr(R (*p_func)(P...), void *ret, const void **p_args) {
-	ptr_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_ptr_args_static_method_ret<R, P...>(p_func, p_args, ret);
 }
 
 template <class R, class... P>
@@ -1288,38 +1260,24 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helperr(R (*p_func)(P...)) {
 // WITHOUT RET
 
 template <class... P, size_t... Is>
-static _FORCE_INLINE_ void call_helperp(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
-	r_error.error = Callable::CallError::CALL_OK;
-	VCALL;
-	(void)p_args;
-	(void)r_error;
-}
-
-template <class... P, size_t... Is>
-static _FORCE_INLINE_ void validated_call_helperp(void (*p_func)(P...), const Variant **p_args, IndexSequence<Is...>) {
-	p_func(VariantCaster<P>::cast(*p_args[Is])...);
-	(void)p_args;
-}
-
-template <class... P, size_t... Is>
 static _FORCE_INLINE_ void ptr_call_helperp(void (*p_func)(P...), const void **p_args, IndexSequence<Is...>) {
 	p_func(PtrToArg<P>::convert(p_args[Is])...);
 	(void)p_args;
 }
 
 template <class... P>
-static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error) {
-	call_helperp(p_func, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
+	call_with_variant_args_static_dv(p_func, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <class... P>
 static _FORCE_INLINE_ void validated_call_helper(void (*p_func)(P...), const Variant **p_args) {
-	validated_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_static_method(p_func, p_args);
 }
 
 template <class... P>
 static _FORCE_INLINE_ void ptr_call_helper(void (*p_func)(P...), const void **p_args) {
-	ptr_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_ptr_args_static_method<P...>(p_func, p_args);
 }
 
 template <class... P>
@@ -1337,105 +1295,105 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	return Variant::NIL;
 }
 
-#define FUNCBINDR(m_func, m_args, m_category)                                                                    \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                              \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                      \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                       \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() { return false; }                                                                \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                    \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDR(m_func, m_args, m_defvals, m_category)                                                                                           \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, p_argcount, p_defvals, r_error);                                          \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                                                                \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                                                        \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                                                         \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() { return false; }                                                                                                  \
+		static Variant::UtilityFunctionType get_type() { return m_category; }                                                                      \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, m_defvals)
 
-#define FUNCBINDVR(m_func, m_args, m_category)                                                                          \
-	class Func_##m_func {                                                                                               \
-	public:                                                                                                             \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {        \
-			r_error.error = Callable::CallError::CALL_OK;                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                              \
-		}                                                                                                               \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                            \
-			Callable::CallError ce;                                                                                     \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                   \
-		}                                                                                                               \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                           \
-			Callable::CallError ce;                                                                                     \
-			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret); \
-		}                                                                                                               \
-		static int get_argument_count() {                                                                               \
-			return 1;                                                                                                   \
-		}                                                                                                               \
-		static Variant::Type get_argument_type(int p_arg) {                                                             \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static Variant::Type get_return_type() {                                                                        \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static bool has_return_type() {                                                                                 \
-			return true;                                                                                                \
-		}                                                                                                               \
-		static bool is_vararg() { return false; }                                                                       \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                           \
-	};                                                                                                                  \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVR(m_func, m_args, m_category)                                                                                                     \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                                                         \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError ce;                                                                                                                \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                                              \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Callable::CallError ce;                                                                                                                \
+			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret);                            \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() { return false; }                                                                                                  \
+		static Variant::UtilityFunctionType get_type() { return m_category; }                                                                      \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                    \
-	class Func_##m_func {                                                                                                          \
-	public:                                                                                                                        \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                   \
-			r_error.error = Callable::CallError::CALL_OK;                                                                          \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                             \
-		}                                                                                                                          \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                       \
-			Callable::CallError ce;                                                                                                \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                  \
-		}                                                                                                                          \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                      \
-			Callable::CallError ce;                                                                                                \
-			Variant r;                                                                                                             \
-			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce); \
-			PtrToArg<Variant>::encode(r, ret);                                                                                     \
-		}                                                                                                                          \
-		static int get_argument_count() {                                                                                          \
-			return 2;                                                                                                              \
-		}                                                                                                                          \
-		static Variant::Type get_argument_type(int p_arg) {                                                                        \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static Variant::Type get_return_type() {                                                                                   \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static bool has_return_type() {                                                                                            \
-			return true;                                                                                                           \
-		}                                                                                                                          \
-		static bool is_vararg() { return false; }                                                                                  \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                                      \
-	};                                                                                                                             \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                                    \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                                             \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError ce;                                                                                                                \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                                  \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Callable::CallError ce;                                                                                                                \
+			Variant r;                                                                                                                             \
+			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce);                 \
+			PtrToArg<Variant>::encode(r, ret);                                                                                                     \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 2;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() { return false; }                                                                                                  \
+		static Variant::UtilityFunctionType get_type() { return m_category; }                                                                      \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 #define FUNCBINDVR3(m_func, m_args, m_category)                                                                                                                           \
 	class Func_##m_func {                                                                                                                                                 \
 	public:                                                                                                                                                               \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                                                          \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {                        \
 			r_error.error = Callable::CallError::CALL_OK;                                                                                                                 \
 			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], r_error);                                                                        \
 		}                                                                                                                                                                 \
@@ -1464,175 +1422,176 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static bool is_vararg() { return false; }                                                                                                                         \
 		static Variant::UtilityFunctionType get_type() { return m_category; }                                                                                             \
 	};                                                                                                                                                                    \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARG(m_func, m_args, m_category)                                                               \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<Variant>::encode(r, ret);                                                                   \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 2;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARG(m_func, m_args, m_category)                                                                                                 \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                 \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                       \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+			PtrToArg<Variant>::encode(r, ret);                                                                                                     \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 2;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                              \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<String>::encode(r.operator String(), ret);                                                  \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::STRING;                                                                              \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                                                                \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                 \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                       \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+			PtrToArg<String>::encode(r.operator String(), ret);                                                                                    \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::STRING;                                                                                                                \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGV(m_func, m_args, m_category)                                                              \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                        \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                              \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARGV(m_func, m_args, m_category)                                                                                                \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                          \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                                \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBIND(m_func, m_args, m_category)                                                                     \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helper(VariantUtilityFunctions::m_func, p_args, r_error);                                       \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                      \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                            \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                  \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                         \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() { return false; }                                                                \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                    \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBIND(m_func, m_args, m_defvals, m_category)                                                                                            \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helper(VariantUtilityFunctions::m_func, p_args, p_argcount, p_defvals, r_error);                                                  \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                                                        \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                                                              \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                                                    \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                                                           \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static bool is_vararg() { return false; }                                                                                                  \
+		static Variant::UtilityFunctionType get_type() { return m_category; }                                                                      \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, m_defvals)
 
 struct VariantUtilityFunctionInfo {
-	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = nullptr;
+	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
 	Variant::ValidatedUtilityFunction validated_call_utility = nullptr;
 	Variant::PTRUtilityFunction ptr_call_utility = nullptr;
+	Vector<Variant> default_arguments;
 	Vector<String> argnames;
 	bool is_vararg = false;
 	bool returns_value = false;
@@ -1646,7 +1605,7 @@ static OAHashMap<StringName, VariantUtilityFunctionInfo> utility_function_table;
 static List<StringName> utility_function_name_table;
 
 template <class T>
-static void register_utility_function(const String &p_name, const Vector<String> &argnames) {
+static void register_utility_function(const String &p_name, const Vector<String> &argnames, const Vector<Variant> &p_def_args) {
 	String name = p_name;
 	if (name.begins_with("_")) {
 		name = name.substr(1, name.length() - 1);
@@ -1659,6 +1618,7 @@ static void register_utility_function(const String &p_name, const Vector<String>
 	bfi.validated_call_utility = T::validated_call;
 	bfi.ptr_call_utility = T::ptrcall;
 	bfi.is_vararg = T::is_vararg();
+	bfi.default_arguments = p_def_args;
 	bfi.argnames = argnames;
 	bfi.argcount = T::get_argument_count();
 	if (!bfi.is_vararg) {
@@ -1676,127 +1636,127 @@ static void register_utility_function(const String &p_name, const Vector<String>
 void Variant::_register_variant_utility_functions() {
 	// Math
 
-	FUNCBINDR(sin, sarray("angle_rad"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(cos, sarray("angle_rad"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(tan, sarray("angle_rad"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(sin, sarray("angle_rad"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cos, sarray("angle_rad"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(tan, sarray("angle_rad"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(sinh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(cosh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(tanh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(sinh, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cosh, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(tanh, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(asin, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(acos, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(atan, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(asin, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(acos, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(atan, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(atan2, sarray("y", "x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(atan2, sarray("y", "x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(asinh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(acosh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(atanh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(asinh, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(acosh, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(atanh, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(sqrt, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(fmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(fposmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(posmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(sqrt, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(fmod, sarray("x", "y"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(fposmod, sarray("x", "y"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(posmod, sarray("x", "y"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(floor, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(floorf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(floori, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(floorf, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(floori, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(ceil, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(ceilf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(ceili, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(ceilf, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(ceili, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(round, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(roundf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(roundi, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(roundf, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(roundi, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(abs, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(absf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(absi, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(absf, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(absi, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(sign, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(signf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(signi, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(signf, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(signi, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR2(snapped, sarray("x", "step"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(snappedf, sarray("x", "step"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(snappedi, sarray("x", "step"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(snappedf, sarray("x", "step"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(snappedi, sarray("x", "step"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(pow, sarray("base", "exp"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(log, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(exp, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(pow, sarray("base", "exp"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(log, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(exp, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(is_nan, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(is_inf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_nan, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_inf, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(is_equal_approx, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(is_zero_approx, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(is_finite, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_equal_approx, sarray("a", "b"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_zero_approx, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_finite, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(ease, sarray("x", "curve"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(step_decimals, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(ease, sarray("x", "curve"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(step_decimals, sarray("x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR3(lerp, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(lerpf, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(cubic_interpolate, sarray("from", "to", "pre", "post", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(cubic_interpolate_angle, sarray("from", "to", "pre", "post", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(cubic_interpolate_in_time, sarray("from", "to", "pre", "post", "weight", "to_t", "pre_t", "post_t"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(cubic_interpolate_angle_in_time, sarray("from", "to", "pre", "post", "weight", "to_t", "pre_t", "post_t"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(bezier_interpolate, sarray("start", "control_1", "control_2", "end", "t"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(bezier_derivative, sarray("start", "control_1", "control_2", "end", "t"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(angle_difference, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(lerp_angle, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(inverse_lerp, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(remap, sarray("value", "istart", "istop", "ostart", "ostop"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(lerpf, sarray("from", "to", "weight"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cubic_interpolate, sarray("from", "to", "pre", "post", "weight"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cubic_interpolate_angle, sarray("from", "to", "pre", "post", "weight"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cubic_interpolate_in_time, sarray("from", "to", "pre", "post", "weight", "to_t", "pre_t", "post_t"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cubic_interpolate_angle_in_time, sarray("from", "to", "pre", "post", "weight", "to_t", "pre_t", "post_t"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(bezier_interpolate, sarray("start", "control_1", "control_2", "end", "t"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(bezier_derivative, sarray("start", "control_1", "control_2", "end", "t"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(angle_difference, sarray("from", "to"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(lerp_angle, sarray("from", "to", "weight"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(inverse_lerp, sarray("from", "to", "weight"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(remap, sarray("value", "istart", "istop", "ostart", "ostop"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(smoothstep, sarray("from", "to", "x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(move_toward, sarray("from", "to", "delta"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(rotate_toward, sarray("from", "to", "delta"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(smoothstep, sarray("from", "to", "x"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(move_toward, sarray("from", "to", "delta"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(rotate_toward, sarray("from", "to", "delta"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(deg_to_rad, sarray("deg"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(rad_to_deg, sarray("rad"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(linear_to_db, sarray("lin"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(db_to_linear, sarray("db"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(deg_to_rad, sarray("deg"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(rad_to_deg, sarray("rad"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(linear_to_db, sarray("lin"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(db_to_linear, sarray("db"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR3(wrap, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(wrapi, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(wrapf, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(wrapi, sarray("value", "min", "max"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(wrapf, sarray("value", "min", "max"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVARARG(max, sarray(), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(maxi, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(maxf, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(maxi, sarray("a", "b"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(maxf, sarray("a", "b"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVARARG(min, sarray(), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(mini, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(minf, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(mini, sarray("a", "b"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(minf, sarray("a", "b"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR3(clamp, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(clampi, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(clampf, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(clampi, sarray("value", "min", "max"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(clampf, sarray("value", "min", "max"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(nearest_po2, sarray("value"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(pingpong, sarray("value", "length"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(nearest_po2, sarray("value"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(pingpong, sarray("value", "length"), varray(), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	// Random
 
-	FUNCBIND(randomize, sarray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randi, sarray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randf, sarray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randi_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randf_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randfn, sarray("mean", "deviation"), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBIND(seed, sarray("base"), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(rand_from_seed, sarray("seed"), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBIND(randomize, sarray(), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(randi, sarray(), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(randf, sarray(), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(randi_range, sarray("from", "to"), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(randf_range, sarray("from", "to"), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(randfn, sarray("mean", "deviation"), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBIND(seed, sarray("base"), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDR(rand_from_seed, sarray("seed"), varray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
 
 	// Utility
 
 	FUNCBINDVR(weakref, sarray("obj"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(_typeof, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(type_convert, sarray("variant", "type"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(_typeof, sarray("variable"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(type_convert, sarray("variant", "type"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGS(str, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(error_string, sarray("error"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(type_string, sarray("type"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(error_string, sarray("error"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(type_string, sarray("type"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print_rich, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printerr, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
@@ -1807,25 +1767,25 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDVARARGV(push_error, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(push_warning, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(var_to_str, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(str_to_var, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(var_to_str, sarray("variable"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(str_to_var, sarray("string"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(var_to_bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(bytes_to_var, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(var_to_bytes, sarray("variable"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(bytes_to_var, sarray("bytes"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(var_to_bytes_with_objects, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(bytes_to_var_with_objects, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(var_to_bytes_with_objects, sarray("variable"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(bytes_to_var_with_objects, sarray("bytes"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(hash, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(hash, sarray("variable"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(instance_from_id, sarray("instance_id"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(is_instance_id_valid, sarray("id"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(is_instance_valid, sarray("instance"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(instance_from_id, sarray("instance_id"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(is_instance_id_valid, sarray("id"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(is_instance_valid, sarray("instance"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(rid_allocate_id, Vector<String>(), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(rid_from_int64, sarray("base"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(rid_allocate_id, Vector<String>(), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(rid_from_int64, sarray("base"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(is_same, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(is_same, sarray("a", "b"), varray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 }
 
 void Variant::_unregister_variant_utility_functions() {
@@ -1854,7 +1814,7 @@ void Variant::call_utility_function(const StringName &p_name, Variant *r_ret, co
 		return;
 	}
 
-	bfi->call_utility(r_ret, p_args, p_argcount, r_error);
+	bfi->call_utility(r_ret, p_args, p_argcount, bfi->default_arguments, r_error);
 }
 
 bool Variant::has_utility_function(const StringName &p_name) {
@@ -1906,6 +1866,7 @@ MethodInfo Variant::get_utility_function_info(const StringName &p_name) {
 			arg.name = bfi->argnames[i];
 			info.arguments.push_back(arg);
 		}
+		info.default_arguments = bfi->default_arguments;
 	}
 	return info;
 }
@@ -1917,6 +1878,24 @@ int Variant::get_utility_function_argument_count(const StringName &p_name) {
 	}
 
 	return bfi->argcount;
+}
+
+Vector<Variant> Variant::get_utility_function_default_arguments(const StringName &p_name) {
+	const VariantUtilityFunctionInfo *bfi = utility_function_table.lookup_ptr(p_name);
+	if (!bfi) {
+		return varray();
+	}
+
+	return bfi->default_arguments;
+}
+
+int Variant::get_utility_function_default_argument_index(const StringName &p_name, int p_arg) {
+	const VariantUtilityFunctionInfo *bfi = utility_function_table.lookup_ptr(p_name);
+	if (!bfi) {
+		return false;
+	}
+
+	return p_arg - (bfi->argcount - bfi->default_arguments.size());
 }
 
 Variant::Type Variant::get_utility_function_argument_type(const StringName &p_name, int p_arg) {

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -933,6 +933,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			if (Variant::is_utility_function_vararg(E)) {
 				md.qualifiers = "vararg";
 			} else {
+				const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(E);
 				for (int i = 0; i < Variant::get_utility_function_argument_count(E); i++) {
 					PropertyInfo pi;
 					pi.type = Variant::get_utility_function_argument_type(E, i);
@@ -942,6 +943,12 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					}
 					DocData::ArgumentDoc ad;
 					DocData::argument_doc_from_arginfo(ad, pi);
+
+					const int dargidx = Variant::get_utility_function_default_argument_index(E, i);
+					if (dargidx >= 0) {
+						ad.default_value = DocData::get_default_value_string(def_args[dargidx]);
+					}
+
 					md.arguments.push_back(ad);
 				}
 			}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -77,6 +77,7 @@ static MethodInfo info_from_utility_func(const StringName &p_function) {
 			pi.type = Variant::get_utility_function_argument_type(p_function, i);
 			info.arguments.push_back(pi);
 		}
+		info.default_arguments = Variant::get_utility_function_default_arguments(p_function);
 	}
 
 	return info;

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -2163,11 +2163,18 @@ TEST_CASE("[Variant] Utility functions") {
 		if (Variant::is_utility_function_vararg(E)) {
 			md.is_vararg = true;
 		} else {
+			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(E);
 			for (int i = 0; i < Variant::get_utility_function_argument_count(E); i++) {
 				ArgumentData arg;
 				arg.type = Variant::get_utility_function_argument_type(E, i);
 				arg.name = Variant::get_utility_function_argument_name(E, i);
 				arg.position = i;
+
+				const int dargidx = Variant::get_utility_function_default_argument_index(E, i);
+				if (dargidx >= 0) {
+					arg.has_defval = true;
+					arg.defval = def_args[dargidx];
+				}
 
 				md.arguments.push_back(arg);
 			}
@@ -2183,6 +2190,13 @@ TEST_CASE("[Variant] Utility functions") {
 
 				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
 						vformat("Unnamed argument in position %d of function '%s'.", arg.position, E.name));
+
+				if (arg.has_defval) {
+					const bool arg_defval_assignable_to_type = arg.type == arg.defval.get_type();
+
+					TEST_COND(!arg_defval_assignable_to_type,
+							vformat("Invalid default value for parameter '%s' of function '%s'.", arg.name, E.name));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Facilitate godotengine/godot-proposals#4425

Made use of helpers from `binder_common.h` to support default arguments in utility functions, the same way it is done in `variant_call.cpp` for static functions. 
Updated doc_tools, api_dump, and tests related to utility functions.

Tested locally by adding `tolerance` as a default argument of `is_zero_approx()`, (see https://github.com/godotengine/godot/commit/c8d6367a9cd8a1d96266fc20777638d1166ba80e), and validated that:
- using `is_zero_approx()` in GDscript with/without the default argument was giving the expected result
- the documentation was correctly generated  
![image](https://github.com/godotengine/godot/assets/24794294/d63e4c36-c4f0-458d-af80-145ee826dab8)
- the hints were correctly displaying default arguments 
![image](https://github.com/godotengine/godot/assets/24794294/698afed3-584a-475a-9d08-9f789cd5b087)

