### PR TITLE
Reduce shader permutations in the compatibility backend

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -273,14 +273,12 @@ public:
 
 		RID material;
 		GLES3::CanvasMaterialData *material_data = nullptr;
-		CanvasShaderGLES3::ShaderVariant shader_variant = CanvasShaderGLES3::MODE_QUAD;
 		uint64_t vertex_input_mask = RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_COLOR | RS::ARRAY_FORMAT_TEX_UV;
+		uint64_t specialization = 0;
 
 		const Item::Command *command = nullptr;
 		Item::Command::Type command_type = Item::Command::TYPE_ANIMATION_SLICE; // Can default to any type that doesn't form a batch.
 		uint32_t primitive_points = 0;
-
-		bool lights_disabled = false;
 	};
 
 	// DataBuffer contains our per-frame data. I.e. the resources that are updated each frame.

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -1,17 +1,16 @@
 /* clang-format off */
 #[modes]
 
-mode_quad =
-mode_ninepatch = #define USE_NINEPATCH
-mode_primitive = #define USE_PRIMITIVE
-mode_attributes = #define USE_ATTRIBUTES
-mode_instanced = #define USE_ATTRIBUTES \n#define USE_INSTANCING
+mode_default =
 
 #[specializations]
 
 DISABLE_LIGHTING = true
 USE_RGBA_SHADOWS = false
-SINGLE_INSTANCE = false
+USE_NINEPATCH = false
+USE_PRIMITIVE = false
+USE_ATTRIBUTES = false
+USE_INSTANCING = false
 
 #[vertex]
 

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -2,17 +2,15 @@
 #[modes]
 
 mode_background =
-mode_half_res = #define USE_HALF_RES_PASS
-mode_quarter_res = #define USE_QUARTER_RES_PASS
 mode_cubemap = #define USE_CUBEMAP_PASS
-mode_cubemap_half_res = #define USE_CUBEMAP_PASS \n#define USE_HALF_RES_PASS
-mode_cubemap_quarter_res = #define USE_CUBEMAP_PASS \n#define USE_QUARTER_RES_PASS
 
 #[specializations]
 
 USE_MULTIVIEW = false
 USE_INVERTED_Y = true
 APPLY_TONEMAPPING = true
+USE_QUARTER_RES_PASS = false
+USE_HALF_RES_PASS = false
 
 #[vertex]
 


### PR DESCRIPTION
Further improvements for https://github.com/godotengine/godot/issues/86731 (not closing as I suspect we can make further improvements still)

Compared to https://github.com/godotengine/godot/pull/87553 this brings compile times down even more

Intel laptop 45 ms -> 30 ms
2015 Macbook 2500 ms -> 700 ms
M2 Macbook 950ms -> 200 ms