### PR TITLE
Allow EditorTranslationParser to add POT comments

### DIFF
--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -7,6 +7,7 @@
 		[EditorTranslationParserPlugin] is invoked when a file is being parsed to extract strings that require translation. To define the parsing and string extraction logic, override the [method _parse_file] method in script.
 		Add the extracted strings to argument [code]msgids[/code] or [code]msgids_context_plural[/code] if context or plural is used.
 		When adding to [code]msgids_context_plural[/code], you must add the data using the format [code]["A", "B", "C"][/code], where [code]A[/code] represents the extracted string, [code]B[/code] represents the context, and [code]C[/code] represents the plural version of the extracted string. If you want to add only context but not plural, put [code]""[/code] for the plural slot. The idea is the same if you only want to add plural but not context. See the code below for concrete examples.
+		Additionally, you may add an optional comment to the [code]msgids_context_plural[/code] array, [code]["A", "B", "C", "D"][/code], where [code]D[/code] is a comment associated with this [code]msgid[/code].
 		The extracted strings will be written into a POT file selected by user under "POT Generation" in "Localization" tab in "Project Settings" menu.
 		Below shows an example of a custom parser that extracts strings from a CSV file to write into a POT.
 		[codeblocks]

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -50,12 +50,18 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 		// Add user's collected translatable messages with context or plurals.
 		for (int i = 0; i < ids_ctx_plural.size(); i++) {
 			Array arr = ids_ctx_plural[i];
-			ERR_FAIL_COND_V_MSG(arr.size() != 3, ERR_INVALID_DATA, "Array entries written into `msgids_context_plural` in `parse_file()` method should have the form [\"message\", \"context\", \"plural message\"]");
+			ERR_FAIL_COND_V_MSG(arr.size() < 3 || arr.size() > 4, ERR_INVALID_DATA, "Array entries written into `msgids_context_plural` in `parse_file()` method should have the form [\"message\", \"context\", \"plural message\", \"<comment>\"]");
 
 			Vector<String> id_ctx_plural;
 			id_ctx_plural.push_back(arr[0]);
 			id_ctx_plural.push_back(arr[1]);
 			id_ctx_plural.push_back(arr[2]);
+
+			// Add the comment if there is one
+			if (arr.size() > 3) {
+				id_ctx_plural.push_back(arr[3]);
+			}
+
 			r_ids_ctx_plural->append(id_ctx_plural);
 		}
 		return OK;

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -81,7 +81,8 @@ void POTGenerator::generate_pot(const String &p_file) {
 
 		for (int j = 0; j < msgids_context_plural.size(); j++) {
 			const Vector<String> &entry = msgids_context_plural[j];
-			_add_new_msgid(entry[0], entry[1], entry[2], file_path);
+			const String &comment = entry.size() > 3 ? entry[3] : String("");
+			_add_new_msgid(entry[0], entry[1], entry[2], file_path, comment);
 		}
 		for (int j = 0; j < msgids.size(); j++) {
 			_add_new_msgid(msgids[j], "", "", file_path);
@@ -129,10 +130,18 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 		for (int i = 0; i < v_msgid_data.size(); i++) {
 			String context = v_msgid_data[i].ctx;
 			String plural = v_msgid_data[i].plural;
+			const HashSet<String> &comments = v_msgid_data[i].comments;
 			const HashSet<String> &locations = v_msgid_data[i].locations;
 
 			// Put the blank line at the start, to avoid a double at the end when closing the file.
 			file->store_line("");
+
+			// Add comments if there are any
+			for (const String &comment : comments) {
+				for (const String &c : comment.split("\n")) {
+					file->store_line("# " + c);
+				}
+			}
 
 			// Write file locations.
 			for (const String &E : locations) {
@@ -191,7 +200,7 @@ void POTGenerator::_write_msgid(Ref<FileAccess> r_file, const String &p_id, bool
 	}
 }
 
-void POTGenerator::_add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location) {
+void POTGenerator::_add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location, const String &p_comment) {
 	// Insert new location if msgid under same context exists already.
 	if (all_translation_strings.has(p_msgid)) {
 		Vector<MsgidData> &v_mdata = all_translation_strings[p_msgid];
@@ -201,6 +210,10 @@ void POTGenerator::_add_new_msgid(const String &p_msgid, const String &p_context
 					WARN_PRINT("Redefinition of plural message (msgid_plural), under the same message (msgid) and context (msgctxt)");
 				}
 				v_mdata.write[i].locations.insert(p_location);
+				if (p_comment != "") {
+					v_mdata.write[i].comments.insert(p_comment);
+				}
+
 				return;
 			}
 		}
@@ -212,6 +225,9 @@ void POTGenerator::_add_new_msgid(const String &p_msgid, const String &p_context
 	mdata.ctx = p_context;
 	mdata.plural = p_plural;
 	mdata.locations.insert(p_location);
+	if (p_comment != "") {
+		mdata.comments.insert(p_comment);
+	}
 	all_translation_strings[p_msgid].push_back(mdata);
 }
 

--- a/editor/pot_generator.h
+++ b/editor/pot_generator.h
@@ -44,13 +44,14 @@ class POTGenerator {
 		String ctx;
 		String plural;
 		HashSet<String> locations;
+		HashSet<String> comments;
 	};
 	// Store msgid as key and the additional data around the msgid - if it's under a context, has plurals and its file locations.
 	HashMap<String, Vector<MsgidData>> all_translation_strings;
 
 	void _write_to_pot(const String &p_file);
 	void _write_msgid(Ref<FileAccess> r_file, const String &p_id, bool p_plural);
-	void _add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location);
+	void _add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location, const String &p_comment = "");
 
 #ifdef DEBUG_POT
 	void _print_all_translation_strings();


### PR DESCRIPTION
This adds an optional fourth item to the `msgids_context_plural` array in `EditorTranslationParserPlugin::parse_file` that can be used to add comments to the generated POT file.

This means that anyone using the custom POT generation system can provide extra help for translators.

![image](https://github.com/godotengine/godot/assets/78984/d4b2fc5f-e8f0-48af-bb23-94535e3e3696)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8917*