### PR TITLE
Update Android dependencies for the project

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -255,7 +255,7 @@ static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/instal
 
 static const int OPENGL_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
 static const int VULKAN_MIN_SDK_VERSION = 24;
-static const int DEFAULT_TARGET_SDK_VERSION = 33; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+static const int DEFAULT_TARGET_SDK_VERSION = 34; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.godot.game"
     android:versionCode="1"
     android:versionName="1.0"
     android:installLocation="auto" >

--- a/platform/android/java/app/assetPacks/installTime/build.gradle
+++ b/platform/android/java/app/assetPacks/installTime/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.asset-pack'
+plugins {
+    id 'com.android.asset-pack'
+}
 
 assetPack {
     packName = "installTime" // Directory name for the asset pack

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -1,17 +1,4 @@
 // Gradle build config for Godot Engine's Android port.
-buildscript {
-    apply from: 'config.gradle'
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath libraries.androidGradlePlugin
-        classpath libraries.kotlinGradlePlugin
-    }
-}
-
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -23,6 +10,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
+        maven { url "https://plugins.gradle.org/m2/" }
 
         // Godot user plugins custom maven repos
         String[] mavenRepos = getGodotPluginsMavenRepos()
@@ -42,8 +31,7 @@ configurations {
 }
 
 dependencies {
-    implementation libraries.kotlinStdLib
-    implementation libraries.androidxFragment
+    implementation "androidx.fragment:fragment:$versions.fragmentVersion"
 
     if (rootProject.findProject(":lib")) {
         implementation project(":lib")
@@ -87,6 +75,8 @@ android {
     }
 
     assetPacks = [":assetPacks:installTime"]
+
+    namespace = 'com.godot.game'
 
     defaultConfig {
         // The default ignore pattern for the 'assets' directory includes hidden files and directories which are used by Godot projects.
@@ -249,4 +239,18 @@ task validateJavaVersion {
     if (JavaVersion.current() != versions.javaVersion) {
         throw new GradleException("Invalid Java version ${JavaVersion.current()}. Version ${versions.javaVersion} is the required Java version for Godot gradle builds.")
     }
+}
+
+/*
+When they're scheduled to run, the copy*AARToAppModule tasks generate dependencies for the 'app'
+module, so we're ensuring the ':app:preBuild' task is set to run after those tasks.
+ */
+if (rootProject.tasks.findByPath("copyDebugAARToAppModule") != null) {
+    preBuild.mustRunAfter(rootProject.tasks.named("copyDebugAARToAppModule"))
+}
+if (rootProject.tasks.findByPath("copyDevAARToAppModule") != null) {
+    preBuild.mustRunAfter(rootProject.tasks.named("copyDevAARToAppModule"))
+}
+if (rootProject.tasks.findByPath("copyReleaseAARToAppModule") != null) {
+    preBuild.mustRunAfter(rootProject.tasks.named("copyReleaseAARToAppModule"))
 }

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,25 +1,18 @@
 ext.versions = [
-    androidGradlePlugin: '7.2.1',
-    compileSdk         : 33,
+    androidGradlePlugin: '8.2.0',
+    compileSdk         : 34,
     // Also update 'platform/android/export/export_plugin.cpp#OPENGL_MIN_SDK_VERSION'
     minSdk             : 21,
     // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
-    targetSdk          : 33,
-    buildTools         : '33.0.2',
-    kotlinVersion      : '1.7.0',
-    fragmentVersion    : '1.3.6',
-    nexusPublishVersion: '1.1.0',
+    targetSdk          : 34,
+    buildTools         : '34.0.0',
+    kotlinVersion      : '1.9.20',
+    fragmentVersion    : '1.6.2',
+    nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '23.2.8568313'
 
-]
-
-ext.libraries = [
-    androidGradlePlugin: "com.android.tools.build:gradle:$versions.androidGradlePlugin",
-    kotlinGradlePlugin : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
-    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlinVersion",
-    androidxFragment   : "androidx.fragment:fragment:$versions.fragmentVersion",
 ]
 
 ext.getExportPackageName = { ->

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -7,8 +7,10 @@ pluginManagement {
         id 'org.jetbrains.kotlin.android' version versions.kotlinVersion
     }
     repositories {
-        gradlePluginPortal()
         google()
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 }
 

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -1,18 +1,3 @@
-buildscript {
-    apply from: 'app/config.gradle'
-
-    repositories {
-        google()
-        mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-        classpath libraries.androidGradlePlugin
-        classpath libraries.kotlinGradlePlugin
-        classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
-    }
-}
-
 plugins {
     id 'io.github.gradle-nexus.publish-plugin'
 }
@@ -31,6 +16,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 }
 
@@ -303,7 +290,7 @@ task generateGodotTemplates {
  */
 task generateDevTemplate {
     // add parameter to set symbols to true
-    gradle.startParameter.projectProperties += [doNotStrip: true]
+    gradle.startParameter.projectProperties += [doNotStrip: "true"]
 
     gradle.startParameter.excludedTaskNames += templateExcludedBuildTask()
     dependsOn = templateBuildTasks()

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -2,14 +2,14 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'base'
 }
 
 dependencies {
-    implementation libraries.kotlinStdLib
-    implementation libraries.androidxFragment
+    implementation "androidx.fragment:fragment:$versions.fragmentVersion"
     implementation project(":lib")
 
-    implementation "androidx.window:window:1.0.0"
+    implementation "androidx.window:window:1.2.0"
 }
 
 ext {
@@ -81,6 +81,8 @@ android {
     buildToolsVersion versions.buildTools
     ndkVersion versions.ndkVersion
 
+    namespace = "org.godotengine.editor"
+
     defaultConfig {
         // The 'applicationId' suffix allows to install Godot 3.x(v3) and 4.x(v4) on the same device
         applicationId "org.godotengine.editor.v4"
@@ -90,7 +92,10 @@ android {
         targetSdkVersion versions.targetSdk
 
         missingDimensionStrategy 'products', 'editor'
-        setProperty("archivesBaseName", "android_editor")
+    }
+
+    base {
+        archivesName = "android_editor"
     }
 
     compileOptions {
@@ -109,6 +114,10 @@ android {
             keyAlias getGodotKeyAlias()
             keyPassword getGodotSigningPassword()
         }
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.godotengine.editor"
     android:installLocation="auto">
 
     <supports-screens

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jan 17 12:08:26 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.godotengine.godot"
     android:versionCode="1"
     android:versionName="1.0">
 

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -10,8 +10,7 @@ ext {
 apply from: "../scripts/publish-module.gradle"
 
 dependencies {
-    implementation libraries.kotlinStdLib
-    implementation libraries.androidxFragment
+    implementation "androidx.fragment:fragment:$versions.fragmentVersion"
 }
 
 def pathToRootDir = "../../../../"
@@ -37,6 +36,11 @@ android {
 
     kotlinOptions {
         jvmTarget = versions.javaVersion
+    }
+
+    buildFeatures {
+        aidl = true
+        buildConfig = true
     }
 
     buildTypes {

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -210,21 +210,23 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 	}
 
 	override fun onScroll(
-		originEvent: MotionEvent,
+		originEvent: MotionEvent?,
 		terminusEvent: MotionEvent,
 		distanceX: Float,
 		distanceY: Float
 	): Boolean {
 		if (scaleInProgress) {
 			if (dragInProgress) {
-				// Cancel the drag
-				GodotInputHandler.handleMotionEvent(
-					originEvent.source,
-					MotionEvent.ACTION_CANCEL,
-					originEvent.buttonState,
-					originEvent.x,
-					originEvent.y
-				)
+				if (originEvent != null) {
+					// Cancel the drag
+					GodotInputHandler.handleMotionEvent(
+						originEvent.source,
+						MotionEvent.ACTION_CANCEL,
+						originEvent.buttonState,
+						originEvent.x,
+						originEvent.y
+					)
+				}
 				dragInProgress = false
 			}
 		}

--- a/platform/android/java/nativeSrcsConfigs/AndroidManifest.xml
+++ b/platform/android/java/nativeSrcsConfigs/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.godotengine.godot" />
+<manifest />

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -9,6 +9,8 @@ android {
     buildToolsVersion versions.buildTools
     ndkVersion versions.ndkVersion
 
+    namespace = "org.godotengine.godot"
+
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -5,12 +5,15 @@ pluginManagement {
     plugins {
         id 'com.android.application' version versions.androidGradlePlugin
         id 'com.android.library' version versions.androidGradlePlugin
+        id 'com.android.asset-pack' version versions.androidGradlePlugin
         id 'org.jetbrains.kotlin.android' version versions.kotlinVersion
         id 'io.github.gradle-nexus.publish-plugin' version versions.nexusPublishVersion
     }
     repositories {
-        gradlePluginPortal()
         google()
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 }
 


### PR DESCRIPTION
Time of the year for another broad Android dependencies update!  

- Update Android gradle plugin version from 7.2.1 to 8.2.0
- Update gradle version from 7.4.2 to 8.2
- Update target SDK from 33 to 34
- Update build tools version from 33.0.2 to 34.0.0
- Update kotlin version from 1.7.0 to 1.9.20
- Update Android fragment version from 1.3.6 to 1.6.2
- Update AndroidX window version from 1.0.0 to 1.2.0

There have been quite a few deprecation and api updates in the gradle buildsystem so this PR updates the gradle build logic where needed to comply.
I've done my best to validate that no regressions were introduced, but I'd appreciate additional testing for thoroughness.

Fixes https://github.com/godotengine/godot/issues/87072 for the `master` branch; need to evaluate if this is safe to backport to 3.x

**Notes:**
- The ndk version was not updated since the new AGP and gradle versions still support the version we use. Due to the changes from ndk 23 to 25, its update will be done in its own separate PR
- https://github.com/godotengine/godot/issues/53749 is still a valid issue as the deprecation for `android.enableResourceOptimizations` was pushed to AGP version 9+. I have a few ideas for how to deal with this when it's fully deprecated but this will require follow-up discussions.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
