### PR TITLE
Replace `mergeInto(LibraryManager.library...` for `addToLibrary(...`

### DIFF
--- a/modules/webrtc/library_godot_webrtc.js
+++ b/modules/webrtc/library_godot_webrtc.js
@@ -227,7 +227,7 @@ const GodotRTCDataChannel = {
 };
 
 autoAddDeps(GodotRTCDataChannel, '$GodotRTCDataChannel');
-mergeInto(LibraryManager.library, GodotRTCDataChannel);
+addToLibrary(GodotRTCDataChannel);
 
 const GodotRTCPeerConnection = {
 	$GodotRTCPeerConnection__deps: ['$IDHandler', '$GodotRuntime', '$GodotRTCDataChannel'],
@@ -499,4 +499,4 @@ const GodotRTCPeerConnection = {
 };
 
 autoAddDeps(GodotRTCPeerConnection, '$GodotRTCPeerConnection');
-mergeInto(LibraryManager.library, GodotRTCPeerConnection);
+addToLibrary(GodotRTCPeerConnection);

--- a/modules/websocket/library_godot_websocket.js
+++ b/modules/websocket/library_godot_websocket.js
@@ -204,4 +204,4 @@ const GodotWebSocket = {
 };
 
 autoAddDeps(GodotWebSocket, '$GodotWebSocket');
-mergeInto(LibraryManager.library, GodotWebSocket);
+addToLibrary(GodotWebSocket);

--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -647,4 +647,4 @@ const GodotWebXR = {
 };
 
 autoAddDeps(GodotWebXR, '$GodotWebXR');
-mergeInto(LibraryManager.library, GodotWebXR);
+addToLibrary(GodotWebXR);

--- a/platform/web/.eslintrc.libs.js
+++ b/platform/web/.eslintrc.libs.js
@@ -5,6 +5,7 @@ module.exports = {
 	"globals": {
 		"LibraryManager": true,
 		"mergeInto": true,
+		"addToLibrary": true,
 		"autoAddDeps": true,
 		"HEAP8": true,
 		"HEAPU8": true,

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -213,7 +213,7 @@ const GodotAudio = {
 };
 
 autoAddDeps(GodotAudio, '$GodotAudio');
-mergeInto(LibraryManager.library, GodotAudio);
+addToLibrary(GodotAudio);
 
 /**
  * The AudioWorklet API driver, used when threads are available.
@@ -409,7 +409,7 @@ const GodotAudioWorklet = {
 };
 
 autoAddDeps(GodotAudioWorklet, '$GodotAudioWorklet');
-mergeInto(LibraryManager.library, GodotAudioWorklet);
+addToLibrary(GodotAudioWorklet);
 
 /*
  * The deprecated ScriptProcessorNode API, used when threads are disabled.
@@ -495,4 +495,4 @@ const GodotAudioScript = {
 };
 
 autoAddDeps(GodotAudioScript, '$GodotAudioScript');
-mergeInto(LibraryManager.library, GodotAudioScript);
+addToLibrary(GodotAudioScript);

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -164,7 +164,7 @@ const GodotDisplayVK = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotDisplayVK);
+addToLibrary(GodotDisplayVK);
 
 /*
  * Display server cursor helper.
@@ -216,7 +216,7 @@ const GodotDisplayCursor = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotDisplayCursor);
+addToLibrary(GodotDisplayCursor);
 
 const GodotDisplayScreen = {
 	$GodotDisplayScreen__deps: ['$GodotConfig', '$GodotOS', '$GL', 'emscripten_webgl_get_current_context'],
@@ -325,7 +325,7 @@ const GodotDisplayScreen = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotDisplayScreen);
+addToLibrary(GodotDisplayScreen);
 
 /**
  * Display server interface.
@@ -798,4 +798,4 @@ const GodotDisplay = {
 };
 
 autoAddDeps(GodotDisplay, '$GodotDisplay');
-mergeInto(LibraryManager.library, GodotDisplay);
+addToLibrary(GodotDisplay);

--- a/platform/web/js/libs/library_godot_fetch.js
+++ b/platform/web/js/libs/library_godot_fetch.js
@@ -241,4 +241,4 @@ const GodotFetch = {
 };
 
 autoAddDeps(GodotFetch, '$GodotFetch');
-mergeInto(LibraryManager.library, GodotFetch);
+addToLibrary(GodotFetch);

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -130,7 +130,7 @@ const GodotIME = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotIME);
+addToLibrary(GodotIME);
 
 /*
  * Gamepad API helper.
@@ -261,7 +261,7 @@ const GodotInputGamepads = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotInputGamepads);
+addToLibrary(GodotInputGamepads);
 
 /*
  * Drag and drop helper.
@@ -436,7 +436,7 @@ const GodotInputDragDrop = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotInputDragDrop);
+addToLibrary(GodotInputDragDrop);
 
 /*
  * Godot exposed input functions.
@@ -691,4 +691,4 @@ const GodotInput = {
 };
 
 autoAddDeps(GodotInput, '$GodotInput');
-mergeInto(LibraryManager.library, GodotInput);
+addToLibrary(GodotInput);

--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -298,7 +298,7 @@ const GodotJSWrapper = {
 };
 
 autoAddDeps(GodotJSWrapper, '$GodotJSWrapper');
-mergeInto(LibraryManager.library, GodotJSWrapper);
+addToLibrary(GodotJSWrapper);
 
 const GodotEval = {
 	godot_js_eval__deps: ['$GodotRuntime'],
@@ -355,4 +355,4 @@ const GodotEval = {
 	},
 };
 
-mergeInto(LibraryManager.library, GodotEval);
+addToLibrary(GodotEval);

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -50,7 +50,7 @@ const IDHandler = {
 };
 
 autoAddDeps(IDHandler, '$IDHandler');
-mergeInto(LibraryManager.library, IDHandler);
+addToLibrary(IDHandler);
 
 const GodotConfig = {
 	$GodotConfig__postset: 'Module["initConfig"] = GodotConfig.init_config;',
@@ -105,7 +105,7 @@ const GodotConfig = {
 };
 
 autoAddDeps(GodotConfig, '$GodotConfig');
-mergeInto(LibraryManager.library, GodotConfig);
+addToLibrary(GodotConfig);
 
 const GodotFS = {
 	$GodotFS__deps: ['$FS', '$IDBFS', '$GodotRuntime'],
@@ -223,7 +223,7 @@ const GodotFS = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotFS);
+addToLibrary(GodotFS);
 
 const GodotOS = {
 	$GodotOS__deps: ['$GodotRuntime', '$GodotConfig', '$GodotFS'],
@@ -366,7 +366,7 @@ const GodotOS = {
 };
 
 autoAddDeps(GodotOS, '$GodotOS');
-mergeInto(LibraryManager.library, GodotOS);
+addToLibrary(GodotOS);
 
 /*
  * Godot event listeners.
@@ -406,7 +406,7 @@ const GodotEventListeners = {
 		},
 	},
 };
-mergeInto(LibraryManager.library, GodotEventListeners);
+addToLibrary(GodotEventListeners);
 
 const GodotPWA = {
 
@@ -463,4 +463,4 @@ const GodotPWA = {
 };
 
 autoAddDeps(GodotPWA, '$GodotPWA');
-mergeInto(LibraryManager.library, GodotPWA);
+addToLibrary(GodotPWA);

--- a/platform/web/js/libs/library_godot_runtime.js
+++ b/platform/web/js/libs/library_godot_runtime.js
@@ -131,4 +131,4 @@ const GodotRuntime = {
 	},
 };
 autoAddDeps(GodotRuntime, '$GodotRuntime');
-mergeInto(LibraryManager.library, GodotRuntime);
+addToLibrary(GodotRuntime);

--- a/platform/web/js/libs/library_godot_webgl2.js
+++ b/platform/web/js/libs/library_godot_webgl2.js
@@ -81,4 +81,4 @@ const GodotWebGL2 = {
 };
 
 autoAddDeps(GodotWebGL2, '$GodotWebGL2');
-mergeInto(LibraryManager.library, GodotWebGL2);
+addToLibrary(GodotWebGL2);


### PR DESCRIPTION
[Since emscripten 3.1.45](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3145---082323), it is possible to use `addToLibrary` instead of `mergeInto` and having to pass `LibraryManager.library` as the first parameter.

> The function used to add symbols the JS library has been renamed from `mergeInto`, to the more specific `addToLibrary`.  This new function does not require the passing of `LibraryManager.library` as a first argument.  The old `mergeInto` continues to exist for backwards compat.

## Note to the merge team
As Godot currently builds with 3.1.39, this PR is to be merged **only when emscripten will be >= 3.1.45**.