### PR TITLE
Fix frame number underflow in visual profiler

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -70,7 +70,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 	updating_frame = true;
 	clear_button->set_disabled(false);
 	cursor_metric_edit->set_max(frame_metrics[last_metric].frame_number);
-	cursor_metric_edit->set_min(MAX(frame_metrics[last_metric].frame_number - frame_metrics.size(), 0u));
+	cursor_metric_edit->set_min(MAX(int64_t(frame_metrics[last_metric].frame_number) - frame_metrics.size(), 0));
 
 	if (!seeking) {
 		cursor_metric_edit->set_value(frame_metrics[last_metric].frame_number);


### PR DESCRIPTION
Fixes #62341 and #77915

Unsigned subtraction underflow caused the frame counter to be locked at 2^64 in the visual profiler until `debugger/profiler_frame_history_size` number of frames had passed.

I'm bad at C++ but I _think_ this cast is safe, even after 2^63 frames.
