### PR TITLE
[macOS] Add SIGTRAP to the crash handler.

### DIFF
--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -75,6 +75,7 @@ static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
 	signal(SIGILL, SIG_DFL);
+	signal(SIGTRAP, SIG_DFL);
 
 	if (OS::get_singleton() == nullptr) {
 		abort();
@@ -193,6 +194,7 @@ void CrashHandler::disable() {
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
 	signal(SIGILL, SIG_DFL);
+	signal(SIGTRAP, SIG_DFL);
 #endif
 
 	disabled = true;
@@ -203,5 +205,6 @@ void CrashHandler::initialize() {
 	signal(SIGSEGV, handle_crash);
 	signal(SIGFPE, handle_crash);
 	signal(SIGILL, handle_crash);
+	signal(SIGTRAP, handle_crash);
 #endif
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87718

It's unnecessary for other platforms and not triggered by real crashes, but useful to get trace from `OS.crash` call.