### PR TITLE
Disable signal callback generation in C#

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -256,6 +256,7 @@ public:
 	virtual bool can_inherit_from_file() const { return false; }
 	virtual int find_function(const String &p_function, const String &p_code) const = 0;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const = 0;
+	virtual bool can_make_function() const { return true; }
 	virtual Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) { return ERR_UNAVAILABLE; }
 	virtual bool overrides_external_editor() { return false; }
 

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -109,6 +109,7 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_can_inherit_from_file);
 	GDVIRTUAL_BIND(_find_function, "function", "code");
 	GDVIRTUAL_BIND(_make_function, "class_name", "function_name", "function_args");
+	GDVIRTUAL_BIND(_can_make_function);
 	GDVIRTUAL_BIND(_open_in_external_editor, "script", "line", "column");
 	GDVIRTUAL_BIND(_overrides_external_editor);
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -373,6 +373,7 @@ public:
 
 	EXBIND2RC(int, find_function, const String &, const String &)
 	EXBIND3RC(String, make_function, const String &, const String &, const PackedStringArray &)
+	EXBIND0RC(bool, can_make_function)
 	EXBIND3R(Error, open_in_external_editor, const Ref<Script> &, int, int)
 	EXBIND0R(bool, overrides_external_editor)
 

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -34,6 +34,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="_can_make_function" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_complete_code" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="code" type="String" />

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -134,6 +134,7 @@ private:
 	CheckButton *advanced = nullptr;
 	Vector<Control *> bind_controls;
 
+	Label *warning_label = nullptr;
 	Label *error_label = nullptr;
 
 	void ok_pressed() override;
@@ -155,6 +156,7 @@ private:
 	void _remove_bind();
 	void _advanced_pressed();
 	void _update_ok_enabled();
+	void _update_warning_label();
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2726,6 +2726,10 @@ void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const 
 	Ref<Script> scr = p_obj->get_script();
 	ERR_FAIL_COND(!scr.is_valid());
 
+	if (!scr->get_language()->can_make_function()) {
+		return;
+	}
+
 	EditorNode::get_singleton()->push_item(scr.ptr());
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -345,14 +345,19 @@ void ScriptTextEditor::reload_text() {
 }
 
 void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray p_args) {
+	ScriptLanguage *language = script->get_language();
+	if (!language->can_make_function()) {
+		return;
+	}
+
 	String code = code_editor->get_text_editor()->get_text();
-	int pos = script->get_language()->find_function(p_function, code);
+	int pos = language->find_function(p_function, code);
 	code_editor->get_text_editor()->remove_secondary_carets();
 	if (pos == -1) {
 		//does not exist
 		code_editor->get_text_editor()->deselect();
 		pos = code_editor->get_text_editor()->get_line_count() + 2;
-		String func = script->get_language()->make_function("", p_function, p_args);
+		String func = language->make_function("", p_function, p_args);
 		//code=code+func;
 		code_editor->get_text_editor()->set_caret_line(pos + 1);
 		code_editor->get_text_editor()->set_caret_column(1000000); //none shall be that big

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -516,22 +516,11 @@ static String variant_type_to_managed_name(const String &p_var_type_name) {
 }
 
 String CSharpLanguage::make_function(const String &, const String &p_name, const PackedStringArray &p_args) const {
-	// FIXME
-	// - Due to Godot's API limitation this just appends the function to the end of the file
-	// - Use fully qualified name if there is ambiguity
-	String s = "private void " + p_name + "(";
-	for (int i = 0; i < p_args.size(); i++) {
-		const String &arg = p_args[i];
-
-		if (i > 0) {
-			s += ", ";
-		}
-
-		s += variant_type_to_managed_name(arg.get_slice(":", 1)) + " " + escape_csharp_keyword(arg.get_slice(":", 0));
-	}
-	s += ")\n{\n    // Replace with function body.\n}\n";
-
-	return s;
+	// The make_function() API does not work for C# scripts.
+	// It will always append the generated function at the very end of the script. In C#, it will break compilation by
+	// appending code after the final closing bracket (either the class' or the namespace's).
+	// To prevent issues, we have can_make_function() returning false, and make_function() is never implemented.
+	return String();
 }
 #else
 String CSharpLanguage::make_function(const String &, const String &, const PackedStringArray &) const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -439,6 +439,7 @@ public:
 		return -1;
 	}
 	String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
+	virtual bool can_make_function() const override { return false; }
 	virtual String _get_indentation() const;
 	/* TODO? */ void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {}
 	/* TODO */ void add_global_constant(const StringName &p_variable, const Variant &p_value) override {}


### PR DESCRIPTION
A while ago, we talked about disabling the signal callback generation altogether for C# until we have a better implementation. Reasons are, it currently generates the method outside the class (creates compilation error, obviously), and the behaviour is weirdly inconsistent depending on how you have external editors configured.

To prevent confusion like "the dialog didn't do the thing", I added a small message in the connection window, depending on the language of the script. Not sure if this is wanted, let me know (also, the message itself probably kinda sucks, feel free to suggest something better).

![godot windows editor dev x86_64 mono_HnMDcxVcl2](https://github.com/godotengine/godot/assets/437025/16a858b1-50eb-43d1-a957-80e50aadb351)

*Bugsquad edit:*
- Works around / fixes #18721.