### PR TITLE
Proof of concept fix for Async GPU Readbacks

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -40,6 +40,7 @@
 #include "rendering_device_driver_vulkan.h"
 #include "servers/display_server.h"
 #include "servers/rendering/renderer_rd/api_context_rd.h"
+#include <cstdint>
 
 #ifdef USE_VOLK
 #include <volk.h>
@@ -133,6 +134,8 @@ private:
 	VkFormat format;
 	VkSemaphore draw_complete_semaphores[FRAME_LAG];
 	VkSemaphore image_ownership_semaphores[FRAME_LAG];
+	VkSemaphore compute_semaphore[1];
+    uint64_t compute_semaphore_signal_value = 0;
 	int frame_index = 0;
 	VkFence fences[FRAME_LAG];
 	VkPhysicalDeviceMemoryProperties memory_properties;
@@ -313,6 +316,7 @@ public:
 	virtual RID local_device_create() override final;
 	virtual void local_device_push_command_buffers(RID p_local_device, const RDD::CommandBufferID *p_buffers, int p_count) override final;
 	virtual void local_device_sync(RID p_local_device) override final;
+    virtual bool local_device_check_status(RID p_local_device) override final;
 	virtual void local_device_free(RID p_local_device) override final;
 
 	VkFormat get_screen_format() const;

--- a/servers/rendering/renderer_rd/api_context_rd.h
+++ b/servers/rendering/renderer_rd/api_context_rd.h
@@ -54,6 +54,7 @@ public:
 	virtual RID local_device_create() = 0;
 	virtual void local_device_push_command_buffers(RID p_local_device, const RDD::CommandBufferID *p_buffers, int p_count) = 0;
 	virtual void local_device_sync(RID p_local_device) = 0;
+    virtual bool local_device_check_status(RID p_local_device) = 0;
 	virtual void local_device_free(RID p_local_device) = 0;
 
 	virtual void set_setup_buffer(RDD::CommandBufferID p_command_buffer) = 0;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "rendering_device.h"
+#include "core/os/thread_safe.h"
 #include "rendering_device.compat.inc"
 
 #include "rendering_device_binds.h"
@@ -4659,6 +4660,12 @@ void RenderingDevice::sync() {
 	local_device_processing = false;
 }
 
+bool RenderingDevice::check_status(){
+	_THREAD_SAFE_METHOD_
+
+        return context->local_device_check_status(local_device);
+}
+
 void RenderingDevice::_free_pending_resources(int p_frame) {
 	// Free in dependency usage order, so nothing weird happens.
 	// Pipelines.
@@ -5340,6 +5347,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_frame_delay"), &RenderingDevice::get_frame_delay);
 	ClassDB::bind_method(D_METHOD("submit"), &RenderingDevice::submit);
 	ClassDB::bind_method(D_METHOD("sync"), &RenderingDevice::sync);
+	ClassDB::bind_method(D_METHOD("check_status"), &RenderingDevice::check_status);
 
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("barrier", "from", "to"), &RenderingDevice::barrier, DEFVAL(BARRIER_MASK_ALL_BARRIERS), DEFVAL(BARRIER_MASK_ALL_BARRIERS));

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1333,6 +1333,7 @@ public:
 
 	void submit();
 	void sync();
+    bool check_status();
 
 	enum MemoryType {
 		MEMORY_TEXTURES,


### PR DESCRIPTION
I have an implementation and a basic demo to show how to achieve Asynchronous Compute Shader execution with Vulkan Timeline Semaphores.

Currently Vulkan specific just to get the ball rolling

And here's a repurposed ray tracing project that demonstrates how my changes can avoid locking up the CPU while waiting for Compute Shaders to finish execution:
https://github.com/granitrocky/Raytracing_Godot4

* *Bugsquad edit, related: https://github.com/godotengine/godot-proposals/issues/7886*

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
