### PR TITLE
C#: Fix duplicate key issue on reload

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -310,13 +310,6 @@ namespace Godot.Bridge
 
                 _pathTypeBiMap.Add(scriptPathAttr.Path, type);
 
-                // This method may be called before initialization.
-                if (NativeFuncs.godotsharp_dotnet_module_is_initialized().ToBool() && Engine.IsEditorHint())
-                {
-                    using godot_string scriptPath = Marshaling.ConvertStringToNative(scriptPathAttr.Path);
-                    NativeFuncs.godotsharp_internal_editor_file_system_update_file(scriptPath);
-                }
-
                 if (AlcReloadCfg.IsAlcReloadingEnabled)
                 {
                     AddTypeForAlcReloading(type);
@@ -364,6 +357,16 @@ namespace Godot.Bridge
 
                         LookupScriptForClass(type);
                     }
+                }
+            }
+
+            // This method may be called before initialization.
+            if (NativeFuncs.godotsharp_dotnet_module_is_initialized().ToBool() && Engine.IsEditorHint())
+            {
+                foreach (var scriptPath in _pathTypeBiMap.Paths)
+                {
+                    using godot_string nativeScriptPath = Marshaling.ConvertStringToNative(scriptPath);
+                    NativeFuncs.godotsharp_internal_editor_file_system_update_file(nativeScriptPath);
                 }
             }
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.types.cs
@@ -61,6 +61,8 @@ public static partial class ScriptManagerBridge
         private System.Collections.Generic.Dictionary<string, Type> _pathTypeMap = new();
         private System.Collections.Generic.Dictionary<Type, string> _typePathMap = new();
 
+        public System.Collections.Generic.IEnumerable<string> Paths => _pathTypeMap.Keys;
+
         public void Add(string scriptPath, Type scriptType)
         {
             _pathTypeMap.Add(scriptPath, scriptType);


### PR DESCRIPTION
Fixes #80175

This is an alternate to #81541, fixing (what seems to be) the root cause of the issue. We were triggering script reloads in the middle of the loop that populates the path/type bimap, ending in creating stump temporary instances instead of loading the actual resource.

I validated the fix with the MRP provided [here](https://github.com/godotengine/godot/issues/80175#issuecomment-1712111596), but I'd greatly appreciate it if people who experienced the issue could test the branch a tad to be sure.