### PR TITLE
Clear 2D editor drag preview when drag ends

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6030,6 +6030,10 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("mouse_exited", callable_mp(this, &CanvasItemEditorViewport::_on_mouse_exit));
 		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			_remove_preview();
+		}
 	}
 }
 


### PR DESCRIPTION
When you drag a resource into 2D editor, its preview will sometimes remain:

https://github.com/godotengine/godot/assets/2223172/a3146b15-7215-4280-8420-2426efb3ef61

The easiest way to reproduce is by pressing Escape to cancel dragging, but it sometimes happens upon dropping in the inspector.

This PR fixes it.