### PR TITLE
Implement maximum undo steps in UndoRedo

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -316,6 +316,14 @@ void UndoRedo::commit_action(bool p_execute) {
 	_redo(p_execute); // perform action
 	committing--;
 
+	if (max_steps > 0) {
+		// Clear early steps.
+
+		while (actions.size() > max_steps) {
+			_pop_history_tail();
+		}
+	}
+
 	if (add_message && callback && actions.size() > 0) {
 		callback(callback_ud, actions[actions.size() - 1].name);
 	}
@@ -473,6 +481,14 @@ uint64_t UndoRedo::get_version() const {
 	return version;
 }
 
+void UndoRedo::set_max_steps(int p_max_steps) {
+	max_steps = p_max_steps;
+}
+
+int UndoRedo::get_max_steps() const {
+	return max_steps;
+}
+
 void UndoRedo::set_commit_notify_callback(CommitNotifyCallback p_callback, void *p_ud) {
 	callback = p_callback;
 	callback_ud = p_ud;
@@ -517,8 +533,12 @@ void UndoRedo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_undo"), &UndoRedo::has_undo);
 	ClassDB::bind_method(D_METHOD("has_redo"), &UndoRedo::has_redo);
 	ClassDB::bind_method(D_METHOD("get_version"), &UndoRedo::get_version);
+	ClassDB::bind_method(D_METHOD("set_max_steps", "max_steps"), &UndoRedo::set_max_steps);
+	ClassDB::bind_method(D_METHOD("get_max_steps"), &UndoRedo::get_max_steps);
 	ClassDB::bind_method(D_METHOD("redo"), &UndoRedo::redo);
 	ClassDB::bind_method(D_METHOD("undo"), &UndoRedo::undo);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_steps", PROPERTY_HINT_RANGE, "0,50,1,or_greater"), "set_max_steps", "get_max_steps");
 
 	ADD_SIGNAL(MethodInfo("version_changed"));
 

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -80,6 +80,7 @@ private:
 	int current_action = -1;
 	bool force_keep_in_merge_ends = false;
 	int action_level = 0;
+	int max_steps = 0;
 	MergeMode merge_mode = MERGE_DISABLE;
 	bool merging = false;
 	uint64_t version = 1;
@@ -134,6 +135,9 @@ public:
 	bool is_merging() const;
 
 	uint64_t get_version() const;
+
+	void set_max_steps(int p_max_steps);
+	int get_max_steps() const;
 
 	void set_commit_notify_callback(CommitNotifyCallback p_callback, void *p_ud);
 

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -255,6 +255,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="max_steps" type="int" setter="set_max_steps" getter="get_max_steps" default="0">
+			The maximum number of steps that can be stored in the undo/redo history. If the number of stored steps exceeds this limit, older steps are removed from history and can no longer be reached by calling [method undo]. A value of [code]0[/code] or lower means no limit.
+		</member>
+	</members>
 	<signals>
 		<signal name="version_changed">
 			<description>


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3575 and brings back the removed code from #15494, with added documentation.

For the future, I think adding a limit for the maximum memory usage as suggested in https://github.com/godotengine/godot-proposals/issues/3575#issuecomment-974671845 is still worth it, if max steps and maximum memory can even work together, but I don't know how to implement that.

Tested with [Pixelorama](https://github.com/Orama-Interactive/Pixelorama), it seems to be working as intended.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/3575_