### PR TITLE
[Import] Add "skip file" import option to skip (and exclude from export) importable formats, auto set it for the images used by bitmap font.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -439,7 +439,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 		}
 	}
 
-	if (importer_name == "keep") {
+	if (importer_name == "keep" || importer_name == "skip") {
 		return false; //keep mode, do not reimport
 	}
 
@@ -1859,7 +1859,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		source_file_options[p_files[i]] = HashMap<StringName, Variant>();
 		importer_name = file_importer_name;
 
-		if (importer_name == "keep") {
+		if (importer_name == "keep" || importer_name == "skip") {
 			continue; //do nothing
 		}
 
@@ -1885,7 +1885,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		base_paths[p_files[i]] = ResourceFormatImporter::get_singleton()->get_import_base_path(p_files[i]);
 	}
 
-	if (importer_name == "keep") {
+	if (importer_name == "keep" || importer_name == "skip") {
 		return OK; // (do nothing)
 	}
 
@@ -2078,7 +2078,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 	}
 
-	if (importer_name == "keep") {
+	if (importer_name == "keep" || importer_name == "skip") {
 		//keep files, do nothing.
 		fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);
 		fs->files[cpos]->import_modified_time = FileAccess::get_modified_time(p_file + ".import");

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1196,6 +1196,11 @@ Error EditorExportPlatform::export_project_files(bool p_main_pack, const Ref<Edi
 
 				String importer_type = config->get_value("remap", "importer");
 
+				if (importer_type == "skip") {
+					// Skip file.
+					continue;
+				}
+
 				if (importer_type == "keep") {
 					// Just keep file as-is.
 					Vector<uint8_t> array = FileAccess::get_file_as_bytes(path);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1160,7 +1160,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			if (err == OK) {
 				if (config->has_section_key("remap", "importer")) {
 					String importer = config->get_value("remap", "importer");
-					if (importer == "keep") {
+					if (importer == "keep" || importer == "skip") {
 						EditorNode::get_singleton()->show_warning(TTR("Importing has been disabled for this file, so it can't be opened for editing."));
 						return;
 					}

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -48,7 +48,8 @@ public:
 	Ref<ResourceImporter> importer;
 	Vector<String> paths;
 	HashSet<StringName> checked;
-	bool checking;
+	bool checking = false;
+	bool skip = false;
 	String base_options_path;
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
@@ -91,10 +92,6 @@ public:
 	void update() {
 		notify_property_list_changed();
 	}
-
-	ImportDockParameters() {
-		checking = false;
-	}
 };
 
 ImportDock *ImportDock::singleton = nullptr;
@@ -109,8 +106,16 @@ void ImportDock::set_edit_path(const String &p_path) {
 	}
 
 	String importer_name = config->get_value("remap", "importer");
-
-	params->importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
+	if (importer_name == "keep") {
+		params->importer.unref();
+		params->skip = false;
+	} else if (importer_name == "skip") {
+		params->importer.unref();
+		params->skip = true;
+	} else {
+		params->importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
+		params->skip = false;
+	}
 
 	params->paths.clear();
 	params->paths.push_back(p_path);
@@ -152,9 +157,13 @@ void ImportDock::set_edit_path(const String &p_path) {
 
 void ImportDock::_add_keep_import_option(const String &p_importer_name) {
 	import_as->add_separator();
-	import_as->add_item(TTR("Keep File (No Import)"));
+	import_as->add_item(TTR("Keep File (exported as is)"));
 	import_as->set_item_metadata(-1, "keep");
+	import_as->add_item(TTR("Skip File (not exported)"));
+	import_as->set_item_metadata(-1, "skip");
 	if (p_importer_name == "keep") {
+		import_as->select(import_as->get_item_count() - 2);
+	} else if (p_importer_name == "skip") {
 		import_as->select(import_as->get_item_count() - 1);
 	}
 }
@@ -163,7 +172,7 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	// Set the importer class to fetch the correct class in the XML class reference.
 	// This allows tooltips to display when hovering properties.
 	if (params->importer != nullptr) {
-		// Null check to avoid crashing if the "Keep File (No Import)" mode is selected.
+		// Null check to avoid crashing if the "Keep File (exported as is)" mode is selected.
 		import_opts->set_object_class(params->importer->get_class_name());
 	}
 
@@ -215,7 +224,17 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		ERR_CONTINUE(err != OK);
 
 		if (i == 0) {
-			params->importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(config->get_value("remap", "importer"));
+			String importer_name = config->get_value("remap", "importer");
+			if (importer_name == "keep") {
+				params->importer.unref();
+				params->skip = false;
+			} else if (importer_name == "skip") {
+				params->importer.unref();
+				params->skip = true;
+			} else {
+				params->importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
+				params->skip = false;
+			}
 			if (params->importer.is_null()) {
 				clear();
 				return;
@@ -372,12 +391,18 @@ void ImportDock::_importer_selected(int i_idx) {
 	String name = import_as->get_selected_metadata();
 	if (name == "keep") {
 		params->importer.unref();
+		params->skip = false;
+		_update_options(params->base_options_path, Ref<ConfigFile>());
+	} else if (name == "skip") {
+		params->importer.unref();
+		params->skip = true;
 		_update_options(params->base_options_path, Ref<ConfigFile>());
 	} else {
 		Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(name);
 		ERR_FAIL_COND(importer.is_null());
 
 		params->importer = importer;
+		params->skip = false;
 		Ref<ConfigFile> config;
 		if (params->paths.size()) {
 			String path = params->paths[0];
@@ -490,7 +515,11 @@ void ImportDock::_reimport_attempt() {
 	if (params->importer.is_valid()) {
 		importer_name = params->importer->get_importer_name();
 	} else {
-		importer_name = "keep";
+		if (params->skip) {
+			importer_name = "skip";
+		} else {
+			importer_name = "keep";
+		}
 	}
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
@@ -566,6 +595,7 @@ void ImportDock::_advanced_options() {
 		params->importer->show_advanced_options(params->paths[0]);
 	}
 }
+
 void ImportDock::_reimport() {
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
@@ -611,7 +641,11 @@ void ImportDock::_reimport() {
 		} else {
 			//set to no import
 			config->clear();
-			config->set_value("remap", "importer", "keep");
+			if (params->skip) {
+				config->set_value("remap", "importer", "skip");
+			} else {
+				config->set_value("remap", "importer", "keep");
+			}
 		}
 
 		config->save(params->paths[i] + ".import");

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1417,6 +1417,10 @@ static const char32_t _oem_to_unicode[][129] = {
 };
 
 Error FontFile::load_bitmap_font(const String &p_path) {
+	return _load_bitmap_font(p_path, nullptr);
+}
+
+Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_files) {
 	reset_state();
 
 	antialiasing = TextServer::FONT_ANTIALIASING_NONE;
@@ -1558,6 +1562,9 @@ Error FontFile::load_bitmap_font(const String &p_path) {
 								img.instantiate();
 								Error err = ImageLoader::load_image(file, img);
 								ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_READ, vformat("Can't load font texture: %s.", file));
+								if (r_image_files) {
+									r_image_files->push_back(file);
+								}
 
 								if (packed) {
 									if (ch[3] == 0) { // 4 x 8 bit monochrome, no outline
@@ -1849,6 +1856,10 @@ Error FontFile::load_bitmap_font(const String &p_path) {
 						img.instantiate();
 						Error err = ImageLoader::load_image(file, img);
 						ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_READ, vformat("Can't load font texture: %s.", file));
+						if (r_image_files) {
+							r_image_files->push_back(file);
+						}
+
 						if (packed) {
 							if (ch[3] == 0) { // 4 x 8 bit monochrome, no outline
 								outline = 0;

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -227,6 +227,8 @@ protected:
 	virtual void reset_state() override;
 
 public:
+	Error _load_bitmap_font(const String &p_path, List<String> *r_image_files);
+
 	Error load_bitmap_font(const String &p_path);
 	Error load_dynamic_font(const String &p_path);
 


### PR DESCRIPTION
As mentioned in https://github.com/godotengine/godot/pull/87971 and https://github.com/godotengine/godot/issues/82254, bitmap fonts use external images, but can't use these images as external resources since in many cases image preprocessing is required.

This PR:
- Adds "skip file" import option to skip (and exclude from export) importable formats (e.g, images).
- Automatically set "skip file" import mode for the images used by bitmap font, to prevent exporting these images twice (as source Image/Texture2D end embedded processed image in the `fontdata`).
