### PR TITLE
Add transform aborted message to 2D matching 3D

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -523,6 +523,12 @@ private:
 
 	friend class CanvasItemEditorPlugin;
 
+	String last_message;
+	String message;
+	double message_time;
+
+	bool drag_cancelled = false;
+
 protected:
 	void _notification(int p_what);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related to: #87616

It's in 3D and I think it's useful.

https://github.com/godotengine/godot/assets/105675984/5b06f562-68f3-4bc4-980c-862159e988d9

