### PR TITLE
[macOS] Update window visible state on deminiaturize.

### DIFF
--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -362,6 +362,7 @@
 	}
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
+	wd.is_visible = ([wd.window_object occlusionState] & NSWindowOcclusionStateVisible) && [wd.window_object isVisible];
 	if ([wd.window_object isKeyWindow]) {
 		wd.focused = true;
 		ds->set_last_focused_window(window_id);


### PR DESCRIPTION
Seems like `windowDidChangeOcclusionState` sometime arrive too early and window stay with `is_visible = false` (rendering disabled) after restoring it from minimized state.

Fixes https://github.com/godotengine/godot/issues/87309