### PR TITLE
Bind physics server methods related to `SoftBody3D`

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1014,10 +1014,262 @@
 				Gets a slider_joint parameter (see [enum SliderJointParam] constants).
 			</description>
 		</method>
+		<method name="soft_body_add_collision_exception">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="body_b" type="RID" />
+			<description>
+				Adds the given body to the list of bodies exempt from collisions.
+			</description>
+		</method>
+		<method name="soft_body_create">
+			<return type="RID" />
+			<description>
+				Creates a new soft body and returns its internal [RID].
+			</description>
+		</method>
 		<method name="soft_body_get_bounds" qualifiers="const">
 			<return type="AABB" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Returns the bounds of the given soft body in global coordinates.
+			</description>
+		</method>
+		<method name="soft_body_get_collision_layer" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the physics layer or layers that the given soft body belongs to.
+			</description>
+		</method>
+		<method name="soft_body_get_collision_mask" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the physics layer or layers that the given soft body can collide with.
+			</description>
+		</method>
+		<method name="soft_body_get_damping_coefficient" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the damping coefficient of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_get_drag_coefficient" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the drag coefficient of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_get_linear_stiffness" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the linear stiffness of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_get_point_global_position" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<description>
+				Returns the current position of the given soft body point in global coordinates.
+			</description>
+		</method>
+		<method name="soft_body_get_pressure_coefficient" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the pressure coefficient of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_get_simulation_precision" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the simulation precision of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_get_space" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the [RID] of the space assigned to the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_get_state" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<description>
+				Returns the given soft body state (see [enum BodyState] constants).
+				[b]Note:[/b] Godot's default physics implementation does not support [constant BODY_STATE_LINEAR_VELOCITY], [constant BODY_STATE_ANGULAR_VELOCITY], [constant BODY_STATE_SLEEPING], or [constant BODY_STATE_CAN_SLEEP].
+			</description>
+		</method>
+		<method name="soft_body_get_total_mass" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the total mass assigned to the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_is_point_pinned" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<description>
+				Returns whether the given soft body point is pinned.
+			</description>
+		</method>
+		<method name="soft_body_move_point">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="global_position" type="Vector3" />
+			<description>
+				Moves the given soft body point to a position in global coordinates.
+			</description>
+		</method>
+		<method name="soft_body_pin_point">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="pin" type="bool" />
+			<description>
+				Pins or unpins the given soft body point based on the value of [param pin].
+				[b]Note:[/b] Pinning a point effectively makes it kinematic, preventing it from being affected by forces, but you can still move it using [method soft_body_move_point].
+			</description>
+		</method>
+		<method name="soft_body_remove_all_pinned_points">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Unpins all points of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_remove_collision_exception">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="body_b" type="RID" />
+			<description>
+				Removes the given body from the list of bodies exempt from collisions.
+			</description>
+		</method>
+		<method name="soft_body_set_collision_layer">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<description>
+				Sets the physics layer or layers the given soft body belongs to.
+			</description>
+		</method>
+		<method name="soft_body_set_collision_mask">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="mask" type="int" />
+			<description>
+				Sets the physics layer or layers the given soft body can collide with.
+			</description>
+		</method>
+		<method name="soft_body_set_damping_coefficient">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="damping_coefficient" type="float" />
+			<description>
+				Sets the damping coefficient of the given soft body. Higher values will slow down the body more noticeably when forces are applied.
+			</description>
+		</method>
+		<method name="soft_body_set_drag_coefficient">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="drag_coefficient" type="float" />
+			<description>
+				Sets the drag coefficient of the given soft body. Higher values increase this body's air resistance.
+				[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
+			</description>
+		</method>
+		<method name="soft_body_set_linear_stiffness">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="stiffness" type="float" />
+			<description>
+				Sets the linear stiffness of the given soft body. Higher values will result in a stiffer body, while lower values will increase the body's ability to bend. The value can be between [code]0.0[/code] and [code]1.0[/code] (inclusive).
+			</description>
+		</method>
+		<method name="soft_body_set_mesh">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="mesh" type="RID" />
+			<description>
+				Sets the mesh of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_set_pressure_coefficient">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="pressure_coefficient" type="float" />
+			<description>
+				Sets the pressure coefficient of the given soft body. Simulates pressure build-up from inside this body. Higher values increase the strength of this effect.
+			</description>
+		</method>
+		<method name="soft_body_set_ray_pickable">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Sets whether the given soft body will be pickable when using object picking.
+			</description>
+		</method>
+		<method name="soft_body_set_simulation_precision">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="simulation_precision" type="int" />
+			<description>
+				Sets the simulation precision of the given soft body. Increasing this value will improve the resulting simulation, but can affect performance. Use with care.
+			</description>
+		</method>
+		<method name="soft_body_set_space">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="space" type="RID" />
+			<description>
+				Assigns a space to the given soft body (see [method space_create]).
+			</description>
+		</method>
+		<method name="soft_body_set_state">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<param index="2" name="variant" type="Variant" />
+			<description>
+				Sets the given body state for the given body (see [enum BodyState] constants).
+				[b]Note:[/b] Godot's default physics implementation does not support [constant BODY_STATE_LINEAR_VELOCITY], [constant BODY_STATE_ANGULAR_VELOCITY], [constant BODY_STATE_SLEEPING], or [constant BODY_STATE_CAN_SLEEP].
+			</description>
+		</method>
+		<method name="soft_body_set_total_mass">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="total_mass" type="float" />
+			<description>
+				Sets the total mass for the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_set_transform">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="transform" type="Transform3D" />
+			<description>
+				Sets the global transform of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_update_rendering_server">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="rendering_server_handler" type="PhysicsServer3DRenderingServerHandler" />
+			<description>
+				Requests that the physics server updates the rendering server with the latest positions of the given soft body's points through the [param rendering_server_handler] interface.
 			</description>
 		</method>
 		<method name="space_create">

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -835,7 +835,59 @@ void PhysicsServer3D::_bind_methods() {
 
 	/* SOFT BODY API */
 
+	ClassDB::bind_method(D_METHOD("soft_body_create"), &PhysicsServer3D::soft_body_create);
+
+	ClassDB::bind_method(D_METHOD("soft_body_update_rendering_server", "body", "rendering_server_handler"), &PhysicsServer3D::soft_body_update_rendering_server);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_space", "body", "space"), &PhysicsServer3D::soft_body_set_space);
+	ClassDB::bind_method(D_METHOD("soft_body_get_space", "body"), &PhysicsServer3D::soft_body_get_space);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_mesh", "body", "mesh"), &PhysicsServer3D::soft_body_set_mesh);
+
 	ClassDB::bind_method(D_METHOD("soft_body_get_bounds", "body"), &PhysicsServer3D::soft_body_get_bounds);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_collision_layer", "body", "layer"), &PhysicsServer3D::soft_body_set_collision_layer);
+	ClassDB::bind_method(D_METHOD("soft_body_get_collision_layer", "body"), &PhysicsServer3D::soft_body_get_collision_layer);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_collision_mask", "body", "mask"), &PhysicsServer3D::soft_body_set_collision_mask);
+	ClassDB::bind_method(D_METHOD("soft_body_get_collision_mask", "body"), &PhysicsServer3D::soft_body_get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("soft_body_add_collision_exception", "body", "body_b"), &PhysicsServer3D::soft_body_add_collision_exception);
+	ClassDB::bind_method(D_METHOD("soft_body_remove_collision_exception", "body", "body_b"), &PhysicsServer3D::soft_body_remove_collision_exception);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_state", "body", "state", "variant"), &PhysicsServer3D::soft_body_set_state);
+	ClassDB::bind_method(D_METHOD("soft_body_get_state", "body", "state"), &PhysicsServer3D::soft_body_get_state);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_transform", "body", "transform"), &PhysicsServer3D::soft_body_set_transform);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_ray_pickable", "body", "enable"), &PhysicsServer3D::soft_body_set_ray_pickable);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_simulation_precision", "body", "simulation_precision"), &PhysicsServer3D::soft_body_set_simulation_precision);
+	ClassDB::bind_method(D_METHOD("soft_body_get_simulation_precision", "body"), &PhysicsServer3D::soft_body_get_simulation_precision);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_total_mass", "body", "total_mass"), &PhysicsServer3D::soft_body_set_total_mass);
+	ClassDB::bind_method(D_METHOD("soft_body_get_total_mass", "body"), &PhysicsServer3D::soft_body_get_total_mass);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_linear_stiffness", "body", "stiffness"), &PhysicsServer3D::soft_body_set_linear_stiffness);
+	ClassDB::bind_method(D_METHOD("soft_body_get_linear_stiffness", "body"), &PhysicsServer3D::soft_body_get_linear_stiffness);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_pressure_coefficient", "body", "pressure_coefficient"), &PhysicsServer3D::soft_body_set_pressure_coefficient);
+	ClassDB::bind_method(D_METHOD("soft_body_get_pressure_coefficient", "body"), &PhysicsServer3D::soft_body_get_pressure_coefficient);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_damping_coefficient", "body", "damping_coefficient"), &PhysicsServer3D::soft_body_set_damping_coefficient);
+	ClassDB::bind_method(D_METHOD("soft_body_get_damping_coefficient", "body"), &PhysicsServer3D::soft_body_get_damping_coefficient);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_drag_coefficient", "body", "drag_coefficient"), &PhysicsServer3D::soft_body_set_drag_coefficient);
+	ClassDB::bind_method(D_METHOD("soft_body_get_drag_coefficient", "body"), &PhysicsServer3D::soft_body_get_drag_coefficient);
+
+	ClassDB::bind_method(D_METHOD("soft_body_move_point", "body", "point_index", "global_position"), &PhysicsServer3D::soft_body_move_point);
+	ClassDB::bind_method(D_METHOD("soft_body_get_point_global_position", "body", "point_index"), &PhysicsServer3D::soft_body_get_point_global_position);
+
+	ClassDB::bind_method(D_METHOD("soft_body_remove_all_pinned_points", "body"), &PhysicsServer3D::soft_body_remove_all_pinned_points);
+
+	ClassDB::bind_method(D_METHOD("soft_body_pin_point", "body", "point_index", "pin"), &PhysicsServer3D::soft_body_pin_point);
+
+	ClassDB::bind_method(D_METHOD("soft_body_is_point_pinned", "body", "point_index"), &PhysicsServer3D::soft_body_is_point_pinned);
 
 	/* JOINT API */
 


### PR DESCRIPTION
This binds (almost) all missing `soft_body_*` methods found in `PhysicsServer3D`, allowing one to create a custom `SoftBody3D`-like scene node from scripts or GDExtension.

The only method omitted was `soft_body_get_collision_exceptions`, which can't be bound due to its `List<RID>*` parameter, similar to `body_get_collision_exceptions`.