### PR TITLE
Wayland: Disable backend at build-time if wayland-scanner is missing

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -208,8 +208,8 @@ def configure(env: "Environment"):
 
     if env["wayland"]:
         if os.system("wayland-scanner -v") != 0:
-            print("wayland-scanner not found. Aborting.")
-            sys.exit(255)
+            print("wayland-scanner not found. Disabling wayland support.")
+            env["wayland"] = False
 
     if env["touch"]:
         env.Append(CPPDEFINES=["TOUCH_ENABLED"])


### PR DESCRIPTION
Fixes #87762

This allows previous X11-only setups to still build Godot with default settings. Note that compilation will still abort if wayland-scanner is present but not the various Wayland libraries.

---

BTW, I wonder if we should disable either backend depending if their libraries are missing instead of straight up aborting, now that we have two of them. This should cover 99% of issues though, as if one has `wayland-scanner` they probably have everything anyways.