### PR TITLE
Fix memory leak from not clearing the buffer barrier vector properly on the render graph.

### DIFF
--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1197,6 +1197,7 @@ void RenderingDeviceGraph::begin() {
 	command_data_offsets.clear();
 	command_normalization_barriers.clear();
 	command_transition_barriers.clear();
+	command_buffer_barriers.clear();
 	command_label_chars.clear();
 	command_label_colors.clear();
 	command_label_offsets.clear();


### PR DESCRIPTION
Fixes a small memory leak that #84976 introduced from the last minute change to buffer barriers, which were not being cleared properly every frame leading to a small but consistent leak every frame.