### PR TITLE
Fix editor will freeze when modifying filesystem filter path in Split Mode

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1004,6 +1004,9 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			}
 		}
 	} else {
+		if (!directory.begins_with("res://")) {
+			directory = "res://" + directory;
+		}
 		// Get infos on the directory + file.
 		if (directory.ends_with("/") && directory != "res://") {
 			directory = directory.substr(0, directory.length() - 1);


### PR DESCRIPTION
A "hack" that fixes https://github.com/godotengine/godot/issues/87525

I post the easy and hack way here for reference. 

As https://github.com/godotengine/godot/issues/87525#issuecomment-1907855777 mentioned there is some code looks problematic. Also the custom color support code here has a strong assumption that `current_path` is begins with `res://` , maybe it's better to re-thinking the assumption instead of hack the `directory`. 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
