### PR TITLE
[D3D12] Add support for building with pre-11.0.0 MinGW versions, make PIX runtime opt-in.

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -33,7 +33,7 @@ if env["agility_sdk_path"] != "" and os.path.exists(env["agility_sdk_path"]):
 
 # PIX.
 
-if env["pix_path"] != "" and os.path.exists(env["pix_path"]):
+if env["use_pix"]:
     env_d3d12_rdd.Append(CPPDEFINES=["PIX_ENABLED"])
     env_d3d12_rdd.Append(CPPPATH=[env["pix_path"] + "/Include"])
 

--- a/drivers/d3d12/d3d12_context.cpp
+++ b/drivers/d3d12/d3d12_context.cpp
@@ -59,6 +59,8 @@
 
 // Note: symbol is not available in MinGW and old MSVC import libraries.
 const CLSID CLSID_D3D12DeviceFactoryGodot = __uuidof(ID3D12DeviceFactory);
+const CLSID CLSID_D3D12DebugGodot = __uuidof(ID3D12Debug);
+const CLSID CLSID_D3D12SDKConfigurationGodot = __uuidof(ID3D12SDKConfiguration);
 
 extern "C" {
 char godot_nir_arch_name[32];
@@ -285,7 +287,7 @@ Error D3D12Context::_initialize_debug_layers() {
 	ComPtr<ID3D12Debug> debug_controller;
 	HRESULT res;
 	if (device_factory) {
-		res = device_factory->GetConfigurationInterface(CLSID_D3D12Debug, IID_PPV_ARGS(&debug_controller));
+		res = device_factory->GetConfigurationInterface(CLSID_D3D12DebugGodot, IID_PPV_ARGS(&debug_controller));
 	} else {
 		res = D3D12GetDebugInterface(IID_PPV_ARGS(&debug_controller));
 	}
@@ -820,7 +822,7 @@ void D3D12Context::_init_device_factory() {
 	ERR_FAIL_COND(!d3d_D3D12GetInterface);
 
 	ID3D12SDKConfiguration *sdk_config = nullptr;
-	if (SUCCEEDED(d3d_D3D12GetInterface(CLSID_D3D12SDKConfiguration, IID_PPV_ARGS(&sdk_config)))) {
+	if (SUCCEEDED(d3d_D3D12GetInterface(CLSID_D3D12SDKConfigurationGodot, IID_PPV_ARGS(&sdk_config)))) {
 		ID3D12SDKConfiguration1 *sdk_config1 = nullptr;
 		if (SUCCEEDED(sdk_config->QueryInterface(&sdk_config1))) {
 			if (SUCCEEDED(sdk_config1->CreateDeviceFactory(agility_sdk_version, agility_sdk_path.ascii().get_data(), IID_PPV_ARGS(device_factory.GetAddressOf())))) {

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -97,7 +97,7 @@ if env["d3d12"]:
     arch_bin_dir = "#bin/" + env["arch"]
 
     # DXC
-    if env["dxc_path"] != "":
+    if env["dxc_path"] != "" and os.path.exists(env["dxc_path"]):
         dxc_dll = "dxil.dll"
         # Whether this one is loaded from arch-specific directory or not can be determined at runtime.
         # Let's copy to both and let the user decide the distribution model.
@@ -121,7 +121,7 @@ if env["d3d12"]:
             )
 
     # PIX
-    if env["pix_path"] != "" and os.path.exists(env["pix_path"]):
+    if env["use_pix"]:
         pix_dll = "WinPixEventRuntime.dll"
         env.Command(
             "#bin/" + pix_dll,


### PR DESCRIPTION
- Add support for building with pre-11.0.0 MinGW versions.
- Removes unnecessary DXC checks.
- Make PIX runtime opt-in (`use_pix` option) and adds architecture checks (PIX is supported on 64-bit systems only).
