### PR TITLE
Honor casing for names of new nodes created from Add Sun to Scene and Add Environment

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7561,6 +7561,7 @@ void Node3DEditor::_add_sun_to_scene(bool p_already_added_environment) {
 	}
 	ERR_FAIL_NULL(base);
 	Node *new_sun = preview_sun->duplicate();
+	new_sun->set_name(EditorNode::adjust_scene_name_casing(new_sun->get_name()));
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Preview Sun to Scene"));
@@ -7595,6 +7596,7 @@ void Node3DEditor::_add_environment_to_scene(bool p_already_added_sun) {
 	if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
 		new_env->set_camera_attributes(preview_environment->get_camera_attributes()->duplicate(true));
 	}
+	new_env->set_name(EditorNode::adjust_name_casing(new_env->get_class_name()));
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Preview Environment to Scene"));


### PR DESCRIPTION
Issue Link: https://github.com/godotengine/godot/issues/87653

**Issues:**

* On creation, the name field for `new_env `is empty. This will cause `Node::validate_node_name` to generate a new name using the class name. This function does not use `EditorNode::adjust_scene_name_casing` to fix the casing.

* `new_sun `copies the same name as `preview_sun`. However, the casing is not being changed to honor the casing setting.

**Changes:**

* Explicitly assigned names for both the newly created nodes (`new_sun `and `new_environment`) prior to adding them to the base root node. 
* Biased towards this instead of modifying `Node::validate_node_name.` This code seems critical may not want to add `EditorNode `at this point. Also, this is a very simple issue and wanted to keep the scope of the impact small.

**Testing:**

* Verified that the names for the nodes created using Add Sun To Scene and Add Environment were respecting the casing settings.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
