### PR TITLE
Remove workaround in GLTF exporter that double converts `ra` textures to `rg`

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3816,7 +3816,6 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 						}
 						img->decompress();
 						img->convert(Image::FORMAT_RGBA8);
-						img->convert_ra_rgba8_to_rg();
 						for (int32_t y = 0; y < img->get_height(); y++) {
 							for (int32_t x = 0; x < img->get_width(); x++) {
 								Color c = img->get_pixel(x, y);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/87770

Also fixes an unreported bug that is the same as https://github.com/godotengine/godot/issues/87770 but for BPTC textures. 

This workaround was introduced by https://github.com/godotengine/godot/commit/3cae9a802bd7d40864be21d36c48d9ee020444d0. At the time DXT5 textures were returned channel swapped. That was fixed by https://github.com/godotengine/godot/pull/85967

Since https://github.com/godotengine/godot/pull/85967 ensures that DXT5 textures a decompressed correctly. We no longer need the workaround. 

The workaround broke BPTC export, but we never noticed. A side effect of this PR is that BPTC GLTF export now works correctly. 

I haven't tested ASTC though. @aaronfranke Can you test ASTC?

For production team. We either want to revert https://github.com/godotengine/godot/pull/85967 in 4.2, or cherrypick this PR to 4.2 before releasing 4.2.2