### PR TITLE
Fully initialize all members of structs `IdentifierActions`, `GeneratedCode` and `DefaultIdentifierActions`

### DIFF
--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -52,38 +52,38 @@ public:
 		HashMap<StringName, bool *> usage_flag_pointers;
 		HashMap<StringName, bool *> write_flag_pointers;
 
-		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> *uniforms;
+		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> *uniforms = nullptr;
 	};
 
 	struct GeneratedCode {
 		Vector<String> defines;
 		struct Texture {
 			StringName name;
-			ShaderLanguage::DataType type;
-			ShaderLanguage::ShaderNode::Uniform::Hint hint;
+			ShaderLanguage::DataType type = ShaderLanguage::DataType::TYPE_VOID;
+			ShaderLanguage::ShaderNode::Uniform::Hint hint = ShaderLanguage::ShaderNode::Uniform::Hint::HINT_NONE;
 			bool use_color = false;
-			ShaderLanguage::TextureFilter filter;
-			ShaderLanguage::TextureRepeat repeat;
-			bool global;
-			int array_size;
+			ShaderLanguage::TextureFilter filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
+			ShaderLanguage::TextureRepeat repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
+			bool global = false;
+			int array_size = 0;
 		};
 
 		Vector<Texture> texture_uniforms;
 
 		Vector<uint32_t> uniform_offsets;
-		uint32_t uniform_total_size;
+		uint32_t uniform_total_size = 0;
 		String uniforms;
 		String stage_globals[STAGE_MAX];
 
 		HashMap<String, String> code;
 
-		bool uses_global_textures;
-		bool uses_fragment_time;
-		bool uses_vertex_time;
-		bool uses_screen_texture_mipmaps;
-		bool uses_screen_texture;
-		bool uses_depth_texture;
-		bool uses_normal_roughness_texture;
+		bool uses_global_textures = false;
+		bool uses_fragment_time = false;
+		bool uses_vertex_time = false;
+		bool uses_screen_texture_mipmaps = false;
+		bool uses_screen_texture = false;
+		bool uses_depth_texture = false;
+		bool uses_normal_roughness_texture = false;
 	};
 
 	struct DefaultIdentifierActions {
@@ -91,8 +91,8 @@ public:
 		HashMap<StringName, String> render_mode_defines;
 		HashMap<StringName, String> usage_defines;
 		HashMap<StringName, String> custom_samplers;
-		ShaderLanguage::TextureFilter default_filter;
-		ShaderLanguage::TextureRepeat default_repeat;
+		ShaderLanguage::TextureFilter default_filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
+		ShaderLanguage::TextureRepeat default_repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
 		int base_texture_binding_index = 0;
 		int texture_layout_set = 0;
 		String base_uniform_string;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88015.

This one simple change

```diff
- ShaderCompiler::DefaultIdentifierActions actions;
+ ShaderCompiler::DefaultIdentifierActions actions = {};
```

is enough for Godot to compile on my setup, however, @akien-mga pointed out that this might be an issue in other places in the code [here](https://github.com/godotengine/godot/pull/88011#discussion_r1479644005). He proposed an alternative fix (changing the struct code to fully initialize all its members), but I'd like to wait for the rendering team to voice their opinions about this.

**EDIT**: I went ahead with the alternative fix (and then some more for completeness' sake).
