### PR TITLE
Display path in tooltips of sub-resource list

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3998,6 +3998,7 @@ void SceneTreeDock::_list_all_subresources(PopupMenu *p_menu) {
 			}
 
 			p_menu->add_item(display_text);
+			p_menu->set_item_tooltip(-1, pair.first->get_path());
 			p_menu->set_item_metadata(-1, pair.first->get_instance_id());
 		}
 	}


### PR DESCRIPTION
List of scene's sub-resources lists them using either names or "unnamed". Sometimes it might be desirable to know the path of resource (mostly when you have an error in built-in script and it can't be opened directly), so this PR adds it in the tooltip:
![image](https://github.com/godotengine/godot/assets/2223172/e963ef5c-d5a1-4733-a9e8-4c409a1fcd08)
Though seems like PopupMenu and tooltips don't work that well together due to some hover issues 🤔