### PR TITLE
Remove duplicated callings `set()` from SceneTreeDock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1824,7 +1824,6 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 					undo_redo->add_do_property(resource, propertyname, updated_variant);
 					undo_redo->add_undo_property(resource, propertyname, old_variant);
-					resource->set(propertyname, updated_variant);
 				}
 			}
 			break;
@@ -1968,7 +1967,6 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->add_do_property(p_base, propertyname, updated_variant);
 			undo_redo->add_undo_property(p_base, propertyname, old_variant);
-			p_base->set(propertyname, updated_variant);
 		}
 	}
 
@@ -2849,7 +2847,6 @@ void SceneTreeDock::perform_node_replace(Node *p_base, Node *p_node, Node *p_by_
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->add_do_property(p_base, propertyname, updated_variant);
 			undo_redo->add_undo_property(p_base, propertyname, old_variant);
-			p_base->set(propertyname, updated_variant);
 			if (!warn_message.is_empty()) {
 				String node_path = (String(edited_scene->get_name()) + "/" + String(edited_scene->get_path_to(p_base))).trim_suffix("/.");
 				WARN_PRINT(warn_message + vformat("Removing the node from variable \"%s\" on node \"%s\".", propertyname, node_path));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77866

SceneTreeDock modifies the value of NodePath when there is a change in the tree, but it duplicates a direct `set()` call, even though the modification is executed in the `UndoRedo::add_do_property()` method.

This duplicated calling is problematic because it indicates an invalid NodePath, since it is actually called before the Node path change is complete. This is also problematic because unlike applying internal properties it calls the actual setter. Basically, setters should not be called if NodePath points to the same thing.

For example, when setting the ExternalSkeleton in BoneAttachment, the ObjectID of the Node is cached, but it does not indicate the correct Node at the time of the first call when the BoneAttachment change the nest in the SceneTree, then the error is caused. (But the `UndoRedo::add_do_property()` is fired immediately after the first call, so the error is resolved immediately afterwards).

This PR remove these unneeded callings `set()`.