### PR TITLE
Fix collided particles getting stuck with zero velocity.

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -995,13 +995,15 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "	\n";
 	if (collision_mode == COLLISION_RIGID) {
 		code += "	if (COLLIDED) {\n";
-		code += "		if (length(VELOCITY) > 3.0) {\n";
-		code += "			TRANSFORM[3].xyz += COLLISION_NORMAL * COLLISION_DEPTH;\n";
-		code += "			VELOCITY -= COLLISION_NORMAL * dot(COLLISION_NORMAL, VELOCITY) * (1.0 + collision_bounce);\n";
-		code += "			VELOCITY = mix(VELOCITY,vec3(0.0),clamp(collision_friction, 0.0, 1.0));\n";
-		code += "		} else {\n";
-		code += "			VELOCITY = vec3(0.0);\n";
-		code += "		}\n";
+		code += "		float collision_response = dot(COLLISION_NORMAL, VELOCITY);\n";
+		code += "		float slide_to_bounce_trigger = step(2.0/clamp(collision_bounce + 1.0, 1.0, 2.0), abs(collision_response));\n";
+		code += "		TRANSFORM[3].xyz += COLLISION_NORMAL * COLLISION_DEPTH;\n";
+		code += "		// Remove all components of VELOCITY that is not tangent to COLLISION_NORMAL\n";
+		code += "		VELOCITY -= COLLISION_NORMAL * collision_response;\n";
+		code += "		// Apply friction only to VELOCITY across the surface (Effectively decouples friction and bounce behavior).\n";
+		code += "		VELOCITY = mix(VELOCITY,vec3(0.0),clamp(collision_friction, 0.0, 1.0));\n";
+		code += "		// Add bounce velocity to VELOCITY\n";
+		code += "		VELOCITY -= COLLISION_NORMAL * collision_response * (collision_bounce * slide_to_bounce_trigger);\n";
 		code += "	}\n";
 	} else if (collision_mode == COLLISION_HIDE_ON_CONTACT) {
 		code += "	if (COLLIDED) {\n";


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/87221 

Changes the behavior of slow collided particles from being set to completely stationary to only removing the part of the velocity that will move the particle into the obstruction.

Project showcasing the change:
[CollisionTest.zip](https://github.com/godotengine/godot/files/13971341/CollisionTest.zip)

It is basically GPUParticles3D falling on a GPUParticlesCollisionBox3D with a GPUParticlesAttractorBox3D trying to push the particles of.

The issue can be seen [here](https://github.com/godotengine/godot/assets/52322745/35111322-061f-4f43-a03c-57c08282e337). The particles get stuck even though this is supposed to be a friction less environment.

How the changes fix the issue can be seen [here](https://github.com/godotengine/godot/assets/52322745/f91ef0f4-32e2-4ea4-8eaf-bf0aec126826). The particles glide on top of the obstruction. And with the the GPUParticlesAttractorBox3D disabled particles still fall normally and become stationary as can be seen [here](https://github.com/godotengine/godot/assets/52322745/14b3e369-5344-4cdf-b00e-1afc2effc722)

An other possible fix was to adjust the if statement found in [particle_process_material.cpp](https://github.com/godotengine/godot/blob/master/scene/resources/particle_process_material.cpp):991
```
		code += "		if (length(VELOCITY) > 3.0) {\n";
		code += "			TRANSFORM[3].xyz += COLLISION_NORMAL * COLLISION_DEPTH;\n";
		code += "			VELOCITY -= COLLISION_NORMAL * dot(COLLISION_NORMAL, VELOCITY) * (1.0 + collision_bounce);\n";
		code += "			VELOCITY = mix(VELOCITY,vec3(0.0),clamp(collision_friction, 0.0, 1.0));\n";
		code += "		} else {\n";
		code += "			VELOCITY = vec3(0.0);\n";
		code += "		}\n";
```
To be less strict with `length(VELOCITY) > 1.0` or something similar. This produced excessively bouncy particles though.

_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/91346_