### PR TITLE
Fix `FileAccessMemory` off by one error in `eof_reached`

### DIFF
--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -119,7 +119,7 @@ uint64_t FileAccessMemory::get_length() const {
 }
 
 bool FileAccessMemory::eof_reached() const {
-	return pos > length;
+	return pos >= length;
 }
 
 uint8_t FileAccessMemory::get_8() const {


### PR DESCRIPTION
A small off by one error in `FileAccessMemory`. With the current implementation `eof_reached` is never true when using eg `get_buffer`. Noticed this when trying to load *.tres files from memory which triggered the warning in `get_buffer` indefinitely.