### PR TITLE
Use callable for `TreeItem` custom draw

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -160,6 +160,13 @@
 				Returns the custom color of column [param column].
 			</description>
 		</method>
+		<method name="get_custom_draw_callback" qualifiers="const">
+			<return type="Callable" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the custom callback of column [param column].
+			</description>
+		</method>
 		<method name="get_custom_font" qualifiers="const">
 			<return type="Font" />
 			<param index="0" name="column" type="int" />
@@ -553,13 +560,23 @@
 				Sets the given column's custom color.
 			</description>
 		</method>
-		<method name="set_custom_draw">
+		<method name="set_custom_draw" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="object" type="Object" />
 			<param index="2" name="callback" type="StringName" />
 			<description>
 				Sets the given column's custom draw callback to [param callback] method on [param object].
+				The [param callback] should accept two arguments: the [TreeItem] that is drawn and its position and size as a [Rect2].
+				[i]Deprecated.[/i] Use [method TreeItem.set_custom_draw_callback] instead.
+			</description>
+		</method>
+		<method name="set_custom_draw_callback">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="callback" type="Callable" />
+			<description>
+				Sets the given column's custom draw callback. Use an empty [Callable] ([code skip-lint]Callable()[/code]) to clear the custom callback.
 				The [param callback] should accept two arguments: the [TreeItem] that is drawn and its position and size as a [Rect2].
 			</description>
 		</method>

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -747,7 +747,7 @@ void FindInFilesPanel::_on_result_found(String fpath, int line_number, int begin
 	String start = vformat("%3s: ", line_number);
 
 	item->set_text(text_index, start + text);
-	item->set_custom_draw(text_index, this, "_draw_result_text");
+	item->set_custom_draw_callback(text_index, callable_mp(this, &FindInFilesPanel::draw_result_text));
 
 	Result r;
 	r.line_number = line_number;
@@ -988,7 +988,6 @@ void FindInFilesPanel::set_progress_visible(bool p_visible) {
 void FindInFilesPanel::_bind_methods() {
 	ClassDB::bind_method("_on_result_found", &FindInFilesPanel::_on_result_found);
 	ClassDB::bind_method("_on_finished", &FindInFilesPanel::_on_finished);
-	ClassDB::bind_method("_draw_result_text", &FindInFilesPanel::draw_result_text);
 
 	ADD_SIGNAL(MethodInfo(SIGNAL_RESULT_SELECTED,
 			PropertyInfo(Variant::STRING, "path"),

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -99,8 +99,7 @@ private:
 		Variant meta;
 		String tooltip;
 
-		ObjectID custom_draw_obj;
-		StringName custom_draw_callback;
+		Callable custom_draw_callback;
 
 		struct Button {
 			int id = 0;
@@ -285,7 +284,11 @@ public:
 	void set_metadata(int p_column, const Variant &p_meta);
 	Variant get_metadata(int p_column) const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_custom_draw(int p_column, Object *p_object, const StringName &p_callback);
+#endif // DISABLE_DEPRECATED
+	void set_custom_draw_callback(int p_column, const Callable &p_callback);
+	Callable get_custom_draw_callback(int p_column) const;
 
 	void set_collapsed(bool p_collapsed);
 	bool is_collapsed();


### PR DESCRIPTION
Old behavior is deprecated
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
