### PR TITLE
Fix incorrect condition for error filtering

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildProblemsView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildProblemsView.cs
@@ -308,14 +308,14 @@ namespace GodotTools.Build
                 return false;
 
             string searchText = _searchBox.Text;
-            if (!string.IsNullOrEmpty(searchText) &&
-                (!diagnostic.Message.Contains(searchText, StringComparison.OrdinalIgnoreCase) ||
-                !(diagnostic.File?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false)))
-            {
-                return false;
-            }
+            if (string.IsNullOrEmpty(searchText))
+                return true;
+            if (diagnostic.Message.Contains(searchText, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (diagnostic.File?.Contains(searchText, StringComparison.OrdinalIgnoreCase) ?? false)
+                return true;
 
-            return true;
+            return false;
         }
 
         private Color? GetProblemItemColor(BuildDiagnostic diagnostic)


### PR DESCRIPTION
Fixes: #87643

The original condition stopped immediately after checking for 'searchText' in the 'Message' field, resulting in premature termination of subsequent checks. This fix ensures that all relevant conditions are appropriately evaluated before determining the filtering outcome.

Additionally, accompanying changes include improved code readability for better comprehension. This adjustment enhances the maintainability of the error filtering mechanism, contributing to a more robust codebase overall.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
