### PR TITLE
OpenXR: Cleanup swapchain logic (was Fix render target multiplier)

### DIFF
--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -196,20 +196,20 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 		return nullptr;
 	}
 
-	if (swapchain_info.swapchain == XR_NULL_HANDLE) {
+	if (swapchain_info.get_swapchain() == XR_NULL_HANDLE) {
 		// Don't have a swapchain to display? Ignore our layer.
 		return nullptr;
 	}
 
-	if (swapchain_info.image_acquired) {
-		openxr_api->release_image(swapchain_info);
+	if (swapchain_info.is_image_acquired()) {
+		swapchain_info.release();
 	}
 
 	// Update the layer struct for the swapchain.
 	switch (composition_layer->type) {
 		case XR_TYPE_COMPOSITION_LAYER_QUAD: {
 			XrCompositionLayerQuad *quad_layer = (XrCompositionLayerQuad *)composition_layer;
-			quad_layer->subImage.swapchain = swapchain_info.swapchain;
+			quad_layer->subImage.swapchain = swapchain_info.get_swapchain();
 			quad_layer->subImage.imageArrayIndex = 0;
 			quad_layer->subImage.imageRect.offset.x = 0;
 			quad_layer->subImage.imageRect.offset.y = 0;
@@ -219,7 +219,7 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 
 		case XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR: {
 			XrCompositionLayerCylinderKHR *cylinder_layer = (XrCompositionLayerCylinderKHR *)composition_layer;
-			cylinder_layer->subImage.swapchain = swapchain_info.swapchain;
+			cylinder_layer->subImage.swapchain = swapchain_info.get_swapchain();
 			cylinder_layer->subImage.imageArrayIndex = 0;
 			cylinder_layer->subImage.imageRect.offset.x = 0;
 			cylinder_layer->subImage.imageRect.offset.y = 0;
@@ -229,7 +229,7 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 
 		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
 			XrCompositionLayerEquirect2KHR *equirect_layer = (XrCompositionLayerEquirect2KHR *)composition_layer;
-			equirect_layer->subImage.swapchain = swapchain_info.swapchain;
+			equirect_layer->subImage.swapchain = swapchain_info.get_swapchain();
 			equirect_layer->subImage.imageArrayIndex = 0;
 			equirect_layer->subImage.imageRect.offset.x = 0;
 			equirect_layer->subImage.imageRect.offset.y = 0;
@@ -269,14 +269,16 @@ bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p
 	}
 
 	// See if our current swapchain is outdated.
-	if (swapchain_info.swapchain != XR_NULL_HANDLE) {
+	if (swapchain_info.get_swapchain() != XR_NULL_HANDLE) {
 		// If this swap chain, or the previous one, were static, then we can't reuse it.
 		if (swapchain_size == viewport_size && !p_static_image && !static_image) {
 			// We're all good! Just acquire it.
-			return openxr_api->acquire_image(swapchain_info);
+			// We can ignore should_render here, return will be false.
+			XrBool32 should_render = true;
+			return swapchain_info.acquire(should_render);
 		}
 
-		openxr_api->free_swapchain(swapchain_info);
+		swapchain_info.queue_free();
 	}
 
 	// Create our new swap chain
@@ -287,13 +289,15 @@ bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p
 	if (p_static_image) {
 		create_flags |= XR_SWAPCHAIN_CREATE_STATIC_IMAGE_BIT;
 	}
-	if (!openxr_api->create_swapchain(create_flags, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, swapchain_format, viewport_size.width, viewport_size.height, sample_count, array_size, swapchain_info.swapchain, &swapchain_info.swapchain_graphics_data)) {
+	if (!swapchain_info.create(create_flags, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, swapchain_format, viewport_size.width, viewport_size.height, sample_count, array_size)) {
 		swapchain_size = Size2i();
 		return false;
 	}
 
-	// Acquire our image so we can start rendering into it
-	bool ret = openxr_api->acquire_image(swapchain_info);
+	// Acquire our image so we can start rendering into it,
+	// we can ignore should_render here, ret will be false.
+	XrBool32 should_render = true;
+	bool ret = swapchain_info.acquire(should_render);
 
 	swapchain_size = viewport_size;
 	static_image = p_static_image;
@@ -301,8 +305,8 @@ bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p
 }
 
 void OpenXRViewportCompositionLayerProvider::free_swapchain() {
-	if (swapchain_info.swapchain != XR_NULL_HANDLE) {
-		openxr_api->free_swapchain(swapchain_info);
+	if (swapchain_info.get_swapchain() != XR_NULL_HANDLE) {
+		swapchain_info.queue_free();
 	}
 
 	swapchain_size = Size2i();
@@ -314,5 +318,5 @@ RID OpenXRViewportCompositionLayerProvider::get_current_swapchain_texture() {
 		return RID();
 	}
 
-	return openxr_api->get_image(swapchain_info);
+	return swapchain_info.get_image();
 }

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -229,6 +229,10 @@ void OpenXRVulkanExtension::get_usable_swapchain_formats(Vector<int64_t> &p_usab
 }
 
 void OpenXRVulkanExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_swap_chains) {
+	// Note, it is very likely we do NOT support any of depth formats where we can combine our stencil support (e.g. _S8_UINT).
+	// Right now this isn't a problem but once stencil support becomes an issue, we need to check for this in the rendering engine
+	// and create a separate buffer for the stencil.
+
 	p_usable_swap_chains.push_back(VK_FORMAT_D24_UNORM_S8_UINT);
 	p_usable_swap_chains.push_back(VK_FORMAT_D32_SFLOAT_S8_UINT);
 	p_usable_swap_chains.push_back(VK_FORMAT_D32_SFLOAT);

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -58,12 +58,28 @@ class OpenXRInterface;
 
 class OpenXRAPI {
 public:
-	struct OpenXRSwapChainInfo {
+	class OpenXRSwapChainInfo {
+	private:
 		XrSwapchain swapchain = XR_NULL_HANDLE;
 		void *swapchain_graphics_data = nullptr;
 		uint32_t image_index = 0;
 		bool image_acquired = false;
 		bool skip_acquire_swapchain = false;
+
+		static Vector<OpenXRSwapChainInfo> free_queue;
+
+	public:
+		_FORCE_INLINE_ XrSwapchain get_swapchain() const { return swapchain; }
+		_FORCE_INLINE_ bool is_image_acquired() const { return image_acquired; }
+
+		bool create(XrSwapchainCreateFlags p_create_flags, XrSwapchainUsageFlags p_usage_flags, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size);
+		void queue_free();
+		static void free_queued();
+		void free();
+
+		bool acquire(XrBool32 &p_should_render);
+		bool release();
+		RID get_image();
 	};
 
 private:
@@ -148,12 +164,14 @@ private:
 
 	int64_t color_swapchain_format = 0;
 	int64_t depth_swapchain_format = 0;
-	OpenXRSwapChainInfo swapchains[OPENXR_SWAPCHAIN_MAX];
+	Size2i main_swapchain_size = { 0, 0 };
+	OpenXRSwapChainInfo main_swapchains[OPENXR_SWAPCHAIN_MAX];
 
 	XrSpace play_space = XR_NULL_HANDLE;
 	XrSpace view_space = XR_NULL_HANDLE;
 	bool view_pose_valid = false;
 	XRPose::TrackingConfidence head_pose_confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	bool has_xr_viewport = false;
 
 	bool emulating_local_floor = false;
 	bool should_reset_emulated_floor_height = false;
@@ -241,7 +259,9 @@ private:
 	bool setup_view_space();
 	bool load_supported_swapchain_formats();
 	bool is_swapchain_format_supported(int64_t p_swapchain_format);
-	bool create_swapchains();
+	bool obtain_swapchain_formats();
+	bool create_main_swapchains(Size2i p_size);
+	void free_main_swapchains();
 	void destroy_session();
 
 	// action map
@@ -312,6 +332,7 @@ public:
 	XrInstance get_instance() const { return instance; };
 	XrSystemId get_system_id() const { return system_id; };
 	XrSession get_session() const { return session; };
+	OpenXRGraphicsExtensionWrapper *get_graphics_extension() const { return graphics_extension; };
 	String get_runtime_name() const { return runtime_name; };
 	String get_runtime_version() const { return runtime_version; };
 
@@ -406,11 +427,7 @@ public:
 
 	// swapchains
 	int64_t get_color_swapchain_format() const { return color_swapchain_format; }
-	bool create_swapchain(XrSwapchainCreateFlags p_create_flags, XrSwapchainUsageFlags p_usage_flags, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, XrSwapchain &r_swapchain, void **r_swapchain_graphics_data);
-	void free_swapchain(OpenXRSwapChainInfo &p_swapchain);
-	bool acquire_image(OpenXRSwapChainInfo &p_swapchain);
-	RID get_image(OpenXRSwapChainInfo &p_swapchain);
-	bool release_image(OpenXRSwapChainInfo &p_swapchain);
+	int64_t get_depth_swapchain_format() const { return depth_swapchain_format; }
 
 	// action map
 	String get_default_action_map_resource_name();


### PR DESCRIPTION
This PR cleans up and, to a minor extent, refactors the swapchain logic in the OpenXR module. This will make it easier to create additional logic in the future where additional swapchains need to be created. @dsnopek already partially improved this for composition layers, I just took it a step further as I'll be needing this for some of the more advanced view configurations as well.

In a nutshell the following changes are applied:
- `OpenXRAPI::OpenXRSwapChainInfo` is now a class with the create/free/acquire and release methods as members
- A queue mechanism for freeing swapchains has been added to give the rendering logic proper time to untangle itself from the swapchain before it is actually removed. While OpenXR has a similar internal mechanism for preventing early freeing of resources, that did not prevent issues on our end.
- Obtaining the supported swapchain formats is now a separate method that is executed only once early on in the initialisation process.
- The logic for creating the main swapchains for rendering HMD output is now identified as such and handled in `pre_render` so that we can swap out the swapchain with a new one if a new swapchain is required.

These changes started in order to fix changing the "render target multiplier" not updating the actual swapchain. This is now working correctly and the result is testable in the Vulkan renderer.

Currently in OpenGL there is still an issue where the swapchain is correctly updated, but the XR runtime is still treating it as if its at it's original size. I'm still investigating this issue.