### PR TITLE
Avoid non-constant-expression cannot be narrowed on Windows on mingw.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -247,8 +247,13 @@ public:
 	// IUnknown methods
 	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppv) {
 		static const QITAB qit[] = {
+#ifdef __MINGW32__
+			{ &__uuidof(IFileDialogEvents), static_cast<decltype(qit[0].dwOffset)>(OFFSETOFCLASS(IFileDialogEvents, FileDialogEventHandler)) },
+			{ &__uuidof(IFileDialogControlEvents), static_cast<decltype(qit[0].dwOffset)>(OFFSETOFCLASS(IFileDialogControlEvents, FileDialogEventHandler)) },
+#else
 			QITABENT(FileDialogEventHandler, IFileDialogEvents),
 			QITABENT(FileDialogEventHandler, IFileDialogControlEvents),
+#endif
 			{ 0, 0 },
 		};
 		return QISearch(this, qit, riid, ppv);


### PR DESCRIPTION
Fixes non-constant-expression cannot be narrowed from type 'DWORD' (aka 'unsigned long') to 'int' in initializer list [-Wc++11-narrowing] #87719

Fixes: https://github.com/godotengine/godot/issues/87719

I don't understand the effects of this.