### PR TITLE
Fix Ogg/Mp3 import loop point not having single-sample precision

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -34,6 +34,11 @@
 				Return the controllable parameters of this stream. This array contains dictionaries with a property info description format (see [method Object.get_property_list]). Additionally, the default value for this parameter must be added tho each dictionary in "default_value" field.
 			</description>
 		</method>
+		<method name="_get_sampling_rate" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_stream_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>
@@ -53,6 +58,12 @@
 			<return type="float" />
 			<description>
 				Returns the length of the audio stream in seconds.
+			</description>
+		</method>
+		<method name="get_sampling_rate" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the sampling rate of the audio stream in samples per second.
 			</description>
 		</method>
 		<method name="instantiate_playback">

--- a/editor/import/audio_stream_import_settings.h
+++ b/editor/import/audio_stream_import_settings.h
@@ -35,6 +35,7 @@
 #include "scene/audio/audio_stream_player.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/texture.h"
 
@@ -42,6 +43,12 @@ class CheckBox;
 
 class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 	GDCLASS(AudioStreamImportSettingsDialog, ConfirmationDialog);
+
+	enum class LoopOffsetUnit {
+		LOOP_OFFSET_UNIT_SECONDS,
+		LOOP_OFFSET_UNIT_SAMPLES,
+		LOOP_OFFSET_UNIT_BEATS
+	};
 
 	CheckBox *bpm_enabled = nullptr;
 	SpinBox *bpm_edit = nullptr;
@@ -51,6 +58,7 @@ class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 	SpinBox *bar_beats_edit = nullptr;
 	CheckBox *loop = nullptr;
 	SpinBox *loop_offset = nullptr;
+	OptionButton *loop_offset_unit = nullptr;
 	ColorRect *color_rect = nullptr;
 	Ref<AudioStream> stream;
 	AudioStreamPlayer *_player = nullptr;
@@ -74,6 +82,7 @@ class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 	bool _beat_len_dragging = false;
 	bool _pausing = false;
 	int _hovering_beat = -1;
+	int64_t _loop_offset_samples = 0;
 
 	HashMap<StringName, Variant> params;
 	String importer;
@@ -84,8 +93,13 @@ class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 	static AudioStreamImportSettingsDialog *singleton;
 
 	void _settings_changed();
+	void _unit_changed();
 
 	void _reimport();
+
+	double _samples_to_unit(int64_t p_samples) const;
+	double _seconds_to_unit(double p_seconds) const;
+	int64_t _unit_to_samples(double p_unit) const;
 
 protected:
 	void _notification(int p_what);

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -253,6 +253,10 @@ bool AudioStreamMP3::is_monophonic() const {
 	return false;
 }
 
+int AudioStreamMP3::get_sampling_rate() const {
+	return (int)sample_rate;
+}
+
 void AudioStreamMP3::get_parameter_list(List<Parameter> *r_parameters) {
 	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -131,6 +131,8 @@ public:
 
 	virtual bool is_monophonic() const override;
 
+	virtual int get_sampling_rate() const override;
+
 	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
 
 	AudioStreamMP3();

--- a/modules/minimp3/doc_classes/ResourceImporterMP3.xml
+++ b/modules/minimp3/doc_classes/ResourceImporterMP3.xml
@@ -28,10 +28,10 @@
 			If enabled, the audio will begin playing at the beginning after playback ends by reaching the end of the audio.
 			[b]Note:[/b] In [AudioStreamPlayer], the [signal AudioStreamPlayer.finished] signal won't be emitted for looping audio when it reaches the end of the audio file, as the audio will keep playing indefinitely.
 		</member>
-		<member name="loop_offset" type="float" setter="" getter="" default="0">
-			Determines where audio will start to loop after playback reaches the end of the audio. This can be used to only loop a part of the audio file, which is useful for some ambient sounds or music. The value is determined in seconds relative to the beginning of the audio. A value of [code]0.0[/code] will loop the entire audio file.
+		<member name="loop_offset_samples" type="int" setter="" getter="" default="0">
+			Determines where audio will start to loop after playback reaches the end of the audio. This can be used to only loop a part of the audio file, which is useful for some ambient sounds or music. The value is determined in samples relative to the beginning of the audio. A value of [code]0[/code] will loop the entire audio file.
 			Only has an effect if [member loop] is [code]true[/code].
-			A more convenient editor for [member loop_offset] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
+			A more convenient editor for [member loop_offset_samples] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 	</members>
 </class>

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -76,7 +76,7 @@ String ResourceImporterMP3::get_preset_name(int p_idx) const {
 
 void ResourceImporterMP3::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), false));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "loop_offset"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "loop_offset_samples"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "bpm", PROPERTY_HINT_RANGE, "0,400,0.01,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "beat_count", PROPERTY_HINT_RANGE, "0,512,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "bar_beats", PROPERTY_HINT_RANGE, "2,32,or_greater"), 4));
@@ -117,7 +117,6 @@ Ref<AudioStreamMP3> ResourceImporterMP3::import_mp3(const String &p_path) {
 
 Error ResourceImporterMP3::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
-	float loop_offset = p_options["loop_offset"];
 	double bpm = p_options["bpm"];
 	float beat_count = p_options["beat_count"];
 	float bar_beats = p_options["bar_beats"];
@@ -127,7 +126,11 @@ Error ResourceImporterMP3::import(const String &p_source_file, const String &p_s
 		return ERR_CANT_OPEN;
 	}
 	mp3_stream->set_loop(loop);
-	mp3_stream->set_loop_offset(loop_offset);
+	if (p_options.has("loop_offset_samples")) {
+		mp3_stream->set_loop_offset((double)p_options["loop_offset_samples"] / mp3_stream->get_sampling_rate());
+	} else {
+		mp3_stream->set_loop_offset(p_options["loop_offset"]);
+	}
 	mp3_stream->set_bpm(bpm);
 	mp3_stream->set_beat_count(beat_count);
 	mp3_stream->set_bar_beats(bar_beats);

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -513,6 +513,11 @@ bool AudioStreamOggVorbis::is_monophonic() const {
 	return false;
 }
 
+int AudioStreamOggVorbis::get_sampling_rate() const {
+	ERR_FAIL_COND_V(packet_sequence.is_null(), 0);
+	return packet_sequence->get_sampling_rate();
+}
+
 void AudioStreamOggVorbis::get_parameter_list(List<Parameter> *r_parameters) {
 	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -157,6 +157,8 @@ public:
 
 	virtual bool is_monophonic() const override;
 
+	virtual int get_sampling_rate() const override;
+
 	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
 
 	AudioStreamOggVorbis();

--- a/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
+++ b/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
@@ -44,10 +44,10 @@
 			If enabled, the audio will begin playing at the beginning after playback ends by reaching the end of the audio.
 			[b]Note:[/b] In [AudioStreamPlayer], the [signal AudioStreamPlayer.finished] signal won't be emitted for looping audio when it reaches the end of the audio file, as the audio will keep playing indefinitely.
 		</member>
-		<member name="loop_offset" type="float" setter="" getter="" default="0">
-			Determines where audio will start to loop after playback reaches the end of the audio. This can be used to only loop a part of the audio file, which is useful for some ambient sounds or music. The value is determined in seconds relative to the beginning of the audio. A value of [code]0.0[/code] will loop the entire audio file.
+		<member name="loop_offset_samples" type="int" setter="" getter="" default="0">
+			Determines where audio will start to loop after playback reaches the end of the audio. This can be used to only loop a part of the audio file, which is useful for some ambient sounds or music. The value is determined in samples relative to the beginning of the audio. A value of [code]0[/code] will loop the entire audio file.
 			Only has an effect if [member loop] is [code]true[/code].
-			A more convenient editor for [member loop_offset] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
+			A more convenient editor for [member loop_offset_samples] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 	</members>
 </class>

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -75,7 +75,7 @@ String ResourceImporterOggVorbis::get_preset_name(int p_idx) const {
 
 void ResourceImporterOggVorbis::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), false));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "loop_offset"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "loop_offset_samples"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "bpm", PROPERTY_HINT_RANGE, "0,400,0.01,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "beat_count", PROPERTY_HINT_RANGE, "0,512,or_greater"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "bar_beats", PROPERTY_HINT_RANGE, "2,32,or_greater"), 4));
@@ -97,7 +97,6 @@ void ResourceImporterOggVorbis::show_advanced_options(const String &p_path) {
 
 Error ResourceImporterOggVorbis::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
-	double loop_offset = p_options["loop_offset"];
 	double bpm = p_options["bpm"];
 	int beat_count = p_options["beat_count"];
 	int bar_beats = p_options["bar_beats"];
@@ -108,7 +107,11 @@ Error ResourceImporterOggVorbis::import(const String &p_source_file, const Strin
 	}
 
 	ogg_vorbis_stream->set_loop(loop);
-	ogg_vorbis_stream->set_loop_offset(loop_offset);
+	if (p_options.has("loop_offset_samples")) {
+		ogg_vorbis_stream->set_loop_offset((double)p_options["loop_offset_samples"] / ogg_vorbis_stream->get_packet_sequence()->get_sampling_rate());
+	} else {
+		ogg_vorbis_stream->set_loop_offset(p_options["loop_offset"]);
+	}
 	ogg_vorbis_stream->set_bpm(bpm);
 	ogg_vorbis_stream->set_beat_count(beat_count);
 	ogg_vorbis_stream->set_bar_beats(bar_beats);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -216,6 +216,12 @@ bool AudioStream::is_monophonic() const {
 	return ret;
 }
 
+int AudioStream::get_sampling_rate() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_sampling_rate, ret);
+	return ret;
+}
+
 double AudioStream::get_bpm() const {
 	double ret = 0;
 	GDVIRTUAL_CALL(_get_bpm, ret);
@@ -274,11 +280,13 @@ void AudioStream::get_parameter_list(List<Parameter> *r_parameters) {
 void AudioStream::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_length"), &AudioStream::get_length);
 	ClassDB::bind_method(D_METHOD("is_monophonic"), &AudioStream::is_monophonic);
+	ClassDB::bind_method(D_METHOD("get_sampling_rate"), &AudioStream::get_sampling_rate);
 	ClassDB::bind_method(D_METHOD("instantiate_playback"), &AudioStream::instantiate_playback);
 	GDVIRTUAL_BIND(_instantiate_playback);
 	GDVIRTUAL_BIND(_get_stream_name);
 	GDVIRTUAL_BIND(_get_length);
 	GDVIRTUAL_BIND(_is_monophonic);
+	GDVIRTUAL_BIND(_get_sampling_rate);
 	GDVIRTUAL_BIND(_get_bpm)
 	GDVIRTUAL_BIND(_get_beat_count)
 	GDVIRTUAL_BIND(_get_parameter_list)

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -127,6 +127,7 @@ protected:
 	GDVIRTUAL0RC(String, _get_stream_name)
 	GDVIRTUAL0RC(double, _get_length)
 	GDVIRTUAL0RC(bool, _is_monophonic)
+	GDVIRTUAL0RC(int, _get_sampling_rate)
 	GDVIRTUAL0RC(double, _get_bpm)
 	GDVIRTUAL0RC(bool, _has_loop)
 	GDVIRTUAL0RC(int, _get_bar_beats)
@@ -144,6 +145,7 @@ public:
 
 	virtual double get_length() const;
 	virtual bool is_monophonic() const;
+	virtual int get_sampling_rate() const;
 
 	void tag_used(float p_offset);
 	uint64_t get_tagged_frame() const;


### PR DESCRIPTION
Fixes #87427. Possibly also contributes to addressing https://github.com/godotengine/godot-proposals/issues/84.

This is another suggestion for how to address the limited loop point precision in the Audio Stream Importer dialog for Ogg and Mp3 and supplements the ideas in #87554 and #87860. It adds a drop down that switches the unit used for the Offset field between Seconds, Samples, and Beats.

![grafik](https://github.com/godotengine/godot/assets/35597337/d9066828-4f97-4b34-ab1e-657b42c1ae19)


Advantages are:
- The default behavior is unchanged (seconds with millisecond resolution).
- Additionally, it is possible to specify loop points that don't map to whole milliseconds with sample precision or beat precision in combination with a BPM number.
- The loop point position is retained across reimports with sample precision.
- Just changing the displayed unit is non-destructive and will not immediately modify the underlying value unless the value is actually changed.
- No changes have been made to the serialization itself. Instead, the precision is kept by serializing the sample count as a 64 bit integer instead of the seconds as a limited-precision floating point representation. (Serialization and deserialization via the `.import` file does not retain the full `float` precision across the conversion to and from a string.)
  - I've changed the `loop_offset` import option to be named `loop_offset_samples` to differentiate what method was used for the import. The dialog and the resource importers work with either option but prefer `loop_offset_samples` if it is present.
- No changes have been made to the actual loop code in the audio streams or the players. These still use seconds at 64 bits resolution. That's not an issue there, because these settings are serialized at full precision in the binary resource.

Issues are:
- This still requires the `AudioStream` class to expose the sample rate so that the dialog can do the necessary conversions.
- If the BPM number is changed from the default 120, this is not retained across reimports. Currently, any number other than 0 is interpreted as the BPM option being enabled (with 0 being interpreted as 120 BPM and the option being disabled). The actual loop point will be retained, but the displayed "Beats" number will be relative to 120 BPM until the BPM number is reset to what it was during the previous import.
- The display unit (Seconds/Samples/Beats) is not serialized, as it's a merely cosmetic setting, so it didn't feel right to make it part of the import options. As a consequence, the dialog will always display seconds initially and only at millisecond precision (the original precision is retained, however, as can be checked by switching the unit to "Samples").