### PR TITLE
Tweak XROrigin3D documentation

### DIFF
--- a/doc/classes/XROrigin3D.xml
+++ b/doc/classes/XROrigin3D.xml
@@ -5,20 +5,19 @@
 	</brief_description>
 	<description>
 		This is a special node within the AR/VR system that maps the physical location of the center of our tracking space to the virtual location within our game world.
-		There should be only one of these nodes in your scene and you must have one. All the XRCamera3D, XRController3D and XRAnchor3D nodes should be direct children of this node for spatial tracking to work correctly.
+		Multiple origin points can be added to the scene tree, but only one can used at a time. All the [XRCamera3D], [XRController3D], and [XRAnchor3D] nodes should be direct children of this node for spatial tracking to work correctly.
 		It is the position of this node that you update when your character needs to move through your game world while we're not moving in the real world. Movement in the real world is always in relation to this origin point.
-		For example, if your character is driving a car, the XROrigin3D node should be a child node of this car. Or, if you're implementing a teleport system to move your character, you should change the position of this node.
+		For example, if your character is driving a car, the [XROrigin3D] node should be a child node of this car. Or, if you're implementing a teleport system to move your character, you should change the position of this node.
 	</description>
 	<tutorials>
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
 	</tutorials>
 	<members>
 		<member name="current" type="bool" setter="set_current" getter="is_current" default="false">
-			Is this XROrigin3D node the current origin used by the [XRServer]?
+			If [code]true[/code], this origin node is currently being used by the [XRServer]. Only one origin point can be used at a time.
 		</member>
 		<member name="world_scale" type="float" setter="set_world_scale" getter="get_world_scale" default="1.0">
-			Allows you to adjust the scale to your game's units. Most AR/VR platforms assume a scale of 1 game world unit = 1 real world meter.
-			[b]Note:[/b] This method is a passthrough to the [XRServer] itself.
+			The scale of the game world compared to the real world. This is the same as [member XRServer.world_scale]. By default, most AR/VR platforms assume that 1 game unit corresponds to 1 real world meter.
 		</member>
 	</members>
 </class>

--- a/doc/classes/XRServer.xml
+++ b/doc/classes/XRServer.xml
@@ -113,7 +113,7 @@
 			[b]Note:[/b] This property is managed by the current [XROrigin3D] node. It is exposed for access from GDExtensions.
 		</member>
 		<member name="world_scale" type="float" setter="set_world_scale" getter="get_world_scale" default="1.0">
-			Allows you to adjust the scale to your game's units. Most AR/VR platforms assume a scale of 1 game world unit = 1 real world meter.
+			The scale of the game world compared to the real world. By default, most AR/VR platforms assume that 1 game unit corresponds to 1 real world meter.
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION

This PR slightly tweaks the documentation of **XROrigin3D**, linking to the other associated XR classes, rewording `world_scale` and-

<img width=50% src=https://github.com/godotengine/godot/assets/66727710/85c116c1-a885-4ea5-9a71-5be44e21bdda>

I don't know, you tell me!
