### PR TITLE
Don't round `loop_offset` on import + Use double for `loop_offset` consistently

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -437,7 +437,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 			beats_edit->set_value(beats);
 			beats_enabled->set_pressed(beats > 0);
 			loop->set_pressed(config_file->get_value("params", "loop", false));
-			loop_offset->set_value(config_file->get_value("params", "loop_offset", 0));
+			loop_offset->set_value(double(config_file->get_value("params", "loop_offset", 0)));
 			bar_beats_edit->set_value(config_file->get_value("params", "bar_beats", 4));
 
 			List<String> keys;
@@ -517,7 +517,7 @@ void AudioStreamImportSettingsDialog::_settings_changed() {
 
 void AudioStreamImportSettingsDialog::_reimport() {
 	params["loop"] = loop->is_pressed();
-	params["loop_offset"] = loop_offset->get_value();
+	params["loop_offset"] = double(loop_offset->get_value());
 	params["bpm"] = bpm_enabled->is_pressed() ? double(bpm_edit->get_value()) : double(0);
 	params["beat_count"] = (bpm_enabled->is_pressed() && beats_enabled->is_pressed()) ? int(beats_edit->get_value()) : int(0);
 	params["bar_beats"] = (bpm_enabled->is_pressed()) ? int(bar_beats_edit->get_value()) : int(4);
@@ -543,7 +543,7 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	loop_hb->add_child(memnew(Label(TTR("Offset:"))));
 	loop_offset = memnew(SpinBox);
 	loop_offset->set_max(10000);
-	loop_offset->set_step(0.001);
+	loop_offset->set_disallow_step_rounding(true);
 	loop_offset->set_suffix("sec");
 	loop_offset->set_tooltip_text(TTR("Loop offset (from beginning). Note that if BPM is set, this setting will be ignored."));
 	loop_offset->connect("value_changed", callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -95,7 +95,7 @@ class AudioStreamMP3 : public AudioStream {
 	int channels = 1;
 	float length = 0.0;
 	bool loop = false;
-	float loop_offset = 0.0;
+	double loop_offset = 0.0;
 	void clear_data();
 
 	double bpm = 0;

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -117,7 +117,7 @@ Ref<AudioStreamMP3> ResourceImporterMP3::import_mp3(const String &p_path) {
 
 Error ResourceImporterMP3::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
-	float loop_offset = p_options["loop_offset"];
+	double loop_offset = p_options["loop_offset"];
 	double bpm = p_options["bpm"];
 	float beat_count = p_options["beat_count"];
 	float bar_beats = p_options["bar_beats"];

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -98,7 +98,7 @@ void Range::_set_value_no_signal(double p_val) {
 		return;
 	}
 
-	if (shared->step > 0) {
+	if (shared->step > 0 && !shared->skip_step_rounding) {
 		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}
 
@@ -165,6 +165,10 @@ void Range::set_step(double p_step) {
 
 	shared->step = p_step;
 	shared->emit_changed("step");
+}
+
+void Range::set_disallow_step_rounding(bool disallow) {
+	shared->skip_step_rounding = disallow;
 }
 
 void Range::set_page(double p_page) {
@@ -258,6 +262,7 @@ void Range::unshare() {
 	nshared->max = shared->max;
 	nshared->val = shared->val;
 	nshared->step = shared->step;
+	nshared->skip_step_rounding = shared->skip_step_rounding;
 	nshared->page = shared->page;
 	nshared->exp_ratio = shared->exp_ratio;
 	nshared->allow_greater = shared->allow_greater;

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -41,6 +41,7 @@ class Range : public Control {
 		double min = 0.0;
 		double max = 100.0;
 		double step = 1.0;
+		bool skip_step_rounding = false;
 		double page = 0.0;
 		bool exp_ratio = false;
 		bool allow_greater = false;
@@ -78,6 +79,7 @@ public:
 	void set_min(double p_min);
 	void set_max(double p_max);
 	void set_step(double p_step);
+	void set_disallow_step_rounding(bool disallow);
 	void set_page(double p_page);
 	void set_as_ratio(double p_value);
 


### PR DESCRIPTION
Not sure if this PR should close https://github.com/godotengine/godot/issues/87427, but it would cover their requirement of a floating point value with the precision of 12 decimal places, as Godot's `float` provides for `double` `14 reliable decimal digits of precision`. **Except the value will be rounded/cut off again on saving to a file?**

I removed the `set_step` call to prevent rounding, as we don't know how the user will use their given precision.

Side note: ogg vorbis was already using `double` consistently.