### PR TITLE
Add OS::get_cwd virtual

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -327,6 +327,10 @@ Error OS::set_cwd(const String &p_cwd) {
 	return ERR_CANT_OPEN;
 }
 
+String OS::get_cwd() const {
+	return get_executable_path();
+}
+
 Dictionary OS::get_memory_info() const {
 	Dictionary meminfo;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -179,6 +179,7 @@ public:
 	virtual Error shell_open(String p_uri);
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder = true);
 	virtual Error set_cwd(const String &p_cwd);
+	virtual String get_cwd() const;
 
 	virtual bool has_environment(const String &p_var) const = 0;
 	virtual String get_environment(const String &p_var) const = 0;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -700,6 +700,17 @@ Error OS_Unix::set_cwd(const String &p_cwd) {
 	return OK;
 }
 
+String OS_Unix::get_cwd() const {
+	String cwd;
+	char ret[PATH_MAX];
+	char *temp = getcwd(ret, PATH_MAX);
+	ERR_FAIL_NULL_V(temp, "");
+	if (cwd.parse_utf8(ret) != OK) {
+		cwd = ret; // No utf8, maybe latin1?
+	}
+	return cwd;
+}
+
 bool OS_Unix::has_environment(const String &p_var) const {
 	return getenv(p_var.utf8().get_data()) != nullptr;
 }

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -60,6 +60,7 @@ public:
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
 	virtual Error set_cwd(const String &p_cwd) override;
+	virtual String get_cwd() const override;
 
 	virtual String get_name() const override;
 	virtual String get_distribution_name() const override;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -914,6 +914,21 @@ Error OS_Windows::set_cwd(const String &p_cwd) {
 	return OK;
 }
 
+String OS_Windows::get_cwd() const {
+	const DWORD size = GetCurrentDirectoryW(0, nullptr);
+
+	Char16String buffer;
+	buffer.resize((int)size);
+	if (GetCurrentDirectoryW(size, (wchar_t *)buffer.ptrw()) == 0) {
+		return OS::get_cwd();
+	}
+
+	String result;
+	result.parse_utf16(buffer.ptr());
+
+	return result;
+}
+
 Vector<String> OS_Windows::get_system_fonts() const {
 	if (!dwrite_init) {
 		return Vector<String>();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -181,6 +181,7 @@ public:
 	virtual double get_unix_time() const override;
 
 	virtual Error set_cwd(const String &p_cwd) override;
+	virtual String get_cwd() const override;
 
 	virtual void delay_usec(uint32_t p_usec) const override;
 	virtual uint64_t get_ticks_usec() const override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
It seems that we get current working directory by creating a DirAccess without path init and use get_current_dir(). It doesn't look intuitive.
In fact, the DirAccess finally calls the cwd getting function of specific platform. This PR move them to the OS::get_cwd virtual.