### PR TITLE
Check if the ref shader is valid in visual shader's `_update_option_menu`

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1791,7 +1791,7 @@ void VisualShaderEditor::_update_options_menu() {
 					}
 
 					Ref<VisualShaderNodeParameterRef> parameter_ref = Object::cast_to<VisualShaderNodeParameterRef>(vsn.ptr());
-					if (parameter_ref.is_valid()) {
+					if (parameter_ref.is_valid() && parameter_ref->is_shader_valid()) {
 						check_result = -1;
 
 						if (members_input_port_type != VisualShaderNode::PORT_TYPE_MAX) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3591,6 +3591,10 @@ String VisualShaderNodeParameterRef::get_output_port_name(int p_port) const {
 	return "";
 }
 
+bool VisualShaderNodeParameterRef::is_shader_valid() const {
+	return shader_rid.is_valid();
+}
+
 void VisualShaderNodeParameterRef::set_shader_rid(const RID &p_shader_rid) {
 	shader_rid = p_shader_rid;
 }

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -640,6 +640,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
+	bool is_shader_valid() const;
 	void set_shader_rid(const RID &p_shader);
 
 	void set_parameter_name(const String &p_name);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87337

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
