### PR TITLE
Do not use a linear sampler on lightmapper when retrieving grid data.

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -13,6 +13,8 @@ denoise = "#define MODE_DENOISE";
 
 #VERSION_DEFINES
 
+#extension GL_EXT_samplerless_texture_functions : enable
+
 // One 2D local group focusing in one layer at a time, though all
 // in parallel (no barriers) makes more sense than a 3D local group
 // as this can take more advantage of the cache for each group.
@@ -152,7 +154,7 @@ uint trace_ray(vec3 p_from, vec3 p_to, bool p_any_hit, out float r_distance, out
 
 	uint iters = 0;
 	while (all(greaterThanEqual(icell, ivec3(0))) && all(lessThan(icell, ivec3(bake_params.grid_size))) && (iters < 1000)) {
-		uvec2 cell_data = texelFetch(usampler3D(grid, linear_sampler), icell, 0).xy;
+		uvec2 cell_data = texelFetch(grid, icell, 0).xy;
 		uint triangle_count = cell_data.x;
 		if (triangle_count > 0) {
 			uint hit = RAY_MISS;


### PR DESCRIPTION
Thanks to @sakrel for the tip on Rocket Chat to use `GL_EXT_samplerless_texture_functions` to fix this issue, that we already [use elsewhere on VoxelGI](https://github.com/godotengine/godot/blob/4b6ad349886288405890b07d4a8da425eb3c97ec/servers/rendering/renderer_rd/shaders/environment/gi.glsl#L8).

This fixes the following validation error on the lightmapper.

```
VALIDATION - Message Id Number: 188609398 | Message Id Name: VUID-vkCmdDispatch-magFilter-04553
Validation Error: [ VUID-vkCmdDispatch-magFilter-04553 ] 
Object 0: handle = 0xf72cdf000000f0e8, name = RID:784918158245889, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; 
Object 1: handle = 0x2dacf7000000f0c7, name = RID:784845143801856, type = VK_OBJECT_TYPE_SAMPLER; 
Object 2: handle = 0xaad35c000000f060, name = RID:784759244455945 View, type = VK_OBJECT_TYPE_IMAGE_VIEW; 
| MessageID = 0xb3df376 | 
vkCmdDispatch():  the descriptor (VkDescriptorSet 0xf72cdf000000f0e8[RID:784918158245889], binding 7, index 0) 
has VkSampler 0x2dacf7000000f0c7[RID:784845143801856] which is set to use VK_FILTER_LINEAR with compareEnable
is set to VK_FALSE, but image view's (VkImageView 0xaad35c000000f060[RID:784759244455945 View]) format 
(VK_FORMAT_R32G32_UINT) does not contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format
features. The Vulkan spec states: If a VkSampler created with magFilter or minFilter equal to VK_FILTER_LINEAR and
compareEnable equal to VK_FALSE is used to sample a VkImageView as a result of this command, then the image 
view's format features must contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT 
(https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDispatch-magFilter-04553)
```

As the format of the grid texture does not support linear filtering and nor should it need to, as they're fixed integer indices anyway.

This is a very low risk fix and we just need to validate it doesn't break the lightmapper (haven't seen any issues on my end).