### PR TITLE
Mention and deprecate InputEventJoypadButton's pressure

### DIFF
--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -16,8 +16,9 @@
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the button's state is pressed. If [code]false[/code], the button's state is released.
 		</member>
-		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0">
-			Represents the pressure the user puts on the button with their finger, if the controller supports it. Ranges from [code]0[/code] to [code]1[/code].
+		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0" is_deprecated="true">
+			Represents the pressure the user puts on a pressure-sensitive button.
+			[i]Deprecated.[/i] This property is never set by the engine and is always [code]0[/code].
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Kinda closes https://github.com/godotengine/godot-docs/issues/8549

TL:DR: This property has never been used by the engine since its conception and no one ever noticed. See [linked issue](https://github.com/godotengine/godot-docs/issues/8549) for more details.