### PR TITLE
RayCast2D and RayCast3D: warn to check `is_colliding` before `get_collision_point` and `get_collision_normal`

### DIFF
--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -69,13 +69,14 @@
 			<return type="Vector2" />
 			<description>
 				Returns the normal of the intersecting object's shape at the collision point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member hit_from_inside] is [code]true[/code].
+				[b]Note:[/b] Check that [method is_colliding] returns [code]true[/code] before calling this method to ensure the returned normal is valid and up-to-date.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the collision point at which the ray intersects the closest object. If [member hit_from_inside] is [code]true[/code] and the ray starts inside of a collision shape, this function will return the origin point of the ray.
-				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
+				Returns the collision point at which the ray intersects the closest object, in the global coordinate system. If [member hit_from_inside] is [code]true[/code] and the ray starts inside of a collision shape, this function will return the origin point of the ray.
+				[b]Note:[/b] Check that [method is_colliding] returns [code]true[/code] before calling this method to ensure the returned point is valid and up-to-date.
 			</description>
 		</method>
 		<method name="is_colliding" qualifiers="const">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -76,13 +76,14 @@
 			<return type="Vector3" />
 			<description>
 				Returns the normal of the intersecting object's shape at the collision point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member hit_from_inside] is [code]true[/code].
+				[b]Note:[/b] Check that [method is_colliding] returns [code]true[/code] before calling this method to ensure the returned normal is valid and up-to-date.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the collision point at which the ray intersects the closest object. If [member hit_from_inside] is [code]true[/code] and the ray starts inside of a collision shape, this function will return the origin point of the ray.
-				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
+				Returns the collision point at which the ray intersects the closest object, in the global coordinate system. If [member hit_from_inside] is [code]true[/code] and the ray starts inside of a collision shape, this function will return the origin point of the ray.
+				[b]Note:[/b] Check that [method is_colliding] returns [code]true[/code] before calling this method to ensure the returned point is valid and up-to-date.
 			</description>
 		</method>
 		<method name="is_colliding" qualifiers="const">


### PR DESCRIPTION
Adds warnings to check `is_colliding` first, in the documentation of `get_collision_point` and `get_collision_normal`.

The warning is phrased in the positive, making no guarantees about what happens if `is_colliding` returns `false`. In that case, if using Godot Physics, the vectors will be zero if the ray never collided, or they will contain the values from the previous time when there was a collision, but I think this implementation detail is not worth documenting. (It may be worth adding an error for that case in the future.)

Also moved some adjacent information from a note to the main text, since the main text was just incomplete without it.

- Closes https://github.com/godotengine/godot/issues/84642