### PR TITLE
Fix `ShaderMaterial::_property_get_revert` crash when given non-existing `p_name`

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -372,7 +372,7 @@ bool ShaderMaterial::_property_can_revert(const StringName &p_name) const {
 bool ShaderMaterial::_property_get_revert(const StringName &p_name, Variant &r_property) const {
 	if (shader.is_valid()) {
 		const StringName *pr = remap_cache.getptr(p_name);
-		if (*pr) {
+		if (pr) {
 			r_property = RenderingServer::get_singleton()->shader_get_parameter_default(shader->get_rid(), *pr);
 			return true;
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/71863

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
