### PR TITLE
Add `Node._scene_instantiated()` method and `@oninstantiated` annotation

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -110,9 +110,18 @@
 			<return type="void" />
 			<description>
 				Called when the node is "ready", i.e. when both the node and its children have entered the scene tree. If the node has children, their [method _ready] callbacks get triggered first, and the parent node will receive the ready notification afterwards.
-				Corresponds to the [constant NOTIFICATION_READY] notification in [method Object._notification]. See also the [code]@onready[/code] annotation for variables.
-				Usually used for initialization. For even earlier initialization, [method Object._init] may be used. See also [method _enter_tree].
+				Corresponds to the [constant NOTIFICATION_READY] notification in [method Object._notification]. See also the [annotation @GDScript.@onready] annotation.
+				Usually used for initialization. For even earlier initialization, [method Object._init] may be used. See also [method _scene_instantiated] and [method _enter_tree].
 				[b]Note:[/b] This method may be called only once for each node. After removing a node from the scene tree and adding it again, [method _ready] will [b]not[/b] be called a second time. This can be bypassed by requesting another call with [method request_ready], which may be called anywhere before adding the node again.
+			</description>
+		</method>
+		<method name="_scene_instantiated" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called on the scene root node when the scene instantiation is complete, after all exported variables have been applied and all child nodes have been added.
+				Corresponds to the [constant NOTIFICATION_SCENE_INSTANTIATED] notification in [method Object._notification]. See also the [annotation @GDScript.@oninstantiated] annotation.
+				Can be used for early initialization if you need to access child nodes before the scene enters the tree.
+				[b]Note:[/b] This method is called only on the scene root node and only when the scene is instantiated via [method PackedScene.instantiate]. This method will [b]not[/b] be called if you create a node using [code]Node.new()[/code].
 			</description>
 		</method>
 		<method name="_shortcut_input" qualifiers="virtual">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -609,6 +609,9 @@
 		<member name="debug/gdscript/warnings/native_method_override" type="int" setter="" getter="" default="2">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when a method in the script overrides a native method, because it may not behave as expected.
 		</member>
+		<member name="debug/gdscript/warnings/oninstantiated_with_export" type="int" setter="" getter="" default="2">
+			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when the [code]@oninstantiated[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.
+		</member>
 		<member name="debug/gdscript/warnings/onready_with_export" type="int" setter="" getter="" default="2">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when the [code]@onready[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.
 		</member>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -775,6 +775,16 @@
 				[b]Note:[/b] Unlike most other annotations, the argument of the [annotation @icon] annotation must be a string literal (constant expressions are not supported).
 			</description>
 		</annotation>
+		<annotation name="@oninstantiated">
+			<return type="void" />
+			<description>
+				Mark the following property as assigned when the [Node] receives notification [constant Node.NOTIFICATION_SCENE_INSTANTIATED]. Values for these properties are not assigned immediately when the node is initialized ([method Object._init]), and instead are computed and stored right before [method Node._scene_instantiated].
+				[codeblock]
+				@oninstantiated var character_name: Label = $Label
+				[/codeblock]
+				[b]Note:[/b] This annotation should only be used with scene root node variables, since child nodes do not receive the [constant Node.NOTIFICATION_SCENE_INSTANTIATED] notification. See [method Node._scene_instantiated] for details.
+			</description>
+		</annotation>
 		<annotation name="@onready">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1464,6 +1464,11 @@ void GDScript::clear() {
 		implicit_initializer = nullptr;
 	}
 
+	if (implicit_scene_instantiated) {
+		functions_to_clear.insert(implicit_scene_instantiated);
+		implicit_scene_instantiated = nullptr;
+	}
+
 	if (implicit_ready) {
 		functions_to_clear.insert(implicit_ready);
 		implicit_ready = nullptr;
@@ -1901,6 +1906,17 @@ int GDScriptInstance::get_method_argument_count(const StringName &p_method, bool
 	return 0;
 }
 
+void GDScriptInstance::_call_implicit_scene_instantiated_recursively(GDScript *p_script) {
+	// Call base class first.
+	if (p_script->base.ptr()) {
+		_call_implicit_scene_instantiated_recursively(p_script->base.ptr());
+	}
+	if (likely(p_script->valid) && p_script->implicit_scene_instantiated) {
+		Callable::CallError err;
+		p_script->implicit_scene_instantiated->call(this, nullptr, 0, err);
+	}
+}
+
 void GDScriptInstance::_call_implicit_ready_recursively(GDScript *p_script) {
 	// Call base class first.
 	if (p_script->base.ptr()) {
@@ -1915,8 +1931,11 @@ void GDScriptInstance::_call_implicit_ready_recursively(GDScript *p_script) {
 Variant GDScriptInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	GDScript *sptr = script.ptr();
 	if (unlikely(p_method == SceneStringName(_ready))) {
-		// Call implicit ready first, including for the super classes recursively.
+		// Call `@implicit_ready()` first, including for the super classes recursively.
 		_call_implicit_ready_recursively(sptr);
+	} else if (unlikely(p_method == SceneStringName(_scene_instantiated))) {
+		// Call `@implicit_scene_instantiated()` first, including for the super classes recursively.
+		_call_implicit_scene_instantiated_recursively(sptr);
 	}
 	while (sptr) {
 		if (likely(sptr->valid)) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -163,11 +163,11 @@ private:
 	void _clear_doc();
 #endif
 
-	GDScriptFunction *initializer = nullptr; // Direct pointer to `new()`/`_init()` member function, faster to locate.
-
-	GDScriptFunction *implicit_initializer = nullptr; // `@implicit_new()` special function.
-	GDScriptFunction *implicit_ready = nullptr; // `@implicit_ready()` special function.
 	GDScriptFunction *static_initializer = nullptr; // `@static_initializer()` special function.
+	GDScriptFunction *initializer = nullptr; // Direct pointer to `new()`/`_init()` member function, faster to locate.
+	GDScriptFunction *implicit_initializer = nullptr; // `@implicit_new()` special function.
+	GDScriptFunction *implicit_scene_instantiated = nullptr; // `@implicit_scene_instantiated()` special function.
+	GDScriptFunction *implicit_ready = nullptr; // `@implicit_ready()` special function.
 
 	Error _static_init();
 	void _static_default_init(); // Initialize static variables with default values based on their types.
@@ -364,6 +364,7 @@ class GDScriptInstance : public ScriptInstance {
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
 
+	void _call_implicit_scene_instantiated_recursively(GDScript *p_script);
 	void _call_implicit_ready_recursively(GDScript *p_script);
 
 public:

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1064,13 +1064,22 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				static_context = previous_static_context;
 
 #ifdef DEBUG_ENABLED
-				if (member.variable->exported && member.variable->onready) {
-					parser->push_warning(member.variable, GDScriptWarning::ONREADY_WITH_EXPORT);
+				if (member.variable->exported) {
+					switch (member.variable->init_stage) {
+						case GDScriptParser::VariableNode::INIT_STAGE_NORMAL:
+							break; // OK.
+						case GDScriptParser::VariableNode::INIT_STAGE_ONINSTANTIATED:
+							parser->push_warning(member.variable, GDScriptWarning::ONINSTANTIATED_WITH_EXPORT);
+							break;
+						case GDScriptParser::VariableNode::INIT_STAGE_ONREADY:
+							parser->push_warning(member.variable, GDScriptWarning::ONREADY_WITH_EXPORT);
+							break;
+					}
 				}
 				if (member.variable->initializer) {
 					// Check if it is call to get_node() on self (using shorthand $ or not), so we can check if @onready is needed.
 					// This could be improved by traversing the expression fully and checking the presence of get_node at any level.
-					if (!member.variable->is_static && !member.variable->onready && member.variable->initializer && (member.variable->initializer->type == GDScriptParser::Node::GET_NODE || member.variable->initializer->type == GDScriptParser::Node::CALL || member.variable->initializer->type == GDScriptParser::Node::CAST)) {
+					if (!member.variable->is_static && member.variable->init_stage == GDScriptParser::VariableNode::INIT_STAGE_NORMAL && member.variable->initializer && (member.variable->initializer->type == GDScriptParser::Node::GET_NODE || member.variable->initializer->type == GDScriptParser::Node::CALL || member.variable->initializer->type == GDScriptParser::Node::CAST)) {
 						GDScriptParser::Node *expr = member.variable->initializer;
 						if (expr->type == GDScriptParser::Node::CAST) {
 							expr = static_cast<GDScriptParser::CastNode *>(expr)->operand;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1406,7 +1406,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 			}
 
-			GDScriptFunction *function = _parse_function(r_error, codegen.script, codegen.class_node, lambda->function, false, true);
+			GDScriptFunction *function = _parse_function(r_error, codegen.script, codegen.class_node, lambda->function, FUNC_TYPE_LAMBDA);
 			if (r_error) {
 				return GDScriptCodeGenerator::Address();
 			}
@@ -2284,7 +2284,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 	return OK;
 }
 
-GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready, bool p_for_lambda) {
+GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, FuncType p_func_type) {
 	r_error = OK;
 	CodeGen codegen;
 	codegen.generator = memnew(GDScriptByteCodeGenerator);
@@ -2301,22 +2301,28 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	return_type.kind = GDScriptDataType::BUILTIN;
 	return_type.builtin_type = Variant::NIL;
 
-	if (p_func) {
-		if (p_func->identifier) {
-			func_name = p_func->identifier->name;
-		} else {
-			func_name = "<anonymous lambda>";
-		}
-		is_abstract = p_func->is_abstract;
-		is_static = p_func->is_static;
-		rpc_config = p_func->rpc_config;
-		return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
-	} else {
-		if (p_for_ready) {
-			func_name = "@implicit_ready";
-		} else {
+	switch (p_func_type) {
+		case FUNC_TYPE_MEMBER:
+		case FUNC_TYPE_LAMBDA:
+			if (p_func->identifier) {
+				func_name = p_func->identifier->name;
+			} else {
+				func_name = "<anonymous lambda>";
+			}
+			is_abstract = p_func->is_abstract;
+			is_static = p_func->is_static;
+			rpc_config = p_func->rpc_config;
+			return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
+			break;
+		case FUNC_TYPE_IMPLICIT_INITIALIZER:
 			func_name = "@implicit_new";
-		}
+			break;
+		case FUNC_TYPE_IMPLICIT_SCENE_INSTANTIATED:
+			func_name = "@implicit_scene_instantiated";
+			break;
+		case FUNC_TYPE_IMPLICIT_READY:
+			func_name = "@implicit_ready";
+			break;
 	}
 
 	MethodInfo method_info;
@@ -2357,15 +2363,10 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		method_info.default_arguments.append_array(p_func->default_arg_values);
 	}
 
-	// Parse initializer if applies.
-	bool is_implicit_initializer = !p_for_ready && !p_func && !p_for_lambda;
-	bool is_initializer = p_func && !p_for_lambda && p_func->identifier->name == GDScriptLanguage::get_singleton()->strings._init;
-	bool is_implicit_ready = !p_func && p_for_ready;
-
-	if (!p_for_lambda && is_implicit_initializer) {
+	if (p_func_type == FUNC_TYPE_IMPLICIT_INITIALIZER) {
 		// Initialize the default values for typed variables before anything.
 		// This avoids crashes if they are accessed with validated calls before being properly initialized.
-		// It may happen with out-of-order access or with `@onready` variables.
+		// It may happen with out-of-order access or with `@onready` and `@oninstantiated` variables.
 		for (const GDScriptParser::ClassNode::Member &member : p_class->members) {
 			if (member.type != GDScriptParser::ClassNode::Member::VARIABLE) {
 				continue;
@@ -2395,7 +2396,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		}
 	}
 
-	if (!p_for_lambda && (is_implicit_initializer || is_implicit_ready)) {
+	if (p_func_type == FUNC_TYPE_IMPLICIT_INITIALIZER || p_func_type == FUNC_TYPE_IMPLICIT_SCENE_INSTANTIATED || p_func_type == FUNC_TYPE_IMPLICIT_READY) {
 		// Initialize class fields.
 		for (int i = 0; i < p_class->members.size(); i++) {
 			if (p_class->members[i].type != GDScriptParser::ClassNode::Member::VARIABLE) {
@@ -2406,8 +2407,19 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 				continue;
 			}
 
-			if (field->onready != is_implicit_ready) {
-				// Only initialize in `@implicit_ready()`.
+			FuncType expected_func_type = FUNC_TYPE_IMPLICIT_INITIALIZER;
+			switch (field->init_stage) {
+				case GDScriptParser::VariableNode::INIT_STAGE_NORMAL:
+					break; // Nothing to do.
+				case GDScriptParser::VariableNode::INIT_STAGE_ONINSTANTIATED:
+					expected_func_type = FUNC_TYPE_IMPLICIT_SCENE_INSTANTIATED;
+					break;
+				case GDScriptParser::VariableNode::INIT_STAGE_ONREADY:
+					expected_func_type = FUNC_TYPE_IMPLICIT_READY;
+					break;
+			}
+
+			if (p_func_type != expected_func_type) {
 				continue;
 			}
 
@@ -2485,7 +2497,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			signature += "::" + String(func_name);
 		}
 
-		if (p_for_lambda) {
+		if (p_func_type == FUNC_TYPE_LAMBDA) {
 			signature += "(lambda)";
 		}
 
@@ -2500,14 +2512,6 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	}
 
 	GDScriptFunction *gd_function = codegen.generator->write_end();
-
-	if (is_initializer) {
-		p_script->initializer = gd_function;
-	} else if (is_implicit_initializer) {
-		p_script->implicit_initializer = gd_function;
-	} else if (is_implicit_ready) {
-		p_script->implicit_ready = gd_function;
-	}
 
 	if (p_func) {
 		// If no `return` statement, then return type is `void`, not `Variant`.
@@ -2527,8 +2531,24 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 
 	gd_function->method_info = method_info;
 
-	if (!is_implicit_initializer && !is_implicit_ready && !p_for_lambda) {
-		p_script->member_functions[func_name] = gd_function;
+	switch (p_func_type) {
+		case FUNC_TYPE_MEMBER:
+			p_script->member_functions[func_name] = gd_function;
+			if (p_func && p_func->identifier->name == GDScriptLanguage::get_singleton()->strings._init) {
+				p_script->initializer = gd_function;
+			}
+			break;
+		case FUNC_TYPE_LAMBDA:
+			break; // Nothing to do.
+		case FUNC_TYPE_IMPLICIT_INITIALIZER:
+			p_script->implicit_initializer = gd_function;
+			break;
+		case FUNC_TYPE_IMPLICIT_SCENE_INSTANTIATED:
+			p_script->implicit_scene_instantiated = gd_function;
+			break;
+		case FUNC_TYPE_IMPLICIT_READY:
+			p_script->implicit_ready = gd_function;
+			break;
 	}
 
 	memdelete(codegen.generator);
@@ -2561,7 +2581,7 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 
 	// Initialize the default values for typed variables before anything.
 	// This avoids crashes if they are accessed with validated calls before being properly initialized.
-	// It may happen with out-of-order access or with `@onready` variables.
+	// It may happen with out-of-order access.
 	for (const GDScriptParser::ClassNode::Member &member : p_class->members) {
 		if (member.type != GDScriptParser::ClassNode::Member::VARIABLE) {
 			continue;
@@ -2680,7 +2700,7 @@ Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptP
 		function = p_variable->getter;
 	}
 
-	_parse_function(err, p_script, p_class, function);
+	_parse_function(err, p_script, p_class, function, FUNC_TYPE_MEMBER);
 
 	return err;
 }
@@ -2729,14 +2749,17 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	p_script->static_variables.clear();
 
+	if (p_script->static_initializer) {
+		memdelete(p_script->static_initializer);
+	}
 	if (p_script->implicit_initializer) {
 		memdelete(p_script->implicit_initializer);
 	}
+	if (p_script->implicit_scene_instantiated) {
+		memdelete(p_script->implicit_scene_instantiated);
+	}
 	if (p_script->implicit_ready) {
 		memdelete(p_script->implicit_ready);
-	}
-	if (p_script->static_initializer) {
-		memdelete(p_script->static_initializer);
 	}
 
 	p_script->member_functions.clear();
@@ -2744,10 +2767,11 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 	p_script->static_variables_indices.clear();
 	p_script->static_variables.clear();
 	p_script->_signals.clear();
+	p_script->static_initializer = nullptr;
 	p_script->initializer = nullptr;
 	p_script->implicit_initializer = nullptr;
+	p_script->implicit_scene_instantiated = nullptr;
 	p_script->implicit_ready = nullptr;
-	p_script->static_initializer = nullptr;
 	p_script->rpc_config.clear();
 	p_script->lambda_info.clear();
 
@@ -3020,7 +3044,7 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 		if (member.type == member.FUNCTION) {
 			const GDScriptParser::FunctionNode *function = member.function;
 			Error err = OK;
-			_parse_function(err, p_script, p_class, function);
+			_parse_function(err, p_script, p_class, function, FUNC_TYPE_MEMBER);
 			if (err) {
 				return err;
 			}
@@ -3046,7 +3070,16 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 	{
 		// Create `@implicit_new()` special function in any case.
 		Error err = OK;
-		_parse_function(err, p_script, p_class, nullptr);
+		_parse_function(err, p_script, p_class, nullptr, FUNC_TYPE_IMPLICIT_INITIALIZER);
+		if (err) {
+			return err;
+		}
+	}
+
+	if (p_class->oninstantiated_used) {
+		// Create an implicit_scene_instantiated constructor.
+		Error err = OK;
+		_parse_function(err, p_script, p_class, nullptr, FUNC_TYPE_IMPLICIT_SCENE_INSTANTIATED);
 		if (err) {
 			return err;
 		}
@@ -3055,7 +3088,7 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 	if (p_class->onready_used) {
 		// Create `@implicit_ready()` special function.
 		Error err = OK;
-		_parse_function(err, p_script, p_class, nullptr, true);
+		_parse_function(err, p_script, p_class, nullptr, FUNC_TYPE_IMPLICIT_READY);
 		if (err) {
 			return err;
 		}
@@ -3237,14 +3270,17 @@ Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lam
 GDScriptCompiler::ScriptLambdaInfo GDScriptCompiler::_get_script_lambda_replacement_info(GDScript *p_script) {
 	ScriptLambdaInfo info;
 
+	if (p_script->static_initializer) {
+		info.static_initializer_info = _get_function_lambda_replacement_info(p_script->static_initializer);
+	}
 	if (p_script->implicit_initializer) {
 		info.implicit_initializer_info = _get_function_lambda_replacement_info(p_script->implicit_initializer);
 	}
+	if (p_script->implicit_scene_instantiated) {
+		info.implicit_scene_instantiated_info = _get_function_lambda_replacement_info(p_script->implicit_scene_instantiated);
+	}
 	if (p_script->implicit_ready) {
 		info.implicit_ready_info = _get_function_lambda_replacement_info(p_script->implicit_ready);
-	}
-	if (p_script->static_initializer) {
-		info.static_initializer_info = _get_function_lambda_replacement_info(p_script->static_initializer);
 	}
 
 	for (const KeyValue<StringName, GDScriptFunction *> &E : p_script->member_functions) {
@@ -3299,9 +3335,10 @@ void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *
 }
 
 void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const ScriptLambdaInfo &p_old_info, const ScriptLambdaInfo *p_new_info) {
-	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_initializer_info, p_new_info != nullptr ? &p_new_info->implicit_initializer_info : nullptr);
-	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_ready_info, p_new_info != nullptr ? &p_new_info->implicit_ready_info : nullptr);
 	_get_function_ptr_replacements(r_replacements, p_old_info.static_initializer_info, p_new_info != nullptr ? &p_new_info->static_initializer_info : nullptr);
+	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_initializer_info, p_new_info != nullptr ? &p_new_info->implicit_initializer_info : nullptr);
+	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_scene_instantiated_info, p_new_info != nullptr ? &p_new_info->implicit_scene_instantiated_info : nullptr);
+	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_ready_info, p_new_info != nullptr ? &p_new_info->implicit_ready_info : nullptr);
 
 	for (const KeyValue<StringName, Vector<FunctionLambdaInfo>> &old_kv : p_old_info.member_function_infos) {
 		_get_function_ptr_replacements(r_replacements, old_kv.value, p_new_info != nullptr ? p_new_info->member_function_infos.getptr(old_kv.key) : nullptr);

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -43,6 +43,14 @@ class GDScriptCompiler {
 	HashSet<GDScript *> parsing_classes;
 	GDScript *main_script = nullptr;
 
+	enum FuncType {
+		FUNC_TYPE_MEMBER, // Methods and inline setters/getters.
+		FUNC_TYPE_LAMBDA,
+		FUNC_TYPE_IMPLICIT_INITIALIZER,
+		FUNC_TYPE_IMPLICIT_SCENE_INSTANTIATED,
+		FUNC_TYPE_IMPLICIT_READY,
+	};
+
 	struct FunctionLambdaInfo {
 		GDScriptFunction *function = nullptr;
 		GDScriptFunction *parent = nullptr;
@@ -63,9 +71,10 @@ class GDScriptCompiler {
 	};
 
 	struct ScriptLambdaInfo {
-		Vector<FunctionLambdaInfo> implicit_initializer_info;
-		Vector<FunctionLambdaInfo> implicit_ready_info;
 		Vector<FunctionLambdaInfo> static_initializer_info;
+		Vector<FunctionLambdaInfo> implicit_initializer_info;
+		Vector<FunctionLambdaInfo> implicit_scene_instantiated_info;
+		Vector<FunctionLambdaInfo> implicit_ready_info;
 		HashMap<StringName, Vector<FunctionLambdaInfo>> member_function_infos;
 		Vector<FunctionLambdaInfo> other_function_infos;
 		HashMap<StringName, ScriptLambdaInfo> subclass_info;
@@ -154,7 +163,7 @@ class GDScriptCompiler {
 	List<GDScriptCodeGenerator::Address> _add_block_locals(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block);
 	void _clear_block_locals(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_locals);
 	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_clear_locals = true);
-	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false);
+	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, FuncType p_func_type);
 	GDScriptFunction *_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
 	Error _prepare_compilation(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -151,7 +151,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
 		register_annotation(MethodInfo("@abstract"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::abstract_annotation);
-		// Onready annotation.
+		// Deferred initialization annotations.
+		register_annotation(MethodInfo("@oninstantiated"), AnnotationInfo::VARIABLE, &GDScriptParser::oninstantiated_annotation);
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
@@ -4524,6 +4525,35 @@ bool GDScriptParser::abstract_annotation(AnnotationNode *p_annotation, Node *p_t
 	ERR_FAIL_V_MSG(false, R"("@abstract" annotation can only be applied to classes and functions.)");
 }
 
+bool GDScriptParser::oninstantiated_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@oninstantiated" annotation can only be applied to class variables.)");
+
+	if (current_class && !ClassDB::is_parent_class(current_class->get_datatype().native_type, SNAME("Node"))) {
+		push_error(R"("@oninstantiated" can only be used in classes that inherit "Node".)", p_annotation);
+	}
+
+	VariableNode *variable = static_cast<VariableNode *>(p_target);
+	if (variable->is_static) {
+		push_error(R"("@oninstantiated" annotation cannot be applied to a static variable.)", p_annotation);
+		return false;
+	}
+
+	switch (variable->init_stage) {
+		case VariableNode::INIT_STAGE_NORMAL:
+			variable->init_stage = VariableNode::INIT_STAGE_ONINSTANTIATED;
+			current_class->oninstantiated_used = true;
+			return true;
+		case VariableNode::INIT_STAGE_ONINSTANTIATED:
+			push_error(R"("@oninstantiated" annotation can only be used once per variable.)", p_annotation);
+			return false;
+		case VariableNode::INIT_STAGE_ONREADY:
+			push_error(R"("@oninstantiated" annotation cannot be used with "@onready".)", p_annotation);
+			return false;
+	}
+
+	ERR_FAIL_V_MSG(false, "Init stage set outside the enum range.");
+}
+
 bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@onready" annotation can only be applied to class variables.)");
 
@@ -4537,13 +4567,21 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 		push_error(R"("@onready" annotation cannot be applied to a static variable.)", p_annotation);
 		return false;
 	}
-	if (variable->onready) {
-		push_error(R"("@onready" annotation can only be used once per variable.)", p_annotation);
-		return false;
+
+	switch (variable->init_stage) {
+		case VariableNode::INIT_STAGE_NORMAL:
+			variable->init_stage = VariableNode::INIT_STAGE_ONREADY;
+			current_class->onready_used = true;
+			return true;
+		case VariableNode::INIT_STAGE_ONINSTANTIATED:
+			push_error(R"("@onready" annotation cannot be used with "@oninstantiated".)", p_annotation);
+			return false;
+		case VariableNode::INIT_STAGE_ONREADY:
+			push_error(R"("@onready" annotation can only be used once per variable.)", p_annotation);
+			return false;
 	}
-	variable->onready = true;
-	current_class->onready_used = true;
-	return true;
+
+	ERR_FAIL_V_MSG(false, "Init stage set outside the enum range.");
 }
 
 static String _get_annotation_error_string(const StringName &p_annotation_name, const Vector<Variant::Type> &p_expected_types, const GDScriptParser::DataType &p_provided_type) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -751,6 +751,7 @@ public:
 		HashMap<StringName, int> members_indices;
 		ClassNode *outer = nullptr;
 		bool extends_used = false;
+		bool oninstantiated_used = false;
 		bool onready_used = false;
 		bool is_abstract = false;
 		bool has_static_data = false;
@@ -1255,6 +1256,12 @@ public:
 			PROP_SETGET,
 		};
 
+		enum InitStage {
+			INIT_STAGE_NORMAL,
+			INIT_STAGE_ONINSTANTIATED,
+			INIT_STAGE_ONREADY,
+		};
+
 		PropertyStyle property = PROP_NONE;
 		union {
 			FunctionNode *setter = nullptr;
@@ -1266,8 +1273,8 @@ public:
 			IdentifierNode *getter_pointer;
 		};
 
+		InitStage init_stage = INIT_STAGE_NORMAL;
 		bool exported = false;
-		bool onready = false;
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
@@ -1557,6 +1564,7 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool oninstantiated_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -163,6 +163,8 @@ String GDScriptWarning::get_message() const {
 		case GET_NODE_DEFAULT_WITHOUT_ONREADY:
 			CHECK_SYMBOLS(1);
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
+		case ONINSTANTIATED_WITH_EXPORT:
+			return R"("@oninstantiated" will set the default value after "@export" takes effect and will override it.)";
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
 #ifndef DISABLE_DEPRECATED
@@ -241,6 +243,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("INFERENCE_ON_VARIANT"),
 		PNAME("NATIVE_METHOD_OVERRIDE"),
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
+		PNAME("ONINSTANTIATED_WITH_EXPORT"),
 		PNAME("ONREADY_WITH_EXPORT"),
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -90,6 +90,7 @@ public:
 		INFERENCE_ON_VARIANT, // The declaration uses type inference but the value is typed as Variant.
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
+		ONINSTANTIATED_WITH_EXPORT, // The `@oninstantiated` annotation will set the value after `@export` which is likely not intended.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
@@ -148,6 +149,7 @@ public:
 		ERROR, // INFERENCE_ON_VARIANT // Most likely done by accident, usually inference is trying for a particular type.
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
+		ERROR, // ONINSTANTIATED_WITH_EXPORT // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/features/allow_get_node_with_oninstantiated.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/allow_get_node_with_oninstantiated.gd
@@ -1,0 +1,18 @@
+extends Node
+
+@oninstantiated var shorthand = $Node
+@oninstantiated var call_no_cast = get_node(^"Node")
+@oninstantiated var shorthand_with_cast = $Node as Node
+@oninstantiated var call_with_cast = get_node(^"Node") as Node
+
+func _init():
+	var node := Node.new()
+	node.name = "Node"
+	add_child(node)
+
+func test():
+	# Those are expected to be `null` since `_scene_instantiated()` is never called on tests.
+	prints("shorthand", shorthand)
+	prints("call_no_cast", call_no_cast)
+	prints("shorthand_with_cast", shorthand_with_cast)
+	prints("call_with_cast", call_with_cast)

--- a/modules/gdscript/tests/scripts/analyzer/features/allow_get_node_with_oninstantiated.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/allow_get_node_with_oninstantiated.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+shorthand <null>
+call_no_cast <null>
+shorthand_with_cast <null>
+call_with_cast <null>

--- a/modules/gdscript/tests/scripts/analyzer/warnings/oninstantiated_with_export.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/oninstantiated_with_export.gd
@@ -1,0 +1,6 @@
+extends Node
+
+@oninstantiated @export var node: Node
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/oninstantiated_with_export.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/oninstantiated_with_export.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+~~ WARNING at line 3: (ONINSTANTIATED_WITH_EXPORT) "@oninstantiated" will set the default value after "@export" takes effect and will override it.

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_oninstantiated_usage.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_oninstantiated_usage.gd
@@ -1,0 +1,11 @@
+class CustomRefCounted extends RefCounted:
+	@oninstantiated var wrong_base_class
+
+class CustomNode extends Node:
+	@oninstantiated static var oninstantiated_static
+	@oninstantiated @oninstantiated var duplicate_oninstantiated
+	@onready @oninstantiated var onready_oninstantiated
+	@oninstantiated @onready var oninstantiated_onready
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_oninstantiated_usage.out
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_oninstantiated_usage.out
@@ -1,0 +1,6 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 2: "@oninstantiated" can only be used in classes that inherit "Node".
+>> ERROR at line 5: "@oninstantiated" annotation cannot be applied to a static variable.
+>> ERROR at line 6: "@oninstantiated" annotation can only be used once per variable.
+>> ERROR at line 7: "@oninstantiated" annotation cannot be used with "@onready".
+>> ERROR at line 8: "@onready" annotation cannot be used with "@oninstantiated".

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -281,6 +281,10 @@ void Node::_notification(int p_notification) {
 			GDVIRTUAL_CALL(_ready);
 		} break;
 
+		case NOTIFICATION_SCENE_INSTANTIATED: {
+			GDVIRTUAL_CALL(_scene_instantiated);
+		} break;
+
 		case NOTIFICATION_PREDELETE: {
 			if (data.tree && !Thread::is_main_thread()) {
 				cancel_free();
@@ -4058,6 +4062,7 @@ void Node::_bind_methods() {
 	GDVIRTUAL_BIND(_enter_tree);
 	GDVIRTUAL_BIND(_exit_tree);
 	GDVIRTUAL_BIND(_ready);
+	GDVIRTUAL_BIND(_scene_instantiated);
 	GDVIRTUAL_BIND(_get_configuration_warnings);
 	GDVIRTUAL_BIND(_get_accessibility_configuration_warnings);
 	GDVIRTUAL_BIND(_input, "event");

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -431,6 +431,7 @@ protected:
 	GDVIRTUAL0(_enter_tree)
 	GDVIRTUAL0(_exit_tree)
 	GDVIRTUAL0(_ready)
+	GDVIRTUAL0(_scene_instantiated)
 	GDVIRTUAL0RC(Vector<String>, _get_accessibility_configuration_warnings)
 	GDVIRTUAL0RC(Vector<String>, _get_configuration_warnings)
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -59,6 +59,7 @@ public:
 	const StringName tree_exited = "tree_exited";
 	const StringName ready = "ready";
 	const StringName _ready = "_ready";
+	const StringName _scene_instantiated = "_scene_instantiated";
 
 	const StringName item_rect_changed = "item_rect_changed";
 	const StringName size_flags_changed = "size_flags_changed";


### PR DESCRIPTION
* Closes godotengine/godot-proposals#5718.
* Closes https://github.com/godotengine/godot-proposals/issues/14599.

This PR has two parts:

1\. (core) This is a very small change. Add `Node._scene_instantiated()` virtual method called when `NOTIFICATION_SCENE_INSTANTIATED` is sent. An additional rationale is that `_notification()` is called for other notifications (e.g. if you override `_process()`, `_draw()`, `_input()`, etc.) and `_notification()` is a multi-level call even in GDScript (see #81139), so it's a bit redundant to use `_notification()` if you just want early initialization.

2\. (GDScript) Add the `@oninstantiated` annotation, which works similar to `@onready`. I'm not sure about this since `NOTIFICATION_SCENE_INSTANTIATED` is more specific (only called on the scene root). Perhaps we should first accept the first part only, get user feedback and accept the second part if the community likes the feature. Or maybe we can first improve the `NOTIFICATION_SCENE_INSTANTIATED` behavior in core.

Example:

```gdscript
var title: String:
    set(value): _title.text = value
    get: return _title.text

@oninstantiated var _title: Label = %Title
@oninstantiated var _buttons: HBoxContainer = %Buttons

func _scene_instantiated() -> void:
    # Clear placeholders.
    title = ""
    clear_buttons()

func add_button(button: Button) -> void:
    _buttons.show()
    _buttons.add_child(button)

func clear_buttons() -> void:
    _buttons.hide()
    for child in _buttons.get_children():
        child.queue_free()
```