### PR TITLE
C#: Fix issues for StringName reference in `CSharpInstanceBridge.Get`.

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -94,7 +94,7 @@ namespace Godot.Bridge
                 // Signals
                 if (godotObject.HasGodotClassSignal(CustomUnsafe.AsRef(name)))
                 {
-                    godot_signal signal = new godot_signal(*name, godotObject.GetInstanceId());
+                    godot_signal signal = new godot_signal(NativeFuncs.godotsharp_string_name_new_copy(*name), godotObject.GetInstanceId());
                     *outRet = VariantUtils.CreateFromSignalTakingOwnershipOfDisposableValue(signal);
                     return godot_bool.True;
                 }
@@ -102,7 +102,7 @@ namespace Godot.Bridge
                 // Methods
                 if (godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(name)))
                 {
-                    godot_callable method = new godot_callable(*name, godotObject.GetInstanceId());
+                    godot_callable method = new godot_callable(NativeFuncs.godotsharp_string_name_new_copy(*name), godotObject.GetInstanceId());
                     *outRet = VariantUtils.CreateFromCallableTakingOwnershipOfDisposableValue(method);
                     return godot_bool.True;
                 }


### PR DESCRIPTION
Pass a new copy of StringName, since both Signal and Callable have its reference.

- Fix #87638
- Help to close - #87129