### PR TITLE
[4.2] Fix crash when previewing a scene with a mesh as the root node

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -311,7 +311,10 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 			Ref<ImporterMesh> editor_mesh = src_mesh_node->get_mesh();
 			mesh_node->set_mesh(editor_mesh->get_mesh());
 		}
-
+		// Replace the original mesh node in the scene tree with the new one.
+		if (unlikely(p_node == scene)) {
+			scene = mesh_node;
+		}
 		p_node->replace_by(mesh_node);
 		memdelete(p_node);
 		p_node = mesh_node;


### PR DESCRIPTION
Manual cherry-pick of https://github.com/godotengine/godot/pull/87781 due to the file organization in master.