### PR TITLE
Fix `set_item_submenu` infinite recursion crash

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1811,6 +1811,11 @@ void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 		return;
 	}
 
+	String submenu_name_safe = p_submenu.replace("@", "_"); // Allow special characters for auto-generated names.
+	if (submenu_name_safe.validate_node_name() != submenu_name_safe) {
+		ERR_FAIL_MSG(vformat("Invalid node name '%s' for a submenu, the following characters are not allowed:\n%s", p_submenu, String::get_invalid_node_name_characters(true)));
+	}
+
 	if (!global_menu_name.is_empty()) {
 		if (items[p_idx].submenu_bound) {
 			PopupMenu *pm = Object::cast_to<PopupMenu>(get_node_or_null(items[p_idx].submenu));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/84692
Same as https://github.com/godotengine/godot/pull/84183

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
