### PR TITLE
Make the Script Editor's parser execute sooner on edit after error was found

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1292,6 +1292,9 @@
 		<member name="text_editor/completion/idle_parse_delay" type="float" setter="" getter="">
 			The delay in seconds after which the script editor should check for errors when the user stops typing.
 		</member>
+		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
+			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
+		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.
 		</member>

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -174,6 +174,8 @@ class CodeTextEditor : public VBoxContainer {
 
 	Label *info = nullptr;
 	Timer *idle = nullptr;
+	float idle_time = 0.0f;
+	float idle_time_with_errors = 0.0f;
 	bool code_complete_enabled = true;
 	Timer *code_complete_timer = nullptr;
 	int code_complete_timer_line = 0;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -724,6 +724,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Completion
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01")
 	_initial_set("text_editor/completion/auto_brace_complete", true, true);
 	_initial_set("text_editor/completion/code_complete_enabled", true, true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8945

This PR is fairly self-explanatory. And dang, does it feel good.

##### Delay is scaled way down for demonstration:
<img src=https://i.gyazo.com/4619e4fdf8ffb0d63c354932b5a2c290.gif>

A new Editor Setting exists, ~~as a multiplier to tweak this behavior~~. I am using a default value of `0.5` and personally, I do find it great. but that may be personal preference.
Naming suggestions for this one would be nice.

Oh and, just for clarity, this does not apply to the Shader editor. Unsure why, honestly. It may be hardcoded. Or maybe this PR would break something about it?