### PR TITLE
C#: Fix loading plugin to support debug symbols

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
@@ -54,19 +54,9 @@ namespace GodotPlugins
             string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
             if (assemblyPath != null)
             {
+                // Loading directly from the path lets `netcoredbg` see the debug symbols
                 AssemblyLoadedPath = assemblyPath;
-
-                // Load in memory to prevent locking the file
-                using var assemblyFile = File.Open(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
-
-                if (File.Exists(pdbPath))
-                {
-                    using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                    return LoadFromStream(assemblyFile, pdbFile);
-                }
-
-                return LoadFromStream(assemblyFile);
+                return LoadFromAssemblyPath(assemblyPath);
             }
 
             return null;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-csharp-vscode/issues/43

This change replaces `LoadFromStream` with a direct `LoadFromAssemblyPath` to allow the C# module to interface with `netcoredbg`

This solution comes from this issue:
https://github.com/Samsung/netcoredbg/issues/91#issuecomment-1189690292