### PR TITLE
macOS: Use autorelease pools

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -160,6 +160,7 @@ DisplayServerMacOS::WindowID DisplayServerMacOS::_create_window(WindowMode p_mod
 							  defer:NO];
 		ERR_FAIL_NULL_V_MSG(wd.window_object, INVALID_WINDOW_ID, "Can't create a window");
 		[wd.window_object setWindowID:window_id_counter];
+		[wd.window_object setReleasedWhenClosed:NO];
 
 		wd.window_view = [[GodotContentView alloc] init];
 		ERR_FAIL_NULL_V_MSG(wd.window_view, INVALID_WINDOW_ID, "Can't create a window view");

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -65,7 +65,9 @@ int main(int argc, char **argv) {
 	// We must override main when testing is enabled.
 	TEST_MAIN_OVERRIDE
 
-	err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
+	@autoreleasepool {
+		err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
+	}
 
 	if (err == ERR_HELP) { // Returned by --help and --version, so success.
 		return 0;
@@ -73,11 +75,17 @@ int main(int argc, char **argv) {
 		return 255;
 	}
 
-	if (Main::start()) {
+	bool ok;
+	@autoreleasepool {
+		ok = Main::start();
+	}
+	if (ok) {
 		os.run(); // It is actually the OS that decides how to run.
 	}
 
-	Main::cleanup();
+	@autoreleasepool {
+		Main::cleanup();
+	}
 
 	return os.get_exit_code();
 }

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -755,21 +755,25 @@ void OS_MacOS::run() {
 		return;
 	}
 
-	main_loop->initialize();
+	@autoreleasepool {
+		main_loop->initialize();
+	}
 
 	bool quit = false;
 	while (!quit) {
-		@try {
-			if (DisplayServer::get_singleton()) {
-				DisplayServer::get_singleton()->process_events(); // Get rid of pending events.
-			}
-			joypad_macos->process_joypads();
+		@autoreleasepool {
+			@try {
+				if (DisplayServer::get_singleton()) {
+					DisplayServer::get_singleton()->process_events(); // Get rid of pending events.
+				}
+				joypad_macos->process_joypads();
 
-			if (Main::iteration()) {
-				quit = true;
+				if (Main::iteration()) {
+					quit = true;
+				}
+			} @catch (NSException *exception) {
+				ERR_PRINT("NSException: " + String::utf8([exception reason].UTF8String));
 			}
-		} @catch (NSException *exception) {
-			ERR_PRINT("NSException: " + String::utf8([exception reason].UTF8String));
 		}
 	}
 


### PR DESCRIPTION
Autorelease pools ensure that autoreleased objects are freed regularly. These changes also reduce the number of allocated objects and memory usage considerably. This is typical of any custom event loop in macOS (and iOS), such as SDLs pump events:

https://github.com/libsdl-org/SDL/blob/68a4bb01e0d549bfa1f2418dd9463f62980eb210/src/video/cocoa/SDL_cocoaevents.m#L564-L569

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
