### PR TITLE
[macOS] Fix missing modifier + space key down events.

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -576,21 +576,23 @@
 			String u32text;
 			u32text.parse_utf16(text.ptr(), text.length());
 
+			DisplayServerMacOS::KeyEvent ke;
+			ke.window_id = window_id;
+			ke.macos_state = [event modifierFlags];
+			ke.pressed = true;
+			ke.echo = [event isARepeat];
+			ke.keycode = KeyMappingMacOS::remap_key([event keyCode], [event modifierFlags], false);
+			ke.physical_keycode = KeyMappingMacOS::translate_key([event keyCode]);
+			ke.key_label = KeyMappingMacOS::remap_key([event keyCode], [event modifierFlags], true);
+			ke.raw = true;
+
+			if (u32text.is_empty()) {
+				ke.unicode = 0;
+				ds->push_to_key_event_buffer(ke);
+			}
 			for (int i = 0; i < u32text.length(); i++) {
 				const char32_t codepoint = u32text[i];
-
-				DisplayServerMacOS::KeyEvent ke;
-
-				ke.window_id = window_id;
-				ke.macos_state = [event modifierFlags];
-				ke.pressed = true;
-				ke.echo = [event isARepeat];
-				ke.keycode = KeyMappingMacOS::remap_key([event keyCode], [event modifierFlags], false);
-				ke.physical_keycode = KeyMappingMacOS::translate_key([event keyCode]);
-				ke.key_label = KeyMappingMacOS::remap_key([event keyCode], [event modifierFlags], true);
 				ke.unicode = fix_unicode(codepoint);
-				ke.raw = true;
-
 				ds->push_to_key_event_buffer(ke);
 			}
 		} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87491

Note: by default `Command` + `Space` is a spotlight shortcut, unless it's disabled in the system setting it's normal to not receive any events for it).
