### PR TITLE
Retain meta data set on importer nodes

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -762,6 +762,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 					StaticBody3D *col = memnew(StaticBody3D);
 					col->set_transform(mi->get_transform());
 					col->set_name(fixed_name);
+					_copy_meta(p_node, col);
 					p_node->replace_by(col);
 					p_node->set_owner(nullptr);
 					memdelete(p_node);
@@ -776,6 +777,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			StaticBody3D *sb = memnew(StaticBody3D);
 			sb->set_name(fixed_name);
 			Object::cast_to<Node3D>(sb)->set_transform(Object::cast_to<Node3D>(p_node)->get_transform());
+			_copy_meta(p_node, sb);
 			p_node->replace_by(sb);
 			p_node->set_owner(nullptr);
 			memdelete(p_node);
@@ -820,6 +822,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 
 			RigidBody3D *rigid_body = memnew(RigidBody3D);
 			rigid_body->set_name(_fixstr(name, "rigid_body"));
+			_copy_meta(p_node, rigid_body);
 			p_node->replace_by(rigid_body);
 			rigid_body->set_transform(mi->get_transform());
 			p_node = rigid_body;
@@ -884,6 +887,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		Ref<NavigationMesh> nmesh = mesh->create_navigation_mesh();
 		nmi->set_navigation_mesh(nmesh);
 		Object::cast_to<Node3D>(nmi)->set_transform(mi->get_transform());
+		_copy_meta(p_node, nmi);
 		p_node->replace_by(nmi);
 		p_node->set_owner(nullptr);
 		memdelete(p_node);
@@ -924,6 +928,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		VehicleBody3D *bv = memnew(VehicleBody3D);
 		String n = _fixstr(p_node->get_name(), "vehicle");
 		bv->set_name(n);
+		_copy_meta(p_node, bv);
 		p_node->replace_by(bv);
 		p_node->set_name(n);
 		bv->add_child(p_node);
@@ -943,6 +948,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		VehicleWheel3D *bv = memnew(VehicleWheel3D);
 		String n = _fixstr(p_node->get_name(), "wheel");
 		bv->set_name(n);
+		_copy_meta(p_node, bv);
 		p_node->replace_by(bv);
 		p_node->set_name(n);
 		bv->add_child(p_node);
@@ -1550,6 +1556,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 							case MESH_PHYSICS_RIGID_BODY_AND_MESH: {
 								RigidBody3D *rigid_body = memnew(RigidBody3D);
 								rigid_body->set_name(p_node->get_name());
+								_copy_meta(p_node, rigid_body);
 								p_node->replace_by(rigid_body);
 								rigid_body->set_transform(mi->get_transform() * get_collision_shapes_transform(node_settings));
 								rigid_body->set_position(p_applied_root_scale * rigid_body->get_position());
@@ -1568,6 +1575,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								col->set_transform(mi->get_transform() * get_collision_shapes_transform(node_settings));
 								col->set_position(p_applied_root_scale * col->get_position());
 								col->set_name(p_node->get_name());
+								_copy_meta(p_node, col);
 								p_node->replace_by(col);
 								p_node->set_owner(nullptr);
 								memdelete(p_node);
@@ -1583,6 +1591,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								area->set_transform(mi->get_transform() * get_collision_shapes_transform(node_settings));
 								area->set_position(p_applied_root_scale * area->get_position());
 								area->set_name(p_node->get_name());
+								_copy_meta(p_node, area);
 								p_node->replace_by(area);
 								p_node->set_owner(nullptr);
 								memdelete(p_node);
@@ -1626,6 +1635,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 
 					if (navmesh_mode == NAVMESH_NAVMESH_ONLY) {
 						nmi->set_transform(mi->get_transform());
+						_copy_meta(p_node, nmi);
 						p_node->replace_by(nmi);
 						p_node->set_owner(nullptr);
 						memdelete(p_node);
@@ -2553,6 +2563,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 			}
 
 			if (mesh.is_valid()) {
+				_copy_meta(src_mesh_node->get_mesh().ptr(), mesh.ptr());
 				mesh_node->set_mesh(mesh);
 				for (int i = 0; i < mesh->get_surface_count(); i++) {
 					mesh_node->set_surface_override_material(i, src_mesh_node->get_surface_material(i));
@@ -2581,6 +2592,8 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 		mesh_node->set_visibility_range_end_margin(src_mesh_node->get_visibility_range_end_margin());
 		mesh_node->set_visibility_range_fade_mode(src_mesh_node->get_visibility_range_fade_mode());
 
+		_copy_meta(p_node, mesh_node);
+
 		p_node->replace_by(mesh_node);
 		p_node->set_owner(nullptr);
 		memdelete(p_node);
@@ -2601,6 +2614,15 @@ void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>>
 		p_node->add_child(cshape, true);
 
 		cshape->set_owner(p_node->get_owner());
+	}
+}
+
+void ResourceImporterScene::_copy_meta(Object *p_src_object, Object *p_dst_object) {
+	List<StringName> meta_list;
+	p_src_object->get_meta_list(&meta_list);
+	for (const StringName &meta_key : meta_list) {
+		Variant meta_value = p_src_object->get_meta(meta_key);
+		p_dst_object->set_meta(meta_key, meta_value);
 	}
 }
 

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -219,6 +219,7 @@ class ResourceImporterScene : public ResourceImporter {
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
 	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes);
+	void _copy_meta(Object *p_src_object, Object *p_dst_object);
 
 	enum AnimationImportTracks {
 		ANIMATION_IMPORT_TRACKS_IF_PRESENT,

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -37,6 +37,15 @@
 void GLTFDocumentExtensionConvertImporterMesh::_bind_methods() {
 }
 
+void GLTFDocumentExtensionConvertImporterMesh::_copy_meta(Object *p_src_object, Object *p_dst_object) {
+	List<StringName> meta_list;
+	p_src_object->get_meta_list(&meta_list);
+	for (const StringName &meta_key : meta_list) {
+		Variant meta_value = p_src_object->get_meta(meta_key);
+		p_dst_object->set_meta(meta_key, meta_value);
+	}
+}
+
 Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_state, Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
@@ -58,6 +67,8 @@ Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_sta
 				mesh_instance_node_3d->set_skin(mesh_3d->get_skin());
 				mesh_instance_node_3d->set_skeleton_path(mesh_3d->get_skeleton_path());
 				node->replace_by(mesh_instance_node_3d);
+				_copy_meta(mesh_3d, mesh_instance_node_3d);
+				_copy_meta(mesh.ptr(), array_mesh.ptr());
 				delete_queue.push_back(node);
 				node = mesh_instance_node_3d;
 			} else {

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.h
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.h
@@ -38,6 +38,7 @@ class GLTFDocumentExtensionConvertImporterMesh : public GLTFDocumentExtension {
 
 protected:
 	static void _bind_methods();
+	static void _copy_meta(Object *p_src_object, Object *p_dst_object);
 
 public:
 	Error import_post(Ref<GLTFState> p_state, Node *p_root) override;


### PR DESCRIPTION
During the import process, ImporterMeshInstance3D nodes are replaced with MeshInstance3D nodes. This change copies over any meta data that might have been set during the import process, for example, in a GLTFDocumentExtension.

This is a resolution for https://github.com/godotengine/godot-proposals/discussions/6586.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
