### PR TITLE
Fix selection regression in `EditorHelpSearch`

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -445,6 +445,9 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 }
 
 void EditorHelpSearch::Runner::_populate_cache() {
+	// Deselect to prevent re-selection issues.
+	results_tree->deselect_all();
+
 	root_item = results_tree->get_root();
 
 	if (root_item) {


### PR DESCRIPTION
Investigated clearing the selection details on removing a `TreeItem` but think that's a bit of a larger investigation so keeping this restricted

The bug was caused by the removed item being currently selected, and then failing on re-select here:
https://github.com/godotengine/godot/blob/0bcc0e92b3f0ac57d4c4650722f347593a258572/scene/gui/tree.cpp#L2615-L2617

* Fixes: https://github.com/godotengine/godot/issues/87472

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
