### PR TITLE
[TreeItem] Add `get_button_color()`

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -96,6 +96,14 @@
 				Returns the button index if there is a button with ID [param id] in column [param column], otherwise returns -1.
 			</description>
 		</method>
+		<method name="get_button_color" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="id" type="int" />
+			<description>
+				Returns the color of the button with ID [param id] in column [param column]. If the specified button does not exist, returns [constant Color.BLACK].
+			</description>
+		</method>
 		<method name="get_button_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="column" type="int" />

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1222,6 +1222,12 @@ int TreeItem::get_button_by_id(int p_column, int p_id) const {
 	return -1;
 }
 
+Color TreeItem::get_button_color(int p_column, int p_index) const {
+	ERR_FAIL_INDEX_V(p_column, cells.size(), Color());
+	ERR_FAIL_INDEX_V(p_index, cells[p_column].buttons.size(), Color());
+	return cells[p_column].buttons[p_index].color;
+}
+
 void TreeItem::set_button_tooltip_text(int p_column, int p_index, const String &p_tooltip) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_INDEX(p_index, cells[p_column].buttons.size());
@@ -1662,6 +1668,7 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_button_tooltip_text", "column", "button_index"), &TreeItem::get_button_tooltip_text);
 	ClassDB::bind_method(D_METHOD("get_button_id", "column", "button_index"), &TreeItem::get_button_id);
 	ClassDB::bind_method(D_METHOD("get_button_by_id", "column", "id"), &TreeItem::get_button_by_id);
+	ClassDB::bind_method(D_METHOD("get_button_color", "column", "id"), &TreeItem::get_button_color);
 	ClassDB::bind_method(D_METHOD("get_button", "column", "button_index"), &TreeItem::get_button);
 	ClassDB::bind_method(D_METHOD("set_button_tooltip_text", "column", "button_index", "tooltip"), &TreeItem::set_button_tooltip_text);
 	ClassDB::bind_method(D_METHOD("set_button", "column", "button_index", "button"), &TreeItem::set_button);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -266,6 +266,7 @@ public:
 	int get_button_id(int p_column, int p_index) const;
 	void erase_button(int p_column, int p_index);
 	int get_button_by_id(int p_column, int p_id) const;
+	Color get_button_color(int p_column, int p_index) const;
 	void set_button_tooltip_text(int p_column, int p_index, const String &p_tooltip);
 	void set_button(int p_column, int p_index, const Ref<Texture2D> &p_button);
 	void set_button_color(int p_column, int p_index, const Color &p_color);


### PR DESCRIPTION
### What?
Adds `TreeItem.get_button_color(column, id)`, a function that returns the color of a button in a `TreeItem`, typically set with `set_button_color`. Returns `Color()` if the specified button column-ID pair is not found in the `TreeItem`.

### Why?
Currently working on something that uses buttons in a tree to open up a color picker. I want to set the starting color of the picker to whatever color the button is, which I couldn't really do before this PR (meaning the starting color of the picker would either be the previously selected color or some default color like `Color.WHITE`).

BASED ON: master
CONFLICTS WITH: Nothing, as far as I know
CLOSES: Something, probably