### PR TITLE
Extract `SafeBinaryMutex` to separate header

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -36,6 +36,7 @@
 #include "core/object/script_language.h"
 #include "core/os/condition_variable.h"
 #include "core/os/os.h"
+#include "core/os/safe_binary_mutex.h"
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
 #include "core/variant/variant_parser.h"

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -39,6 +39,9 @@
 
 class ConditionVariable;
 
+template <int Tag>
+class SafeBinaryMutex;
+
 class ResourceFormatLoader : public RefCounted {
 	GDCLASS(ResourceFormatLoader, RefCounted);
 


### PR DESCRIPTION
This change simply extracts 'SafeBinaryMutex' from 'mutex.h' to 'safe_binary_mutex.h', in an effort to reduce the compilation speed impact of including `mutex.h`.

Similarly in nature to #87871, this is a pure refactoring PR that shouldn't affect the behavior or Godot in any way or form.