### PR TITLE
Expose Read Only and Write Only storage buffers

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1873,7 +1873,7 @@
 			Buffer can only be read by the shader using it.
 		</constant>
 		<constant name="STORAGE_BUFFER_USAGE_WRITEONLY" value="4" enum="StorageBufferUsage" is_bitfield="true">
-			Buffer can only be written to by the shader using it, usually used by an outpupt buffer to be copied back to the CPU later.
+			Buffer can only be written to by the shader using it, usually used by an output buffer to be copied back to the CPU later.
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">
 			Sampler uniform.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1868,6 +1868,8 @@
 			Index buffer in 32-bit unsigned integer format. This limits the maximum index that can be specified to [code]4294967295[/code].
 		</constant>
 		<constant name="STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT" value="1" enum="StorageBufferUsage" is_bitfield="true">
+		<constant name="STORAGE_BUFFER_USAGE_READONLY" value="2" enum="StorageBufferUsage" is_bitfield="true">
+		<constant name="STORAGE_BUFFER_USAGE_WRITEONLY" value="4" enum="StorageBufferUsage" is_bitfield="true">
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">
 			Sampler uniform.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1868,8 +1868,12 @@
 			Index buffer in 32-bit unsigned integer format. This limits the maximum index that can be specified to [code]4294967295[/code].
 		</constant>
 		<constant name="STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT" value="1" enum="StorageBufferUsage" is_bitfield="true">
+		</constant>
 		<constant name="STORAGE_BUFFER_USAGE_READONLY" value="2" enum="StorageBufferUsage" is_bitfield="true">
+			Buffer can only be read by the shader using it.
+		</constant>
 		<constant name="STORAGE_BUFFER_USAGE_WRITEONLY" value="4" enum="StorageBufferUsage" is_bitfield="true">
+			Buffer can only be written to by the shader using it, usually used by an outpupt buffer to be copied back to CPU later.
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">
 			Sampler uniform.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1873,7 +1873,7 @@
 			Buffer can only be read by the shader using it.
 		</constant>
 		<constant name="STORAGE_BUFFER_USAGE_WRITEONLY" value="4" enum="StorageBufferUsage" is_bitfield="true">
-			Buffer can only be written to by the shader using it, usually used by an outpupt buffer to be copied back to CPU later.
+			Buffer can only be written to by the shader using it, usually used by an outpupt buffer to be copied back to the CPU later.
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">
 			Sampler uniform.

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -533,7 +533,7 @@ RID RenderingDevice::storage_buffer_create(uint32_t p_size_bytes, const Vector<u
 	ERR_FAIL_COND_V_MSG(p_usage.has_flag(STORAGE_BUFFER_USAGE_READONLY) && p_usage.has_flag(STORAGE_BUFFER_USAGE_WRITEONLY), RID(), "Cannot set both read and write ONLY flags");
 
 	Buffer buffer;
-	buffer.size = p_size_bytes; 
+	buffer.size = p_size_bytes;
 	buffer.usage = RDD::BUFFER_USAGE_STORAGE_BIT;
 	if (p_usage.has_flag(STORAGE_BUFFER_USAGE_READONLY)) {
 		buffer.usage.set_flag(RDD::BUFFER_USAGE_TRANSFER_FROM_BIT);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -530,10 +530,19 @@ RID RenderingDevice::storage_buffer_create(uint32_t p_size_bytes, const Vector<u
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(p_data.size() && (uint32_t)p_data.size() != p_size_bytes, RID());
+	ERR_FAIL_COND_V_MSG(p_usage.has_flag(STORAGE_BUFFER_USAGE_READONLY) && p_usage.has_flag(STORAGE_BUFFER_USAGE_WRITEONLY), RID(), "Cannot set both read and write ONLY flags");
 
 	Buffer buffer;
-	buffer.size = p_size_bytes;
-	buffer.usage = (RDD::BUFFER_USAGE_TRANSFER_FROM_BIT | RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_STORAGE_BIT);
+	buffer.size = p_size_bytes; 
+	buffer.usage = RDD::BUFFER_USAGE_STORAGE_BIT;
+	if (p_usage.has_flag(STORAGE_BUFFER_USAGE_READONLY)) {
+		buffer.usage.set_flag(RDD::BUFFER_USAGE_TRANSFER_FROM_BIT);
+	} else if (p_usage.has_flag(STORAGE_BUFFER_USAGE_WRITEONLY)) {
+		buffer.usage.set_flag(RDD::BUFFER_USAGE_TRANSFER_TO_BIT);
+	} else {
+		buffer.usage.set_flag(RDD::BUFFER_USAGE_TRANSFER_FROM_BIT);
+		buffer.usage.set_flag(RDD::BUFFER_USAGE_TRANSFER_TO_BIT);
+	}
 	if (p_usage.has_flag(STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT)) {
 		buffer.usage.set_flag(RDD::BUFFER_USAGE_INDIRECT_BIT);
 	}
@@ -5696,6 +5705,8 @@ void RenderingDevice::_bind_methods() {
 	BIND_ENUM_CONSTANT(INDEX_BUFFER_FORMAT_UINT32);
 
 	BIND_BITFIELD_FLAG(STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT);
+	BIND_BITFIELD_FLAG(STORAGE_BUFFER_USAGE_READONLY);
+	BIND_BITFIELD_FLAG(STORAGE_BUFFER_USAGE_WRITEONLY);
 
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_SAMPLER); //for sampling only (sampler GLSL type)
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_SAMPLER_WITH_TEXTURE); // for sampling only); but includes a texture); (samplerXX GLSL type)); first a sampler then a texture

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -851,7 +851,7 @@ public:
 	enum StorageBufferUsage {
 		STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT = 1,
 		STORAGE_BUFFER_USAGE_READONLY = 2,
-		STORAGE_BUFFER_USAGE_WRITEONLY = 4
+		STORAGE_BUFFER_USAGE_WRITEONLY = 4,
 	};
 
 	RID uniform_buffer_create(uint32_t p_size_bytes, const Vector<uint8_t> &p_data = Vector<uint8_t>());

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -850,6 +850,8 @@ public:
 
 	enum StorageBufferUsage {
 		STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT = 1,
+		STORAGE_BUFFER_USAGE_READONLY = 2,
+		STORAGE_BUFFER_USAGE_WRITEONLY = 4
 	};
 
 	RID uniform_buffer_create(uint32_t p_size_bytes, const Vector<uint8_t> &p_data = Vector<uint8_t>());


### PR DESCRIPTION
Enable flags so you can create buffers using the read only or write only flags which translate to BUFFER_USAGE_TRANSFER_FROM_BIT and BUFFER_USAGE_TRANSFER_TO_BIT
