### PR TITLE
Allow `Node.create_tween()` outside SceneTree

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -205,7 +205,7 @@
 		<method name="create_tween">
 			<return type="Tween" />
 			<description>
-				Creates a new [Tween] and binds it to this node. Fails if the node is not inside the tree.
+				Creates a new [Tween] and binds it to this node.
 				This is the equivalent of doing:
 				[codeblocks]
 				[gdscript]
@@ -215,7 +215,8 @@
 				GetTree().CreateTween().BindNode(this);
 				[/csharp]
 				[/codeblocks]
-				The Tween will start automatically on the next process frame or physics frame (depending on [enum Tween.TweenProcessMode]).
+				The Tween will start automatically on the next process frame or physics frame (depending on [enum Tween.TweenProcessMode]). See [method Tween.bind_node] for more info on Tweens bound to nodes.
+				[b]Note:[/b] The method can still be used when the node is not inside [SceneTree]. It can fail in an unlikely case of using a custom [MainLoop].
 			</description>
 		</method>
 		<method name="duplicate" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2326,8 +2326,14 @@ void Node::_propagate_replace_owner(Node *p_owner, Node *p_by_owner) {
 
 Ref<Tween> Node::create_tween() {
 	ERR_THREAD_GUARD_V(Ref<Tween>());
-	ERR_FAIL_NULL_V_MSG(data.tree, nullptr, "Can't create Tween when not inside scene tree.");
-	Ref<Tween> tween = get_tree()->create_tween();
+
+	SceneTree *tree = data.tree;
+	if (!tree) {
+		tree = SceneTree::get_singleton();
+	}
+	ERR_FAIL_NULL_V_MSG(tree, Ref<Tween>(), "No available SceneTree to create the Tween.");
+
+	Ref<Tween> tween = tree->create_tween();
 	tween->bind_node(this);
 	return tween;
 }


### PR DESCRIPTION
`Node.create_tween()` does not work when the node is outside tree. This was never an intended limitation, I just forgot that we have global access to SceneTree.