### PR TITLE
Add support for material-based debanding in the Compatibility renderer

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2391,8 +2391,8 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				When using the Mobile renderer, [method material_set_use_debanding] can be used to enable or disable the debanding feature of 3D materials ([BaseMaterial3D] and [ShaderMaterial]).
-				[method material_set_use_debanding] has no effect when using the Compatibility or Forward+ renderer. In Forward+, [Viewport] debanding can be used instead.
+				When using the Mobile and Compatibility renderers, [method material_set_use_debanding] can be used to enable or disable the debanding feature of 3D materials ([BaseMaterial3D] and [ShaderMaterial]).
+				[method material_set_use_debanding] has no effect when using the Forward+ renderer. In Forward+, [Viewport] debanding can be used instead.
 				See also [member ProjectSettings.rendering/anti_aliasing/quality/use_debanding] and [method RenderingServer.viewport_set_use_debanding].
 			</description>
 		</method>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3480,6 +3480,10 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					}
 				}
 
+				if (material_use_debanding) {
+					spec_constants |= SceneShaderGLES3::USE_MATERIAL_DEBANDING;
+				}
+
 				if (uses_additive_lighting) {
 					spec_constants |= SceneShaderGLES3::USE_ADDITIVE_LIGHTING;
 
@@ -3525,6 +3529,11 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						} else if (scene_state.directional_shadow_quality >= RS::SHADOW_QUALITY_SOFT_LOW) {
 							spec_constants |= SceneShaderGLES3::SHADOW_MODE_PCF_5;
 						}
+					}
+
+					if (material_use_debanding) {
+						// Additive lighting also needs to use debanding.
+						spec_constants |= SceneShaderGLES3::USE_MATERIAL_DEBANDING;
 					}
 				}
 			}
@@ -4366,7 +4375,7 @@ void RasterizerSceneGLES3::lightmaps_set_bicubic_filter(bool p_enable) {
 }
 
 void RasterizerSceneGLES3::material_set_use_debanding(bool p_enable) {
-	// Material debanding not yet implemented.
+	material_use_debanding = p_enable;
 }
 
 RasterizerSceneGLES3::RasterizerSceneGLES3() {
@@ -4383,6 +4392,7 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 	positional_soft_shadow_filter_set_quality((RS::ShadowQuality)(int)GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality"));
 	directional_soft_shadow_filter_set_quality((RS::ShadowQuality)(int)GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality"));
 	lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));
+	material_set_use_debanding(GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding"));
 
 	{
 		// Setup Lights

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -765,6 +765,7 @@ protected:
 	bool glow_bicubic_upscale = false;
 
 	bool lightmap_bicubic_upscale = false;
+	bool material_use_debanding = false;
 
 	/* Sky */
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -39,6 +39,7 @@ RENDER_MATERIAL = false
 SECOND_REFLECTION_PROBE = false
 LIGHTMAP_BICUBIC_FILTER = false
 RENDER_MOTION_VECTORS = false
+USE_MATERIAL_DEBANDING = false
 
 
 #[vertex]
@@ -1997,6 +1998,20 @@ vec4 textureArray_bicubic(sampler2DArray tex, vec3 uv, vec2 texture_size) {
 #endif //LIGHTMAP_BICUBIC_FILTER
 #endif // RENDER_MOTION_VECTORS
 
+#ifdef USE_MATERIAL_DEBANDING
+// From https://alex.vlachos.com/graphics/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
+// and https://www.shadertoy.com/view/MslGR8 (5th one starting from the bottom)
+// NOTE: `frag_coord` is in pixels (i.e. not normalized UV).
+vec3 screen_space_dither(vec2 frag_coord) {
+	// Iestyn's RGB dither (7 asm instructions) from Portal 2 X360, slightly modified for VR.
+	vec3 dither = vec3(dot(vec2(171.0, 231.0), frag_coord));
+	dither.rgb = fract(dither.rgb / vec3(103.0, 71.0, 97.0));
+
+	// Subtract 0.5 to avoid slightly brightening the whole viewport.
+	return (dither.rgb - 0.5) / 255.0;
+}
+#endif // USE_MATERIAL_DEBANDING
+
 void main() {
 #ifndef RENDER_MOTION_VECTORS
 	//lay out everything, whatever is unused is optimized away anyway
@@ -2560,6 +2575,11 @@ void main() {
 
 	// Tonemap before writing as we are writing to an sRGB framebuffer
 	frag_color.rgb *= exposure;
+
+#ifdef USE_MATERIAL_DEBANDING
+	frag_color.rgb += screen_space_dither(gl_FragCoord.xy);
+#endif // USE_MATERIAL_DEBANDING
+
 #ifdef APPLY_TONEMAPPING
 	frag_color.rgb = apply_tonemapping(frag_color.rgb);
 #endif
@@ -2829,6 +2849,19 @@ void main() {
 
 	additive_light_color *= (1.0 - fog.a);
 #endif // !FOG_DISABLED
+
+#ifdef USE_MATERIAL_DEBANDING
+	// Apply a per-light offset to avoid making the dithering pattern too noticeable
+	// when using multiple lights with additive blending.
+#if defined(ADDITIVE_OMNI)
+	vec2 offset = vec2(float(omni_light_index) * 5.0, float(omni_light_index) * 2.0);
+#elif defined(ADDITIVE_SPOT)
+	vec2 offset = vec2(float(spot_light_index) * 5.0, float(spot_light_index) * 2.0);
+#else // Directional
+	vec2 offset = vec2(0.0);
+#endif
+	frag_color.rgb += screen_space_dither(gl_FragCoord.xy + offset);
+#endif // USE_MATERIAL_DEBANDING
 
 	// Tonemap before writing as we are writing to an sRGB framebuffer
 	additive_light_color *= exposure;


### PR DESCRIPTION
This works in a fashion similar to the Mobile renderer, with some adjustments to better account for the additive lighting approach used for lights with shadows enabled.

- This closes https://github.com/godotengine/godot-proposals/issues/4193
and closes https://github.com/godotengine/godot-proposals/issues/7336.

**Testing project:** [test_material_debanding.zip](https://github.com/godotengine/godot/files/13980617/test_material_debanding.zip)

## Preview

*All screenshots use the Compatibility renderer.*

### Real-time lights

No debanding | With debanding
-|-
![No debanding](https://github.com/user-attachments/assets/99091253-39c3-4db1-a238-cba3712f3d27) | ![With debanding](https://github.com/user-attachments/assets/7a0dd406-e8cd-4c9a-b09d-dac83cd6c3d9)

### Lightmaps

No debanding | With debanding
-|-
![No debanding](https://github.com/user-attachments/assets/9a54576e-3d65-4615-8f8d-e2a14633a05a) | ![With debanding](https://github.com/user-attachments/assets/b0b8cbbb-65a3-47ea-901b-5bfddca52077)

<details>
<summary>Old version</summary>

*Click to view at full size (images **must** be compared at their original size).*

### Forward+

No debanding | Viewport-based debanding | Material-based debanding | Both debanding
-|-|-|-
![Screenshot_20240118_191618_forward_plus_no_debanding webp](https://github.com/godotengine/godot/assets/180032/197c4596-b8f6-49c3-9e7d-f7353129a8e6) | ![Screenshot_20240118_191651_forward_plus_viewport_debanding webp](https://github.com/godotengine/godot/assets/180032/c85e3b3d-431a-4262-ab72-ffab31c1f801) | ![Screenshot_20240118_191730_forward_plus_material_debanding webp](https://github.com/godotengine/godot/assets/180032/283b5fc7-0556-49ea-9227-dcff4cb83c5b) | ![Screenshot_20240118_191739_forward_plus_viewport_material_debanding webp](https://github.com/godotengine/godot/assets/180032/7f4e2971-cb72-4151-af67-380fea34b72f)

### Mobile

No debanding | Viewport-based debanding | Material-based debanding | Both debanding
-|-|-|-
![Screenshot_20240118_192121_mobile_no_debanding webp](https://github.com/godotengine/godot/assets/180032/9377a254-ea65-4d20-b95b-f49c6833af23) | ![Screenshot_20240118_192136_mobile_viewport_debanding webp](https://github.com/godotengine/godot/assets/180032/7119f14a-cae6-4846-9041-ca7a91eeb56a) | ![Screenshot_20240118_192137_mobile_material_debanding webp](https://github.com/godotengine/godot/assets/180032/e785671a-d707-4ee2-9bbd-af623caa0f35) | ![Screenshot_20240118_192137_mobile_viewport_material_debanding webp](https://github.com/godotengine/godot/assets/180032/c0d2b5d0-f723-4630-bf88-4906ac4b56b4)

<details>
<summary>With debanding applied after the division by `sc_luminance_multiplier` (looks too strong)</summary>

No debanding | Viewport-based debanding | Material-based debanding | Both debanding
-|-|-|-
![Screenshot_20240118_192121_mobile_no_debanding webp](https://github.com/godotengine/godot/assets/180032/9377a254-ea65-4d20-b95b-f49c6833af23) | ![Screenshot_20240118_192136_mobile_viewport_debanding webp](https://github.com/godotengine/godot/assets/180032/7119f14a-cae6-4846-9041-ca7a91eeb56a) | ![Screenshot_20240118_192649_mobile_lum_material_debanding webp](https://github.com/godotengine/godot/assets/180032/b331591e-f611-4f89-b7d5-39785c482a13) | ![Screenshot_20240118_192601_mobile_lum_viewport_material_debanding webp](https://github.com/godotengine/godot/assets/180032/1c3fc6ab-7762-4e72-9d64-e86196ab6b23) | 
</details>

### Compatibility

No debanding | Viewport-based debanding | Material-based debanding | Both debanding
-|-|-|-
![Screenshot_20240118_192346_compatibility_no_debanding webp](https://github.com/godotengine/godot/assets/180032/52a1f000-cec9-4fdc-92f2-85833b04c3d1) | ![Not available](https://placehold.co/1152x648?text=Not%20available) | ![Screenshot_20240118_192338_compatibility_material_debanding webp](https://github.com/godotengine/godot/assets/180032/4b1af6ee-ee91-4479-9449-74022069779b) | ![Not available](https://placehold.co/1152x648?text=Not%20available)
</details>
