### PR TITLE
Quaternion swing twist decomposition

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -292,6 +292,29 @@ real_t Quaternion::get_angle() const {
 	return 2 * Math::acos(w);
 }
 
+Quaternion Quaternion::get_twist(const Vector3 &p_axis) const {
+	Vector3 rotationAxis = Vector3(x, y, z);
+	double dotProd = p_axis.dot(rotationAxis);
+	Vector3 projection = p_axis * dotProd;
+	Quaternion twist = Quaternion(projection.x, projection.y, projection.z, w).normalized();
+	if (dotProd < 0.0) {
+		twist = -twist;
+	}
+	return twist;
+}
+
+Quaternion Quaternion::get_swing(const Vector3 &p_axis) const {
+	return *this * get_twist(p_axis).inverse();
+}
+
+Quaternion Quaternion::get_rotation_around(const Vector3 &p_axis) const {
+#ifdef MATH_CHECLS
+	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion{}, "The quaternion " + operator String() + " must be normalized.");
+	ERR_FAIL_COND_V_MSG(!p_axis.is_normalized(), Quaternion{}, "The axis vector " + (String)p_axis + " must be normalized.");
+#endif
+	return get_twist(p_axis).normalized();
+}
+
 Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_MSG(!p_axis.is_normalized(), "The axis Vector3 " + p_axis.operator String() + " must be normalized.");

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -75,6 +75,9 @@ struct _NO_DISCARD_ Quaternion {
 
 	Vector3 get_axis() const;
 	real_t get_angle() const;
+	Quaternion get_twist(const Vector3 &p_axis) const;
+	Quaternion get_swing(const Vector3 &p_axis) const;
+	Quaternion get_rotation_around(const Vector3 &p_axis) const;
 
 	_FORCE_INLINE_ void get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		r_angle = 2 * Math::acos(w);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2027,6 +2027,9 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(Quaternion, from_euler, sarray("euler"), varray());
 	bind_method(Quaternion, get_axis, sarray(), varray());
 	bind_method(Quaternion, get_angle, sarray(), varray());
+	bind_method(Quaternion, get_twist, sarray("axis"), varray());
+	bind_method(Quaternion, get_swing, sarray("axis"), varray());
+	bind_method(Quaternion, get_rotation_around, sarray("axis"), varray());
 
 	/* Color */
 

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -118,6 +118,30 @@
 				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). By default, the YXZ convention is used ([constant EULER_ORDER_YXZ]): Z (roll) is calculated first, then X (pitch), and lastly Y (yaw). When using the opposite method [method from_euler], this order is reversed.
 			</description>
 		</method>
+		<method name="get_rotation_around" qualifiers="const">
+			<return type="Quaternion" />
+			<param index="0" name="axis" type="Vector3" />
+			<description>
+				Returns the quaternion's rotation [b]around[/b] the normalized axis vector. The quaternion and the axis vector must be normalized, otherwise it returns the identity quaternion.
+				This method is related to the swing-twist decomposition, but provide some safe-check and a proper name.
+			</description>
+		</method>
+		<method name="get_swing" qualifiers="const">
+			<return type="Quaternion" />
+			<param index="0" name="axis" type="Vector3" />
+			<description>
+				Returns the quaternion's rotation [b]about[/b] the normalized axis vector. Part of the swing-twist decomposition of the quaternion. Multiplying the result of [code]get_twist(axis)[/code] and [code]get_swing(axis)[/code] returns the original quaternion.
+				[b]Note:[/b] If [code]get_twist(axis)[/code] return the rotation around an axis, the [code]get_swing(axis)[/code] return the rest of the rotation.
+			</description>
+		</method>
+		<method name="get_twist" qualifiers="const">
+			<return type="Quaternion" />
+			<param index="0" name="axis" type="Vector3" />
+			<description>
+				Returns the quaternion's rotation [b]around[/b] the normalized axis vector. Part of the swing-twist decomposition of the quaternion. Multiplying the result of [code]get_twist(axis)[/code] and [code]get_swing(axis)[/code] returns the original quaternion.
+				[b]Note:[/b] This is probably the one you want to use if you want to get the rotation around an axis.
+			</description>
+		</method>
 		<method name="inverse" qualifiers="const">
 			<return type="Quaternion" />
 			<description>

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -252,6 +252,33 @@ TEST_CASE("[Quaternion] Get Euler Orders") {
 	}
 }
 
+TEST_CASE("[Quaternion] Swing-Twist Decomposition") {
+	{
+		Quaternion id = Quaternion();
+		Vector3 not_normalized = Vector3(0.0, 0.0, 0.0);
+		Quaternion q = id.get_rotation_around(not_normalized);
+
+		CHECK(q.is_equal_approx(Quaternion()));
+		CHECK_EQ(q.get_angle(), 0.0);
+	}
+	{
+		Vector3 axis = Vector3(1, 0, 0);
+		real_t angle = Math::deg_to_rad(27.0);
+		Quaternion q = Quaternion(axis, angle);
+		Quaternion t = q.get_rotation_around(axis).normalized();
+		CHECK(Math::is_equal_approx(t.get_angle(), angle));
+	}
+	{
+		Vector3 axis = Vector3(1, 2, 3).normalized();
+		real_t angle = Math::deg_to_rad(27.0);
+		Quaternion original = Quaternion(axis, angle);
+		Quaternion t = original.get_twist(Vector3(1, 0, 0));
+		Quaternion s = original.get_swing(Vector3(1, 0, 0));
+		Quaternion result = s * t;
+		CHECK(result.is_equal_approx(original));
+	}
+}
+
 TEST_CASE("[Quaternion] Product (book)") {
 	// Example from "Quaternions and Rotation Sequences" by Jack Kuipers, p. 108.
 	Quaternion p(1.0, -2.0, 1.0, 3.0);


### PR DESCRIPTION
Resolve https://github.com/godotengine/godot-proposals/issues/8906

Add a relatively simple quaternion utility. Allow to decompose a quaternion around and about an axis. 

For more info, please read [this link](https://allenchou.net/2018/05/game-math-swing-twist-interpolation-sterp/)

Swing and twist aren't the most obvious name for the feature, but the doc tries to differentiate them. This is the original names, but we can change the name to `get_twist_decomposition` or `get_rotation_around`. However I believe a clear reference in the name and the doc to the original algorithm make it clearer.
