### PR TITLE
Don't invoke adb with no runnable Android preset

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -110,8 +110,13 @@ void EditorExport::save_presets() {
 	save_timer->start();
 }
 
+void EditorExport::emit_presets_runnable_changed() {
+	emit_signal(_export_presets_runnable_updated);
+}
+
 void EditorExport::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("export_presets_updated"));
+	ADD_SIGNAL(MethodInfo(_export_presets_updated));
+	ADD_SIGNAL(MethodInfo(_export_presets_runnable_updated));
 }
 
 void EditorExport::add_export_platform(const Ref<EditorExportPlatform> &p_platform) {
@@ -135,6 +140,7 @@ void EditorExport::add_export_preset(const Ref<EditorExportPreset> &p_preset, in
 	} else {
 		export_presets.insert(p_at_pos, p_preset);
 	}
+	emit_presets_runnable_changed();
 }
 
 int EditorExport::get_export_preset_count() const {
@@ -149,6 +155,7 @@ Ref<EditorExportPreset> EditorExport::get_export_preset(int p_idx) {
 void EditorExport::remove_export_preset(int p_idx) {
 	export_presets.remove_at(p_idx);
 	save_presets();
+	emit_presets_runnable_changed();
 }
 
 void EditorExport::add_export_plugin(const Ref<EditorExportPlugin> &p_plugin) {
@@ -380,6 +387,10 @@ bool EditorExport::poll_export_platforms() {
 	return changed;
 }
 
+void EditorExport::connect_presets_runnable_updated(const Callable &p_target) {
+	connect(_export_presets_runnable_updated, p_target);
+}
+
 EditorExport::EditorExport() {
 	save_timer = memnew(Timer);
 	add_child(save_timer);
@@ -388,6 +399,7 @@ EditorExport::EditorExport() {
 	save_timer->connect("timeout", callable_mp(this, &EditorExport::_save));
 
 	_export_presets_updated = "export_presets_updated";
+	_export_presets_runnable_updated = "export_presets_runnable_updated";
 
 	singleton = this;
 	set_process(true);

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -41,7 +41,8 @@ class EditorExport : public Node {
 	Vector<Ref<EditorExportPreset>> export_presets;
 	Vector<Ref<EditorExportPlugin>> export_plugins;
 
-	StringName _export_presets_updated;
+	static inline StringName _export_presets_updated;
+	static inline StringName _export_presets_runnable_updated;
 
 	Timer *save_timer = nullptr;
 	bool block_save = false;
@@ -54,6 +55,7 @@ class EditorExport : public Node {
 protected:
 	friend class EditorExportPreset;
 	void save_presets();
+	void emit_presets_runnable_changed();
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -77,6 +79,7 @@ public:
 	void load_config();
 	void update_export_presets();
 	bool poll_export_platforms();
+	void connect_presets_runnable_updated(const Callable &p_target);
 
 	EditorExport();
 	~EditorExport();

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -180,6 +180,7 @@ String EditorExportPreset::get_name() const {
 
 void EditorExportPreset::set_runnable(bool p_enable) {
 	runnable = p_enable;
+	EditorExport::singleton->emit_presets_runnable_changed();
 	EditorExport::singleton->save_presets();
 }
 

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -291,7 +291,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 
 		// Check for devices updates
 		String adb = get_adb_path();
-		if (FileAccess::exists(adb)) {
+		if (ea->has_runnable_preset.is_set() && FileAccess::exists(adb)) {
 			String devices;
 			List<String> args;
 			args.push_back("devices");
@@ -421,6 +421,25 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 		List<String> args;
 		args.push_back("kill-server");
 		OS::get_singleton()->execute(adb, args);
+	}
+}
+
+void EditorExportPlatformAndroid::_update_preset_status() {
+	const int preset_count = EditorExport::get_singleton()->get_export_preset_count();
+	bool has_runnable = false;
+
+	for (int i = 0; i < preset_count; i++) {
+		const Ref<EditorExportPreset> &preset = EditorExport::get_singleton()->get_export_preset(i);
+		if (preset->get_platform() == this && preset->is_runnable()) {
+			has_runnable = true;
+			break;
+		}
+	}
+
+	if (has_runnable) {
+		has_runnable_preset.set();
+	} else {
+		has_runnable_preset.clear();
 	}
 }
 #endif
@@ -803,6 +822,15 @@ bool EditorExportPlatformAndroid::_uses_vulkan() {
 	String current_renderer = GLOBAL_GET("rendering/renderer/rendering_method.mobile");
 	bool uses_vulkan = (current_renderer == "forward_plus" || current_renderer == "mobile") && GLOBAL_GET("rendering/rendering_device/driver.android") == "vulkan";
 	return uses_vulkan;
+}
+
+void EditorExportPlatformAndroid::_notification(int p_what) {
+#ifndef ANDROID_ENABLED
+	if (p_what == NOTIFICATION_POSTINITIALIZE) {
+		ERR_FAIL_NULL(EditorExport::get_singleton());
+		EditorExport::get_singleton()->connect_presets_runnable_updated(callable_mp(this, &EditorExportPlatformAndroid::_update_preset_status));
+	}
+#endif
 }
 
 void EditorExportPlatformAndroid::_get_permissions(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, Vector<String> &r_permissions) {
@@ -3530,6 +3558,7 @@ EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
 		android_plugins_changed.set();
 #endif // DISABLE_DEPRECATED
 #ifndef ANDROID_ENABLED
+		_update_preset_status();
 		check_for_changes_thread.start(_check_for_changes_poll_thread, this);
 #endif
 	}

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -97,8 +97,10 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 #ifndef ANDROID_ENABLED
 	Thread check_for_changes_thread;
 	SafeFlag quit_request;
+	SafeFlag has_runnable_preset;
 
 	static void _check_for_changes_poll_thread(void *ud);
+	void _update_preset_status();
 #endif
 
 	String get_project_name(const String &p_name) const;
@@ -190,10 +192,12 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static bool _uses_vulkan();
 
+protected:
+	void _notification(int p_what);
+
 public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
 
-public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -124,6 +124,14 @@ String EditorExportPlatformIOS::get_export_option_warning(const EditorExportPres
 	return String();
 }
 
+void EditorExportPlatformIOS::_notification(int p_what) {
+#ifdef MACOS_ENABLED
+	if (p_what == NOTIFICATION_POSTINITIALIZE) {
+		EditorExport::get_singleton()->connect_presets_runnable_updated(callable_mp(this, &EditorExportPlatformIOS::_update_preset_status));
+	}
+#endif
+}
+
 bool EditorExportPlatformIOS::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
 	return true;
 }
@@ -2228,7 +2236,7 @@ void EditorExportPlatformIOS::_check_for_changes_poll_thread(void *ud) {
 
 		// Enum real devices (via ios_deploy, pre Xcode 15).
 		String idepl = EDITOR_GET("export/ios/ios_deploy");
-		if (!idepl.is_empty()) {
+		if (ea->has_runnable_preset.is_set() && !idepl.is_empty()) {
 			String devices;
 			List<String> args;
 			args.push_back("-c");
@@ -2266,7 +2274,7 @@ void EditorExportPlatformIOS::_check_for_changes_poll_thread(void *ud) {
 		}
 
 		// Enum simulators.
-		if (_check_xcode_install() && (FileAccess::exists("/usr/bin/xcrun") || FileAccess::exists("/bin/xcrun"))) {
+		if (ea->has_runnable_preset.is_set() && _check_xcode_install() && (FileAccess::exists("/usr/bin/xcrun") || FileAccess::exists("/bin/xcrun"))) {
 			{
 				String devices;
 				List<String> args;
@@ -2304,7 +2312,7 @@ void EditorExportPlatformIOS::_check_for_changes_poll_thread(void *ud) {
 			}
 
 			// Enum simulators.
-			{
+			if (ea->has_runnable_preset.is_set()) {
 				String devices;
 				List<String> args;
 				args.push_back("simctl");
@@ -2371,6 +2379,25 @@ void EditorExportPlatformIOS::_check_for_changes_poll_thread(void *ud) {
 				break;
 			}
 		}
+	}
+}
+
+void EditorExportPlatformIOS::_update_preset_status() {
+	const int preset_count = EditorExport::get_singleton()->get_export_preset_count();
+	bool has_runnable = false;
+
+	for (int i = 0; i < preset_count; i++) {
+		const Ref<EditorExportPreset> &preset = EditorExport::get_singleton()->get_export_preset(i);
+		if (preset->get_platform() == this && preset->is_runnable()) {
+			has_runnable = true;
+			break;
+		}
+	}
+
+	if (has_runnable) {
+		has_runnable_preset.set();
+	} else {
+		has_runnable_preset.clear();
 	}
 }
 #endif
@@ -2637,6 +2664,7 @@ EditorExportPlatformIOS::EditorExportPlatformIOS() {
 		plugins_changed.set();
 		devices_changed.set();
 #ifdef MACOS_ENABLED
+		_update_preset_status();
 		check_for_changes_thread.start(_check_for_changes_poll_thread, this);
 #endif
 	}

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -81,9 +81,11 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 #ifdef MACOS_ENABLED
 	Thread check_for_changes_thread;
 	SafeFlag quit_request;
+	SafeFlag has_runnable_preset;
 
 	static bool _check_xcode_install();
 	static void _check_for_changes_poll_thread(void *ud);
+	void _update_preset_status();
 #endif
 
 	typedef Error (*FileHandler)(String p_file, void *p_userdata);
@@ -151,6 +153,8 @@ protected:
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
 	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
 	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
+
+	void _notification(int p_what);
 
 public:
 	virtual String get_name() const override { return "iOS"; }


### PR DESCRIPTION
Android export plugin will periodically call adb.exe to check for available devices. It does this constantly while the editor is running, regardless if the project is targeted for Android or not. Performance implications aside, this check will sometimes fail and spit an error that reminds you that it runs in the background.

This PR tweaks this behavior. The adb will be called only if the project has an export preset for Android and it's marked runnable (AFAIK it's a requirement to run something on a device). I added a new signal that gets emitted when adding/removing preset and toggling Runnable.