### PR TITLE
Fix crash when previewing a scene with a mesh as the root node

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -311,7 +311,10 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 			Ref<ImporterMesh> editor_mesh = src_mesh_node->get_mesh();
 			mesh_node->set_mesh(editor_mesh->get_mesh());
 		}
-
+		// Replace the original mesh node in the scene tree with the new one.
+		if (unlikely(p_node == scene)) {
+			scene = mesh_node;
+		}
 		p_node->replace_by(mesh_node);
 		memdelete(p_node);
 		p_node = mesh_node;


### PR DESCRIPTION
This PR fixes a crash that happens during an edge case where the imported scene's root node is a mesh. The code replaces each ImporterMeshInstance3D node with a MeshInstance3D, but in the case of the scene root, the reference to the scene was being left as a dangling pointer. Now it sets the scene to the new root node. Also I added a comment.

I have used `unlikely` here because this check will only be true at most once for each file and usually 0 times.

Test file: [crashlight.glb.zip](https://github.com/godotengine/godot/files/14111598/crashlight.glb.zip)

In master: *crash*

With this PR: 
<img width="658" alt="Screenshot 2024-01-31 at 6 19 00 AM" src="https://github.com/godotengine/godot/assets/1646875/63cd52c8-078b-4630-bc9a-4a5355adaab8">
