### PR TITLE
Fix SubViewport physics picking

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -738,6 +738,14 @@ void Viewport::_process_picking() {
 
 	while (physics_picking_events.size()) {
 		local_input_handled = false;
+		if (!handle_input_locally) {
+			Viewport *vp = this;
+			while (!Object::cast_to<Window>(vp) && vp->get_parent()) {
+				vp = vp->get_parent()->get_viewport();
+			}
+			vp->local_input_handled = false;
+		}
+
 		Ref<InputEvent> ev = physics_picking_events.front()->get();
 		physics_picking_events.pop_front();
 


### PR DESCRIPTION
Apply the logic of `handle_input_locally` for physics picking.

resolve #84258
cherry-pick of #85665 from 4.2 to master.

I see this as an interim solution until #77926 gets reviewed.
I believe, that it is unlikely that #77926 gets reviews anytime soon, but since #84258 is quite nasty, I want to provide a bugfix-PR, that is easier to review and that already received some testing in 4.2.