### PR TITLE
Fix `get_contact_count` sometimes being incorrect in `_process`

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -446,6 +446,8 @@ void RigidBody2D::_sync_body_state(PhysicsDirectBodyState2D *p_state) {
 	linear_velocity = p_state->get_linear_velocity();
 	angular_velocity = p_state->get_angular_velocity();
 
+	contact_count = p_state->get_contact_count();
+
 	if (sleeping != p_state->is_sleeping()) {
 		sleeping = p_state->is_sleeping();
 		emit_signal(SceneStringNames::get_singleton()->sleeping_state_changed);
@@ -797,9 +799,7 @@ int RigidBody2D::get_max_contacts_reported() const {
 }
 
 int RigidBody2D::get_contact_count() const {
-	PhysicsDirectBodyState2D *bs = PhysicsServer2D::get_singleton()->body_get_direct_state(get_rid());
-	ERR_FAIL_NULL_V(bs, 0);
-	return bs->get_contact_count();
+	return contact_count;
 }
 
 void RigidBody2D::apply_central_impulse(const Vector2 &p_impulse) {

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -164,6 +164,7 @@ private:
 	bool sleeping = false;
 
 	int max_contacts_reported = 0;
+	int contact_count = 0;
 
 	bool custom_integrator = false;
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -502,6 +502,8 @@ void RigidBody3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
 
 	inverse_inertia_tensor = p_state->get_inverse_inertia_tensor();
 
+	contact_count = p_state->get_contact_count();
+
 	if (sleeping != p_state->is_sleeping()) {
 		sleeping = p_state->is_sleeping();
 		emit_signal(SceneStringNames::get_singleton()->sleeping_state_changed);
@@ -877,9 +879,7 @@ int RigidBody3D::get_max_contacts_reported() const {
 }
 
 int RigidBody3D::get_contact_count() const {
-	PhysicsDirectBodyState3D *bs = PhysicsServer3D::get_singleton()->body_get_direct_state(get_rid());
-	ERR_FAIL_NULL_V(bs, 0);
-	return bs->get_contact_count();
+	return contact_count;
 }
 
 void RigidBody3D::apply_central_impulse(const Vector3 &p_impulse) {

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -177,6 +177,7 @@ private:
 	bool ccd = false;
 
 	int max_contacts_reported = 0;
+	int contact_count = 0;
 
 	bool custom_integrator = false;
 


### PR DESCRIPTION
Fixes #88018.

This replaces the usage of `body_get_direct_state` in `RigidBody*D.get_contact_count` with a cached value that's populated as part of `RigidBody*D._sync_body_state`, similar to other states in the physics bodies, which prevents `_process` from accessing a yet-to-be-synced future contact count.

This also fixes the inability to use `get_contact_count` from `_process` when using the `physics/*d/run_on_separate_thread` project setting.