### PR TITLE
Add 'Skip to next (text) occurrence' feature to text editor

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -383,6 +383,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_text_select_all",                            TTRC("Select All") },
     { "ui_text_select_word_under_caret",               TTRC("Select Word Under Caret") },
     { "ui_text_add_selection_for_next_occurrence",     TTRC("Add Selection for Next Occurrence") },
+    { "ui_text_skip_selection_for_next_occurrence",    TTRC("Skip Selection for Next Occurrence") },
     { "ui_text_clear_carets_and_selection",            TTRC("Clear Carets and Selection") },
     { "ui_text_toggle_insert_mode",                    TTRC("Toggle Insert Mode") },
     { "ui_text_submit",                                TTRC("Submit Text") },
@@ -720,6 +721,10 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::D | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_add_selection_for_next_occurrence", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::D | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT));
+	default_builtin_cache.insert("ui_text_skip_selection_for_next_occurrence", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::ESCAPE));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1334,6 +1334,12 @@
 		<member name="input/ui_text_select_word_under_caret.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to select the word currently under the caret.
 		</member>
+		<member name="input/ui_text_skip_selection_for_next_occurrence" type="Dictionary" setter="" getter="">
+			If no selection is currently active with the last caret in text fields, searches for the next occurrence of the the word currently under the caret and moves the caret to the next occurrence. The action can be performed sequentially for other occurrences of the word under the last caret.
+			If a selection is currently active with the last caret in text fields, searches for the next occurrence of the selection, adds a caret, selects the next occurrence then deselects the previous selection and its associated caret. The action can be performed sequentially for other occurrences of the selection of the last caret.
+			The viewport is adjusted to the latest newly added caret.
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_text_submit" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to submit a text field.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1070,6 +1070,12 @@
 				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code].
 			</description>
 		</method>
+		<method name="skip_selection_for_next_occurrence">
+			<return type="void" />
+			<description>
+				Moves a selection and a caret for the next occurrence of the current selection. If there is no active selection, moves to the next occurrence of the word under caret.
+			</description>
+		</method>
 		<method name="start_action">
 			<return type="void" />
 			<param index="0" name="action" type="int" enum="TextEdit.EditAction" />

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -890,6 +890,7 @@ public:
 	void select_all();
 	void select_word_under_caret(int p_caret = -1);
 	void add_selection_for_next_occurrence();
+	void skip_selection_for_next_occurrence();
 	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column, int p_caret = 0);
 
 	bool has_selection(int p_caret = -1) const;


### PR DESCRIPTION
Adds `ui_text_skip_selection_for_next_occurrence` action and related implementation to text editor. This action is bound to `Ctrl+Alt+D` shorcut.

Used in conjunction with `ui_add_selection_for_next_occurrence`, it gives the user the ability to select many occurrences of a selection and avoid some of them.
Used without a previous selection, the action jumps to the next occurrence of the current word under the caret.
