### PR TITLE
Add `Callable` `call_deferred()` C# example

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -98,10 +98,18 @@
 			<return type="void" />
 			<description>
 				Calls the method represented by this [Callable] in deferred mode, i.e. at the end of the current frame. Arguments can be passed and should match the method's signature.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _ready():
 				    grab_focus.call_deferred()
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _Ready()
+				{
+				    Callable.From(GrabFocus).CallDeferred();
+				}
+				[/csharp]
+				[/codeblocks]
 				See also [method Object.call_deferred].
 			</description>
 		</method>


### PR DESCRIPTION
`Callable.From(...).CallDeferred();` helps keep type safety in C# vs. using `GodotObject`'s `StringName`-based `call_deferred`. Add a C# example to `call_deferred` to avoid people seeing this as a GDScript-only feature.