### PR TITLE
Fix editor profiler script function sort order

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -350,7 +350,7 @@ void EditorProfiler::_update_frame() {
 			category->set_custom_color(0, _get_color_from_signature(m.categories[i].signature));
 		}
 
-		for (int j = m.categories[i].items.size() - 1; j >= 0; j--) {
+		for (int j = 0; j < m.categories[i].items.size(); j++) {
 			const Metric::Category::Item &it = m.categories[i].items[j];
 
 			if (it.internal == it.total && !display_internal_profiles->is_pressed() && m.categories[i].name == "Script Functions") {

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -198,7 +198,7 @@ class ServersDebugger::ScriptsProfiler : public EngineProfiler {
 	typedef ServersDebugger::ScriptFunctionInfo FunctionInfo;
 	struct ProfileInfoSort {
 		bool operator()(ScriptLanguage::ProfilingInfo *A, ScriptLanguage::ProfilingInfo *B) const {
-			return A->total_time < B->total_time;
+			return A->total_time > B->total_time;
 		}
 	};
 	Vector<ScriptLanguage::ProfilingInfo> info;


### PR DESCRIPTION
In 4.2.1 stable, and at HEAD, a busy frame in a gdscript-only game may show next to no time in Script Functions (note 70ms in Process, 0.00ms in Scripts):
![image](https://github.com/godotengine/godot/assets/1522777/37c90959-7d57-40ee-bda4-722d59240c6c)

However, looking at a similar frame with the CLI `--profiling` flag shows much more useful output:

```
FRAME: total: 0.662813 script: 0.612449/92 %
0:res://autoload/skill_manager.gd::61::restore_skill
        total: 0.679129/102 %   self: 0.000074/0 % tcalls: 8
1:res://spawners/components/spawn_placer_component.gd::28::SpawnPlacerComponent._place_loop
        total: 0.611002/92 %    self: 0.000103/0 % tcalls: 1
2:res://actor/actor.gd::28::Actor.run
        total: 0.610062/92 %    self: 0.000166/0 % tcalls: 1
3:res://components/behavior_component.gd::57::BehaviorComponent.run
        total: 0.60987/92 %     self: 0.000004/0 % tcalls: 1
4:res://autoload/skill_manager.gd::132::restore_behavior
        total: 0.609817/92 %    self: 0.00001/0 % tcalls: 1
5:res://autoload/skill_manager.gd::54::restore_rule
        total: 0.60979/92 %     self: 0.00003/0 % tcalls: 2
6:res://autoload/skill_manager.gd::0::Resource.duplicate
        total: 0.609644/91 %    self: 0.609644/91 % tcalls: 9
```

After this PR, we see the more expensive functions in the editor list as well: 

![image](https://github.com/godotengine/godot/assets/1522777/11bf5252-2cf5-4008-b0f3-426629fc6482)

---

The engine internally limits the number of functions reported back (to 16 by default). To this point, it's been sort the profiling info in *ascending* order of time spent, then trimming the list. This meant we may only see the *best* (fastest) functions, instead of the worst, which you probably want when profiling.

Now the servers sort more closely matches the local_debugger, which worked fine.

Cleans up #25328