### PR TITLE
[3.x] Fix the documentation of `Bone2D::apply_rest`

### DIFF
--- a/doc/classes/Bone2D.xml
+++ b/doc/classes/Bone2D.xml
@@ -15,7 +15,7 @@
 		<method name="apply_rest">
 			<return type="void" />
 			<description>
-				Stores the node's current transforms in [member rest].
+				Resets the bone to the rest pose. This is equivalent to setting [member Node2D.transform] to [member rest].
 			</description>
 		</method>
 		<method name="get_index_in_skeleton" qualifiers="const">


### PR DESCRIPTION
Backports https://github.com/godotengine/godot/pull/85503 -- I checked `git blame`, this is how the function has worked since the creation of 2D skeletons.

(The Co-Authored-By has been preserved in the commit as the wording ultimately used was given by Mickeon. Really having it be "authored by" makes more sense given the 'story' of the commit, but that'd be metadata forgery...)

*This is relevant, but not necessarily cherry-pickable, for all Godot 3.x versions since and including 3.1-stable, and should be cherry-pickable for all versions since 3.2-stable.*

(The main thing preventing cherry-picking this commit for 3.1-stable in particular is that the function did not have documentation until 3.2-stable.)