### PR TITLE
Allow an optional editor SCsub in platforms

### DIFF
--- a/editor/SCsub
+++ b/editor/SCsub
@@ -45,6 +45,11 @@ if env.editor_build:
 
     methods.write_file_if_needed("register_exporters.gen.cpp", reg_exporters_inc + reg_exporters)
 
+    for e in env.platform_exporters:
+        scsub_path = os.path.join(Dir("#platform/%s/editor" % e).abspath, "SCsub")
+        if os.path.exists(scsub_path):
+            SConscript(scsub_path)
+
     # Core API documentation.
     docs = []
     docs += Glob("#doc/classes/*.xml")


### PR DESCRIPTION
Each platform port have `detect.py` and `SCsub` scripts, but they are only relevant when building precisely for that platform. However, their editor part ~`export/`~ can't be further customized and have to be happy with the simple logic the editor build script features for them. This PR lets platforms have an optional `SCsub` to allow further customizations, like adding extra files (e.g., and this is my current real-world need, having third-party code scoped to the editor portion of a given platform).

**UPDATE:** Added also a way to extend modules with per-plaform `SCsub`. Moving to draft until this is discussed further.

**UPDATE:** Removed the addition above, as it turned out to be a bad approach.