### PR TITLE
Undefine yet another macro from Windows headers

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -93,6 +93,7 @@
 #undef OK
 #undef CONNECT_DEFERRED // override from Windows SDK, clashes with Object enum
 #undef MemoryBarrier
+#undef MONO_FONT
 #endif
 
 // Make room for our constexpr's below by overriding potential system-specific macros.


### PR DESCRIPTION
For some reason, `MONO_FONT` from Win32 has started conflicting with `rich_text_label.h`'s `DefaultFont::MONO_FONT` for me.

So I'd like to get rid of the issue.