### PR TITLE
Do not reflect the origin lines in a mirror

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6490,7 +6490,7 @@ void Node3DEditor::_init_indicators() {
 // 3D editor origin line shader.
 
 shader_type spatial;
-render_mode blend_mix,cull_disabled,unshaded, fog_disabled;
+render_mode blend_mix, cull_disabled, unshaded, fog_disabled;
 
 void vertex() {
 	vec3 point_a = MODEL_MATRIX[3].xyz;
@@ -6602,7 +6602,6 @@ void fragment() {
 		RS::get_singleton()->instance_set_layer_mask(origin_instance, 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
 		RS::get_singleton()->instance_geometry_set_flag(origin_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 		RS::get_singleton()->instance_geometry_set_flag(origin_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-		RS::get_singleton()->instance_set_ignore_culling(origin_instance, true);
 
 		RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, RS::SHADOW_CASTING_SETTING_OFF);
 


### PR DESCRIPTION
Fixes #87684

Do not ignore culling on the origin lines, in order for their layer mask to be taken into account.

(+ a quick spacing change for consistency with the other shaders in the file)
