### PR TITLE
Use `os_unfair_lock` on Apple platforms

### DIFF
--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -33,6 +33,25 @@
 
 #include "core/typedefs.h"
 
+#if defined(__APPLE__)
+
+#include <os/lock.h>
+
+class SpinLock {
+	mutable os_unfair_lock _lock = OS_UNFAIR_LOCK_INIT;
+
+public:
+	_ALWAYS_INLINE_ void lock() const {
+		os_unfair_lock_lock(&_lock);
+	}
+
+	_ALWAYS_INLINE_ void unlock() const {
+		os_unfair_lock_unlock(&_lock);
+	}
+};
+
+#else
+
 #include <atomic>
 
 class SpinLock {
@@ -48,5 +67,7 @@ public:
 		locked.clear(std::memory_order_release);
 	}
 };
+
+#endif // __APPLE__
 
 #endif // SPIN_LOCK_H


### PR DESCRIPTION
Specialise the `SpinLock` implementation on Apple platforms to use an `os_unfair_lock`, which is more efficient and often recommended by Apple for games and other realtime applications. `os_unfair_lock` is particularly important for Apple Silicon, as it ensures that performance (P) cores are not tied up in busy loops and handles priority inversion issues between threads.

Apple discusses their use in the context of game engines and real-time apps regularly in their videos and tech talks:

* [priority inversion](https://developer.apple.com/videos/play/tech-talks/110147?time=1782)
* [handling input events for visionOS](https://developer.apple.com/wwdc23/10089?time=1172)
* [busy loops stealing P cores](https://developer.apple.com/wwdc20/10214?time=1637)

    > On Apple Silicon Macs, busy-waiting can have the effect of pointlessly occupying the P cores, causing an overall delay in completion of the entire work. You should prefer a synchronization primitives that block when they can't make progress, NSLock, os_unfair_lock, pthread mutexes, are all examples of blocking locks.

`os_unfair_lock` also appears regularly in the context of Metal frameworks, such as this call stack:

<img src="https://github.com/godotengine/godot/assets/52852/782328c7-85ad-4b33-b4a4-adf169c7c55b" width=45% />
 