### PR TITLE
Core: Implement a XOR operator for BitField

### DIFF
--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -300,6 +300,7 @@ public:
 	_FORCE_INLINE_ constexpr BitField(T p_value) { value = (int64_t)p_value; }
 	_FORCE_INLINE_ operator int64_t() const { return value; }
 	_FORCE_INLINE_ operator Variant() const { return value; }
+	_FORCE_INLINE_ BitField<T> operator^(const BitField<T> &p_b) const { return BitField<T>(value ^ p_b.value); }
 };
 
 #define TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_impl)                                                                                            \

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1555,7 +1555,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 	}
 
 	if (old_pd.pressed_button_mask != pd.pressed_button_mask) {
-		BitField<MouseButtonMask> pressed_mask_delta = BitField<MouseButtonMask>((uint32_t)old_pd.pressed_button_mask ^ (uint32_t)pd.pressed_button_mask);
+		BitField<MouseButtonMask> pressed_mask_delta = old_pd.pressed_button_mask ^ pd.pressed_button_mask;
 
 		const MouseButton buttons_to_test[] = {
 			MouseButton::LEFT,


### PR DESCRIPTION
At least the Wayland backend had to do a horrible backwards-and-forwards with casts to achieve a XOR operation, in our case used to get a button difference.

I'm not aware of other uses, but the core chat over RC seemed favourable at a simple operator overload.

I've never worked with core types so tell me if this is a good idea and if so, if this is implemented correctly :D