### PR TITLE
Add transfer queue support to RenderingDevice and enable multithreaded resource loading

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -250,20 +250,11 @@ private:
 		uint8_t groups_count = 0;
 		static const D3D12_RESOURCE_STATES DELETED_GROUP = D3D12_RESOURCE_STATES(0xFFFFFFFFU);
 	};
-	PagedAllocator<HashMapElement<ResourceInfo::States *, BarrierRequest>> res_barriers_requests_allocator;
-	HashMap<ResourceInfo::States *, BarrierRequest, HashMapHasherDefault, HashMapComparatorDefault<ResourceInfo::States *>, decltype(res_barriers_requests_allocator)> res_barriers_requests;
 
-	LocalVector<D3D12_RESOURCE_BARRIER> res_barriers;
-	uint32_t res_barriers_count = 0;
-	uint32_t res_barriers_batch = 0;
-#ifdef DEV_ENABLED
-	int frame_barriers_count = 0;
-	int frame_barriers_batches_count = 0;
-	uint64_t frame_barriers_cpu_time = 0;
-#endif
+	struct CommandBufferInfo;
 
-	void _resource_transition_batch(ResourceInfo *p_resource, uint32_t p_subresource, uint32_t p_num_planes, D3D12_RESOURCE_STATES p_new_state);
-	void _resource_transitions_flush(ID3D12GraphicsCommandList *p_cmd_list);
+	void _resource_transition_batch(CommandBufferInfo *p_command_buffer, ResourceInfo *p_resource, uint32_t p_subresource, uint32_t p_num_planes, D3D12_RESOURCE_STATES p_new_state);
+	void _resource_transitions_flush(CommandBufferInfo *p_command_buffer);
 
 	/*****************/
 	/**** BUFFERS ****/
@@ -317,7 +308,6 @@ private:
 	UINT _compute_plane_slice(DataFormat p_format, BitField<TextureAspectBits> p_aspect_bits);
 	UINT _compute_plane_slice(DataFormat p_format, TextureAspect p_aspect);
 
-	struct CommandBufferInfo;
 	void _discard_texture_subresources(const TextureInfo *p_tex_info, const CommandBufferInfo *p_cmd_buf_info);
 
 public:
@@ -474,6 +464,10 @@ private:
 		};
 		LocalVector<FamilyFallbackCopy> family_fallback_copies;
 		uint32_t family_fallback_copy_count = 0;
+		HashMap<ResourceInfo::States *, BarrierRequest> res_barriers_requests;
+		LocalVector<D3D12_RESOURCE_BARRIER> res_barriers;
+		uint32_t res_barriers_count = 0;
+		uint32_t res_barriers_batch = 0;
 	};
 
 public:
@@ -1012,7 +1006,7 @@ private:
 			UniformSetInfo,
 			RenderPassInfo,
 			TimestampQueryPoolInfo>;
-	PagedAllocator<VersatileResource> resources_allocator;
+	PagedAllocator<VersatileResource, true> resources_allocator;
 
 	/******************/
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -637,7 +637,7 @@ private:
 			VertexFormatInfo,
 			ShaderInfo,
 			UniformSetInfo>;
-	PagedAllocator<VersatileResource> resources_allocator;
+	PagedAllocator<VersatileResource, true> resources_allocator;
 
 	/******************/
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -185,9 +185,8 @@ TextureStorage::TextureStorage() {
 				ptr[i] = Math::make_half_float(1.0f);
 			}
 
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(sv);
-			default_rd_textures[DEFAULT_RD_TEXTURE_DEPTH] = RD::get_singleton()->texture_create(tf, RD::TextureView(), vpv);
+			default_rd_textures[DEFAULT_RD_TEXTURE_DEPTH] = RD::get_singleton()->texture_create(tf, RD::TextureView());
+			RD::get_singleton()->texture_update(default_rd_textures[DEFAULT_RD_TEXTURE_DEPTH], 0, sv);
 		}
 
 		for (int i = 0; i < 16; i++) {
@@ -460,9 +459,8 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vsv;
-			vsv.push_back(sv);
-			default_rd_textures[DEFAULT_RD_TEXTURE_2D_ARRAY_DEPTH] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vsv);
+			default_rd_textures[DEFAULT_RD_TEXTURE_2D_ARRAY_DEPTH] = RD::get_singleton()->texture_create(tformat, RD::TextureView());
+			RD::get_singleton()->texture_update(default_rd_textures[DEFAULT_RD_TEXTURE_2D_ARRAY_DEPTH], 0, sv);
 		}
 	}
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -33,6 +33,7 @@
 
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/condition_variable.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
@@ -62,6 +63,10 @@ class RenderingDevice : public RenderingDeviceCommons {
 	GDCLASS(RenderingDevice, Object)
 
 	_THREAD_SAFE_CLASS_
+
+private:
+	Thread::ID render_thread_id;
+
 public:
 	enum ShaderLanguage {
 		SHADER_LANGUAGE_GLSL,
@@ -175,14 +180,16 @@ private:
 		uint32_t size = 0;
 		BitField<RDD::BufferUsageBits> usage;
 		RDG::ResourceTracker *draw_tracker = nullptr;
+		int32_t transfer_worker_index = -1;
+		uint64_t transfer_worker_operation = 0;
 	};
 
 	Buffer *_get_buffer_from_owner(RID p_buffer);
-	Error _buffer_update(Buffer *p_buffer, RID p_buffer_id, size_t p_offset, const uint8_t *p_data, size_t p_data_size, bool p_use_draw_queue = false, uint32_t p_required_align = 32);
+	Error _buffer_initialize(Buffer *p_buffer, const uint8_t *p_data, size_t p_data_size, uint32_t p_required_align = 32);
 
-	RID_Owner<Buffer> uniform_buffer_owner;
-	RID_Owner<Buffer> storage_buffer_owner;
-	RID_Owner<Buffer> texture_buffer_owner;
+	RID_Owner<Buffer, true> uniform_buffer_owner;
+	RID_Owner<Buffer, true> storage_buffer_owner;
+	RID_Owner<Buffer, true> texture_buffer_owner;
 
 public:
 	Error buffer_copy(RID p_src_buffer, RID p_dst_buffer, uint32_t p_src_offset, uint32_t p_dst_offset, uint32_t p_size);
@@ -235,6 +242,8 @@ public:
 
 		RDG::ResourceTracker *draw_tracker = nullptr;
 		HashMap<Rect2i, RDG::ResourceTracker *> slice_trackers;
+		int32_t transfer_worker_index = -1;
+		uint64_t transfer_worker_operation = 0;
 
 		RDD::TextureSubresourceRange barrier_range() const {
 			RDD::TextureSubresourceRange r;
@@ -247,11 +256,13 @@ public:
 		}
 	};
 
-	RID_Owner<Texture> texture_owner;
+	RID_Owner<Texture, true> texture_owner;
 	uint32_t texture_upload_region_size_px = 0;
 
 	Vector<uint8_t> _texture_get_data(Texture *tex, uint32_t p_layer, bool p_2d = false);
-	Error _texture_update(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data, bool p_use_setup_queue, bool p_validate_can_update);
+	uint32_t _texture_layer_count(Texture *p_texture) const;
+	uint32_t _texture_alignment(Texture *p_texture) const;
+	Error _texture_initialize(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data);
 
 public:
 	struct TextureView {
@@ -530,7 +541,7 @@ private:
 		uint32_t view_count;
 	};
 
-	RID_Owner<Framebuffer> framebuffer_owner;
+	RID_Owner<Framebuffer, true> framebuffer_owner;
 
 public:
 	// This ID is warranted to be unique for the same formats, does not need to be freed
@@ -551,7 +562,7 @@ public:
 	/**** SAMPLER ****/
 	/*****************/
 private:
-	RID_Owner<RDD::SamplerID> sampler_owner;
+	RID_Owner<RDD::SamplerID, true> sampler_owner;
 
 public:
 	RID sampler_create(const SamplerState &p_state);
@@ -573,7 +584,7 @@ private:
 	// This mapping is done here internally, and it's not
 	// exposed.
 
-	RID_Owner<Buffer> vertex_buffer_owner;
+	RID_Owner<Buffer, true> vertex_buffer_owner;
 
 	struct VertexDescriptionKey {
 		Vector<VertexAttribute> vertex_formats;
@@ -653,10 +664,12 @@ private:
 		Vector<RDD::BufferID> buffers; // Not owned, just referenced.
 		Vector<RDG::ResourceTracker *> draw_trackers; // Not owned, just referenced.
 		Vector<uint64_t> offsets;
+		Vector<int32_t> transfer_worker_indices;
+		Vector<uint64_t> transfer_worker_operations;
 		HashSet<RID> untracked_buffers;
 	};
 
-	RID_Owner<VertexArray> vertex_array_owner;
+	RID_Owner<VertexArray, true> vertex_array_owner;
 
 	struct IndexBuffer : public Buffer {
 		uint32_t max_index = 0; // Used for validation.
@@ -665,7 +678,7 @@ private:
 		bool supports_restart_indices = false;
 	};
 
-	RID_Owner<IndexBuffer> index_buffer_owner;
+	RID_Owner<IndexBuffer, true> index_buffer_owner;
 
 	struct IndexArray {
 		uint32_t max_index = 0; // Remember the maximum index here too, for validation.
@@ -675,9 +688,11 @@ private:
 		uint32_t indices = 0;
 		IndexBufferFormat format = INDEX_BUFFER_FORMAT_UINT16;
 		bool supports_restart_indices = false;
+		int32_t transfer_worker_index = -1;
+		uint64_t transfer_worker_operation = 0;
 	};
 
-	RID_Owner<IndexArray> index_array_owner;
+	RID_Owner<IndexArray, true> index_array_owner;
 
 public:
 	RID vertex_buffer_create(uint32_t p_size_bytes, const Vector<uint8_t> &p_data = Vector<uint8_t>(), bool p_use_as_storage = false);
@@ -754,7 +769,7 @@ private:
 
 	String _shader_uniform_debug(RID p_shader, int p_set = -1);
 
-	RID_Owner<Shader> shader_owner;
+	RID_Owner<Shader, true> shader_owner;
 
 #ifndef DISABLE_DEPRECATED
 public:
@@ -922,7 +937,7 @@ private:
 		void *invalidated_callback_userdata = nullptr;
 	};
 
-	RID_Owner<UniformSet> uniform_set_owner;
+	RID_Owner<UniformSet, true> uniform_set_owner;
 
 public:
 	RID uniform_set_create(const Vector<Uniform> &p_uniforms, RID p_shader, uint32_t p_shader_set);
@@ -967,7 +982,7 @@ private:
 		uint32_t push_constant_size = 0;
 	};
 
-	RID_Owner<RenderPipeline> render_pipeline_owner;
+	RID_Owner<RenderPipeline, true> render_pipeline_owner;
 
 	bool pipeline_cache_enabled = false;
 	size_t pipeline_cache_size = 0;
@@ -988,7 +1003,7 @@ private:
 		uint32_t local_group_size[3] = { 0, 0, 0 };
 	};
 
-	RID_Owner<ComputePipeline> compute_pipeline_owner;
+	RID_Owner<ComputePipeline, true> compute_pipeline_owner;
 
 public:
 	RID render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const PipelineRasterizationState &p_rasterization_state, const PipelineMultisampleState &p_multisample_state, const PipelineDepthStencilState &p_depth_stencil_state, const PipelineColorBlendState &p_blend_state, BitField<PipelineDynamicStateFlags> p_dynamic_state_flags = 0, uint32_t p_for_render_pass = 0, const Vector<PipelineSpecializationConstant> &p_specialization_constants = Vector<PipelineSpecializationConstant>());
@@ -1095,8 +1110,6 @@ private:
 	void _draw_list_insert_clear_region(DrawList *p_draw_list, Framebuffer *p_framebuffer, Point2i p_viewport_offset, Point2i p_viewport_size, bool p_clear_color, const Vector<Color> &p_clear_colors, bool p_clear_depth, float p_depth, uint32_t p_stencil);
 	Error _draw_list_setup_framebuffer(Framebuffer *p_framebuffer, InitialAction p_initial_color_action, FinalAction p_final_color_action, InitialAction p_initial_depth_action, FinalAction p_final_depth_action, RDD::FramebufferID *r_framebuffer, RDD::RenderPassID *r_render_pass, uint32_t *r_subpass_count);
 	Error _draw_list_render_pass_begin(Framebuffer *p_framebuffer, InitialAction p_initial_color_action, FinalAction p_final_color_action, InitialAction p_initial_depth_action, FinalAction p_final_depth_action, const Vector<Color> &p_clear_colors, float p_clear_depth, uint32_t p_clear_stencil, Point2i p_viewport_offset, Point2i p_viewport_size, RDD::FramebufferID p_framebuffer_driver_id, RDD::RenderPassID p_render_pass);
-	void _draw_list_set_viewport(Rect2i p_rect);
-	void _draw_list_set_scissor(Rect2i p_rect);
 	_FORCE_INLINE_ DrawList *_get_draw_list_ptr(DrawListID p_id);
 	Error _draw_list_allocate(const Rect2i &p_viewport, uint32_t p_subpass);
 	void _draw_list_free(Rect2i *r_last_viewport = nullptr);
@@ -1181,6 +1194,50 @@ public:
 	void compute_list_end();
 
 private:
+	/*************************/
+	/**** TRANSFER WORKER ****/
+	/*************************/
+
+	struct TransferWorker {
+		uint32_t index = 0;
+		RDD::BufferID staging_buffer;
+		uint32_t max_transfer_size = 0;
+		uint32_t staging_buffer_size_in_use = 0;
+		uint32_t staging_buffer_size_allocated = 0;
+		RDD::CommandBufferID command_buffer;
+		RDD::CommandPoolID command_pool;
+		RDD::FenceID command_fence;
+		RDD::SemaphoreID command_semaphore;
+		bool recording = false;
+		bool submitted = false;
+		BinaryMutex thread_mutex;
+		uint64_t operations_processed = 0;
+		uint64_t operations_submitted = 0;
+		uint64_t operations_counter = 0;
+		BinaryMutex operations_mutex;
+	};
+
+	LocalVector<TransferWorker *> transfer_worker_pool;
+	uint32_t transfer_worker_pool_max_size = 1;
+	LocalVector<uint64_t> transfer_worker_operation_used_by_draw;
+	LocalVector<uint32_t> transfer_worker_pool_available_list;
+	BinaryMutex transfer_worker_pool_mutex;
+	ConditionVariable transfer_worker_pool_condition;
+
+	TransferWorker *_acquire_transfer_worker(uint32_t p_transfer_size, uint32_t p_required_align, uint32_t &r_staging_offset);
+	void _release_transfer_worker(TransferWorker *p_transfer_worker);
+	void _end_transfer_worker(TransferWorker *p_transfer_worker);
+	void _submit_transfer_worker(TransferWorker *p_transfer_worker, bool p_signal_semaphore);
+	void _wait_for_transfer_worker(TransferWorker *p_transfer_worker);
+	void _check_transfer_worker_operation(uint32_t p_transfer_worker_index, uint64_t p_transfer_worker_operation);
+	void _check_transfer_worker_buffer(Buffer *p_buffer);
+	void _check_transfer_worker_texture(Texture *p_texture);
+	void _check_transfer_worker_vertex_array(VertexArray *p_vertex_array);
+	void _check_transfer_worker_index_array(IndexArray *p_index_array);
+	void _submit_transfer_workers(bool p_operations_used_by_draw);
+	void _wait_for_transfer_workers();
+	void _free_transfer_workers();
+
 	/***********************/
 	/**** COMMAND GRAPH ****/
 	/***********************/
@@ -1191,6 +1248,7 @@ private:
 	bool _index_array_make_mutable(IndexArray *p_index_array, RDG::ResourceTracker *p_resource_tracker);
 	bool _uniform_set_make_mutable(UniformSet *p_uniform_set, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker);
 	bool _dependency_make_mutable(RID p_id, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker);
+	bool _dependencies_make_mutable_recursive(RID p_id, RDG::ResourceTracker *p_resource_tracker);
 	bool _dependencies_make_mutable(RID p_id, RDG::ResourceTracker *p_resource_tracker);
 
 	RenderingDeviceGraph draw_graph;
@@ -1200,8 +1258,10 @@ private:
 	/**************************/
 
 	RDD::CommandQueueFamilyID main_queue_family;
+	RDD::CommandQueueFamilyID transfer_queue_family;
 	RDD::CommandQueueFamilyID present_queue_family;
 	RDD::CommandQueueID main_queue;
+	RDD::CommandQueueID transfer_queue;
 	RDD::CommandQueueID present_queue;
 
 	/**************************/
@@ -1233,28 +1293,21 @@ private:
 		List<RenderPipeline> render_pipelines_to_dispose_of;
 		List<ComputePipeline> compute_pipelines_to_dispose_of;
 
+		// The command pool used by the command buffer.
 		RDD::CommandPoolID command_pool;
 
-		// Used at the beginning of every frame for set-up.
-		// Used for filling up newly created buffers with data provided on creation.
-		// Primarily intended to be accessed by worker threads.
-		// Ideally this command buffer should use an async transfer queue.
-		RDD::CommandBufferID setup_command_buffer;
+		// The command buffer used by the main thread when recording the frame.
+		RDD::CommandBufferID command_buffer;
 
-		// The main command buffer for drawing and compute.
-		// Primarily intended to be used by the main thread to do most stuff.
-		RDD::CommandBufferID draw_command_buffer;
+		// Signaled by the command buffer submission. Present must wait on this semaphore.
+		RDD::SemaphoreID semaphore;
 
-		// Signaled by the setup submission. Draw must wait on this semaphore.
-		RDD::SemaphoreID setup_semaphore;
+		// Signaled by the command buffer submission. Must wait on this fence before beginning command recording for the frame.
+		RDD::FenceID fence;
+		bool fence_signaled = false;
 
-		// Signaled by the draw submission. Present must wait on this semaphore.
-		RDD::SemaphoreID draw_semaphore;
-
-		// Signaled by the draw submission. Must wait on this fence before beginning
-		// command recording for the frame.
-		RDD::FenceID draw_fence;
-		bool draw_fence_signaled = false;
+		// Semaphores the frame must wait on before executing the command buffer.
+		LocalVector<RDD::SemaphoreID> semaphores_to_wait_on;
 
 		// Swap chains prepared for drawing during the frame that must be presented.
 		LocalVector<RDD::SwapChainID> swap_chains_to_present;

--- a/servers/rendering/rendering_device_commons.cpp
+++ b/servers/rendering/rendering_device_commons.cpp
@@ -600,7 +600,7 @@ void RenderingDeviceCommons::get_compressed_image_format_block_dimensions(DataFo
 	}
 }
 
-uint32_t RenderingDeviceCommons::get_compressed_image_format_block_byte_size(DataFormat p_format) {
+uint32_t RenderingDeviceCommons::get_compressed_image_format_block_byte_size(DataFormat p_format) const {
 	switch (p_format) {
 		case DATA_FORMAT_BC1_RGB_UNORM_BLOCK:
 		case DATA_FORMAT_BC1_RGB_SRGB_BLOCK:

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -853,7 +853,7 @@ protected:
 
 	static uint32_t get_image_format_pixel_size(DataFormat p_format);
 	static void get_compressed_image_format_block_dimensions(DataFormat p_format, uint32_t &r_w, uint32_t &r_h);
-	uint32_t get_compressed_image_format_block_byte_size(DataFormat p_format);
+	uint32_t get_compressed_image_format_block_byte_size(DataFormat p_format) const;
 	static uint32_t get_compressed_image_format_pixel_rshift(DataFormat p_format);
 	static uint32_t get_image_format_required_size(DataFormat p_format, uint32_t p_width, uint32_t p_height, uint32_t p_depth, uint32_t p_mipmaps, uint32_t *r_blockw = nullptr, uint32_t *r_blockh = nullptr, uint32_t *r_depth = nullptr);
 	static uint32_t get_image_required_mipmaps(uint32_t p_width, uint32_t p_height, uint32_t p_depth);

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -104,14 +104,14 @@ struct VersatileResourceTemplate {
 	uint8_t data[MAX_RESOURCE_SIZE];
 
 	template <typename T>
-	static T *allocate(PagedAllocator<VersatileResourceTemplate> &p_allocator) {
+	static T *allocate(PagedAllocator<VersatileResourceTemplate, true> &p_allocator) {
 		T *obj = (T *)p_allocator.alloc();
 		memnew_placement(obj, T);
 		return obj;
 	}
 
 	template <typename T>
-	static void free(PagedAllocator<VersatileResourceTemplate> &p_allocator, T *p_object) {
+	static void free(PagedAllocator<VersatileResourceTemplate, true> &p_allocator, T *p_object) {
 		p_object->~T();
 		p_allocator.free((VersatileResourceTemplate *)p_object);
 	}


### PR DESCRIPTION
A few major bottlenecks were identified in Godot that this PR addresses.
- Access to RenderingDevice is pretty much entirely blocked using a single thread safety mutex. This means that any thread that wishes to create buffers or textures from different threads needs to wait for the others or even the main thread to free its access.
- When Vsync is enabled, waiting is performed while inside the mutex itself, so any arbitrary waiting caused by the presentation rate of the screen potentially stalls all efforts of loading resources in background threads. This can result in major increases in loading times in most games that choose to draw a loading screen and have Vsync enabled.
- While the hardware provides dedicated queues for transfer operations that are much faster for the process and can be run independently from the main application loop, Godot chooses to use the same staging buffer logic that it uses for resources uploading during each frame that it uses for resources uploaded from background threads.

The PR solves all these bottlenecks and also simplifies the separate setup command buffer logic that was in place in RenderingDevice. RenderingDevice is now able to create "Transfer Workers" on the fly that can use their own staging buffer and command buffer to record the upload of all resources queued by the thread. Once it reaches a certain saturation point, it'll submit all the work to the dedicated transfer queue. The main loop will wait if necessary for these transfer workers if it's been determined that one of the resources that was uploaded with a transfer worker was used in the frame. This design allows to effectively upload resources in the background without stalling the main thread at all until the resource needs to be used.

The PR also changes the flexibility of the thread safety of RenderingDevice: whatever is allowed to be called from different threads is now allowed with no mutex involved, and whatever is not allowed now has a thread guard in place instead. A thread guard is a much cheaper option than a mutex and it also verifies that RenderingDevice is being used with its intended behavior: drawing from the main loop and not from other threads that could potentially cause issues. This was mostly done following @reduz's advice as noted [here](https://gist.github.com/reduz/950a9c9dd2878e56cd545d790b3f6a9b).

So far we lack a public project that allows to showcase loading a large amount of resources, but one of W4's internal projects that uses a large amount of textures and meshes had some good results:
- `master` with Vsync enabled (60 HZ Monitor): ~25 seconds
- `master` with Vsync disabled: ~2.5 seconds (10x faster!)
- `transfer_queues` with both Vsync enabled and disabled: ~2.1 seconds

We can see one of the major benefits of this approach is that it makes the behavior much more consistent regardless of the user's vsync settings and refresh rate.

Projects with lots of resources that rely on background resource loading during loading screens or even during gameplay are the ideal candidates for testing out this PR.

TODO:
- [ ] Decide on how to configure the max amount of transfer workers (right now it is just derived from the CPU count since it matches the logic of WorkerThreadPool).
- [x] Experiment with taking out the thread-safety of RID Owner by adding the logic from @reduz's PR (https://github.com/godotengine/godot/pull/86333).