### PR TITLE
Significantly improve the speed of shader compilation in compatibility backend

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -9,7 +9,7 @@ mode_instanced = #define USE_ATTRIBUTES \n#define USE_INSTANCING
 
 #[specializations]
 
-DISABLE_LIGHTING = false
+DISABLE_LIGHTING = true
 USE_RGBA_SHADOWS = false
 SINGLE_INSTANCE = false
 


### PR DESCRIPTION
Partially addresses: https://github.com/godotengine/godot/issues/86731

When we first create shaders in the compatibility backend we compile all shader "modes" with the default set of specializations. The canvas shader has 5 "modes". The specialization with lights enabled is about 60x larger than when lights are disabled. Specializations (other than the default) are only compiled when used. So by disabling lights by default we can compile only the simple version by default and then only compile the expensive shaders when needed. 

On my laptop (Intel® Core™ i7-1165G7, Mesa Intel® Xe Graphics) the shader cache for each canvasitem shader in the MRP totaled about 2.9 mb, with this PR they are ~50 kb and when a light is used in the scene it increases to ~650. 

It is hard to gather accurate measurements, but in this case the performance difference is obvious. It goes from having a noticeable stall to no stall at all. 

**Testing the MRP from https://github.com/godotengine/godot/issues/86731**
No caching:
Before: 374 ms
After: 162 ms (debug build, so might be slightly faster in practice)

Caching:
Before: 359 ms
After: 46 ms (debug build, so might be slightly faster in practice)

On my MacBook Pro (early 2015, intel 15 dual core 2.7 GHz) I also see a significant improvement from about 7ms to about 2.5 ms in the same MRP

**Note: To fully take advantage of this PR, you must clear your shader cache. This approach doesn't break the shader cache so its totally safe to use and backport, but the full benefits are only seen with a clean cache. On that note, non-cached runs are a bit faster with this change.**

CC @djrain

I'd like to leave https://github.com/godotengine/godot/issues/86731 open as I think we can do quite a bit more to bring shader compilation time down. I'm making this PR in the meantime as it makes a huge difference and is super safe.