### PR TITLE
Fix for: ogg importer dialog rounds loop offset values to 3 digits, introducing a sampling imprecision that can lead to an audible pop on loop.

### DIFF
--- a/editor/import/audio_stream_import_settings.h
+++ b/editor/import/audio_stream_import_settings.h
@@ -50,7 +50,9 @@ class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 	Label *bar_beats_label = nullptr;
 	SpinBox *bar_beats_edit = nullptr;
 	CheckBox *loop = nullptr;
+	Label *loop_offset_label = nullptr;
 	SpinBox *loop_offset = nullptr;
+	CheckBox *loop_use_samples = nullptr;
 	ColorRect *color_rect = nullptr;
 	Ref<AudioStream> stream;
 	AudioStreamPlayer *_player = nullptr;

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -50,7 +50,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 
 	bool beat_loop = use_loop && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
 	if (beat_loop) {
-		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
+		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->get_sample_rate() * 60 / mp3_stream->get_bpm();
 	}
 
 	while (todo && active) {
@@ -125,7 +125,7 @@ int AudioStreamPlaybackMP3::get_loop_count() const {
 }
 
 double AudioStreamPlaybackMP3::get_playback_position() const {
-	return double(frames_mixed) / mp3_stream->sample_rate;
+	return double(frames_mixed) / mp3_stream->get_sample_rate();
 }
 
 void AudioStreamPlaybackMP3::seek(double p_time) {
@@ -137,7 +137,7 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 		p_time = 0;
 	}
 
-	frames_mixed = uint32_t(mp3_stream->sample_rate * p_time);
+	frames_mixed = uint32_t(mp3_stream->get_sample_rate() * p_time);
 	mp3dec_ex_seek(mp3d, (uint64_t)frames_mixed * mp3_stream->channels);
 }
 
@@ -251,6 +251,10 @@ double AudioStreamMP3::get_length() const {
 
 bool AudioStreamMP3::is_monophonic() const {
 	return false;
+}
+
+float AudioStreamMP3::get_sample_rate() const {
+	return sample_rate;
 }
 
 void AudioStreamMP3::get_parameter_list(List<Parameter> *r_parameters) {

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -131,6 +131,8 @@ public:
 
 	virtual bool is_monophonic() const override;
 
+	virtual float get_sample_rate() const override;
+
 	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
 
 	AudioStreamMP3();

--- a/modules/minimp3/doc_classes/ResourceImporterMP3.xml
+++ b/modules/minimp3/doc_classes/ResourceImporterMP3.xml
@@ -33,5 +33,8 @@
 			Only has an effect if [member loop] is [code]true[/code].
 			A more convenient editor for [member loop_offset] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
+		<member name="loop_use_samples" type="bool" setter="" getter="" default="false">
+			If enabled, [member loop_offset] will be interpreted as being defined in samples, instead of in seconds. This allows for greater precision, but will often not be needed. Use this if you notice a pop whenever your audio loops.
+		</member>
 	</members>
 </class>

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -77,6 +77,7 @@ String ResourceImporterMP3::get_preset_name(int p_idx) const {
 void ResourceImporterMP3::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "loop_offset"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop_use_samples"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "bpm", PROPERTY_HINT_RANGE, "0,400,0.01,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "beat_count", PROPERTY_HINT_RANGE, "0,512,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "bar_beats", PROPERTY_HINT_RANGE, "2,32,or_greater"), 4));
@@ -117,7 +118,8 @@ Ref<AudioStreamMP3> ResourceImporterMP3::import_mp3(const String &p_path) {
 
 Error ResourceImporterMP3::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
-	float loop_offset = p_options["loop_offset"];
+	double loop_offset = p_options["loop_offset"];
+	bool loop_use_samples = p_options["loop_use_samples"];
 	double bpm = p_options["bpm"];
 	float beat_count = p_options["beat_count"];
 	float bar_beats = p_options["bar_beats"];
@@ -126,6 +128,11 @@ Error ResourceImporterMP3::import(const String &p_source_file, const String &p_s
 	if (mp3_stream.is_null()) {
 		return ERR_CANT_OPEN;
 	}
+
+	if (loop_use_samples) {
+		loop_offset = mp3_stream->sample_to_seconds(loop_offset);
+	}
+
 	mp3_stream->set_loop(loop);
 	mp3_stream->set_loop_offset(loop_offset);
 	mp3_stream->set_bpm(bpm);

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -513,6 +513,10 @@ bool AudioStreamOggVorbis::is_monophonic() const {
 	return false;
 }
 
+float AudioStreamOggVorbis::get_sample_rate() const {
+	return get_packet_sequence()->get_sampling_rate();
+}
+
 void AudioStreamOggVorbis::get_parameter_list(List<Parameter> *r_parameters) {
 	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -157,6 +157,8 @@ public:
 
 	virtual bool is_monophonic() const override;
 
+	virtual float get_sample_rate() const override;
+
 	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
 
 	AudioStreamOggVorbis();

--- a/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
+++ b/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
@@ -49,5 +49,8 @@
 			Only has an effect if [member loop] is [code]true[/code].
 			A more convenient editor for [member loop_offset] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
+		<member name="loop_use_samples" type="bool" setter="" getter="" default="false">
+			If enabled, [member loop_offset] will be interpreted as being defined in samples, instead of in seconds. This allows for greater precision, but will often not be needed. Use this if you notice a pop whenever your audio loops.
+		</member>
 	</members>
 </class>

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -76,6 +76,7 @@ String ResourceImporterOggVorbis::get_preset_name(int p_idx) const {
 void ResourceImporterOggVorbis::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "loop_offset"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop_use_samples"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "bpm", PROPERTY_HINT_RANGE, "0,400,0.01,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "beat_count", PROPERTY_HINT_RANGE, "0,512,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "bar_beats", PROPERTY_HINT_RANGE, "2,32,or_greater"), 4));
@@ -98,6 +99,7 @@ void ResourceImporterOggVorbis::show_advanced_options(const String &p_path) {
 Error ResourceImporterOggVorbis::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
 	double loop_offset = p_options["loop_offset"];
+	bool loop_use_samples = p_options["loop_use_samples"];
 	double bpm = p_options["bpm"];
 	int beat_count = p_options["beat_count"];
 	int bar_beats = p_options["bar_beats"];
@@ -105,6 +107,10 @@ Error ResourceImporterOggVorbis::import(const String &p_source_file, const Strin
 	Ref<AudioStreamOggVorbis> ogg_vorbis_stream = load_from_file(p_source_file);
 	if (ogg_vorbis_stream.is_null()) {
 		return ERR_CANT_OPEN;
+	}
+
+	if (loop_use_samples) {
+		loop_offset = ogg_vorbis_stream->sample_to_seconds(loop_offset);
 	}
 
 	ogg_vorbis_stream->set_loop(loop);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -216,6 +216,21 @@ bool AudioStream::is_monophonic() const {
 	return ret;
 }
 
+float AudioStream::get_sample_rate() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_sample_rate, ret);
+	return ret;
+}
+
+double AudioStream::sample_to_seconds(int p_sample_index) const {
+	float sample_rate = get_sample_rate();
+	if (sample_rate == 0) {
+		WARN_PRINT("The AudioStream sample rate was 0. Assumed 44,100 Hz instead.");
+		sample_rate = 44100;
+	}
+	return p_sample_index / sample_rate;
+}
+
 double AudioStream::get_bpm() const {
 	double ret = 0;
 	GDVIRTUAL_CALL(_get_bpm, ret);

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -127,6 +127,7 @@ protected:
 	GDVIRTUAL0RC(String, _get_stream_name)
 	GDVIRTUAL0RC(double, _get_length)
 	GDVIRTUAL0RC(bool, _is_monophonic)
+	GDVIRTUAL0RC(float, _get_sample_rate)
 	GDVIRTUAL0RC(double, _get_bpm)
 	GDVIRTUAL0RC(bool, _has_loop)
 	GDVIRTUAL0RC(int, _get_bar_beats)
@@ -144,6 +145,8 @@ public:
 
 	virtual double get_length() const;
 	virtual bool is_monophonic() const;
+	virtual float get_sample_rate() const;
+	double sample_to_seconds(int p_sample_index) const;
 
 	void tag_used(float p_offset);
 	uint64_t get_tagged_frame() const;


### PR DESCRIPTION
Fixes #87427 for ogg and mp3 files, by introducing a toggle that allows the user to enter their loop offsets in either seconds or in samples. AudioStream classes are mostly left unchanged, except that I had to add 2 methods (get_sample_rate and sample_to_seconds) to make this work. Wav stuff was left unchanged.

I also took the liberty to make the importer dialog a little nicer to use, by making the loop offset field a little larger, and making loop-related stuff invisible when looping is disabled.

Disclaimer: I'm a total git newbie, so hopefully I did everything right.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/84.*