### PR TITLE
Fix crash with `PhysicsBody2D/3D::get_gravity` with invalid state

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -147,7 +147,9 @@ bool PhysicsBody2D::test_move(const Transform2D &p_from, const Vector2 &p_motion
 }
 
 Vector2 PhysicsBody2D::get_gravity() const {
-	return PhysicsServer2D::get_singleton()->body_get_direct_state(get_rid())->get_total_gravity();
+	PhysicsDirectBodyState2D *state = PhysicsServer2D::get_singleton()->body_get_direct_state(get_rid());
+	ERR_FAIL_NULL_V(state, Vector2());
+	return state->get_total_gravity();
 }
 
 TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -189,7 +189,9 @@ bool PhysicsBody3D::test_move(const Transform3D &p_from, const Vector3 &p_motion
 }
 
 Vector3 PhysicsBody3D::get_gravity() const {
-	return PhysicsServer3D::get_singleton()->body_get_direct_state(get_rid())->get_total_gravity();
+	PhysicsDirectBodyState3D *state = PhysicsServer3D::get_singleton()->body_get_direct_state(get_rid());
+	ERR_FAIL_NULL_V(state, Vector3());
+	return state->get_total_gravity();
 }
 
 void PhysicsBody3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock) {


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/87975
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
