### PR TITLE
Fix passing int to tween's `from` with float property will be forced to interpolate as int

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -505,11 +505,13 @@ Tween::Tween(bool p_valid) {
 
 Ref<PropertyTweener> PropertyTweener::from(const Variant &p_value) {
 	ERR_FAIL_COND_V(tween.is_null(), nullptr);
-	if (!tween->_validate_type_match(p_value, final_val)) {
+
+	Variant from_value = p_value;
+	if (!tween->_validate_type_match(final_val, from_value)) {
 		return nullptr;
 	}
 
-	initial_val = p_value;
+	initial_val = from_value;
 	do_continue = false;
 	return this;
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87326

As I mentioned in https://github.com/godotengine/godot/issues/87326#issuecomment-1898071259, "the final value is validated by the property value type in tween_property already, IMHO it should validate the from value by the final value instead of doing the opposite"

Feel free to correct me 


https://github.com/godotengine/godot/assets/8315986/4ecd97da-6657-4b62-bc56-e0e157dd9ea2



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
