### PR TITLE
Fix data race regarding `prof_time` in `AudioDriver` and `AudioServer`

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -316,7 +316,7 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 	}
 
 #ifdef DEBUG_ENABLED
-	prof_time += OS::get_singleton()->get_ticks_usec() - prof_ticks;
+	prof_time.add(OS::get_singleton()->get_ticks_usec() - prof_ticks);
 #endif
 }
 
@@ -1400,7 +1400,7 @@ void AudioServer::update() {
 		// Driver time includes server time + effects times
 		// Server time includes effects times
 		uint64_t driver_time = AudioDriver::get_singleton()->get_profiling_time();
-		uint64_t server_time = prof_time;
+		uint64_t server_time = prof_time.get();
 
 		// Subtract the server time from the driver time
 		if (driver_time > server_time) {
@@ -1459,7 +1459,7 @@ void AudioServer::update() {
 	}
 
 	AudioDriver::get_singleton()->reset_profiling_time();
-	prof_time = 0;
+	prof_time.set(0);
 #endif
 
 	for (CallbackItem *ci : update_callback_list) {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -52,8 +52,8 @@ class AudioDriver {
 	uint64_t _last_mix_frames = 0;
 
 #ifdef DEBUG_ENABLED
-	uint64_t prof_ticks = 0;
-	uint64_t prof_time = 0;
+	SafeNumeric<uint64_t> prof_ticks;
+	SafeNumeric<uint64_t> prof_time;
 #endif
 
 protected:
@@ -69,8 +69,8 @@ protected:
 	int _get_configured_mix_rate();
 
 #ifdef DEBUG_ENABLED
-	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks = OS::get_singleton()->get_ticks_usec(); }
-	_FORCE_INLINE_ void stop_counting_ticks() { prof_time += OS::get_singleton()->get_ticks_usec() - prof_ticks; }
+	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks.set(OS::get_singleton()->get_ticks_usec()); }
+	_FORCE_INLINE_ void stop_counting_ticks() { prof_time.add(OS::get_singleton()->get_ticks_usec() - prof_ticks.get()); }
 #else
 	_FORCE_INLINE_ void start_counting_ticks() {}
 	_FORCE_INLINE_ void stop_counting_ticks() {}
@@ -125,8 +125,8 @@ public:
 	unsigned int get_input_size() { return input_size; }
 
 #ifdef DEBUG_ENABLED
-	uint64_t get_profiling_time() const { return prof_time; }
-	void reset_profiling_time() { prof_time = 0; }
+	uint64_t get_profiling_time() const { return prof_time.get(); }
+	void reset_profiling_time() { prof_time.set(0); }
 #endif
 
 	AudioDriver() {}
@@ -183,7 +183,7 @@ private:
 	uint64_t mix_count = 0;
 	uint64_t mix_frames = 0;
 #ifdef DEBUG_ENABLED
-	uint64_t prof_time = 0;
+	SafeNumeric<uint64_t> prof_time;
 #endif
 
 	float channel_disable_threshold_db = 0.0f;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/87997
- Fixes https://github.com/godotengine/godot/issues/87998

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
