### PR TITLE
Add HeightMapShape3D update with Image data

### DIFF
--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -6,6 +6,19 @@
 	<description>
 		A 3D heightmap shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape3D]. This is useful for terrain, but it is limited as overhangs (such as caves) cannot be stored. Holes in a [HeightMapShape3D] are created by assigning very low values to points in the desired area.
 		[b]Performance:[/b] [HeightMapShape3D] is faster to check collisions against than [ConcavePolygonShape3D], but it is significantly slower than primitive shapes like [BoxShape3D].
+		A heightmap collision shape can also be build by using an [Image] reference:
+		[codeblocks]
+		[gdscript]
+		var heightmap_texture: Texture = ResourceLoader.load("res://heightmap_image.exr")
+		var heightmap_image: Image = heightmap_texture.get_image()
+		heightmap_image.convert(Image.FORMAT_RF)
+
+		var height_min: float = 0.0
+		var height_max: float = 10.0
+
+		update_map_data_from_image(heightmap_image, height_min, height_max)
+		[/gdscript]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -20,6 +33,17 @@
 			<return type="float" />
 			<description>
 				Returns the smallest height value found in [member map_data]. Recalculates only when [member map_data] changes.
+			</description>
+		</method>
+		<method name="update_map_data_from_image">
+			<return type="void" />
+			<param index="0" name="image" type="Image" />
+			<param index="1" name="height_min" type="float" />
+			<param index="2" name="height_max" type="float" />
+			<description>
+				Updates [member map_data] with data read from an [Image] reference. Automatically resizes heightmap [member map_width] and [member map_depth] to fit the full image width and height.
+				The image needs to be in either [constant Image.FORMAT_RF] (32 bit), [constant Image.FORMAT_RH] (16 bit), or [constant Image.FORMAT_R8] (8 bit).
+				Each image pixel is read in as a float on the range from [code]0.0[/code] (black pixel) to [code]1.0[/code] (white pixel). This range value gets remapped to [param height_min] and [param height_max] to form the final height value.
 			</description>
 		</method>
 	</methods>

--- a/scene/resources/3d/height_map_shape_3d.h
+++ b/scene/resources/3d/height_map_shape_3d.h
@@ -33,6 +33,8 @@
 
 #include "scene/resources/3d/shape_3d.h"
 
+class Image;
+
 class HeightMapShape3D : public Shape3D {
 	GDCLASS(HeightMapShape3D, Shape3D);
 
@@ -56,6 +58,8 @@ public:
 
 	real_t get_min_height() const;
 	real_t get_max_height() const;
+
+	void update_map_data_from_image(const Ref<Image> &p_image, real_t p_height_min, real_t p_height_max);
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;


### PR DESCRIPTION
Adds `HeightMapShape3D` update with `Image` data.

Populating height values in a heightmap collision from an image file is a common use.
It shouldnt be required that users need to read large image data arrays with slow scripts to achieve this basic thing.

So what this pr does is add `update_map_data_from_image()` as a new function to `HeightMapShape3D`.

The function allows a single component black&white Image in format  `FORMAT_RF` (32 bit) or `FORMAT_RH`  (16 bit) or `FORMAT_R8` (8 bit) as input and to define a minimum and maximum height range. The image pixel values read in `0.0` to `1.0` range are then remapped to those values.

The code for this was actually found in part on the PhysicsServer3D as more or less dead-code not reachable by users. It also makes far more sense to have this functionality on the collision shape directly to update the `map_data`. This data array is commonly used for other related stuff, like creating procedual meshes from the heightmap data.

Full usage example to create heightmap collision from an image file:

```gdscript
extends Node3D

func _ready() -> void:
    var heightmap_texture: Texture = ResourceLoader.load("res://heightmap_image.exr")
    var heightmap_image: Image = heightmap_texture.get_image()
    heightmap_image.convert(Image.FORMAT_RF)

    var heightmap_shape: HeightMapShape3D = HeightMapShape3D.new()
    var height_min: float = 0.0
    var height_max: float = 10.0
    heightmap_shape.update_map_data_from_image(heightmap_image, height_min, height_max)

    var static_body: StaticBody3D = StaticBody3D.new()
    var collision_shape: CollisionShape3D = CollisionShape3D.new()
    collision_shape.shape = heightmap_shape
    static_body.add_child(collision_shape)
    add_child(static_body)
```
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
