### PR TITLE
Make script UIDs optional

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -253,6 +253,7 @@ public:
 #endif
 	virtual bool supports_builtin_mode() const = 0;
 	virtual bool supports_documentation() const { return false; }
+	virtual bool supports_uid() const { return false; }
 	virtual bool can_inherit_from_file() const { return false; }
 	virtual int find_function(const String &p_function, const String &p_code) const = 0;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const = 0;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1429,6 +1429,30 @@ void ScriptEditor::_menu_option(int p_option) {
 				es->run();
 			} break;
 
+			case FILE_INSERT_UID: {
+				Ref<Script> scr = current->get_edited_resource();
+				if (scr.is_null()) {
+					EditorToaster::get_singleton()->popup_str(TTR("Cannot insert UID: edited file is not a Script."), EditorToaster::SEVERITY_WARNING);
+					break;
+				}
+				if (!scr->get_language()->supports_uid()) {
+					EditorToaster::get_singleton()->popup_str(TTR("Cannot insert UID: edited script's language does not support UIDs."), EditorToaster::SEVERITY_WARNING);
+					break;
+				}
+				if (scr->is_built_in()) {
+					EditorToaster::get_singleton()->popup_str(TTR("Cannot insert UID: edited script is built-in."), EditorToaster::SEVERITY_WARNING);
+					break;
+				}
+
+				const ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(scr->get_path(), false);
+				if (uid != ResourceUID::INVALID_ID) {
+					EditorToaster::get_singleton()->popup_str(TTR("Cannot insert UID: edited script already has a UID."), EditorToaster::SEVERITY_WARNING);
+					break;
+				}
+				
+				ResourceSaver::set_uid(scr->get_path(), ResourceUID::get_singleton()->create_id());
+			} break;
+
 			case FILE_CLOSE: {
 				if (current->is_unsaved()) {
 					_ask_close_current_unsaved_tab(current);
@@ -4005,6 +4029,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/run_file", TTR("Run"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::X), FILE_RUN);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/insert_uid", TTR("Insert UID")), FILE_INSERT_UID);
 
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KeyModifierMask::CMD_OR_CTRL | Key::BACKSLASH), TOGGLE_SCRIPTS_PANEL);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -222,6 +222,7 @@ class ScriptEditor : public PanelContainer {
 		FILE_SAVE_ALL,
 		FILE_THEME,
 		FILE_RUN,
+		FILE_INSERT_UID,
 		FILE_CLOSE,
 		CLOSE_DOCS,
 		CLOSE_ALL,

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -63,6 +63,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Button *path_button = nullptr;
 	EditorFileDialog *file_browse = nullptr;
 	CheckBox *built_in = nullptr;
+	CheckBox *add_uid = nullptr;
 	CheckBox *use_templates = nullptr;
 	VBoxContainer *path_vb = nullptr;
 	AcceptDialog *alert = nullptr;
@@ -99,6 +100,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _path_changed(const String &p_path = String());
 	void _language_changed(int l = 0);
 	void _built_in_pressed();
+	void _add_uid_toggled(bool p_enabled);
 	void _use_template_pressed();
 	bool _validate_parent(const String &p_string);
 	String _validate_path(const String &p_path, bool p_file_must_exist);
@@ -111,6 +113,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	virtual void ok_pressed() override;
 	void _create_new();
 	void _load_exist();
+	void _update_uid_button();
 	void _update_template_menu();
 	void _update_dialog();
 	ScriptLanguage::ScriptTemplate _get_current_template() const;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -552,6 +552,7 @@ public:
 #endif
 	virtual bool supports_builtin_mode() const override;
 	virtual bool supports_documentation() const override;
+	virtual bool supports_uid() const override;
 	virtual bool can_inherit_from_file() const override { return true; }
 	virtual int find_function(const String &p_function, const String &p_code) const override;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -209,6 +209,10 @@ bool GDScriptLanguage::supports_documentation() const {
 	return true;
 }
 
+bool GDScriptLanguage::supports_uid() const {
+	return true;
+}
+
 int GDScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	GDScriptTokenizer tokenizer;
 	tokenizer.set_source_code(p_code);

--- a/modules/gdscript/tests/test_gdscript_uid.h
+++ b/modules/gdscript/tests/test_gdscript_uid.h
@@ -55,6 +55,7 @@ static void test_script(const String &p_source, const String &p_target_source) {
 	script.instantiate();
 	script->set_source_code(p_source);
 	ResourceSaver::save(script, script_path);
+	ResourceSaver::set_uid(script_path, _resource_saver_get_resource_id_for_path(script_path, true));
 
 	Ref<FileAccess> fa = FileAccess::open(script_path, FileAccess::READ);
 	CHECK_EQ(fa->get_as_text(), p_target_source);
@@ -100,11 +101,9 @@ extends Node
 class_name TestClass
 )";
 
-		// Script has wrong UID saved. Remove it and add a correct one.
+		// Set script UID, replacing the old one.
 		// Inserts in the same line, but multiline annotations are flattened.
 		test_script(wrong_id_source, corrected_id_source);
-		// The stored UID is correct, so do not modify it.
-		test_script(correct_id_source, correct_id_source);
 	}
 }
 


### PR DESCRIPTION
This PR removes the UID code from GDScript's `save()` and instead the ScriptCreateDialog is now responsible for adding UIDs, which means that script no longer force adding UIDs.
![image](https://github.com/godotengine/godot/assets/2223172/8dca3b89-4f82-472d-affa-2e17fe12f19b)
The new checkbox is enabled by default and it's state is remembered per-project. The script is created as before and the UID is added afterwards by `ResourceSaver.set_uid()`.

The script editor got a new File menu option to add UID to existing files:
![image](https://github.com/godotengine/godot/assets/2223172/9287327c-f785-4f9f-9d69-110c7cf189eb)
Deleting a UID will now unlink it from the script, so you'll need to re-add it manually or generate a new one. I also added a method to ScriptLanguage to check whether the language supports UIDs.

There are still some bugs, so putting as draft.