### PR TITLE
Make MeshLibrary export do recursive depth-search for MeshInstance3D nodes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2026,8 +2026,11 @@ void EditorNode::_dialog_action(String p_file) {
 		} break;
 
 		case FILE_EXPORT_MESH_LIBRARY: {
+			bool merge_with_existing_library = file_export_lib_merge->is_pressed();
+			bool apply_mesh_instance_transforms = file_export_lib_apply_xforms->is_pressed();
+
 			Ref<MeshLibrary> ml;
-			if (file_export_lib_merge->is_pressed() && FileAccess::exists(p_file)) {
+			if (merge_with_existing_library && FileAccess::exists(p_file)) {
 				ml = ResourceLoader::load(p_file, "MeshLibrary");
 
 				if (ml.is_null()) {
@@ -2040,7 +2043,7 @@ void EditorNode::_dialog_action(String p_file) {
 				ml = Ref<MeshLibrary>(memnew(MeshLibrary));
 			}
 
-			MeshLibraryEditor::update_library_file(editor_data.get_edited_scene_root(), ml, true, file_export_lib_apply_xforms->is_pressed());
+			MeshLibraryEditor::update_library_file(editor_data.get_edited_scene_root(), ml, merge_with_existing_library, apply_mesh_instance_transforms);
 
 			Error err = ResourceSaver::save(ml, p_file);
 			if (err) {

--- a/editor/plugins/mesh_library_editor_plugin.h
+++ b/editor/plugins/mesh_library_editor_plugin.h
@@ -37,6 +37,7 @@
 class EditorFileDialog;
 class ConfirmationDialog;
 class MenuButton;
+class MeshInstance3D;
 
 class MeshLibraryEditor : public Control {
 	GDCLASS(MeshLibraryEditor, Control);
@@ -65,6 +66,7 @@ class MeshLibraryEditor : public Control {
 	void _menu_update_confirm(bool p_apply_xforms);
 
 	static void _import_scene(Node *p_scene, Ref<MeshLibrary> p_library, bool p_merge, bool p_apply_xforms);
+	static void _import_scene_parse_node(Ref<MeshLibrary> p_library, HashMap<int, MeshInstance3D *> &p_mesh_instances, Node *p_node, bool p_merge, bool p_apply_xforms);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Makes MeshLibrary export do recursive depth-search for MeshInstance3D nodes.

Fixes https://github.com/godotengine/godot/issues/85085
Fixes https://github.com/godotengine/godot/issues/81850
Likely other issues as it has been a long-standing issue with the MeshLibrary exporter.

Would supersede https://github.com/godotengine/godot/pull/82792 and https://github.com/godotengine/godot/pull/87651 that increases the number of searched child tiers to a hard-coded higher number.

The current MeshLibrary export has the limitation of only searching 2 node child tiers.

In the wild there are often convoluted files (e.g. GLTF import) with far more nested child nodes so those mesh items would not be detected and exported.

This pr now makes the export do a recursive depth-search until a MeshInstance3D is encountered. At this point it stops searching further children of that node and instead proceeds as normal. It will still process all sibling nodes for more items, just stop the search for the children of that specific MeshInstance3D node.

This means users can still add supporting nodes in their export scenes below their mesh instances that are not exported. E.g. the source geometry to bake the navigation mesh that gets exported. This also means very convoluted and exaggerated tree setups like this now can work in the MeshLibrary export:

![meshlib_tree_export](https://github.com/godotengine/godot/assets/52464204/2348bbfb-ead1-4dae-9d57-0606239688ab)

As far as compatibility is concerned I think the only way that things break with this recursive search is if users had a MeshInstance3D in their scenes that was already not exported correctly. If exported now this would obviously change the id numbers of the MeshLibrary. I would assume that any dev worth their salt already fixed their export scenes if they encountered such an export bug with a missing mesh so this is imo only a hypothetical concern and they can easy fix it by moving that suspicious node at the end of the tree so it receives an unused id.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
