### PR TITLE
Replace internal usage of ImageTexture in VideoStreamPlayer for Texture2D

### DIFF
--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -31,7 +31,6 @@
 #include "video_stream_player.h"
 
 #include "core/os/os.h"
-#include "scene/resources/image_texture.h"
 #include "scene/scene_string_names.h"
 #include "servers/audio_server.h"
 

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -36,8 +36,6 @@
 #include "servers/audio/audio_rb_resampler.h"
 #include "servers/audio_server.h"
 
-class ImageTexture;
-
 class VideoStreamPlayer : public Control {
 	GDCLASS(VideoStreamPlayer, Control);
 
@@ -54,7 +52,7 @@ class VideoStreamPlayer : public Control {
 
 	RID stream_rid;
 
-	Ref<ImageTexture> texture;
+	Ref<Texture2D> texture;
 
 	AudioRBResampler resampler;
 	Vector<AudioFrame> mix_buffer;


### PR DESCRIPTION
Currently Godot uses an ImageTexture internally for the video player, this is problematic in any case where an ImageTexture isn't returned by the VideoStreamPlayback (it does indeed look like an oversight, since that returns a normal Texture2D).

I stumbled upon this while working on a compute shader based implementation of YUV conversions using Texture2DRD.