### PR TITLE
Use more reliable method to `get_window_at_screen_position` in Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1229,7 +1229,7 @@ DisplayServer::WindowID DisplayServerWindows::get_window_at_screen_position(cons
 	POINT p;
 	p.x = p_position.x + offset.x;
 	p.y = p_position.y + offset.y;
-	HWND hwnd = WindowFromPoint(p);
+	HWND hwnd = ChildWindowFromPoint(HWND_DESKTOP, p);
 	for (const KeyValue<WindowID, WindowData> &E : windows) {
 		if (E.value.hWnd == hwnd) {
 			return E.key;


### PR DESCRIPTION
`WindowFromPoint` is not reliable when using transparent windows. `ChildWindowFromPoint(HWND_DESKTOP, p)` does practically the same as `WindowFromPoint` with the only difference that it will not ignore transparent windows.

I had issues with physics picking because `gui.mouse_in_viewport` was false in `Viewport::_process_picking` since `WindowFromPoint` would return the Window below mine which was not a godot window.