### PR TITLE
Manage time singleton in `register_core_types`

### DIFF
--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -189,9 +189,6 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 Time *Time::singleton = nullptr;
 
 Time *Time::get_singleton() {
-	if (!singleton) {
-		memnew(Time);
-	}
 	return singleton;
 }
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -102,6 +102,7 @@ static core_bind::Marshalls *_marshalls = nullptr;
 static core_bind::EngineDebugger *_engine_debugger = nullptr;
 
 static IP *ip = nullptr;
+static Time *_time = nullptr;
 
 static core_bind::Geometry2D *_geometry_2d = nullptr;
 static core_bind::Geometry3D *_geometry_3d = nullptr;
@@ -128,6 +129,7 @@ void register_core_types() {
 	ObjectDB::setup();
 
 	StringName::setup();
+	_time = memnew(Time);
 	ResourceLoader::initialize();
 
 	register_global_constants();
@@ -436,6 +438,7 @@ void unregister_core_types() {
 	ResourceLoader::finalize();
 
 	ClassDB::cleanup_defaults();
+	memdelete(_time);
 	ObjectDB::cleanup();
 
 	Variant::unregister_types();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -132,7 +132,6 @@ static InputMap *input_map = nullptr;
 static TranslationServer *translation_server = nullptr;
 static Performance *performance = nullptr;
 static PackedData *packed_data = nullptr;
-static Time *time_singleton = nullptr;
 #ifdef MINIZIP_ENABLED
 static ZipArchive *zip_packed_data = nullptr;
 #endif
@@ -783,7 +782,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	MAIN_PRINT("Main: Initialize Globals");
 
 	input_map = memnew(InputMap);
-	time_singleton = memnew(Time);
 	globals = memnew(ProjectSettings);
 
 	register_core_settings(); //here globals are present
@@ -2288,9 +2286,6 @@ error:
 	}
 	if (input_map) {
 		memdelete(input_map);
-	}
-	if (time_singleton) {
-		memdelete(time_singleton);
 	}
 	if (translation_server) {
 		memdelete(translation_server);
@@ -4029,9 +4024,6 @@ void Main::cleanup(bool p_force) {
 	}
 	if (input_map) {
 		memdelete(input_map);
-	}
-	if (time_singleton) {
-		memdelete(time_singleton);
 	}
 	if (translation_server) {
 		memdelete(translation_server);


### PR DESCRIPTION
the time singleton is used rlly early on, and `Time::get_singleton()` was always called before it was initialized, creating a memory leak when it `memnew`ed, then ObjectDB caught the stray instance
this registers it in a more specific place right after StringName and ObjectDB are initialized, 