### PR TITLE
Disable scissor test after rendering batches in compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -775,6 +775,7 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 		_render_batch(p_lights, i, r_render_info);
 	}
 
+	glDisable(GL_SCISSOR_TEST);
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
 	state.last_item_index += index;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/87396

The scissor test was accidentally left enabled. Already, it is disabled before rendering the batches, but we don't want the scissor state to leak into other areas. So its best to disable it after as well. 