### PR TITLE
Update Range.xml: fix incorrect default value for `step`

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -326,6 +326,9 @@ void Range::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_greater"), "set_allow_greater", "is_greater_allowed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_lesser"), "set_allow_lesser", "is_lesser_allowed");
 
+	// Default value would be 0.01 otherwise, override for doc generation purposes.
+	ADD_PROPERTY_DEFAULT("step", 1.0);
+
 	GDVIRTUAL_BIND(_value_changed, "new_value");
 
 	ADD_LINKED_PROPERTY("min_value", "value");


### PR DESCRIPTION
Unless there's a hidden change from `1.0` to `0.01`, the correct default value is `1.0`.

See https://github.com/godotengine/godot/blob/10e111477db68fe65776a1d68fb1ffccaf6520fc/scene/gui/range.h#L43

**EDIT**: If I'm not mistaken, the internal tools cannot handle this case, see https://github.com/godotengine/godot/pull/87865#issuecomment-1953095025