### PR TITLE
[3.x] SCons: Fix Web build when compiler version isn't properly detected

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -7,7 +7,7 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: 3.x
   SCONSFLAGS: verbose=yes warnings=all werror=yes debug_symbols=no
-  EM_VERSION: 3.1.45
+  EM_VERSION: 3.1.39
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -176,7 +176,7 @@ def configure(env):
     env["LIBSUFFIXES"] = ["$LIBSUFFIX"]
 
     # Get version info for checks below.
-    cc_semver = tuple(get_compiler_version(env))
+    cc_semver = tuple(get_compiler_version(env) or (3, 1, 39))
 
     env.Prepend(CPPPATH=["#platform/javascript"])
     env.Append(CPPDEFINES=["JAVASCRIPT_ENABLED", "UNIX_ENABLED"])


### PR DESCRIPTION
Quick fix for #82585.

A better fix requires refactoring the way we detect the compiler version to make it more reliable, and get a consistent output. But I prefer to keep changes minimal for 3.x branches at this point.

Also set CI version to 3.1.39, which is what we use for official 3.6 builds since 3.6-beta4.
Note to self: That part shouldn't be cherry-picked to `3.5`, and the hardcoded version should be `(3, 1, 14)`.