### PR TITLE
Refactor and fix issues in Editor Dock Manager

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -49,8 +49,6 @@
 
 EditorDockManager *EditorDockManager::singleton = nullptr;
 
-static const char *META_TOGGLE_SHORTCUT = "_toggle_shortcut";
-
 void DockSplitContainer::_update_visibility() {
 	if (is_updating) {
 		return;
@@ -106,308 +104,77 @@ void DockSplitContainer::remove_child_notify(Node *p_child) {
 	_update_visibility();
 }
 
-void EditorDockManager::_dock_select_popup_theme_changed() {
-	if (dock_float) {
-		dock_float->set_icon(dock_select_popup->get_editor_theme_icon(SNAME("MakeFloating")));
-	}
-	if (dock_select_popup->is_layout_rtl()) {
-		dock_tab_move_left->set_icon(dock_select_popup->get_editor_theme_icon(SNAME("Forward")));
-		dock_tab_move_right->set_icon(dock_select_popup->get_editor_theme_icon(SNAME("Back")));
-	} else {
-		dock_tab_move_left->set_icon(dock_select_popup->get_editor_theme_icon(SNAME("Back")));
-		dock_tab_move_right->set_icon(dock_select_popup->get_editor_theme_icon(SNAME("Forward")));
-	}
-
-	dock_to_bottom->set_icon(dock_select_popup->get_editor_theme_icon(SNAME("ControlAlignBottomWide")));
-}
-
-void EditorDockManager::_dock_popup_exit() {
-	dock_select_rect_over_idx = -1;
-	dock_select->queue_redraw();
-}
-
-void EditorDockManager::_dock_pre_popup(int p_dock_slot) {
-	dock_popup_selected_idx = p_dock_slot;
-	dock_bottom_selected_idx = -1;
-
-	if (bool(dock_slot[p_dock_slot]->get_current_tab_control()->call("_can_dock_horizontal"))) {
-		dock_to_bottom->show();
-	} else {
-		dock_to_bottom->hide();
-	}
-
-	if (dock_float) {
-		dock_float->show();
-	}
-	dock_tab_move_right->show();
-	dock_tab_move_left->show();
-}
-
-void EditorDockManager::_dock_move_left() {
-	if (dock_popup_selected_idx < 0 || dock_popup_selected_idx >= DOCK_SLOT_MAX) {
-		return;
-	}
-	Control *current_ctl = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab());
-	Control *prev_ctl = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab() - 1);
-	if (!current_ctl || !prev_ctl) {
-		return;
-	}
-	dock_slot[dock_popup_selected_idx]->move_child(current_ctl, prev_ctl->get_index(false));
-	dock_select->queue_redraw();
-	_edit_current();
-	emit_signal(SNAME("layout_changed"));
-}
-
-void EditorDockManager::_dock_move_right() {
-	if (dock_popup_selected_idx < 0 || dock_popup_selected_idx >= DOCK_SLOT_MAX) {
-		return;
-	}
-	Control *current_ctl = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab());
-	Control *next_ctl = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab() + 1);
-	if (!current_ctl || !next_ctl) {
-		return;
-	}
-	dock_slot[dock_popup_selected_idx]->move_child(next_ctl, current_ctl->get_index(false));
-	dock_select->queue_redraw();
-	_edit_current();
-	emit_signal(SNAME("layout_changed"));
-}
-
-void EditorDockManager::_dock_select_input(const Ref<InputEvent> &p_input) {
-	Ref<InputEventMouse> me = p_input;
-
-	if (me.is_valid()) {
-		Vector2 point = me->get_position();
-
-		int nrect = -1;
-		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-			if (dock_select_rect[i].has_point(point)) {
-				nrect = i;
-				break;
-			}
-		}
-
-		if (nrect != dock_select_rect_over_idx) {
-			dock_select->queue_redraw();
-			dock_select_rect_over_idx = nrect;
-		}
-
-		if (nrect == -1) {
-			return;
-		}
-
-		Ref<InputEventMouseButton> mb = me;
-
-		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-			if (dock_bottom_selected_idx != -1) {
-				EditorNode::get_bottom_panel()->remove_item(bottom_docks[dock_bottom_selected_idx]);
-
-				bottom_docks[dock_bottom_selected_idx]->call("_set_dock_horizontal", false);
-
-				dock_slot[nrect]->add_child(bottom_docks[dock_bottom_selected_idx]);
-				dock_slot[nrect]->show();
-				bottom_docks.remove_at(dock_bottom_selected_idx);
-				dock_bottom_selected_idx = -1;
-				dock_popup_selected_idx = nrect; // Move to dock popup selected.
-				dock_select->queue_redraw();
-
-				update_dock_slots_visibility(true);
-
-				_edit_current();
-				emit_signal(SNAME("layout_changed"));
-			}
-
-			if (dock_popup_selected_idx != nrect) {
-				dock_slot[nrect]->move_tab_from_tab_container(dock_slot[dock_popup_selected_idx], dock_slot[dock_popup_selected_idx]->get_current_tab(), dock_slot[nrect]->get_tab_count());
-
-				if (dock_slot[dock_popup_selected_idx]->get_tab_count() == 0) {
-					dock_slot[dock_popup_selected_idx]->hide();
-				} else {
-					dock_slot[dock_popup_selected_idx]->set_current_tab(0);
-				}
-
-				dock_popup_selected_idx = nrect;
-				dock_slot[nrect]->show();
-				dock_select->queue_redraw();
-
-				update_dock_slots_visibility(true);
-
-				_edit_current();
-				emit_signal(SNAME("layout_changed"));
-			}
-		}
-	}
-}
-
-void EditorDockManager::_dock_select_draw() {
-	Size2 s = dock_select->get_size();
-	s.y /= 2.0;
-	s.x /= 6.0;
-
-	Color used = Color(0.6, 0.6, 0.6, 0.8);
-	Color used_selected = Color(0.8, 0.8, 0.8, 0.8);
-	Color tab_selected = dock_select->get_theme_color(SNAME("mono_color"), EditorStringName(Editor));
-	Color unused = used;
-	unused.a = 0.4;
-	Color unusable = unused;
-	unusable.a = 0.1;
-
-	Rect2 unr(s.x * 2, 0, s.x * 2, s.y * 2);
-	unr.position += Vector2(2, 5);
-	unr.size -= Vector2(4, 7);
-
-	dock_select->draw_rect(unr, unusable);
-
-	dock_tab_move_left->set_disabled(true);
-	dock_tab_move_right->set_disabled(true);
-
-	if (dock_popup_selected_idx != -1 && dock_slot[dock_popup_selected_idx]->get_tab_count()) {
-		dock_tab_move_left->set_disabled(dock_slot[dock_popup_selected_idx]->get_current_tab() == 0);
-		dock_tab_move_right->set_disabled(dock_slot[dock_popup_selected_idx]->get_current_tab() >= dock_slot[dock_popup_selected_idx]->get_tab_count() - 1);
-	}
-
-	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-		Vector2 ofs;
-
-		switch (i) {
-			case DOCK_SLOT_LEFT_UL: {
-			} break;
-			case DOCK_SLOT_LEFT_BL: {
-				ofs.y += s.y;
-			} break;
-			case DOCK_SLOT_LEFT_UR: {
-				ofs.x += s.x;
-			} break;
-			case DOCK_SLOT_LEFT_BR: {
-				ofs += s;
-			} break;
-			case DOCK_SLOT_RIGHT_UL: {
-				ofs.x += s.x * 4;
-			} break;
-			case DOCK_SLOT_RIGHT_BL: {
-				ofs.x += s.x * 4;
-				ofs.y += s.y;
-
-			} break;
-			case DOCK_SLOT_RIGHT_UR: {
-				ofs.x += s.x * 4;
-				ofs.x += s.x;
-
-			} break;
-			case DOCK_SLOT_RIGHT_BR: {
-				ofs.x += s.x * 4;
-				ofs += s;
-
-			} break;
-		}
-
-		Rect2 r(ofs, s);
-		dock_select_rect[i] = r;
-		r.position += Vector2(2, 5);
-		r.size -= Vector2(4, 7);
-
-		if (i == dock_select_rect_over_idx) {
-			dock_select->draw_rect(r, used_selected);
-		} else if (dock_slot[i]->get_tab_count() == 0) {
-			dock_select->draw_rect(r, unused);
-		} else {
-			dock_select->draw_rect(r, used);
-		}
-
-		for (int j = 0; j < MIN(3, dock_slot[i]->get_tab_count()); j++) {
-			int xofs = (r.size.width / 3) * j;
-			Color c = used;
-			if (i == dock_popup_selected_idx && (dock_slot[i]->get_current_tab() > 3 || dock_slot[i]->get_current_tab() == j)) {
-				c = tab_selected;
-			}
-			dock_select->draw_rect(Rect2(2 + ofs.x + xofs, ofs.y, r.size.width / 3 - 1, 3), c);
-		}
-	}
-}
-
 void EditorDockManager::_dock_split_dragged(int p_offset) {
 	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
 
-void EditorDockManager::_dock_tab_changed(int p_tab) {
-	// Update visibility but don't set current tab.
-	update_dock_slots_visibility(true);
+void EditorDockManager::_dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container) {
+	Ref<InputEventMouseButton> mb = p_input;
+
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
+		int tab_id = p_dock_container->get_tab_bar()->get_hovered_tab();
+		if (tab_id < 0) {
+			return;
+		}
+
+		// Right click context menu.
+		dock_context_popup->set_dock(p_dock_container->get_tab_control(tab_id));
+		dock_context_popup->set_position(p_dock_container->get_screen_position() + mb->get_position());
+		dock_context_popup->popup();
+	}
 }
 
-void EditorDockManager::_edit_current() {
+void EditorDockManager::_bottom_dock_button_gui_input(const Ref<InputEvent> &p_input, Control *p_dock, Button *p_bottom_button) {
+	Ref<InputEventMouseButton> mb = p_input;
+
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
+		// Right click context menu.
+		dock_context_popup->set_dock(p_dock);
+		dock_context_popup->set_position(p_bottom_button->get_screen_position() + mb->get_position());
+		dock_context_popup->popup();
+	}
+}
+
+void EditorDockManager::_dock_container_update_visibility(TabContainer *p_dock_container) {
+	if (!docks_visible) {
+		return;
+	}
+	// Hide the dock container if there are no tabs.
+	p_dock_container->set_visible(p_dock_container->get_tab_count() > 0);
+}
+
+void EditorDockManager::_update_layout() {
+	if (!dock_context_popup->is_inside_tree() || EditorNode::get_singleton()->is_exiting()) {
+		return;
+	}
 	EditorNode::get_singleton()->edit_current();
+	dock_context_popup->docks_updated();
+	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
 
-void EditorDockManager::_dock_floating_close_request(WindowWrapper *p_wrapper) {
-	int dock_slot_num = p_wrapper->get_meta("dock_slot");
-	int dock_slot_index = p_wrapper->get_meta("dock_index");
+void EditorDockManager::_window_close_request(WindowWrapper *p_wrapper) {
+	// Give the dock back to the original owner.
+	Control *dock = _close_window(p_wrapper);
+	ERR_FAIL_COND(!all_docks.has(dock));
 
-	// Give back the dock to the original owner.
+	all_docks[dock].open = false;
+	open_dock(dock);
+	focus_dock(dock);
+}
+
+Control *EditorDockManager::_close_window(WindowWrapper *p_wrapper) {
+	p_wrapper->set_block_signals(true);
 	Control *dock = p_wrapper->release_wrapped_control();
+	p_wrapper->set_block_signals(false);
+	ERR_FAIL_COND_V(!all_docks.has(dock), nullptr);
 
-	int target_index = MIN(dock_slot_index, dock_slot[dock_slot_num]->get_tab_count());
-	dock_slot[dock_slot_num]->add_child(dock);
-	dock_slot[dock_slot_num]->move_child(dock, target_index);
-	dock_slot[dock_slot_num]->set_current_tab(target_index);
-
-	floating_docks.erase(p_wrapper);
+	all_docks[dock].dock_window = nullptr;
+	dock_windows.erase(p_wrapper);
 	p_wrapper->queue_free();
-
-	update_dock_slots_visibility(true);
-
-	_edit_current();
+	return dock;
 }
 
-void EditorDockManager::_dock_make_selected_float() {
-	Control *dock = dock_slot[dock_popup_selected_idx]->get_current_tab_control();
-	_dock_make_float(dock, dock_popup_selected_idx);
-
-	dock_select_popup->hide();
-	_edit_current();
-}
-
-void EditorDockManager::bottom_dock_show_placement_popup(const Rect2i &p_position, Control *p_dock) {
-	dock_bottom_selected_idx = bottom_docks.find(p_dock);
-	ERR_FAIL_COND(dock_bottom_selected_idx == -1);
-	dock_popup_selected_idx = -1;
-	dock_to_bottom->hide();
-
-	Vector2 popup_pos = p_position.position;
-	popup_pos.y += p_position.size.height;
-
-	if (!EditorNode::get_singleton()->get_gui_base()->is_layout_rtl()) {
-		popup_pos.x -= dock_select_popup->get_size().width;
-		popup_pos.x += p_position.size.width;
-	}
-	dock_select_popup->set_position(popup_pos);
-	dock_select_popup->popup();
-	if (dock_float) {
-		dock_float->hide();
-	}
-	dock_tab_move_right->hide();
-	dock_tab_move_left->hide();
-}
-
-void EditorDockManager::_dock_move_selected_to_bottom() {
-	Control *dock = dock_slot[dock_popup_selected_idx]->get_current_tab_control();
-	dock_slot[dock_popup_selected_idx]->remove_child(dock);
-
-	dock->call("_set_dock_horizontal", true);
-
-	bottom_docks.push_back(dock);
-
-	// Force docks moved to the bottom to appear first in the list, and give them their associated shortcut to toggle their bottom panel.
-	EditorNode::get_bottom_panel()->add_item(dock->get_name(), dock, dock->get_meta(META_TOGGLE_SHORTCUT), true);
-
-	dock_select_popup->hide();
-	update_dock_slots_visibility(true);
-	_edit_current();
-	emit_signal(SNAME("layout_changed"));
-
-	EditorNode::get_bottom_panel()->make_item_visible(dock);
-}
-
-void EditorDockManager::_dock_make_float(Control *p_dock, int p_slot_index, bool p_show_window) {
+void EditorDockManager::_open_dock_in_window(Control *p_dock, bool p_show_window) {
 	ERR_FAIL_NULL(p_dock);
 
 	Size2 borders = Size2(4, 4) * EDSCALE;
@@ -415,50 +182,137 @@ void EditorDockManager::_dock_make_float(Control *p_dock, int p_slot_index, bool
 	Size2 dock_size = p_dock->get_size() + borders * 2;
 	Point2 dock_screen_pos = p_dock->get_screen_position();
 
-	int dock_index = p_dock->get_index() - 1;
-	dock_slot[p_slot_index]->remove_child(p_dock);
-
 	WindowWrapper *wrapper = memnew(WindowWrapper);
-	wrapper->set_window_title(vformat(TTR("%s - Godot Engine"), p_dock->get_name()));
+	wrapper->set_window_title(vformat(TTR("%s - Godot Engine"), all_docks[p_dock].title));
 	wrapper->set_margins_enabled(true);
 
 	EditorNode::get_singleton()->get_gui_base()->add_child(wrapper);
 
+	_move_dock(p_dock, nullptr);
 	wrapper->set_wrapped_control(p_dock);
-	wrapper->set_meta("dock_slot", p_slot_index);
-	wrapper->set_meta("dock_index", dock_index);
-	wrapper->set_meta("dock_name", p_dock->get_name().operator String());
+
+	all_docks[p_dock].dock_window = wrapper;
+	all_docks[p_dock].open = true;
 	p_dock->show();
 
-	wrapper->connect("window_close_requested", callable_mp(this, &EditorDockManager::_dock_floating_close_request).bind(wrapper));
-
-	dock_select_popup->hide();
+	wrapper->connect("window_close_requested", callable_mp(this, &EditorDockManager::_window_close_request).bind(wrapper));
+	dock_windows.push_back(wrapper);
 
 	if (p_show_window) {
 		wrapper->restore_window(Rect2i(dock_screen_pos, dock_size), EditorNode::get_singleton()->get_gui_base()->get_window()->get_current_screen());
+		_update_layout();
+		p_dock->get_window()->grab_focus();
 	}
-
-	update_dock_slots_visibility(true);
-
-	floating_docks.push_back(wrapper);
-
-	_edit_current();
 }
 
-void EditorDockManager::_restore_floating_dock(const Dictionary &p_dock_dump, Control *p_dock, int p_slot_index) {
-	WindowWrapper *wrapper = Object::cast_to<WindowWrapper>(p_dock);
-	if (!wrapper) {
-		_dock_make_float(p_dock, p_slot_index, false);
-		wrapper = floating_docks[floating_docks.size() - 1];
+void EditorDockManager::_restore_dock_to_saved_window(Control *p_dock, const Dictionary &p_window_dump) {
+	if (!all_docks[p_dock].dock_window) {
+		_open_dock_in_window(p_dock, false);
 	}
 
-	wrapper->restore_window_from_saved_position(
-			p_dock_dump.get("window_rect", Rect2i()),
-			p_dock_dump.get("window_screen", -1),
-			p_dock_dump.get("window_screen_rect", Rect2i()));
+	all_docks[p_dock].dock_window->restore_window_from_saved_position(
+			p_window_dump.get("window_rect", Rect2i()),
+			p_window_dump.get("window_screen", -1),
+			p_window_dump.get("window_screen_rect", Rect2i()));
+}
+
+void EditorDockManager::_dock_move_to_bottom(Control *p_dock) {
+	_move_dock(p_dock, nullptr);
+
+	all_docks[p_dock].at_bottom = true;
+	all_docks[p_dock].previous_at_bottom = false;
+
+	p_dock->call("_set_dock_horizontal", true);
+
+	// Force docks moved to the bottom to appear first in the list, and give them their associated shortcut to toggle their bottom panel.
+	Button *bottom_button = EditorNode::get_bottom_panel()->add_item(all_docks[p_dock].title, p_dock, all_docks[p_dock].shortcut, true);
+	bottom_button->connect("gui_input", callable_mp(this, &EditorDockManager::_bottom_dock_button_gui_input).bind(bottom_button).bind(p_dock));
+	EditorNode::get_bottom_panel()->make_item_visible(p_dock);
+}
+
+void EditorDockManager::_dock_remove_from_bottom(Control *p_dock) {
+	all_docks[p_dock].at_bottom = false;
+	all_docks[p_dock].previous_at_bottom = true;
+
+	EditorNode::get_bottom_panel()->remove_item(p_dock);
+	p_dock->call("_set_dock_horizontal", false);
+}
+
+bool EditorDockManager::_is_dock_at_bottom(Control *p_dock) {
+	ERR_FAIL_COND_V(!all_docks.has(p_dock), false);
+	return all_docks[p_dock].at_bottom;
+}
+
+void EditorDockManager::_move_dock_tab_index(Control *p_dock, int p_tab_index, bool p_set_current) {
+	TabContainer *dock_tab_container = Object::cast_to<TabContainer>(p_dock->get_parent());
+	if (!dock_tab_container) {
+		return;
+	}
+
+	dock_tab_container->set_block_signals(true);
+	int target_index = CLAMP(p_tab_index, 0, dock_tab_container->get_tab_count() - 1);
+	dock_tab_container->move_child(p_dock, dock_tab_container->get_tab_control(target_index)->get_index(false));
+	all_docks[p_dock].previous_tab_index = target_index;
+
+	if (p_set_current) {
+		dock_tab_container->set_current_tab(target_index);
+	}
+	dock_tab_container->set_block_signals(false);
+}
+
+void EditorDockManager::_move_dock(Control *p_dock, Control *p_target, int p_tab_index, bool p_set_current) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot move unknown dock '%s'.", p_dock->get_name()));
+
+	Node *parent = p_dock->get_parent();
+	if (parent == p_target) {
+		if (p_tab_index >= 0 && parent) {
+			// Only change the tab index.
+			_move_dock_tab_index(p_dock, p_tab_index, p_set_current);
+		}
+		return;
+	}
+
+	// Remove dock from its existing parent.
+	if (parent) {
+		if (all_docks[p_dock].dock_window) {
+			_close_window(all_docks[p_dock].dock_window);
+		} else if (all_docks[p_dock].at_bottom) {
+			_dock_remove_from_bottom(p_dock);
+		} else {
+			all_docks[p_dock].previous_at_bottom = false;
+			TabContainer *parent_tabs = Object::cast_to<TabContainer>(parent);
+			if (parent_tabs) {
+				all_docks[p_dock].previous_tab_index = parent_tabs->get_tab_idx_from_control(p_dock);
+			}
+			parent->set_block_signals(true);
+			parent->remove_child(p_dock);
+			parent->set_block_signals(false);
+			if (parent_tabs) {
+				_dock_container_update_visibility(parent_tabs);
+			}
+		}
+	}
+
+	// Add dock to its new parent, at the given tab index.
+	if (!p_target) {
+		return;
+	}
+	p_target->set_block_signals(true);
+	p_target->add_child(p_dock);
+	p_target->set_block_signals(false);
+	TabContainer *dock_tab_container = Object::cast_to<TabContainer>(p_target);
+	if (dock_tab_container) {
+		dock_tab_container->set_tab_title(dock_tab_container->get_tab_idx_from_control(p_dock), all_docks[p_dock].title);
+		if (p_tab_index >= 0) {
+			_move_dock_tab_index(p_dock, p_tab_index, p_set_current);
+		}
+		_dock_container_update_visibility(dock_tab_container);
+	}
 }
 
 void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
+	// Save docks by dock slot.
 	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
 		String names;
 		for (int j = 0; j < dock_slot[i]->get_tab_count(); j++) {
@@ -485,22 +339,23 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 		}
 	}
 
+	// Save docks in windows.
 	Dictionary floating_docks_dump;
-
-	for (WindowWrapper *wrapper : floating_docks) {
+	for (WindowWrapper *wrapper : dock_windows) {
 		Control *dock = wrapper->get_wrapped_control();
 
-		Dictionary dock_dump;
-		dock_dump["window_rect"] = wrapper->get_window_rect();
+		Dictionary window_dump;
+		window_dump["window_rect"] = wrapper->get_window_rect();
 
 		int screen = wrapper->get_window_screen();
-		dock_dump["window_screen"] = wrapper->get_window_screen();
-		dock_dump["window_screen_rect"] = DisplayServer::get_singleton()->screen_get_usable_rect(screen);
+		window_dump["window_screen"] = wrapper->get_window_screen();
+		window_dump["window_screen_rect"] = DisplayServer::get_singleton()->screen_get_usable_rect(screen);
 
 		String name = dock->get_name();
-		floating_docks_dump[name] = dock_dump;
+		floating_docks_dump[name] = window_dump;
 
-		int dock_slot_id = wrapper->get_meta("dock_slot");
+		// Append to regular dock section so we know where to restore it to.
+		int dock_slot_id = all_docks[dock].dock_slot_index;
 		String config_key = "dock_" + itos(dock_slot_id + 1);
 
 		String names = p_layout->get_value(p_section, config_key, "");
@@ -511,17 +366,39 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 		}
 		p_layout->set_value(p_section, config_key, names);
 	}
-
 	p_layout->set_value(p_section, "dock_floating", floating_docks_dump);
 
+	// Save closed and bottom docks.
 	Array bottom_docks_dump;
+	Array closed_docks_dump;
+	for (const KeyValue<Control *, DockInfo> &d : all_docks) {
+		if (!d.value.at_bottom && d.value.open && (!d.value.previous_at_bottom || !d.value.dock_window)) {
+			continue;
+		}
+		// Use the name of the Control since it isn't translated.
+		String name = d.key->get_name();
+		if (d.value.at_bottom || (d.value.previous_at_bottom && d.value.dock_window)) {
+			bottom_docks_dump.push_back(name);
+		}
+		if (!d.value.open) {
+			closed_docks_dump.push_back(name);
+		}
 
-	for (Control *bdock : bottom_docks) {
-		bottom_docks_dump.push_back(bdock->get_name());
+		int dock_slot_id = all_docks[d.key].dock_slot_index;
+		String config_key = "dock_" + itos(dock_slot_id + 1);
+
+		String names = p_layout->get_value(p_section, config_key, "");
+		if (names.is_empty()) {
+			names = name;
+		} else {
+			names += "," + name;
+		}
+		p_layout->set_value(p_section, config_key, names);
 	}
-
 	p_layout->set_value(p_section, "dock_bottom", bottom_docks_dump);
+	p_layout->set_value(p_section, "dock_closed", closed_docks_dump);
 
+	// Save SplitContainer offsets.
 	for (int i = 0; i < vsplits.size(); i++) {
 		if (vsplits[i]->is_visible_in_tree()) {
 			p_layout->set_value(p_section, "dock_split_" + itos(i + 1), vsplits[i]->get_split_offset());
@@ -537,9 +414,18 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 
 void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
 	Dictionary floating_docks_dump = p_layout->get_value(p_section, "dock_floating", Dictionary());
+	Array dock_bottom = p_layout->get_value(p_section, "dock_bottom", Array());
+	Array closed_docks = p_layout->get_value(p_section, "dock_closed", Array());
 
 	bool restore_window_on_load = EDITOR_GET("interface/multi_window/restore_windows_on_load");
 
+	// Store the docks by name for easy lookup.
+	HashMap<String, Control *> dock_map;
+	for (const KeyValue<Control *, DockInfo> &dock : all_docks) {
+		dock_map[dock.key->get_name()] = dock.key;
+	}
+
+	// Load docks by slot.
 	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
 		if (!p_layout->has_section_key(p_section, "dock_" + itos(i + 1))) {
 			continue;
@@ -550,135 +436,57 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 		for (int j = names.size() - 1; j >= 0; j--) {
 			String name = names[j];
 
-			// FIXME: Find it, in a horribly inefficient way.
-			int atidx = -1;
-			int bottom_idx = -1;
-			Control *node = nullptr;
-			for (int k = 0; k < DOCK_SLOT_MAX; k++) {
-				if (!dock_slot[k]->has_node(name)) {
-					continue;
-				}
-				node = Object::cast_to<Control>(dock_slot[k]->get_node(name));
-				if (!node) {
-					continue;
-				}
-				atidx = k;
-				break;
-			}
-
-			if (atidx == -1) {
-				// Try floating docks.
-				for (WindowWrapper *wrapper : floating_docks) {
-					if (wrapper->get_meta("dock_name") == name) {
-						if (restore_window_on_load && floating_docks_dump.has(name)) {
-							_restore_floating_dock(floating_docks_dump[name], wrapper, i);
-						} else {
-							atidx = wrapper->get_meta("dock_slot");
-							node = wrapper->get_wrapped_control();
-							wrapper->set_window_enabled(false);
-						}
-						break;
-					}
-				}
-			}
-
-			if (atidx == -1) {
-				// Try bottom docks.
-				for (Control *bdock : bottom_docks) {
-					if (bdock->get_name() == name) {
-						node = bdock;
-						bottom_idx = bottom_docks.find(node);
-						break;
-					}
-				}
-			}
-
-			if (!node) {
-				// Well, it's not anywhere.
+			if (!dock_map.has(name)) {
 				continue;
 			}
+			Control *dock = dock_map[name];
 
-			if (atidx == i) {
-				dock_slot[i]->move_child(node, 0);
-			} else if (atidx != -1) {
-				dock_slot[i]->set_block_signals(true);
-				dock_slot[atidx]->set_block_signals(true);
-				dock_slot[i]->move_tab_from_tab_container(dock_slot[atidx], dock_slot[atidx]->get_tab_idx_from_control(node), 0);
-				dock_slot[i]->set_block_signals(false);
-				dock_slot[atidx]->set_block_signals(false);
-			} else if (bottom_idx != -1) {
-				bottom_docks.erase(node);
-				EditorNode::get_bottom_panel()->remove_item(node);
-				dock_slot[i]->add_child(node);
-				node->call("_set_dock_horizontal", false);
+			if (!all_docks[dock].enabled) {
+				// Don't open disabled docks.
+				continue;
 			}
-
-			WindowWrapper *wrapper = Object::cast_to<WindowWrapper>(node);
 			if (restore_window_on_load && floating_docks_dump.has(name)) {
-				if (!dock_slot[i]->is_tab_hidden(dock_slot[i]->get_tab_idx_from_control(node))) {
-					_restore_floating_dock(floating_docks_dump[name], node, i);
-				}
-			} else if (wrapper) {
-				wrapper->set_window_enabled(false);
+				all_docks[dock].previous_at_bottom = dock_bottom.has(name);
+				_restore_dock_to_saved_window(dock, floating_docks_dump[name]);
+			} else if (dock_bottom.has(name)) {
+				_dock_move_to_bottom(dock);
+			} else {
+				_move_dock(dock, dock_slot[i], 0);
 			}
-		}
 
-		if (!p_layout->has_section_key(p_section, "dock_" + itos(i + 1) + "_selected_tab_idx")) {
+			if (closed_docks.has(name)) {
+				_move_dock(dock, closed_dock_parent);
+				all_docks[dock].open = false;
+				dock->hide();
+			} else {
+				// Make sure it is open.
+				all_docks[dock].open = true;
+				dock->show();
+			}
+
+			all_docks[dock].dock_slot_index = i;
+			all_docks[dock].previous_tab_index = j;
+		}
+	}
+
+	// Set the selected tabs.
+	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
+		if (dock_slot[i]->get_tab_count() == 0 || !p_layout->has_section_key(p_section, "dock_" + itos(i + 1) + "_selected_tab_idx")) {
 			continue;
 		}
-
 		int selected_tab_idx = p_layout->get_value(p_section, "dock_" + itos(i + 1) + "_selected_tab_idx");
 		if (selected_tab_idx >= 0 && selected_tab_idx < dock_slot[i]->get_tab_count()) {
-			callable_mp(dock_slot[i], &TabContainer::set_current_tab).call_deferred(selected_tab_idx);
+			dock_slot[i]->set_block_signals(true);
+			dock_slot[i]->set_current_tab(selected_tab_idx);
+			dock_slot[i]->set_block_signals(false);
 		}
 	}
 
-	Array dock_bottom = p_layout->get_value(p_section, "dock_bottom", Array());
-	for (int i = 0; i < dock_bottom.size(); i++) {
-		const String &name = dock_bottom[i];
-		// FIXME: Find it, in a horribly inefficient way.
-		int atidx = -1;
-		Control *node = nullptr;
-		for (int k = 0; k < DOCK_SLOT_MAX; k++) {
-			if (!dock_slot[k]->has_node(name)) {
-				continue;
-			}
-			node = Object::cast_to<Control>(dock_slot[k]->get_node(name));
-			if (!node) {
-				continue;
-			}
-			atidx = k;
-			break;
-		}
-
-		if (atidx == -1) {
-			// Try floating docks.
-			for (WindowWrapper *wrapper : floating_docks) {
-				if (wrapper->get_meta("dock_name") == name) {
-					atidx = wrapper->get_meta("dock_slot");
-					node = wrapper->get_wrapped_control();
-					wrapper->set_window_enabled(false);
-					break;
-				}
-			}
-		}
-
-		if (node) {
-			dock_slot[atidx]->remove_child(node);
-
-			node->call("_set_dock_horizontal", true);
-
-			bottom_docks.push_back(node);
-			// Force docks moved to the bottom to appear first in the list, and give them their associated shortcut to toggle their bottom panel.
-			EditorNode::get_bottom_panel()->add_item(node->get_name(), node, node->get_meta(META_TOGGLE_SHORTCUT), true);
-		}
-	}
-
+	// Load SplitContainer offsets.
 	for (int i = 0; i < vsplits.size(); i++) {
 		if (!p_layout->has_section_key(p_section, "dock_split_" + itos(i + 1))) {
 			continue;
 		}
-
 		int ofs = p_layout->get_value(p_section, "dock_split_" + itos(i + 1));
 		vsplits[i]->set_split_offset(ofs);
 	}
@@ -691,87 +499,155 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 		hsplits[i]->set_split_offset(ofs);
 	}
 
-	update_dock_slots_visibility(false);
-
 	FileSystemDock::get_singleton()->load_layout_from_config(p_layout, p_section);
 }
 
-void EditorDockManager::update_dock_slots_visibility(bool p_keep_selected_tabs) {
-	if (!docks_visible) {
-		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-			dock_slot[i]->hide();
-		}
+void EditorDockManager::bottom_dock_show_placement_popup(const Rect2i &p_position, Control *p_dock) {
+	ERR_FAIL_COND(!all_docks.has(p_dock));
+
+	dock_context_popup->set_dock(p_dock);
+
+	Vector2 popup_pos = p_position.position;
+	popup_pos.y += p_position.size.height;
+
+	if (!EditorNode::get_singleton()->get_gui_base()->is_layout_rtl()) {
+		popup_pos.x -= dock_context_popup->get_size().width;
+		popup_pos.x += p_position.size.width;
+	}
+	dock_context_popup->set_position(popup_pos);
+	dock_context_popup->popup();
+}
+
+void EditorDockManager::set_dock_enabled(Control *p_dock, bool p_enabled) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot set enabled unknown dock '%s'.", p_dock->get_name()));
+
+	if (all_docks[p_dock].enabled == p_enabled) {
+		return;
+	}
+
+	all_docks[p_dock].enabled = p_enabled;
+	if (p_enabled) {
+		open_dock(p_dock, false);
 	} else {
-		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-			int first_tab_visible = -1;
-			for (int j = 0; j < dock_slot[i]->get_tab_count(); j++) {
-				if (!dock_slot[i]->is_tab_hidden(j)) {
-					first_tab_visible = j;
-					break;
-				}
-			}
-			if (first_tab_visible >= 0) {
-				dock_slot[i]->show();
-				if (p_keep_selected_tabs) {
-					int current_tab = dock_slot[i]->get_current_tab();
-					if (dock_slot[i]->is_tab_hidden(current_tab)) {
-						dock_slot[i]->set_block_signals(true);
-						dock_slot[i]->select_next_available();
-						dock_slot[i]->set_block_signals(false);
-					}
-				} else {
-					dock_slot[i]->set_block_signals(true);
-					dock_slot[i]->set_current_tab(first_tab_visible);
-					dock_slot[i]->set_block_signals(false);
-				}
-			} else {
-				dock_slot[i]->hide();
-			}
+		close_dock(p_dock);
+	}
+}
+
+void EditorDockManager::close_dock(Control *p_dock) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot close unknown dock '%s'.", p_dock->get_name()));
+
+	if (!all_docks[p_dock].open) {
+		return;
+	}
+
+	_move_dock(p_dock, closed_dock_parent);
+
+	all_docks[p_dock].open = false;
+	p_dock->hide();
+
+	_update_layout();
+}
+
+void EditorDockManager::open_dock(Control *p_dock, bool p_set_current) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot open unknown dock '%s'.", p_dock->get_name()));
+
+	if (all_docks[p_dock].open) {
+		return;
+	}
+
+	all_docks[p_dock].open = true;
+	p_dock->show();
+
+	// Open dock to its previous location.
+	if (all_docks[p_dock].previous_at_bottom) {
+		_dock_move_to_bottom(p_dock);
+	} else {
+		TabContainer *slot = dock_slot[all_docks[p_dock].dock_slot_index];
+		int tab_index = all_docks[p_dock].previous_tab_index;
+		if (tab_index < 0) {
+			tab_index = slot->get_tab_count();
 		}
+		_move_dock(p_dock, slot, tab_index, p_set_current);
 	}
+
+	_update_layout();
 }
 
-void EditorDockManager::close_all_floating_docks() {
-	for (WindowWrapper *wrapper : floating_docks) {
-		wrapper->set_window_enabled(false);
-	}
+TabContainer *EditorDockManager::get_dock_tab_container(Control *p_dock) const {
+	return Object::cast_to<TabContainer>(p_dock->get_parent());
 }
 
-void EditorDockManager::add_control_to_dock(DockSlot p_slot, Control *p_control, const String &p_name, const Ref<Shortcut> &p_shortcut) {
+void EditorDockManager::focus_dock(Control *p_dock) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot focus unknown dock '%s'.", p_dock->get_name()));
+
+	if (!all_docks[p_dock].enabled) {
+		return;
+	}
+
+	if (!all_docks[p_dock].open) {
+		open_dock(p_dock);
+	}
+
+	if (all_docks[p_dock].dock_window) {
+		p_dock->get_window()->grab_focus();
+		return;
+	}
+
+	if (all_docks[p_dock].at_bottom) {
+		EditorNode::get_bottom_panel()->make_item_visible(p_dock);
+		return;
+	}
+
+	if (!docks_visible) {
+		return;
+	}
+
+	TabContainer *tab_container = get_dock_tab_container(p_dock);
+	if (!tab_container) {
+		return;
+	}
+	int tab_index = tab_container->get_tab_idx_from_control(p_dock);
+	tab_container->get_tab_bar()->grab_focus();
+	tab_container->set_current_tab(tab_index);
+}
+
+void EditorDockManager::add_control_to_dock(DockSlot p_slot, Control *p_dock, const String &p_title, const Ref<Shortcut> &p_shortcut) {
+	ERR_FAIL_NULL(p_dock);
 	ERR_FAIL_INDEX(p_slot, DOCK_SLOT_MAX);
-	p_control->set_meta(META_TOGGLE_SHORTCUT, p_shortcut);
-	dock_slot[p_slot]->add_child(p_control);
-	if (!p_name.is_empty()) {
-		dock_slot[p_slot]->set_tab_title(dock_slot[p_slot]->get_tab_idx_from_control(p_control), p_name);
-	}
+	ERR_FAIL_COND_MSG(all_docks.has(p_dock), vformat("Cannot add dock '%s', already added.", p_dock->get_name()));
+
+	DockInfo dock_info;
+	dock_info.title = !p_title.is_empty() ? p_title : String(p_dock->get_name());
+	dock_info.dock_slot_index = p_slot;
+	dock_info.shortcut = p_shortcut;
+	all_docks[p_dock] = dock_info;
+
+	open_dock(p_dock, false);
 }
 
-void EditorDockManager::remove_control_from_dock(Control *p_control) {
-	// If the dock is floating, close it first.
-	for (WindowWrapper *wrapper : floating_docks) {
-		if (p_control == wrapper->get_wrapped_control()) {
-			wrapper->set_window_enabled(false);
-			break;
-		}
-	}
+void EditorDockManager::remove_control_from_dock(Control *p_dock) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot remove unknown dock '%s'.", p_dock->get_name()));
 
-	Control *dock = nullptr;
-	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-		if (p_control->get_parent() == dock_slot[i]) {
-			dock = dock_slot[i];
-			break;
-		}
-	}
+	_move_dock(p_dock, nullptr);
 
-	ERR_FAIL_NULL_MSG(dock, "Control is not in a dock.");
-
-	dock->remove_child(p_control);
-	update_dock_slots_visibility();
+	all_docks.erase(p_dock);
+	_update_layout();
 }
 
 void EditorDockManager::set_docks_visible(bool p_show) {
+	if (docks_visible == p_show) {
+		return;
+	}
 	docks_visible = p_show;
-	update_dock_slots_visibility(true);
+	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
+		dock_slot[i]->set_visible(docks_visible && dock_slot[i]->get_tab_count() > 0);
+	}
+	_update_layout();
 }
 
 bool EditorDockManager::are_docks_visible() const {
@@ -796,80 +672,307 @@ void EditorDockManager::register_dock_slot(DockSlot p_dock_slot, TabContainer *p
 
 	p_tab_container->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
 	p_tab_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	p_tab_container->set_popup(dock_select_popup);
-	p_tab_container->connect("pre_popup_pressed", callable_mp(this, &EditorDockManager::_dock_pre_popup).bind(p_dock_slot));
+	p_tab_container->set_popup(dock_context_popup);
+	p_tab_container->connect("pre_popup_pressed", callable_mp(dock_context_popup, &DockContextPopup::select_current_dock_in_dock_slot).bind(p_dock_slot));
 	p_tab_container->set_drag_to_rearrange_enabled(true);
 	p_tab_container->set_tabs_rearrange_group(1);
-	p_tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_dock_tab_changed));
+	p_tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+	p_tab_container->connect("active_tab_rearranged", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+	p_tab_container->connect("child_order_changed", callable_mp(this, &EditorDockManager::_dock_container_update_visibility).bind(p_tab_container));
 	p_tab_container->set_use_hidden_tabs_for_min_size(true);
+	p_tab_container->get_tab_bar()->connect("gui_input", callable_mp(this, &EditorDockManager::_dock_container_gui_input).bind(p_tab_container));
+	p_tab_container->hide();
 }
 
 int EditorDockManager::get_vsplit_count() const {
 	return vsplits.size();
 }
 
-void EditorDockManager::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("layout_changed"));
-}
-
 EditorDockManager::EditorDockManager() {
 	singleton = this;
 
-	dock_select_popup = memnew(PopupPanel);
-	EditorNode::get_singleton()->get_gui_base()->add_child(dock_select_popup);
-	VBoxContainer *dock_vb = memnew(VBoxContainer);
-	dock_select_popup->add_child(dock_vb);
-	dock_select_popup->connect("theme_changed", callable_mp(this, &EditorDockManager::_dock_select_popup_theme_changed));
+	closed_dock_parent = EditorNode::get_singleton()->get_gui_base();
 
-	HBoxContainer *dock_hb = memnew(HBoxContainer);
-	dock_tab_move_left = memnew(Button);
-	dock_tab_move_left->set_flat(true);
-	dock_tab_move_left->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_left->connect("pressed", callable_mp(this, &EditorDockManager::_dock_move_left));
-	dock_hb->add_child(dock_tab_move_left);
+	dock_context_popup = memnew(DockContextPopup);
+	EditorNode::get_singleton()->get_gui_base()->add_child(dock_context_popup);
+}
 
-	Label *dock_label = memnew(Label);
-	dock_label->set_text(TTR("Dock Position"));
-	dock_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	dock_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	dock_hb->add_child(dock_label);
+void DockContextPopup::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			if (make_float_button) {
+				make_float_button->set_icon(get_editor_theme_icon(SNAME("MakeFloating")));
+			}
+			if (is_layout_rtl()) {
+				tab_move_left_button->set_icon(get_editor_theme_icon(SNAME("Forward")));
+				tab_move_right_button->set_icon(get_editor_theme_icon(SNAME("Back")));
+				tab_move_left_button->set_tooltip_text(TTR("Move this dock right one tab."));
+				tab_move_right_button->set_tooltip_text(TTR("Move this dock left one tab."));
+			} else {
+				tab_move_left_button->set_icon(get_editor_theme_icon(SNAME("Back")));
+				tab_move_right_button->set_icon(get_editor_theme_icon(SNAME("Forward")));
+				tab_move_left_button->set_tooltip_text(TTR("Move this dock left one tab."));
+				tab_move_right_button->set_tooltip_text(TTR("Move this dock right one tab."));
+			}
+			dock_to_bottom_button->set_icon(get_editor_theme_icon(SNAME("ControlAlignBottomWide")));
+		} break;
+	}
+}
 
-	dock_tab_move_right = memnew(Button);
-	dock_tab_move_right->set_flat(true);
-	dock_tab_move_right->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_right->connect("pressed", callable_mp(this, &EditorDockManager::_dock_move_right));
+void DockContextPopup::_tab_move_left() {
+	TabContainer *tab_container = dock_manager->get_dock_tab_container(context_dock);
+	if (!tab_container) {
+		return;
+	}
+	int new_index = tab_container->get_tab_idx_from_control(context_dock) - 1;
+	dock_manager->_move_dock(context_dock, tab_container, new_index);
+	dock_manager->_update_layout();
+	dock_select->queue_redraw();
+}
 
-	dock_hb->add_child(dock_tab_move_right);
-	dock_vb->add_child(dock_hb);
+void DockContextPopup::_tab_move_right() {
+	TabContainer *tab_container = dock_manager->get_dock_tab_container(context_dock);
+	if (!tab_container) {
+		return;
+	}
+	int new_index = tab_container->get_tab_idx_from_control(context_dock) + 1;
+	dock_manager->_move_dock(context_dock, tab_container, new_index);
+	dock_manager->_update_layout();
+	dock_select->queue_redraw();
+}
+
+void DockContextPopup::_float_dock() {
+	hide();
+	dock_manager->_open_dock_in_window(context_dock);
+}
+
+void DockContextPopup::_move_dock_to_bottom() {
+	hide();
+	dock_manager->_dock_move_to_bottom(context_dock);
+	dock_manager->_update_layout();
+}
+
+void DockContextPopup::_dock_select_input(const Ref<InputEvent> &p_input) {
+	Ref<InputEventMouse> me = p_input;
+
+	if (me.is_valid()) {
+		Vector2 point = me->get_position();
+
+		int over_dock_slot = -1;
+		for (int i = 0; i < EditorDockManager::DOCK_SLOT_MAX; i++) {
+			if (dock_select_rects[i].has_point(point)) {
+				over_dock_slot = i;
+				break;
+			}
+		}
+
+		if (over_dock_slot != dock_select_rect_over_idx) {
+			dock_select->queue_redraw();
+			dock_select_rect_over_idx = over_dock_slot;
+		}
+
+		if (over_dock_slot == -1) {
+			return;
+		}
+
+		Ref<InputEventMouseButton> mb = me;
+		TabContainer *target_tab_container = dock_manager->dock_slot[over_dock_slot];
+
+		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+			if (dock_manager->get_dock_tab_container(context_dock) != target_tab_container) {
+				dock_manager->_move_dock(context_dock, target_tab_container, target_tab_container->get_tab_count());
+				dock_manager->all_docks[context_dock].dock_slot_index = over_dock_slot;
+				dock_manager->_update_layout();
+				hide();
+			}
+		}
+	}
+}
+
+void DockContextPopup::_dock_select_mouse_exited() {
+	dock_select_rect_over_idx = -1;
+	dock_select->queue_redraw();
+}
+
+void DockContextPopup::_dock_select_draw() {
+	Color used_dock_color = Color(0.6, 0.6, 0.6, 0.8);
+	Color hovered_dock_color = Color(0.8, 0.8, 0.8, 0.8);
+	Color tab_selected_color = dock_select->get_theme_color(SNAME("mono_color"), EditorStringName(Editor));
+	Color tab_unselected_color = used_dock_color;
+	Color unused_dock_color = used_dock_color;
+	unused_dock_color.a = 0.4;
+	Color unusable_dock_color = unused_dock_color;
+	unusable_dock_color.a = 0.1;
+
+	// Update sizes.
+	Size2 dock_size = dock_select->get_size();
+	dock_size.x /= 6.0;
+	dock_size.y /= 2.0;
+
+	Size2 center_panel_size = dock_size * 2.0;
+	Rect2 center_panel_rect(center_panel_size.x, 0, center_panel_size.x, center_panel_size.y);
+
+	if (dock_select->is_layout_rtl()) {
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_UR] = Rect2(Point2(), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_BR] = Rect2(Point2(0, dock_size.y), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_UL] = Rect2(Point2(dock_size.x, 0), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_BL] = Rect2(dock_size, dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_UR] = Rect2(Point2(dock_size.x * 4, 0), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_BR] = Rect2(Point2(dock_size.x * 4, dock_size.y), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_UL] = Rect2(Point2(dock_size.x * 5, 0), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_BL] = Rect2(Point2(dock_size.x * 5, dock_size.y), dock_size);
+	} else {
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_UL] = Rect2(Point2(), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_BL] = Rect2(Point2(0, dock_size.y), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_UR] = Rect2(Point2(dock_size.x, 0), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_LEFT_BR] = Rect2(dock_size, dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_UL] = Rect2(Point2(dock_size.x * 4, 0), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_BL] = Rect2(Point2(dock_size.x * 4, dock_size.y), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_UR] = Rect2(Point2(dock_size.x * 5, 0), dock_size);
+		dock_select_rects[EditorDockManager::DOCK_SLOT_RIGHT_BR] = Rect2(Point2(dock_size.x * 5, dock_size.y), dock_size);
+	}
+
+	int max_tabs = 3;
+	int rtl_dir = dock_select->is_layout_rtl() ? -1 : 1;
+	real_t tab_height = 3.0 * EDSCALE;
+	real_t tab_spacing = 1.0 * EDSCALE;
+	real_t dock_spacing = 2.0 * EDSCALE;
+	real_t dock_top_spacing = tab_height + dock_spacing;
+
+	TabContainer *context_tab_container = dock_manager->get_dock_tab_container(context_dock);
+	int context_tab_index = -1;
+	if (context_tab_container && context_tab_container->get_tab_count() > 0) {
+		context_tab_index = context_tab_container->get_tab_idx_from_control(context_dock);
+	}
+
+	// Draw center panel.
+	Rect2 center_panel_draw_rect = center_panel_rect.grow_individual(-dock_spacing, -dock_top_spacing, -dock_spacing, -dock_spacing);
+	dock_select->draw_rect(center_panel_draw_rect, unusable_dock_color);
+
+	// Draw all dock slots.
+	for (int i = 0; i < EditorDockManager::DOCK_SLOT_MAX; i++) {
+		Rect2 dock_slot_draw_rect = dock_select_rects[i].grow_individual(-dock_spacing, -dock_top_spacing, -dock_spacing, -dock_spacing);
+		real_t tab_width = Math::round(dock_slot_draw_rect.size.width / max_tabs);
+		Rect2 tab_draw_rect = Rect2(dock_slot_draw_rect.position.x, dock_select_rects[i].position.y, tab_width - tab_spacing, tab_height);
+		if (dock_select->is_layout_rtl()) {
+			tab_draw_rect.position.x += dock_slot_draw_rect.size.x - tab_draw_rect.size.x;
+		}
+		bool is_context_dock = context_tab_container == dock_manager->dock_slot[i];
+		int tabs_to_draw = MIN(max_tabs, dock_manager->dock_slot[i]->get_tab_count());
+
+		if (i == dock_select_rect_over_idx) {
+			dock_select->draw_rect(dock_slot_draw_rect, hovered_dock_color);
+		} else if (tabs_to_draw == 0) {
+			dock_select->draw_rect(dock_slot_draw_rect, unused_dock_color);
+		} else {
+			dock_select->draw_rect(dock_slot_draw_rect, used_dock_color);
+		}
+
+		// Draw tabs above each used dock slot.
+		for (int j = 0; j < tabs_to_draw; j++) {
+			Color tab_color = tab_unselected_color;
+			if (is_context_dock && context_tab_index == j) {
+				tab_color = tab_selected_color;
+			}
+			Rect2 tabj_draw_rect = tab_draw_rect;
+			tabj_draw_rect.position.x += tab_width * j * rtl_dir;
+			dock_select->draw_rect(tabj_draw_rect, tab_color);
+		}
+	}
+}
+
+void DockContextPopup::_update_buttons() {
+	TabContainer *context_tab_container = dock_manager->get_dock_tab_container(context_dock);
+	bool dock_at_bottom = dock_manager->_is_dock_at_bottom(context_dock);
+
+	// Update tab move buttons.
+	tab_move_left_button->set_disabled(true);
+	tab_move_right_button->set_disabled(true);
+	if (!dock_at_bottom && context_tab_container && context_tab_container->get_tab_count() > 0) {
+		int context_tab_index = context_tab_container->get_tab_idx_from_control(context_dock);
+		tab_move_left_button->set_disabled(context_tab_index == 0);
+		tab_move_right_button->set_disabled(context_tab_index >= context_tab_container->get_tab_count() - 1);
+	}
+
+	dock_to_bottom_button->set_visible(!dock_at_bottom && bool(context_dock->call("_can_dock_horizontal")));
+	reset_size();
+}
+
+void DockContextPopup::select_current_dock_in_dock_slot(int p_dock_slot) {
+	context_dock = dock_manager->dock_slot[p_dock_slot]->get_current_tab_control();
+	_update_buttons();
+}
+
+void DockContextPopup::set_dock(Control *p_dock) {
+	context_dock = p_dock;
+	_update_buttons();
+}
+
+Control *DockContextPopup::get_dock() const {
+	return context_dock;
+}
+
+void DockContextPopup::docks_updated() {
+	if (!is_visible()) {
+		return;
+	}
+	_update_buttons();
+}
+
+DockContextPopup::DockContextPopup() {
+	dock_manager = EditorDockManager::get_singleton();
+
+	dock_select_popup_vb = memnew(VBoxContainer);
+	add_child(dock_select_popup_vb);
+
+	HBoxContainer *header_hb = memnew(HBoxContainer);
+	tab_move_left_button = memnew(Button);
+	tab_move_left_button->set_flat(true);
+	tab_move_left_button->set_focus_mode(Control::FOCUS_NONE);
+	tab_move_left_button->connect("pressed", callable_mp(this, &DockContextPopup::_tab_move_left));
+	header_hb->add_child(tab_move_left_button);
+
+	Label *position_label = memnew(Label);
+	position_label->set_text(TTR("Dock Position"));
+	position_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	position_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	header_hb->add_child(position_label);
+
+	tab_move_right_button = memnew(Button);
+	tab_move_right_button->set_flat(true);
+	tab_move_right_button->set_focus_mode(Control::FOCUS_NONE);
+	tab_move_right_button->connect("pressed", callable_mp(this, &DockContextPopup::_tab_move_right));
+
+	header_hb->add_child(tab_move_right_button);
+	dock_select_popup_vb->add_child(header_hb);
 
 	dock_select = memnew(Control);
 	dock_select->set_custom_minimum_size(Size2(128, 64) * EDSCALE);
-	dock_select->connect("gui_input", callable_mp(this, &EditorDockManager::_dock_select_input));
-	dock_select->connect("draw", callable_mp(this, &EditorDockManager::_dock_select_draw));
-	dock_select->connect("mouse_exited", callable_mp(this, &EditorDockManager::_dock_popup_exit));
+	dock_select->connect("gui_input", callable_mp(this, &DockContextPopup::_dock_select_input));
+	dock_select->connect("draw", callable_mp(this, &DockContextPopup::_dock_select_draw));
+	dock_select->connect("mouse_exited", callable_mp(this, &DockContextPopup::_dock_select_mouse_exited));
 	dock_select->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	dock_vb->add_child(dock_select);
+	dock_select_popup_vb->add_child(dock_select);
 
-	dock_float = memnew(Button);
-	dock_float->set_text(TTR("Make Floating"));
+	make_float_button = memnew(Button);
+	make_float_button->set_text(TTR("Make Floating"));
 	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
-		dock_float->set_disabled(true);
-		dock_float->set_tooltip_text(EditorNode::get_singleton()->get_multiwindow_support_tooltip_text());
+		make_float_button->set_disabled(true);
+		make_float_button->set_tooltip_text(EditorNode::get_singleton()->get_multiwindow_support_tooltip_text());
 	} else {
-		dock_float->set_tooltip_text(TTR("Make this dock floating."));
+		make_float_button->set_tooltip_text(TTR("Make this dock floating."));
 	}
-	dock_float->set_focus_mode(Control::FOCUS_NONE);
-	dock_float->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	dock_float->connect("pressed", callable_mp(this, &EditorDockManager::_dock_make_selected_float));
-	dock_vb->add_child(dock_float);
+	make_float_button->set_focus_mode(Control::FOCUS_NONE);
+	make_float_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	make_float_button->connect("pressed", callable_mp(this, &DockContextPopup::_float_dock));
+	dock_select_popup_vb->add_child(make_float_button);
 
-	dock_to_bottom = memnew(Button);
-	dock_to_bottom->set_text(TTR("Move to Bottom"));
-	dock_to_bottom->set_focus_mode(Control::FOCUS_NONE);
-	dock_to_bottom->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	dock_to_bottom->connect("pressed", callable_mp(this, &EditorDockManager::_dock_move_selected_to_bottom));
-	dock_to_bottom->hide();
-	dock_vb->add_child(dock_to_bottom);
-
-	dock_select_popup->reset_size();
+	dock_to_bottom_button = memnew(Button);
+	dock_to_bottom_button->set_text(TTR("Move to Bottom"));
+	dock_to_bottom_button->set_tooltip_text(TTR("Move this dock to the bottom panel."));
+	dock_to_bottom_button->set_focus_mode(Control::FOCUS_NONE);
+	dock_to_bottom_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	dock_to_bottom_button->connect("pressed", callable_mp(this, &DockContextPopup::_move_dock_to_bottom));
+	dock_to_bottom_button->hide();
+	dock_select_popup_vb->add_child(dock_to_bottom_button);
 }

--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -31,13 +31,15 @@
 #ifndef EDITOR_DOCK_MANAGER_H
 #define EDITOR_DOCK_MANAGER_H
 
+#include "scene/gui/popup.h"
 #include "scene/gui/split_container.h"
 
 class Button;
 class ConfigFile;
 class Control;
-class PopupPanel;
+class PopupMenu;
 class TabContainer;
+class VBoxContainer;
 class WindowWrapper;
 
 class DockSplitContainer : public SplitContainer {
@@ -52,6 +54,8 @@ protected:
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 };
+
+class DockContextPopup;
 
 class EditorDockManager : public Object {
 	GDCLASS(EditorDockManager, Object);
@@ -70,49 +74,51 @@ public:
 	};
 
 private:
+	friend class DockContextPopup;
+
+	struct DockInfo {
+		String title;
+		bool open = false;
+		bool enabled = true;
+		bool at_bottom = false;
+		int previous_tab_index = -1;
+		bool previous_at_bottom = false;
+		WindowWrapper *dock_window = nullptr;
+		int dock_slot_index = DOCK_SLOT_LEFT_UL;
+		Ref<Shortcut> shortcut;
+	};
+
 	static EditorDockManager *singleton;
 
 	// To access splits easily by index.
 	Vector<DockSplitContainer *> vsplits;
 	Vector<DockSplitContainer *> hsplits;
 
-	Vector<WindowWrapper *> floating_docks;
-	Vector<Control *> bottom_docks;
+	Vector<WindowWrapper *> dock_windows;
 	TabContainer *dock_slot[DOCK_SLOT_MAX];
+	HashMap<Control *, DockInfo> all_docks;
 	bool docks_visible = true;
 
-	PopupPanel *dock_select_popup = nullptr;
-	Button *dock_float = nullptr;
-	Button *dock_to_bottom = nullptr;
-	Button *dock_tab_move_left = nullptr;
-	Button *dock_tab_move_right = nullptr;
-	Control *dock_select = nullptr;
-	Rect2 dock_select_rect[DOCK_SLOT_MAX];
-	int dock_select_rect_over_idx = -1;
-	int dock_popup_selected_idx = -1;
-	int dock_bottom_selected_idx = -1;
+	DockContextPopup *dock_context_popup = nullptr;
+	Control *closed_dock_parent = nullptr;
 
-	void _dock_select_popup_theme_changed();
-	void _dock_popup_exit();
-	void _dock_pre_popup(int p_dock_slot);
-	void _dock_move_left();
-	void _dock_move_right();
-	void _dock_select_input(const Ref<InputEvent> &p_input);
-	void _dock_select_draw();
 	void _dock_split_dragged(int p_offset);
+	void _dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container);
+	void _bottom_dock_button_gui_input(const Ref<InputEvent> &p_input, Control *p_dock, Button *p_bottom_button);
+	void _dock_container_update_visibility(TabContainer *p_dock_container);
+	void _update_layout();
 
-	void _dock_tab_changed(int p_tab);
-	void _edit_current();
+	void _window_close_request(WindowWrapper *p_wrapper);
+	Control *_close_window(WindowWrapper *p_wrapper);
+	void _open_dock_in_window(Control *p_dock, bool p_show_window = true);
+	void _restore_dock_to_saved_window(Control *p_dock, const Dictionary &p_window_dump);
 
-	void _dock_floating_close_request(WindowWrapper *p_wrapper);
-	void _dock_make_selected_float();
-	void _dock_make_float(Control *p_control, int p_slot_index, bool p_show_window = true);
-	void _restore_floating_dock(const Dictionary &p_dock_dump, Control *p_wrapper, int p_slot_index);
+	void _dock_move_to_bottom(Control *p_dock);
+	void _dock_remove_from_bottom(Control *p_dock);
+	bool _is_dock_at_bottom(Control *p_dock);
 
-	void _dock_move_selected_to_bottom();
-
-protected:
-	static void _bind_methods();
+	void _move_dock_tab_index(Control *p_dock, int p_tab_index, bool p_set_current);
+	void _move_dock(Control *p_dock, Control *p_target, int p_tab_index = -1, bool p_set_current = true);
 
 public:
 	static EditorDockManager *get_singleton() { return singleton; }
@@ -124,19 +130,64 @@ public:
 
 	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
 	void load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section);
-	void update_dock_slots_visibility(bool p_keep_selected_tabs = false);
+
+	void set_dock_enabled(Control *p_dock, bool p_enabled);
+	void close_dock(Control *p_dock);
+	void open_dock(Control *p_dock, bool p_set_current = true);
+	void focus_dock(Control *p_dock);
+
+	TabContainer *get_dock_tab_container(Control *p_dock) const;
 
 	void bottom_dock_show_placement_popup(const Rect2i &p_position, Control *p_dock);
-
-	void close_all_floating_docks();
 
 	void set_docks_visible(bool p_show);
 	bool are_docks_visible() const;
 
-	void add_control_to_dock(DockSlot p_slot, Control *p_control, const String &p_name = "", const Ref<Shortcut> &p_shortcut = nullptr);
-	void remove_control_from_dock(Control *p_control);
+	void add_control_to_dock(DockSlot p_slot, Control *p_dock, const String &p_title = "", const Ref<Shortcut> &p_shortcut = nullptr);
+	void remove_control_from_dock(Control *p_dock);
 
 	EditorDockManager();
+};
+
+class DockContextPopup : public PopupPanel {
+	GDCLASS(DockContextPopup, PopupPanel);
+
+	VBoxContainer *dock_select_popup_vb = nullptr;
+
+	Button *make_float_button = nullptr;
+	Button *tab_move_left_button = nullptr;
+	Button *tab_move_right_button = nullptr;
+	Button *dock_to_bottom_button = nullptr;
+
+	Control *dock_select = nullptr;
+	Rect2 dock_select_rects[EditorDockManager::DOCK_SLOT_MAX];
+	int dock_select_rect_over_idx = -1;
+
+	Control *context_dock = nullptr;
+
+	EditorDockManager *dock_manager = nullptr;
+
+	void _tab_move_left();
+	void _tab_move_right();
+	void _float_dock();
+	void _move_dock_to_bottom();
+
+	void _dock_select_input(const Ref<InputEvent> &p_input);
+	void _dock_select_mouse_exited();
+	void _dock_select_draw();
+
+	void _update_buttons();
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void select_current_dock_in_dock_slot(int p_dock_slot);
+	void set_dock(Control *p_dock);
+	Control *get_dock() const;
+	void docks_updated();
+
+	DockContextPopup();
 };
 
 #endif // EDITOR_DOCK_MANAGER_H

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6047,19 +6047,13 @@ void EditorNode::_resource_loaded(Ref<Resource> p_resource, const String &p_path
 
 void EditorNode::_feature_profile_changed() {
 	Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
-	// FIXME: Close all floating docks to avoid crash.
-	editor_dock_manager->close_all_floating_docks();
-	TabContainer *import_tabs = cast_to<TabContainer>(ImportDock::get_singleton()->get_parent());
-	TabContainer *node_tabs = cast_to<TabContainer>(NodeDock::get_singleton()->get_parent());
-	TabContainer *fs_tabs = cast_to<TabContainer>(FileSystemDock::get_singleton()->get_parent());
-	TabContainer *history_tabs = cast_to<TabContainer>(history_dock->get_parent());
 	if (profile.is_valid()) {
-		node_tabs->set_tab_hidden(node_tabs->get_tab_idx_from_control(NodeDock::get_singleton()), profile->is_feature_disabled(EditorFeatureProfile::FEATURE_NODE_DOCK));
+		editor_dock_manager->set_dock_enabled(NodeDock::get_singleton(), !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_NODE_DOCK));
 		// The Import dock is useless without the FileSystem dock. Ensure the configuration is valid.
 		bool fs_dock_disabled = profile->is_feature_disabled(EditorFeatureProfile::FEATURE_FILESYSTEM_DOCK);
-		fs_tabs->set_tab_hidden(fs_tabs->get_tab_idx_from_control(FileSystemDock::get_singleton()), fs_dock_disabled);
-		import_tabs->set_tab_hidden(import_tabs->get_tab_idx_from_control(ImportDock::get_singleton()), fs_dock_disabled || profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
-		history_tabs->set_tab_hidden(history_tabs->get_tab_idx_from_control(history_dock), profile->is_feature_disabled(EditorFeatureProfile::FEATURE_HISTORY_DOCK));
+		editor_dock_manager->set_dock_enabled(FileSystemDock::get_singleton(), !fs_dock_disabled);
+		editor_dock_manager->set_dock_enabled(ImportDock::get_singleton(), !fs_dock_disabled && !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
+		editor_dock_manager->set_dock_enabled(history_dock, !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_HISTORY_DOCK));
 
 		main_editor_buttons[EDITOR_3D]->set_visible(!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT));
@@ -6072,18 +6066,16 @@ void EditorNode::_feature_profile_changed() {
 			editor_select(EDITOR_2D);
 		}
 	} else {
-		import_tabs->set_tab_hidden(import_tabs->get_tab_idx_from_control(ImportDock::get_singleton()), false);
-		node_tabs->set_tab_hidden(node_tabs->get_tab_idx_from_control(NodeDock::get_singleton()), false);
-		fs_tabs->set_tab_hidden(fs_tabs->get_tab_idx_from_control(FileSystemDock::get_singleton()), false);
-		history_tabs->set_tab_hidden(history_tabs->get_tab_idx_from_control(history_dock), false);
+		editor_dock_manager->set_dock_enabled(ImportDock::get_singleton(), true);
+		editor_dock_manager->set_dock_enabled(NodeDock::get_singleton(), true);
+		editor_dock_manager->set_dock_enabled(FileSystemDock::get_singleton(), true);
+		editor_dock_manager->set_dock_enabled(history_dock, true);
 		main_editor_buttons[EDITOR_3D]->set_visible(true);
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(true);
 		if (AssetLibraryEditorPlugin::is_available()) {
 			main_editor_buttons[EDITOR_ASSETLIB]->set_visible(true);
 		}
 	}
-
-	editor_dock_manager->update_dock_slots_visibility();
 }
 
 void EditorNode::_bind_methods() {
@@ -6542,7 +6534,6 @@ EditorNode::EditorNode() {
 	right_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR]);
 
 	editor_dock_manager = memnew(EditorDockManager);
-	editor_dock_manager->connect("layout_changed", callable_mp(this, &EditorNode::_save_editor_layout));
 
 	// Save the splits for easier access.
 	editor_dock_manager->add_vsplit(left_l_vsplit);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -736,12 +736,7 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 	_navigate_to_path(p_path);
 
 	// Ensure that the FileSystem dock is visible.
-	if (get_window() == get_tree()->get_root()) {
-		TabContainer *tab_container = (TabContainer *)get_parent_control();
-		tab_container->set_current_tab(tab_container->get_tab_idx_from_control((Control *)this));
-	} else {
-		get_window()->grab_focus();
-	}
+	EditorDockManager::get_singleton()->focus_dock(this);
 }
 
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/script_language.h"
+#include "editor/editor_dock_manager.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -166,18 +167,15 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 
 		set_selected(n);
 
-		TabContainer *tab_container = Object::cast_to<TabContainer>(NodeDock::get_singleton()->get_parent());
-		NodeDock::get_singleton()->get_parent()->call("set_current_tab", tab_container->get_tab_idx_from_control(NodeDock::get_singleton()));
+		EditorDockManager::get_singleton()->focus_dock(NodeDock::get_singleton());
 		NodeDock::get_singleton()->show_connections();
-
 	} else if (p_id == BUTTON_GROUPS) {
 		editor_selection->clear();
 		editor_selection->add_node(n);
 
 		set_selected(n);
 
-		TabContainer *tab_container = Object::cast_to<TabContainer>(NodeDock::get_singleton()->get_parent());
-		NodeDock::get_singleton()->get_parent()->call("set_current_tab", tab_container->get_tab_idx_from_control(NodeDock::get_singleton()));
+		EditorDockManager::get_singleton()->focus_dock(NodeDock::get_singleton());
 		NodeDock::get_singleton()->show_groups();
 	} else if (p_id == BUTTON_UNIQUE) {
 		undo_redo->create_action(TTR("Disable Scene Unique Name"));


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/88000
- Fixes https://github.com/godotengine/godot/issues/87234
- Fixes https://github.com/godotengine/godot/issues/74215
- Fixes crash when disabling the Filesystem in Editor Features when it is at the bottom. (related: #84125)
- Fixes both `// FIXME: Find it, in a horribly inefficient way.` in `EditorDockManager::load_docks_from_config()`
- Fixes `// FIXME: Close all floating docks to avoid crash.` in `EditorNode::_feature_profile_changed()` from #84122
	- removed `close_all_floating_docks()`
- Fixes dock select popup drawing issues with scaling, sizes, and rtl.
- Fixes dock names being untranslated when moving to floating window or to bottom panel.
- Fixes clicking on the signals or group button in the Scene Tree Dock while the Node dock is floating shows errors.
- related https://github.com/godotengine/godot/pull/84193


#### Implementation Details

EditorDockManager
- Added `DockInfo` struct and a HashMap<Control *, DockInfo> of all docks to be able to easily access information on docks.
	- This replaces the `bottom_docks` Vector.
- Replaced `_edit_current()` with `_update_layout()` to handle all updating that needs to happen after any dock moves. Previously some actions like floating a dock wouldn't save the layout, so it wouldn't restore if a crash occurs.
- Docks disabled with Editor features are moved out of the dock and hidden, instead of using hidden tabs. They use `set_dock_enabled()` which sets a flag and closes or opens the dock.
- `close_dock()` will hide the dock and move it out of the tab container, so it doesn't affect anything and isn't seen in the dock menu. `open_dock()` will restore the dock to its previous location. These will also be useful for https://github.com/godotengine/godot-proposals/issues/8206
- Saving a closed disabled dock will still add it to a slot so we know where to restore it to after loading, just like floating windows.
- Saving bottom docks was changed to do the same so it is more like closed and floating docks. This means that previous layouts with a bottom dock will need to be resaved.
- Simplified and made private `_update_dock_slots_visibility()` because hidden tabs no longer need to be checked.
- Added `_move_dock()` to handle moving the dock, to make sure it is always properly handled when removed from the bottom panel or a floating window, and making sure the title is set when moving to a TabContainer.
- `focus_dock()` handles focusing on a dock no matter where it is.

Extracts the dock popup into its own class `DockContextPopup`. (https://github.com/godotengine/godot/pull/84193#discussion_r1452675069)
- It now operates on a dock Control, rather than indexes for the dock and bottom panel item.
- Added tooltips for the L/R move tab buttons.
- The docks are drawn now at the appropriate position when in rtl.
- Editor scale is now used for tab drawing.
  - Before (150%):
![image](https://github.com/godotengine/godot/assets/10054226/2b9f22ed-1ddf-4c1d-990d-7aa0ae8569ec)
  - After (150%):
![image](https://github.com/godotengine/godot/assets/10054226/ff38aa95-594c-4c25-b1af-9ed764d2304f)
- Size issues when buttons were added/removed are fixed.
  - Before:
![Screenshot 2024-02-05 172557](https://github.com/godotengine/godot/assets/10054226/d1ad1df9-e0ab-41ed-93ff-4330b22f6eac)
  - After:
![image](https://github.com/godotengine/godot/assets/10054226/f77adbdd-f81a-40aa-ad87-0a5d9f0e8dbe)
- Docks at the bottom panel can now float directly (https://github.com/godotengine/godot/pull/86765#issuecomment-1904962229).
- Tabs can be right clicked to open the popup.