### PR TITLE
[3.x] Preserve selection when focusing SpinBox

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1400,6 +1400,26 @@ void LineEdit::set_text(String p_text) {
 	scroll_offset = 0;
 }
 
+void LineEdit::set_text_with_selection(const String &p_text) {
+	Selection selection_copy = selection;
+
+	clear_internal();
+	append_at_cursor(p_text);
+	_create_undo_state();
+
+	if (expand_to_text_length) {
+		minimum_size_changed();
+	}
+
+	int tlen = text.length();
+	selection = selection_copy;
+	selection.begin = MIN(selection.begin, tlen);
+	selection.end = MIN(selection.end, tlen);
+	selection.cursor_start = MIN(selection.cursor_start, tlen);
+
+	update();
+}
+
 void LineEdit::clear() {
 	clear_internal();
 	_text_changed();

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -208,6 +208,7 @@ public:
 	void delete_char();
 	void delete_text(int p_from_column, int p_to_column);
 	void set_text(String p_text);
+	void set_text_with_selection(const String &p_text); // Set text, while preserving selection.
 	String get_text() const;
 	void set_placeholder(String p_text);
 	String get_placeholder() const;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -50,7 +50,7 @@ void SpinBox::_value_changed(double) {
 		}
 	}
 
-	line_edit->set_text(value);
+	line_edit->set_text_with_selection(value);
 }
 
 void SpinBox::_text_entered(const String &p_string) {


### PR DESCRIPTION
Backport of #78092

I copied the code and replaced function calls with their equivalents, but I didn't test it.