### PR TITLE
Modify display and documentation of attenuation for Light3D

### DIFF
--- a/doc/classes/OmniLight3D.xml
+++ b/doc/classes/OmniLight3D.xml
@@ -14,8 +14,10 @@
 	</tutorials>
 	<members>
 		<member name="omni_attenuation" type="float" setter="set_param" getter="get_param" default="1.0">
-			The light's attenuation (drop-off) curve. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve. Zero and negative values are allowed but can produce unusual effects.
-			[b]Note:[/b] Very high [member omni_attenuation] values (typically above 10) can impact performance negatively if the light is made to use a larger [member omni_range] to compensate. This is because culling opportunities will become less common and shading costs will be increased (as the light will cover more pixels on screen while resulting in the same amount of brightness). To improve performance, use the lowest [member omni_attenuation] value possible for the visuals you're trying to achieve.
+			Controls the distance attenuation function for omnilights.
+			A value of [code]0.0[/code] smoothly attenuates light at the edge of the range. A value of [code]1.0[/code] approaches a physical lighting model. A value of [code]0.5[/code] approximates linear attenuation.
+			[b]Note:[/b] Setting it to [code]1.0[/code] may result in distant objects receiving minimal light, even within range. For example, with a range of [code]4096[/code], an object at [code]100[/code] units receives less than [code]0.1[/code] energy.
+			[b]Note:[/b] Using negative or values higher than [code]10.0[/code] may lead to unexpected results.
 		</member>
 		<member name="omni_range" type="float" setter="set_param" getter="get_param" default="5.0">
 			The light's radius. Note that the effectively lit area may appear to be smaller depending on the [member omni_attenuation] in use. No matter the [member omni_attenuation] in use, the light will never reach anything outside this radius.

--- a/doc/classes/SpotLight3D.xml
+++ b/doc/classes/SpotLight3D.xml
@@ -24,8 +24,10 @@
 			The spotlight's [i]angular[/i] attenuation curve. See also [member spot_attenuation].
 		</member>
 		<member name="spot_attenuation" type="float" setter="set_param" getter="get_param" default="1.0">
-			The spotlight's light energy (drop-off) attenuation curve. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve. Zero and negative values are allowed but can produce unusual effects. See also [member spot_angle_attenuation].
-			[b]Note:[/b] Very high [member spot_attenuation] values (typically above 10) can impact performance negatively if the light is made to use a larger [member spot_range] to compensate. This is because culling opportunities will become less common and shading costs will be increased (as the light will cover more pixels on screen while resulting in the same amount of brightness). To improve performance, use the lowest [member spot_attenuation] value possible for the visuals you're trying to achieve.
+			Controls the distance attenuation function for spotlights.
+			A value of [code]0.0[/code] smoothly attenuates light at the edge of the range. A value of [code]1.0[/code] approaches a physical lighting model. A value of [code]0.5[/code] approximates linear attenuation.
+			[b]Note:[/b] Setting it to [code]1.0[/code] may result in distant objects receiving minimal light, even within range. For example, with a range of [code]4096[/code], an object at [code]100[/code] units receives less than [code]0.1[/code] energy.
+			[b]Note:[/b] Using negative or values higher than [code]10.0[/code] may lead to unexpected results.
 		</member>
 		<member name="spot_range" type="float" setter="set_param" getter="get_param" default="5.0">
 			The maximal range that can be reached by the spotlight. Note that the effectively lit area may appear to be smaller depending on the [member spot_attenuation] in use. No matter the [member spot_attenuation] in use, the light will never reach anything outside this range.

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -616,7 +616,7 @@ void OmniLight3D::_bind_methods() {
 
 	ADD_GROUP("Omni", "omni_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "omni_range", PROPERTY_HINT_RANGE, "0,4096,0.001,or_greater,exp"), "set_param", "get_param", PARAM_RANGE);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "omni_attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_param", "get_param", PARAM_ATTENUATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "omni_attenuation", PROPERTY_HINT_RANGE, "-10,10,0.001,or_greater,or_less"), "set_param", "get_param", PARAM_ATTENUATION);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "omni_shadow_mode", PROPERTY_HINT_ENUM, "Dual Paraboloid,Cube"), "set_shadow_mode", "get_shadow_mode");
 
 	BIND_ENUM_CONSTANT(SHADOW_DUAL_PARABOLOID);
@@ -649,7 +649,7 @@ PackedStringArray SpotLight3D::get_configuration_warnings() const {
 void SpotLight3D::_bind_methods() {
 	ADD_GROUP("Spot", "spot_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_range", PROPERTY_HINT_RANGE, "0,4096,0.001,or_greater,exp,suffix:m"), "set_param", "get_param", PARAM_RANGE);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_param", "get_param", PARAM_ATTENUATION);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_attenuation", PROPERTY_HINT_RANGE, "-10,10,0.01,or_greater,or_less"), "set_param", "get_param", PARAM_ATTENUATION);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_angle", PROPERTY_HINT_RANGE, "0,180,0.01,degrees"), "set_param", "get_param", PARAM_SPOT_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_angle_attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_param", "get_param", PARAM_SPOT_ATTENUATION);
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
When using `OmniLight3D` or `SpotLight3D` in a 3D scene, adjusting the `attenuation` property doesn't behave as expected in the editing panel. The default value of `1.0` doesn't result in linear changes in light intensity over distance, and the modes selected through right-clicking on the property, such as `Zero` and `Ease In-Out`, don't influence the light intensity decay as their names suggest.

This description can be confusing for users. For example, with `Attenuation` set to 1, `Range` set to 5, and the light source positioned at (0, 2.5, 0), the color values at the center point of a plane with no lighting (color: rgb(0.5,0.5,0.5)) and a default white plane at (0,0,0) (color: rgb(1,1,1)) are not the same. It is evident that the decay is not linear.

![PixPin_2024-01-25_20-08-36](https://github.com/godotengine/godot/assets/17810390/0cebf948-1f5c-4520-a1a2-dfdc7c55e392)

Upon inspecting the source code, found that Godot uses the following formula to calculate light attenuation in Forward+ mode:

```glsl
float get_omni_attenuation(float distance, float inv_range, float decay) {
    float nd = distance * inv_range;
    nd *= nd;
    nd *= nd; // nd^4
    nd = max(1.0 - nd, 0.0);
    nd *= nd; // nd^2
    return nd * pow(max(distance, 0.0001), -decay);
}
```

Here, `distance` is the distance from the light to the vertex, `inv_range` is the reciprocal of the light's `range` property, and `decay` is the light's `attenuation` property.

The formula can be expressed as:

$$
attenuation = \frac{(1 - (\frac{distance}{range})^4)^2}{distance^{decay}}
$$

When `attenuation` is 1 and `range` is 5, the distance decay function produces the following curve:

![image-20240125201324384](https://github.com/godotengine/godot/assets/17810390/b36abca7-caab-41aa-b19e-6737fd2619e1)

Clearly, it is not linear within the range [0, 5].

Conversely, when `attenuation` is 0.5 and `range` is 5, it behaves more like linear decay:

![image-20240125201912582](https://github.com/godotengine/godot/assets/17810390/05195ae2-7f86-42f7-a0c6-b38051f71a3e)

In the editor, the `attenuation` property is displayed using an ease curve:

```c++
ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "omni_attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_param", "get_param", PARAM_ATTENUATION);
```

The curve code is:

```c++
double Math::ease(double p_x, double p_c) {
	if (p_x < 0) {
		p_x = 0;
	} else if (p_x > 1.0) {
		p_x = 1.0;
	}
	if (p_c > 0) {
		if (p_c < 1.0) {
			return 1.0 - Math::pow(1.0 - p_x, 1.0 / p_c);
		} else {
			return Math::pow(p_x, p_c);
		}
	} else if (p_c < 0) {
		//inout ease

		if (p_x < 0.5) {
			return Math::pow(p_x * 2.0, -p_c) * 0.5;
		} else {
			return (1.0 - Math::pow(1.0 - (p_x - 0.5) * 2.0, -p_c)) * 0.5 + 0.5;
		}
	} else {
		return 0; // no ease (raw)
	}
}
```

This curve code clearly differs from the actual distance attenuation function. Therefore, it is suggested to replace `PROPERTY_HINT_EXP_EASING` in the editor with `PROPERTY_HINT_RANGE` and set the default value to 0. When the default value is 0, the light attenuation is more uniform within the range, and adjusting the range from 5 to 10 significantly increases the coverage:

![image-20240125202637904](https://github.com/godotengine/godot/assets/17810390/ac64667c-f46f-4052-91de-f21a9f23855c)

When set to 1, adjusting the range has almost no effect on the function, and beyond half the range, the light's impact on objects is minimal (even with a range set to 4096, objects beyond 20 units from the light receive less than 1/20th of the illumination), which might not align with the developer's expectation when adjusting the range to cover a larger area:

![image-20240125202817845](https://github.com/godotengine/godot/assets/17810390/22d37db7-5de0-4feb-baea-c3746ff288ef)

The issue with `SpotLight3D` is similar to `OmniLight3D` and should be addressed accordingly.