### PR TITLE
[3.x] Document some `Image` methods can unlock it (making `set_pixel` fail)

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -385,6 +385,13 @@
 				img.unlock()
 				img.set_pixel(x, y, color) # Does not have an effect
 				[/codeblock]
+				[b]Note:[/b] Some image methods can leave the image unlocked, making subsequent [method set_pixel] calls fail unless the image is locked again. Methods potentially unlocking the image: [method blend_rect], [method blend_rect_mask], [method blit_rect_mask], [method convert], [method fill], [method fill_rect], [method get_used_rect], and [method rgbe_to_srgb].
+				[codeblock]
+				img.lock()
+				img.set_pixel(x, y, color) # Works
+				img.fill(color) # Unlocks the image
+				img.set_pixel(x, y, color) # Does not have an effect
+				[/codeblock]
 			</description>
 		</method>
 		<method name="set_pixelv">
@@ -399,6 +406,13 @@
 				img.lock()
 				img.set_pixelv(Vector2(x, y), color) # Works
 				img.unlock()
+				img.set_pixelv(Vector2(x, y), color) # Does not have an effect
+				[/codeblock]
+				[b]Note:[/b] Some image methods can leave the image unlocked, making subsequent [method set_pixelv] calls fail unless the image is locked again. Methods potentially unlocking the image: [method blend_rect], [method blend_rect_mask], [method blit_rect_mask], [method convert], [method fill], [method fill_rect], [method get_used_rect], and [method rgbe_to_srgb].
+				[codeblock]
+				img.lock()
+				img.set_pixelv(Vector2(x, y), color) # Works
+				img.fill(dcolor) # Unlocks the image
 				img.set_pixelv(Vector2(x, y), color) # Does not have an effect
 				[/codeblock]
 			</description>


### PR DESCRIPTION
When interleaving `Image.set_pixel` calls with some other method calls (like `Image.fill`) it can potentially fail because such other method could `Image.unlock()` the image. This PR notes this in the docs of `Image.set_pixel`/`Image.set_pixelv` which are the only methods requiring the image to be locked.

[Confused Reddit user in action](https://www.reddit.com/r/godot/comments/1ai4qvk/using_image_resource_fill_works_but_set_pixel).

(Not sure if we still cherry-pick such PRs to `3.5`.)