### PR TITLE
Remove unused `prev_rot` variable

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -56,7 +56,6 @@ class CanvasItemEditorSelectedItem : public Object {
 
 public:
 	Transform2D prev_xform;
-	real_t prev_rot = 0;
 	Rect2 prev_rect;
 	Vector2 prev_pivot;
 	real_t prev_anchors[4] = { (real_t)0.0 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related to #87343

This variable is unused and is redundant anyways due to the prev_xform declaration above it which stores rotation. 

![image](https://github.com/godotengine/godot/assets/105675984/a0c8022c-6222-4a10-b95f-5aaa8d441507)
