### PR TITLE
[3.x] Mention InputEventJoypadButton's pressure not working

### DIFF
--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -20,6 +20,7 @@
 		</member>
 		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0">
 			Represents the pressure the user puts on the button with their finger, if the controller supports it. Ranges from [code]0[/code] to [code]1[/code].
+			[b]Note:[/b] This property is never set by the engine and is always [code]0[/code].
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/87676