### PR TITLE
Remove unnecessary `_set_global_invalid` added by mistake

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -277,8 +277,6 @@ void CanvasItem::_notification(int p_what) {
 			ERR_MAIN_THREAD_GUARD;
 			ERR_FAIL_COND(!is_inside_tree());
 
-			_set_global_invalid(true);
-
 			Node *parent = get_parent();
 			if (parent) {
 				CanvasItem *ci = Object::cast_to<CanvasItem>(parent);


### PR DESCRIPTION
This mistake was introduced in https://github.com/godotengine/godot/pull/87115 but the issue was already solved in https://github.com/godotengine/godot/pull/86841.

The call to `_set_global_invalid` is indeed already done at line 319.

(I marked it as a bug, but I don't think it has any impact. I marked it a "bug" because it's solving a mistake. If that makes any sense :sweat_smile: )