### PR TITLE
Close editor inspector popup on scroll

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4059,6 +4059,8 @@ void EditorInspector::_vscroll_changed(double p_offset) {
 		return;
 	}
 
+	propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST);
+
 	if (object) {
 		scroll_cache[object->get_instance_id()] = p_offset;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: #65191

I'm not sure if the scroll wheel should close all popups because this may break some functionality when used in games, so I limited it to just the editor inspectors. 

I tried to find a more straightforward and more efficient way to do this, but this was the simplest that didn't seem to have any side effects or require major surgery in the code.

Before: 

https://github.com/godotengine/godot/assets/105675984/a23d90ab-6aae-4811-9e3a-4e9e5ab014bd

After:

https://github.com/godotengine/godot/assets/105675984/d7d82f00-99e2-4644-b447-d14de0b5ac8e

