### PR TITLE
GDScript: Use autoload singleton name in `GDScriptDocGen`

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.h
+++ b/modules/gdscript/editor/gdscript_docgen.h
@@ -39,10 +39,13 @@ class GDScriptDocGen {
 	using GDP = GDScriptParser;
 	using GDType = GDP::DataType;
 
-	static String _get_script_path(const String &p_path);
+	static HashMap<String, String> singletons; // Script path to singleton name.
+
+	static String _get_script_name(const String &p_path);
 	static String _get_class_name(const GDP::ClassNode &p_class);
 	static void _doctype_from_gdtype(const GDType &p_gdtype, String &r_type, String &r_enum, bool p_is_return = false);
 	static String _docvalue_from_variant(const Variant &p_variant, int p_recursion_level = 1);
+	static void _generate_docs(GDScript *p_script, const GDP::ClassNode *p_class);
 
 public:
 	static void generate_docs(GDScript *p_script, const GDP::ClassNode *p_class);


### PR DESCRIPTION
* Closes godotengine/godot-proposals#8441.

You can't use the autoload singleton name as a class name, so I think it's safe to use the autoload name instead of the script path in the docs. If the autoload script also has a global name, then it will be used first.

![](https://github.com/godotengine/godot/assets/47700418/f65d4e1f-9062-4a7b-b1e5-fc59694e3303)

[test-autoload-doc.zip](https://github.com/godotengine/godot/files/13999143/test-autoload-doc.zip)