### PR TITLE
GDScript: Add `is not` operator

### DIFF
--- a/modules/gdscript/tests/scripts/parser/features/is_not_operator.gd
+++ b/modules/gdscript/tests/scripts/parser/features/is_not_operator.gd
@@ -1,0 +1,11 @@
+func test():
+	var i: Variant = 123
+	var s: Variant = "str"
+	prints(i is int, i is not int)
+	prints(s is int, s is not int)
+
+	var a: Variant = false
+	var b: Variant = true
+	prints(a == b is int, a == b is not int)
+	prints(a == (b is int), a == (b is not int))
+	prints((a == b) is int, (a == b) is not int)

--- a/modules/gdscript/tests/scripts/parser/features/is_not_operator.out
+++ b/modules/gdscript/tests/scripts/parser/features/is_not_operator.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+true false
+false true
+true false
+true false
+false true


### PR DESCRIPTION
* Closes godotengine/godot-proposals#1319.

```gdscript
func test():
    var s: Variant = "str"
    print(await s is not int)
    print(not(await s is int))
    print(await (s is not int))
```

```
Class <unnamed> :
|   Function test(  ) :
|   |   Variable s : Variant
|   |   |   = "str"

|   |   print( (NOTAwait s IS int) )
|   |   print( (NOTAwait s IS int) )
|   |   print( Await (NOTs IS int) )
```

![](https://github.com/godotengine/godot/assets/47700418/ca21c570-4552-465d-95ff-a0ea025364c5)

https://github.com/godotengine/godot/blob/b4e2a24c1f62088b3f7ce0197afc90832fc25009/modules/gdscript/gdscript_parser.h#L1397-L1402
