### PR TITLE
Add GDScript `@uid` stub

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -681,6 +681,15 @@
 				[b]Note:[/b] As annotations describe their subject, the [annotation @tool] annotation must be placed before the class definition and inheritance.
 			</description>
 		</annotation>
+		<annotation name="@uid">
+			<return type="void" />
+			<param index="0" name="uid" type="String" />
+			<description>
+				[i]This annotation exists for forward compatibility with 4.3 and beyond. It has no functionality in version 4.2 and below.[/i]
+				Stores information about UID of this script. This annotation is auto-generated when saving the script and must not be modified manually. Only applies to scripts saved as separate files (i.e. not built-in).
+				[b]Note:[/b] Unlike most other annotations, the argument of the [annotation @uid] annotation must be a string literal (constant expressions are not supported).
+			</description>
+		</annotation>
 		<annotation name="@warning_ignore" qualifiers="vararg">
 			<return type="void" />
 			<param index="0" name="warning" type="String" />

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -90,6 +90,7 @@ bool GDScriptParser::annotation_exists(const String &p_annotation_name) const {
 GDScriptParser::GDScriptParser() {
 	// Register valid annotations.
 	// TODO: Should this be static?
+	register_annotation(MethodInfo("@uid", PropertyInfo(Variant::STRING, "uid")), AnnotationInfo::SCRIPT, &GDScriptParser::uid_annotation);
 	register_annotation(MethodInfo("@tool"), AnnotationInfo::SCRIPT, &GDScriptParser::tool_annotation);
 	register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 	register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
@@ -3839,6 +3840,11 @@ bool GDScriptParser::validate_annotation_arguments(AnnotationNode *p_annotation)
 
 	// For other annotations, see `GDScriptAnalyzer::resolve_annotation()`.
 
+	return true;
+}
+
+// This annotation exists for forward compatibility with 4.3 and beyond. It has no functionality in version 4.2 and below.
+bool GDScriptParser::uid_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	return true;
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1461,6 +1461,7 @@ private:
 	bool register_annotation(const MethodInfo &p_info, uint32_t p_target_kinds, AnnotationAction p_apply, const Vector<Variant> &p_default_arguments = Vector<Variant>(), bool p_is_vararg = false);
 	bool validate_annotation_arguments(AnnotationNode *p_annotation);
 	void clear_unused_annotations();
+	bool uid_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool tool_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(const AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);


### PR DESCRIPTION
Adds a @uid stub in GDScript for Godot 4.2 in order for plugins and code built to run on 4.3 could also work in 4.2

Needed after the merge of #67132.

### Before
![Capture d’écran du 2024-01-22 09-47-07](https://github.com/godotengine/godot/assets/270928/ef129411-b7b8-4788-b9f9-90fe2ae05df5)

### After
![Capture d’écran du 2024-01-22 09-48-57](https://github.com/godotengine/godot/assets/270928/9eb87485-ede9-464d-91ee-3522c2ef8d0f)
