### PR TITLE
Clean up D3D12 objects on shutdown

### DIFF
--- a/drivers/d3d12/d3d12_context.cpp
+++ b/drivers/d3d12/d3d12_context.cpp
@@ -1127,6 +1127,10 @@ D3D12Context::D3D12Context() {
 }
 
 D3D12Context::~D3D12Context() {
+	if (md.driver) {
+		memdelete(md.driver);
+	}
+
 	if (md.fence_event) {
 		CloseHandle(md.fence_event);
 	}

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1831,8 +1831,7 @@ RDD::CommandBufferID RenderingDeviceDriverD3D12::command_buffer_create(CommandBu
 	if (elem != nullptr) {
 		elem->value().push_back(cmd_buf_info);
 	} else {
-		LocalVector<CommandBufferInfo *> command_buffer_infos;
-		command_buffer_infos.push_back(cmd_buf_info);
+		LocalVector<CommandBufferInfo *> command_buffer_infos({ cmd_buf_info });
 		pools_command_buffers.insert(p_cmd_pool, command_buffer_infos);
 	}
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1782,7 +1782,7 @@ RDD::CommandPoolID RenderingDeviceDriverD3D12::command_pool_create(CommandBuffer
 }
 
 void RenderingDeviceDriverD3D12::command_pool_free(CommandPoolID p_cmd_pool) {
-	RBMap<CommandPoolID, LocalVector<CommandBufferInfo *>>::Element* elem = pools_command_buffers.find(p_cmd_pool);
+	RBMap<CommandPoolID, LocalVector<CommandBufferInfo *>>::Element *elem = pools_command_buffers.find(p_cmd_pool);
 	if (elem != nullptr) {
 		for (LocalVector<CommandBufferInfo *>::Iterator it = elem->value().begin(); it != elem->value().end(); ++it) {
 			(*it)->cmd_allocator.Reset();

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1815,8 +1815,8 @@ RDD::CommandBufferID RenderingDeviceDriverD3D12::command_buffer_create(CommandBu
 	// Bookkeep
 
 	CommandBufferInfo *cmd_buf_info = VersatileResource::allocate<CommandBufferInfo>(resources_allocator);
-	cmd_buf_info->cmd_allocator = cmd_allocator;
-	cmd_buf_info->cmd_list = cmd_list;
+	cmd_buf_info->cmd_allocator.Attach(cmd_allocator);
+	cmd_buf_info->cmd_list.Attach(cmd_list);
 
 	return CommandBufferID(cmd_buf_info);
 }

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5529,4 +5529,6 @@ RenderingDeviceDriverD3D12::~RenderingDeviceDriverD3D12() {
 	glsl_type_singleton_decref();
 
 	DEV_ASSERT(pools_command_buffers.is_empty());
+
+	resources_allocator.reset(true);
 }

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5467,14 +5467,14 @@ RenderingDeviceDriverD3D12::RenderingDeviceDriverD3D12(D3D12Context *p_context, 
 
 				CD3DX12_RESOURCE_DESC resource_desc = CD3DX12_RESOURCE_DESC::Buffer(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
 
-				ID3D12Resource *resource = nullptr;
+				ComPtr<ID3D12Resource> resource;
 				res = allocator->CreateResource(
 						&allocation_desc,
 						&resource_desc,
 						D3D12_RESOURCE_STATE_COMMON,
 						nullptr,
 						&frames[frame_idx].aux_resource,
-						IID_PPV_ARGS(&resource));
+						IID_PPV_ARGS(resource.GetAddressOf()));
 				ERR_FAIL_COND_MSG(!SUCCEEDED(res), "D3D12MA::CreateResource failed with error " + vformat("0x%08ux", (uint64_t)res) + ".");
 			}
 		}

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1827,7 +1827,7 @@ RDD::CommandBufferID RenderingDeviceDriverD3D12::command_buffer_create(CommandBu
 	cmd_buf_info->cmd_allocator.Attach(cmd_allocator);
 	cmd_buf_info->cmd_list.Attach(cmd_list);
 
-	RBMap<CommandPoolID, LocalVector<CommandBufferInfo *>>::Element* elem = pools_command_buffers.find(p_cmd_pool);
+	RBMap<CommandPoolID, LocalVector<CommandBufferInfo *>>::Element *elem = pools_command_buffers.find(p_cmd_pool);
 	if (elem != nullptr) {
 		elem->value().push_back(cmd_buf_info);
 	} else {


### PR DESCRIPTION
When running with debug layer enabled received a bunch of warnings on shutdown

```
D3D12 WARNING: Process is terminating. Using simple reporting. Please call ReportLiveObjects() at runtime for standard reporting. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: Live Producer at 0x0000020A0A976B10, Refcount: 46. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0AA7BF40, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0AA7C3C0, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0B3E1A10, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E4DC3F0, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E4D4590, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E4CCE60, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0B5105C0, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0AEDBC30, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0B5D1440, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A9B64E0, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0AB3E280, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CA90E0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CAAD00, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CAB660, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CAC2E0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A791910, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0B510B60, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A793120, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CABCA0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CAC600, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09CA9400, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A09B7D2C0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A790100, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E77D5E0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E781140, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E77F840, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E77FB60, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A790F70, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E77F200, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E77D900, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E7807E0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E77DF40, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E8531F0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A7E94C0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A7E9720, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0A7E6540, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E87F340, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0F1FBC60, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E8802A0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0F21EBF0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E8807C0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0F241CD0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E880A50, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0F257A70, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E87F0B0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0F26B340, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E87FAF0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A262ABA90, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E87F5D0, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0EF86E90, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A262F2560, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0EF9AF10, Refcount: 2. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A0E851040, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A2630ECA0, Refcount: 1. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A667B0, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A5C770, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A52730, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A75810, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A707F0, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A5EF80, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A4D710, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: 	Live Object at 0x0000020A33A61790, Refcount: 0. [ STATE_CREATION WARNING #0: UNKNOWN]
D3D12 WARNING: Live                         Object :     62 [ STATE_CREATION WARNING #0: UNKNOWN]
DXGI WARNING: Live Producer at 0x0000020A09EBE170, Refcount: 2. [ STATE_CREATION WARNING #0: ]
DXGI WARNING: 	Live Object at 0x0000020A09EBFB70, Refcount: 2. [ STATE_CREATION WARNING #0: ]
DXGI WARNING: Live                         Object :      1 [ STATE_CREATION WARNING #0: ]
The program '[18132] godot.windows.template_debug.dev.x86_64.exe' has exited with code 1 (0x1).
```

and (unrelated to the debug layer, but related to D3D12 driver)

```
core/templates/paged_allocator.h:170 - Pages in use exist at exit in PagedAllocator: struct VersatileResourceTemplate<struct RenderingDeviceDriverD3D12::BufferInfo,struct RenderingDeviceDriverD3D12::TextureInfo,struct RenderingDeviceDriverD3D12::TextureInfo,struct RenderingDeviceDriverD3D12::TextureInfo,struct RenderingDeviceDriverD3D12::VertexFormatInfo,struct RenderingDeviceDriverD3D12::CommandBufferInfo,struct RenderingDeviceDriverD3D12::FramebufferInfo,struct RenderingDeviceDriverD3D12::ShaderInfo,struct RenderingDeviceDriverD3D12::UniformSetInfo,struct RenderingDeviceDriverD3D12::RenderPassInfo,struct RenderingDeviceDriverD3D12::TimestampQueryPoolInfo>
```