### PR TITLE
Add basic Emacs `.gitignore` entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,10 @@ cppcheck-cppcheck-build-dir/
 *.pydevproject
 *.launch
 
+# Emacs
+\#*\#
+.\#*
+
 # GCOV code coverage
 *.gcda
 *.gcno


### PR DESCRIPTION
Adds these entries to the `.gitignore` file for the [Emacs editor](https://www.gnu.org/software/emacs/).
```
\#*#
.\#*
```
These are temporary files.