### PR TITLE
[Editor] Allow selecting instanced scenes with select list

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -928,16 +928,27 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayRe
 
 	HashSet<Node3D *> found_nodes;
 
+	Node *edited_scene = get_tree()->get_edited_scene_root();
+
 	for (Node3D *spat : nodes_with_gizmos) {
 		if (!spat) {
 			continue;
 		}
 
-		if (found_nodes.has(spat)) {
+		Node3D *item = spat;
+		if (item != edited_scene) {
+			item = Object::cast_to<Node3D>(edited_scene->get_deepest_editable_node(item));
+		}
+
+		if (!item) {
 			continue;
 		}
 
-		if (!p_include_locked_nodes && _is_node_locked(spat)) {
+		if (found_nodes.has(item)) {
+			continue;
+		}
+
+		if (!p_include_locked_nodes && _is_node_locked(item)) {
 			continue;
 		}
 
@@ -964,10 +975,10 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayRe
 				continue;
 			}
 
-			found_nodes.insert(spat);
+			found_nodes.insert(item);
 
 			_RayResult res;
-			res.item = spat;
+			res.item = item;
 			res.depth = dist;
 			r_results.push_back(res);
 			break;
@@ -1743,10 +1754,9 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			if (_is_node_locked(spat)) {
 				locked = 1;
 			} else {
-				Node *ed_scene = EditorNode::get_singleton()->get_edited_scene();
 				Node *node = spat;
 
-				while (node && node != ed_scene->get_parent()) {
+				while (node && node != edited_scene->get_parent()) {
 					Node3D *selected_tmp = Object::cast_to<Node3D>(node);
 					if (selected_tmp && node->has_meta("_edit_group_")) {
 						locked = 2;


### PR DESCRIPTION
Picks the owning instance as is done in other selection methods

Unsure if this change is desired, and not familiar with the exact code here, so need some eyes on it to verify nothing is wrong, but it works correctly in my testing, only selects the parent once if there's multiple nodes to pick inside it

* Closes: https://github.com/godotengine/godot/issues/87607

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
