### PR TITLE
Expose `set_uid()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -169,6 +169,10 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 	return ::ResourceSaver::save(p_resource, p_path, p_flags);
 }
 
+Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	return ::ResourceSaver::set_uid(p_path, p_uid);
+}
+
 Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
 	List<String> exts;
 	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
@@ -195,6 +199,7 @@ ResourceSaver *ResourceSaver::singleton = nullptr;
 
 void ResourceSaver::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save", "resource", "path", "flags"), &ResourceSaver::save, DEFVAL(""), DEFVAL((uint32_t)FLAG_NONE));
+	ClassDB::bind_method(D_METHOD("set_uid", "resource", "uid"), &ResourceSaver::set_uid);
 	ClassDB::bind_method(D_METHOD("get_recognized_extensions", "type"), &ResourceSaver::get_recognized_extensions);
 	ClassDB::bind_method(D_METHOD("add_resource_format_saver", "format_saver", "at_front"), &ResourceSaver::add_resource_format_saver, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_resource_format_saver", "format_saver"), &ResourceSaver::remove_resource_format_saver);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -110,6 +110,7 @@ public:
 	static ResourceSaver *get_singleton() { return singleton; }
 
 	Error save(const Ref<Resource> &p_resource, const String &p_path, BitField<SaverFlags> p_flags);
+	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	Vector<String> get_recognized_extensions(const Ref<Resource> &p_resource);
 	void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front);
 	void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -53,6 +53,15 @@
 				[b]Note:[/b] When the project is running, any generated UID associated with the resource will not be saved as the required code is only executed in editor mode.
 			</description>
 		</method>
+		<method name="set_uid">
+			<return type="int" enum="Error" />
+			<param index="0" name="resource" type="String" />
+			<param index="1" name="uid" type="int" />
+			<description>
+				Sets the UID of the given [param resource] path to [param uid]. You can generate a new UID using [method ResourceUID.create_id].
+				Since resources will normally get a UID automatically, this method is only useful in very specific cases.
+			</description>
+		</method>
 	</methods>
 	<constants>
 		<constant name="FLAG_NONE" value="0" enum="SaverFlags" is_bitfield="true">


### PR DESCRIPTION
Exposes `set_uid()` method. Given the exposed methods in ResourceUID singleton, exposing this method too is only logical and has some valid use-cases (like https://github.com/godotengine/godot/pull/87706#issuecomment-1915441490).

Closes https://github.com/godotengine/godot-proposals/issues/11971