### PR TITLE
SCons: Add `num_jobs` as an explicit option so it can be set from other sources

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -234,6 +234,11 @@ opts.Add(BoolVariable("tests", "Build the unit tests", False))
 opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False))
 opts.Add(BoolVariable("ninja", "Use the ninja backend for faster rebuilds", False))
 opts.Add(BoolVariable("compiledb", "Generate compilation DB (`compile_commands.json`) for external tools", False))
+opts.Add(
+    "num_jobs",
+    "Use up to N jobs when compiling (equivalent to `-j N`). Defaults to max jobs - 1. Ignored if -j is used.",
+    "",
+)
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
 opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
 opts.Add(EnumVariable("warnings", "Level of compilation warnings", "all", ("extra", "all", "moderate", "no")))
@@ -537,16 +542,22 @@ initial_num_jobs = env.GetOption("num_jobs")
 altered_num_jobs = initial_num_jobs + 1
 env.SetOption("num_jobs", altered_num_jobs)
 if env.GetOption("num_jobs") == altered_num_jobs:
-    cpu_count = os.cpu_count()
-    if cpu_count is None:
-        print_warning("Couldn't auto-detect CPU count to configure build parallelism. Specify it with the -j argument.")
+    num_jobs = env.get("num_jobs", "")
+    if str(num_jobs).isdigit() and int(num_jobs) > 0:
+        env.SetOption("num_jobs", num_jobs)
     else:
-        safer_cpu_count = cpu_count if cpu_count <= 4 else cpu_count - 1
-        print(
-            "Auto-detected %d CPU cores available for build parallelism. Using %d cores by default. You can override it with the -j argument."
-            % (cpu_count, safer_cpu_count)
-        )
-        env.SetOption("num_jobs", safer_cpu_count)
+        cpu_count = os.cpu_count()
+        if cpu_count is None:
+            print_warning(
+                "Couldn't auto-detect CPU count to configure build parallelism. Specify it with the `-j` or `num_jobs` arguments."
+            )
+        else:
+            safer_cpu_count = cpu_count if cpu_count <= 4 else cpu_count - 1
+            print(
+                "Auto-detected %d CPU cores available for build parallelism. Using %d cores by default. You can override it with the `-j` or `num_jobs` arguments."
+                % (cpu_count, safer_cpu_count)
+            )
+            env.SetOption("num_jobs", safer_cpu_count)
 
 env.extra_suffix = ""
 


### PR DESCRIPTION
The `-j` flag is only settable via the command line, which makes it hard to configure when running builds from places like VS, where the flag isn't easily exposed or configurable.

This adds a `num_jobs` option, which lets users configure the number of jobs to be used by default (in a custom.py file or other similar mechanism) if `-j` isn't specified, instead of always defaulting to number of cores - 1. 

*Contributed by W4 Games :heart:*
