### PR TITLE
Add a scan_importer_support check that was missing

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -524,7 +524,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 	return false; //nothing changed
 }
 
-bool EditorFileSystem::_scan_import_support(Vector<String> reimports) {
+bool EditorFileSystem::scan_import_support(Vector<String> p_reimports) {
 	if (import_support_queries.size() == 0) {
 		return false;
 	}
@@ -545,8 +545,8 @@ bool EditorFileSystem::_scan_import_support(Vector<String> reimports) {
 		return false; //well nothing to do
 	}
 
-	for (int i = 0; i < reimports.size(); i++) {
-		HashMap<String, int>::Iterator E = import_support_test.find(reimports[i].get_extension().to_lower());
+	for (int i = 0; i < p_reimports.size(); i++) {
+		HashMap<String, int>::Iterator E = import_support_test.find(p_reimports[i].get_extension().to_lower());
 		if (E) {
 			import_support_tested.write[E->value] = true;
 		}
@@ -693,7 +693,7 @@ bool EditorFileSystem::_update_scan_actions() {
 	}
 
 	if (reimports.size()) {
-		if (_scan_import_support(reimports)) {
+		if (scan_import_support(reimports)) {
 			return true;
 		}
 

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -298,7 +298,6 @@ class EditorFileSystem : public Node {
 	static ResourceUID::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
 
 	bool _scan_extensions();
-	bool _scan_import_support(Vector<String> reimports);
 
 	Vector<Ref<EditorFileSystemImportFormatSupportQuery>> import_support_queries;
 
@@ -316,6 +315,7 @@ public:
 	void scan();
 	void scan_changes();
 	void update_file(const String &p_file);
+	bool scan_import_support(Vector<String> p_reimports);
 	HashSet<String> get_valid_extensions() const;
 
 	EditorFileSystemDirectory *get_filesystem_path(const String &p_path);

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -572,6 +572,12 @@ void ImportDock::_reimport() {
 		Error err = config->load(params->paths[i] + ".import");
 		ERR_CONTINUE(err != OK);
 
+		// Added this to check if we have proper importer support for
+		// these files before we actually attempt to import it.
+		// This will allow user to set blender_path and fbx2gltf_paths
+		// if they reimport those files and don't have the settings set.
+		EditorFileSystem::get_singleton()->scan_import_support(params->paths);
+
 		if (params->importer.is_valid()) {
 			String importer_name = params->importer->get_importer_name();
 


### PR DESCRIPTION
This PR is to move the changes to scan_import_support from https://github.com/godotengine/godot/pull/85448

This PR fixes a use case where you open a project that contains .blend or .fbx files in it, but had import support off.

So it will check for import support for those assets before attempting import.

If you have don't have import support for those assets configured and attempt to import it will start the wizard to auto detect the path for either/or blend/fbx files.