### PR TITLE
Better hide internal properties from users

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2862,9 +2862,17 @@ void EditorHelpTooltip::parse_tooltip(const String &p_text) {
 	const String &property_name = slices[2];
 	const String &property_args = slices[3];
 
+	String formatted_text;
+
+	// Exclude internal properties, they are not documented.
+	if (type == "internal_property") {
+		formatted_text = "[i]" + TTR("This property can only be set in the Inspector.") + "[/i]";
+		set_text(formatted_text);
+		return;
+	}
+
 	String title;
 	String description;
-	String formatted_text;
 
 	if (type == "class") {
 		title = class_name;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -74,6 +74,7 @@ private:
 	StringName property;
 	String property_path;
 	String doc_path;
+	bool internal = false;
 	bool has_doc_tooltip = false;
 
 	int property_usage;
@@ -156,6 +157,7 @@ public:
 	EditorInspector *get_parent_inspector() const;
 
 	void set_doc_path(const String &p_doc_path);
+	void set_internal(bool p_internal);
 
 	virtual void update_property();
 	void update_editor_property_status();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1135,7 +1135,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							List<PropertyInfo> members;
 							scr->get_script_property_list(&members);
 							for (const PropertyInfo &E : members) {
-								if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP)) {
+								if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 									continue;
 								}
 								if (E.name.contains("/")) {
@@ -1210,7 +1210,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						List<PropertyInfo> pinfo;
 						ClassDB::get_property_list(type, &pinfo);
 						for (const PropertyInfo &E : pinfo) {
-							if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP)) {
+							if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 								continue;
 							}
 							if (E.name.contains("/")) {
@@ -1273,7 +1273,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 					}
 
 					for (const PropertyInfo &E : members) {
-						if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP)) {
+						if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 							continue;
 						}
 						if (!String(E.name).contains("/")) {
@@ -3514,6 +3514,12 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				if (ClassDB::has_property(class_name, p_symbol, true)) {
+					PropertyInfo prop_info;
+					ClassDB::get_property_info(class_name, p_symbol, &prop_info, true);
+					if (prop_info.usage & PROPERTY_USAGE_INTERNAL) {
+						return ERR_CANT_RESOLVE;
+					}
+
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
 					r_result.class_name = base_type.native_type;
 					r_result.class_member = p_symbol;


### PR DESCRIPTION
This addresses some of pain points raised by https://github.com/godotengine/godot/issues/87374 and other similar tickets. Internal properties are not meant to be used in scripting, they aren't documented. So this PR does a couple of things.

- Adds a custom tooltip for internal properties to the inspector dock. I'm open to suggestions for what it should say, but so far it's this:

<img width="394" alt="godot windows editor dev x86_64_2024-01-19_18-43-00" src="https://github.com/godotengine/godot/assets/11782833/ec8ab854-6815-4243-88a6-5a178c0cf5ee">

- Removes internal properties from GDScript code suggestions and makes them unresolvable for symbol lookup (i.e. ctrl-clicking).

<img width="272" alt="godot windows editor dev x86_64_2024-01-19_18-50-10" src="https://github.com/godotengine/godot/assets/11782833/ac7613e6-3fd8-41e5-b7c2-994c2a9f2aa2">

This doesn't really solve the root of the issue, nor does it help C# or GDExtension users. But it should help reduce the confusion.

----

Edit: Since the issue is specific to GDScript, this PR would effectively "fix" and close https://github.com/godotengine/godot/issues/25651.