### PR TITLE
GDExtension method calls should not pass nullptr args

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -230,12 +230,14 @@ public:
 			const void **argptrs = (const void **)alloca(argument_count * sizeof(void *));
 			for (uint32_t i = 0; i < argument_count; i++) {
 				argptrs[i] = VariantInternal::get_opaque_pointer(p_args[i]);
+				ERR_FAIL_NULL(argptrs[i]);
 			}
 
 			void *ret_opaque = nullptr;
 			if (r_ret) {
 				VariantInternal::initialize(r_ret, return_value_info.type);
-				ret_opaque = r_ret->get_type() == Variant::NIL ? r_ret : VariantInternal::get_opaque_pointer(r_ret);
+				ret_opaque = VariantInternal::get_opaque_pointer(r_ret);
+				ERR_FAIL_NULL(ret_opaque);
 			}
 
 			ptrcall(p_object, argptrs, ret_opaque);

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -341,10 +341,11 @@ public:
 		}
 	}
 
+	inline static void *static_nil_ptr = nullptr;
 	_FORCE_INLINE_ static void *get_opaque_pointer(Variant *v) {
 		switch (v->type) {
 			case Variant::NIL:
-				return nullptr;
+				return &static_nil_ptr;
 			case Variant::BOOL:
 				return get_bool(v);
 			case Variant::INT:
@@ -428,7 +429,7 @@ public:
 	_FORCE_INLINE_ static const void *get_opaque_pointer(const Variant *v) {
 		switch (v->type) {
 			case Variant::NIL:
-				return nullptr;
+				return &static_nil_ptr;
 			case Variant::BOOL:
 				return get_bool(v);
 			case Variant::INT:


### PR DESCRIPTION
fix for a nasty crash that happens when passing a null variant to any gdextension function parameter expecting any kind of Object *.
the GDExtensionMethodBind  expects a pointer to an `Object *` but `get_opaque_pointer` returns a nullptr which it tries to dereference..

could also be fixed in godot-cpp with a nullptr check, but this seemed more in line with what the binding code expects 

this or another fix should rlly be applied to 4.2, 4.1, nd 4.0
it can be easily cherrypicked for 4.2 but 4.1 and 4.0 have different binding code, ill make a PR for 4.1 when its apropriate 

fixes https://github.com/godotengine/godot/issues/86478
fixes https://github.com/godotengine/godot-cpp/issues/1056