### PR TITLE
Use subgizmos for Path3D position editing and declutter the UI

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -646,6 +646,18 @@ void Node3DEditorViewport::cancel_transform() {
 			continue;
 		}
 
+		if (se && se->gizmo.is_valid()) {
+			Vector<int> ids;
+			Vector<Transform3D> restore;
+
+			for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
+				ids.push_back(GE.key);
+				restore.push_back(GE.value);
+			}
+
+			se->gizmo->commit_subgizmos(ids, restore, true);
+		}
+
 		sp->set_global_transform(se->original);
 	}
 
@@ -8071,6 +8083,7 @@ void Node3DEditor::_bind_methods() {
 	ClassDB::bind_method("_refresh_menu_icons", &Node3DEditor::_refresh_menu_icons);
 
 	ClassDB::bind_method("update_all_gizmos", &Node3DEditor::update_all_gizmos);
+	ClassDB::bind_method("update_transform_gizmo", &Node3DEditor::update_transform_gizmo);
 
 	ADD_SIGNAL(MethodInfo("transform_key_request"));
 	ADD_SIGNAL(MethodInfo("item_lock_status_changed"));

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -509,7 +509,7 @@ public:
 	RID sbox_instance_xray;
 	RID sbox_instance_xray_offset;
 	Ref<EditorNode3DGizmo> gizmo;
-	HashMap<int, Transform3D> subgizmos; // map ID -> initial transform
+	HashMap<int, Transform3D> subgizmos; // Key: Subgizmo ID, Value: Initial subgizmo transform.
 
 	Node3DEditorSelectedItem() {
 		sp = nullptr;

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -63,6 +63,8 @@ class Path3DGizmo : public EditorNode3DGizmo {
 	// Cache information of secondary handles.
 	Vector<HandleInfo> _secondary_handles_info;
 
+	void _update_transform_gizmo();
+
 public:
 	virtual String get_handle_name(int p_id, bool p_secondary) const override;
 	virtual Variant get_handle_value(int p_id, bool p_secondary) const override;
@@ -78,11 +80,25 @@ class Path3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 	float disk_size = 0.8;
 
+	// Locking basis is meant to ensure a predictable behavior during translation of the curve points in "local space transform mode".
+	// Without the locking, the gizmo/point, in "local space transform mode", wouldn't follow a straight path and would curve and twitch in an unpredictable way.
+	HashMap<int, Basis> transformation_locked_basis;
+
 protected:
 	Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial) override;
 
 public:
+	virtual bool has_gizmo(Node3D *p_spatial) override;
 	String get_gizmo_name() const override;
+
+	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
+
+	virtual int subgizmos_intersect_ray(const EditorNode3DGizmo *p_gizmo, Camera3D *p_camera, const Vector2 &p_point) const override;
+	virtual Vector<int> subgizmos_intersect_frustum(const EditorNode3DGizmo *p_gizmo, const Camera3D *p_camera, const Vector<Plane> &p_frustum) const override;
+	virtual Transform3D get_subgizmo_transform(const EditorNode3DGizmo *p_gizmo, int p_id) const override;
+	virtual void set_subgizmo_transform(const EditorNode3DGizmo *p_gizmo, int p_id, Transform3D p_transform) override;
+	virtual void commit_subgizmos(const EditorNode3DGizmo *p_gizmo, const Vector<int> &p_ids, const Vector<Transform3D> &p_restore, bool p_cancel = false) override;
+
 	int get_priority() const override;
 	Path3DGizmoPlugin(float p_disk_size);
 };


### PR DESCRIPTION
Implements 3-axis gizmo translation of 3D curve points.  
As well as "contextual" displaying of handles. In an attempt to declutter the UI.  
Inspired mainly by Blender and Affinity Designer's curve editing UX.  
  
The proposal (https://github.com/godotengine/godot-proposals/issues/527) has accumulated many ideas, this PR aims to be a step towards improving the 3D curve editing UX and does NOT intend to satisfy everything mentioned in the proposal.

This PR:

https://github.com/godotengine/godot/assets/2036806/7809c274-9140-4f0f-98b3-6d8ee1bcb8f6

4.2.1:

https://github.com/godotengine/godot/assets/2036806/e6fa6021-6e94-4add-8974-aa91e4673e92
