### PR TITLE
Use meshes instead of colliders for positioning drag to instantiate in 3D

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -209,7 +209,6 @@ private:
 	void _menu_option(int p_option);
 	void _set_auto_orthogonal();
 	Node3D *preview_node = nullptr;
-	bool update_preview_node = false;
 	Point2 preview_node_viewport_pos;
 	Vector3 preview_node_pos;
 	AABB *preview_bounds = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This is a proof of concept because it probably breaks compatibility, and the original solution may be more desirable in some circumstances. 

If anyone is interested in it, feel free to build off it.  

Some ideas: 

Account for the bounds for both target and preview, so it doesn't sink into the target.
Create a mechanism to select positioning based off mesh or collisions.
Use a modifier key to ignore meshes/collisions.
Use this code to snap existing meshes to other existing meshes. 

Currently the engine uses a physics-based ray to get an intersection of colliders to decide where to position the preview node. This comes with downsides such as depending on this physics tick rate, not snapping to meshes without colliders which is arguably the more intuitive behavior, and the code not being really straight forward as it needs to handle physics being ran on separate thread.   

This PR uses the same cull ray that node selections use to detect a target mesh, and then calculates the intersection using the Visual Instance AABB.

https://github.com/godotengine/godot/assets/105675984/249967aa-fcab-4c7e-abc0-c141f18341fa

