### PR TITLE
Use `_v` shorthand for type traits and `if constexpr` where appropriate

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -188,7 +188,7 @@ public:
 	template <class T>
 	static void register_class(bool p_virtual = false) {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
+		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -203,7 +203,7 @@ public:
 	template <class T>
 	static void register_abstract_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
+		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -216,7 +216,7 @@ public:
 	template <class T>
 	static void register_internal_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
+		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -239,7 +239,7 @@ public:
 	template <class T>
 	static void register_custom_instance_class() {
 		GLOBAL_LOCK_FUNCTION;
-		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
+		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
@@ -296,7 +296,7 @@ public:
 			argptrs[i] = &args[i];
 		}
 		MethodBind *bind = create_method_bind(p_method);
-		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
+		if constexpr (std::is_same_v<typename member_function_traits<M>::return_type, Object *>) {
 			bind->set_return_type_is_raw_object_ptr(true);
 		}
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, false, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
@@ -311,7 +311,7 @@ public:
 		}
 		MethodBind *bind = create_static_method_bind(p_method);
 		bind->set_instance_class(p_class);
-		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
+		if constexpr (std::is_same_v<typename member_function_traits<M>::return_type, Object *>) {
 			bind->set_return_type_is_raw_object_ptr(true);
 		}
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, false, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
@@ -325,7 +325,7 @@ public:
 			argptrs[i] = &args[i];
 		}
 		MethodBind *bind = create_method_bind(p_method);
-		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
+		if constexpr (std::is_same_v<typename member_function_traits<M>::return_type, Object *>) {
 			bind->set_return_type_is_raw_object_ptr(true);
 		}
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, true, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
@@ -340,7 +340,7 @@ public:
 		}
 		MethodBind *bind = create_static_method_bind(p_method);
 		bind->set_instance_class(p_class);
-		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
+		if constexpr (std::is_same_v<typename member_function_traits<M>::return_type, Object *>) {
 			bind->set_return_type_is_raw_object_ptr(true);
 		}
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, true, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
@@ -353,7 +353,7 @@ public:
 		MethodBind *bind = create_vararg_method_bind(p_method, p_info, p_return_nil_is_variant);
 		ERR_FAIL_NULL_V(bind, nullptr);
 
-		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
+		if constexpr (std::is_same_v<typename member_function_traits<M>::return_type, Object *>) {
 			bind->set_return_type_is_raw_object_ptr(true);
 		}
 		return _bind_vararg_method(bind, p_name, p_default_args, false);
@@ -366,7 +366,7 @@ public:
 		MethodBind *bind = create_vararg_method_bind(p_method, p_info, p_return_nil_is_variant);
 		ERR_FAIL_NULL_V(bind, nullptr);
 
-		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
+		if constexpr (std::is_same_v<typename member_function_traits<M>::return_type, Object *>) {
 			bind->set_return_type_is_raw_object_ptr(true);
 		}
 		return _bind_vararg_method(bind, p_name, p_default_args, true);

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -105,7 +105,7 @@ void memdelete(T *p_class) {
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
 	}
-	if (!std::is_trivially_destructible<T>::value) {
+	if constexpr (!std::is_trivially_destructible_v<T>) {
 		p_class->~T();
 	}
 
@@ -117,7 +117,7 @@ void memdelete_allocator(T *p_class) {
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
 	}
-	if (!std::is_trivially_destructible<T>::value) {
+	if constexpr (!std::is_trivially_destructible_v<T>) {
 		p_class->~T();
 	}
 
@@ -147,7 +147,7 @@ T *memnew_arr_template(size_t p_elements) {
 	ERR_FAIL_NULL_V(mem, failptr);
 	*(mem - 1) = p_elements;
 
-	if (!std::is_trivially_constructible<T>::value) {
+	if constexpr (!std::is_trivially_constructible_v<T>) {
 		T *elems = (T *)mem;
 
 		/* call operator new */
@@ -174,7 +174,7 @@ template <typename T>
 void memdelete_arr(T *p_class) {
 	uint64_t *ptr = (uint64_t *)p_class;
 
-	if (!std::is_trivially_destructible<T>::value) {
+	if constexpr (!std::is_trivially_destructible_v<T>) {
 		uint64_t elem_count = *(ptr - 1);
 
 		for (uint64_t i = 0; i < elem_count; i++) {

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -233,7 +233,7 @@ void CowData<T>::_unref(void *p_data) {
 	}
 	// clean up
 
-	if (!std::is_trivially_destructible<T>::value) {
+	if constexpr (!std::is_trivially_destructible_v<T>) {
 		USize *count = _get_size();
 		T *data = (T *)(count + 1);
 
@@ -269,7 +269,7 @@ typename CowData<T>::USize CowData<T>::_copy_on_write() {
 		T *_data = (T *)(mem_new);
 
 		// initialize new elements
-		if (std::is_trivially_copyable<T>::value) {
+		if constexpr (std::is_trivially_copyable_v<T>) {
 			memcpy(mem_new, _ptr, current_size * sizeof(T));
 
 		} else {
@@ -335,7 +335,7 @@ Error CowData<T>::resize(Size p_size) {
 
 		// construct the newly created elements
 
-		if (!std::is_trivially_constructible<T>::value) {
+		if constexpr (!std::is_trivially_constructible_v<T>) {
 			for (Size i = *_get_size(); i < p_size; i++) {
 				memnew_placement(&_ptr[i], T);
 			}
@@ -346,7 +346,7 @@ Error CowData<T>::resize(Size p_size) {
 		*_get_size() = p_size;
 
 	} else if (p_size < current_size) {
-		if (!std::is_trivially_destructible<T>::value) {
+		if constexpr (!std::is_trivially_destructible_v<T>) {
 			// deinitialize no longer needed elements
 			for (USize i = p_size; i < *_get_size(); i++) {
 				T *t = &_ptr[i];

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -64,7 +64,7 @@ public:
 			CRASH_COND_MSG(!data, "Out of memory");
 		}
 
-		if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
 			data[count++] = p_elem;
@@ -77,7 +77,7 @@ public:
 		for (U i = p_index; i < count; i++) {
 			data[i] = data[i + 1];
 		}
-		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -90,7 +90,7 @@ public:
 		if (count > p_index) {
 			data[p_index] = data[count];
 		}
-		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -133,7 +133,7 @@ public:
 	_FORCE_INLINE_ U size() const { return count; }
 	void resize(U p_size) {
 		if (p_size < count) {
-			if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+			if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 				for (U i = p_size; i < count; i++) {
 					data[i].~T();
 				}
@@ -145,7 +145,7 @@ public:
 				data = (T *)memrealloc(data, capacity * sizeof(T));
 				CRASH_COND_MSG(!data, "Out of memory");
 			}
-			if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+			if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 				for (U i = count; i < p_size; i++) {
 					memnew_placement(&data[i], T);
 				}

--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -101,7 +101,7 @@ public:
 
 private:
 	void _reset(bool p_allow_unfreed) {
-		if (!p_allow_unfreed || !std::is_trivially_destructible<T>::value) {
+		if (!p_allow_unfreed || !std::is_trivially_destructible_v<T>) {
 			ERR_FAIL_COND(allocs_available < pages_allocated * page_size);
 		}
 		if (pages_allocated) {

--- a/core/templates/paged_array.h
+++ b/core/templates/paged_array.h
@@ -202,7 +202,7 @@ public:
 		uint32_t page = count >> page_size_shift;
 		uint32_t offset = count & page_size_mask;
 
-		if (!std::is_trivially_constructible<T>::value) {
+		if constexpr (!std::is_trivially_constructible_v<T>) {
 			memnew_placement(&page_data[page][offset], T(p_value));
 		} else {
 			page_data[page][offset] = p_value;
@@ -214,7 +214,7 @@ public:
 	_FORCE_INLINE_ void pop_back() {
 		ERR_FAIL_COND(count == 0);
 
-		if (!std::is_trivially_destructible<T>::value) {
+		if constexpr (!std::is_trivially_destructible_v<T>) {
 			uint32_t page = (count - 1) >> page_size_shift;
 			uint32_t offset = (count - 1) & page_size_mask;
 			page_data[page][offset].~T();
@@ -237,7 +237,7 @@ public:
 
 	void clear() {
 		//destruct if needed
-		if (!std::is_trivially_destructible<T>::value) {
+		if constexpr (!std::is_trivially_destructible_v<T>) {
 			for (uint64_t i = 0; i < count; i++) {
 				uint32_t page = i >> page_size_shift;
 				uint32_t offset = i & page_size_mask;
@@ -318,13 +318,13 @@ public:
 				uint32_t to_copy = MIN(page_size - new_remainder, remainder);
 
 				for (uint32_t i = 0; i < to_copy; i++) {
-					if (!std::is_trivially_constructible<T>::value) {
+					if constexpr (!std::is_trivially_constructible_v<T>) {
 						memnew_placement(&dst_page[i + new_remainder], T(remainder_page[i + remainder - to_copy]));
 					} else {
 						dst_page[i + new_remainder] = remainder_page[i + remainder - to_copy];
 					}
 
-					if (!std::is_trivially_destructible<T>::value) {
+					if constexpr (!std::is_trivially_destructible_v<T>) {
 						remainder_page[i + remainder - to_copy].~T();
 					}
 				}

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -54,7 +54,7 @@
 #define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type)                    \
 	static_assert(sizeof(SafeNumeric<m_type>) == sizeof(m_type));   \
 	static_assert(alignof(SafeNumeric<m_type>) == alignof(m_type)); \
-	static_assert(std::is_trivially_destructible<std::atomic<m_type>>::value);
+	static_assert(std::is_trivially_destructible_v<std::atomic<m_type>>);
 #define SAFE_FLAG_TYPE_PUN_GUARANTEES                \
 	static_assert(sizeof(SafeFlag) == sizeof(bool)); \
 	static_assert(alignof(SafeFlag) == alignof(bool));

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -51,7 +51,7 @@ template <class T>
 struct VariantCaster {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
-		if constexpr (std::is_base_of<Object, TStripped>::value) {
+		if constexpr (std::is_base_of_v<Object, TStripped>) {
 			return Object::cast_to<TStripped>(p_variant);
 		} else {
 			return p_variant;
@@ -63,7 +63,7 @@ template <class T>
 struct VariantCaster<T &> {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
-		if constexpr (std::is_base_of<Object, TStripped>::value) {
+		if constexpr (std::is_base_of_v<Object, TStripped>) {
 			return Object::cast_to<TStripped>(p_variant);
 		} else {
 			return p_variant;
@@ -75,7 +75,7 @@ template <class T>
 struct VariantCaster<const T &> {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
-		if constexpr (std::is_base_of<Object, TStripped>::value) {
+		if constexpr (std::is_base_of_v<Object, TStripped>) {
 			return Object::cast_to<TStripped>(p_variant);
 		} else {
 			return p_variant;
@@ -226,7 +226,7 @@ template <typename T>
 struct VariantObjectClassChecker {
 	static _FORCE_INLINE_ bool check(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
-		if constexpr (std::is_base_of<Object, TStripped>::value) {
+		if constexpr (std::is_base_of_v<Object, TStripped>) {
 			Object *obj = p_variant;
 			return Object::cast_to<TStripped>(p_variant) || !obj;
 		} else {

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -43,14 +43,10 @@ struct EnableIf<false, T> {
 };
 
 template <typename, typename>
-struct TypesAreSame {
-	static bool const value = false;
-};
+inline constexpr bool types_are_same_v = false;
 
-template <typename A>
-struct TypesAreSame<A, A> {
-	static bool const value = true;
-};
+template <typename T>
+inline constexpr bool types_are_same_v<T, T> = true;
 
 template <typename B, typename D>
 struct TypeInherits {
@@ -60,7 +56,7 @@ struct TypeInherits {
 	static char (&test(...))[2];
 
 	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
-			!TypesAreSame<B volatile const, void volatile const>::value;
+			!types_are_same_v<B volatile const, void volatile const>;
 };
 
 namespace GodotTypeInfo {

--- a/servers/rendering/storage/variant_converters.h
+++ b/servers/rendering/storage/variant_converters.h
@@ -243,10 +243,10 @@ inline bool is_convertible_array(Variant::Type type) {
 }
 
 template <class, class = void>
-struct is_vector_type : std::false_type {};
+inline constexpr bool is_vector_type_v = false;
 
 template <class T>
-struct is_vector_type<T, std::void_t<decltype(T::AXIS_COUNT)>> : std::true_type {};
+inline constexpr bool is_vector_type_v<T, std::void_t<decltype(T::AXIS_COUNT)>> = true;
 
 template <typename T, typename P>
 void convert_item_std140(const T &p_item, P *p_write, bool p_compact = false) {
@@ -274,7 +274,7 @@ Vector<P> convert_array_std140(const Variant &p_variant, [[maybe_unused]] bool p
 			const Variant &item = array.get(i);
 			P *offset = write + (i * elements);
 
-			if constexpr (is_vector_type<T>::value) {
+			if constexpr (is_vector_type_v<T>) {
 				const T &vec = convert_to_vector<T>(item, p_linear_color);
 				convert_item_std140<T, P>(vec, offset, true);
 			} else {


### PR DESCRIPTION
This is a pure refactoring PR that shouldn't affect the behavior or Godot in any way or form. I've used the shorthand `_v` notation for type traits (which is more concise, and faster to compile on modern compilers) and promoted some `if` constructs to `if constexpr` where appropriate.

Both of the changes had a precedent in the codebase.

BTW, I'm working on some more improvements to the internals, hope this kind of PR is appreciated!