### PR TITLE
Document bone list for SkeletonProfileHumanoid

### DIFF
--- a/doc/classes/SkeletonProfileHumanoid.xml
+++ b/doc/classes/SkeletonProfileHumanoid.xml
@@ -5,6 +5,63 @@
 	</brief_description>
 	<description>
 		A [SkeletonProfile] as a preset that is optimized for the human form. This exists for standardization, so all parameters are read-only.
+		A humanoid skeleton profile contains 54 bones divided in 4 groups: [code]"Body"[/code], [code]"Face"[/code], [code]"LeftHand"[/code], and [code]"RightHand"[/code]. It is structured as follows:
+		[codeblock]
+		Root
+		└─ Hips
+		    ├─ LeftUpperLeg
+		    │  └─ LeftLowerLeg
+		    │     └─ LeftFoot
+		    │        └─ LeftToes
+		    ├─ RightUpperLeg
+		    │  └─ RightLowerLeg
+		    │     └─ RightFoot
+		    │        └─ RightToes
+		    └─ Spine
+		        └─ Chest
+		            └─ UpperChest
+		                ├─ Neck
+		                │   └─ Head
+		                │       ├─ Jaw
+		                │       ├─ LeftEye
+		                │       └─ RightEye
+		                ├─ LeftShoulder
+		                │  └─ LeftUpperArm
+		                │     └─ LeftLowerArm
+		                │        └─ LeftHand
+		                │           ├─ LeftThumbMetacarpal
+		                │           │  └─ LeftThumbProximal
+		                │           ├─ LeftIndexProximal
+		                │           │  └─ LeftIndexIntermediate
+		                │           │    └─ LeftIndexDistal
+		                │           ├─ LeftMiddleProximal
+		                │           │  └─ LeftMiddleIntermediate
+		                │           │    └─ LeftMiddleDistal
+		                │           ├─ LeftRingProximal
+		                │           │  └─ LeftRingIntermediate
+		                │           │    └─ LeftRingDistal
+		                │           └─ LeftLittleProximal
+		                │              └─ LeftLittleIntermediate
+		                │                └─ LeftLittleDistal
+		                └─ RightShoulder
+		                   └─ RightUpperArm
+		                      └─ RightLowerArm
+		                         └─ RightHand
+		                            ├─ RightThumbMetacarpal
+		                            │  └─ RightThumbProximal
+		                            ├─ RightIndexProximal
+		                            │  └─ RightIndexIntermediate
+		                            │     └─ RightIndexDistal
+		                            ├─ RightMiddleProximal
+		                            │  └─ RightMiddleIntermediate
+		                            │     └─ RightMiddleDistal
+		                            ├─ RightRingProximal
+		                            │  └─ RightRingIntermediate
+		                            │     └─ RightRingDistal
+		                            └─ RightLittleProximal
+		                               └─ RightLittleIntermediate
+		                                 └─ RightLittleDistal
+		[/codeblock]
 	</description>
 	<tutorials>
 		<link title="Retargeting 3D Skeletons">$DOCS_URL/tutorials/assets_pipeline/retargeting_3d_skeletons.html</link>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/7214

This PR adds a big list of bones to **SkeletonProfileHumanoid**'s documentation (courtesy of @fire).

Unlike the provided list, the raw transform is not mentioned. If this is necessary, do say, and let's make them look a little nicer than that.