### PR TITLE
Enable ALT + RMB to list select only on the select tool matching 2D and tooltips

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1659,7 +1659,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					_edit.gizmo = Ref<EditorNode3DGizmo>();
 				}
 
-				if (_edit.mode == TRANSFORM_NONE && b->is_pressed()) {
+				if (b->is_pressed() && spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT) {
 					if (b->is_alt_pressed()) {
 						if (nav_scheme == NAVIGATION_MAYA) {
 							break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: #87924