### PR TITLE
Fix property of type Node duplication when script is attached to a child node

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -247,6 +247,7 @@ private:
 	void _propagate_groups_dirty();
 	Array _get_node_and_resource(const NodePath &p_path);
 
+	void _duplicate_properties_node(const Node *p_root, const Node *p_original, Node *p_copy) const;
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
 	Node *_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap = nullptr) const;
 


### PR DESCRIPTION
This is a continuation of a last PR where I seemed to have only partially solved the problem with node duplication as pointed out by one of the comments [after the PR got merged](https://github.com/godotengine/godot/pull/83343#issuecomment-1872988602). 

This PR should hopefully solve the edge case when a script is attached to a child node but the user duplicates that node's parent.