### PR TITLE
Remove now unused `year` member from `version.py`

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -110,7 +110,6 @@ Dictionary Engine::get_version_info() const {
 	dict["hex"] = VERSION_HEX;
 	dict["status"] = VERSION_STATUS;
 	dict["build"] = VERSION_BUILD;
-	dict["year"] = VERSION_YEAR;
 
 	String hash = String(VERSION_HASH);
 	dict["hash"] = hash.is_empty() ? String("unknown") : hash;

--- a/core/version.h
+++ b/core/version.h
@@ -33,6 +33,12 @@
 
 #include "core/version_generated.gen.h"
 
+// Copied from typedefs.h to stay lean.
+#ifndef _STR
+#define _STR(m_x) #m_x
+#define _MKSTR(m_x) _STR(m_x)
+#endif
+
 // Godot versions are of the form <major>.<minor> for the initial release,
 // and then <major>.<minor>.<patch> for subsequent bugfix releases where <patch> != 0
 // That's arbitrary, but we find it pretty and it's the current policy.

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -179,7 +179,6 @@
 				[code]status[/code]   - Holds the status (e.g. "beta", "rc1", "rc2", ... "stable") as a String
 				[code]build[/code]    - Holds the build name (e.g. "custom_build") as a String
 				[code]hash[/code]     - Holds the full Git commit hash as a String
-				[code]year[/code]     - Holds the year the version was released in as an int
 				[code]string[/code]   - [code]major[/code] + [code]minor[/code] + [code]patch[/code] + [code]status[/code] + [code]build[/code] in a single String
 				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code]. [b]Note:[/b] It's still an int internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for easy version comparisons from code:
 				[codeblocks]

--- a/methods.py
+++ b/methods.py
@@ -163,7 +163,6 @@ def get_version_info(module_version_string="", silent=False):
         "status": str(version.status),
         "build": str(build_name),
         "module_config": str(version.module_config) + module_version_string,
-        "year": int(version.year),
         "website": str(version.website),
         "docs_branch": str(version.docs),
     }
@@ -232,7 +231,6 @@ def generate_version_header(module_version_string=""):
 #define VERSION_STATUS "{status}"
 #define VERSION_BUILD "{build}"
 #define VERSION_MODULE_CONFIG "{module_config}"
-#define VERSION_YEAR {year}
 #define VERSION_WEBSITE "{website}"
 #define VERSION_DOCS_BRANCH "{docs_branch}"
 #define VERSION_DOCS_URL "https://docs.godotengine.org/en/" VERSION_DOCS_BRANCH

--- a/platform/windows/godot_res.rc
+++ b/platform/windows/godot_res.rc
@@ -1,16 +1,12 @@
 #include "core/version.h"
-#ifndef _STR
-#define _STR(m_x) #m_x
-#define _MKSTR(m_x) _STR(m_x)
-#endif
 
 GODOT_ICON ICON platform/windows/godot.ico
 
 1 VERSIONINFO
-FILEVERSION    	VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
-PRODUCTVERSION 	VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
-FILEOS         	4
-FILETYPE       	1
+FILEVERSION     VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
+PRODUCTVERSION  VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
+FILEOS          4
+FILETYPE        1
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -21,7 +17,7 @@ BEGIN
             VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME
             VALUE "Licence",                "MIT"
-            VALUE "LegalCopyright",         "Copyright (c) 2007-" _MKSTR(VERSION_YEAR) " Juan Linietsky, Ariel Manzur and contributors"
+            VALUE "LegalCopyright",         "(c) 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
             VALUE "Info",                   "https://godotengine.org"
             VALUE "ProductVersion",         VERSION_FULL_BUILD
         END

--- a/platform/windows/godot_res_wrap.rc
+++ b/platform/windows/godot_res_wrap.rc
@@ -1,16 +1,12 @@
 #include "core/version.h"
-#ifndef _STR
-#define _STR(m_x) #m_x
-#define _MKSTR(m_x) _STR(m_x)
-#endif
 
 GODOT_ICON ICON platform/windows/godot_console.ico
 
 1 VERSIONINFO
-FILEVERSION    	VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
-PRODUCTVERSION 	VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
-FILEOS         	4
-FILETYPE       	1
+FILEVERSION     VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
+PRODUCTVERSION  VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
+FILEOS          4
+FILETYPE        1
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -21,7 +17,7 @@ BEGIN
             VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME " (Console)"
             VALUE "Licence",                "MIT"
-            VALUE "LegalCopyright",         "Copyright (c) 2007-" _MKSTR(VERSION_YEAR) " Juan Linietsky, Ariel Manzur and contributors"
+            VALUE "LegalCopyright",         "(c) 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
             VALUE "Info",                   "https://godotengine.org"
             VALUE "ProductVersion",         VERSION_FULL_BUILD
         END

--- a/thirdparty/miniupnpc/src/miniupnpcstrings.h
+++ b/thirdparty/miniupnpc/src/miniupnpcstrings.h
@@ -1,9 +1,7 @@
 #ifndef MINIUPNPCSTRINGS_H_INCLUDED
 #define MINIUPNPCSTRINGS_H_INCLUDED
 
-#include "core/version.h"
-
-#define OS_STRING VERSION_NAME "/1.0"
+#define OS_STRING "Godot Engine/1.0"
 #define MINIUPNPC_VERSION_STRING "2.2.5"
 
 #if 0

--- a/version.py
+++ b/version.py
@@ -5,6 +5,5 @@ minor = 3
 patch = 0
 status = "dev"
 module_config = ""
-year = 2023
 website = "https://godotengine.org"
 docs = "latest"


### PR DESCRIPTION
We changed copyright to use "present" for the current year, so we no longer need to hardcode this and (like now) forget to bump it yearly.

_Technically_ it breaks compat by removing `year` from the `Engine.get_version_info()` dictionary.
I think it's in the scope of acceptable changes for 4.3, but shouldn't be cherry-picked to 4.2.x (instead, we'll just bump the `year` to 2024).

Non-compat breaking version for `3.x`: #87579