### PR TITLE
C#: Fix incorrect GC handle for non-instantiable types.

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1621,9 +1621,13 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 					   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
 			} else {
 				// Hide the constructor
-				output.append(MEMBER_BEGIN "internal ");
-				output.append(itype.proxy_name);
-				output.append("() {}\n");
+				output << MEMBER_BEGIN "internal " << itype.proxy_name << "() : this("
+					   << (itype.memory_own ? "true" : "false") << ")\n" OPEN_BLOCK_L1
+					   << INDENT2 "unsafe\n" INDENT2 OPEN_BLOCK
+					   << INDENT3 "_ConstructAndInitialize(null, "
+					   << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
+					   << (itype.is_ref_counted ? "true" : "false") << ");\n"
+					   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
 			}
 
 			// Add.. em.. trick constructor. Sort of.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -38,6 +38,8 @@ namespace Godot
         {
             if (NativePtr == IntPtr.Zero)
             {
+                Debug.Assert(nativeCtor != null);
+
                 NativePtr = nativeCtor();
 
                 InteropUtils.TieManagedToUnmanaged(this, NativePtr,


### PR DESCRIPTION
- Fix #87515.

As #87515 explained, the binding generator didn't consider `_ConstructAndInitialize` for non-instantiable types.

This PR modifies its generation.
From:
```csharp
internal DirAccess() {}
```
To:
```csharp
internal DirAccess() : this(true)
{
    unsafe
    {
        _ConstructAndInitialize(null, NativeName, CachedType, refCounted: true);
    }
}
```

This will pass correct native type (`CachedType` above) and avoid accident GC handle.



- Help to close #71081.
- May alternative to #75434.