### PR TITLE
Add HeightMapShape3D functions to get min / max height

### DIFF
--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -9,9 +9,23 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_max_height" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the largest height value found in [member map_data]. Recalculates only when [member map_data] changes.
+			</description>
+		</method>
+		<method name="get_min_height" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the smallest height value found in [member map_data]. Recalculates only when [member map_data] changes.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="map_data" type="PackedFloat32Array" setter="set_map_data" getter="get_map_data" default="PackedFloat32Array(0, 0, 0, 0)">
-			Height map data, pool array must be of [member map_width] * [member map_depth] size.
+			Height map data. The array's size must be equal to [member map_width] multiplied by [member map_depth].
 		</member>
 		<member name="map_depth" type="int" setter="set_map_depth" getter="get_map_depth" default="2">
 			Number of vertices in the depth of the height map. Changing this will resize the [member map_data].

--- a/scene/resources/height_map_shape_3d.cpp
+++ b/scene/resources/height_map_shape_3d.cpp
@@ -179,6 +179,14 @@ Vector<real_t> HeightMapShape3D::get_map_data() const {
 	return map_data;
 }
 
+real_t HeightMapShape3D::get_min_height() const {
+	return min_height;
+}
+
+real_t HeightMapShape3D::get_max_height() const {
+	return max_height;
+}
+
 void HeightMapShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_map_width", "width"), &HeightMapShape3D::set_map_width);
 	ClassDB::bind_method(D_METHOD("get_map_width"), &HeightMapShape3D::get_map_width);
@@ -186,6 +194,8 @@ void HeightMapShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_map_depth"), &HeightMapShape3D::get_map_depth);
 	ClassDB::bind_method(D_METHOD("set_map_data", "data"), &HeightMapShape3D::set_map_data);
 	ClassDB::bind_method(D_METHOD("get_map_data"), &HeightMapShape3D::get_map_data);
+	ClassDB::bind_method(D_METHOD("get_min_height"), &HeightMapShape3D::get_min_height);
+	ClassDB::bind_method(D_METHOD("get_max_height"), &HeightMapShape3D::get_max_height);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_width", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_map_width", "get_map_width");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_depth", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_map_depth", "get_map_depth");

--- a/scene/resources/height_map_shape_3d.h
+++ b/scene/resources/height_map_shape_3d.h
@@ -54,6 +54,9 @@ public:
 	void set_map_data(Vector<real_t> p_new);
 	Vector<real_t> get_map_data() const;
 
+	real_t get_min_height() const;
+	real_t get_max_height() const;
+
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 


### PR DESCRIPTION
Adds `HeightMapShape3D` functions to get `min` / `max` height.

Not sure why those were never exposed while already tracked on the shape. Knowing what is the min and max height in the heights array is very useful information to avoid looping over the entire large array manually.

Also there are no longer pool arrays in Godot 4, they are now packed arrays, but I don't see much value in mentioning this in the text when the function makes it obvious.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
