### PR TITLE
Wayland: Suspend window after frame timeout or suspend state

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -127,14 +127,6 @@ void OS_LinuxBSD::alert(const String &p_alert, const String &p_title) {
 	}
 }
 
-int OS_LinuxBSD::get_low_processor_usage_mode_sleep_usec() const {
-	if (DisplayServer::get_singleton() == nullptr || DisplayServer::get_singleton()->get_name() != "Wayland" || is_in_low_processor_usage_mode()) {
-		return OS::get_low_processor_usage_mode_sleep_usec();
-	}
-
-	return 500; // Roughly 2000 FPS, improves frame time when emulating VSync.
-}
-
 void OS_LinuxBSD::initialize() {
 	crash_handler.initialize();
 

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -127,8 +127,6 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
-	virtual int get_low_processor_usage_mode_sleep_usec() const override;
-
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 	void run();

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -117,7 +117,7 @@ class DisplayServerWayland : public DisplayServer {
 
 	Context context;
 
-	bool frame = false;
+	bool suspended = false;
 	bool emulate_vsync = false;
 
 	String rendering_driver;

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -177,6 +177,7 @@ public:
 
 		Rect2i rect;
 		DisplayServer::WindowMode mode = DisplayServer::WINDOW_MODE_WINDOWED;
+		bool suspended = false;
 
 		// These are true by default as it isn't guaranteed that we'll find an
 		// xdg-shell implementation with wm_capabilities available. If and once we
@@ -939,6 +940,9 @@ public:
 
 	void set_frame();
 	bool get_reset_frame();
+	bool wait_frame_suspend_ms(int p_timeout);
+
+	bool is_suspended() const;
 
 	Error init();
 	void destroy();


### PR DESCRIPTION
Depends on #88374.

Fixes #87963.

This is a pretty popular approach that took a while for me to wrap my head around and which only recently got "official" support through an update (xdg_shell version 6), so I think that this is all-in-all a better option than the overkill 2000Hz ticking we have now :P

Basically, we wait for a frame event and, if either too much time passes or we get the new `suspended` state, we consider the window as "hidden" and stop drawing, ticking by the low usage rate.

This should work great for KDE and Mutter, which support the new state, but not yet for sway, which is still stuck at a very old xdg_shell version and thus falls back to the timeout approach.

Be aware that if we rely on timing out the engine will have to stall for the whole timeout, which _could_ be problematic but doensn't seem like it. Further testing is needed.

Special thanks go to the guys over at #wayland on OFTC, who very patiently explained me this approach way too many times.


---

FTR, the current timeout is 1 second, but I think that we could go as low as 200ms without any big consequence. Further testing is needed. **Edit:** Seems to not cause big issues, I think we can keep it like this for now.

~~Note that the new xdg-shell extension is not implemented in this PR, as I can't really test is as sway doesn't implement it yet.~~ **Edit:** It is implemented now! Sway still doesn't support it though :(

*Bugsquad edit:*
- Also fixes #88248.
