### PR TITLE
Stabilize snapping 2D transforms to pixel

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -268,8 +268,9 @@ void AnimatedSprite2D::_notification(int p_what) {
 			}
 
 			if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-				ofs = ofs.floor();
+				ofs = ofs.round();
 			}
+
 			Rect2 dst_rect(ofs, s);
 
 			if (hflip) {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -99,7 +99,7 @@ void Sprite2D::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_c
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		dest_offset = dest_offset.floor();
+		dest_offset = dest_offset.round();
 	}
 
 	r_dst_rect = Rect2(dest_offset, frame_size);
@@ -402,7 +402,7 @@ Rect2 Sprite2D::get_rect() const {
 	}
 
 	if (get_viewport() && get_viewport()->is_snap_2d_transforms_to_pixel_enabled()) {
-		ofs = ofs.floor();
+		ofs = ofs.round();
 	}
 
 	if (s == Size2(0, 0)) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -223,7 +223,7 @@ void RendererCanvasCull::_attach_canvas_item_for_draw(RendererCanvasCull::Item *
 	}
 }
 
-void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask) {
+void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask) {
 	Item *ci = p_canvas_item;
 
 	if (!ci->visible) {
@@ -248,10 +248,14 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	}
 
 	Transform2D xform = ci->xform;
+	Transform2D parent_xform = p_parent_xform;
+
 	if (snapping_2d_transforms_to_pixel) {
-		xform.columns[2] = xform.columns[2].floor();
+		xform.columns[2] = xform.columns[2].round();
+		parent_xform.columns[2] = parent_xform.columns[2].round();
 	}
-	xform = p_transform * xform;
+
+	xform = parent_xform * xform;
 
 	Rect2 global_rect = xform.xform(rect);
 	global_rect.position += p_clip_rect.position;

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -188,7 +188,7 @@ public:
 
 private:
 	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
-	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask);
+	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_allow_y_sort, uint32_t p_canvas_cull_mask);
 
 	static constexpr int z_range = RS::CANVAS_ITEM_Z_MAX - RS::CANVAS_ITEM_Z_MIN + 1;
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -43,19 +43,11 @@ static Transform2D _canvas_get_transform(RendererViewport::Viewport *p_viewport,
 	float scale = 1.0;
 	if (p_viewport->canvas_map.has(p_canvas->parent)) {
 		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
-		if (p_viewport->snap_2d_transforms_to_pixel) {
-			c_xform.columns[2] = c_xform.columns[2].floor();
-		}
 		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
 	}
 
 	Transform2D c_xform = p_canvas_data->transform;
-
-	if (p_viewport->snap_2d_transforms_to_pixel) {
-		c_xform.columns[2] = c_xform.columns[2].floor();
-	}
-
 	xf = xf * c_xform;
 
 	if (scale != 1.0 && !RSG::canvas->disable_scale) {


### PR DESCRIPTION
# tl;dr
This PR simplifies greatly the snapping of 2D transforms to pixel. Instead of relying on flooring sprites, CanvasItems (so twice flooring for sprites) and the camera transform, this PR only rounds each CanvasItem position.

# Co-authorship
This PR is heavily inspired by #84380 by @KeyboardDanni, so I added them to the commit as co-author.

# Why?
There's some issues with pixel perfect both due to:
- the numerous places where flooring occurs;
- the flooring itself;

# Superseding
- Supersedes #84380
- Supersedes #87058

# Tests
- Passes #84380 [PixelPerfectTest.zip](https://github.com/godotengine/godot/files/13244300/PixelPerfectTest.zip)

## #84380 test

### master

[master.webm](https://github.com/godotengine/godot/assets/270928/d95512f2-af68-4cb8-8737-82bb01147f6b)


### This PR

[87297.webm](https://github.com/godotengine/godot/assets/270928/f626b3d2-2a7f-4388-9b84-4a918f40b40f)

## [Merlin: Scale of the Magic](https://github.com/nicolasbize/Scalazard)

(author note: the project was edited to add debug info)

### master

[master.webm](https://github.com/godotengine/godot/assets/270928/9d970751-83e9-458c-9639-b7e9a8586aca)

### This PR

[87297.webm](https://github.com/godotengine/godot/assets/270928/0d8b030c-e266-4258-9b7a-4ae61c20641f)

_Production edit: closes godotengine/godot-roadmap#79_

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/56793
- Fixes https://github.com/godotengine/godot/issues/84632