### PR TITLE
[3.x] Portals - Improve conversion logging

### DIFF
--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -154,7 +154,7 @@ private:
 
 	bool _convert_manual_bound(Room *p_room, Spatial *p_node, const LocalVector<Portal *> &p_portals);
 	void _check_portal_for_warnings(Portal *p_portal, const AABB &p_room_aabb_without_portals);
-	void _process_static(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts, bool p_add_to_portal_renderer);
+	void _process_static(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts, bool p_add_to_portal_renderer, bool p_autoplaced);
 	void _find_statics_recursive(Room *p_room, Spatial *p_node, Vector<Vector3> &r_room_pts, bool p_add_to_portal_renderer);
 	bool _convert_room_hull_preliminary(Room *p_room, const Vector<Vector3> &p_room_pts, const LocalVector<Portal *> &p_portals);
 


### PR DESCRIPTION
Logging is now allowed in any TOOLS build (rather than just in the editor), but still prevented in final exports.
Logging can be switched off via project settings.
Autoplacement is now logged.

Example:
```
		AUTOLINK OK from Hall2 to Room2
		AUTOLINK OK from Hall2 to Room3
		AUTOLINK OK from Hall to Room3
		AUTOLINK OK from Hall to Room5
ROOM	Room2
		PIN 	Hall2
			MESH	Bounds
ROOM	Room3
		PIN 	Hall2
		PIN 	Hall
			MESH	Bounds
			contained 8 planes before simplification, 7 planes after.
ROOM	Hall2
		POUT	Room2
		POUT	Room3
			MESH	MeshInstance
			contained 7 planes before simplification, 6 planes after.
ROOM	Room5
		PIN 	Hall
			MESH	Bounds
			contained 7 planes before simplification, 6 planes after.
ROOM	Hall
		POUT	Room3
		POUT	Room5
			MESH	MeshInstance

AUTOPLACED in Room5	MESH	MeshInstance3
AUTOPLACED in Room3	MESH	MeshInstance4
AUTOPLACED in Room2	MESH	MeshInstance5
```

## Notes
* Minor quality of life improvements while investigating #87685

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
