### PR TITLE
[Editor] Fix threading problems with `TileMap` preview

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -68,6 +68,9 @@ void TilesEditorUtils::_thread_func(void *ud) {
 }
 
 void TilesEditorUtils::_thread() {
+	CallQueue queue;
+	MessageQueue::set_thread_singleton_override(&queue);
+
 	pattern_thread_exited.clear();
 	while (!pattern_thread_exit.is_set()) {
 		pattern_preview_sem.wait();
@@ -127,6 +130,8 @@ void TilesEditorUtils::_thread() {
 				// Add the viewport at the last moment to avoid rendering too early.
 				callable_mp((Node *)EditorNode::get_singleton(), &Node::add_child).call_deferred(viewport, false, Node::INTERNAL_MODE_DISABLED);
 
+				MessageQueue::get_singleton()->flush();
+
 				RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(const_cast<TilesEditorUtils *>(this), &TilesEditorUtils::_preview_frame_started), Object::CONNECT_ONE_SHOT);
 
 				pattern_preview_done.wait();
@@ -139,7 +144,11 @@ void TilesEditorUtils::_thread() {
 				viewport->queue_free();
 			}
 		}
+
+		MessageQueue::get_singleton()->flush();
 	}
+
+	MessageQueue::get_singleton()->flush();
 	pattern_thread_exited.set();
 }
 


### PR DESCRIPTION
As investigated in #87458 this is due to threading problems in the editor, specifically the preview generation, this solves this by handling deferred calls on a separate queue, rather than adding thread safety mechanisms to `TileMapLayer` which I'd say aren't necessary otherwise due to thread safety guarantees, I also suspect there are other possible race conditions here that won't be solved by adding those thread safety features, instead I suggest removing the thread safety from the equation entirely by controlling the timing

The general topic of thread safety of nodes not on the tree is a problem and other nodes suffer from problems due to deferred calls AFAIK, so a broader investigation of that and how `TileMap` and `TileMapLayer` relates to this should be done as well, but I think the pressing concern here is the editor related crash

* Fixes: https://github.com/godotengine/godot/issues/86226

Alternative to:
* https://github.com/godotengine/godot/pull/87458

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
