### PR TITLE
Prevent `PhysicsDirectSpaceState3D::instersect_ray` when mouse is over non-ignorable gui

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -881,7 +881,7 @@ void Viewport::_process_picking() {
 					}
 				}
 			}
-		} else {
+		} else if (!gui.mouse_over || gui.mouse_over->get_mouse_filter() != Control::MOUSE_FILTER_STOP) {
 			if (camera_3d) {
 				Vector3 from = camera_3d->project_ray_origin(pos);
 				Vector3 dir = camera_3d->project_ray_normal(pos);
@@ -3172,6 +3172,7 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 		// Find the common ancestor of `gui.mouse_over` and `over`.
 		Control *common_ancestor = nullptr;
 		LocalVector<Control *> over_ancestors;
+		bool ancestor_is_stop_filter = false;
 
 		if (over) {
 			// Get all ancestors that the mouse is currently over and need an enter signal.
@@ -3189,6 +3190,7 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 					}
 					if (ancestor_control->get_mouse_filter() == Control::MOUSE_FILTER_STOP) {
 						// MOUSE_FILTER_STOP breaks the propagation chain.
+						ancestor_is_stop_filter = true;
 						break;
 					}
 				}
@@ -3203,7 +3205,7 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 		if (gui.mouse_over || !gui.mouse_over_hierarchy.is_empty()) {
 			// Send Mouse Exit Self and Mouse Exit notifications.
 			_drop_mouse_over(common_ancestor);
-		} else {
+		} else if (ancestor_is_stop_filter) {
 			_drop_physics_mouseover();
 		}
 


### PR DESCRIPTION
## Overview
This PR is intended to fix https://github.com/godotengine/godot/issues/87322, where a non-ignorable gui element was not blocking a `CollisionShape3D`'s `_mouse_enter` from being emitted.

## Issue
The cause of this bug is that `_drop_physics_mouseover` (in viewport.cpp) would get called when the mouse would move over gui, and that would cause a `_mouse_exit` to occur, and it would also result in the following if statement condition to be true: `new_collider != physics_object_over` because the `physics_object_over` would be null.  That shouldn't be an issue, except that it is possible for `_process_picking` to be invoked on the same exact frame as the previous `_drop_physics_mouseover`.

I'm not 100% certain about the last sentence above, but that was my best understanding based on my debugging.  I look forward to hearing from others that understand the engine better than I do.

## Fix
I think the fix is to only check for 3D objects in `process_picking` if `!gui.mouse_over`.  This does not break the Stop, Ignore, and Pass settings (as far as I can tell), but I have only tested on the minimum example project attached to this PR, and in the MRPs created based on comments from others.

## Minimum Fix Project
[minimal_mouse_hove_example.zip](https://github.com/godotengine/godot/files/13986723/minimal_mouse_hove_example.zip)
 
## Screen Recording of Fix

https://github.com/godotengine/godot/assets/8028662/1376f503-4ac5-4221-86e1-830cd44fbc28

When the mouse hovers over the 3D shape (it looks 2D because there is no lighting), the shape scales up use _mouse_enter.  When the mouse hovers off the 3D shape it scales down to its original scale.  I can explain the logs further if people have questions, but I want to keep this description short so I will hold off on that.
