### PR TITLE
Add NavigationMesh `border_size` property for tile baking

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -96,6 +96,11 @@
 			The distance to erode/shrink the walkable area of the heightfield away from obstructions.
 			[b]Note:[/b] While baking, this value will be rounded up to the nearest multiple of [member cell_size].
 		</member>
+		<member name="border_size" type="float" setter="set_border_size" getter="get_border_size" default="0.0">
+			The size of the non-navigable border around the bake bounding area.
+			In conjunction with the [member filter_baking_aabb] and a [member edge_max_error] value at [code]1.0[/code] or below the border size can be used to bake tile aligned navigation meshes without the tile edges being shrunk by [member agent_radius].
+			[b]Note:[/b] While baking and not zero, this value will be rounded up to the nearest multiple of [member cell_size].
+		</member>
 		<member name="cell_height" type="float" setter="set_cell_height" getter="get_cell_height" default="0.25">
 			The cell height used to rasterize the navigation mesh vertices on the Y axis. Must match with the cell height on the navigation map.
 		</member>

--- a/modules/navigation/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/nav_mesh_generator_3d.cpp
@@ -625,6 +625,9 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 
 	cfg.cs = p_navigation_mesh->get_cell_size();
 	cfg.ch = p_navigation_mesh->get_cell_height();
+	if (p_navigation_mesh->get_border_size() > 0.0) {
+		cfg.borderSize = (int)Math::ceil(p_navigation_mesh->get_border_size() / cfg.cs);
+	}
 	cfg.walkableSlopeAngle = p_navigation_mesh->get_agent_max_slope();
 	cfg.walkableHeight = (int)Math::ceil(p_navigation_mesh->get_agent_height() / cfg.ch);
 	cfg.walkableClimb = (int)Math::floor(p_navigation_mesh->get_agent_max_climb() / cfg.ch);
@@ -637,6 +640,9 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 	cfg.detailSampleDist = MAX(p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance(), 0.1f);
 	cfg.detailSampleMaxError = p_navigation_mesh->get_cell_height() * p_navigation_mesh->get_detail_sample_max_error();
 
+	if (p_navigation_mesh->get_border_size() > 0.0 && !Math::is_equal_approx(p_navigation_mesh->get_cell_size(), p_navigation_mesh->get_border_size())) {
+		WARN_PRINT("Property border_size is ceiled to cell_size voxel units and loses precision.");
+	}
 	if (!Math::is_equal_approx((float)cfg.walkableHeight * cfg.ch, p_navigation_mesh->get_agent_height())) {
 		WARN_PRINT("Property agent_height is ceiled to cell_height voxel units and loses precision.");
 	}
@@ -738,11 +744,11 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<Navigation
 
 	if (p_navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_WATERSHED) {
 		ERR_FAIL_COND(!rcBuildDistanceField(&ctx, *chf));
-		ERR_FAIL_COND(!rcBuildRegions(&ctx, *chf, 0, cfg.minRegionArea, cfg.mergeRegionArea));
+		ERR_FAIL_COND(!rcBuildRegions(&ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea));
 	} else if (p_navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_MONOTONE) {
-		ERR_FAIL_COND(!rcBuildRegionsMonotone(&ctx, *chf, 0, cfg.minRegionArea, cfg.mergeRegionArea));
+		ERR_FAIL_COND(!rcBuildRegionsMonotone(&ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea));
 	} else {
-		ERR_FAIL_COND(!rcBuildLayerRegions(&ctx, *chf, 0, cfg.minRegionArea));
+		ERR_FAIL_COND(!rcBuildLayerRegions(&ctx, *chf, cfg.borderSize, cfg.minRegionArea));
 	}
 
 	bake_state = "Creating contours..."; // step #8

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -153,6 +153,15 @@ float NavigationMesh::get_cell_height() const {
 	return cell_height;
 }
 
+void NavigationMesh::set_border_size(float p_value) {
+	ERR_FAIL_COND(p_value < 0);
+	border_size = p_value;
+}
+
+float NavigationMesh::get_border_size() const {
+	return border_size;
+}
+
 void NavigationMesh::set_agent_height(float p_value) {
 	ERR_FAIL_COND(p_value < 0);
 	agent_height = p_value;
@@ -464,6 +473,9 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_cell_height", "cell_height"), &NavigationMesh::set_cell_height);
 	ClassDB::bind_method(D_METHOD("get_cell_height"), &NavigationMesh::get_cell_height);
 
+	ClassDB::bind_method(D_METHOD("set_border_size", "border_size"), &NavigationMesh::set_border_size);
+	ClassDB::bind_method(D_METHOD("get_border_size"), &NavigationMesh::get_border_size);
+
 	ClassDB::bind_method(D_METHOD("set_agent_height", "agent_height"), &NavigationMesh::set_agent_height);
 	ClassDB::bind_method(D_METHOD("get_agent_height"), &NavigationMesh::get_agent_height);
 
@@ -537,9 +549,10 @@ void NavigationMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_source_geometry_mode", PROPERTY_HINT_ENUM, "Root Node Children,Group With Children,Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "geometry_source_group_name"), "set_source_group_name", "get_source_group_name");
 	ADD_PROPERTY_DEFAULT("geometry_source_group_name", StringName("navigation_mesh_source_group"));
-	ADD_GROUP("Cells", "cell_");
+	ADD_GROUP("Cells", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_size", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater,suffix:m"), "set_cell_size", "get_cell_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_height", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater,suffix:m"), "set_cell_height", "get_cell_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "border_size", PROPERTY_HINT_RANGE, "0.0,500.0,0.01,or_greater,suffix:m"), "set_border_size", "get_border_size");
 	ADD_GROUP("Agents", "agent_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_height", PROPERTY_HINT_RANGE, "0.0,500.0,0.01,or_greater,suffix:m"), "set_agent_height", "get_agent_height");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_radius", PROPERTY_HINT_RANGE, "0.0,500.0,0.01,or_greater,suffix:m"), "set_agent_radius", "get_agent_radius");

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -80,6 +80,7 @@ public:
 protected:
 	float cell_size = 0.25f; // Must match ProjectSettings default 3D cell_size and NavigationServer NavMap cell_size.
 	float cell_height = 0.25f; // Must match ProjectSettings default 3D cell_height and NavigationServer NavMap cell_height.
+	float border_size = 0.0f;
 	float agent_height = 1.5f;
 	float agent_radius = 0.5f;
 	float agent_max_climb = 0.25f;
@@ -130,6 +131,9 @@ public:
 
 	void set_cell_height(float p_value);
 	float get_cell_height() const;
+
+	void set_border_size(float p_value);
+	float get_border_size() const;
 
 	void set_agent_height(float p_value);
 	float get_agent_height() const;


### PR DESCRIPTION
Adds NavigationMesh `border_size` property for tile baking.

This allows users to partition larger game worlds into regions that have navigation meshes with easy to align tile edges. This tile edges can be efficiently merged by the navigation map using edgekeys. It also avoids problems with the agent_radius offset affecting the tile edges.

The difference between baking AABB and border size is, that the AABB limits the entire source geometry used in the baking as a bounding area while the border size limits the surface of the resulting navigation mesh.

This means in conjunction they can be used to limit the final navigation mesh without having unwanted offsets by e.g. agent radius at tile edges.

![nav_mesh_border_size](https://github.com/godotengine/godot/assets/52464204/4d22439a-4eb9-4b5f-9f16-b5de8f901914)

When users do the setup the border_size should be larger than the agent_radius and the AABB should be grown by the exact amount of the border_size.

The border size that ReCast uses internally is in voxel units, so the Godot border size float is ceiled to the cell size.

To bake a "perfect" aligned tile navigation mesh additional properties need to be considered. E.g. the edge_max_error should be at or blow 1.0.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
