### PR TITLE
[Editor] Add pan and zoom sensitivity settings.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -289,7 +289,7 @@
 			See also [member editors/3d/navigation/navigation_scheme].
 		</member>
 		<member name="editors/3d/freelook/freelook_sensitivity" type="float" setter="" getter="">
-			The mouse sensitivity to use while freelook mode is active in the 3D editor. See also [member editors/3d/navigation_feel/orbit_sensitivity].
+			The mouse/trackpad sensitivity to use while freelook mode is active in the 3D editor. See also [member editors/3d/navigation_feel/orbit_sensitivity], [member editors/3d/navigation/zoom_sensitivity], and [member editors/3d/navigation/pan_sensitivity].
 		</member>
 		<member name="editors/3d/freelook/freelook_speed_zoom_link" type="bool" setter="" getter="">
 			If [code]true[/code], freelook speed is linked to the zoom value used in the camera orbit mode in the 3D editor.
@@ -346,12 +346,18 @@
 			The modifier key that must be held to pan in the 3D editor.
 			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
+		<member name="editors/3d/navigation/pan_sensitivity" type="float" setter="" getter="">
+			The mouse/trackpad sensitivity to use when panning in the 3D editor. See also [member editors/3d/freelook/freelook_sensitivity], [member editors/3d/navigation/zoom_sensitivity], and [member editors/3d/navigation_feel/orbit_sensitivity].
+		</member>
 		<member name="editors/3d/navigation/warped_mouse_panning" type="bool" setter="" getter="">
 			If [code]true[/code], warps the mouse around the 3D viewport while panning in the 3D editor. This makes it possible to pan over a large area without having to exit panning and adjust the mouse cursor.
 		</member>
 		<member name="editors/3d/navigation/zoom_modifier" type="int" setter="" getter="">
 			The modifier key that must be held to zoom in the 3D editor.
 			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
+		</member>
+		<member name="editors/3d/navigation/zoom_sensitivity" type="float" setter="" getter="">
+			The mouse/trackpad sensitivity to use when zooming the 3D editor. See also [member editors/3d/freelook/freelook_sensitivity], [member editors/3d/navigation_feel/orbit_sensitivity], and [member editors/3d/navigation/pan_sensitivity].
 		</member>
 		<member name="editors/3d/navigation/zoom_style" type="int" setter="" getter="">
 			The mouse cursor movement direction to use when zooming by moving the mouse. This does not affect zooming with the mouse wheel.
@@ -360,7 +366,7 @@
 			The inertia to use when orbiting in the 3D editor. Higher values make the camera start and stop slower, which looks smoother but adds latency.
 		</member>
 		<member name="editors/3d/navigation_feel/orbit_sensitivity" type="float" setter="" getter="">
-			The mouse sensitivity to use when orbiting in the 3D editor. See also [member editors/3d/freelook/freelook_sensitivity].
+			The mouse/trackpad sensitivity to use when orbiting in the 3D editor. See also [member editors/3d/freelook/freelook_sensitivity], [member editors/3d/navigation/zoom_sensitivity], and [member editors/3d/navigation/pan_sensitivity].
 		</member>
 		<member name="editors/3d/navigation_feel/translation_inertia" type="float" setter="" getter="">
 			The inertia to use when panning in the 3D editor. Higher values make the camera start and stop slower, which looks smoother but adds latency.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -676,17 +676,19 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/orbit_modifier", 0, "None,Shift,Alt,Meta,Ctrl")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/pan_modifier", 1, "None,Shift,Alt,Meta,Ctrl")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/zoom_modifier", 4, "None,Shift,Alt,Meta,Ctrl")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation/pan_sensitivity", 0.25, "0.01,5,0.001")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation/zoom_sensitivity", 0.25, "0.01,5,0.001")
 	_initial_set("editors/3d/navigation/warped_mouse_panning", true);
 
 	// 3D: Navigation feel
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation_feel/orbit_sensitivity", 0.25, "0.01,2,0.001")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation_feel/orbit_sensitivity", 0.25, "0.01,5,0.001")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation_feel/orbit_inertia", 0.0, "0,1,0.001")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation_feel/translation_inertia", 0.05, "0,1,0.001")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/navigation_feel/zoom_inertia", 0.05, "0,1,0.001")
 
 	// 3D: Freelook
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/freelook/freelook_navigation_scheme", 0, "Default,Partially Axis-Locked (id Tech),Fully Axis-Locked (Minecraft)")
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_sensitivity", 0.25, "0.01,2,0.001")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_sensitivity", 0.25, "0.01,5,0.001")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_inertia", 0.0, "0,1,0.001")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_base_speed", 5.0, "0,10,0.01")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/freelook/freelook_activation_modifier", 0, "None,Shift,Alt,Meta,Ctrl")

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2374,10 +2374,11 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 void Node3DEditorViewport::_nav_pan(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative) {
 	const NavigationScheme nav_scheme = (NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
+	float sensitivity = EDITOR_GET("editors/3d/navigation/pan_sensitivity").operator float();
 
-	real_t pan_speed = 1 / 150.0;
+	real_t pan_speed = sensitivity / 35;
 	if (p_event.is_valid() && nav_scheme == NAVIGATION_MAYA && p_event->is_shift_pressed()) {
-		pan_speed *= 10;
+		pan_speed *= 10.0;
 	}
 
 	Transform3D camera_transform;
@@ -2398,10 +2399,11 @@ void Node3DEditorViewport::_nav_pan(Ref<InputEventWithModifiers> p_event, const 
 
 void Node3DEditorViewport::_nav_zoom(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative) {
 	const NavigationScheme nav_scheme = (NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
+	float sensitivity = EDITOR_GET("editors/3d/navigation/zoom_sensitivity").operator float();
 
-	real_t zoom_speed = 1 / 80.0;
+	real_t zoom_speed = sensitivity / 20.0;
 	if (p_event.is_valid() && nav_scheme == NAVIGATION_MAYA && p_event->is_shift_pressed()) {
-		zoom_speed *= 10;
+		zoom_speed *= 10.0;
 	}
 
 	NavigationZoomStyle zoom_style = (NavigationZoomStyle)EDITOR_GET("editors/3d/navigation/zoom_style").operator int();


### PR DESCRIPTION
Default setting is too slow for Mac trackpad (but OK for mouse). And there were complaints about it being both too high and too low, so it should be user configurable.

Fixes https://github.com/godotengine/godot-proposals/issues/8559