### PR TITLE
GDScript: Assume freed object to be of any Object type

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -106,10 +106,10 @@ public:
 					return false;
 				}
 
-				bool was_freed = false;
-				Object *obj = p_variant.get_validated_object_with_check(was_freed);
+				Object *obj = p_variant.get_validated_object();
 				if (!obj) {
-					return !was_freed;
+					// Assume null or freed to be Object.
+					return true;
 				}
 
 				if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {
@@ -126,10 +126,10 @@ public:
 					return false;
 				}
 
-				bool was_freed = false;
-				Object *obj = p_variant.get_validated_object_with_check(was_freed);
+				Object *obj = p_variant.get_validated_object();
 				if (!obj) {
-					return !was_freed;
+					// Assume null or freed to be Object.
+					return true;
 				}
 
 				Ref<Script> base = obj && obj->get_script_instance() ? obj->get_script_instance()->get_script() : nullptr;

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -101,15 +101,6 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 		args.resize(p_argcount + captures_amount);
 		for (int i = 0; i < captures_amount; i++) {
 			args.write[i] = &captures[i];
-			if (captures[i].get_type() == Variant::OBJECT) {
-				bool was_freed = false;
-				captures[i].get_validated_object_with_check(was_freed);
-				if (was_freed) {
-					ERR_PRINT(vformat(R"(Lambda capture at index %d was freed. Passed "null" instead.)", i));
-					static Variant nil;
-					args.write[i] = &nil;
-				}
-			}
 		}
 		for (int i = 0; i < p_argcount; i++) {
 			args.write[i + captures_amount] = p_arguments[i];
@@ -229,15 +220,6 @@ void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcoun
 		args.resize(p_argcount + captures_amount);
 		for (int i = 0; i < captures_amount; i++) {
 			args.write[i] = &captures[i];
-			if (captures[i].get_type() == Variant::OBJECT) {
-				bool was_freed = false;
-				captures[i].get_validated_object_with_check(was_freed);
-				if (was_freed) {
-					ERR_PRINT(vformat(R"(Lambda capture at index %d was freed. Passed "null" instead.)", i));
-					static Variant nil;
-					args.write[i] = &nil;
-				}
-			}
 		}
 		for (int i = 0; i < p_argcount; i++) {
 			args.write[i + captures_amount] = p_arguments[i];

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -826,13 +826,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
 				const StringName native_type = _global_names_ptr[native_type_idx];
 
-				bool was_freed = false;
-				Object *object = value->get_validated_object_with_check(was_freed);
-				if (was_freed) {
-					err_text = "Left operand of 'is' is a previously freed instance.";
-					OPCODE_BREAK;
-				}
-
+				Object *object = value->get_validated_object();
 				*dst = object && ClassDB::is_parent_class(object->get_class_name(), native_type);
 				ip += 4;
 			}
@@ -848,12 +842,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Script *script_type = Object::cast_to<Script>(type->operator Object *());
 				GD_ERR_BREAK(!script_type);
 
-				bool was_freed = false;
-				Object *object = value->get_validated_object_with_check(was_freed);
-				if (was_freed) {
-					err_text = "Left operand of 'is' is a previously freed instance.";
-					OPCODE_BREAK;
-				}
+				Object *object = value->get_validated_object();
 
 				bool result = false;
 				if (object && object->get_script_instance()) {

--- a/modules/gdscript/tests/scripts/runtime/features/freed_treated_as_object_for_argument.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/freed_treated_as_object_for_argument.gd
@@ -1,0 +1,7 @@
+func typed(node: Node) -> void:
+	print(node)
+
+func test():
+	var node := Node.new()
+	node.free()
+	typed(node)

--- a/modules/gdscript/tests/scripts/runtime/features/freed_treated_as_object_for_argument.out
+++ b/modules/gdscript/tests/scripts/runtime/features/freed_treated_as_object_for_argument.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+<Freed Object>

--- a/modules/gdscript/tests/scripts/runtime/features/lambda_with_freed_capture.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/lambda_with_freed_capture.gd
@@ -1,0 +1,7 @@
+# https://github.com/godotengine/godot/issues/79707
+
+func test():
+	var node := Node.new()
+	var lambda = func(): print(node)
+	node.free()
+	lambda.call()

--- a/modules/gdscript/tests/scripts/runtime/features/lambda_with_freed_capture.out
+++ b/modules/gdscript/tests/scripts/runtime/features/lambda_with_freed_capture.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+<Freed Object>

--- a/modules/gdscript/tests/scripts/runtime/features/type_test_with_freed_object.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/type_test_with_freed_object.gd
@@ -1,0 +1,5 @@
+func test():
+	var obj := Object.new()
+	print(obj is Object)
+	obj.free()
+	print(obj is Object)

--- a/modules/gdscript/tests/scripts/runtime/features/type_test_with_freed_object.out
+++ b/modules/gdscript/tests/scripts/runtime/features/type_test_with_freed_object.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+true
+false


### PR DESCRIPTION
Since we can't check the actual type, we assume the type is correct if the expected type is Object-derived, the same as what happen with null values.

* Fix #86609

Edit: added an exception for `is` to also allow it on freed objects, but in this case it's always `false`. Also added a few test cases.

* _Bugsquad edit:_ Fixes #101423.