### PR TITLE
[3.x] Linux: Disable webm module on arm32, we can't build libvpx properly

### DIFF
--- a/modules/webm/config.py
+++ b/modules/webm/config.py
@@ -1,7 +1,13 @@
 def can_build(env, platform):
     if env["arch"].startswith("rv"):
         return False
-    return platform not in ["iphone"]
+    if platform == "iphone":
+        return False
+    # Can work in theory but our libvpx/SCsub is too broken to compile NEON .s
+    # files properly on Linux arm32. Could be fixed by someone motivated.
+    if platform in ["x11", "server"] and env["arch"] in ["arm", "arm32"]:
+        return False
+    return True
 
 
 def configure(env):


### PR DESCRIPTION
libvpx arm32 build with NEON can be supported in theory (and it works
on Android armv7), but our SCons logic for it is super convoluted and
broken. It needs significant rework to be made less error prone, and
ensure we can compile `.s` files properly with cross-compilation
toolchains.

The demand to play WebM videos on older Pi3-style SoCs is likely low,
so for now this is a simple compromise.

Could be improved with some effort if someone is motivated.