### PR TITLE
Fix editor properties vector ratio breaking when an element is set to zero

### DIFF
--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -105,8 +105,6 @@ void EditorPropertyVectorN::_update_ratio() {
 
 		if (spin_sliders[base_slider_idx]->get_value() != 0) {
 			ratio_write[i] = spin_sliders[secondary_slider_idx]->get_value() / spin_sliders[base_slider_idx]->get_value();
-		} else {
-			ratio_write[i] = 0;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

A ratio should be maintained even when an element in a vector is set to zero. 

Before: 

https://github.com/godotengine/godot/assets/105675984/71707513-9aa7-4c37-b2a1-9df3188417c1

After: 

https://github.com/godotengine/godot/assets/105675984/32a7e56f-1096-416f-b25e-125824bd9ee6

