### PR TITLE
[3.x] [Android 14] Fix GodotEditText white box showing during game load

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -60,6 +60,7 @@ import android.content.pm.ConfigurationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
@@ -385,6 +386,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		GodotEditText edittext = new GodotEditText(activity);
 		edittext.setLayoutParams(new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT,
 				(int)getResources().getDimension(R.dimen.text_edit_height)));
+		// Prevent GodotEditText from showing on splash screen on devices with Android 14 or newer.
+		edittext.setBackgroundColor(Color.TRANSPARENT);
 		// ...add to FrameLayout
 		containerLayout.addView(edittext);
 


### PR DESCRIPTION
Prevent GodotEditText white box from showing at the top of the splash screen during game load on Android 14 devices.

This fix is for an issue (#87059) that does not apply to the master branch, hence pull request for the 3.x branch.

Fixes #87059