### PR TITLE
[3.x] Update `year` property in `version.py` to 2024

### DIFF
--- a/core/version.h
+++ b/core/version.h
@@ -33,6 +33,12 @@
 
 #include "core/version_generated.gen.h"
 
+// Copied from typedefs.h to stay lean.
+#ifndef _STR
+#define _STR(m_x) #m_x
+#define _MKSTR(m_x) _STR(m_x)
+#endif
+
 // Godot versions are of the form <major>.<minor> for the initial release,
 // and then <major>.<minor>.<patch> for subsequent bugfix releases where <patch> != 0
 // That's arbitrary, but we find it pretty and it's the current policy.

--- a/platform/windows/godot_res.rc
+++ b/platform/windows/godot_res.rc
@@ -1,16 +1,12 @@
 #include "core/version.h"
-#ifndef _STR
-#define _STR(m_x) #m_x
-#define _MKSTR(m_x) _STR(m_x)
-#endif
 
 GODOT_ICON ICON platform/windows/godot.ico
 
 1 VERSIONINFO
-FILEVERSION    	VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
-PRODUCTVERSION 	VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
-FILEOS         	4
-FILETYPE       	1
+FILEVERSION     VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
+PRODUCTVERSION  VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,0
+FILEOS          4
+FILETYPE        1
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -21,7 +17,7 @@ BEGIN
             VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME
             VALUE "Licence",                "MIT"
-            VALUE "LegalCopyright",         "Copyright (c) 2007-" _MKSTR(VERSION_YEAR) " Juan Linietsky, Ariel Manzur and contributors"
+            VALUE "LegalCopyright",         "(c) 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
             VALUE "Info",                   "https://godotengine.org"
             VALUE "ProductVersion",         VERSION_FULL_BUILD
         END

--- a/thirdparty/miniupnpc/src/miniupnpcstrings.h
+++ b/thirdparty/miniupnpc/src/miniupnpcstrings.h
@@ -1,9 +1,7 @@
 #ifndef MINIUPNPCSTRINGS_H_INCLUDED
 #define MINIUPNPCSTRINGS_H_INCLUDED
 
-#include "core/version.h"
-
-#define OS_STRING VERSION_NAME "/1.0"
+#define OS_STRING "Godot Engine/1.0"
 #define MINIUPNPC_VERSION_STRING "2.2.5"
 
 #if 0

--- a/version.py
+++ b/version.py
@@ -5,6 +5,6 @@ minor = 6
 patch = 0
 status = "beta"
 module_config = ""
-year = 2022
+year = 2024
 website = "https://godotengine.org"
 docs = "3.5"


### PR DESCRIPTION
Seems like we missed this one when changing the copyright statements to use `present` instead of the hardcoded `year`.

And backport other minor improvements from #87543.