### PR TITLE
Fix validation errors by improving stage and slice tracking behavior of RenderingDeviceGraph.

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -35,6 +35,8 @@
 #include "thirdparty/misc/smolv.h"
 #include "vulkan_context.h"
 
+#define PRINT_NATIVE_COMMANDS 0
+
 /*****************/
 /**** GENERIC ****/
 /*****************/
@@ -622,6 +624,10 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create(const TextureFormat &
 	tex_info->allocation.handle = allocation;
 	vmaGetAllocationInfo(allocator, tex_info->allocation.handle, &tex_info->allocation.info);
 
+#if PRINT_NATIVE_COMMANDS
+	print_line(vformat("vkCreateImageView: 0x%uX for 0x%uX", uint64_t(vk_image_view), uint64_t(vk_image)));
+#endif
+
 	return TextureID(tex_info);
 }
 
@@ -710,6 +716,10 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create_shared(TextureID p_or
 	tex_info->vk_view_create_info = image_view_create_info;
 	tex_info->allocation = {};
 
+#if PRINT_NATIVE_COMMANDS
+	print_line(vformat("vkCreateImageView: 0x%uX for 0x%uX", uint64_t(new_vk_image_view), uint64_t(owner_tex_info->vk_view_create_info.image)));
+#endif
+
 	return TextureID(tex_info);
 }
 
@@ -758,6 +768,10 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create_shared_from_slice(Tex
 	tex_info->vk_view = new_vk_image_view;
 	tex_info->vk_view_create_info = image_view_create_info;
 	tex_info->allocation = {};
+
+#if PRINT_NATIVE_COMMANDS
+	print_line(vformat("vkCreateImageView: 0x%uX for 0x%uX (%d %d %d %d)", uint64_t(new_vk_image_view), uint64_t(owner_tex_info->vk_view_create_info.image), p_mipmap, p_mipmaps, p_layer, p_layers));
+#endif
 
 	return TextureID(tex_info);
 }
@@ -1071,6 +1085,23 @@ void RenderingDeviceDriverVulkan::command_pipeline_barrier(
 		vk_image_barriers[i].subresourceRange.layerCount = p_texture_barriers[i].subresources.layer_count;
 	}
 
+#if PRINT_NATIVE_COMMANDS
+	print_line(vformat("vkCmdPipelineBarrier MEMORY %d BUFFER %d TEXTURE %d", p_memory_barriers.size(), p_buffer_barriers.size(), p_texture_barriers.size()));
+	for (uint32_t i = 0; i < p_memory_barriers.size(); i++) {
+		print_line(vformat("  VkMemoryBarrier #%d src 0x%uX dst 0x%uX", i, vk_memory_barriers[i].srcAccessMask, vk_memory_barriers[i].dstAccessMask));
+	}
+
+	for (uint32_t i = 0; i < p_buffer_barriers.size(); i++) {
+		print_line(vformat("  VkBufferMemoryBarrier #%d src 0x%uX dst 0x%uX buffer 0x%ux", i, vk_buffer_barriers[i].srcAccessMask, vk_buffer_barriers[i].dstAccessMask, uint64_t(vk_buffer_barriers[i].buffer)));
+	}
+
+	for (uint32_t i = 0; i < p_texture_barriers.size(); i++) {
+		print_line(vformat("  VkImageMemoryBarrier #%d src 0x%uX dst 0x%uX image 0x%ux old %d new %d (%d %d %d %d)", i, vk_image_barriers[i].srcAccessMask, vk_image_barriers[i].dstAccessMask,
+				uint64_t(vk_image_barriers[i].image), vk_image_barriers[i].oldLayout, vk_image_barriers[i].newLayout, vk_image_barriers[i].subresourceRange.baseMipLevel, vk_image_barriers[i].subresourceRange.levelCount,
+				vk_image_barriers[i].subresourceRange.baseArrayLayer, vk_image_barriers[i].subresourceRange.layerCount));
+	}
+#endif
+
 	vkCmdPipelineBarrier(
 			(VkCommandBuffer)p_cmd_buffer.id,
 			(VkPipelineStageFlags)p_src_stages,
@@ -1224,6 +1255,14 @@ RDD::FramebufferID RenderingDeviceDriverVulkan::framebuffer_create(RenderPassID 
 	VkFramebuffer vk_framebuffer = VK_NULL_HANDLE;
 	VkResult err = vkCreateFramebuffer(vk_device, &framebuffer_create_info, nullptr, &vk_framebuffer);
 	ERR_FAIL_COND_V_MSG(err, FramebufferID(), "vkCreateFramebuffer failed with error " + itos(err) + ".");
+
+#if PRINT_NATIVE_COMMANDS
+	print_line(vformat("vkCreateFramebuffer 0x%uX with %d attachments", uint64_t(vk_framebuffer), p_attachments.size()));
+	for (uint32_t i = 0; i < p_attachments.size(); i++) {
+		const TextureInfo *attachment_info = (const TextureInfo *)p_attachments[i].id;
+		print_line(vformat("  Attachment #%d: IMAGE 0x%uX VIEW 0x%uX", i, uint64_t(attachment_info->vk_view_create_info.image), uint64_t(attachment_info->vk_view)));
+	}
+#endif
 
 	return FramebufferID(vk_framebuffer);
 }
@@ -2467,10 +2506,18 @@ void RenderingDeviceDriverVulkan::command_begin_render_pass(CommandBufferID p_cm
 
 	VkSubpassContents vk_subpass_contents = p_cmd_buffer_type == COMMAND_BUFFER_TYPE_PRIMARY ? VK_SUBPASS_CONTENTS_INLINE : VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS;
 	vkCmdBeginRenderPass((VkCommandBuffer)p_cmd_buffer.id, &render_pass_begin, vk_subpass_contents);
+
+#if PRINT_NATIVE_COMMANDS
+	print_line(vformat("vkCmdBeginRenderPass Pass 0x%uX Framebuffer 0x%uX", p_render_pass.id, p_framebuffer.id));
+#endif
 }
 
 void RenderingDeviceDriverVulkan::command_end_render_pass(CommandBufferID p_cmd_buffer) {
 	vkCmdEndRenderPass((VkCommandBuffer)p_cmd_buffer.id);
+
+#if PRINT_NATIVE_COMMANDS
+	print_line("vkCmdEndRenderPass");
+#endif
 }
 
 void RenderingDeviceDriverVulkan::command_next_render_subpass(CommandBufferID p_cmd_buffer, CommandBufferType p_cmd_buffer_type) {


### PR DESCRIPTION
Makes some improvements to the tracking behavior of RenderingDeviceGraph to fix some errors that were spotted in other scenes.

- Stage bits could be missed between operations to be inserted correctly due to the pipeline stage changing between subsequent operations that don't imply transition barriers. The stage bits have been split off into their own bitfield and are added to the destination as well when detecting adjacency on the graph.
- The graph could potentially reorder operations that normalize a texture's slices to be performed after the slices were already transitioned due to not tracking the entire area of the resource as a write operation when this happens. Whenever normalization happens now, the area of whatever is normalized is merged and considered for searching previous commands for intersections.
- The graph could potentially cause a validation error by missing the dependency between a command that only reads from a resource (without causing a transition) and a command that writes to a resource slice. This has been fixed by introducing separate lists for reading resources completely and only reading slices. Both lists can be cleared separately depending on whether the resource is modifying only a slice or the entire resource: if it's the entire resource, it'll always delete both lists. If it's only a slice, it won't delete them at all from the full read list, but it'll delete them if it completely encloses the area of a previous read operation. It'll also only add a dependency if there's an intersection between both areas.

This has been verified to fix various issues that could crop up when using certain effects. The https://github.com/godotengine/godot/issues/75440 showed a few of these errors as well as using a heavy amount of omni lights and various effects in other projects. It might not be possible to identify visual differences depending on the nature of the errors, so checking with validation layers is recommended.

The PR also adds a few optional print commands behind a macro to help aid future debugging, as it can be very troublesome to identify these issues without the information from the driver backend that matches the IDs reported by the Vulkan layers.