### PR TITLE
Grab focus of renamed file in file system dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1791,6 +1791,11 @@ void FileSystemDock::_rename_operation_confirm() {
 
 	print_verbose("FileSystem: calling rescan.");
 	_rescan();
+
+	if (ti) {
+		tree->set_selected(ti);
+		tree->grab_focus();
+	}
 }
 
 void FileSystemDock::_duplicate_operation_confirm() {


### PR DESCRIPTION
## Current problem

It is rather frustrating to rename a lot of files, as renaming a file removes focus from a file and one has to manually click the row again to then use the arrow keys to navigate to the next file.

## Solution

After a file is moved or renamed, grab focus of currently selected file so one does not have to use the mouse at all but can simply use arrow keys to rename things. This makes the edit/rename experience super fast!

https://github.com/godotengine/godot/assets/822035/1a6009a5-ebf5-49b5-82c3-247b422a75ba

