### PR TITLE
Add GLES3 infrastructure for lightmap baking in the compatibility backend

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -9,7 +9,7 @@
 		[b]Performance:[/b] [LightmapGI] provides the best possible run-time performance for global illumination. It is suitable for low-end hardware including integrated graphics and mobile devices.
 		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 		[b]Note:[/b] Lightmap baking on [CSGShape3D]s and [PrimitiveMesh]es is not supported, as these cannot store UV2 data required for baking.
-		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked when using the Vulkan backend (Forward+ or Mobile), not OpenGL.
+		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked from devices that support the Forward+ or Mobile rendering backends.
 	</description>
 	<tutorials>
 		<link title="Using Lightmap global illumination">$DOCS_URL/tutorials/3d/global_illumination/using_lightmap_gi.html</link>

--- a/drivers/gles3/effects/copy_effects.cpp
+++ b/drivers/gles3/effects/copy_effects.cpp
@@ -152,7 +152,17 @@ void CopyEffects::copy_cube_to_rect(const Rect2 &p_rect) {
 		return;
 	}
 
-	copy.shader.version_set_uniform(CopyShaderGLES3::COPY_SECTION, p_rect.position.x, p_rect.position.y, p_rect.size.x, p_rect.size.y, copy.shader_version, CopyShaderGLES3::MODE_COPY_SECTION);
+	copy.shader.version_set_uniform(CopyShaderGLES3::COPY_SECTION, p_rect.position.x, p_rect.position.y, p_rect.size.x, p_rect.size.y, copy.shader_version, CopyShaderGLES3::MODE_CUBE_TO_OCTAHEDRAL);
+	draw_screen_quad();
+}
+
+void CopyEffects::copy_cube_to_panorama(float p_mip_level) {
+	bool success = copy.shader.version_bind_shader(copy.shader_version, CopyShaderGLES3::MODE_CUBE_TO_PANORAMA);
+	if (!success) {
+		return;
+	}
+
+	copy.shader.version_set_uniform(CopyShaderGLES3::MIP_LEVEL, p_mip_level, copy.shader_version, CopyShaderGLES3::MODE_CUBE_TO_PANORAMA);
 	draw_screen_quad();
 }
 

--- a/drivers/gles3/effects/copy_effects.h
+++ b/drivers/gles3/effects/copy_effects.h
@@ -65,6 +65,7 @@ public:
 	void copy_to_and_from_rect(const Rect2 &p_rect);
 	void copy_screen();
 	void copy_cube_to_rect(const Rect2 &p_rect);
+	void copy_cube_to_panorama(float p_mip_level);
 	void bilinear_blur(GLuint p_source_texture, int p_mipmap_count, const Rect2i &p_region);
 	void gaussian_blur(GLuint p_source_texture, int p_mipmap_count, const Rect2i &p_region, const Size2i &p_size);
 	void set_color(const Color &p_color, const Rect2i &p_region);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -61,6 +61,7 @@ enum PassMode {
 	PASS_MODE_COLOR_TRANSPARENT,
 	PASS_MODE_SHADOW,
 	PASS_MODE_DEPTH,
+	PASS_MODE_MATERIAL,
 };
 
 // These should share as much as possible with SkyUniform Location
@@ -375,7 +376,7 @@ private:
 			float ambient_light_color_energy[4];
 
 			float ambient_color_sky_mix;
-			uint32_t material_uv2_mode;
+			uint32_t pad2;
 			float emissive_exposure_normalization;
 			uint32_t use_ambient_light = 0;
 
@@ -465,13 +466,15 @@ private:
 		bool reverse_cull = false;
 		uint64_t spec_constant_base_flags = 0;
 		bool force_wireframe = false;
+		Vector2 uv_offset = Vector2(0, 0);
 
-		RenderListParameters(GeometryInstanceSurface **p_elements, int p_element_count, bool p_reverse_cull, uint64_t p_spec_constant_base_flags, bool p_force_wireframe = false) {
+		RenderListParameters(GeometryInstanceSurface **p_elements, int p_element_count, bool p_reverse_cull, uint64_t p_spec_constant_base_flags, bool p_force_wireframe = false, Vector2 p_uv_offset = Vector2()) {
 			elements = p_elements;
 			element_count = p_element_count;
 			reverse_cull = p_reverse_cull;
 			spec_constant_base_flags = p_spec_constant_base_flags;
 			force_wireframe = p_force_wireframe;
+			uv_offset = p_uv_offset;
 		}
 	};
 
@@ -647,6 +650,10 @@ protected:
 	void _draw_sky(RID p_env, const Projection &p_projection, const Transform3D &p_transform, float p_luminance_multiplier, bool p_use_multiview, bool p_flip_y);
 	void _free_sky_data(Sky *p_sky);
 
+	// Needed for a single argument calls (material and uv2).
+	PagedArrayPool<RenderGeometryInstance *> cull_argument_pool;
+	PagedArray<RenderGeometryInstance *> cull_argument;
+
 public:
 	static RasterizerSceneGLES3 *get_singleton() { return singleton; }
 
@@ -747,6 +754,7 @@ public:
 	void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override;
 
 	TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) override;
+	void _render_uv2(const PagedArray<RenderGeometryInstance *> &p_instances, GLuint p_framebuffer, const Rect2i &p_region);
 
 	bool free(RID p_rid) override;
 	void update() override;

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -31,6 +31,7 @@ USE_ADDITIVE_LIGHTING = false
 // these are false, we are doing a directional light pass.
 ADDITIVE_OMNI = false
 ADDITIVE_SPOT = false
+RENDER_MATERIAL = false
 
 
 #[vertex]
@@ -90,7 +91,7 @@ layout(location = 3) in vec4 color_attrib;
 layout(location = 4) in vec2 uv_attrib;
 #endif
 
-#if defined(UV2_USED) || defined(USE_LIGHTMAP)
+#if defined(UV2_USED) || defined(USE_LIGHTMAP) || defined(RENDER_MATERIAL)
 layout(location = 5) in vec2 uv2_attrib;
 #endif
 
@@ -160,12 +161,12 @@ layout(std140) uniform SceneData { // ubo:2
 	mediump vec4 ambient_light_color_energy;
 
 	mediump float ambient_color_sky_mix;
-	bool material_uv2_mode;
+	float pad2;
 	float emissive_exposure_normalization;
 	bool use_ambient_light;
+
 	bool use_ambient_cubemap;
 	bool use_reflection_cubemap;
-
 	float fog_aerial_perspective;
 	float time;
 
@@ -248,6 +249,10 @@ uniform highp vec3 compressed_aabb_size;
 uniform highp vec4 uv_scale;
 
 uniform highp uint model_flags;
+
+#ifdef RENDER_MATERIAL
+uniform mediump vec2 uv_offset;
+#endif
 
 /* Varyings */
 
@@ -511,6 +516,12 @@ void main() {
 #else
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
 #endif
+
+#ifdef RENDER_MATERIAL
+	gl_Position.xy = (uv2_attrib.xy + uv_offset) * 2.0 - 1.0;
+	gl_Position.z = 0.00001;
+	gl_Position.w = 1.0;
+#endif
 }
 
 /* clang-format off */
@@ -632,12 +643,12 @@ layout(std140) uniform SceneData { // ubo:2
 	mediump vec4 ambient_light_color_energy;
 
 	mediump float ambient_color_sky_mix;
-	bool material_uv2_mode;
+	float pad2;
 	float emissive_exposure_normalization;
 	bool use_ambient_light;
+
 	bool use_ambient_cubemap;
 	bool use_reflection_cubemap;
-
 	float fog_aerial_perspective;
 	float time;
 
@@ -878,7 +889,19 @@ vec2 multiview_uv(vec2 uv) {
 uniform highp mat4 world_transform;
 uniform mediump float opaque_prepass_threshold;
 
+#ifndef MODE_RENDER_DEPTH
+#ifdef RENDER_MATERIAL
+layout(location = 0) out vec4 albedo_output_buffer;
+layout(location = 1) out vec4 normal_output_buffer;
+layout(location = 2) out vec4 orm_output_buffer;
+layout(location = 3) out vec4 emission_output_buffer;
+
+#else // !RENDER_MATERIAL
+// Normal color rendering.
 layout(location = 0) out vec4 frag_color;
+
+#endif // !RENDER_MATERIAL
+#endif // !MODE_RENDER_DEPTH
 
 vec3 F0(float metallic, float specular, vec3 albedo) {
 	float dielectric = 0.16 * specular * specular;
@@ -1660,6 +1683,23 @@ void main() {
 
 // Nothing happens, so a tree-ssa optimizer will result in no fragment shader :)
 #else // !MODE_RENDER_DEPTH
+
+#ifdef RENDER_MATERIAL
+
+	albedo_output_buffer.rgb = albedo;
+	albedo_output_buffer.a = alpha;
+
+	normal_output_buffer.rgb = normal * 0.5 + 0.5;
+	normal_output_buffer.a = 0.0;
+
+	orm_output_buffer.r = ao;
+	orm_output_buffer.g = roughness;
+	orm_output_buffer.b = metallic;
+	orm_output_buffer.a = 1.0;
+
+	emission_output_buffer.rgb = emission;
+	emission_output_buffer.a = 0.0;
+#else // !RENDER_MATERIAL
 #ifdef BASE_PASS
 #ifdef MODE_UNSHADED
 	frag_color = vec4(albedo, alpha);
@@ -1914,6 +1954,6 @@ void main() {
 
 	frag_color.rgb += additive_light_color;
 #endif // USE_ADDITIVE_LIGHTING
-
+#endif // !RENDER_MATERIAL
 #endif //!MODE_RENDER_DEPTH
 }

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -494,6 +494,10 @@ public:
 	};
 	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); };
 
+	void texture_2d_initialize_from_texture(RID p_texture, Texture &p_tex) {
+		texture_owner.initialize_rid(p_texture, p_tex);
+	}
+
 	virtual bool can_create_resources_async() const override;
 
 	virtual RID texture_allocate() override;

--- a/drivers/gles3/storage/utilities.h
+++ b/drivers/gles3/storage/utilities.h
@@ -111,6 +111,7 @@ public:
 	}
 
 	// Records that data was allocated for state tracking purposes.
+	// Size is measured in bytes.
 	_FORCE_INLINE_ void texture_allocated_data(GLuint p_id, uint32_t p_size, String p_name = "") {
 		texture_mem_cache += p_size;
 #ifdef DEV_ENABLED

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -769,7 +769,7 @@ LightmapperRD::BakeError LightmapperRD::_dilate(RenderingDevice *rd, Ref<RDShade
 
 #ifdef DEBUG_TEXTURES
 	for (int i = 0; i < atlas_slices; i++) {
-		Vector<uint8_t> s = rd->texture_get_data(light_accum_tex, i);
+		Vector<uint8_t> s = rd->texture_get_data(source_light_tex, i);
 		Ref<Image> img = Image::create_from_data(atlas_size.width, atlas_size.height, false, Image::FORMAT_RGBAH, s);
 		img->convert(Image::FORMAT_RGBA8);
 		img->save_png("res://5_dilated_" + itos(i) + ".png");

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1532,7 +1532,7 @@ PackedStringArray LightmapGI::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
-		warnings.push_back(RTR("Lightmap cannot be baked when using the GL Compatibility backend yet. Support will be added in a future release."));
+		warnings.push_back(RTR("Lightmap can only be baked from a device that supports the RD backends. Lightmap baking may fail."));
 		return warnings;
 	}
 


### PR DESCRIPTION
Combined with https://github.com/godotengine/godot/pull/87340 this allows baking lightmaps from the compatibility backend as long as the device supports creating an RD context. 

This was needed to verify that https://github.com/godotengine/godot/pull/87340 works as intended. 

This PR can still be tested without merging https://github.com/godotengine/godot/pull/87340 as the functions it implements are all available through the RenderingServer API directly.

Skies are slightly brighter in the compatibility backend right now and this has an impact on lightmap brightness. The results when baking from the compatibility backend are slightly brighter than in the other backends, but the results are very close. 