### PR TITLE
Fix emscripten 3.1.51 breaking change about `*glGetProcAddress()`

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -206,6 +206,11 @@ def configure(env: "Environment"):
         env.Append(LINKFLAGS=["-s", "USE_WEBGL2=1"])
         # Allow use to take control of swapping WebGL buffers.
         env.Append(LINKFLAGS=["-s", "OFFSCREEN_FRAMEBUFFER=1"])
+        # Breaking change since emscripten 3.1.51
+        # https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3151---121323
+        if cc_semver >= (3, 1, 51):
+            # Enables the use of *glGetProcAddress()
+            env.Append(LINKFLAGS=["-s", "GL_ENABLE_GET_PROC_ADDRESS=1"])
 
     if env["javascript_eval"]:
         env.Append(CPPDEFINES=["JAVASCRIPT_EVAL_ENABLED"])


### PR DESCRIPTION
[Since emscripten 3.1.51](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3151---121323), a link flag is now required in order to use `*glGetProcAddress()` family of functions.

This PR fixes that breaking change.

We use `*glGetProcAddress()` (relating to the web platform) in:
- `drivers/gles3/rasterizer_gles3.cpp`
- `drivers/gles3/storage/config.cpp`

A check is done to apply the link flag `-s GL_ENABLE_GET_PROC_ADDRESS` only if it detects emscripten ≥ 3.1.51.