### PR TITLE
Update `XRPose.get_adjusted_transform` documentation

### DIFF
--- a/doc/classes/XRPose.xml
+++ b/doc/classes/XRPose.xml
@@ -14,7 +14,7 @@
 		<method name="get_adjusted_transform" qualifiers="const">
 			<return type="Transform3D" />
 			<description>
-				Returns the [member transform] with world scale and our reference frame applied. This is the transform used to position [XRNode3D] objects.
+				Returns the [member transform] with world scale and our reference frame applied. This is the transform used to position [XRNode3D] objects. Only the origin is adjusted, not the basis.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The basis is not adjusted by this function, make this explicit in the documentation.

https://github.com/godotengine/godot/blob/master/servers/xr/xr_pose.cpp#L96

Can decline if you think it is already obvious enough without needing further explanation.