### PR TITLE
ThorVG: update from v0.12.3 to v0.12.4

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -862,7 +862,7 @@ instead of `miniz.h` as an external dependency.
 ## thorvg
 
 - Upstream: https://github.com/thorvg/thorvg
-- Version: 0.12.3 (9d79f0ccef632fd3b43b8ea02def529b6a8d2288, 2024)
+- Version: 0.12.4 (331839d49368e19ca15f35abee5ac541dbf23637, 2024)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -9,5 +9,5 @@
 // For internal debugging:
 //#define THORVG_LOG_ENABLED
 
-#define THORVG_VERSION_STRING "0.12.3"
+#define THORVG_VERSION_STRING "0.12.4"
 #endif

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgPath.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgPath.cpp
@@ -51,8 +51,8 @@
 #define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
 
 #include <cstring>
-#include <math.h>
 #include <ctype.h>
+#include "tvgMath.h"
 #include "tvgShape.h"
 #include "tvgSvgLoaderCommon.h"
 #include "tvgSvgPath.h"
@@ -471,9 +471,16 @@ static bool _processCommand(Array<PathCommand>* cmds, Array<Point>* pts, char cm
         }
         case 'a':
         case 'A': {
-            _pathAppendArcTo(cmds, pts, cur, curCtl, arr[5], arr[6], arr[0], arr[1], arr[2], arr[3], arr[4]);
-            *cur = *curCtl = {arr[5], arr[6]};
-            *isQuadratic = false;
+            if (mathZero(arr[0]) || mathZero(arr[1])) {
+                Point p = {arr[5], arr[6]};
+                cmds->push(PathCommand::LineTo);
+                pts->push(p);
+                *cur = {arr[5], arr[6]};
+            } else if (!mathEqual(cur->x, arr[5]) || !mathEqual(cur->y, arr[6])) {
+                _pathAppendArcTo(cmds, pts, cur, curCtl, arr[5], arr[6], fabsf(arr[0]), fabsf(arr[1]), arr[2], arr[3], arr[4]);
+                *cur = *curCtl = {arr[5], arr[6]};
+                *isQuadratic = false;
+            }
             break;
         }
         default: {

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -63,7 +63,7 @@ struct SwTask : Task
         return region;
     }
 
-    virtual bool dispose() = 0;
+    virtual void dispose() = 0;
     virtual bool clip(SwRleData* target) = 0;
     virtual SwRleData* rle() = 0;
 
@@ -196,10 +196,9 @@ struct SwShapeTask : SwTask
         shapeDelOutline(&shape, mpool, tid);
     }
 
-    bool dispose() override
+    void dispose() override
     {
        shapeFree(&shape);
-       return true;
     }
 };
 
@@ -250,10 +249,9 @@ struct SwSceneTask : SwTask
         }
     }
 
-    bool dispose() override
+    void dispose() override
     {
         rleFree(sceneRle);
-        return true;
     }
 };
 
@@ -318,10 +316,9 @@ struct SwImageTask : SwTask
         imageDelOutline(&image, mpool, tid);
     }
 
-    bool dispose() override
+    void dispose() override
     {
        imageFree(&image);
-       return true;
     }
 };
 
@@ -703,17 +700,15 @@ ColorSpace SwRenderer::colorSpace()
 }
 
 
-bool SwRenderer::dispose(RenderData data)
+void SwRenderer::dispose(RenderData data)
 {
     auto task = static_cast<SwTask*>(data);
-    if (!task) return true;
+    if (!task) return;
     task->done();
     task->dispose();
 
     if (task->pushed) task->disposed = true;
     else delete(task);
-
-    return true;
 }
 
 

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRenderer.h
@@ -43,7 +43,7 @@ public:
     bool renderShape(RenderData data) override;
     bool renderImage(RenderData data) override;
     bool postRender() override;
-    bool dispose(RenderData data) override;
+    void dispose(RenderData data) override;
     RenderRegion region(RenderData data) override;
     RenderRegion viewport() override;
     bool viewport(const RenderRegion& vp) override;

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwShape.cpp
@@ -122,7 +122,9 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix* trans
     Line cur = {dash.ptCur, *to};
     auto len = _lineLength(cur.pt1, cur.pt2);
 
-    if (len < dash.curLen) {
+    if (mathZero(len)) {
+        _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
+    } else if (len < dash.curLen) {
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {
@@ -179,7 +181,9 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
     Bezier cur = {dash.ptCur, *ctrl1, *ctrl2, *to};
     auto len = bezLength(cur);
 
-    if (len < dash.curLen) {
+    if (mathZero(len)) {
+        _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
+    } else if (len < dash.curLen) {
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {

--- a/thirdparty/thorvg/src/renderer/tvgPaint.cpp
+++ b/thirdparty/thorvg/src/renderer/tvgPaint.cpp
@@ -106,20 +106,10 @@ static bool _compFastTrack(Paint* cmpTarget, const RenderTransform* pTransform, 
 }
 
 
-RenderRegion Paint::Impl::bounds(RenderMethod& renderer) const
+RenderRegion Paint::Impl::bounds(RenderMethod* renderer) const
 {
     RenderRegion ret;
     PAINT_METHOD(ret, bounds(renderer));
-    return ret;
-}
-
-
-bool Paint::Impl::dispose(RenderMethod& renderer)
-{
-    if (compData) compData->target->pImpl->dispose(renderer);
-
-    bool ret;
-    PAINT_METHOD(ret, dispose(renderer));
     return ret;
 }
 
@@ -198,7 +188,7 @@ bool Paint::Impl::translate(float x, float y)
 }
 
 
-bool Paint::Impl::render(RenderMethod& renderer)
+bool Paint::Impl::render(RenderMethod* renderer)
 {
     Compositor* cmp = nullptr;
 
@@ -210,27 +200,33 @@ bool Paint::Impl::render(RenderMethod& renderer)
 
         if (MASK_REGION_MERGING(compData->method)) region.add(P(compData->target)->bounds(renderer));
         if (region.w == 0 || region.h == 0) return true;
-        cmp = renderer.target(region, COMPOSITE_TO_COLORSPACE(renderer, compData->method));
-        if (renderer.beginComposite(cmp, CompositeMethod::None, 255)) {
+        cmp = renderer->target(region, COMPOSITE_TO_COLORSPACE(renderer, compData->method));
+        if (renderer->beginComposite(cmp, CompositeMethod::None, 255)) {
             compData->target->pImpl->render(renderer);
         }
     }
 
-    if (cmp) renderer.beginComposite(cmp, compData->method, compData->target->pImpl->opacity);
+    if (cmp) renderer->beginComposite(cmp, compData->method, compData->target->pImpl->opacity);
 
-    renderer.blend(blendMethod);
+    renderer->blend(blendMethod);
 
     bool ret;
     PAINT_METHOD(ret, render(renderer));
 
-    if (cmp) renderer.endComposite(cmp);
+    if (cmp) renderer->endComposite(cmp);
 
     return ret;
 }
 
 
-RenderData Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
+RenderData Paint::Impl::update(RenderMethod* renderer, const RenderTransform* pTransform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
 {
+    if (this->renderer != renderer) {
+        if (this->renderer) TVGERR("RENDERER", "paint's renderer has been changed!");
+        renderer->ref();
+        this->renderer = renderer;
+    }
+
     if (renderFlag & RenderUpdateFlag::Transform) {
         if (!rTransform) return nullptr;
         rTransform->update();
@@ -265,9 +261,9 @@ RenderData Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pT
             if (tryFastTrack) {
                 RenderRegion viewport2;
                 if ((compFastTrack = _compFastTrack(target, pTransform, target->pImpl->rTransform, viewport2))) {
-                    viewport = renderer.viewport();
+                    viewport = renderer->viewport();
                     viewport2.intersect(viewport);
-                    renderer.viewport(viewport2);
+                    renderer->viewport(viewport2);
                     target->pImpl->ctxFlag |= ContextFlag::FastTrack;
                 }
             }
@@ -289,7 +285,7 @@ RenderData Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pT
     PAINT_METHOD(rd, update(renderer, &outTransform, clips, opacity, newFlag, clipper));
 
     /* 3. Composition Post Processing */
-    if (compFastTrack) renderer.viewport(viewport);
+    if (compFastTrack) renderer->viewport(viewport);
     else if (childClipper) clips.pop();
 
     return rd;

--- a/thirdparty/thorvg/src/renderer/tvgPaint.h
+++ b/thirdparty/thorvg/src/renderer/tvgPaint.h
@@ -50,16 +50,15 @@ namespace tvg
         Paint* paint = nullptr;
         RenderTransform* rTransform = nullptr;
         Composite* compData = nullptr;
-        BlendMethod blendMethod = BlendMethod::Normal;              //uint8_t
+        RenderMethod* renderer = nullptr;
+        BlendMethod blendMethod = BlendMethod::Normal;   //uint8_t
         uint8_t renderFlag = RenderUpdateFlag::None;
         uint8_t ctxFlag = ContextFlag::Invalid;
         uint8_t id;
         uint8_t opacity = 255;
-        uint8_t refCnt = 0;
+        uint8_t refCnt = 0;                              //reference count
 
-        Impl(Paint* pnt) : paint(pnt)
-        {
-        }
+        Impl(Paint* pnt) : paint(pnt) {}
 
         ~Impl()
         {
@@ -68,18 +67,19 @@ namespace tvg
                 free(compData);
             }
             delete(rTransform);
+            if (renderer && (renderer->unref() == 0)) delete(renderer);
         }
 
         uint8_t ref()
         {
             if (refCnt == 255) TVGERR("RENDERER", "Corrupted reference count!");
-            return (++refCnt);
+            return ++refCnt;
         }
 
         uint8_t unref()
         {
             if (refCnt == 0) TVGERR("RENDERER", "Corrupted reference count!");
-            return (--refCnt);
+            return --refCnt;
         }
 
         bool transform(const Matrix& m)
@@ -131,15 +131,14 @@ namespace tvg
             return true;
         }
 
-        RenderRegion bounds(RenderMethod& renderer) const;
-        bool dispose(RenderMethod& renderer);
+        RenderRegion bounds(RenderMethod* renderer) const;
         Iterator* iterator();
         bool rotate(float degree);
         bool scale(float factor);
         bool translate(float x, float y);
         bool bounds(float* x, float* y, float* w, float* h, bool transformed, bool stroking);
-        RenderData update(RenderMethod& renderer, const RenderTransform* pTransform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper = false);
-        bool render(RenderMethod& renderer);
+        RenderData update(RenderMethod* renderer, const RenderTransform* pTransform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper = false);
+        bool render(RenderMethod* renderer);
         Paint* duplicate();
     };
 }

--- a/thirdparty/thorvg/src/renderer/tvgPicture.cpp
+++ b/thirdparty/thorvg/src/renderer/tvgPicture.cpp
@@ -69,18 +69,18 @@ bool Picture::Impl::needComposition(uint8_t opacity)
 }
 
 
-bool Picture::Impl::render(RenderMethod &renderer)
+bool Picture::Impl::render(RenderMethod* renderer)
 {
     bool ret = false;
-    if (surface) return renderer.renderImage(rd);
+    if (surface) return renderer->renderImage(rd);
     else if (paint) {
         Compositor* cmp = nullptr;
         if (needComp) {
-            cmp = renderer.target(bounds(renderer), renderer.colorSpace());
-            renderer.beginComposite(cmp, CompositeMethod::None, 255);
+            cmp = renderer->target(bounds(renderer), renderer->colorSpace());
+            renderer->beginComposite(cmp, CompositeMethod::None, 255);
         }
         ret = paint->pImpl->render(renderer);
-        if (cmp) renderer.endComposite(cmp);
+        if (cmp) renderer->endComposite(cmp);
     }
     return ret;
 }
@@ -95,9 +95,9 @@ bool Picture::Impl::size(float w, float h)
 }
 
 
-RenderRegion Picture::Impl::bounds(RenderMethod& renderer)
+RenderRegion Picture::Impl::bounds(RenderMethod* renderer)
 {
-    if (rd) return renderer.region(rd);
+    if (rd) return renderer->region(rd);
     if (paint) return paint->pImpl->bounds(renderer);
     return {0, 0, 0, 0};
 }

--- a/thirdparty/thorvg/src/renderer/tvgRender.h
+++ b/thirdparty/thorvg/src/renderer/tvgRender.h
@@ -261,7 +261,23 @@ struct RenderShape
 
 class RenderMethod
 {
+private:
+    uint32_t refCnt = 0;        //reference count
+    Key key;
+
 public:
+    uint32_t ref()
+    {
+        ScopedLock lock(key);
+        return (++refCnt);
+    }
+
+    uint32_t unref()
+    {
+        ScopedLock lock(key);
+        return (--refCnt);
+    }
+
     virtual ~RenderMethod() {}
     virtual RenderData prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper) = 0;
     virtual RenderData prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) = 0;
@@ -270,7 +286,7 @@ public:
     virtual bool renderShape(RenderData data) = 0;
     virtual bool renderImage(RenderData data) = 0;
     virtual bool postRender() = 0;
-    virtual bool dispose(RenderData data) = 0;
+    virtual void dispose(RenderData data) = 0;
     virtual RenderRegion region(RenderData data) = 0;
     virtual RenderRegion viewport() = 0;
     virtual bool viewport(const RenderRegion& vp) = 0;
@@ -322,7 +338,7 @@ static inline uint8_t CHANNEL_SIZE(ColorSpace cs)
     }
 }
 
-static inline ColorSpace COMPOSITE_TO_COLORSPACE(RenderMethod& renderer, CompositeMethod method)
+static inline ColorSpace COMPOSITE_TO_COLORSPACE(RenderMethod* renderer, CompositeMethod method)
 {
     switch(method) {
         case CompositeMethod::AlphaMask:
@@ -335,7 +351,7 @@ static inline ColorSpace COMPOSITE_TO_COLORSPACE(RenderMethod& renderer, Composi
         //TODO: Optimize Luma/InvLuma colorspace to Grayscale8
         case CompositeMethod::LumaMask:
         case CompositeMethod::InvLumaMask:
-            return renderer.colorSpace();
+            return renderer->colorSpace();
         default:
             TVGERR("RENDERER", "Unsupported Composite Size! = %d", (int)method);
             return ColorSpace::Unsupported;

--- a/thirdparty/thorvg/src/renderer/tvgShape.h
+++ b/thirdparty/thorvg/src/renderer/tvgShape.h
@@ -41,25 +41,25 @@ struct Shape::Impl
     {
     }
 
-    bool dispose(RenderMethod& renderer)
+    ~Impl()
     {
-        renderer.dispose(rd);
-        rd = nullptr;
-        return true;
+        if (auto renderer = PP(shape)->renderer) {
+            renderer->dispose(rd);
+        }
     }
 
-    bool render(RenderMethod& renderer)
+    bool render(RenderMethod* renderer)
     {
         Compositor* cmp = nullptr;
         bool ret;
 
         if (needComp) {
-            cmp = renderer.target(bounds(renderer), renderer.colorSpace());
-            renderer.beginComposite(cmp, CompositeMethod::None, opacity);
+            cmp = renderer->target(bounds(renderer), renderer->colorSpace());
+            renderer->beginComposite(cmp, CompositeMethod::None, opacity);
             needComp = false;
         }
-        ret = renderer.renderShape(rd);
-        if (cmp) renderer.endComposite(cmp);
+        ret = renderer->renderShape(rd);
+        if (cmp) renderer->endComposite(cmp);
         return ret;
     }
 
@@ -83,7 +83,7 @@ struct Shape::Impl
         return true;
     }
 
-    RenderData update(RenderMethod& renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
+    RenderData update(RenderMethod* renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
     {     
         if ((needComp = needComposition(opacity))) {
             /* Overriding opacity value. If this scene is half-translucent,
@@ -92,14 +92,14 @@ struct Shape::Impl
             opacity = 255;
         }
 
-        rd = renderer.prepare(rs, rd, transform, clips, opacity, static_cast<RenderUpdateFlag>(pFlag | flag), clipper);
+        rd = renderer->prepare(rs, rd, transform, clips, opacity, static_cast<RenderUpdateFlag>(pFlag | flag), clipper);
         flag = RenderUpdateFlag::None;
         return rd;
     }
 
-    RenderRegion bounds(RenderMethod& renderer)
+    RenderRegion bounds(RenderMethod* renderer)
     {
-        return renderer.region(rd);
+        return renderer->region(rd);
     }
 
     bool bounds(float* x, float* y, float* w, float* h, bool stroking)

--- a/thirdparty/thorvg/src/renderer/tvgText.h
+++ b/thirdparty/thorvg/src/renderer/tvgText.h
@@ -35,7 +35,6 @@
 
 struct Text::Impl
 {
-    RenderData rd = nullptr;
     FontLoader* loader = nullptr;
     Shape* paint = nullptr;
     char* utf8 = nullptr;
@@ -92,12 +91,13 @@ struct Text::Impl
         return Result::Success;
     }
 
-    RenderRegion bounds(RenderMethod& renderer)
+    RenderRegion bounds(RenderMethod* renderer)
     {
-        return renderer.region(rd);
+        if (paint) return P(paint)->bounds(renderer);
+        else return {0, 0, 0, 0};
     }
 
-    bool render(RenderMethod& renderer)
+    bool render(RenderMethod* renderer)
     {
         if (paint) return PP(paint)->render(renderer);
         return false;
@@ -120,7 +120,7 @@ struct Text::Impl
         return false;
     }
 
-    RenderData update(RenderMethod& renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
+    RenderData update(RenderMethod* renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
     {
         if (!load()) return nullptr;
 
@@ -142,21 +142,13 @@ struct Text::Impl
                 P(static_cast<RadialGradient*>(fill))->fr *= scale;
             }
         }
-        rd = PP(paint)->update(renderer, transform, clips, opacity, pFlag, clipper);
-        return rd;
+        return PP(paint)->update(renderer, transform, clips, opacity, pFlag, clipper);
     }
 
     bool bounds(float* x, float* y, float* w, float* h, TVG_UNUSED bool stroking)
     {
         if (!load() || !paint) return false;
         paint->bounds(x, y, w, h, true);
-        return true;
-    }
-
-    bool dispose(RenderMethod& renderer)
-    {
-        renderer.dispose(rd);
-        this->rd = nullptr;
         return true;
     }
 

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION=0.12.3
+VERSION=0.12.4
 
 cd thirdparty/thorvg/ || true
 rm -rf AUTHORS LICENSE inc/ src/ *.zip *.tar.gz tmp/


### PR DESCRIPTION
https://github.com/thorvg/thorvg/releases/tag/v0.12.4

+ Full Changelog: https://github.com/thorvg/thorvg/compare/v0.12.3...v0.12.4

Godot-related SVG bug fixes:

+ loader/svg: Apply specification of out-of-range elliptical arc
 parameters, fix zero check of arc's rx and ry.
    thorvg/thorvg#1938



![editor_screenshot_2024-02-02T145203](https://github.com/godotengine/godot/assets/4047289/b409519d-577e-44bb-8369-2f1c2a45cf4c)

![0_example_x10](https://github.com/godotengine/godot/assets/4047289/395ad7f2-a1a4-40cd-80cc-d68a79a8b2da)

The Linux thread sanitizer CI errors don't mention or report any issues with the ThorVG source code:
```log
2024-02-02T13:52:19.9976310Z ERROR: The Image format specified (4294967295) is out of range. See Image's Format enum.
2024-02-02T13:52:19.9977236Z    at: convert (core/io/image.cpp:512)
2024-02-02T13:52:19.9978113Z ERROR: The Image format specified (40) is out of range. See Image's Format enum.
2024-02-02T13:52:19.9978723Z    at: convert (core/io/image.cpp:512)
2024-02-02T13:52:20.0216580Z ERROR: Resource was not pre cached for the resource section, bug?
2024-02-02T13:52:20.0217953Z    at: _write_resource (scene/resources/resource_format_text.cpp:1852)
2024-02-02T13:52:20.0233776Z WARNING: Couldn't load resource (no cache): local://Resource_g8td4
2024-02-02T13:52:20.0234783Z      at: parse_variant (core/io/resource_format_binary.cpp:412)
2024-02-02T13:54:36.0221836Z ERROR: Condition "p_rings < 0" is true.
2024-02-02T13:54:36.0222642Z    at: set_rings (scene/resources/primitive_meshes.cpp:595)
2024-02-02T13:54:36.7959844Z ERROR: Condition "p_rings < 0" is true.
2024-02-02T13:54:36.7960684Z    at: set_rings (scene/resources/primitive_meshes.cpp:1208)
2024-02-02T13:54:38.3465052Z ERROR: Condition "p_rings < 1" is true.
2024-02-02T13:54:38.3465936Z    at: set_rings (scene/resources/primitive_meshes.cpp:1922)
```




