### PR TITLE
Separate and unify iterators from `Vector` and `LocalVector`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -31,11 +31,14 @@
 #ifndef LOCAL_VECTOR_H
 #define LOCAL_VECTOR_H
 
+#include "core/error/error_list.h"
 #include "core/error/error_macros.h"
 #include "core/os/memory.h"
 #include "core/templates/sort_array.h"
 #include "core/templates/vector.h"
+#include "core/templates/vector_iterator.h"
 
+#include <cstring>
 #include <initializer_list>
 #include <type_traits>
 
@@ -46,38 +49,64 @@ class LocalVector {
 private:
 	U count = 0;
 	U capacity = 0;
-	T *data = nullptr;
+	T *data = nullptr; 
+
+protected:
+	_FORCE_INLINE_ void realloc_more(U p_size) {
+		CRASH_COND_MSG(p_size <= capacity, "Precondition for realloc_more not met");
+		
+		T *p_data = (T *)memrealloc(data, p_size * sizeof(T));
+		if (likely(p_data)) {
+			data = p_data;
+			capacity = p_size;
+		}
+		else {
+			CRASH_NOW_MSG(error_names[ERR_OUT_OF_MEMORY])
+		}
+	}
 
 public:
-	T *ptr() {
-		return data;
-	}
+	using Iterator = VectorIterator<T>;
+	using ConstIterator = ConstVectorIterator<T>;
 
-	const T *ptr() const {
-		return data;
-	}
+	T *ptr() { return data; }
+	const T *ptr() const { return data; }
 
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {
-			capacity = tight ? (capacity + 1) : MAX((U)1, capacity << 1);
-			data = (T *)memrealloc(data, capacity * sizeof(T));
-			CRASH_COND_MSG(!data, "Out of memory");
+			constexpr auto new_cap = [](U p_cap) noexcept {
+				if constexpr (tight) {
+					return p_cap + 1;
+				}
+				else {
+					return = MAX((U)1, p_cap << 1);
+				}
+			};
+
+			realloc_more(new_cap(capacity));
 		}
 
-		if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 			memnew_placement(&data[count++], T(p_elem));
-		} else {
+		}
+		else {
 			data[count++] = p_elem;
 		}
 	}
 
 	void remove_at(U p_index) {
 		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
-		count--;
-		for (U i = p_index; i < count; i++) {
-			data[i] = data[i + 1];
+		--count;
+		if constexpr (std::is_trivially_copyable_v<T>/* && !force_trivial ?*/) {
+			std::memmove(&data[p_index], &data[p_index + 1], 
+				(count - p_index) * sizeof(T));
 		}
-		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+		else {
+			for (U i = p_index; i < count - 1; ++i) {
+				data[i] = data[i + 1];
+			}
+		}
+		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -86,11 +115,11 @@ public:
 	/// remove. It's generally faster than `remove_at`.
 	void remove_at_unordered(U p_index) {
 		ERR_FAIL_INDEX(p_index, count);
-		count--;
+		--count;
 		if (count > p_index) {
 			data[p_index] = data[count];
 		}
-		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -105,7 +134,7 @@ public:
 	}
 
 	void invert() {
-		for (U i = 0; i < count / 2; i++) {
+		for (U i = 0; i < count / 2; ++i) {
 			SWAP(data[i], data[count - i - 1]);
 		}
 	}
@@ -122,37 +151,42 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 	_FORCE_INLINE_ void reserve(U p_size) {
-		p_size = tight ? p_size : nearest_power_of_2_templated(p_size);
+		constexpr auto new_size = [](U _p_size) noexcept {
+			if constexpr (tight) {
+				return _p_size;
+			}
+			else {
+				return nearest_power_of_2_templated(_p_size);
+			}
+		};
+		p_size = new_size(p_size);
+		
 		if (p_size > capacity) {
-			capacity = p_size;
-			data = (T *)memrealloc(data, capacity * sizeof(T));
-			CRASH_COND_MSG(!data, "Out of memory");
+			realloc_more(p_size);
 		}
 	}
 
 	_FORCE_INLINE_ U size() const { return count; }
 	void resize(U p_size) {
 		if (p_size < count) {
-			if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
-				for (U i = p_size; i < count; i++) {
+			if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
+				for (U i = p_size; i < count; ++i) {
 					data[i].~T();
 				}
 			}
 			count = p_size;
-		} else if (p_size > count) {
-			if (unlikely(p_size > capacity)) {
-				capacity = tight ? p_size : nearest_power_of_2_templated(p_size);
-				data = (T *)memrealloc(data, capacity * sizeof(T));
-				CRASH_COND_MSG(!data, "Out of memory");
-			}
-			if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
-				for (U i = count; i < p_size; i++) {
+		}
+		else if (p_size > count) {
+			reserve(p_size);
+			if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
+				for (U i = count; i < p_size; ++i) {
 					memnew_placement(&data[i], T);
 				}
 			}
 			count = p_size;
 		}
 	}
+
 	_FORCE_INLINE_ const T &operator[](U p_index) const {
 		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
 		return data[p_index];
@@ -162,85 +196,34 @@ public:
 		return data[p_index];
 	}
 
-	struct Iterator {
-		_FORCE_INLINE_ T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ Iterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ Iterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
+	_FORCE_INLINE_ Iterator begin() { return { data }; }
+	_FORCE_INLINE_ Iterator end() { return { data + size() }; }
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
+	_FORCE_INLINE_ ConstIterator begin() const { return { ptr() }; }
+	_FORCE_INLINE_ ConstIterator end() const { return { ptr() + size()) }; }
 
-		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
-		Iterator() {}
-		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		T *elem_ptr = nullptr;
-	};
-
-	struct ConstIterator {
-		_FORCE_INLINE_ const T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ const T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ ConstIterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ ConstIterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
-
-		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
-		ConstIterator() {}
-		ConstIterator(const ConstIterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		const T *elem_ptr = nullptr;
-	};
-
-	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(data);
-	}
-	_FORCE_INLINE_ Iterator end() {
-		return Iterator(data + size());
-	}
-
-	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(ptr());
-	}
-	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(ptr() + size());
-	}
-
-	void insert(U p_pos, T p_val) {
-		ERR_FAIL_UNSIGNED_INDEX(p_pos, count + 1);
-		if (p_pos == count) {
+	void insert(U p_index, T p_val) {
+		ERR_FAIL_UNSIGNED_INDEX(p_index, count + 1);
+		if (p_index == count) {
 			push_back(p_val);
-		} else {
+		}
+		else {
 			resize(count + 1);
-			for (U i = count - 1; i > p_pos; i--) {
-				data[i] = data[i - 1];
+			if constexpr (std::is_trivially_copyable_v<T>/* && !force_trivial ?*/) {
+				std::memmove(&data[p_index + 1], &data[p_index], 
+					(count - p_index - 1) * sizeof(T));
 			}
-			data[p_pos] = p_val;
+			else {
+				for (U i = count - 1; i > p_index; --i) {
+					data[i] = data[i - 1];
+				}
+			}	
+			data[p_index] = p_val;
 		}
 	}
 
 	int64_t find(const T &p_val, U p_from = 0) const {
-		for (U i = p_from; i < count; i++) {
+		for (U i = p_from; i < count; ++i) {
 			if (data[i] == p_val) {
 				return int64_t(i);
 			}
@@ -265,7 +248,7 @@ public:
 
 	void ordered_insert(T p_val) {
 		U i;
-		for (i = 0; i < count; i++) {
+		for (i = 0; i < count; ++i) {
 			if (p_val < data[i]) {
 				break;
 			}
@@ -298,19 +281,19 @@ public:
 	}
 	_FORCE_INLINE_ LocalVector(const LocalVector &p_from) {
 		resize(p_from.size());
-		for (U i = 0; i < p_from.count; i++) {
+		for (U i = 0; i < p_from.count; ++i) {
 			data[i] = p_from.data[i];
 		}
 	}
 	inline void operator=(const LocalVector &p_from) {
 		resize(p_from.size());
-		for (U i = 0; i < p_from.count; i++) {
+		for (U i = 0; i < p_from.count; ++i) {
 			data[i] = p_from.data[i];
 		}
 	}
 	inline void operator=(const Vector<T> &p_from) {
 		resize(p_from.size());
-		for (U i = 0; i < count; i++) {
+		for (U i = 0; i < count; ++i) {
 			data[i] = p_from[i];
 		}
 	}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -215,26 +215,31 @@ public:
 		return false;
 	}
 
-	_FORCE_INLINE_ Iterator begin() { return { ptrw() }; }
-	_FORCE_INLINE_ Iterator end() { return { ptrw() + size() }; }
+	_FORCE_INLINE_ Iterator begin() { return Iterator(ptrw()); }
+	_FORCE_INLINE_ Iterator end(){ return Iterator(ptrw() + size()) };
+}
 
-	_FORCE_INLINE_ ConstIterator begin() const { return { ptr() }; }
-	_FORCE_INLINE_ ConstIterator end() const { return { ptr() + size() }; }
+_FORCE_INLINE_ ConstIterator
+begin() const {
+	return ConstIterator(ptr());
+}
+_FORCE_INLINE_ ConstIterator end() const { return ConstIterator(ptr() + size()); }
 
-	_FORCE_INLINE_ Vector() {}
-	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {
-		Error err = _cowdata.resize(p_init.size());
-		ERR_FAIL_COND(err);
+_FORCE_INLINE_ Vector() {}
+_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {
+	Error err = _cowdata.resize(p_init.size());
+	ERR_FAIL_COND(err);
 
-		Size i = 0;
-		for (const T &element : p_init) {
-			_cowdata.set(i++, element);
-		}
+	Size i = 0;
+	for (const T &element : p_init) {
+		_cowdata.set(i++, element);
 	}
-	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+}
+_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
 
-	_FORCE_INLINE_ ~Vector() {}
-};
+_FORCE_INLINE_ ~Vector() {}
+}
+;
 
 template <class T>
 void Vector<T>::reverse() {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -41,6 +41,7 @@
 #include "core/templates/cowdata.h"
 #include "core/templates/search_array.h"
 #include "core/templates/sort_array.h"
+#include "core/templates/vector_iterator.h"
 
 #include <climits>
 #include <initializer_list>
@@ -61,7 +62,9 @@ class Vector {
 
 public:
 	VectorWriteProxy<T> write;
-	typedef typename CowData<T>::Size Size;
+	using Size = CowData<T>::Size;
+	using Iterator = VectorIterator<T>;
+	using ConstIterator = ConstVectorIterator<T>;
 
 private:
 	CowData<T> _cowdata;
@@ -212,69 +215,11 @@ public:
 		return false;
 	}
 
-	struct Iterator {
-		_FORCE_INLINE_ T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ Iterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ Iterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
+	_FORCE_INLINE_ Iterator begin() { return { ptrw() }; }
+	_FORCE_INLINE_ Iterator end() { return { ptrw() + size() }; }
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
-		Iterator() {}
-		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		T *elem_ptr = nullptr;
-	};
-
-	struct ConstIterator {
-		_FORCE_INLINE_ const T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ const T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ ConstIterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ ConstIterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
-
-		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
-		ConstIterator() {}
-		ConstIterator(const ConstIterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		const T *elem_ptr = nullptr;
-	};
-
-	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(ptrw());
-	}
-	_FORCE_INLINE_ Iterator end() {
-		return Iterator(ptrw() + size());
-	}
-
-	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(ptr());
-	}
-	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(ptr() + size());
-	}
+	_FORCE_INLINE_ ConstIterator begin() const { return { ptr() }; }
+	_FORCE_INLINE_ ConstIterator end() const { return { ptr() + size() }; }
 
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -216,30 +216,25 @@ public:
 	}
 
 	_FORCE_INLINE_ Iterator begin() { return Iterator(ptrw()); }
-	_FORCE_INLINE_ Iterator end(){ return Iterator(ptrw() + size()) };
-}
+	_FORCE_INLINE_ Iterator end() { return Iterator(ptrw() + size()); }
 
-_FORCE_INLINE_ ConstIterator
-begin() const {
-	return ConstIterator(ptr());
-}
-_FORCE_INLINE_ ConstIterator end() const { return ConstIterator(ptr() + size()); }
+	_FORCE_INLINE_ ConstIterator begin() const { return ConstIterator(ptr()); }
+	_FORCE_INLINE_ ConstIterator end() const { return ConstIterator(ptr() + size()); }
 
-_FORCE_INLINE_ Vector() {}
-_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {
-	Error err = _cowdata.resize(p_init.size());
-	ERR_FAIL_COND(err);
+	_FORCE_INLINE_ Vector() {}
+	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {
+		Error err = _cowdata.resize(p_init.size());
+		ERR_FAIL_COND(err);
 
-	Size i = 0;
-	for (const T &element : p_init) {
-		_cowdata.set(i++, element);
+		Size i = 0;
+		for (const T &element : p_init) {
+			_cowdata.set(i++, element);
+		}
 	}
-}
-_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
 
-_FORCE_INLINE_ ~Vector() {}
-}
-;
+	_FORCE_INLINE_ ~Vector() {}
+};
 
 template <class T>
 void Vector<T>::reverse() {

--- a/core/templates/vector_iterator.h
+++ b/core/templates/vector_iterator.h
@@ -1,0 +1,171 @@
+/**************************************************************************/
+/*  vector_iterator.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef VECTOR_ITERATOR_H
+#define VECTOR_ITERATOR_H
+
+/**
+ * @class VectorIterator
+ * Iterator for Vector and LocalVector.
+ */
+
+#include <iterator>
+
+template <class T>
+struct ConstVectorIterator {
+	using iterator_category = std::random_access_iterator_tag;
+	using value_type = T;
+	using difference_type = ptrdiff_t;
+	using pointer = const value_type*;
+	using reference = const value_type&;
+	
+	reference operator*() const noexcept { return *elem_ptr; }
+	pointer operator->() const noexcept { return elem_ptr; }
+
+	ConstVectorIterator &operator++() noexcept  {
+		++elem_ptr;
+		return *this;
+	}
+	ConstVectorIterator operator++(int) noexcept {
+		ConstVectorIterator tmp = *this;
+		++*this;
+		return tmp;
+	}
+
+	ConstVectorIterator &operator--() noexcept {
+		--elem_ptr;
+		return *this;
+	}
+	ConstVectorIterator operator--(int) noexcept {
+		ConstVectorIterator tmp = *this;
+		--*this;
+		return tmp;
+	}
+
+	bool operator==(const ConstVectorIterator &p_it) const noexcept
+		{ return elem_ptr == p_it.elem_ptr; }
+	bool operator!=(const ConstVectorIterator &p_it) const noexcept
+		{ return elem_ptr != p_it.elem_ptr; }
+
+	bool operator< (const ConstVectorIterator &p_it) const noexcept 
+		{ return this->elem_ptr < p_it.elem_ptr; }
+	bool operator> (const ConstVectorIterator &p_it) const noexcept
+		{ return this->elem_ptr > p_it.elem_ptr; }
+	bool operator>=(const ConstVectorIterator &p_it) const noexcept
+		{ return !(this->elem_ptr < p_it.elem_ptr); }
+	bool operator<=(const ConstVectorIterator &p_it) const noexcept
+		{ return !(this->elem_ptr > p_it.elem_ptr); }
+
+	difference_type operator-(const ConstVectorIterator &p_it) const noexcept
+		{ return elem_ptr - p_it.elem_ptr; }
+
+	ConstVectorIterator operator+(const difference_type &p_diff) const noexcept
+		{ return { elem_ptr + p_diff }; }
+	ConstVectorIterator operator-(const difference_type &p_diff) const noexcept
+		{ return { elem_ptr - p_diff }; }
+
+	reference operator[] (const difference_type &p_offset) const noexcept 
+		{ return *(*this + p_offset); }
+
+	ConstVectorIterator(const T *p_ptr) noexcept : elem_ptr{ const_cast<T*>(p_ptr) } {}
+	ConstVectorIterator(T *p_ptr) noexcept : elem_ptr{ p_ptr } {}
+	ConstVectorIterator() noexcept {}
+	ConstVectorIterator(const ConstVectorIterator& p_it) noexcept = default;
+
+protected:
+	T *elem_ptr = nullptr;
+};
+static_assert(std::is_trivially_copyable_v<ConstVectorIterator<size_t>>);
+
+template <class T>
+struct VectorIterator : ConstVectorIterator<T> 
+{
+	using _base = ConstVectorIterator<T>;
+	using _base::_base;
+
+	using iterator_category = std::random_access_iterator_tag;
+	using value_type = T;
+	using difference_type = ptrdiff_t;
+	using pointer = value_type*;
+	using reference = value_type&;
+	
+	reference operator*() const noexcept { return *elem_ptr; }
+	pointer operator->() const noexcept { return elem_ptr; }
+
+	VectorIterator& operator++() noexcept {
+		++elem_ptr;
+		return *this;
+	}
+	VectorIterator operator++(int) noexcept {
+		VectorIterator tmp = *this;
+		++*this;
+		return tmp;
+	}
+
+	VectorIterator &operator--() noexcept {
+		--elem_ptr;
+		return *this;
+	}
+	VectorIterator operator--(int) noexcept {
+		VectorIterator tmp = *this;
+		--*this;
+		return tmp;
+	}
+
+	bool operator==(const VectorIterator &p_it) const noexcept
+		{ return elem_ptr == p_it.elem_ptr; }
+	bool operator!=(const VectorIterator &p_it) const noexcept
+		{ return elem_ptr != p_it.elem_ptr; }
+
+	bool operator< (const VectorIterator &p_it) const noexcept
+		{ return this->elem_ptr < p_it.elem_ptr; }
+	bool operator> (const VectorIterator &p_it) const noexcept
+		{ return this->elem_ptr > p_it.elem_ptr; }
+	bool operator>=(const VectorIterator &p_it) const noexcept
+		{ return !(this->elem_ptr < p_it.elem_ptr); }
+	bool operator<=(const VectorIterator &p_it) const noexcept
+		{ return !(this->elem_ptr > p_it.elem_ptr); }
+
+	difference_type operator-(const VectorIterator &p_it) const noexcept
+		{ return elem_ptr - p_it.elem_ptr; }
+
+	VectorIterator operator+(const difference_type &p_diff) const noexcept
+		{ return { elem_ptr + p_diff }; }
+	VectorIterator operator-(const difference_type &p_diff) const noexcept
+		{ return { elem_ptr - p_diff }; }
+
+	reference operator[] (const difference_type &p_offset) const noexcept 
+		{ return *(*this + p_offset); }
+
+	VectorIterator(const T *p_ptr) = delete;
+};
+static_assert(std::is_trivially_copyable_v<VectorIterator<size_t>>);
+
+#endif // VECTOR_ITERATOR_H

--- a/core/templates/vector_iterator.h
+++ b/core/templates/vector_iterator.h
@@ -31,141 +31,118 @@
 #ifndef VECTOR_ITERATOR_H
 #define VECTOR_ITERATOR_H
 
+#include <cstddef>
+
 /**
  * @class VectorIterator
  * Iterator for Vector and LocalVector.
  */
 
-#include <iterator>
-
 template <class T>
 struct ConstVectorIterator {
-	using iterator_category = std::random_access_iterator_tag;
 	using value_type = T;
 	using difference_type = ptrdiff_t;
-	using pointer = const value_type*;
-	using reference = const value_type&;
-	
-	reference operator*() const noexcept { return *elem_ptr; }
-	pointer operator->() const noexcept { return elem_ptr; }
+	using pointer = const value_type *;
+	using reference = const value_type &;
 
-	ConstVectorIterator &operator++() noexcept  {
+	reference operator*() const { return *elem_ptr; }
+	pointer operator->() const { return elem_ptr; }
+
+	ConstVectorIterator &operator++() {
 		++elem_ptr;
 		return *this;
 	}
-	ConstVectorIterator operator++(int) noexcept {
+	ConstVectorIterator operator++(int) {
 		ConstVectorIterator tmp = *this;
 		++*this;
 		return tmp;
 	}
 
-	ConstVectorIterator &operator--() noexcept {
+	ConstVectorIterator &operator--() {
 		--elem_ptr;
 		return *this;
 	}
-	ConstVectorIterator operator--(int) noexcept {
+	ConstVectorIterator operator--(int) {
 		ConstVectorIterator tmp = *this;
 		--*this;
 		return tmp;
 	}
 
-	bool operator==(const ConstVectorIterator &p_it) const noexcept
-		{ return elem_ptr == p_it.elem_ptr; }
-	bool operator!=(const ConstVectorIterator &p_it) const noexcept
-		{ return elem_ptr != p_it.elem_ptr; }
+	bool operator==(const ConstVectorIterator &p_it) const { return elem_ptr == p_it.elem_ptr; }
+	bool operator!=(const ConstVectorIterator &p_it) const { return elem_ptr != p_it.elem_ptr; }
 
-	bool operator< (const ConstVectorIterator &p_it) const noexcept 
-		{ return this->elem_ptr < p_it.elem_ptr; }
-	bool operator> (const ConstVectorIterator &p_it) const noexcept
-		{ return this->elem_ptr > p_it.elem_ptr; }
-	bool operator>=(const ConstVectorIterator &p_it) const noexcept
-		{ return !(this->elem_ptr < p_it.elem_ptr); }
-	bool operator<=(const ConstVectorIterator &p_it) const noexcept
-		{ return !(this->elem_ptr > p_it.elem_ptr); }
+	bool operator<(const ConstVectorIterator &p_it) const { return this->elem_ptr < p_it.elem_ptr; }
+	bool operator>(const ConstVectorIterator &p_it) const { return this->elem_ptr > p_it.elem_ptr; }
+	bool operator>=(const ConstVectorIterator &p_it) const { return !(this->elem_ptr < p_it.elem_ptr); }
+	bool operator<=(const ConstVectorIterator &p_it) const { return !(this->elem_ptr > p_it.elem_ptr); }
 
-	difference_type operator-(const ConstVectorIterator &p_it) const noexcept
-		{ return elem_ptr - p_it.elem_ptr; }
+	difference_type operator-(const ConstVectorIterator &p_it) const { return elem_ptr - p_it.elem_ptr; }
 
-	ConstVectorIterator operator+(const difference_type &p_diff) const noexcept
-		{ return { elem_ptr + p_diff }; }
-	ConstVectorIterator operator-(const difference_type &p_diff) const noexcept
-		{ return { elem_ptr - p_diff }; }
+	ConstVectorIterator operator+(const difference_type &p_diff) const { return { elem_ptr + p_diff }; }
+	ConstVectorIterator operator-(const difference_type &p_diff) const { return { elem_ptr - p_diff }; }
 
-	reference operator[] (const difference_type &p_offset) const noexcept 
-		{ return *(*this + p_offset); }
+	reference operator[](const difference_type &p_offset) const { return *(*this + p_offset); }
 
-	ConstVectorIterator(const T *p_ptr) noexcept : elem_ptr{ const_cast<T*>(p_ptr) } {}
-	ConstVectorIterator(T *p_ptr) noexcept : elem_ptr{ p_ptr } {}
-	ConstVectorIterator() noexcept {}
-	ConstVectorIterator(const ConstVectorIterator& p_it) noexcept = default;
+	ConstVectorIterator(const T *p_ptr) :
+			elem_ptr{ const_cast<T *>(p_ptr) } {}
+	ConstVectorIterator(T *p_ptr) :
+			elem_ptr{ p_ptr } {}
+	ConstVectorIterator() {}
+	ConstVectorIterator(const ConstVectorIterator &p_it) = default;
 
 protected:
 	T *elem_ptr = nullptr;
 };
-static_assert(std::is_trivially_copyable_v<ConstVectorIterator<size_t>>);
 
 template <class T>
-struct VectorIterator : ConstVectorIterator<T> 
-{
+struct VectorIterator : ConstVectorIterator<T> {
 	using _base = ConstVectorIterator<T>;
 	using _base::_base;
 
-	using iterator_category = std::random_access_iterator_tag;
 	using value_type = T;
 	using difference_type = ptrdiff_t;
-	using pointer = value_type*;
-	using reference = value_type&;
-	
-	reference operator*() const noexcept { return *elem_ptr; }
-	pointer operator->() const noexcept { return elem_ptr; }
+	using pointer = value_type *;
+	using reference = value_type &;
 
-	VectorIterator& operator++() noexcept {
+	reference operator*() const { return *elem_ptr; }
+	pointer operator->() const { return elem_ptr; }
+
+	VectorIterator &operator++() {
 		++elem_ptr;
 		return *this;
 	}
-	VectorIterator operator++(int) noexcept {
+	VectorIterator operator++(int) {
 		VectorIterator tmp = *this;
 		++*this;
 		return tmp;
 	}
 
-	VectorIterator &operator--() noexcept {
+	VectorIterator &operator--() {
 		--elem_ptr;
 		return *this;
 	}
-	VectorIterator operator--(int) noexcept {
+	VectorIterator operator--(int) {
 		VectorIterator tmp = *this;
 		--*this;
 		return tmp;
 	}
 
-	bool operator==(const VectorIterator &p_it) const noexcept
-		{ return elem_ptr == p_it.elem_ptr; }
-	bool operator!=(const VectorIterator &p_it) const noexcept
-		{ return elem_ptr != p_it.elem_ptr; }
+	bool operator==(const VectorIterator &p_it) const { return elem_ptr == p_it.elem_ptr; }
+	bool operator!=(const VectorIterator &p_it) const { return elem_ptr != p_it.elem_ptr; }
 
-	bool operator< (const VectorIterator &p_it) const noexcept
-		{ return this->elem_ptr < p_it.elem_ptr; }
-	bool operator> (const VectorIterator &p_it) const noexcept
-		{ return this->elem_ptr > p_it.elem_ptr; }
-	bool operator>=(const VectorIterator &p_it) const noexcept
-		{ return !(this->elem_ptr < p_it.elem_ptr); }
-	bool operator<=(const VectorIterator &p_it) const noexcept
-		{ return !(this->elem_ptr > p_it.elem_ptr); }
+	bool operator<(const VectorIterator &p_it) const { return this->elem_ptr < p_it.elem_ptr; }
+	bool operator>(const VectorIterator &p_it) const { return this->elem_ptr > p_it.elem_ptr; }
+	bool operator>=(const VectorIterator &p_it) const { return !(this->elem_ptr < p_it.elem_ptr); }
+	bool operator<=(const VectorIterator &p_it) const { return !(this->elem_ptr > p_it.elem_ptr); }
 
-	difference_type operator-(const VectorIterator &p_it) const noexcept
-		{ return elem_ptr - p_it.elem_ptr; }
+	difference_type operator-(const VectorIterator &p_it) const { return elem_ptr - p_it.elem_ptr; }
 
-	VectorIterator operator+(const difference_type &p_diff) const noexcept
-		{ return { elem_ptr + p_diff }; }
-	VectorIterator operator-(const difference_type &p_diff) const noexcept
-		{ return { elem_ptr - p_diff }; }
+	VectorIterator operator+(const difference_type &p_diff) const { return { elem_ptr + p_diff }; }
+	VectorIterator operator-(const difference_type &p_diff) const { return { elem_ptr - p_diff }; }
 
-	reference operator[] (const difference_type &p_offset) const noexcept 
-		{ return *(*this + p_offset); }
+	reference operator[](const difference_type &p_offset) const { return *(*this + p_offset); }
 
 	VectorIterator(const T *p_ptr) = delete;
 };
-static_assert(std::is_trivially_copyable_v<VectorIterator<size_t>>);
 
 #endif // VECTOR_ITERATOR_H

--- a/core/templates/vector_iterator.h
+++ b/core/templates/vector_iterator.h
@@ -78,8 +78,8 @@ struct ConstVectorIterator {
 
 	difference_type operator-(const ConstVectorIterator &p_it) const { return elem_ptr - p_it.elem_ptr; }
 
-	ConstVectorIterator operator+(const difference_type &p_diff) const { return { elem_ptr + p_diff }; }
-	ConstVectorIterator operator-(const difference_type &p_diff) const { return { elem_ptr - p_diff }; }
+	ConstVectorIterator operator+(const difference_type &p_diff) const { return ConstVectorIterator(elem_ptr + p_diff); }
+	ConstVectorIterator operator-(const difference_type &p_diff) const { return ConstVectorIterator(elem_ptr - p_diff); }
 
 	reference operator[](const difference_type &p_offset) const { return *(*this + p_offset); }
 
@@ -137,8 +137,8 @@ struct VectorIterator : ConstVectorIterator<T> {
 
 	difference_type operator-(const VectorIterator &p_it) const { return elem_ptr - p_it.elem_ptr; }
 
-	VectorIterator operator+(const difference_type &p_diff) const { return { elem_ptr + p_diff }; }
-	VectorIterator operator-(const difference_type &p_diff) const { return { elem_ptr - p_diff }; }
+	VectorIterator operator+(const difference_type &p_diff) const { return VectorIterator(elem_ptr + p_diff); }
+	VectorIterator operator-(const difference_type &p_diff) const { return VectorIterator(elem_ptr - p_diff); }
 
 	reference operator[](const difference_type &p_offset) const { return *(*this + p_offset); }
 


### PR DESCRIPTION
Both `LocalVector` and `Vector` now use the same `VectorIterator` defined in STL-algorithms-compatible `vector_iterator.h` ([#86573](https://github.com/godotengine/godot/pull/86573) included)

`LocalVector` `if(tight)` checks are now [compile-time](https://godbolt.org/z/W1YcrK1aY), and `remove_at()` and `insert()` now use `std::memmove()` for _trivially copyable_ types to shift data.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
