### PR TITLE
Document `OS.execute()` limitations on Android

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -125,6 +125,7 @@
 				[b]Note:[/b] To execute a PowerShell built-in command, specify [code]powershell.exe[/code] in [param path], [code]-Command[/code] as the first argument, and the desired command as the second argument.
 				[b]Note:[/b] To execute a Unix shell built-in command, specify shell executable name in [param path], [code]-c[/code] as the first argument, and the desired command as the second argument.
 				[b]Note:[/b] On macOS, sandboxed applications are limited to run only embedded helper executables, specified during export.
+				[b]Note:[/b] On Android, system commands such as [code]dumpsys[/code] can only be run on a rooted device.
 			</description>
 		</method>
 		<method name="find_keycode_from_string" qualifiers="const">
@@ -204,7 +205,7 @@
 				Returns the command-line user arguments passed to the engine. User arguments are ignored by the engine and reserved for the user. They are passed after the double dash [code]--[/code] argument. [code]++[/code] may be used when [code]--[/code] is intercepted by another program (such as [code]startx[/code]).
 				[codeblock]
 				# Godot has been executed with the following command:
-				# godot --fullscreen -- --level=2 --hardcore 
+				# godot --fullscreen -- --level=2 --hardcore
 
 				OS.get_cmdline_args()      # Returns ["--fullscreen", "--level=2", "--hardcore"]
 				OS.get_cmdline_user_args() # Returns ["--level=2", "--hardcore"]


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/77639.
