### PR TITLE
Auto-bake edited NavigationPolygons in the Editor on a timer

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -429,6 +429,9 @@
 		<member name="editors/panning/warped_mouse_panning" type="bool" setter="" getter="">
 			If [code]true[/code], warps the mouse around the 2D viewport while panning in the 2D editor. This makes it possible to pan over a large area without having to exit panning and adjust the mouse cursor.
 		</member>
+		<member name="editors/polygon_editor/auto_bake_delay" type="float" setter="" getter="">
+			The delay in seconds until more complex and performance costly polygon editors commit their outlines, e.g. the 2D navigation polygon editor rebakes the navigation mesh polygons. A negative value stops the auto bake.
+		</member>
 		<member name="editors/polygon_editor/point_grab_radius" type="int" setter="" getter="">
 			The radius in which points can be selected in the [Polygon2D] and [CollisionPolygon2D] editors (in pixels). Higher values make it easier to select points quickly, but can make it more difficult to select the expected point when several points are located close to each other.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -756,6 +756,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Polygon editor
 	_initial_set("editors/polygon_editor/point_grab_radius", has_touchscreen_ui ? 32 : 8);
 	_initial_set("editors/polygon_editor/show_previous_outline", true);
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/polygon_editor/auto_bake_delay", 1.5, "-1.0,10.0,0.01");
 
 	// Animation
 	_initial_set("editors/animation/autorename_animation_tracks", true);

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -56,6 +56,10 @@ class NavigationPolygonEditor : public AbstractPolygon2DEditor {
 	Button *button_reset = nullptr;
 	Label *bake_info = nullptr;
 
+	Timer *rebake_timer = nullptr;
+	float _rebake_timer_delay = 1.5;
+	void _rebake_timer_timeout();
+
 	void _bake_pressed();
 	void _clear_pressed();
 


### PR DESCRIPTION
Auto-bakes edited NavigationPolygons in the Editor on a timer.

The pre-4.2 NavigationRegion2D did automatically rebake the entire NavigationPolygon everytime it was changed even a little.

This caused severe performance problems while editing more complex polygons.

Baking a navigation mesh is not exactly a quick process. It was very noticeable while developing the 2D navigation mesh baking with the Editor freezing all the time while dragging outline points. That was the reason why with 4.2. this auto-bake was removed from the Editor. It was expected that now with the 2D navigation mesh very complex polygons will be far more common then before and users will complain about this performance problem.

That is also what happened (the complex polygon part) but now some users started to miss the convenience of the old feature and want it back. If they only have simple projects it was convenient to not hit the bake button all the time to see how things turn out when baked. It is also regularly confusing new users that do not understand why there is no polygon, not having discovered the bake button yet.

So this pr adds back the auto-bake on a timer that refreshes on every change before firing the bake. By default 1.5 seconds which gives enough time to drag around multiple polygon outline points without triggering the bake. The timer can be adjusted in the EditorSettings. By turning it down to 0.0 seconds the old instant-bake is back. By going negativ <0 with the timer it gets disabled completely again. Slower users that need more time to arrange things can increase the timer near infinite, so the feature stays accesible.

I think this solves the issue for all the 3 major user groups.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
