### PR TITLE
Fix freeze in TextEdit with `scroll_past_end_of_file` and `fit_content_height`

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7333,7 +7333,7 @@ void TextEdit::_update_scrollbars() {
 
 	int visible_rows = get_visible_line_count();
 	int total_rows = draw_placeholder ? placeholder_wraped_rows.size() - 1 : get_total_visible_line_count();
-	if (scroll_past_end_of_file_enabled) {
+	if (scroll_past_end_of_file_enabled && !fit_content_height) {
 		total_rows += visible_rows - 1;
 	}
 


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/84742

`scroll_past_end_of_file` and `fit_content_height` don't make sense together so `scroll_past_end_of_file` now needs `fit_content_height` to be false.