### PR TITLE
Allow `free()` to be used as Callable

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -31,6 +31,7 @@
 #include "class_db.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 #include "core/os/mutex.h"
@@ -1297,6 +1298,12 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 		}
 
 		check = check->inherits_ptr;
+	}
+
+	// The "free()" method is special, so we assume it exists and return a Callable.
+	if (p_property == CoreStringNames::get_singleton()->_free) {
+		r_value = Callable(p_object, p_property);
+		return true;
 	}
 
 	return false;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -37,6 +37,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 
 bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringName &p_name) {
 	if (codegen.function_node && codegen.function_node->is_static) {
@@ -345,7 +346,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							scr = scr->_base;
 						}
 
-						if (nc && (ClassDB::has_signal(nc->get_name(), identifier) || ClassDB::has_method(nc->get_name(), identifier))) {
+						if (nc && (identifier == CoreStringNames::get_singleton()->_free || ClassDB::has_signal(nc->get_name(), identifier) || ClassDB::has_method(nc->get_name(), identifier))) {
 							// Get like it was a property.
 							GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Get type here.
 							GDScriptCodeGenerator::Address self(GDScriptCodeGenerator::Address::SELF);

--- a/modules/gdscript/tests/scripts/runtime/features/free_is_callable.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/free_is_callable.gd
@@ -1,0 +1,10 @@
+func test():
+	var node := Node.new()
+	var callable: Callable = node.free
+	callable.call()
+	print(node)
+
+	node = Node.new()
+	callable = node["free"]
+	callable.call()
+	print(node)

--- a/modules/gdscript/tests/scripts/runtime/features/free_is_callable.out
+++ b/modules/gdscript/tests/scripts/runtime/features/free_is_callable.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+<Freed Object>
+<Freed Object>


### PR DESCRIPTION
This method is registered in a special way so ClassDB doesn't naturally know about its existence. Here it is hardcoded if any other option fail to check if it is about the "free()" method and, if so, say it exists and return a Callable.

Fix #86706
