### PR TITLE
Prevent `LineEdit` focus loss when text is submitted or rejected and allow selecting without editing with arrow keys.

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -4,7 +4,14 @@
 		An input field for single-line text.
 	</brief_description>
 	<description>
-		[LineEdit] provides an input field for editing a single line of text. It features many built-in shortcuts that are always available ([kbd]Ctrl[/kbd] here maps to [kbd]Cmd[/kbd] on macOS):
+		[LineEdit] provides an input field for editing a single line of text.
+		- When the [LineEdit] control is focused using the keyboard arrow keys, it will only gain focus and not enter edit mode.
+		- To enter edit mode, click on the control with the mouse or press the "ui_text_submit" action (default: [kbd]Enter[/kbd] or [kbd]Kp Enter[/kbd]).
+		- To exit edit mode, press "ui_text_submit" or "ui_cancel" (default: [kbd]Escape[/kbd]) actions.
+		- Check [method is_editing] and [signal editing_toggled] for more information.
+		[b]Important:[/b]
+		- Focusing the [LineEdit] with "ui_focus_next" (default: [kbd]Tab[/kbd]) or "ui_focus_prev" (default: [kbd]Shift + Tab[/kbd]) or [method Control.grab_focus] still enters edit mode (for compatibility).
+		[LineEdit] features many built-in shortcuts that are always available ([kbd]Ctrl[/kbd] here maps to [kbd]Cmd[/kbd] on macOS):
 		- [kbd]Ctrl + C[/kbd]: Copy
 		- [kbd]Ctrl + X[/kbd]: Cut
 		- [kbd]Ctrl + V[/kbd] or [kbd]Ctrl + Y[/kbd]: Paste/"yank"
@@ -137,6 +144,12 @@
 			<param index="0" name="text" type="String" />
 			<description>
 				Inserts [param text] at the caret. If the resulting value is longer than [member max_length], nothing happens.
+			</description>
+		</method>
+		<method name="is_editing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the [LineEdit] is being edited.
 			</description>
 		</method>
 		<method name="is_menu_visible" qualifiers="const">
@@ -301,6 +314,12 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="editing_toggled">
+			<param index="0" name="toggled_on" type="bool" />
+			<description>
+				Emitted when the [LineEdit] switches in or out of edit mode.
+			</description>
+		</signal>
 		<signal name="text_change_rejected">
 			<param index="0" name="rejected_substring" type="String" />
 			<description>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -81,7 +81,6 @@ void EditorPropertyText::_text_submitted(const String &p_string) {
 	}
 
 	if (text->has_focus()) {
-		text->release_focus();
 		_text_changed(p_string);
 	}
 }

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -86,6 +86,7 @@ public:
 private:
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
 
+	bool editing = false;
 	bool editable = false;
 	bool pass = false;
 	bool text_changed_dirty = false;
@@ -205,6 +206,9 @@ private:
 		float base_scale = 1.0;
 	} theme_cache;
 
+	void _edit();
+	void _unedit();
+
 	void _clear_undo_stack();
 	void _clear_redo();
 	void _create_undo_state();
@@ -257,6 +261,8 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
+	bool is_editing() const;
+
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;
 

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -86,8 +86,7 @@ class SpinBox : public Range {
 		bool down_button_disabled = false;
 	} state_cache;
 
-	void _line_edit_focus_enter();
-	void _line_edit_focus_exit();
+	void _line_edit_editing_toggled(bool p_toggled_on);
 
 	inline void _compute_sizes();
 	inline int _get_widest_button_icon_width();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/87673

- Prevent focus loss when text is rejected by pressing `Escape`.
- [Editor] Prevent focus loss when a text property is submitted by pressing `Enter`.
- Allow exiting edit mode by pressing `Escape` to select other focusable `Control` nodes.
- Allow entering focus mode only without editing by entering focus with arrow keys, pressing `Enter` will toggle between select/edit modes and pressing `Escape` while editing will return back to select mode.