### PR TITLE
Export `EditorInspector::instantiate_property_editor` for use by plugins

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -26,6 +26,19 @@
 				Gets the path of the currently selected property.
 			</description>
 		</method>
+		<method name="instantiate_property_editor" qualifiers="static">
+			<return type="EditorProperty" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="type" type="int" enum="Variant.Type" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="hint" type="int" enum="PropertyHint" />
+			<param index="4" name="hint_text" type="String" />
+			<param index="5" name="usage" type="int" />
+			<param index="6" name="wide" type="bool" default="false" />
+			<description>
+				Creates a property editor that can be used by plugin UI to edit the specified property of an [param object].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" overrides="ScrollContainer" default="true" />

--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -29,6 +29,12 @@
 				If any of the controls added can gain keyboard focus, add it here. This ensures that focus will be restored if the inspector is refreshed.
 			</description>
 		</method>
+		<method name="deselect">
+			<return type="void" />
+			<description>
+				Draw property as not selected. Used by the inspector.
+			</description>
+		</method>
 		<method name="emit_changed">
 			<return type="void" />
 			<param index="0" name="property" type="StringName" />
@@ -51,11 +57,39 @@
 				Gets the edited property. If your editor is for a single property (added via [method EditorInspectorPlugin._parse_property]), then this will return the property.
 			</description>
 		</method>
+		<method name="is_selected" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if property is drawn as selected. Used by the inspector.
+			</description>
+		</method>
+		<method name="select">
+			<return type="void" />
+			<param index="0" name="focusable" type="int" default="-1" />
+			<description>
+				Draw property as selected. Used by the inspector.
+			</description>
+		</method>
 		<method name="set_bottom_editor">
 			<return type="void" />
 			<param index="0" name="editor" type="Control" />
 			<description>
 				Puts the [param editor] control below the property label. The control must be previously added using [method Node.add_child].
+			</description>
+		</method>
+		<method name="set_label_reference">
+			<return type="void" />
+			<param index="0" name="control" type="Control" />
+			<description>
+				Used by the inspector, set to a control that will be used as a reference to calculate the size of the label.
+			</description>
+		</method>
+		<method name="set_object_and_property">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="property" type="StringName" />
+			<description>
+				Assigns object and property to edit.
 			</description>
 		</method>
 		<method name="update_property">
@@ -84,8 +118,17 @@
 		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
 			Set this property to change the label (if you want to show one).
 		</member>
+		<member name="name_split_ratio" type="float" setter="set_name_split_ratio" getter="get_name_split_ratio" default="0.5">
+			Space distribution ratio between the label and the editing field.
+		</member>
 		<member name="read_only" type="bool" setter="set_read_only" getter="is_read_only" default="false" keywords="enabled, disabled, editable">
 			Used by the inspector, set to [code]true[/code] when the property is read-only.
+		</member>
+		<member name="selectable" type="bool" setter="set_selectable" getter="is_selectable" default="true">
+			Used by the inspector, set to [code]true[/code] when the property is selectable.
+		</member>
+		<member name="use_folding" type="bool" setter="set_use_folding" getter="is_using_folding" default="false">
+			Used by the inspector, set to [code]true[/code] when the property is using folding.
 		</member>
 	</members>
 	<signals>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -999,6 +999,21 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_focusable", "control"), &EditorProperty::add_focusable);
 	ClassDB::bind_method(D_METHOD("set_bottom_editor", "editor"), &EditorProperty::set_bottom_editor);
 
+	ClassDB::bind_method(D_METHOD("set_selectable", "selectable"), &EditorProperty::set_selectable);
+	ClassDB::bind_method(D_METHOD("is_selectable"), &EditorProperty::is_selectable);
+
+	ClassDB::bind_method(D_METHOD("set_use_folding", "use_folding"), &EditorProperty::set_use_folding);
+	ClassDB::bind_method(D_METHOD("is_using_folding"), &EditorProperty::is_using_folding);
+
+	ClassDB::bind_method(D_METHOD("set_name_split_ratio", "ratio"), &EditorProperty::set_name_split_ratio);
+	ClassDB::bind_method(D_METHOD("get_name_split_ratio"), &EditorProperty::get_name_split_ratio);
+
+	ClassDB::bind_method(D_METHOD("deselect"), &EditorProperty::deselect);
+	ClassDB::bind_method(D_METHOD("is_selected"), &EditorProperty::is_selected);
+	ClassDB::bind_method(D_METHOD("select", "focusable"), &EditorProperty::select, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("set_object_and_property", "object", "property"), &EditorProperty::set_object_and_property);
+	ClassDB::bind_method(D_METHOD("set_label_reference", "control"), &EditorProperty::set_label_reference);
+
 	ClassDB::bind_method(D_METHOD("emit_changed", "property", "value", "field", "changing"), &EditorProperty::emit_changed, DEFVAL(StringName()), DEFVAL(false));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");
@@ -1008,6 +1023,9 @@ void EditorProperty::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_warning"), "set_draw_warning", "is_draw_warning");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keying"), "set_keying", "is_keying");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deletable"), "set_deletable", "is_deletable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selectable"), "set_selectable", "is_selectable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_folding"), "set_use_folding", "is_using_folding");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "name_split_ratio"), "set_name_split_ratio", "get_name_split_ratio");
 
 	ADD_SIGNAL(MethodInfo("property_changed", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::STRING_NAME, "field"), PropertyInfo(Variant::BOOL, "changing")));
 	ADD_SIGNAL(MethodInfo("multiple_properties_changed", PropertyInfo(Variant::PACKED_STRING_ARRAY, "properties"), PropertyInfo(Variant::ARRAY, "value")));
@@ -4250,6 +4268,8 @@ void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
 	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);
+
+	ClassDB::bind_static_method("EditorInspector", D_METHOD("instantiate_property_editor", "object", "type", "path", "hint", "hint_text", "usage", "wide"), &EditorInspector::instantiate_property_editor, DEFVAL(false));
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -153,7 +153,10 @@ public:
 
 	Object *get_edited_object();
 	StringName get_edited_property() const;
-	inline Variant get_edited_property_value() const { return object->get(property); }
+	inline Variant get_edited_property_value() const {
+		ERR_FAIL_NULL_V(object, Variant());
+		return object->get(property);
+	}
 	EditorInspector *get_parent_inspector() const;
 
 	void set_doc_path(const String &p_doc_path);


### PR DESCRIPTION
This PR exports `EditorInspector::instantiate_property_editor` in the Godot API, so that plugin developers could reuse existing property editors in their projects. It also exports several useful properties and methods in the `EditorProperty`. Some of those properties are needed to implement custom inspectors (demo below).

See proposal: closes https://github.com/godotengine/godot-proposals/issues/8908

With this change, users can create a property editor like this:
```gdscript
EditorInspector.instantiate_property_editor(obj, TYPE_STRING, "some_property", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_DEFAULT, false)
```

Test/demo project: Plugin that adds a custom inspector for a data object in the bottom panel: https://github.com/limbonaut/godot-custom-inspector-demo

![image](https://github.com/godotengine/godot/assets/2766569/e4ed30cc-424b-4aae-be81-ea7b1155c309)
