### PR TITLE
Make `GDScriptUtilityCallable` return call error when method is invalid

### DIFF
--- a/modules/gdscript/gdscript_utility_callable.cpp
+++ b/modules/gdscript/gdscript_utility_callable.cpp
@@ -83,7 +83,10 @@ ObjectID GDScriptUtilityCallable::get_object() const {
 void GDScriptUtilityCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
 	switch (type) {
 		case TYPE_INVALID:
-			ERR_PRINT(vformat(R"(Trying to call invalid utility function "%s".)", function_name));
+			r_return_value = vformat(R"(Trying to call invalid utility function "%s".)", function_name);
+			r_call_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_call_error.argument = 0;
+			r_call_error.expected = 0;
 			break;
 		case TYPE_GLOBAL:
 			Variant::call_utility_function(function_name, &r_return_value, p_arguments, p_argcount, r_call_error);


### PR DESCRIPTION
Follow-up to:
* #86823

For completeness, all other callables appear to have proper error reporting when possible

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
