### PR TITLE
Fix grammar typo in `platform/web/js/engine/config.js`

### DIFF
--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -19,7 +19,7 @@ const EngineConfig = {}; // eslint-disable-line no-unused-vars
 const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-vars
 	const cfg = /** @lends {InternalConfig.prototype} */ {
 		/**
-		 * Whether the unload the engine automatically after the instance is initialized.
+		 * Whether to unload the engine automatically after the instance is initialized.
 		 *
 		 * @memberof EngineConfig
 		 * @default


### PR DESCRIPTION
There was a grammatical error in the Godot web export. Fixed: platform/web/js/engine/config.js
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
