### PR TITLE
OpenXR: Make it possible to implement vendor extensions to hand tracking from GDExtension

### DIFF
--- a/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
@@ -123,6 +123,14 @@
 				Called when the OpenXR session state is changed to visible. This means OpenXR is now ready to receive frames.
 			</description>
 		</method>
+		<method name="_set_hand_joint_locations_and_get_next_pointer" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="hand_index" type="int" />
+			<param index="1" name="next_pointer" type="void*" />
+			<description>
+				Adds additional data structures when each hand tracker is created.
+			</description>
+		</method>
 		<method name="_set_instance_create_info_and_get_next_pointer" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="next_pointer" type="void*" />

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -60,6 +60,7 @@ public:
 	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; } // Add additional data structures when we create our OpenXR instance.
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; } // Add additional data structures when we create our OpenXR session.
 	virtual void *set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; } // Add additional data structures when creating OpenXR swap chains.
+	virtual void *set_hand_joint_locations_and_get_next_pointer(int p_hand_index, void *p_next_pointer) { return p_next_pointer; }
 
 	// `on_register_metadata` allows extensions to register additional controller metadata.
 	// This function is called even when OpenXRApi is not constructured as the metadata

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
@@ -38,6 +38,7 @@ void OpenXRExtensionWrapperExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_set_instance_create_info_and_get_next_pointer, "next_pointer");
 	GDVIRTUAL_BIND(_set_session_create_and_get_next_pointer, "next_pointer");
 	GDVIRTUAL_BIND(_set_swapchain_create_info_and_get_next_pointer, "next_pointer");
+	GDVIRTUAL_BIND(_set_hand_joint_locations_and_get_next_pointer, "hand_index", "next_pointer");
 	GDVIRTUAL_BIND(_on_register_metadata);
 	GDVIRTUAL_BIND(_on_before_instance_created);
 	GDVIRTUAL_BIND(_on_instance_created, "instance");
@@ -111,6 +112,16 @@ void *OpenXRExtensionWrapperExtension::set_swapchain_create_info_and_get_next_po
 	uint64_t pointer;
 
 	if (GDVIRTUAL_CALL(_set_swapchain_create_info_and_get_next_pointer, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+
+	return nullptr;
+}
+
+void *OpenXRExtensionWrapperExtension::set_hand_joint_locations_and_get_next_pointer(int p_hand_index, void *p_next_pointer) {
+	uint64_t pointer;
+
+	if (GDVIRTUAL_CALL(_set_hand_joint_locations_and_get_next_pointer, p_hand_index, GDExtensionPtr<void>(p_next_pointer), pointer)) {
 		return reinterpret_cast<void *>(pointer);
 	}
 

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.h
@@ -58,12 +58,14 @@ public:
 	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
 	virtual void *set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer) override;
+	virtual void *set_hand_joint_locations_and_get_next_pointer(int p_hand_index, void *p_next_pointer) override;
 
 	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
 	GDVIRTUAL1R(uint64_t, _set_system_properties_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL1R(uint64_t, _set_instance_create_info_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL1R(uint64_t, _set_session_create_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL1R(uint64_t, _set_swapchain_create_info_and_get_next_pointer, GDExtensionPtr<void>);
+	GDVIRTUAL2R(uint64_t, _set_hand_joint_locations_and_get_next_pointer, int, GDExtensionPtr<void>);
 
 	virtual void on_register_metadata() override;
 	virtual void on_before_instance_created() override;

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -179,6 +179,14 @@ void OpenXRHandTrackingExtension::on_process() {
 					next_pointer = &hand_trackers[i].data_source;
 				}
 
+				// Needed for vendor hand tracking extensions implemented from GDExtension.
+				for (OpenXRExtensionWrapper *wrapper : OpenXRAPI::get_singleton()->get_registered_extension_wrappers()) {
+					void *np = wrapper->set_hand_joint_locations_and_get_next_pointer(i, next_pointer);
+					if (np != nullptr) {
+						next_pointer = np;
+					}
+				}
+
 				hand_trackers[i].locations.type = XR_TYPE_HAND_JOINT_LOCATIONS_EXT;
 				hand_trackers[i].locations.next = next_pointer;
 				hand_trackers[i].locations.isActive = false;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1415,6 +1415,10 @@ void OpenXRAPI::unregister_extension_wrapper(OpenXRExtensionWrapper *p_extension
 	registered_extension_wrappers.erase(p_extension_wrapper);
 }
 
+const Vector<OpenXRExtensionWrapper *> &OpenXRAPI::get_registered_extension_wrappers() {
+	return registered_extension_wrappers;
+}
+
 void OpenXRAPI::register_extension_metadata() {
 	for (OpenXRExtensionWrapper *extension_wrapper : registered_extension_wrappers) {
 		extension_wrapper->on_register_metadata();

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -324,6 +324,7 @@ public:
 	void set_xr_interface(OpenXRInterface *p_xr_interface);
 	static void register_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper);
 	static void unregister_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper);
+	static const Vector<OpenXRExtensionWrapper *> &get_registered_extension_wrappers();
 	static void register_extension_metadata();
 	static void cleanup_extension_wrappers();
 


### PR DESCRIPTION
There are a number of OpenXR vendor extensions for hand tracking that need to be able to add structures to the `next` pointer chain on the `XrHandJointLocationEXT` structure, including:

- [XR_FB_hand_tracking_aim](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_hand_tracking_aim)
- [XR_FB_hand_tracking_capsule](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_hand_tracking_capsules)
- [XR_FB_hand_tracking_mesh](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_hand_tracking_mesh)

As vendor extensions, these should be implemented in [godot_openxr_vendors](https://github.com/GodotVR/godot_openxr_vendors) via GDExtension, however, there isn't presently a way to add something to this particular `next` pointer chain from GDExtension.

This PR aims to fix that!

The API here is a little awkward, in that it adds a `_set_hand_joint_locations_and_get_next_pointer()` method to `OpenXRExtensionWrapper`, where hand tracking is itself implemented as an `OpenXRExtensionWrapper`. However, I'm not sure there's a way to do it that doesn't have worse downsides, especially for GDExtension. So, in my opinion, this is an acceptable awkwardness. :-)

Also, don't worry about having to loop over all the extension wrappers. That bit is only run when setting up each "hand tracker" for the first time. Once setup, it'll keep writing data to the structures we provide.

Anyway, please let me know what you think!