### PR TITLE
C#: Fix not assigning `runtime_initialized` when initializing with AOT.

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -395,6 +395,7 @@ void GDMono::initialize() {
 
 		if (godot_plugins_initialize != nullptr) {
 			is_native_aot = true;
+			runtime_initialized = true;
 		} else {
 			ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 		}


### PR DESCRIPTION
- Fix #87596

Add the assignment after loading AOT library.