### PR TITLE
Minor fix in DisplayServer docs to include Linux & Windows in `FEATURE_NATIVE_DIALOG`

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1713,7 +1713,7 @@
 			Display server supports setting the mouse cursor shape to a custom image. [b]Windows, macOS, Linux (X11/Wayland), Web[/b]
 		</constant>
 		<constant name="FEATURE_NATIVE_DIALOG" value="9" enum="Feature">
-			Display server supports spawning dialogs using the operating system's native look-and-feel. [b]macOS[/b]
+			Display server supports spawning dialogs using the operating system's native look-and-feel. [b]Windows, macOS, Linux (X11/Wayland)[/b]
 		</constant>
 		<constant name="FEATURE_IME" value="10" enum="Feature">
 			Display server supports [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url], which is commonly used for inputting Chinese/Japanese/Korean text. This is handled by the operating system, rather than by Godot. [b]Windows, macOS, Linux (X11)[/b]


### PR DESCRIPTION
Makes it consistent with the rest of the documentation, which states that native file dialogs are supported in Windows and Linux. Tested it myself on Linux X11, `DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG)` does indeed return `true`.

Not sure if cherry-pickable to 4.2 because of lack of Wayland support. Let me know if I should open another PR targeted at the 4.2 branch that does not mention Wayland.