### PR TITLE
Make Callable `bind` method const

### DIFF
--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -99,7 +99,7 @@ public:
 	bool is_valid() const;
 
 	template <typename... VarArgs>
-	Callable bind(VarArgs... p_args);
+	Callable bind(VarArgs... p_args) const;
 	Callable bindv(const Array &p_arguments);
 
 	Callable bindp(const Variant **p_arguments, int p_argcount) const;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -865,7 +865,7 @@ Variant Callable::call(VarArgs... p_args) const {
 }
 
 template <typename... VarArgs>
-Callable Callable::bind(VarArgs... p_args) {
+Callable Callable::bind(VarArgs... p_args) const {
 	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 	const Variant *argptrs[sizeof...(p_args) + 1];
 	for (uint32_t i = 0; i < sizeof...(p_args); i++) {


### PR DESCRIPTION
This allows using `bind` from a `const` context. `bind` is an internal method exposed through a custom binding, so we can change it. In the future we should make this same change to `bindv` but that would break compatibility and there is no way to bind compat methods for Variant yet (see the discussion in #79140).