### PR TITLE
Prevent tilemap editor hang and crash by mutex guarding tile_map_layer dirty.cell_list.

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2111,6 +2111,8 @@ void TileMapLayer::notify_tile_map_change(DirtyFlags p_what) {
 }
 
 void TileMapLayer::internal_update() {
+	MutexLock lock(dirty.mutex);
+
 	// Find TileData that need a runtime modification.
 	// This may add cells to the dirty list is a runtime modification has been notified.
 	_build_runtime_update_tile_data();
@@ -2187,6 +2189,7 @@ void TileMapLayer::set_cell(const Vector2i &p_coords, int p_source_id, const Vec
 	c.alternative_tile = alternative_tile;
 
 	// Make the given cell dirty.
+	MutexLock lock(dirty.mutex);
 	if (!E->value.dirty_list_element.in_list()) {
 		dirty.cell_list.add(&(E->value.dirty_list_element));
 	}

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -262,6 +262,7 @@ private:
 
 	// Dirty flag. Allows knowing what was modified since the last update.
 	struct {
+		Mutex mutex;
 		bool flags[DIRTY_FLAGS_MAX] = { false };
 		SelfList<CellData>::List cell_list;
 	} dirty;


### PR DESCRIPTION
TilesEditorUtils calls tile_map->set_pattern from a thread (to refresh tile pattern preview images). set_pattern sets each of the cells into the temporary map, marking them dirty via set_cell.

This can race against the tree invoking the TileMapLayer's internal_update, which proceses dirty.cell_list and eventually clears it. If a cell's shared dirty entry ends up losing the race, clear can get stuck in an infinite loop where remove refuses to change it because the entry doesn't think it's a member of the list, but the list head still points to it. This spams

```
ERROR: Condition "p_elem->_root != this" is true.
   at: remove (./core/templates/self_list.h:80)
```

And eventually leads to a crash when the error message buffer fills.

Guarding the list mutations avoids the race that sets up for this failure, fixes #86226.

* *Bugsquad edit, alternative to: https://github.com/godotengine/godot/pull/87470*