### PR TITLE
Add workaround for emscripten >= 3.1.47 LTO build

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -229,6 +229,9 @@ def configure(env: "Environment"):
         # Workaround https://github.com/emscripten-core/emscripten/issues/19781.
         if cc_semver >= (3, 1, 42) and cc_semver < (3, 1, 46):
             env.Append(LINKFLAGS=["-Wl,-u,scalbnf"])
+        # Workaround https://github.com/emscripten-core/emscripten/issues/16836.
+        if cc_semver >= (3, 1, 47):
+            env.Append(LINKFLAGS=["-Wl,-u,_emscripten_run_callback_on_thread"])
 
     if env["dlink_enabled"]:
         if env["proxy_to_pthread"]:


### PR DESCRIPTION
This PR adds a workaround to `platform/web/detect.py` in order to add `-Wl,-u,_emscripten_run_callback_on_thread` as a linker flag if the emscripten version is equal or higher than 3.1.47, when building with LTO enabled. It was suggested as a workaround on emscripten-core/emscripten#16836.

I commented and shared my findings here: https://github.com/emscripten-core/emscripten/issues/16836#issuecomment-1925903719

Fixes #87611
Fixes godotengine/godot-docs#8589