### PR TITLE
Add custom paths support (custom `res://`/`user://`-like paths)

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -268,6 +268,15 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 		return p_path.replace("user://", "");
 	}
 
+	// Custom resource paths
+	Dictionary resource_paths = FileAccess::get_resource_paths();
+	for (int i = 0; i < resource_paths.size(); i++) {
+		String key = resource_paths.get_key_at_index(i);
+		if (p_path.begins_with(key + "://")) {
+			return p_path.replace(key + ":/", resource_paths[key]);
+		}
+	}
+
 	return p_path;
 }
 

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -270,8 +270,10 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 
 	// Custom resource paths
 	Dictionary resource_paths = FileAccess::get_resource_paths();
-	for (int i = 0; i < resource_paths.size(); i++) {
-		String key = resource_paths.get_key_at_index(i);
+	List<Variant> resource_keys;
+	resource_paths.get_key_list(&resource_keys);
+	for (const Variant &v : resource_keys) {
+		String key = v;
 		if (p_path.begins_with(key + "://")) {
 			return p_path.replace(key + ":/", resource_paths[key]);
 		}

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -268,17 +268,20 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 		return p_path.replace("user://", "");
 	}
 
-	// Custom resource paths
-	Dictionary resource_paths = FileAccess::get_resource_paths();
-	List<Variant> resource_keys;
-	resource_paths.get_key_list(&resource_keys);
-	for (const Variant &v : resource_keys) {
-		String key = v;
-		if (p_path.begins_with(key + "://")) {
-			return p_path.replace(key + ":/", resource_paths[key]);
+	// Custom paths
+	Vector<String> custom_paths = FileAccess::get_custom_paths();
+	for (const String &prefix : custom_paths) {
+		if (!p_path.begins_with(prefix + "://")) {
+			continue;
+		}
+		Dictionary data = FileAccess::get_custom_path_data(prefix);
+		if (data["type"] == "path") {
+			return p_path.replace(prefix + ":/", data["path"]);
+		} else {
+			// `data["type"]` is of type `"class"`, so no path is available.
+			return p_path;
 		}
 	}
-
 	return p_path;
 }
 

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -213,13 +213,18 @@ String DirAccess::fix_path(const String &p_path) const {
 
 		} break;
 		case ACCESS_FILESYSTEM: {
-			Dictionary resource_paths = FileAccess::get_resource_paths();
+			Vector<String> custom_paths = FileAccess::get_custom_paths();
 			List<Variant> resource_keys;
-			resource_paths.get_key_list(&resource_keys);
-			for (const Variant &v : resource_keys) {
-				String key = v;
-				if (p_path.begins_with(key + "://")) {
-					return p_path.replace(key + ":/", resource_paths[key]);
+			for (const String &prefix : custom_paths) {
+				if (!p_path.begins_with(prefix + "://")) {
+					continue;
+				}
+				Dictionary data = FileAccess::get_custom_path_data(prefix);
+				if (data["type"] == "path") {
+					return p_path.replace(prefix + ":/", data["path"]);
+				} else {
+					// `data["type"]` is of type `"class"`, so no path is available.
+					return p_path;
 				}
 			}
 			return p_path;

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -213,6 +213,13 @@ String DirAccess::fix_path(const String &p_path) const {
 
 		} break;
 		case ACCESS_FILESYSTEM: {
+			Dictionary resource_paths = FileAccess::get_resource_paths();
+			for (int i = 0; i < resource_paths.size(); i++) {
+				String key = resource_paths.get_key_at_index(i);
+				if (p_path.begins_with(key + "://")) {
+					return p_path.replace(key + ":/", resource_paths[key]);
+				}
+			}
 			return p_path;
 		} break;
 		case ACCESS_MAX:

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -214,8 +214,10 @@ String DirAccess::fix_path(const String &p_path) const {
 		} break;
 		case ACCESS_FILESYSTEM: {
 			Dictionary resource_paths = FileAccess::get_resource_paths();
-			for (int i = 0; i < resource_paths.size(); i++) {
-				String key = resource_paths.get_key_at_index(i);
+			List<Variant> resource_keys;
+			resource_paths.get_key_list(&resource_keys);
+			for (const Variant &v : resource_keys) {
+				String key = v;
 				if (p_path.begins_with(key + "://")) {
 					return p_path.replace(key + ":/", resource_paths[key]);
 				}

--- a/core/io/dir_access_extension.cpp
+++ b/core/io/dir_access_extension.cpp
@@ -34,7 +34,7 @@
 #include "core/object/object.h"
 
 String DirAccessExtension::fix_path(String p_path) const {
-	String path;
+	String path = "";
 	if (GDVIRTUAL_CALL(_fix_path, p_path, path)) {
 		return path;
 	}
@@ -42,25 +42,25 @@ String DirAccessExtension::fix_path(String p_path) const {
 }
 
 Error DirAccessExtension::list_dir_begin() {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_list_dir_begin, err);
 	return err;
 }
 
 String DirAccessExtension::get_next() {
-	String next;
+	String next = "";
 	GDVIRTUAL_REQUIRED_CALL(_get_next, next);
 	return next;
 }
 
 bool DirAccessExtension::current_is_dir() const {
-	bool current_is_dir;
+	bool current_is_dir = false;
 	GDVIRTUAL_REQUIRED_CALL(_current_is_dir, current_is_dir);
 	return current_is_dir;
 }
 
 bool DirAccessExtension::current_is_hidden() const {
-	bool current_is_hidden;
+	bool current_is_hidden = false;
 	GDVIRTUAL_REQUIRED_CALL(_current_is_hidden, current_is_hidden);
 	return current_is_hidden;
 }
@@ -70,19 +70,19 @@ void DirAccessExtension::list_dir_end() {
 }
 
 int DirAccessExtension::get_drive_count() {
-	int count;
+	int count = 0;
 	GDVIRTUAL_REQUIRED_CALL(_get_drive_count, count);
 	return count;
 }
 
 String DirAccessExtension::get_drive(int p_drive) {
-	String drive;
+	String drive = "";
 	GDVIRTUAL_REQUIRED_CALL(_get_drive, p_drive, drive);
 	return drive;
 }
 
 int DirAccessExtension::get_current_drive() {
-	int drive;
+	int drive = 0;
 	if (GDVIRTUAL_CALL(_get_current_drive, drive)) {
 		return drive;
 	}
@@ -90,7 +90,7 @@ int DirAccessExtension::get_current_drive() {
 }
 
 bool DirAccessExtension::drives_are_shortcuts() {
-	bool drives_are_shortcuts;
+	bool drives_are_shortcuts = true;
 	if (GDVIRTUAL_CALL(_drives_are_shortcuts, drives_are_shortcuts)) {
 		return drives_are_shortcuts;
 	}
@@ -98,25 +98,25 @@ bool DirAccessExtension::drives_are_shortcuts() {
 }
 
 Error DirAccessExtension::change_dir(String p_dir) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_change_dir, p_dir, err);
 	return err;
 }
 
 String DirAccessExtension::get_current_dir(bool p_include_drive) const {
-	String current_dir;
+	String current_dir = "";
 	GDVIRTUAL_REQUIRED_CALL(_get_current_dir, p_include_drive, current_dir);
 	return current_dir;
 }
 
 Error DirAccessExtension::make_dir(String p_dir) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_make_dir, p_dir, err);
 	return err;
 }
 
 Error DirAccessExtension::make_dir_recursive(String p_dir) {
-	Error err;
+	Error err = OK;
 	if (GDVIRTUAL_CALL(_make_dir_recursive, p_dir, err)) {
 		return err;
 	}
@@ -124,7 +124,7 @@ Error DirAccessExtension::make_dir_recursive(String p_dir) {
 }
 
 Error DirAccessExtension::erase_contents_recursive() {
-	Error err;
+	Error err = OK;
 	if (GDVIRTUAL_CALL(_erase_contents_recursive, err)) {
 		return err;
 	}
@@ -132,19 +132,19 @@ Error DirAccessExtension::erase_contents_recursive() {
 }
 
 bool DirAccessExtension::file_exists(String p_file) {
-	bool file_exists;
+	bool file_exists = false;
 	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_file, file_exists);
 	return file_exists;
 }
 
 bool DirAccessExtension::dir_exists(String p_file) {
-	bool dir_exists;
+	bool dir_exists = false;
 	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_file, dir_exists);
 	return dir_exists;
 }
 
 bool DirAccessExtension::is_readable(String p_dir) {
-	bool is_readable;
+	bool is_readable = false;
 	if (GDVIRTUAL_CALL(_is_readable, p_dir, is_readable)) {
 		return is_readable;
 	}
@@ -152,7 +152,7 @@ bool DirAccessExtension::is_readable(String p_dir) {
 }
 
 bool DirAccessExtension::is_writable(String p_dir) {
-	bool is_writable;
+	bool is_writable = false;
 	if (GDVIRTUAL_CALL(_is_writable, p_dir, is_writable)) {
 		return is_writable;
 	}
@@ -160,13 +160,13 @@ bool DirAccessExtension::is_writable(String p_dir) {
 }
 
 uint64_t DirAccessExtension::get_space_left() {
-	uint64_t space_left;
+	uint64_t space_left = 0;
 	GDVIRTUAL_REQUIRED_CALL(_get_space_left, space_left);
 	return space_left;
 }
 
 Error DirAccessExtension::copy(String p_from, String p_to, int p_chmod_flags) {
-	Error err;
+	Error err = OK;
 	if (GDVIRTUAL_CALL(_copy, p_from, p_to, p_chmod_flags, err)) {
 		return err;
 	}
@@ -174,43 +174,43 @@ Error DirAccessExtension::copy(String p_from, String p_to, int p_chmod_flags) {
 }
 
 Error DirAccessExtension::rename(String p_from, String p_to) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_rename, p_from, p_to, err);
 	return err;
 }
 
 Error DirAccessExtension::remove(String p_name) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_remove, p_name, err);
 	return err;
 }
 
 bool DirAccessExtension::is_link(String p_file) {
-	bool is_link;
+	bool is_link = OK;
 	GDVIRTUAL_REQUIRED_CALL(_is_link, p_file, is_link);
 	return is_link;
 }
 
 String DirAccessExtension::read_link(String p_file) {
-	String link;
+	String link = "";
 	GDVIRTUAL_REQUIRED_CALL(_read_link, p_file, link);
 	return link;
 }
 
 Error DirAccessExtension::create_link(String p_source, String p_target) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_create_link, p_source, p_target, err);
 	return err;
 }
 
 String DirAccessExtension::get_filesystem_type() const {
-	String filesystem_type;
+	String filesystem_type = "";
 	GDVIRTUAL_REQUIRED_CALL(_get_filesystem_type, filesystem_type);
 	return filesystem_type;
 }
 
 bool DirAccessExtension::is_case_sensitive(const String &p_path) const {
-	bool is_case_sensitive;
+	bool is_case_sensitive = false;
 	if (GDVIRTUAL_CALL(_is_case_sensitive, p_path, is_case_sensitive)) {
 		return is_case_sensitive;
 	}

--- a/core/io/dir_access_extension.cpp
+++ b/core/io/dir_access_extension.cpp
@@ -34,7 +34,7 @@
 #include "core/object/object.h"
 
 String DirAccessExtension::fix_path(String p_path) const {
-	String path = "";
+	String path;
 	if (GDVIRTUAL_CALL(_fix_path, p_path, path)) {
 		return path;
 	}
@@ -48,7 +48,7 @@ Error DirAccessExtension::list_dir_begin() {
 }
 
 String DirAccessExtension::get_next() {
-	String next = "";
+	String next;
 	GDVIRTUAL_REQUIRED_CALL(_get_next, next);
 	return next;
 }
@@ -76,7 +76,7 @@ int DirAccessExtension::get_drive_count() {
 }
 
 String DirAccessExtension::get_drive(int p_drive) {
-	String drive = "";
+	String drive;
 	GDVIRTUAL_REQUIRED_CALL(_get_drive, p_drive, drive);
 	return drive;
 }
@@ -104,7 +104,7 @@ Error DirAccessExtension::change_dir(String p_dir) {
 }
 
 String DirAccessExtension::get_current_dir(bool p_include_drive) const {
-	String current_dir = "";
+	String current_dir;
 	GDVIRTUAL_REQUIRED_CALL(_get_current_dir, p_include_drive, current_dir);
 	return current_dir;
 }
@@ -192,7 +192,7 @@ bool DirAccessExtension::is_link(String p_file) {
 }
 
 String DirAccessExtension::read_link(String p_file) {
-	String link = "";
+	String link;
 	GDVIRTUAL_REQUIRED_CALL(_read_link, p_file, link);
 	return link;
 }
@@ -204,7 +204,7 @@ Error DirAccessExtension::create_link(String p_source, String p_target) {
 }
 
 String DirAccessExtension::get_filesystem_type() const {
-	String filesystem_type = "";
+	String filesystem_type;
 	GDVIRTUAL_REQUIRED_CALL(_get_filesystem_type, filesystem_type);
 	return filesystem_type;
 }

--- a/core/io/dir_access_extension.cpp
+++ b/core/io/dir_access_extension.cpp
@@ -33,7 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/object/object.h"
 
-String DirAccessExtension::fix_path(String p_path) const {
+String DirAccessExtension::fix_path(const String &p_path) const {
 	String path;
 	if (GDVIRTUAL_CALL(_fix_path, p_path, path)) {
 		return path;
@@ -115,7 +115,7 @@ Error DirAccessExtension::make_dir(String p_dir) {
 	return err;
 }
 
-Error DirAccessExtension::make_dir_recursive(String p_dir) {
+Error DirAccessExtension::make_dir_recursive(const String &p_dir) {
 	Error err = OK;
 	if (GDVIRTUAL_CALL(_make_dir_recursive, p_dir, err)) {
 		return err;
@@ -165,7 +165,7 @@ uint64_t DirAccessExtension::get_space_left() {
 	return space_left;
 }
 
-Error DirAccessExtension::copy(String p_from, String p_to, int p_chmod_flags) {
+Error DirAccessExtension::copy(const String &p_from, const String &p_to, int p_chmod_flags) {
 	Error err = OK;
 	if (GDVIRTUAL_CALL(_copy, p_from, p_to, p_chmod_flags, err)) {
 		return err;

--- a/core/io/dir_access_extension.cpp
+++ b/core/io/dir_access_extension.cpp
@@ -41,25 +41,25 @@ String DirAccessExtension::fix_path(String p_path) const {
 }
 
 Error DirAccessExtension::list_dir_begin() {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_list_dir_begin, err);
 	return err;
 }
 
 String DirAccessExtension::get_next() {
-	String next = "";
+	String next;
 	GDVIRTUAL_REQUIRED_CALL(_get_next, next);
 	return next;
 }
 
 bool DirAccessExtension::current_is_dir() const {
-	bool current_is_dir = false;
+	bool current_is_dir;
 	GDVIRTUAL_REQUIRED_CALL(_current_is_dir, current_is_dir);
 	return current_is_dir;
 }
 
 bool DirAccessExtension::current_is_hidden() const {
-	bool current_is_hidden = false;
+	bool current_is_hidden;
 	GDVIRTUAL_REQUIRED_CALL(_current_is_hidden, current_is_hidden);
 	return current_is_hidden;
 }
@@ -69,19 +69,19 @@ void DirAccessExtension::list_dir_end() {
 }
 
 int DirAccessExtension::get_drive_count() {
-	int count = 0;
+	int count;
 	GDVIRTUAL_REQUIRED_CALL(_get_drive_count, count);
 	return count;
 }
 
 String DirAccessExtension::get_drive(int p_drive) {
-	String drive = "";
+	String drive;
 	GDVIRTUAL_REQUIRED_CALL(_get_drive, p_drive, drive);
 	return drive;
 }
 
 int DirAccessExtension::get_current_drive() {
-	int drive = 0;
+	int drive;
 	if (GDVIRTUAL_CALL(_get_current_drive, drive)) {
 		return drive;
 	}
@@ -89,7 +89,7 @@ int DirAccessExtension::get_current_drive() {
 }
 
 bool DirAccessExtension::drives_are_shortcuts() {
-	bool drives_are_shortcuts = false;
+	bool drives_are_shortcuts;
 	if (GDVIRTUAL_CALL(_drives_are_shortcuts, drives_are_shortcuts)) {
 		return drives_are_shortcuts;
 	}
@@ -97,25 +97,25 @@ bool DirAccessExtension::drives_are_shortcuts() {
 }
 
 Error DirAccessExtension::change_dir(String p_dir) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_change_dir, p_dir, err);
 	return err;
 }
 
 String DirAccessExtension::get_current_dir(bool p_include_drive) const {
-	String current_dir = "";
+	String current_dir;
 	GDVIRTUAL_REQUIRED_CALL(_get_current_dir, p_include_drive, current_dir);
 	return current_dir;
 }
 
 Error DirAccessExtension::make_dir(String p_dir) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_make_dir, p_dir, err);
 	return err;
 }
 
 Error DirAccessExtension::make_dir_recursive(String p_dir) {
-	Error err = OK;
+	Error err;
 	if (GDVIRTUAL_CALL(_make_dir_recursive, p_dir, err)) {
 		return err;
 	}
@@ -123,7 +123,7 @@ Error DirAccessExtension::make_dir_recursive(String p_dir) {
 }
 
 Error DirAccessExtension::erase_contents_recursive() {
-	Error err = OK;
+	Error err;
 	if (GDVIRTUAL_CALL(_erase_contents_recursive, err)) {
 		return err;
 	}
@@ -131,19 +131,19 @@ Error DirAccessExtension::erase_contents_recursive() {
 }
 
 bool DirAccessExtension::file_exists(String p_file) {
-	bool file_exists = false;
+	bool file_exists;
 	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_file, file_exists);
 	return file_exists;
 }
 
 bool DirAccessExtension::dir_exists(String p_file) {
-	bool dir_exists = false;
+	bool dir_exists;
 	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_file, dir_exists);
 	return dir_exists;
 }
 
 bool DirAccessExtension::is_readable(String p_dir) {
-	bool is_readable = false;
+	bool is_readable;
 	if (GDVIRTUAL_CALL(_is_readable, p_dir, is_readable)) {
 		return is_readable;
 	}
@@ -151,7 +151,7 @@ bool DirAccessExtension::is_readable(String p_dir) {
 }
 
 bool DirAccessExtension::is_writable(String p_dir) {
-	bool is_writable = false;
+	bool is_writable;
 	if (GDVIRTUAL_CALL(_is_writable, p_dir, is_writable)) {
 		return is_writable;
 	}
@@ -159,13 +159,13 @@ bool DirAccessExtension::is_writable(String p_dir) {
 }
 
 uint64_t DirAccessExtension::get_space_left() {
-	uint64_t space_left = 0;
+	uint64_t space_left;
 	GDVIRTUAL_REQUIRED_CALL(_get_space_left, space_left);
 	return space_left;
 }
 
 Error DirAccessExtension::copy(String p_from, String p_to, int p_chmod_flags) {
-	Error err = OK;
+	Error err;
 	if (GDVIRTUAL_CALL(_copy, p_from, p_to, p_chmod_flags, err)) {
 		return err;
 	}
@@ -173,19 +173,19 @@ Error DirAccessExtension::copy(String p_from, String p_to, int p_chmod_flags) {
 }
 
 Error DirAccessExtension::rename(String p_from, String p_to) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_rename, p_from, p_to, err);
 	return err;
 }
 
 Error DirAccessExtension::remove(String p_name) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_remove, p_name, err);
 	return err;
 }
 
 bool DirAccessExtension::is_link(String p_file) {
-	bool is_link = false;
+	bool is_link;
 	GDVIRTUAL_REQUIRED_CALL(_is_link, p_file, is_link);
 	return is_link;
 }
@@ -197,19 +197,19 @@ String DirAccessExtension::read_link(String p_file) {
 }
 
 Error DirAccessExtension::create_link(String p_source, String p_target) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_create_link, p_source, p_target, err);
 	return err;
 }
 
 String DirAccessExtension::get_filesystem_type() const {
-	String filesystem_type = "";
+	String filesystem_type;
 	GDVIRTUAL_REQUIRED_CALL(_get_filesystem_type, filesystem_type);
 	return filesystem_type;
 }
 
 bool DirAccessExtension::is_case_sensitive(const String &p_path) const {
-	bool is_case_sensitive = false;
+	bool is_case_sensitive;
 	if (GDVIRTUAL_CALL(_is_case_sensitive, p_path, is_case_sensitive)) {
 		return is_case_sensitive;
 	}

--- a/core/io/dir_access_extension.cpp
+++ b/core/io/dir_access_extension.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "dir_access_extension.h"
+
 #include "core/io/dir_access.h"
 #include "core/object/object.h"
 

--- a/core/io/dir_access_extension.cpp
+++ b/core/io/dir_access_extension.cpp
@@ -1,0 +1,263 @@
+/**************************************************************************/
+/*  dir_access_extension.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dir_access_extension.h"
+#include "core/io/dir_access.h"
+#include "core/object/object.h"
+
+String DirAccessExtension::fix_path(String p_path) const {
+	String path;
+	if (GDVIRTUAL_CALL(_fix_path, p_path, path)) {
+		return path;
+	}
+	return DirAccess::fix_path(p_path);
+}
+
+Error DirAccessExtension::list_dir_begin() {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(_list_dir_begin, err);
+	return err;
+}
+
+String DirAccessExtension::get_next() {
+	String next = "";
+	GDVIRTUAL_REQUIRED_CALL(_get_next, next);
+	return next;
+}
+
+bool DirAccessExtension::current_is_dir() const {
+	bool current_is_dir = false;
+	GDVIRTUAL_REQUIRED_CALL(_current_is_dir, current_is_dir);
+	return current_is_dir;
+}
+
+bool DirAccessExtension::current_is_hidden() const {
+	bool current_is_hidden = false;
+	GDVIRTUAL_REQUIRED_CALL(_current_is_hidden, current_is_hidden);
+	return current_is_hidden;
+}
+
+void DirAccessExtension::list_dir_end() {
+	GDVIRTUAL_REQUIRED_CALL(_list_dir_end);
+}
+
+int DirAccessExtension::get_drive_count() {
+	int count = 0;
+	GDVIRTUAL_REQUIRED_CALL(_get_drive_count, count);
+	return count;
+}
+
+String DirAccessExtension::get_drive(int p_drive) {
+	String drive = "";
+	GDVIRTUAL_REQUIRED_CALL(_get_drive, p_drive, drive);
+	return drive;
+}
+
+int DirAccessExtension::get_current_drive() {
+	int drive = 0;
+	if (GDVIRTUAL_CALL(_get_current_drive, drive)) {
+		return drive;
+	}
+	return DirAccess::get_current_drive();
+}
+
+bool DirAccessExtension::drives_are_shortcuts() {
+	bool drives_are_shortcuts = false;
+	if (GDVIRTUAL_CALL(_drives_are_shortcuts, drives_are_shortcuts)) {
+		return drives_are_shortcuts;
+	}
+	return DirAccess::drives_are_shortcuts();
+}
+
+Error DirAccessExtension::change_dir(String p_dir) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(_change_dir, p_dir, err);
+	return err;
+}
+
+String DirAccessExtension::get_current_dir(bool p_include_drive) const {
+	String current_dir = "";
+	GDVIRTUAL_REQUIRED_CALL(_get_current_dir, p_include_drive, current_dir);
+	return current_dir;
+}
+
+Error DirAccessExtension::make_dir(String p_dir) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(_make_dir, p_dir, err);
+	return err;
+}
+
+Error DirAccessExtension::make_dir_recursive(String p_dir) {
+	Error err = OK;
+	if (GDVIRTUAL_CALL(_make_dir_recursive, p_dir, err)) {
+		return err;
+	}
+	return DirAccess::make_dir_recursive(p_dir);
+}
+
+Error DirAccessExtension::erase_contents_recursive() {
+	Error err = OK;
+	if (GDVIRTUAL_CALL(_erase_contents_recursive, err)) {
+		return err;
+	}
+	return DirAccess::erase_contents_recursive();
+}
+
+bool DirAccessExtension::file_exists(String p_file) {
+	bool file_exists = false;
+	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_file, file_exists);
+	return file_exists;
+}
+
+bool DirAccessExtension::dir_exists(String p_file) {
+	bool dir_exists = false;
+	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_file, dir_exists);
+	return dir_exists;
+}
+
+bool DirAccessExtension::is_readable(String p_dir) {
+	bool is_readable = false;
+	if (GDVIRTUAL_CALL(_is_readable, p_dir, is_readable)) {
+		return is_readable;
+	}
+	return DirAccess::is_readable(p_dir);
+}
+
+bool DirAccessExtension::is_writable(String p_dir) {
+	bool is_writable = false;
+	if (GDVIRTUAL_CALL(_is_writable, p_dir, is_writable)) {
+		return is_writable;
+	}
+	return DirAccess::is_writable(p_dir);
+}
+
+uint64_t DirAccessExtension::get_space_left() {
+	uint64_t space_left = 0;
+	GDVIRTUAL_REQUIRED_CALL(_get_space_left, space_left);
+	return space_left;
+}
+
+Error DirAccessExtension::copy(String p_from, String p_to, int p_chmod_flags) {
+	Error err = OK;
+	if (GDVIRTUAL_CALL(_copy, p_from, p_to, p_chmod_flags, err)) {
+		return err;
+	}
+	return DirAccess::copy(p_from, p_to, p_chmod_flags);
+}
+
+Error DirAccessExtension::rename(String p_from, String p_to) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(_rename, p_from, p_to, err);
+	return err;
+}
+
+Error DirAccessExtension::remove(String p_name) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(_remove, p_name, err);
+	return err;
+}
+
+bool DirAccessExtension::is_link(String p_file) {
+	bool is_link = false;
+	GDVIRTUAL_REQUIRED_CALL(_is_link, p_file, is_link);
+	return is_link;
+}
+
+String DirAccessExtension::read_link(String p_file) {
+	String link;
+	GDVIRTUAL_REQUIRED_CALL(_read_link, p_file, link);
+	return link;
+}
+
+Error DirAccessExtension::create_link(String p_source, String p_target) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(_create_link, p_source, p_target, err);
+	return err;
+}
+
+String DirAccessExtension::get_filesystem_type() const {
+	String filesystem_type = "";
+	GDVIRTUAL_REQUIRED_CALL(_get_filesystem_type, filesystem_type);
+	return filesystem_type;
+}
+
+bool DirAccessExtension::is_case_sensitive(const String &p_path) const {
+	bool is_case_sensitive = false;
+	if (GDVIRTUAL_CALL(_is_case_sensitive, p_path, is_case_sensitive)) {
+		return is_case_sensitive;
+	}
+	return DirAccess::is_case_sensitive(p_path);
+}
+
+void DirAccessExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_fix_path, "path");
+
+	GDVIRTUAL_BIND(_list_dir_begin);
+	GDVIRTUAL_BIND(_get_next);
+	GDVIRTUAL_BIND(_current_is_dir);
+	GDVIRTUAL_BIND(_current_is_hidden);
+
+	GDVIRTUAL_BIND(_list_dir_end);
+
+	GDVIRTUAL_BIND(_get_drive_count);
+	GDVIRTUAL_BIND(_get_drive, "drive");
+	GDVIRTUAL_BIND(_get_current_drive);
+	GDVIRTUAL_BIND(_drives_are_shortcuts);
+
+	GDVIRTUAL_BIND(_change_dir, "dir");
+	GDVIRTUAL_BIND(_get_current_dir, "include_drive");
+	GDVIRTUAL_BIND(_make_dir, "dir");
+	GDVIRTUAL_BIND(_make_dir_recursive, "dir");
+	GDVIRTUAL_BIND(_erase_contents_recursive);
+
+	GDVIRTUAL_BIND(_file_exists, "file");
+	GDVIRTUAL_BIND(_dir_exists, "dir");
+	GDVIRTUAL_BIND(_is_readable, "dir");
+	GDVIRTUAL_BIND(_is_writable, "dir");
+	GDVIRTUAL_BIND(_get_space_left);
+
+	GDVIRTUAL_BIND(_copy, "from", "to", "chmod_flags");
+	GDVIRTUAL_BIND(_rename, "from", "to");
+	GDVIRTUAL_BIND(_remove, "name");
+
+	GDVIRTUAL_BIND(_is_link, "file")
+	GDVIRTUAL_BIND(_read_link, "file")
+	GDVIRTUAL_BIND(_create_link, "source", "target")
+
+	GDVIRTUAL_BIND(_get_filesystem_type)
+
+	GDVIRTUAL_BIND(_is_case_sensitive, "path");
+}
+
+DirAccessExtension::DirAccessExtension() {
+}
+
+DirAccessExtension::~DirAccessExtension() {
+}

--- a/core/io/dir_access_extension.h
+++ b/core/io/dir_access_extension.h
@@ -39,7 +39,7 @@ class DirAccessExtension : public DirAccess {
 
 protected:
 	GDVIRTUAL1RC(String, _fix_path, String);
-	virtual String fix_path(String p_path) const override;
+	virtual String fix_path(const String &p_path) const override;
 
 public:
 	GDVIRTUAL0R(Error, _list_dir_begin);
@@ -70,7 +70,7 @@ public:
 	GDVIRTUAL1R(Error, _make_dir, String);
 	virtual Error make_dir(String p_dir) override;
 	GDVIRTUAL1R(Error, _make_dir_recursive, String);
-	virtual Error make_dir_recursive(String p_dir) override;
+	virtual Error make_dir_recursive(const String &p_dir) override;
 	GDVIRTUAL0R(Error, _erase_contents_recursive);
 	virtual Error erase_contents_recursive() override;
 
@@ -86,7 +86,7 @@ public:
 	virtual uint64_t get_space_left() override;
 
 	GDVIRTUAL3R(Error, _copy, String, String, int);
-	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1) override;
+	virtual Error copy(const String &p_from, const String &p_to, int p_chmod_flags = -1) override;
 	GDVIRTUAL2R(Error, _rename, String, String);
 	virtual Error rename(String p_from, String p_to) override;
 	GDVIRTUAL1R(Error, _remove, String);

--- a/core/io/dir_access_extension.h
+++ b/core/io/dir_access_extension.h
@@ -1,0 +1,116 @@
+/**************************************************************************/
+/*  dir_access_extension.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DIR_ACCESS_EXTENSION_H
+#define DIR_ACCESS_EXTENSION_H
+
+#include "core/io/dir_access.h"
+#include "core/object/gdvirtual.gen.inc"
+
+class DirAccessExtension : public DirAccess {
+	GDCLASS(DirAccessExtension, DirAccess);
+
+protected:
+	GDVIRTUAL1RC(String, _fix_path, String);
+	virtual String fix_path(String p_path) const override;
+
+public:
+	GDVIRTUAL0R(Error, _list_dir_begin);
+	virtual Error list_dir_begin() override;
+	GDVIRTUAL0R(String, _get_next);
+	virtual String get_next() override;
+	GDVIRTUAL0RC(bool, _current_is_dir);
+	virtual bool current_is_dir() const override;
+	GDVIRTUAL0RC(bool, _current_is_hidden);
+	virtual bool current_is_hidden() const override;
+
+	GDVIRTUAL0(_list_dir_end);
+	virtual void list_dir_end() override;
+
+	GDVIRTUAL0R(int, _get_drive_count);
+	virtual int get_drive_count() override;
+	GDVIRTUAL1R(String, _get_drive, int);
+	virtual String get_drive(int p_drive) override;
+	GDVIRTUAL0R(int, _get_current_drive);
+	virtual int get_current_drive() override;
+	GDVIRTUAL0R(bool, _drives_are_shortcuts);
+	virtual bool drives_are_shortcuts() override;
+
+	GDVIRTUAL1R(Error, _change_dir, String);
+	virtual Error change_dir(String p_dir) override;
+	GDVIRTUAL1RC(String, _get_current_dir, bool);
+	virtual String get_current_dir(bool p_include_drive = true) const override;
+	GDVIRTUAL1R(Error, _make_dir, String);
+	virtual Error make_dir(String p_dir) override;
+	GDVIRTUAL1R(Error, _make_dir_recursive, String);
+	virtual Error make_dir_recursive(String p_dir) override;
+	GDVIRTUAL0R(Error, _erase_contents_recursive);
+	virtual Error erase_contents_recursive() override;
+
+	GDVIRTUAL1R(bool, _file_exists, String);
+	virtual bool file_exists(String p_file) override;
+	GDVIRTUAL1R(bool, _dir_exists, String);
+	virtual bool dir_exists(String p_dir) override;
+	GDVIRTUAL1R(bool, _is_readable, String);
+	virtual bool is_readable(String p_dir) override;
+	GDVIRTUAL1R(bool, _is_writable, String);
+	virtual bool is_writable(String p_dir) override;
+	GDVIRTUAL0R(uint64_t, _get_space_left);
+	virtual uint64_t get_space_left() override;
+
+	GDVIRTUAL3R(Error, _copy, String, String, int);
+	virtual Error copy(String p_from, String p_to, int p_chmod_flags = -1) override;
+	GDVIRTUAL2R(Error, _rename, String, String);
+	virtual Error rename(String p_from, String p_to) override;
+	GDVIRTUAL1R(Error, _remove, String);
+	virtual Error remove(String p_name) override;
+
+	GDVIRTUAL1R(bool, _is_link, String);
+	virtual bool is_link(String p_file) override;
+	GDVIRTUAL1R(String, _read_link, String);
+	virtual String read_link(String p_file) override;
+	GDVIRTUAL2R(Error, _create_link, String, String);
+	virtual Error create_link(String p_source, String p_target) override;
+
+	GDVIRTUAL0RC(String, _get_filesystem_type);
+	virtual String get_filesystem_type() const override;
+
+	GDVIRTUAL1RC(bool, _is_case_sensitive, String);
+	virtual bool is_case_sensitive(const String &p_path) const override;
+
+protected:
+	static void _bind_methods();
+
+public:
+	DirAccessExtension();
+	~DirAccessExtension();
+};
+
+#endif // DIR_ACCESS_EXTENSION_H

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -900,6 +900,9 @@ void FileAccess::add_resource_path(const String &p_protocol, const String &p_pat
 	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
 	ERR_FAIL_COND_MSG(resource_paths.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path.)", protocol));
 	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path class.)", protocol));
+	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint() && protocol == "editor", R"(Protocol "editor://" cannot be registered when the editor is not running.)");
+
+	print_line(vformat("adding %s as a protocol for %s", p_protocol, p_path));
 
 	resource_paths[protocol] = p_path;
 }
@@ -909,6 +912,7 @@ void FileAccess::remove_resource_path(const String &p_protocol) {
 	String protocol = _get_protocol(p_protocol);
 	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
 	ERR_FAIL_COND_MSG(!resource_paths.has(protocol), vformat(R"(Protocol "%s://" is not registered as a resource class.)", protocol));
+	ERR_FAIL_COND_MSG(protocol == "editor", R"(Protocol "editor://" cannot be unregistered.)");
 
 	resource_paths.erase(protocol);
 }
@@ -942,6 +946,7 @@ void FileAccess::add_resource_path_class(const String &p_protocol, const String 
 	ERR_FAIL_COND_MSG(p_protocol.is_empty(), "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
 	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
+	ERR_FAIL_COND_MSG(protocol == "editor", R"(Protocol "editor://" cannot be added with `FileAccess::add_resource_path_class`)");
 	ERR_FAIL_COND_MSG(resource_paths.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path.)", protocol));
 	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path class.)", protocol));
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -902,8 +902,6 @@ void FileAccess::add_resource_path(const String &p_protocol, const String &p_pat
 	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path class.)", protocol));
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint() && protocol == "editor", R"(Protocol "editor://" cannot be registered when the editor is not running.)");
 
-	print_line(vformat("adding %s as a protocol for %s", p_protocol, p_path));
-
 	resource_paths[protocol] = p_path;
 }
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -899,7 +899,11 @@ void FileAccess::map_path_to_custom_path(const String &p_prefix, const String &p
 	ERR_FAIL_COND_MSG(p_prefix.is_empty(), "`p_prefix` parameter is empty.");
 	String prefix = _get_custom_path_prefix(p_prefix);
 	ERR_FAIL_COND_MSG(prefix == "res" || prefix == "user", vformat(R"(Prefix "%s://" is a built-in path. Doing nothing.)", prefix));
+
+#ifndef TOOLS_ENABLED
 	ERR_FAIL_COND_MSG(prefix == "editor", R"(Prefix "editor://" cannot be added with as a custom path.)");
+#endif
+
 	ERR_FAIL_COND_MSG(custom_path_paths.has(prefix) || custom_path_classes.has(prefix), vformat(R"(Prefix "%s://" is already registered as a custom path.)", prefix));
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint() && prefix == "editor", R"(Prefix "editor://" cannot be registered when the editor is not running.)");
 
@@ -912,7 +916,11 @@ void FileAccess::map_classes_to_custom_path(const String &p_prefix, const String
 	ERR_FAIL_COND_MSG(p_dir_access_class.is_empty(), "`p_dir_access_class` parameter is empty.");
 	String prefix = _get_custom_path_prefix(p_prefix);
 	ERR_FAIL_COND_MSG(prefix == "res" || prefix == "user", vformat(R"(Prefix "%s://" is a built-in path. Doing nothing.)", prefix));
+
+#ifndef TOOLS_ENABLED
 	ERR_FAIL_COND_MSG(prefix == "editor", R"(Prefix "editor://" cannot be added with as a custom path.)");
+#endif
+
 	ERR_FAIL_COND_MSG(custom_path_paths.has(prefix) || custom_path_classes.has(prefix), vformat(R"(Prefix "%s://" is already registered as a custom path.)", prefix));
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint() && prefix == "editor", R"(Prefix "editor://" cannot be registered when the editor is not running.)");
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -1037,14 +1037,14 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_static_method("FileAccess", D_METHOD("set_read_only_attribute", "file", "ro"), &FileAccess::set_read_only_attribute);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_read_only_attribute", "file"), &FileAccess::get_read_only_attribute);
 
-	// Resource paths
+	// Custom paths
 	ClassDB::bind_static_method("FileAccess", D_METHOD("map_path_to_custom_path", "protocol", "path"), &FileAccess::map_path_to_custom_path);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("map_classes_to_custom_path", "protocol", "file_access_class", "dir_access_class"), &FileAccess::map_classes_to_custom_path);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("remove_custom_path", "protocol"), &FileAccess::remove_custom_path);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("is_custom_path", "protocol"), &FileAccess::is_custom_path);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_custom_path_data", "protocol"), &FileAccess::get_custom_path_data);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_custom_paths"), &FileAccess::get_custom_paths);
-	// End resource paths
+	// End custom paths
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian");
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -895,28 +895,28 @@ String FileAccess::_get_protocol(const String &p_protocol) {
 }
 
 void FileAccess::add_resource_path(const String &p_protocol, const String &p_path) {
-	ERR_FAIL_COND_MSG(p_protocol.length() == 0, "Protocol parameter is empty.");
+	ERR_FAIL_COND_MSG(p_protocol.is_empty(), "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
-	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat("Protocol \"%s://\" is built-in.", protocol));
-	ERR_FAIL_COND_MSG(resource_paths.has(protocol), vformat("Protocol \"%s://\" is already registered as a resource path.", protocol));
-	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat("Protocol \"%s://\" is already registered as a resource path class.", protocol));
+	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
+	ERR_FAIL_COND_MSG(resource_paths.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path.)", protocol));
+	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path class.)", protocol));
 
 	resource_paths[protocol] = p_path;
 }
 
 void FileAccess::remove_resource_path(const String &p_protocol) {
-	ERR_FAIL_COND_MSG(p_protocol.length() == 0, "Protocol parameter is empty.");
+	ERR_FAIL_COND_MSG(p_protocol.is_empty(), "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
-	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat("Protocol \"%s://\" is built-in.", protocol));
-	ERR_FAIL_COND_MSG(!resource_paths.has(protocol), vformat("Protocol \"%s://\" is not registered as a resource class.", protocol));
+	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
+	ERR_FAIL_COND_MSG(!resource_paths.has(protocol), vformat(R"(Protocol "%s://" is not registered as a resource class.)", protocol));
 
 	resource_paths.erase(protocol);
 }
 
 bool FileAccess::is_resource_path(const String &p_protocol) {
-	ERR_FAIL_COND_V_MSG(p_protocol.length() == 0, false, "Protocol parameter is empty.");
+	ERR_FAIL_COND_V_MSG(p_protocol.is_empty(), false, "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
-	ERR_FAIL_COND_V_MSG(protocol == "res" || protocol == "user", false, vformat("Protocol \"%s://\" is built-in.", protocol));
+	ERR_FAIL_COND_V_MSG(protocol == "res" || protocol == "user", false, vformat(R"(Protocol "%s://" is built-in.)", protocol));
 
 	return resource_paths.has(protocol);
 }
@@ -939,28 +939,28 @@ Dictionary FileAccess::get_resource_paths() {
 }
 
 void FileAccess::add_resource_path_class(const String &p_protocol, const String &p_file_access_class, const String &p_dir_access_class) {
-	ERR_FAIL_COND_MSG(p_protocol.length() == 0, "Protocol parameter is empty.");
+	ERR_FAIL_COND_MSG(p_protocol.is_empty(), "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
-	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat("Protocol \"%s://\" is built-in.", protocol));
-	ERR_FAIL_COND_MSG(resource_paths.has(protocol), vformat("Protocol \"%s://\" is already registered as a resource path.", protocol));
-	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat("Protocol \"%s://\" is already registered as a resource path class.", protocol));
+	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
+	ERR_FAIL_COND_MSG(resource_paths.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path.)", protocol));
+	ERR_FAIL_COND_MSG(resource_paths_class.has(protocol), vformat(R"(Protocol "%s://" is already registered as a resource path class.)", protocol));
 
 	resource_paths_class[protocol] = Vector<String>({ p_file_access_class, p_dir_access_class });
 }
 
 void FileAccess::remove_resource_path_class(const String &p_protocol) {
-	ERR_FAIL_COND_MSG(p_protocol.length() == 0, "Protocol parameter is empty.");
+	ERR_FAIL_COND_MSG(p_protocol.is_empty(), "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
-	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat("Protocol \"%s://\" is built-in.", protocol));
-	ERR_FAIL_COND_MSG(!resource_paths_class.has(protocol) && !resource_paths_class.has(protocol), vformat("Protocol \"%s://\" is not registered as a resource path class.", protocol));
+	ERR_FAIL_COND_MSG(protocol == "res" || protocol == "user", vformat(R"(Protocol "%s://" is built-in.)", protocol));
+	ERR_FAIL_COND_MSG(!resource_paths_class.has(protocol) && !resource_paths_class.has(protocol), vformat(R"(Protocol "%s://" is not registered as a resource path class.)", protocol));
 
 	resource_paths_class.erase(protocol);
 }
 
 bool FileAccess::is_resource_path_class(const String &p_protocol) {
-	ERR_FAIL_COND_V_MSG(p_protocol.length() == 0, false, "Protocol parameter is empty.");
+	ERR_FAIL_COND_V_MSG(p_protocol.is_empty(), false, "Protocol parameter is empty.");
 	String protocol = _get_protocol(p_protocol);
-	ERR_FAIL_COND_V_MSG(protocol == "res" || protocol == "user", false, vformat("Protocol \"%s://\" is built-in.", protocol));
+	ERR_FAIL_COND_V_MSG(protocol == "res" || protocol == "user", false, vformat(R"(Protocol "%s://" is built-in.)", protocol));
 
 	return resource_paths_class.has(protocol);
 }

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -122,6 +122,8 @@ private:
 	static Ref<FileAccess> _open(const String &p_path, ModeFlags p_mode_flags);
 
 	static HashMap<String, String> resource_paths;
+	static HashMap<String, Vector<String>> resource_paths_class;
+	static String _get_protocol(const String &p_protocol);
 
 public:
 	static void set_file_close_fail_notify_callback(FileCloseFailNotify p_cbk) { close_fail_notify = p_cbk; }
@@ -228,11 +230,19 @@ public:
 	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
 	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
 
+	// Resource paths
 	static void add_resource_path(const String &p_protocol, const String &p_path);
 	static void remove_resource_path(const String &p_protocol);
 	static bool is_resource_path(const String &p_protocol);
 	static String get_resource_path(const String &p_protocol);
 	static Dictionary get_resource_paths();
+
+	static void add_resource_path_class(const String &p_protocol, const String &p_custom_file_access_class, const String &p_custom_dir_access_class);
+	static void remove_resource_path_class(const String &p_protocol);
+	static bool is_resource_path_class(const String &p_protocol);
+	static Vector<String> get_resource_path_class(const String &p_protocol);
+	static Dictionary get_resource_paths_class();
+	// End resource paths
 
 	template <class T>
 	static void make_default(AccessType p_access) {

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -121,6 +121,8 @@ private:
 
 	static Ref<FileAccess> _open(const String &p_path, ModeFlags p_mode_flags);
 
+	static HashMap<String, String> resource_paths;
+
 public:
 	static void set_file_close_fail_notify_callback(FileCloseFailNotify p_cbk) { close_fail_notify = p_cbk; }
 
@@ -225,6 +227,12 @@ public:
 
 	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
 	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
+
+	static void add_resource_path(const String &p_protocol, const String &p_path);
+	static void remove_resource_path(const String &p_protocol);
+	static bool is_resource_path(const String &p_protocol);
+	static String get_resource_path(const String &p_protocol);
+	static Dictionary get_resource_paths();
 
 	template <class T>
 	static void make_default(AccessType p_access) {

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -121,10 +121,6 @@ private:
 
 	static Ref<FileAccess> _open(const String &p_path, ModeFlags p_mode_flags);
 
-	static HashMap<String, String> resource_paths;
-	static HashMap<String, Vector<String>> resource_paths_class;
-	static String _get_protocol(const String &p_protocol);
-
 public:
 	static void set_file_close_fail_notify_callback(FileCloseFailNotify p_cbk) { close_fail_notify = p_cbk; }
 
@@ -230,20 +226,22 @@ public:
 	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
 	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
 
-	// Resource paths
-	static void add_resource_path(const String &p_protocol, const String &p_path);
-	static void remove_resource_path(const String &p_protocol);
-	static bool is_resource_path(const String &p_protocol);
-	static String get_resource_path(const String &p_protocol);
-	static Dictionary get_resource_paths();
+	// Custom paths
+private:
+	static HashMap<String, String> custom_path_paths;
+	static HashMap<String, Vector<String>> custom_path_classes;
+	static String _get_custom_path_prefix(const String &p_prefix);
 
-	static void add_resource_path_class(const String &p_protocol, const String &p_custom_file_access_class, const String &p_custom_dir_access_class);
-	static void remove_resource_path_class(const String &p_protocol);
-	static bool is_resource_path_class(const String &p_protocol);
-	static Vector<String> get_resource_path_class(const String &p_protocol);
-	static Dictionary get_resource_paths_class();
-	// End resource paths
+public:
+	static void map_path_to_custom_path(const String &p_prefix, const String &p_path);
+	static void map_classes_to_custom_path(const String &p_prefix, const String &p_custom_file_access_class, const String &p_custom_dir_access_class);
+	static void remove_custom_path(const String &p_prefix);
+	static bool is_custom_path(const String &p_prefix);
+	static Dictionary get_custom_path_data(const String &p_prefix);
+	static Vector<String> get_custom_paths();
+	// Custom paths end
 
+public:
 	template <class T>
 	static void make_default(AccessType p_access) {
 		create_func[p_access] = _create_builtin<T>;

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -33,61 +33,61 @@
 #include "core/object/object.h"
 
 BitField<FileAccess::UnixPermissionFlags> FileAccessExtension::_get_unix_permissions(const String &p_file) {
-	BitField<UnixPermissionFlags> permissions = 0;
+	BitField<UnixPermissionFlags> permissions;
 	GDVIRTUAL_REQUIRED_CALL(__get_unix_permissions, p_file, permissions);
 	return permissions;
 }
 
 Error FileAccessExtension::_set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(__set_unix_permissions, p_file, p_permissions, err);
 	return err;
 }
 
 bool FileAccessExtension::_get_hidden_attribute(const String &p_file) {
-	bool hidden_attribute = false;
+	bool hidden_attribute;
 	GDVIRTUAL_REQUIRED_CALL(__get_hidden_attribute, p_file, hidden_attribute);
 	return hidden_attribute;
 }
 
 Error FileAccessExtension::_set_hidden_attribute(const String &p_file, bool p_hidden) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(__set_hidden_attribute, p_file, p_hidden, err);
 	return err;
 }
 
 bool FileAccessExtension::_get_read_only_attribute(const String &p_file) {
-	bool read_only_attribute = false;
+	bool read_only_attribute;
 	GDVIRTUAL_REQUIRED_CALL(__get_read_only_attribute, p_file, read_only_attribute);
 	return read_only_attribute;
 }
 
 Error FileAccessExtension::_set_read_only_attribute(const String &p_file, bool p_read_only) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(__set_read_only_attribute, p_file, p_read_only, err);
 	return err;
 }
 
 Error FileAccessExtension::open_internal(const String &p_path, int p_mode_flags) {
-	Error err = OK;
+	Error err;
 	GDVIRTUAL_REQUIRED_CALL(_open_internal, p_path, p_mode_flags, err);
 	return err;
 }
 
 uint64_t FileAccessExtension::_get_modified_time(const String &p_file) {
-	uint64_t time = 0;
+	uint64_t time;
 	GDVIRTUAL_REQUIRED_CALL(__get_modified_time, p_file, time);
 	return time;
 }
 
 bool FileAccessExtension::is_open() const {
-	bool is_open = false;
+	bool is_open;
 	GDVIRTUAL_REQUIRED_CALL(_is_open, is_open);
 	return is_open;
 }
 
 String FileAccessExtension::get_path() const {
-	String path = "";
+	String path;
 	if (GDVIRTUAL_CALL(_get_path, path)) {
 		return path;
 	}
@@ -95,7 +95,7 @@ String FileAccessExtension::get_path() const {
 }
 
 String FileAccessExtension::get_path_absolute() const {
-	String path_absolute = "";
+	String path_absolute;
 	if (GDVIRTUAL_CALL(_get_path_absolute, path_absolute)) {
 		return path_absolute;
 	}
@@ -111,31 +111,31 @@ void FileAccessExtension::seek_end(int64_t p_position) {
 }
 
 uint64_t FileAccessExtension::get_position() const {
-	uint64_t position = 0;
+	uint64_t position;
 	GDVIRTUAL_REQUIRED_CALL(_get_position, position);
 	return position;
 }
 
 uint64_t FileAccessExtension::get_length() const {
-	uint64_t length = 0;
+	uint64_t length;
 	GDVIRTUAL_REQUIRED_CALL(_get_length, length);
 	return length;
 }
 
 bool FileAccessExtension::eof_reached() const {
-	bool eof_reached = false;
+	bool eof_reached;
 	GDVIRTUAL_REQUIRED_CALL(_eof_reached, eof_reached);
 	return eof_reached;
 }
 
 uint8_t FileAccessExtension::get_8() const {
-	uint8_t val = 0;
+	uint8_t val;
 	GDVIRTUAL_REQUIRED_CALL(_get_8, val);
 	return val;
 }
 
 uint16_t FileAccessExtension::get_16() const {
-	uint16_t val = 0;
+	uint16_t val;
 	if (GDVIRTUAL_CALL(_get_16, val)) {
 		return val;
 	}
@@ -143,7 +143,7 @@ uint16_t FileAccessExtension::get_16() const {
 }
 
 uint32_t FileAccessExtension::get_32() const {
-	uint32_t val = 0;
+	uint32_t val;
 	if (GDVIRTUAL_CALL(_get_32, val)) {
 		return val;
 	}
@@ -151,7 +151,7 @@ uint32_t FileAccessExtension::get_32() const {
 }
 
 uint64_t FileAccessExtension::get_64() const {
-	uint64_t val = 0;
+	uint64_t val;
 	if (GDVIRTUAL_CALL(_get_64, val)) {
 		return val;
 	}
@@ -159,7 +159,7 @@ uint64_t FileAccessExtension::get_64() const {
 }
 
 float FileAccessExtension::get_float() const {
-	float val = 0;
+	float val;
 	if (GDVIRTUAL_CALL(_get_float, val)) {
 		return val;
 	}
@@ -167,7 +167,7 @@ float FileAccessExtension::get_float() const {
 }
 
 double FileAccessExtension::get_double() const {
-	double val = 0;
+	double val;
 	if (GDVIRTUAL_CALL(_get_double, val)) {
 		return val;
 	}
@@ -175,7 +175,7 @@ double FileAccessExtension::get_double() const {
 }
 
 real_t FileAccessExtension::get_real() const {
-	real_t val = 0;
+	real_t val;
 	if (GDVIRTUAL_CALL(_get_real, val)) {
 		return val;
 	}
@@ -365,7 +365,7 @@ bool FileAccessExtension::file_exists(const String &p_name) {
 }
 
 Error FileAccessExtension::reopen(const String &p_path, int p_mode_flags) {
-	Error err = OK;
+	Error err;
 	if (GDVIRTUAL_CALL(_reopen, p_path, p_mode_flags, err)) {
 		return err;
 	}

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -33,61 +33,61 @@
 #include "core/object/object.h"
 
 BitField<FileAccess::UnixPermissionFlags> FileAccessExtension::_get_unix_permissions(const String &p_file) {
-	BitField<UnixPermissionFlags> permissions;
+	BitField<UnixPermissionFlags> permissions = 0;
 	GDVIRTUAL_REQUIRED_CALL(__get_unix_permissions, p_file, permissions);
 	return permissions;
 }
 
 Error FileAccessExtension::_set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(__set_unix_permissions, p_file, p_permissions, err);
 	return err;
 }
 
 bool FileAccessExtension::_get_hidden_attribute(const String &p_file) {
-	bool hidden_attribute;
+	bool hidden_attribute = false;
 	GDVIRTUAL_REQUIRED_CALL(__get_hidden_attribute, p_file, hidden_attribute);
 	return hidden_attribute;
 }
 
 Error FileAccessExtension::_set_hidden_attribute(const String &p_file, bool p_hidden) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(__set_hidden_attribute, p_file, p_hidden, err);
 	return err;
 }
 
 bool FileAccessExtension::_get_read_only_attribute(const String &p_file) {
-	bool read_only_attribute;
+	bool read_only_attribute = false;
 	GDVIRTUAL_REQUIRED_CALL(__get_read_only_attribute, p_file, read_only_attribute);
 	return read_only_attribute;
 }
 
 Error FileAccessExtension::_set_read_only_attribute(const String &p_file, bool p_read_only) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(__set_read_only_attribute, p_file, p_read_only, err);
 	return err;
 }
 
 Error FileAccessExtension::open_internal(const String &p_path, int p_mode_flags) {
-	Error err;
+	Error err = OK;
 	GDVIRTUAL_REQUIRED_CALL(_open_internal, p_path, p_mode_flags, err);
 	return err;
 }
 
 uint64_t FileAccessExtension::_get_modified_time(const String &p_file) {
-	uint64_t time;
+	uint64_t time = 0;
 	GDVIRTUAL_REQUIRED_CALL(__get_modified_time, p_file, time);
 	return time;
 }
 
 bool FileAccessExtension::is_open() const {
-	bool is_open;
+	bool is_open = false;
 	GDVIRTUAL_REQUIRED_CALL(_is_open, is_open);
 	return is_open;
 }
 
 String FileAccessExtension::get_path() const {
-	String path;
+	String path = "";
 	if (GDVIRTUAL_CALL(_get_path, path)) {
 		return path;
 	}
@@ -95,7 +95,7 @@ String FileAccessExtension::get_path() const {
 }
 
 String FileAccessExtension::get_path_absolute() const {
-	String path_absolute;
+	String path_absolute = "";
 	if (GDVIRTUAL_CALL(_get_path_absolute, path_absolute)) {
 		return path_absolute;
 	}
@@ -111,31 +111,31 @@ void FileAccessExtension::seek_end(int64_t p_position) {
 }
 
 uint64_t FileAccessExtension::get_position() const {
-	uint64_t position;
+	uint64_t position = 0;
 	GDVIRTUAL_REQUIRED_CALL(_get_position, position);
 	return position;
 }
 
 uint64_t FileAccessExtension::get_length() const {
-	uint64_t length;
+	uint64_t length = 0;
 	GDVIRTUAL_REQUIRED_CALL(_get_length, length);
 	return length;
 }
 
 bool FileAccessExtension::eof_reached() const {
-	bool eof_reached;
+	bool eof_reached = false;
 	GDVIRTUAL_REQUIRED_CALL(_eof_reached, eof_reached);
 	return eof_reached;
 }
 
 uint8_t FileAccessExtension::get_8() const {
-	uint8_t val;
+	uint8_t val = 0;
 	GDVIRTUAL_REQUIRED_CALL(_get_8, val);
 	return val;
 }
 
 uint16_t FileAccessExtension::get_16() const {
-	uint16_t val;
+	uint16_t val = 0;
 	if (GDVIRTUAL_CALL(_get_16, val)) {
 		return val;
 	}
@@ -143,7 +143,7 @@ uint16_t FileAccessExtension::get_16() const {
 }
 
 uint32_t FileAccessExtension::get_32() const {
-	uint32_t val;
+	uint32_t val = 0;
 	if (GDVIRTUAL_CALL(_get_32, val)) {
 		return val;
 	}
@@ -151,7 +151,7 @@ uint32_t FileAccessExtension::get_32() const {
 }
 
 uint64_t FileAccessExtension::get_64() const {
-	uint64_t val;
+	uint64_t val = 0;
 	if (GDVIRTUAL_CALL(_get_64, val)) {
 		return val;
 	}
@@ -159,7 +159,7 @@ uint64_t FileAccessExtension::get_64() const {
 }
 
 float FileAccessExtension::get_float() const {
-	float val;
+	float val = 0;
 	if (GDVIRTUAL_CALL(_get_float, val)) {
 		return val;
 	}
@@ -167,7 +167,7 @@ float FileAccessExtension::get_float() const {
 }
 
 double FileAccessExtension::get_double() const {
-	double val;
+	double val = 0;
 	if (GDVIRTUAL_CALL(_get_double, val)) {
 		return val;
 	}
@@ -175,7 +175,7 @@ double FileAccessExtension::get_double() const {
 }
 
 real_t FileAccessExtension::get_real() const {
-	real_t val;
+	real_t val = 0;
 	if (GDVIRTUAL_CALL(_get_real, val)) {
 		return val;
 	}
@@ -183,7 +183,7 @@ real_t FileAccessExtension::get_real() const {
 }
 
 Variant FileAccessExtension::get_var(bool p_allow_objects) const {
-	Variant var;
+	Variant var = Variant();
 	if (GDVIRTUAL_CALL(_get_var, p_allow_objects, var)) {
 		return var;
 	}
@@ -204,7 +204,7 @@ uint64_t FileAccessExtension::get_buffer(uint8_t *p_dst, uint64_t p_length) cons
 }
 
 Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
-	Vector<uint8_t> buffer;
+	Vector<uint8_t> buffer = Vector<uint8_t>();
 	if (GDVIRTUAL_CALL(_get_buffer, p_length, buffer)) {
 		return buffer;
 	}
@@ -212,7 +212,7 @@ Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
 }
 
 String FileAccessExtension::get_line() const {
-	String line;
+	String line = "";
 	if (GDVIRTUAL_CALL(_get_line, line)) {
 		return line;
 	}
@@ -220,7 +220,7 @@ String FileAccessExtension::get_line() const {
 }
 
 String FileAccessExtension::get_token() const {
-	String token;
+	String token = "";
 	if (GDVIRTUAL_CALL(_get_token, token)) {
 		return token;
 	}
@@ -228,7 +228,7 @@ String FileAccessExtension::get_token() const {
 }
 
 Vector<String> FileAccessExtension::get_csv_line(const String &p_delim) const {
-	Vector<String> csv_line;
+	Vector<String> csv_line = Vector<String>();
 	if (GDVIRTUAL_CALL(_get_csv_line, p_delim, csv_line)) {
 		return csv_line;
 	}
@@ -236,7 +236,7 @@ Vector<String> FileAccessExtension::get_csv_line(const String &p_delim) const {
 }
 
 String FileAccessExtension::get_as_text(bool p_skip_cr) const {
-	String val_as_text;
+	String val_as_text = "";
 	if (GDVIRTUAL_CALL(_get_as_text, p_skip_cr, val_as_text)) {
 		return val_as_text;
 	}
@@ -244,7 +244,7 @@ String FileAccessExtension::get_as_text(bool p_skip_cr) const {
 }
 
 String FileAccessExtension::get_as_utf8_string(bool p_skip_cr) const {
-	String val_as_utf8_string;
+	String val_as_utf8_string = "";
 	if (GDVIRTUAL_CALL(_get_as_utf8_string, p_skip_cr, val_as_utf8_string)) {
 		return val_as_utf8_string;
 	}
@@ -326,7 +326,7 @@ void FileAccessExtension::store_pascal_string(const String &p_string) {
 }
 
 String FileAccessExtension::get_pascal_string() {
-	String string;
+	String string = "";
 	if (GDVIRTUAL_CALL(_get_pascal_string, string)) {
 		return string;
 	}
@@ -334,7 +334,7 @@ String FileAccessExtension::get_pascal_string() {
 }
 
 void FileAccessExtension::store_buffer(const uint8_t *p_src, uint64_t p_length) {
-	Vector<uint8_t> buffer;
+	Vector<uint8_t> buffer = Vector<uint8_t>();
 	uint64_t i = 0;
 	for (i = 0; i < p_length; i++) {
 		buffer.insert(i, p_src[i]);
@@ -359,13 +359,13 @@ void FileAccessExtension::close() {
 }
 
 bool FileAccessExtension::file_exists(const String &p_name) {
-	bool file_exists;
+	bool file_exists = false;
 	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_name, file_exists);
 	return file_exists;
 }
 
 Error FileAccessExtension::reopen(const String &p_path, int p_mode_flags) {
-	Error err;
+	Error err = OK;
 	if (GDVIRTUAL_CALL(_reopen, p_path, p_mode_flags, err)) {
 		return err;
 	}

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -124,6 +124,14 @@ Variant FileAccessExtension::get_var(bool p_allow_objects) const {
 	return var;
 }
 
+uint64_t FileAccess::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
+
+	Vector<uint8_t> buffer = get_buffer(p_length);
+	p_dst = buffer.ptrw();
+	return buffer.size();
+}
+
 Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
 	Vector<uint8_t> buffer;
 	GDVIRTUAL_CALL(_get_buffer, p_length, buffer);

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -87,7 +87,7 @@ bool FileAccessExtension::is_open() const {
 }
 
 String FileAccessExtension::get_path() const {
-	String path = "";
+	String path;
 	if (GDVIRTUAL_CALL(_get_path, path)) {
 		return path;
 	}
@@ -95,7 +95,7 @@ String FileAccessExtension::get_path() const {
 }
 
 String FileAccessExtension::get_path_absolute() const {
-	String path_absolute = "";
+	String path_absolute;
 	if (GDVIRTUAL_CALL(_get_path_absolute, path_absolute)) {
 		return path_absolute;
 	}
@@ -183,7 +183,7 @@ real_t FileAccessExtension::get_real() const {
 }
 
 Variant FileAccessExtension::get_var(bool p_allow_objects) const {
-	Variant var = Variant();
+	Variant var;
 	if (GDVIRTUAL_CALL(_get_var, p_allow_objects, var)) {
 		return var;
 	}
@@ -212,7 +212,7 @@ Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
 }
 
 String FileAccessExtension::get_line() const {
-	String line = "";
+	String line;
 	if (GDVIRTUAL_CALL(_get_line, line)) {
 		return line;
 	}
@@ -220,7 +220,7 @@ String FileAccessExtension::get_line() const {
 }
 
 String FileAccessExtension::get_token() const {
-	String token = "";
+	String token;
 	if (GDVIRTUAL_CALL(_get_token, token)) {
 		return token;
 	}
@@ -228,7 +228,7 @@ String FileAccessExtension::get_token() const {
 }
 
 Vector<String> FileAccessExtension::get_csv_line(const String &p_delim) const {
-	Vector<String> csv_line = Vector<String>();
+	Vector<String> csv_line;
 	if (GDVIRTUAL_CALL(_get_csv_line, p_delim, csv_line)) {
 		return csv_line;
 	}
@@ -236,7 +236,7 @@ Vector<String> FileAccessExtension::get_csv_line(const String &p_delim) const {
 }
 
 String FileAccessExtension::get_as_text(bool p_skip_cr) const {
-	String val_as_text = "";
+	String val_as_text;
 	if (GDVIRTUAL_CALL(_get_as_text, p_skip_cr, val_as_text)) {
 		return val_as_text;
 	}
@@ -244,7 +244,7 @@ String FileAccessExtension::get_as_text(bool p_skip_cr) const {
 }
 
 String FileAccessExtension::get_as_utf8_string(bool p_skip_cr) const {
-	String val_as_utf8_string = "";
+	String val_as_utf8_string;
 	if (GDVIRTUAL_CALL(_get_as_utf8_string, p_skip_cr, val_as_utf8_string)) {
 		return val_as_utf8_string;
 	}
@@ -326,7 +326,7 @@ void FileAccessExtension::store_pascal_string(const String &p_string) {
 }
 
 String FileAccessExtension::get_pascal_string() {
-	String string = "";
+	String string;
 	if (GDVIRTUAL_CALL(_get_pascal_string, string)) {
 		return string;
 	}
@@ -334,7 +334,7 @@ String FileAccessExtension::get_pascal_string() {
 }
 
 void FileAccessExtension::store_buffer(const uint8_t *p_src, uint64_t p_length) {
-	Vector<uint8_t> buffer = Vector<uint8_t>();
+	Vector<uint8_t> buffer;
 	uint64_t i = 0;
 	for (i = 0; i < p_length; i++) {
 		buffer.insert(i, p_src[i]);

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -32,6 +32,18 @@
 
 #include "core/object/object.h"
 
+Error FileAccessExtension::open_internal(const String &p_path, int p_mode_flags) {
+	Error err = OK;
+	GDVIRTUAL_CALL(_open_internal, p_path, p_mode_flags, err);
+	return err;
+}
+
+uint64_t FileAccessExtension::_get_modified_time(const String &p_file) {
+	uint64_t time = 0;
+	GDVIRTUAL_CALL(__get_modified_time, p_file, time);
+	return time;
+}
+
 bool FileAccessExtension::is_open() const {
 	bool is_open = false;
 	GDVIRTUAL_CALL(_is_open, is_open);
@@ -124,12 +136,17 @@ Variant FileAccessExtension::get_var(bool p_allow_objects) const {
 	return var;
 }
 
-uint64_t FileAccess::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessExtension::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	Vector<uint8_t> buffer = get_buffer(p_length);
-	p_dst = buffer.ptrw();
-	return buffer.size();
+
+	int64_t i = 0;
+	for (i = 0; i < buffer.size(); i++) {
+		p_dst[i] = buffer.get(i);
+	}
+
+	return i;
 }
 
 Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
@@ -168,7 +185,107 @@ String FileAccessExtension::get_as_utf8_string(bool p_skip_cr) const {
 	return val_as_utf8_string;
 }
 
+void FileAccessExtension::set_big_endian(bool p_big_endian) {
+	GDVIRTUAL_CALL(_set_big_endian, p_big_endian);
+}
+
+Error FileAccessExtension::get_error() const {
+	Error err = OK;
+	GDVIRTUAL_CALL(_get_error, err);
+	return err;
+}
+
+void FileAccessExtension::flush() {
+	GDVIRTUAL_CALL(_flush);
+}
+
+void FileAccessExtension::store_8(uint8_t p_dest) {
+	GDVIRTUAL_CALL(_store_8, p_dest);
+}
+
+void FileAccessExtension::store_16(uint16_t p_dest) {
+	GDVIRTUAL_CALL(_store_16, p_dest);
+}
+
+void FileAccessExtension::store_32(uint32_t p_dest) {
+	GDVIRTUAL_CALL(_store_32, p_dest);
+}
+
+void FileAccessExtension::store_64(uint64_t p_dest) {
+	GDVIRTUAL_CALL(_store_64, p_dest);
+}
+
+void FileAccessExtension::store_float(float p_dest) {
+	GDVIRTUAL_CALL(_store_float, p_dest);
+}
+
+void FileAccessExtension::store_double(double p_dest) {
+	GDVIRTUAL_CALL(_store_double, p_dest);
+}
+
+void FileAccessExtension::store_real(real_t p_dest) {
+	GDVIRTUAL_CALL(_store_real, p_dest);
+}
+
+void FileAccessExtension::store_string(const String &p_string) {
+	GDVIRTUAL_CALL(_store_string, p_string);
+}
+
+void FileAccessExtension::store_line(const String &p_line) {
+	GDVIRTUAL_CALL(_store_line, p_line);
+}
+
+void FileAccessExtension::store_csv_line(const Vector<String> &p_values, const String &p_delim) {
+	GDVIRTUAL_CALL(_store_csv_line, p_values, p_delim);
+}
+
+void FileAccessExtension::store_pascal_string(const String &p_string) {
+	GDVIRTUAL_CALL(_store_pascal_string, p_string);
+}
+
+String FileAccessExtension::get_pascal_string() {
+	String string;
+	GDVIRTUAL_CALL(_get_pascal_string, string);
+	return string;
+}
+
+void FileAccessExtension::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	Vector<uint8_t> buffer;
+	uint64_t i = 0;
+	for (i = 0; i < p_length; i++) {
+		buffer.insert(i, p_src[i]);
+	}
+	store_buffer(buffer);
+}
+
+void FileAccessExtension::store_buffer(const Vector<uint8_t> &p_buffer) {
+	GDVIRTUAL_CALL(_store_buffer, p_buffer);
+}
+
+void FileAccessExtension::store_var(const Variant &p_var, bool p_full_objects) {
+	GDVIRTUAL_CALL(_store_var, p_var, p_full_objects);
+}
+
+void FileAccessExtension::close() {
+	GDVIRTUAL_CALL(_close);
+}
+
+bool FileAccessExtension::file_exists(const String &p_name) {
+	bool file_exists;
+	GDVIRTUAL_CALL(_file_exists, p_name, file_exists);
+	return file_exists;
+}
+
+Error FileAccessExtension::reopen(const String &p_path, int p_mode_flags) {
+	Error err = OK;
+	GDVIRTUAL_CALL(_reopen, p_path, p_mode_flags, err);
+	return err;
+}
+
 void FileAccessExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_open_internal, "path", "mode_flags");
+	GDVIRTUAL_BIND(__get_modified_time, "file");
+
 	GDVIRTUAL_BIND(_is_open);
 
 	GDVIRTUAL_BIND(_get_path);
@@ -198,6 +315,37 @@ void FileAccessExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_csv_line, "delim");
 	GDVIRTUAL_BIND(_get_as_text, "skip_cr");
 	GDVIRTUAL_BIND(_get_as_utf8_string, "skip_cr");
+
+	GDVIRTUAL_BIND(_set_big_endian, "big_endian");
+
+	GDVIRTUAL_BIND(_get_error);
+
+	GDVIRTUAL_BIND(_flush);
+	GDVIRTUAL_BIND(_store_8, "dest");
+	GDVIRTUAL_BIND(_store_16, "dest");
+	GDVIRTUAL_BIND(_store_32, "dest");
+	GDVIRTUAL_BIND(_store_64, "dest");
+
+	GDVIRTUAL_BIND(_store_float, "dest");
+	GDVIRTUAL_BIND(_store_double, "dest");
+	GDVIRTUAL_BIND(_store_real, "dest");
+
+	GDVIRTUAL_BIND(_store_string, "string");
+	GDVIRTUAL_BIND(_store_line, "line");
+	GDVIRTUAL_BIND(_store_csv_line, "values", "delim");
+
+	GDVIRTUAL_BIND(_store_pascal_string, "string");
+	GDVIRTUAL_BIND(_get_pascal_string);
+
+	GDVIRTUAL_BIND(_store_buffer, "buffer");
+
+	GDVIRTUAL_BIND(_store_var, "var", "full_objects");
+
+	GDVIRTUAL_BIND(_close);
+
+	GDVIRTUAL_BIND(_file_exists, "name");
+
+	GDVIRTUAL_BIND(_reopen, "path", "mode_flags");
 }
 
 FileAccessExtension::FileAccessExtension() {

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -32,12 +32,6 @@
 
 #include "core/object/object.h"
 
-// Ref<FileAccessExtension> FileAccessExtension::create() {
-// 	Ref<FileAccessExtension> file_access;
-// 	file_access.instantiate();
-// 	return file_access;
-// }
-
 BitField<FileAccess::UnixPermissionFlags> FileAccessExtension::_get_unix_permissions(const String &p_file) {
 	BitField<UnixPermissionFlags> permissions = 0;
 	GDVIRTUAL_REQUIRED_CALL(__get_unix_permissions, p_file, permissions);
@@ -379,8 +373,6 @@ Error FileAccessExtension::reopen(const String &p_path, int p_mode_flags) {
 }
 
 void FileAccessExtension::_bind_methods() {
-	// ClassDB::bind_static_method("FileAccessExtension", D_METHOD("create"), &FileAccessExtension::create);
-
 	GDVIRTUAL_BIND(__get_unix_permissions, "file");
 	GDVIRTUAL_BIND(__set_unix_permissions, "file", "permissions");
 

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -32,108 +32,168 @@
 
 #include "core/object/object.h"
 
+// Ref<FileAccessExtension> FileAccessExtension::create() {
+// 	Ref<FileAccessExtension> file_access;
+// 	file_access.instantiate();
+// 	return file_access;
+// }
+
+BitField<FileAccess::UnixPermissionFlags> FileAccessExtension::_get_unix_permissions(const String &p_file) {
+	BitField<UnixPermissionFlags> permissions = 0;
+	GDVIRTUAL_REQUIRED_CALL(__get_unix_permissions, p_file, permissions);
+	return permissions;
+}
+
+Error FileAccessExtension::_set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(__set_unix_permissions, p_file, p_permissions, err);
+	return err;
+}
+
+bool FileAccessExtension::_get_hidden_attribute(const String &p_file) {
+	bool hidden_attribute = false;
+	GDVIRTUAL_REQUIRED_CALL(__get_hidden_attribute, p_file, hidden_attribute);
+	return hidden_attribute;
+}
+
+Error FileAccessExtension::_set_hidden_attribute(const String &p_file, bool p_hidden) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(__set_hidden_attribute, p_file, p_hidden, err);
+	return err;
+}
+
+bool FileAccessExtension::_get_read_only_attribute(const String &p_file) {
+	bool read_only_attribute = false;
+	GDVIRTUAL_REQUIRED_CALL(__get_read_only_attribute, p_file, read_only_attribute);
+	return read_only_attribute;
+}
+
+Error FileAccessExtension::_set_read_only_attribute(const String &p_file, bool p_read_only) {
+	Error err = OK;
+	GDVIRTUAL_REQUIRED_CALL(__set_read_only_attribute, p_file, p_read_only, err);
+	return err;
+}
+
 Error FileAccessExtension::open_internal(const String &p_path, int p_mode_flags) {
 	Error err = OK;
-	GDVIRTUAL_CALL(_open_internal, p_path, p_mode_flags, err);
+	GDVIRTUAL_REQUIRED_CALL(_open_internal, p_path, p_mode_flags, err);
 	return err;
 }
 
 uint64_t FileAccessExtension::_get_modified_time(const String &p_file) {
 	uint64_t time = 0;
-	GDVIRTUAL_CALL(__get_modified_time, p_file, time);
+	GDVIRTUAL_REQUIRED_CALL(__get_modified_time, p_file, time);
 	return time;
 }
 
 bool FileAccessExtension::is_open() const {
 	bool is_open = false;
-	GDVIRTUAL_CALL(_is_open, is_open);
+	GDVIRTUAL_REQUIRED_CALL(_is_open, is_open);
 	return is_open;
 }
 
 String FileAccessExtension::get_path() const {
 	String path = "";
-	GDVIRTUAL_CALL(_get_path, path);
-	return path;
+	if (GDVIRTUAL_CALL(_get_path, path)) {
+		return path;
+	}
+	return FileAccess::get_path();
 }
 
 String FileAccessExtension::get_path_absolute() const {
 	String path_absolute = "";
-	GDVIRTUAL_CALL(_get_path_absolute, path_absolute);
-	return path_absolute;
+	if (GDVIRTUAL_CALL(_get_path_absolute, path_absolute)) {
+		return path_absolute;
+	}
+	return FileAccess::get_path_absolute();
 }
 
 void FileAccessExtension::seek(uint64_t p_position) {
-	GDVIRTUAL_CALL(_seek, p_position);
+	GDVIRTUAL_REQUIRED_CALL(_seek, p_position);
 }
 
 void FileAccessExtension::seek_end(int64_t p_position) {
-	GDVIRTUAL_CALL(_seek_end, p_position);
+	GDVIRTUAL_REQUIRED_CALL(_seek_end, p_position);
 }
 
 uint64_t FileAccessExtension::get_position() const {
 	uint64_t position = 0;
-	GDVIRTUAL_CALL(_get_position, position);
+	GDVIRTUAL_REQUIRED_CALL(_get_position, position);
 	return position;
 }
 
 uint64_t FileAccessExtension::get_length() const {
 	uint64_t length = 0;
-	GDVIRTUAL_CALL(_get_length, length);
+	GDVIRTUAL_REQUIRED_CALL(_get_length, length);
 	return length;
 }
 
 bool FileAccessExtension::eof_reached() const {
 	bool eof_reached = false;
-	GDVIRTUAL_CALL(_eof_reached, eof_reached);
+	GDVIRTUAL_REQUIRED_CALL(_eof_reached, eof_reached);
 	return eof_reached;
 }
 
 uint8_t FileAccessExtension::get_8() const {
 	uint8_t val = 0;
-	GDVIRTUAL_CALL(_get_8, val);
+	GDVIRTUAL_REQUIRED_CALL(_get_8, val);
 	return val;
 }
 
 uint16_t FileAccessExtension::get_16() const {
 	uint16_t val = 0;
-	GDVIRTUAL_CALL(_get_16, val);
-	return val;
+	if (GDVIRTUAL_CALL(_get_16, val)) {
+		return val;
+	}
+	return FileAccess::get_16();
 }
 
 uint32_t FileAccessExtension::get_32() const {
 	uint32_t val = 0;
-	GDVIRTUAL_CALL(_get_32, val);
-	return val;
+	if (GDVIRTUAL_CALL(_get_32, val)) {
+		return val;
+	}
+	return FileAccess::get_32();
 }
 
 uint64_t FileAccessExtension::get_64() const {
 	uint64_t val = 0;
-	GDVIRTUAL_CALL(_get_64, val);
-	return val;
+	if (GDVIRTUAL_CALL(_get_64, val)) {
+		return val;
+	}
+	return FileAccess::get_64();
 }
 
 float FileAccessExtension::get_float() const {
 	float val = 0;
-	GDVIRTUAL_CALL(_get_float, val);
-	return val;
+	if (GDVIRTUAL_CALL(_get_float, val)) {
+		return val;
+	}
+	return FileAccess::get_float();
 }
 
 double FileAccessExtension::get_double() const {
 	double val = 0;
-	GDVIRTUAL_CALL(_get_double, val);
-	return val;
+	if (GDVIRTUAL_CALL(_get_double, val)) {
+		return val;
+	}
+	return FileAccess::get_double();
 }
 
 real_t FileAccessExtension::get_real() const {
 	real_t val = 0;
-	GDVIRTUAL_CALL(_get_real, val);
-	return val;
+	if (GDVIRTUAL_CALL(_get_real, val)) {
+		return val;
+	}
+	return FileAccess::get_real();
 }
 
 Variant FileAccessExtension::get_var(bool p_allow_objects) const {
 	Variant var;
-	GDVIRTUAL_CALL(_get_var, p_allow_objects, var);
-	return var;
+	if (GDVIRTUAL_CALL(_get_var, p_allow_objects, var)) {
+		return var;
+	}
+	return FileAccess::get_var(p_allow_objects);
 }
 
 uint64_t FileAccessExtension::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
@@ -151,102 +211,132 @@ uint64_t FileAccessExtension::get_buffer(uint8_t *p_dst, uint64_t p_length) cons
 
 Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
 	Vector<uint8_t> buffer;
-	GDVIRTUAL_CALL(_get_buffer, p_length, buffer);
-	return buffer;
+	if (GDVIRTUAL_CALL(_get_buffer, p_length, buffer)) {
+		return buffer;
+	}
+	return FileAccess::get_buffer(p_length);
 }
 
 String FileAccessExtension::get_line() const {
 	String line;
-	GDVIRTUAL_CALL(_get_line, line);
-	return line;
+	if (GDVIRTUAL_CALL(_get_line, line)) {
+		return line;
+	}
+	return FileAccess::get_line();
 }
 
 String FileAccessExtension::get_token() const {
 	String token;
-	GDVIRTUAL_CALL(_get_token, token);
-	return token;
+	if (GDVIRTUAL_CALL(_get_token, token)) {
+		return token;
+	}
+	return FileAccess::get_token();
 }
 
 Vector<String> FileAccessExtension::get_csv_line(const String &p_delim) const {
 	Vector<String> csv_line;
-	GDVIRTUAL_CALL(_get_csv_line, p_delim, csv_line);
-	return csv_line;
+	if (GDVIRTUAL_CALL(_get_csv_line, p_delim, csv_line)) {
+		return csv_line;
+	}
+	return FileAccess::get_csv_line(p_delim);
 }
 
 String FileAccessExtension::get_as_text(bool p_skip_cr) const {
 	String val_as_text;
-	GDVIRTUAL_CALL(_get_as_text, p_skip_cr, val_as_text);
-	return val_as_text;
+	if (GDVIRTUAL_CALL(_get_as_text, p_skip_cr, val_as_text)) {
+		return val_as_text;
+	}
+	return FileAccess::get_as_text(p_skip_cr);
 }
 
 String FileAccessExtension::get_as_utf8_string(bool p_skip_cr) const {
 	String val_as_utf8_string;
-	GDVIRTUAL_CALL(_get_as_utf8_string, p_skip_cr, val_as_utf8_string);
-	return val_as_utf8_string;
-}
-
-void FileAccessExtension::set_big_endian(bool p_big_endian) {
-	GDVIRTUAL_CALL(_set_big_endian, p_big_endian);
+	if (GDVIRTUAL_CALL(_get_as_utf8_string, p_skip_cr, val_as_utf8_string)) {
+		return val_as_utf8_string;
+	}
+	return FileAccess::get_as_utf8_string(p_skip_cr);
 }
 
 Error FileAccessExtension::get_error() const {
 	Error err = OK;
-	GDVIRTUAL_CALL(_get_error, err);
+	GDVIRTUAL_REQUIRED_CALL(_get_error, err);
 	return err;
 }
 
 void FileAccessExtension::flush() {
-	GDVIRTUAL_CALL(_flush);
+	GDVIRTUAL_REQUIRED_CALL(_flush);
 }
 
 void FileAccessExtension::store_8(uint8_t p_dest) {
-	GDVIRTUAL_CALL(_store_8, p_dest);
+	GDVIRTUAL_REQUIRED_CALL(_store_8, p_dest);
 }
 
 void FileAccessExtension::store_16(uint16_t p_dest) {
-	GDVIRTUAL_CALL(_store_16, p_dest);
+	if (!GDVIRTUAL_CALL(_store_16, p_dest)) {
+		FileAccess::store_16(p_dest);
+	}
 }
 
 void FileAccessExtension::store_32(uint32_t p_dest) {
-	GDVIRTUAL_CALL(_store_32, p_dest);
+	if (!GDVIRTUAL_CALL(_store_32, p_dest)) {
+		FileAccess::store_32(p_dest);
+	}
 }
 
 void FileAccessExtension::store_64(uint64_t p_dest) {
-	GDVIRTUAL_CALL(_store_64, p_dest);
+	if (!GDVIRTUAL_CALL(_store_64, p_dest)) {
+		FileAccess::store_64(p_dest);
+	}
 }
 
 void FileAccessExtension::store_float(float p_dest) {
-	GDVIRTUAL_CALL(_store_float, p_dest);
+	if (!GDVIRTUAL_CALL(_store_float, p_dest)) {
+		FileAccess::store_float(p_dest);
+	}
 }
 
 void FileAccessExtension::store_double(double p_dest) {
-	GDVIRTUAL_CALL(_store_double, p_dest);
+	if (!GDVIRTUAL_CALL(_store_double, p_dest)) {
+		FileAccess::store_double(p_dest);
+	}
 }
 
 void FileAccessExtension::store_real(real_t p_dest) {
-	GDVIRTUAL_CALL(_store_real, p_dest);
+	if (!GDVIRTUAL_CALL(_store_real, p_dest)) {
+		FileAccess::store_real(p_dest);
+	}
 }
 
 void FileAccessExtension::store_string(const String &p_string) {
-	GDVIRTUAL_CALL(_store_string, p_string);
+	if (!GDVIRTUAL_CALL(_store_string, p_string)) {
+		FileAccess::store_string(p_string);
+	}
 }
 
 void FileAccessExtension::store_line(const String &p_line) {
-	GDVIRTUAL_CALL(_store_line, p_line);
+	if (!GDVIRTUAL_CALL(_store_line, p_line)) {
+		FileAccess::store_line(p_line);
+	}
 }
 
 void FileAccessExtension::store_csv_line(const Vector<String> &p_values, const String &p_delim) {
-	GDVIRTUAL_CALL(_store_csv_line, p_values, p_delim);
+	if (!GDVIRTUAL_CALL(_store_csv_line, p_values, p_delim)) {
+		FileAccess::store_csv_line(p_values, p_delim);
+	}
 }
 
 void FileAccessExtension::store_pascal_string(const String &p_string) {
-	GDVIRTUAL_CALL(_store_pascal_string, p_string);
+	if (!GDVIRTUAL_CALL(_store_pascal_string, p_string)) {
+		FileAccess::store_pascal_string(p_string);
+	}
 }
 
 String FileAccessExtension::get_pascal_string() {
 	String string;
-	GDVIRTUAL_CALL(_get_pascal_string, string);
-	return string;
+	if (GDVIRTUAL_CALL(_get_pascal_string, string)) {
+		return string;
+	}
+	return FileAccess::get_pascal_string();
 }
 
 void FileAccessExtension::store_buffer(const uint8_t *p_src, uint64_t p_length) {
@@ -259,30 +349,46 @@ void FileAccessExtension::store_buffer(const uint8_t *p_src, uint64_t p_length) 
 }
 
 void FileAccessExtension::store_buffer(const Vector<uint8_t> &p_buffer) {
-	GDVIRTUAL_CALL(_store_buffer, p_buffer);
+	if (!GDVIRTUAL_CALL(_store_buffer, p_buffer)) {
+		FileAccess::store_buffer(p_buffer);
+	}
 }
 
 void FileAccessExtension::store_var(const Variant &p_var, bool p_full_objects) {
-	GDVIRTUAL_CALL(_store_var, p_var, p_full_objects);
+	if (!GDVIRTUAL_CALL(_store_var, p_var, p_full_objects)) {
+		FileAccess::store_var(p_var, p_full_objects);
+	}
 }
 
 void FileAccessExtension::close() {
-	GDVIRTUAL_CALL(_close);
+	GDVIRTUAL_REQUIRED_CALL(_close);
 }
 
 bool FileAccessExtension::file_exists(const String &p_name) {
 	bool file_exists;
-	GDVIRTUAL_CALL(_file_exists, p_name, file_exists);
+	GDVIRTUAL_REQUIRED_CALL(_file_exists, p_name, file_exists);
 	return file_exists;
 }
 
 Error FileAccessExtension::reopen(const String &p_path, int p_mode_flags) {
 	Error err = OK;
-	GDVIRTUAL_CALL(_reopen, p_path, p_mode_flags, err);
-	return err;
+	if (GDVIRTUAL_CALL(_reopen, p_path, p_mode_flags, err)) {
+		return err;
+	}
+	return FileAccess::reopen(p_path, p_mode_flags);
 }
 
 void FileAccessExtension::_bind_methods() {
+	// ClassDB::bind_static_method("FileAccessExtension", D_METHOD("create"), &FileAccessExtension::create);
+
+	GDVIRTUAL_BIND(__get_unix_permissions, "file");
+	GDVIRTUAL_BIND(__set_unix_permissions, "file", "permissions");
+
+	GDVIRTUAL_BIND(__get_hidden_attribute, "file");
+	GDVIRTUAL_BIND(__set_hidden_attribute, "file", "hidden");
+	GDVIRTUAL_BIND(__get_read_only_attribute, "file");
+	GDVIRTUAL_BIND(__set_read_only_attribute, "file", "ro");
+
 	GDVIRTUAL_BIND(_open_internal, "path", "mode_flags");
 	GDVIRTUAL_BIND(__get_modified_time, "file");
 
@@ -315,8 +421,6 @@ void FileAccessExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_csv_line, "delim");
 	GDVIRTUAL_BIND(_get_as_text, "skip_cr");
 	GDVIRTUAL_BIND(_get_as_utf8_string, "skip_cr");
-
-	GDVIRTUAL_BIND(_set_big_endian, "big_endian");
 
 	GDVIRTUAL_BIND(_get_error);
 

--- a/core/io/file_access_extension.cpp
+++ b/core/io/file_access_extension.cpp
@@ -1,0 +1,199 @@
+/**************************************************************************/
+/*  file_access_extension.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "file_access_extension.h"
+
+#include "core/object/object.h"
+
+bool FileAccessExtension::is_open() const {
+	bool is_open = false;
+	GDVIRTUAL_CALL(_is_open, is_open);
+	return is_open;
+}
+
+String FileAccessExtension::get_path() const {
+	String path = "";
+	GDVIRTUAL_CALL(_get_path, path);
+	return path;
+}
+
+String FileAccessExtension::get_path_absolute() const {
+	String path_absolute = "";
+	GDVIRTUAL_CALL(_get_path_absolute, path_absolute);
+	return path_absolute;
+}
+
+void FileAccessExtension::seek(uint64_t p_position) {
+	GDVIRTUAL_CALL(_seek, p_position);
+}
+
+void FileAccessExtension::seek_end(int64_t p_position) {
+	GDVIRTUAL_CALL(_seek_end, p_position);
+}
+
+uint64_t FileAccessExtension::get_position() const {
+	uint64_t position = 0;
+	GDVIRTUAL_CALL(_get_position, position);
+	return position;
+}
+
+uint64_t FileAccessExtension::get_length() const {
+	uint64_t length = 0;
+	GDVIRTUAL_CALL(_get_length, length);
+	return length;
+}
+
+bool FileAccessExtension::eof_reached() const {
+	bool eof_reached = false;
+	GDVIRTUAL_CALL(_eof_reached, eof_reached);
+	return eof_reached;
+}
+
+uint8_t FileAccessExtension::get_8() const {
+	uint8_t val = 0;
+	GDVIRTUAL_CALL(_get_8, val);
+	return val;
+}
+
+uint16_t FileAccessExtension::get_16() const {
+	uint16_t val = 0;
+	GDVIRTUAL_CALL(_get_16, val);
+	return val;
+}
+
+uint32_t FileAccessExtension::get_32() const {
+	uint32_t val = 0;
+	GDVIRTUAL_CALL(_get_32, val);
+	return val;
+}
+
+uint64_t FileAccessExtension::get_64() const {
+	uint64_t val = 0;
+	GDVIRTUAL_CALL(_get_64, val);
+	return val;
+}
+
+float FileAccessExtension::get_float() const {
+	float val = 0;
+	GDVIRTUAL_CALL(_get_float, val);
+	return val;
+}
+
+double FileAccessExtension::get_double() const {
+	double val = 0;
+	GDVIRTUAL_CALL(_get_double, val);
+	return val;
+}
+
+real_t FileAccessExtension::get_real() const {
+	real_t val = 0;
+	GDVIRTUAL_CALL(_get_real, val);
+	return val;
+}
+
+Variant FileAccessExtension::get_var(bool p_allow_objects) const {
+	Variant var;
+	GDVIRTUAL_CALL(_get_var, p_allow_objects, var);
+	return var;
+}
+
+Vector<uint8_t> FileAccessExtension::get_buffer(int64_t p_length) const {
+	Vector<uint8_t> buffer;
+	GDVIRTUAL_CALL(_get_buffer, p_length, buffer);
+	return buffer;
+}
+
+String FileAccessExtension::get_line() const {
+	String line;
+	GDVIRTUAL_CALL(_get_line, line);
+	return line;
+}
+
+String FileAccessExtension::get_token() const {
+	String token;
+	GDVIRTUAL_CALL(_get_token, token);
+	return token;
+}
+
+Vector<String> FileAccessExtension::get_csv_line(const String &p_delim) const {
+	Vector<String> csv_line;
+	GDVIRTUAL_CALL(_get_csv_line, p_delim, csv_line);
+	return csv_line;
+}
+
+String FileAccessExtension::get_as_text(bool p_skip_cr) const {
+	String val_as_text;
+	GDVIRTUAL_CALL(_get_as_text, p_skip_cr, val_as_text);
+	return val_as_text;
+}
+
+String FileAccessExtension::get_as_utf8_string(bool p_skip_cr) const {
+	String val_as_utf8_string;
+	GDVIRTUAL_CALL(_get_as_utf8_string, p_skip_cr, val_as_utf8_string);
+	return val_as_utf8_string;
+}
+
+void FileAccessExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_is_open);
+
+	GDVIRTUAL_BIND(_get_path);
+	GDVIRTUAL_BIND(_get_path_absolute);
+
+	GDVIRTUAL_BIND(_seek, "position");
+	GDVIRTUAL_BIND(_seek_end, "position");
+	GDVIRTUAL_BIND(_get_position);
+	GDVIRTUAL_BIND(_get_length);
+
+	GDVIRTUAL_BIND(_eof_reached);
+
+	GDVIRTUAL_BIND(_get_8);
+	GDVIRTUAL_BIND(_get_16);
+	GDVIRTUAL_BIND(_get_32);
+	GDVIRTUAL_BIND(_get_64);
+
+	GDVIRTUAL_BIND(_get_float);
+	GDVIRTUAL_BIND(_get_double);
+	GDVIRTUAL_BIND(_get_real);
+
+	GDVIRTUAL_BIND(_get_var, "allow_objects");
+
+	GDVIRTUAL_BIND(_get_buffer, "length");
+	GDVIRTUAL_BIND(_get_line);
+	GDVIRTUAL_BIND(_get_token);
+	GDVIRTUAL_BIND(_get_csv_line, "delim");
+	GDVIRTUAL_BIND(_get_as_text, "skip_cr");
+	GDVIRTUAL_BIND(_get_as_utf8_string, "skip_cr");
+}
+
+FileAccessExtension::FileAccessExtension() {
+}
+
+FileAccessExtension::~FileAccessExtension() {
+}

--- a/core/io/file_access_extension.h
+++ b/core/io/file_access_extension.h
@@ -38,6 +38,20 @@
 class FileAccessExtension : public FileAccess {
 	GDCLASS(FileAccessExtension, FileAccess);
 
+	GDVIRTUAL1R(BitField<UnixPermissionFlags>, __get_unix_permissions, String);
+	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_file) override;
+	GDVIRTUAL2R(Error, __set_unix_permissions, String, BitField<UnixPermissionFlags>);
+	virtual Error _set_unix_permissions(const String &p_file, BitField<UnixPermissionFlags> p_permissions) override;
+
+	GDVIRTUAL1R(bool, __get_hidden_attribute, String);
+	virtual bool _get_hidden_attribute(const String &p_file) override;
+	GDVIRTUAL2R(Error, __set_hidden_attribute, String, bool);
+	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override;
+	GDVIRTUAL1R(bool, __get_read_only_attribute, String);
+	virtual bool _get_read_only_attribute(const String &p_file) override;
+	GDVIRTUAL2R(Error, __set_read_only_attribute, String, bool);
+	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
+
 protected:
 	static void _bind_methods();
 
@@ -47,6 +61,8 @@ protected:
 	virtual uint64_t _get_modified_time(const String &p_file) override;
 
 public:
+	// static Ref<FileAccessExtension> create();
+
 	GDVIRTUAL0RC(bool, _is_open);
 	virtual bool is_open() const override;
 
@@ -99,9 +115,6 @@ public:
 	String get_as_text(bool p_skip_cr = false) const;
 	GDVIRTUAL1RC(String, _get_as_utf8_string, bool);
 	virtual String get_as_utf8_string(bool p_skip_cr = false) const override;
-
-	GDVIRTUAL1(_set_big_endian, bool);
-	virtual void set_big_endian(bool p_big_endian) override;
 
 	GDVIRTUAL0RC(Error, _get_error);
 	virtual Error get_error() const override;

--- a/core/io/file_access_extension.h
+++ b/core/io/file_access_extension.h
@@ -38,6 +38,10 @@
 class FileAccessExtension : public FileAccess {
 	GDCLASS(FileAccessExtension, FileAccess);
 
+protected:
+	static void _bind_methods();
+
+private:
 	GDVIRTUAL1R(BitField<UnixPermissionFlags>, __get_unix_permissions, String);
 	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_file) override;
 	GDVIRTUAL2R(Error, __set_unix_permissions, String, BitField<UnixPermissionFlags>);
@@ -52,17 +56,12 @@ class FileAccessExtension : public FileAccess {
 	GDVIRTUAL2R(Error, __set_read_only_attribute, String, bool);
 	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
 
-protected:
-	static void _bind_methods();
-
 	GDVIRTUAL2R(Error, _open_internal, String, int);
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override;
 	GDVIRTUAL1R(uint64_t, __get_modified_time, String);
 	virtual uint64_t _get_modified_time(const String &p_file) override;
 
 public:
-	// static Ref<FileAccessExtension> create();
-
 	GDVIRTUAL0RC(bool, _is_open);
 	virtual bool is_open() const override;
 

--- a/core/io/file_access_extension.h
+++ b/core/io/file_access_extension.h
@@ -41,6 +41,11 @@ class FileAccessExtension : public FileAccess {
 protected:
 	static void _bind_methods();
 
+	GDVIRTUAL2R(Error, _open_internal, String, int);
+	virtual Error open_internal(const String &p_path, int p_mode_flags) override;
+	GDVIRTUAL1R(uint64_t, __get_modified_time, String);
+	virtual uint64_t _get_modified_time(const String &p_file) override;
+
 public:
 	GDVIRTUAL0RC(bool, _is_open);
 	virtual bool is_open() const override;
@@ -94,6 +99,58 @@ public:
 	String get_as_text(bool p_skip_cr = false) const;
 	GDVIRTUAL1RC(String, _get_as_utf8_string, bool);
 	virtual String get_as_utf8_string(bool p_skip_cr = false) const override;
+
+	GDVIRTUAL1(_set_big_endian, bool);
+	virtual void set_big_endian(bool p_big_endian) override;
+
+	GDVIRTUAL0RC(Error, _get_error);
+	virtual Error get_error() const override;
+
+	GDVIRTUAL0(_flush);
+	virtual void flush() override;
+	GDVIRTUAL1(_store_8, uint8_t);
+	virtual void store_8(uint8_t p_dest) override;
+	GDVIRTUAL1(_store_16, uint16_t);
+	virtual void store_16(uint16_t p_dest) override;
+	GDVIRTUAL1(_store_32, uint32_t);
+	virtual void store_32(uint32_t p_dest) override;
+	GDVIRTUAL1(_store_64, uint64_t);
+	virtual void store_64(uint64_t p_dest) override;
+
+	GDVIRTUAL1(_store_float, float);
+	virtual void store_float(float p_dest) override;
+	GDVIRTUAL1(_store_double, double);
+	virtual void store_double(double p_dest) override;
+	GDVIRTUAL1(_store_real, real_t);
+	virtual void store_real(real_t p_real) override;
+
+	GDVIRTUAL1(_store_string, String);
+	virtual void store_string(const String &p_string) override;
+	GDVIRTUAL1(_store_line, String);
+	virtual void store_line(const String &p_line) override;
+	GDVIRTUAL2(_store_csv_line, Vector<String>, String);
+	virtual void store_csv_line(const Vector<String> &p_values, const String &p_delim = ",") override;
+
+	GDVIRTUAL1(_store_pascal_string, String);
+	virtual void store_pascal_string(const String &p_string) override;
+	GDVIRTUAL0RC(String, _get_pascal_string);
+	virtual String get_pascal_string() override;
+
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override;
+	GDVIRTUAL1(_store_buffer, Vector<uint8_t>);
+	void store_buffer(const Vector<uint8_t> &p_buffer);
+
+	GDVIRTUAL2(_store_var, Variant, bool);
+	void store_var(const Variant &p_var, bool p_full_objects = false);
+
+	GDVIRTUAL0(_close);
+	virtual void close() override;
+
+	GDVIRTUAL1R(bool, _file_exists, String);
+	virtual bool file_exists(const String &p_name) override;
+
+	GDVIRTUAL2R(Error, _reopen, String, int);
+	virtual Error reopen(const String &p_path, int p_mode_flags) override;
 
 	FileAccessExtension();
 	~FileAccessExtension();

--- a/core/io/file_access_extension.h
+++ b/core/io/file_access_extension.h
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  file_access_extension.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef FILE_ACCESS_EXTENSION_H
+#define FILE_ACCESS_EXTENSION_H
+
+#include "core/io/file_access.h"
+#include "core/object/gdvirtual.gen.inc"
+#include "core/object/object.h"
+
+class FileAccessExtension : public FileAccess {
+	GDCLASS(FileAccessExtension, FileAccess);
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDVIRTUAL0RC(bool, _is_open);
+	virtual bool is_open() const override;
+
+	GDVIRTUAL0RC(String, _get_path);
+	virtual String get_path() const override;
+	GDVIRTUAL0RC(String, _get_path_absolute);
+	virtual String get_path_absolute() const override;
+
+	GDVIRTUAL1(_seek, uint64_t);
+	virtual void seek(uint64_t p_position) override;
+	GDVIRTUAL1(_seek_end, int64_t);
+	virtual void seek_end(int64_t p_position) override;
+	GDVIRTUAL0RC(uint64_t, _get_position);
+	virtual uint64_t get_position() const override;
+	GDVIRTUAL0RC(uint64_t, _get_length);
+	virtual uint64_t get_length() const override;
+
+	GDVIRTUAL0RC(bool, _eof_reached);
+	virtual bool eof_reached() const override;
+
+	GDVIRTUAL0RC(uint8_t, _get_8);
+	virtual uint8_t get_8() const override;
+	GDVIRTUAL0RC(uint16_t, _get_16);
+	virtual uint16_t get_16() const override;
+	GDVIRTUAL0RC(uint32_t, _get_32);
+	virtual uint32_t get_32() const override;
+	GDVIRTUAL0RC(uint64_t, _get_64);
+	virtual uint64_t get_64() const override;
+
+	GDVIRTUAL0RC(float, _get_float);
+	virtual float get_float() const override;
+	GDVIRTUAL0RC(double, _get_double);
+	virtual double get_double() const override;
+	GDVIRTUAL0RC(real_t, _get_real);
+	virtual real_t get_real() const override;
+
+	GDVIRTUAL1RC(Variant, _get_var, bool);
+	Variant get_var(bool p_allow_objects = false) const;
+
+	GDVIRTUAL1RC(Vector<uint8_t>, _get_buffer, int64_t);
+	Vector<uint8_t> get_buffer(int64_t p_length) const;
+	GDVIRTUAL0RC(String, _get_line);
+	virtual String get_line() const override;
+	GDVIRTUAL0RC(String, _get_token);
+	virtual String get_token() const override;
+	GDVIRTUAL1RC(Vector<String>, _get_csv_line, String);
+	virtual Vector<String> get_csv_line(const String &p_delim = ",") const override;
+	GDVIRTUAL1RC(String, _get_as_text, bool);
+	String get_as_text(bool p_skip_cr = false) const;
+	GDVIRTUAL1RC(String, _get_as_utf8_string, bool);
+	virtual String get_as_utf8_string(bool p_skip_cr = false) const override;
+
+	FileAccessExtension();
+	~FileAccessExtension();
+};
+
+#endif // FILE_ACCESS_EXTENSION_H

--- a/core/io/file_access_extension.h
+++ b/core/io/file_access_extension.h
@@ -81,6 +81,7 @@ public:
 	GDVIRTUAL1RC(Variant, _get_var, bool);
 	Variant get_var(bool p_allow_objects = false) const;
 
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 	GDVIRTUAL1RC(Vector<uint8_t>, _get_buffer, int64_t);
 	Vector<uint8_t> get_buffer(int64_t p_length) const;
 	GDVIRTUAL0RC(String, _get_line);

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -46,6 +46,8 @@
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/dtls_server.h"
+#include "core/io/file_access.h"
+#include "core/io/file_access_extension.h"
 #include "core/io/http_client.h"
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
@@ -242,6 +244,7 @@ void register_core_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
 	GDREGISTER_ABSTRACT_CLASS(DirAccess);
+	GDREGISTER_ABSTRACT_CLASS(FileAccessExtension);
 	GDREGISTER_CLASS(core_bind::Thread);
 	GDREGISTER_CLASS(core_bind::Mutex);
 	GDREGISTER_CLASS(core_bind::Semaphore);

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -45,6 +45,7 @@
 #include "core/input/shortcut.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
+#include "core/io/dir_access_extension.h"
 #include "core/io/dtls_server.h"
 #include "core/io/file_access.h"
 #include "core/io/file_access_extension.h"
@@ -243,8 +244,9 @@ void register_core_types() {
 	GDREGISTER_CLASS(ResourceFormatSaver);
 
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
-	GDREGISTER_ABSTRACT_CLASS(DirAccess);
 	GDREGISTER_VIRTUAL_CLASS(FileAccessExtension);
+	GDREGISTER_ABSTRACT_CLASS(DirAccess);
+	GDREGISTER_VIRTUAL_CLASS(DirAccessExtension);
 	GDREGISTER_CLASS(core_bind::Thread);
 	GDREGISTER_CLASS(core_bind::Mutex);
 	GDREGISTER_CLASS(core_bind::Semaphore);

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -244,7 +244,7 @@ void register_core_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
 	GDREGISTER_ABSTRACT_CLASS(DirAccess);
-	GDREGISTER_ABSTRACT_CLASS(FileAccessExtension);
+	GDREGISTER_VIRTUAL_CLASS(FileAccessExtension);
 	GDREGISTER_CLASS(core_bind::Thread);
 	GDREGISTER_CLASS(core_bind::Mutex);
 	GDREGISTER_CLASS(core_bind::Semaphore);

--- a/doc/classes/DirAccessExtension.xml
+++ b/doc/classes/DirAccessExtension.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DirAccessExtension" inherits="DirAccess" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_change_dir" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="dir" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_copy" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="from" type="String" />
+			<param index="1" name="to" type="String" />
+			<param index="2" name="chmod_flags" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_create_link" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="source" type="String" />
+			<param index="1" name="target" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_current_is_dir" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_current_is_hidden" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_dir_exists" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="dir" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_drives_are_shortcuts" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_erase_contents_recursive" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<description>
+			</description>
+		</method>
+		<method name="_file_exists" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_fix_path" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_current_dir" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="include_drive" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_current_drive" qualifiers="virtual">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_drive" qualifiers="virtual">
+			<return type="String" />
+			<param index="0" name="drive" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_drive_count" qualifiers="virtual">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_filesystem_type" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_next" qualifiers="virtual">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_space_left" qualifiers="virtual">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_case_sensitive" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_link" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_readable" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="dir" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_writable" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="dir" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_list_dir_begin" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<description>
+			</description>
+		</method>
+		<method name="_list_dir_end" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_make_dir" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="dir" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_make_dir_recursive" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="dir" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_read_link" qualifiers="virtual">
+			<return type="String" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_remove" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="name" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_rename" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="from" type="String" />
+			<param index="1" name="to" type="String" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -43,13 +43,6 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<methods>
-		<method name="add_resource_path" qualifiers="static">
-			<return type="void" />
-			<param index="0" name="protocol" type="String" />
-			<param index="1" name="path" type="String" />
-			<description>
-			</description>
-		</method>
 		<method name="close">
 			<return type="void" />
 			<description>
@@ -144,6 +137,17 @@
 				Alice,"I thought you'd reply with ""Hello, world""."
 				[/codeblock]
 				Note how the second line can omit the enclosing quotes as it does not include the delimiter. However it [i]could[/i] very well use quotes, it was only written without for demonstration purposes. The third line must use [code]""[/code] for each quotation mark that needs to be interpreted as such instead of the end of a text value.
+			</description>
+		</method>
+		<method name="get_custom_path_data" qualifiers="static">
+			<return type="Dictionary" />
+			<param index="0" name="protocol" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="get_custom_paths" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
 			</description>
 		</method>
 		<method name="get_double" qualifiers="const">
@@ -260,17 +264,6 @@
 				Returns the next bits from the file as a floating-point number.
 			</description>
 		</method>
-		<method name="get_resource_path" qualifiers="static">
-			<return type="String" />
-			<param index="0" name="protocol" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="get_resource_paths" qualifiers="static">
-			<return type="Dictionary" />
-			<description>
-			</description>
-		</method>
 		<method name="get_sha256" qualifiers="static">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
@@ -295,15 +288,30 @@
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
+		<method name="is_custom_path" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="protocol" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="is_open" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the file is currently opened.
 			</description>
 		</method>
-		<method name="is_resource_path" qualifiers="static">
-			<return type="bool" />
+		<method name="map_classes_to_custom_path" qualifiers="static">
+			<return type="void" />
 			<param index="0" name="protocol" type="String" />
+			<param index="1" name="file_access_class" type="String" />
+			<param index="2" name="dir_access_class" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="map_path_to_custom_path" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="protocol" type="String" />
+			<param index="1" name="path" type="String" />
 			<description>
 			</description>
 		</method>
@@ -348,7 +356,7 @@
 				Returns [code]null[/code] if opening the file failed. You can use [method get_open_error] to check the error that occurred.
 			</description>
 		</method>
-		<method name="remove_resource_path" qualifiers="static">
+		<method name="remove_custom_path" qualifiers="static">
 			<return type="void" />
 			<param index="0" name="protocol" type="String" />
 			<description>

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -43,6 +43,13 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<methods>
+		<method name="add_resource_path" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="protocol" type="String" />
+			<param index="1" name="path" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="close">
 			<return type="void" />
 			<description>
@@ -253,6 +260,17 @@
 				Returns the next bits from the file as a floating-point number.
 			</description>
 		</method>
+		<method name="get_resource_path" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="protocol" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="get_resource_paths" qualifiers="static">
+			<return type="Dictionary" />
+			<description>
+			</description>
+		</method>
 		<method name="get_sha256" qualifiers="static">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
@@ -281,6 +299,12 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the file is currently opened.
+			</description>
+		</method>
+		<method name="is_resource_path" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="protocol" type="String" />
+			<description>
 			</description>
 		</method>
 		<method name="open" qualifiers="static">
@@ -322,6 +346,12 @@
 			<description>
 				Creates a new [FileAccess] object and opens an encrypted file in write or read mode. You need to pass a password to encrypt/decrypt it.
 				Returns [code]null[/code] if opening the file failed. You can use [method get_open_error] to check the error that occurred.
+			</description>
+		</method>
+		<method name="remove_resource_path" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="protocol" type="String" />
+			<description>
 			</description>
 		</method>
 		<method name="seek">

--- a/doc/classes/FileAccessExtension.xml
+++ b/doc/classes/FileAccessExtension.xml
@@ -7,9 +7,48 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="__get_hidden_attribute" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="__get_modified_time" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="__get_read_only_attribute" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="__get_unix_permissions" qualifiers="virtual">
+			<return type="int" enum="FileAccess.UnixPermissionFlags" is_bitfield="true" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="__set_hidden_attribute" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="file" type="String" />
+			<param index="1" name="hidden" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="__set_read_only_attribute" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="file" type="String" />
+			<param index="1" name="ro" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="__set_unix_permissions" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="file" type="String" />
+			<param index="1" name="permissions" type="int" enum="FileAccess.UnixPermissionFlags" is_bitfield="true" />
 			<description>
 			</description>
 		</method>
@@ -167,12 +206,6 @@
 		<method name="_seek_end" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="position" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="_set_big_endian" qualifiers="virtual">
-			<return type="void" />
-			<param index="0" name="big_endian" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/FileAccessExtension.xml
+++ b/doc/classes/FileAccessExtension.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="FileAccessExtension" inherits="FileAccess" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="__get_modified_time" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="file" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_close" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_eof_reached" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_file_exists" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="name" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_flush" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_8" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_16" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_32" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_64" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_as_text" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="skip_cr" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_as_utf8_string" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="skip_cr" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_buffer" qualifiers="virtual const">
+			<return type="PackedByteArray" />
+			<param index="0" name="length" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_csv_line" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<param index="0" name="delim" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_double" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_error" qualifiers="virtual const">
+			<return type="int" enum="Error" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_float" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_length" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_line" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_pascal_string" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_path" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_path_absolute" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_position" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_real" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_token" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_var" qualifiers="virtual const">
+			<return type="Variant" />
+			<param index="0" name="allow_objects" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_open" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_open_internal" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="mode_flags" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_reopen" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="mode_flags" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_seek" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="position" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_seek_end" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="position" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_big_endian" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="big_endian" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_8" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_16" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_32" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_64" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_buffer" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="buffer" type="PackedByteArray" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_csv_line" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="values" type="PackedStringArray" />
+			<param index="1" name="delim" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_double" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_float" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_line" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="line" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_pascal_string" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="string" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_real" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="dest" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_string" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="string" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_store_var" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="var" type="Variant" />
+			<param index="1" name="full_objects" type="bool" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7376,7 +7376,7 @@ EditorNode::EditorNode() {
 
 	// Register `editor://` custom resource path
 	String editor_path = OS::get_singleton()->get_data_path().path_join(OS::get_singleton()->get_godot_dir_name());
-	FileAccess::add_resource_path("editor", editor_path);
+	FileAccess::map_path_to_custom_path("editor", editor_path);
 	Ref<DirAccess> editor_dir = DirAccess::open(String("editor://"));
 	editor_dir->make_dir("addons");
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7373,6 +7373,12 @@ EditorNode::EditorNode() {
 	add_child(system_theme_timer);
 	system_theme_timer->set_owner(get_owner());
 	system_theme_timer->set_autostart(true);
+
+	// Register `editor://` custom resource path
+	String editor_path = OS::get_singleton()->get_data_path().path_join(OS::get_singleton()->get_godot_dir_name());
+	FileAccess::add_resource_path("editor", editor_path);
+	Ref<DirAccess> editor_dir = DirAccess::open(String("editor://"));
+	editor_dir->make_dir("addons");
 }
 
 EditorNode::~EditorNode() {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -865,6 +865,15 @@ Variant GDScript::callp(const StringName &p_method, const Variant **p_args, int 
 		top = top->_base;
 	}
 
+	if (native.is_valid()) {
+		Callable::CallError err;
+		Variant ret = native->callp(p_method, p_args, p_argcount, err);
+		if (err.error == Callable::CallError::CALL_OK) {
+			r_error = err;
+			return ret;
+		}
+	}
+
 	//none found, regular
 
 	return Script::callp(p_method, p_args, p_argcount, r_error);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -865,15 +865,6 @@ Variant GDScript::callp(const StringName &p_method, const Variant **p_args, int 
 		top = top->_base;
 	}
 
-	if (native.is_valid()) {
-		Callable::CallError err;
-		Variant ret = native->callp(p_method, p_args, p_argcount, err);
-		if (err.error == Callable::CallError::CALL_OK) {
-			r_error = err;
-			return ret;
-		}
-	}
-
 	//none found, regular
 
 	return Script::callp(p_method, p_args, p_argcount, r_error);


### PR DESCRIPTION
![Capture d’écran du 2024-01-25 09-45-02_2](https://github.com/godotengine/godot/assets/270928/2c2fc37c-b803-4898-b104-85ee9e4ba987)

# tl;dr
Enables custom resource paths that users can setup and use themselves.

```gdscript
# Maps a path to a custom path
FileAccess.map_path_to_custom_path("home", "/home/myself")
# (with or without the ://, it removes it automatically)
FileAccess.map_path_to_custom_path("home://", "/home/myself")
# Map classes (custom `FileAccess` and `DirAccess`) to custom path
FileAccess.map_classes_to_custom_path("cloud://", "CloudFileAccess", "CloudDirAccess")
# Removes a custom path
FileAccess.remove_custom_path("home")
# Checks if the prefix is supported
FileAccess.is_custom_path("home")
# Returns a dictionary containing the definition of the custom path
FileAccess.get_custom_path_data("home")
# Returns an array containing all the custom path prefixes
FileAccess.get_custom_paths()
```

# Todo
- [ ] Write the documentation

# Fixes
- Fix godotengine/godot-proposals#6307
- Closes godotengine/internal-team-priorities#92