### PR TITLE
Fix `Camera2D` is enabled when dragging scene files to the `CanvasItemEditor`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2437,7 +2437,7 @@ StringName Node::get_property_store_alias(const StringName &p_property) const {
 
 bool Node::is_part_of_edited_scene() const {
 	return Engine::get_singleton()->is_editor_hint() && is_inside_tree() && get_tree()->get_edited_scene_root() &&
-			(get_tree()->get_edited_scene_root() == this || get_tree()->get_edited_scene_root()->is_ancestor_of(this));
+			get_tree()->get_edited_scene_root()->get_parent()->is_ancestor_of(this);
 }
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/87704
