### PR TITLE
SCons: Fix Windows cross-compilation from Linux after #86717

### DIFF
--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -5,7 +5,13 @@ import urllib.request
 import shutil
 
 # Base Godot dependencies path
-deps_folder = os.path.join(f"{os.getenv('LOCALAPPDATA')}", "Godot", "build_deps")
+# If cross-compiling (no LOCALAPPDATA), we install in `bin`
+deps_folder = os.getenv("LOCALAPPDATA")
+if deps_folder:
+    deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
+else:
+    deps_folder = os.path.join("bin", "build_deps")
+
 # DirectX Shader Compiler
 dxc_version = "v1.7.2308"
 dxc_filename = "dxc_2023_08_14.zip"

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -164,8 +164,21 @@ def get_opts():
 
     mingw = os.getenv("MINGW_PREFIX", "")
 
-    # Direct3D 12 SDK dependencies folder
-    d3d12_deps_folder = os.path.join(os.getenv("LOCALAPPDATA"), "Godot", "build_deps")
+    # Direct3D 12 SDK dependencies folder.
+    d3d12_deps_folder = os.getenv("LOCALAPPDATA")
+    if d3d12_deps_folder:
+        d3d12_deps_folder = os.path.join(d3d12_deps_folder, "Godot", "build_deps")
+    else:
+        # Cross-compiling, the deps install script puts things in `bin`.
+        # Getting an absolute path to it is a bit hacky in Python.
+        try:
+            import inspect
+
+            caller_frame = inspect.stack()[1]
+            caller_script_dir = os.path.dirname(os.path.abspath(caller_frame[1]))
+            d3d12_deps_folder = os.path.join(caller_script_dir, "bin", "build_deps")
+        except:  # Give up.
+            d3d12_deps_folder = ""
 
     return [
         ("mingw_prefix", "MinGW prefix", mingw),


### PR DESCRIPTION
#86717 broke building Godot on Linux (for any platform) as long as mingw is installed, as the Windows `detect.py` would fail parsing its options due to `os.getenv("LOCALAPPDATA")` being `None` and not a string.

So I fixed it, adding support for actually installing deps on Linux too (and likely macOS). I chose to put them in `bin/build_deps`, since this is a more niche use case so I don't think they need to be cached system wide.