### PR TITLE
SCons: Fix incremental builds breaking when querying the dependency tree from a SCsub

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -152,7 +152,7 @@ env_base["x86_libtheora_opt_gcc"] = False
 env_base["x86_libtheora_opt_vc"] = False
 
 # avoid issues when building with different versions of python out of the same directory
-env_base.SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
+env_base.SConsignFile(File("#.sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL)).abspath)
 
 # Build options
 


### PR DESCRIPTION
I'm querying the scons dependency tree to calculate some build information in a `SCsub`, via `SCons.Node.FS.File.children()`. This call causes scons to access the .sconsign database, to lookup the build information up to that point. When this happens on an `SCsub` invoked via a `Sconscript()` call, the path to the .sconsign file is interpreted as being relative to the current executing `SCsub`, not to the top-level `SConstruct` file.

When this happens, it completely breaks incremental builds, because scons can't find build information in the "local" sconsign file (which is created on the spot with only the local `SCsub` build information), so scons decides to rebuild everything.

I don't know why scons is doing this, given that all other build information is recorded on the top level sconsign file, including the build information related to the executing SCsub, but it is happening. Possibly a scons bug?

This PR sets an absolute path for `SConsignFile`, so any queries to the dependency database use the same database file, regardless of local executing SCsub context.

*Contributed by W4Games :heart:*

/cc @akien-mga @mhilbrunner 