### PR TITLE
CI scripts: Fix `printf` for format checks

### DIFF
--- a/misc/scripts/black_format.sh
+++ b/misc/scripts/black_format.sh
@@ -20,7 +20,7 @@ fi
 # A diff has been created, notify the user, clean up, and exit.
 printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
 # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
-printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+printf "%s\n" "$diff" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 
 printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -47,7 +47,7 @@ fi
 # A diff has been created, notify the user, clean up, and exit.
 printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
 # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
-printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+printf "%s\n" "$diff" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 
 printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/clang_tidy.sh
+++ b/misc/scripts/clang_tidy.sh
@@ -27,7 +27,7 @@ fi
 # A diff has been created, notify the user, clean up, and exit.
 printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
 # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
-printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+printf "%s\n" "$diff" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 
 printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/dotnet_format.sh
+++ b/misc/scripts/dotnet_format.sh
@@ -31,7 +31,7 @@ fi
 # A diff has been created, notify the user, clean up, and exit.
 printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
 # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
-printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+printf "%s\n" "$diff" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 
 printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -82,7 +82,7 @@ then
     # A diff has been created, notify the user, clean up, and exit.
     printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
     # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
-    printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+    printf "%s\n" "$diff" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 fi
 
 printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"

--- a/misc/scripts/header_guards.sh
+++ b/misc/scripts/header_guards.sh
@@ -81,7 +81,7 @@ fi
 # A diff has been created, notify the user, clean up, and exit.
 printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
 # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
-printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+printf "%s\n" "$diff" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 
 printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1


### PR DESCRIPTION
Prevents errors with input being invalid format strings

Discovered in:
* https://github.com/godotengine/godot/pull/87352

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
