### PR TITLE
Fix framebuffer created for reflection probe in mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -263,28 +263,11 @@ RID RenderForwardMobile::RenderBufferDataForwardMobile::get_color_fbs(Framebuffe
 
 RID RenderForwardMobile::reflection_probe_create_framebuffer(RID p_color, RID p_depth) {
 	// Our attachments
-	Vector<RID> fb;
-	fb.push_back(p_color); // 0
-	fb.push_back(p_depth); // 1
+	Vector<RID> attachments;
+	attachments.push_back(p_color); // 0
+	attachments.push_back(p_depth); // 1
 
-	// Now define our subpasses
-	Vector<RD::FramebufferPass> passes;
-	RD::FramebufferPass pass;
-
-	// re-using the same attachments
-	pass.color_attachments.push_back(0);
-	pass.depth_attachment = 1;
-
-	// - opaque pass
-	passes.push_back(pass);
-
-	// - sky pass
-	passes.push_back(pass);
-
-	// - alpha pass
-	passes.push_back(pass);
-
-	return RD::get_singleton()->framebuffer_create_multipass(fb, passes);
+	return RD::get_singleton()->framebuffer_create(attachments);
 }
 
 void RenderForwardMobile::setup_render_buffer_data(Ref<RenderSceneBuffersRD> p_render_buffers) {
@@ -1048,10 +1031,6 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				RENDER_TIMESTAMP("Render Transparent");
 
 				rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_ALPHA, p_render_data, radiance_texture, samplers, true);
-
-				if (rb_data.is_valid()) {
-					framebuffer = rb_data->get_color_fbs(RenderBufferDataForwardMobile::FB_CONFIG_RENDER_PASS);
-				}
 
 				// this may be needed if we re-introduced steps that change info, not sure which do so in the previous implementation
 				//_setup_environment(p_render_data, is_reflection_probe, screen_size, !is_reflection_probe, p_default_bg_color, false);


### PR DESCRIPTION
In the mobile renderer, if reflection probes are used, we were getting the following GPU validation error:
```
VUID-vkCmdEndRenderPass-None-00910(ERROR / SPEC): msgNum: 2050775817 - Validation Error: [ VUID-vkCmdEndRenderPass-None-00910 ] Object 0: handle = 0x1aa2db36d50, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x3e5a36000000fffc, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x7a3c5b09 | vkCmdEndRenderPass():  Called before reaching final subpass. The Vulkan spec states: The current subpass index must be equal to the number of subpasses in the render pass minus one (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdEndRenderPass-None-00910)
    Objects: 2
       [0]  0x1aa2db36d50, type: 6, name: NULL
       [1]  0x3e5a36000000fffc, type: 18, name: NULL
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 2050775817 | Message Id Name: VUID-vkCmdEndRenderPass-None-00910
	Validation Error: [ VUID-vkCmdEndRenderPass-None-00910 ] Object 0: handle = 0x1aa2db36d50, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x3e5a36000000fffc, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x7a3c5b09 | vkCmdEndRenderPass():  Called before reaching final subpass. The Vulkan spec states: The current subpass index must be equal to the number of subpasses in the render pass minus one (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdEndRenderPass-None-00910)
	Objects - 2
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1830422801744
		Object[1] - VK_OBJECT_TYPE_RENDER_PASS, Handle 4492962951883456508
```

This is due to a recent improvement in the mobile renderer where we no longer use subpasses to render the opaque, sky and transparent passes but join them into a single pass if possible.

I however forgot to update the code for reflection probes to remove the subpasses here as well.