### PR TITLE
Explicitly initialize all of `FileAccess::create_func[ACCESS_MAX]`

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -38,7 +38,7 @@
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 
-FileAccess::CreateFunc FileAccess::create_func[ACCESS_MAX] = { nullptr, nullptr };
+FileAccess::CreateFunc FileAccess::create_func[ACCESS_MAX] = {};
 
 FileAccess::FileCloseFailNotify FileAccess::close_fail_notify = nullptr;
 


### PR DESCRIPTION
It looks like it should have three entries.