### PR TITLE
Remove unnecessary focus methods and directly bind to `set_close_on_escape`

### DIFF
--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -263,14 +263,6 @@ void InputEventConfigurationDialog::_on_listen_input_changed(const Ref<InputEven
 	_set_event(received_event, received_original_event);
 }
 
-void InputEventConfigurationDialog::_on_listen_focus_changed() {
-	if (event_listener->has_focus()) {
-		set_close_on_escape(false);
-	} else {
-		set_close_on_escape(true);
-	}
-}
-
 void InputEventConfigurationDialog::_search_term_updated(const String &) {
 	_update_input_list();
 }
@@ -656,8 +648,8 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	event_listener->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	event_listener->set_stretch_ratio(0.75);
 	event_listener->connect("event_changed", callable_mp(this, &InputEventConfigurationDialog::_on_listen_input_changed));
-	event_listener->connect("focus_entered", callable_mp(this, &InputEventConfigurationDialog::_on_listen_focus_changed));
-	event_listener->connect("focus_exited", callable_mp(this, &InputEventConfigurationDialog::_on_listen_focus_changed));
+	event_listener->connect("focus_entered", callable_mp((AcceptDialog *)this, &AcceptDialog::set_close_on_escape).bind(false));
+	event_listener->connect("focus_exited", callable_mp((AcceptDialog *)this, &AcceptDialog::set_close_on_escape).bind(true));
 	main_vbox->add_child(event_listener);
 
 	main_vbox->add_child(memnew(HSeparator));

--- a/editor/input_event_configuration_dialog.h
+++ b/editor/input_event_configuration_dialog.h
@@ -104,7 +104,6 @@ private:
 
 	void _set_event(const Ref<InputEvent> &p_event, const Ref<InputEvent> &p_original_event, bool p_update_input_list_selection = true);
 	void _on_listen_input_changed(const Ref<InputEvent> &p_event);
-	void _on_listen_focus_changed();
 
 	void _search_term_updated(const String &p_term);
 	void _update_input_list();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -575,14 +575,6 @@ void ProjectSettingsEditor::_update_theme() {
 	}
 }
 
-void ProjectSettingsEditor::_input_filter_focused() {
-	set_close_on_escape(false);
-}
-
-void ProjectSettingsEditor::_input_filter_unfocused() {
-	set_close_on_escape(true);
-}
-
 void ProjectSettingsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -715,8 +707,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	action_map_editor->connect("action_removed", callable_mp(this, &ProjectSettingsEditor::_action_removed));
 	action_map_editor->connect("action_renamed", callable_mp(this, &ProjectSettingsEditor::_action_renamed));
 	action_map_editor->connect("action_reordered", callable_mp(this, &ProjectSettingsEditor::_action_reordered));
-	action_map_editor->connect(SNAME("filter_focused"), callable_mp(this, &ProjectSettingsEditor::_input_filter_focused));
-	action_map_editor->connect(SNAME("filter_unfocused"), callable_mp(this, &ProjectSettingsEditor::_input_filter_unfocused));
+	action_map_editor->connect(SNAME("filter_focused"), callable_mp((AcceptDialog *)this, &AcceptDialog::set_close_on_escape).bind(false));
+	action_map_editor->connect(SNAME("filter_unfocused"), callable_mp((AcceptDialog *)this, &AcceptDialog::set_close_on_escape).bind(true));
 	tab_container->add_child(action_map_editor);
 
 	localization_editor = memnew(LocalizationEditor);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -112,9 +112,6 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _update_action_map_editor();
 	void _update_theme();
 
-	void _input_filter_focused();
-	void _input_filter_unfocused();
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Suggested by @AThousandShips for #86654, figured I would apply it everywhere else. 