### PR TITLE
Web: Bump closure compiler spec to `ECMASCRIPT_2021`

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -169,7 +169,7 @@ def configure(env: "Environment"):
     env.AddMethod(create_template_zip, "CreateTemplateZip")
 
     # Closure compiler extern and support for ecmascript specs (const, let, etc).
-    env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT_2020"
+    env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT_2021"
 
     env["CC"] = "emcc"
     env["CXX"] = "em++"


### PR DESCRIPTION
Fixes #88008.