### PR TITLE
Make viewport message dependent on framerate not physics step

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2836,7 +2836,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 					last_message = message;
 				}
 
-				message_time -= get_physics_process_delta_time();
+				message_time -= get_process_delta_time();
 				if (message_time < 0) {
 					surface->queue_redraw();
 				}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related to #87621

How long this message appear is currently depending on the framerate when less than 60fps because it under the process notification. At 30 frames per second the message will appear twice as long, because the notification is being called half the time of each physics tick. 

![image](https://github.com/godotengine/godot/assets/105675984/724fcdf9-e408-4d0d-94fd-e8817cf7e9fa)
