### PR TITLE
Tweak Joint2D and Joint3D documentation for consistency

### DIFF
--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -4,7 +4,7 @@
 		Abstract base class for all 2D physics joints.
 	</brief_description>
 	<description>
-		Abstract base class for all joints in 2D physics. 2D joints bind together two physics bodies and apply a constraint.
+		Abstract base class for all joints in 2D physics. 2D joints bind together two physics bodies ([member node_a] and [member node_b]) and apply a constraint.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,7 +12,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the joint's [RID].
+				Returns the joint's internal [RID] from the [PhysicsServer2D].
 			</description>
 		</method>
 	</methods>
@@ -22,13 +22,13 @@
 			When set to [code]0[/code], the default value from [member ProjectSettings.physics/2d/solver/default_constraint_bias] is used.
 		</member>
 		<member name="disable_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
-			If [code]true[/code], [member node_a] and [member node_b] can not collide.
+			If [code]true[/code], the two bodies bound together do not collide with each other.
 		</member>
 		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
-			The first body attached to the joint. Must derive from [PhysicsBody2D].
+			Path to the first body (A) attached to the joint. The node must inherit [PhysicsBody2D].
 		</member>
 		<member name="node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
-			The second body attached to the joint. Must derive from [PhysicsBody2D].
+			Path to the second body (B) attached to the joint. The node must inherit [PhysicsBody2D].
 		</member>
 	</members>
 </class>

--- a/doc/classes/Joint3D.xml
+++ b/doc/classes/Joint3D.xml
@@ -4,7 +4,7 @@
 		Abstract base class for all 3D physics joints.
 	</brief_description>
 	<description>
-		Abstract base class for all joints in 3D physics. 3D joints bind together two physics bodies and apply a constraint.
+		Abstract base class for all joints in 3D physics. 3D joints bind together two physics bodies ([member node_a] and [member node_b]) and apply a constraint. If only one body is defined, it is attached to a fixed [StaticBody3D] without collision shapes.
 	</description>
 	<tutorials>
 		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/524</link>
@@ -13,19 +13,21 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the joint's [RID].
+				Returns the joint's internal [RID] from the [PhysicsServer3D].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="exclude_nodes_from_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
-			If [code]true[/code], the two bodies of the nodes are not able to collide with each other.
+			If [code]true[/code], the two bodies bound together do not collide with each other.
 		</member>
 		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
-			The node attached to the first side (A) of the joint.
+			Path to the first node (A) attached to the joint. The node must inherit [PhysicsBody3D].
+			If left empty and [member node_b] is set, the body is attached to a fixed [StaticBody3D] without collision shapes.
 		</member>
 		<member name="node_b" type="NodePath" setter="set_node_b" getter="get_node_b" default="NodePath(&quot;&quot;)">
-			The node attached to the second side (B) of the joint.
+			Path to the second node (B) attached to the joint. The node must inherit [PhysicsBody3D].
+			If left empty and [member node_a] is set, the body is attached to a fixed [StaticBody3D] without collision shapes.
 		</member>
 		<member name="solver_priority" type="int" setter="set_solver_priority" getter="get_solver_priority" default="1">
 			The priority used to define which solver is executed first for multiple joints. The lower the value, the higher the priority.


### PR DESCRIPTION
Small tweaks to both **Joint2D** and **Joint3D** to make the wording consistent between the two. Also makes the description of `node_a` and `node_b` less misleading.