### PR TITLE
Add basic multimesh data needed for headless export to the Dummy rendering server

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.cpp
+++ b/servers/rendering/dummy/storage/mesh_storage.cpp
@@ -63,3 +63,33 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 
 	m->surfaces.clear();
 }
+
+RID MeshStorage::multimesh_allocate() {
+	return multimesh_owner.allocate_rid();
+}
+
+void MeshStorage::multimesh_initialize(RID p_rid) {
+	multimesh_owner.initialize_rid(p_rid, DummyMultiMesh());
+}
+
+void MeshStorage::multimesh_free(RID p_rid) {
+	DummyMultiMesh *multimesh = multimesh_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(multimesh);
+
+	multimesh_owner.free(p_rid);
+}
+
+void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) {
+	DummyMultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_NULL(multimesh);
+	multimesh->buffer.resize(p_buffer.size());
+	float *cache_data = multimesh->buffer.ptrw();
+	memcpy(cache_data, p_buffer.ptr(), p_buffer.size() * sizeof(float));
+}
+
+Vector<float> MeshStorage::multimesh_get_buffer(RID p_multimesh) const {
+	DummyMultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_NULL_V(multimesh, Vector<float>());
+
+	return multimesh->buffer;
+}

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -50,6 +50,12 @@ private:
 
 	mutable RID_Owner<DummyMesh> mesh_owner;
 
+	struct DummyMultiMesh {
+		PackedFloat32Array buffer;
+	};
+
+	mutable RID_Owner<DummyMultiMesh> multimesh_owner;
+
 public:
 	static MeshStorage *get_singleton() {
 		return singleton;
@@ -131,9 +137,9 @@ public:
 
 	/* MULTIMESH API */
 
-	virtual RID multimesh_allocate() override { return RID(); }
-	virtual void multimesh_initialize(RID p_rid) override {}
-	virtual void multimesh_free(RID p_rid) override {}
+	virtual RID multimesh_allocate() override;
+	virtual void multimesh_initialize(RID p_rid) override;
+	virtual void multimesh_free(RID p_rid) override;
 
 	virtual void multimesh_allocate_data(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors = false, bool p_use_custom_data = false) override {}
 	virtual int multimesh_get_instance_count(RID p_multimesh) const override { return 0; }
@@ -151,8 +157,8 @@ public:
 	virtual Transform2D multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const override { return Transform2D(); }
 	virtual Color multimesh_instance_get_color(RID p_multimesh, int p_index) const override { return Color(); }
 	virtual Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const override { return Color(); }
-	virtual void multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) override {}
-	virtual Vector<float> multimesh_get_buffer(RID p_multimesh) const override { return Vector<float>(); }
+	virtual void multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) override;
+	virtual Vector<float> multimesh_get_buffer(RID p_multimesh) const override;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) override {}
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const override { return 0; }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/86396

Multimesh relies on storing and retrieving the buffer in the rendering server to function. So we need to have at least that information in the RenderingServer. 

This PR adds the bare minimum amount of data to store and retrieve the multimesh buffer for export.