### PR TITLE
SCons: Add proper MinGW support to D3D12 deps install script

### DIFF
--- a/drivers/d3d12/d3d12ma.cpp
+++ b/drivers/d3d12/d3d12ma.cpp
@@ -42,6 +42,7 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wnonnull-compare"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
 #if defined(_MSC_VER)

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -2885,7 +2885,7 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 					uint32_t binding = (p_register % GODOT_NIR_DESCRIPTOR_SET_MULTIPLIER) / GODOT_NIR_BINDING_MULTIPLIER;
 
 					DEV_ASSERT(set < (uint32_t)shader_data_in.sets_bindings.size());
-					bool found = false;
+					[[maybe_unused]] bool found = false;
 					for (int j = 0; j < shader_data_in.sets_bindings[set].size(); j++) {
 						if (shader_data_in.sets_bindings[set][j].binding != binding) {
 							continue;
@@ -2903,7 +2903,6 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 						} else {
 							CRASH_NOW();
 						}
-
 						found = true;
 						break;
 					}
@@ -2913,8 +2912,7 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 
 			godot_nir_callbacks.report_sc_bit_offset_fn = [](uint32_t p_sc_id, uint64_t p_bit_offset, void *p_data) {
 				ShaderData &shader_data_in = *(ShaderData *)p_data;
-
-				bool found = false;
+				[[maybe_unused]] bool found = false;
 				for (int j = 0; j < shader_data_in.specialization_constants.size(); j++) {
 					if (shader_data_in.specialization_constants[j].constant_id != p_sc_id) {
 						continue;
@@ -2923,7 +2921,6 @@ Vector<uint8_t> RenderingDeviceDriverD3D12::shader_compile_binary_from_spirv(Vec
 					uint32_t offset_idx = SHADER_STAGES_BIT_OFFSET_INDICES[shader_data_in.stage];
 					DEV_ASSERT(shader_data_in.specialization_constants.write[j].stages_bit_offsets[offset_idx] == 0);
 					shader_data_in.specialization_constants.write[j].stages_bit_offsets[offset_idx] = p_bit_offset;
-
 					found = true;
 					break;
 				}


### PR DESCRIPTION
I'm not super happy about the change in `platform/windows/detect.py` to figure out whether to modify the `env["mesa_libs"]` path to add a `-mingw` suffix...

Open to suggestions to make this less hacky, especially having to pass the detected d3d12 deps path as an option, because we can't easily pass info otherwise from `get_opts` to the env or `configure_mingw` (`global` doesn't seem to work).

Might also work on macOS to cross-compile, worth testing.