### PR TITLE
C#: Fix sorting for generic types when reloading assemblies.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -697,18 +697,24 @@ struct CSharpScriptDepSort {
 			// Shouldn't happen but just in case...
 			return false;
 		}
-		const Script *I = B->get_base_script().ptr();
+		const CSharpScript *I = get_base_script(B.ptr()).ptr();
 		while (I) {
 			if (I == A.ptr()) {
 				// A is a base of B
 				return true;
 			}
 
-			I = I->get_base_script().ptr();
+			I = get_base_script(I).ptr();
 		}
 
 		// A isn't a base of B
 		return false;
+	}
+
+	// Special fix for constructed generic types.
+	Ref<CSharpScript> get_base_script(const CSharpScript *p_script) const {
+		Ref<CSharpScript> base_script = p_script->base_script;
+		return base_script.is_valid() && !base_script->class_name.is_empty() ? base_script : nullptr;
 	}
 };
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -60,6 +60,7 @@ class CSharpScript : public Script {
 
 	friend class CSharpInstance;
 	friend class CSharpLanguage;
+	friend struct CSharpScriptDepSort;
 
 	bool tool = false;
 	bool global_class = false;


### PR DESCRIPTION
Fixes (partially) #78513 that caused by generic type.


When reloading assemblies, base types are reloaded first, followed by inherited types. But with generic types, the sorting function doesn't work properly, resulting in the inherited type being loaded before the base type, which creates duplicate CSharpScript by accident.

The sorting algorithm (`CSharpScriptDepSort`) uses `CSharpScript::get_base_script`, but the script for generic type do not have a `resource_path`, so it returns null:

https://github.com/godotengine/godot/blob/4b6ad349886288405890b07d4a8da425eb3c97ec/modules/mono/csharp_script.cpp#L2779-L2781

This PR makes minor changes to fix fail reloading by generics, and developers can use generic types in editor basically. To completely support it, there is still work to do, like adding virtual path for generic `CSharpScript`.

- Close #79519 
- Supersede #83204 
- Supersede #86305 


_Thanks to @Delsin-Yu for helping with debugging._