### PR TITLE
Add check in `CompressedTextureLayered::get_layer_data` to prevent crash

### DIFF
--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -808,6 +808,7 @@ RID CompressedTextureLayered::get_rid() const {
 
 Ref<Image> CompressedTextureLayered::get_layer_data(int p_layer) const {
 	if (texture.is_valid()) {
+		ERR_FAIL_INDEX_V(p_layer, get_layers(), Ref<Image>());
 		return RS::get_singleton()->texture_2d_layer_get(texture, p_layer);
 	} else {
 		return Ref<Image>();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87367

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
