### PR TITLE
GDScript: Set `has_type` false if it is `BUILTIN` but `Variant::NIL`

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -429,7 +429,7 @@ void GDScriptByteCodeGenerator::set_initial_line(int p_line) {
 	(m_var.type.has_type && m_var.type.kind == GDScriptDataType::BUILTIN)
 
 #define IS_BUILTIN_TYPE(m_var, m_type) \
-	(m_var.type.has_type && m_var.type.kind == GDScriptDataType::BUILTIN && m_var.type.builtin_type == m_type)
+	(m_var.type.has_type && m_var.type.kind == GDScriptDataType::BUILTIN && m_var.type.builtin_type == m_type && m_type != Variant::NIL)
 
 void GDScriptByteCodeGenerator::write_type_adjust(const Address &p_target, Variant::Type p_new_type) {
 	switch (p_new_type) {

--- a/modules/gdscript/tests/scripts/runtime/features/match_test_null.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/match_test_null.gd
@@ -1,0 +1,6 @@
+func test():
+	match null:
+		null:
+			print('null matched')
+		_:
+			pass

--- a/modules/gdscript/tests/scripts/runtime/features/match_test_null.out
+++ b/modules/gdscript/tests/scripts/runtime/features/match_test_null.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+null matched


### PR DESCRIPTION
This change fixes #87932 by preventing edge case for **null** value when used with a **match**. Even though edge case is happening with third check in **IS_BUILTIN_TYPE()**, `m_var.type.builtin_type == m_type`, there is no other default type other than **Variant::NIL**, so this check wouldn't change. But returning false with **has_type** in the first check for **Variant::NIL** makes more sense since it is also the default value in **GDScriptDataType**.  

https://github.com/godotengine/godot/blob/b4e2a24c1f62088b3f7ce0197afc90832fc25009/modules/gdscript/gdscript_byte_codegen.cpp#L430-L434

https://github.com/godotengine/godot/blob/b4e2a24c1f62088b3f7ce0197afc90832fc25009/modules/gdscript/gdscript_function.h#L47-L65

 
