### PR TITLE
Fix error when pinning soft body point without attachment

### DIFF
--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -714,9 +714,6 @@ void SoftBody3D::_update_cache_pin_points_datas() {
 		if (!w[i].spatial_attachment_path.is_empty()) {
 			w[i].spatial_attachment = Object::cast_to<Node3D>(get_node(w[i].spatial_attachment_path));
 		}
-		if (!w[i].spatial_attachment) {
-			ERR_PRINT("Node3D node not defined in the pinned point, this is undefined behavior for SoftBody3D!");
-		}
 	}
 }
 


### PR DESCRIPTION
For reasons I don't quite understand, soft bodies currently emit an error when you pin a point without providing an attachment for that pinned point, saying `Node3D node not defined in the pinned point, this is undefined behavior for SoftBody3D!`.

This doesn't make a whole lot of sense to me, since pinning a point just sets the inverse mass of that point to 0, effectively making it kinematic, which can then be moved either by an attachment or explicitly through `PhysicsServer3D::soft_body_move_point`, meaning pinning is in no way dependent on attachments.

The documentation for `SoftBody3D` even states that the attachment path is optional:

https://github.com/godotengine/godot/blob/74c32faa78b54863f8f25c538083907c2bf71791/doc/classes/SoftBody3D.xml#L90

I figured it might have been some misplaced error handling that should've gone inside the if-statement before it, but the error checking for the path itself is already happening as part of `SoftBody3D::_add_pinned_point`:

https://github.com/godotengine/godot/blob/74c32faa78b54863f8f25c538083907c2bf71791/scene/3d/soft_body_3d.cpp#L746-L749

... so I opted to remove the error altogether.