### PR TITLE
[3.x] Portals - include in bound and special cases in start room

### DIFF
--- a/doc/classes/Portal.xml
+++ b/doc/classes/Portal.xml
@@ -23,6 +23,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="include_in_bound" type="bool" setter="set_include_in_bound" getter="get_include_in_bound" default="false">
+			When a manual bound has not been explicitly specified for a [Room], the convex hull bound will be estimated from the geometry of the objects within the room. This setting determines whether the portal geometry is included in this estimate of the room bound.
+		</member>
 		<member name="linked_room" type="NodePath" setter="set_linked_room" getter="get_linked_room" default="NodePath(&quot;&quot;)">
 			This is a shortcut for setting the linked [Room] in the name of the [Portal] (the name is used during conversion).
 		</member>

--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -46,6 +46,7 @@ Portal::Portal() {
 
 	_settings_active = true;
 	_settings_two_way = true;
+	_settings_include_in_bound = false;
 	_internal = false;
 	_linkedroom_ID[0] = -1;
 	_linkedroom_ID[1] = -1;
@@ -696,8 +697,12 @@ void Portal::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_point", "index", "position"), &Portal::set_point);
 
+	ClassDB::bind_method(D_METHOD("set_include_in_bound", "p_enabled"), &Portal::set_include_in_bound);
+	ClassDB::bind_method(D_METHOD("get_include_in_bound"), &Portal::get_include_in_bound);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "portal_active"), "set_portal_active", "get_portal_active");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "two_way"), "set_two_way", "is_two_way");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_in_bound"), "set_include_in_bound", "get_include_in_bound");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "linked_room", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Room"), "set_linked_room", "get_linked_room");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_default_margin"), "set_use_default_margin", "get_use_default_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "portal_margin", PROPERTY_HINT_RANGE, "0.0,10.0,0.01"), "set_portal_margin", "get_portal_margin");

--- a/scene/3d/portal.h
+++ b/scene/3d/portal.h
@@ -87,6 +87,9 @@ public:
 	// primarily for the gizmo
 	void set_point(int p_idx, const Vector2 &p_point);
 
+	void set_include_in_bound(bool p_enabled) { _settings_include_in_bound = p_enabled; }
+	bool get_include_in_bound() const { return _settings_include_in_bound; }
+
 	String get_configuration_warning() const;
 
 	Portal();

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -1538,6 +1538,11 @@ bool RoomManager::_convert_room_hull_final(Room *p_room, const LocalVector<Porta
 		int portal_id = p_room->_portals[n];
 		Portal *portal = p_portals[portal_id];
 
+		// User can select whether to include in bound.
+		if (!portal->get_include_in_bound()) {
+			continue;
+		}
+
 		// don't add portals to the world bound that are internal to this room!
 		if (portal->is_portal_internal(p_room->_room_ID)) {
 			continue;

--- a/servers/visual/portals/portal_tracer.h
+++ b/servers/visual/portals/portal_tracer.h
@@ -66,6 +66,7 @@ public:
 	};
 
 	struct TraceParams {
+		int start_room_id;
 		bool use_pvs;
 		uint8_t *decompressed_room_pvs;
 	};


### PR DESCRIPTION
* Re-introduces a property for portals to decide whether they are included in room bounds during room conversion.
* Adds a special case for portals that extend into the start room, which may be caused by level design inaccuracies.

Fixes #87685

## Explanation
The special case deals with the case where the user has placed a portal inside a room but not coplanar to the bound. This previously had the effect of shrinking the bound, leading to a "no man's land" where it wasn't sure what to render, and you could get drop outs where objects were incorrectly culled as the camera moved between two rooms (see #87685  for example).

In order to get around this problem firstly I re-added the ability to exclude a portal from the room bound. I must have removed this ability inadvertently in the initial PR and not realised. This enables the rooms to not be "shrunk" by portals that are slightly misplaced.

The second special case deals with the problems where a portal in the start room is not co-planar to the bound _exactly_. Previously, providing the portal was pretty close, you were unlikely to see drop outs. These are caused when the camera moves _in front_ of the portal, but still _within_ the start room. Previously when the camera was in front of a portal, the logic determined it could not see through it.

The solution in this PR was to simply disable rejection of portals in the start room if you move in front of them. Theoretically, this should not be possible anyway with a perfectly built room. If you do move in front, it is likely you would expect to be able to see through the portal anyway, so the tracing traverses directly into the linked room, and does not create any extra culling planes for the portal (these are undefined in this "fudge" scenario).

## Notes
* A lot of the changes here are just comments (in the end I fixed up the capitalization of existing comments in the trace function, so they were consistent with the new standard).
* The special case treatment for the start room is disabled for internal portals, in order to work well with internal rooms.
* I've tested this as best I can with regular rooms and internal rooms. It should be more robust than before.
* The case where in front of a portal plane in the start room when the camera is "to the side" of the portal and thus shouldn't be able to really see through it is sidestepped for now. This could be made more efficient (in terms of less rendered), but if anything it will currently over-render in this rare situation - i.e. there should be no falsely occluded objects and the viewer shouldn't see any artifacts.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
