### PR TITLE
Fix `ResourceLoader.load_threaded_get_status` returning `[0]` constantly in exported projects.

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -244,11 +244,11 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 		thread_load_mutex.lock();
 		HashMap<String, ThreadLoadTask>::Iterator E = thread_load_tasks.find(load_paths_stack->get(load_paths_stack->size() - 1));
 		if (E) {
-			E->value.sub_tasks.insert(p_path);
+			E->value.sub_tasks.insert(p_original_path);
 		}
 		thread_load_mutex.unlock();
 	}
-	load_paths_stack->push_back(p_path);
+	load_paths_stack->push_back(p_original_path);
 
 	// Try all loaders and pick the first match for the type hint
 	bool found = false;


### PR DESCRIPTION
This PR fixes #56882 (which wasn't completely fixed by #74405) by pushing `p_original_path` instead of `p_path` into `load_paths_stack` and `sub_tasks`.

I believe the issue is that `thread_load_tasks` always uses the original path of to the resource in `res://` but in exported projects `p_path` is the path to the imported file in the `.godot` folder so `load_paths_stack` doesn't store the correct path.
This causes the lookup at [line 245](https://github.com/godotengine/godot/blob/master/core/io/resource_loader.cpp#L245) to fail, which causes `sub_tasks` to remain empty, which causes `dep_count` at [line 512](https://github.com/godotengine/godot/blob/master/core/io/resource_loader.cpp#L512) to be 0, causing `_dependency_get_progress` to return 0, etc.

Using `p_original_path` fixes this issue.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
