### PR TITLE
Only recurse depth wise in `Tree::_count_selected_items`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2587,12 +2587,8 @@ int Tree::_count_selected_items(TreeItem *p_from) const {
 		}
 	}
 
-	if (p_from->get_first_child()) {
-		count += _count_selected_items(p_from->get_first_child());
-	}
-
-	if (p_from->get_next()) {
-		count += _count_selected_items(p_from->get_next());
+	for (TreeItem *c = p_from->get_first_child(); c; c = c->get_next()) {
+		count += _count_selected_items(c);
 	}
 
 	return count;


### PR DESCRIPTION
The current implementation for `Tree::_count_selected_items` recurses on both depth and width. This very quickly leads to a stackoverflow. I noticed this in the integrated `FileDialog` which would crash when opening folders with a lot of files.

The new implementation only recurses on depth and iterates on width. Ideally it probably shouldn't recurse at all but I didn't know if std::stack was permitted to use and I guess a `Tree` shouldn't ever be deep enough to lead to a stack overflow here anyways.