### PR TITLE
Namespace shader cache files by graphics API

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -36,6 +36,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/version.h"
 #include "renderer_compositor_rd.h"
+#include "servers/rendering/renderer_rd/api_context_rd.h"
 #include "servers/rendering/rendering_device.h"
 #include "thirdparty/misc/smolv.h"
 
@@ -395,10 +396,15 @@ String ShaderRD::_version_get_sha1(Version *p_version) const {
 static const char *shader_file_header = "GDSC";
 static const uint32_t cache_file_version = 3;
 
-bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
-	String sha1 = _version_get_sha1(p_version);
-	String path = shader_cache_dir.path_join(name).path_join(group_sha256[p_group]).path_join(sha1) + ".cache";
+String ShaderRD::_get_cache_file_path(Version *p_version, int p_group) {
+	const String &sha1 = _version_get_sha1(p_version);
+	const String &api_safe_name = String(RD::get_singleton()->get_context()->get_api_name()).validate_filename().to_lower();
+	const String &path = shader_cache_dir.path_join(name).path_join(group_sha256[p_group]).path_join(sha1) + "." + api_safe_name + ".cache";
+	return path;
+}
 
+bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
+	const String &path = _get_cache_file_path(p_version, p_group);
 	Ref<FileAccess> f = FileAccess::open(path, FileAccess::READ);
 	if (f.is_null()) {
 		return false;
@@ -464,9 +470,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 
 void ShaderRD::_save_to_cache(Version *p_version, int p_group) {
 	ERR_FAIL_COND(!shader_cache_dir_valid);
-	String sha1 = _version_get_sha1(p_version);
-	String path = shader_cache_dir.path_join(name).path_join(group_sha256[p_group]).path_join(sha1) + ".cache";
-
+	const String &path = _get_cache_file_path(p_version, p_group);
 	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 	f->store_buffer((const uint8_t *)shader_file_header, 4);

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -143,6 +143,7 @@ private:
 	void _add_stage(const char *p_code, StageType p_stage_type);
 
 	String _version_get_sha1(Version *p_version) const;
+	String _get_cache_file_path(Version *p_version, int p_group);
 	bool _load_from_cache(Version *p_version, int p_group);
 	void _save_to_cache(Version *p_version, int p_group);
 	void _initialize_cache();


### PR DESCRIPTION
Namely, cache files now end with `.d3d12.cache` or `.vulkan.cache` instead of just `.cache`. This avoids the whole shader cache from being invalidated (and thus regenerated) when switching rendering drivers.