### PR TITLE
Use more reliable method to `get_window_at_screen_position` in Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2867,9 +2867,9 @@ void DisplayServerWindows::set_context(Context p_context) {
 #define SIGNATURE_MASK 0xFFFFFF00
 // Keeping the name suggested by Microsoft, but this macro really answers:
 // Is this mouse event emulated from touch or pen input?
-#define IsPenEvent(dw) (((dw)&SIGNATURE_MASK) == MI_WP_SIGNATURE)
+#define IsPenEvent(dw) (((dw) & SIGNATURE_MASK) == MI_WP_SIGNATURE)
 // This one tells whether the event comes from touchscreen (and not from pen).
-#define IsTouchEvent(dw) (IsPenEvent(dw) && ((dw)&0x80))
+#define IsTouchEvent(dw) (IsPenEvent(dw) && ((dw) & 0x80))
 
 void DisplayServerWindows::_touch_event(WindowID p_window, bool p_pressed, float p_x, float p_y, int idx) {
 	if (touch_state.has(idx) == p_pressed) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1229,7 +1229,7 @@ DisplayServer::WindowID DisplayServerWindows::get_window_at_screen_position(cons
 	POINT p;
 	p.x = p_position.x + offset.x;
 	p.y = p_position.y + offset.y;
-	HWND hwnd = WindowFromPoint(p);
+	HWND hwnd = ChildWindowFromPoint(HWND_DESKTOP, p);
 	for (const KeyValue<WindowID, WindowData> &E : windows) {
 		if (E.value.hWnd == hwnd) {
 			return E.key;


### PR DESCRIPTION
`WindowFromPoint` is not reliable when using transparent windows. `ChildWindowFromPoint(HWND_DESKTOP, p)` does practically the same as `WindowFromPoint` with the only difference that it will not ignore transparent windows.

I had issues with physics picking because `gui.mouse_in_viewport` was false in `Viewport::_process_picking` since `WindowFromPoint` would return the Window below mine which was not a godot window.