### PR TITLE
Do not grab focus of editor viewport surface when the mouse is captured in freelook mode

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1488,7 +1488,9 @@ Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const
 }
 
 void Node3DEditorViewport::_surface_mouse_enter() {
-	if (!surface->has_focus() && (!get_viewport()->gui_get_focus_owner() || !get_viewport()->gui_get_focus_owner()->is_text_field())) {
+	Input::MouseMode mouse_mode = Input::get_singleton()->get_mouse_mode();
+
+	if (mouse_mode != Input::MouseMode::MOUSE_MODE_CAPTURED && !surface->has_focus() && (!get_viewport()->gui_get_focus_owner() || !get_viewport()->gui_get_focus_owner()->is_text_field())) {
 		surface->grab_focus();
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: #87639

Currently when the mouse is captured by freelook mode it will refocus to a different viewport surface when the mouse is moved which leads to undesired behavior like allowing shortcuts to be pressed since technically the newly focused viewport's freelook is not enabled. 

Take note of the editor modes, animation player and viewport borders below.

Before: 

https://github.com/godotengine/godot/assets/105675984/e610c9f6-7e96-4813-aa24-5b1819fdb3aa

After:

https://github.com/godotengine/godot/assets/105675984/5d20ca98-1ea2-453d-ba66-5b547f4870e9

