### PR TITLE
MeshLibrary scene import: recurse 4 nodes deep

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -75,21 +75,31 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		p_library->clear();
 	}
 
+	// maximum depth how far into a node we look to find a MeshInstance3D
+	// note that we only pick the first found MeshInstance3D child of any given root node.
+	const int max_parenting_nodes = 4;
+
 	HashMap<int, MeshInstance3D *> mesh_instances;
 
 	for (int i = 0; i < p_scene->get_child_count(); i++) {
 		Node *child = p_scene->get_child(i);
 
 		if (!Object::cast_to<MeshInstance3D>(child)) {
-			if (child->get_child_count() > 0) {
-				child = child->get_child(0);
-				if (!Object::cast_to<MeshInstance3D>(child)) {
-					continue;
+			bool found = false;
+			for (int try_no = 0; try_no < max_parenting_nodes; try_no++) {
+				if (child->get_child_count() > 0) {
+					child = child->get_child(0);
+					if (Object::cast_to<MeshInstance3D>(child)) {
+						found = true;
+						break;
+					}
+				} else {
+					break;
 				}
-
-			} else {
-				continue;
 			}
+
+			if (!found)
+				continue;
 		}
 
 		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(child);


### PR DESCRIPTION
before we only recursed 2 nodes deep, now we just do 4 nodes deep - this should be sufficient until there is a new system for exporting nodes with more control.

Fixes importing certain Kenney assets, like described in #85085 or shown in https://dev.to/robpc/why-godot-drops-objects-when-creating-a-meshlibrary-14bg

We still only pick at most 1 MeshInstance3D from every node of only the immediate scene children.

Only tested this locally on my specific use-case where it fixed the issue (with Kenney's assets, different pack but same root issue as in the link)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
