### PR TITLE
Silence wayland-scanner check in buildsystem

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -207,8 +207,8 @@ def configure(env: "Environment"):
         env.Append(CPPDEFINES=["SOWRAP_ENABLED"])
 
     if env["wayland"]:
-        if os.system("wayland-scanner -v") != 0:
-            print("wayland-scanner not found. Disabling wayland support.")
+        if os.system("wayland-scanner -v 2>/dev/null") != 0:
+            print("wayland-scanner not found. Disabling Wayland support.")
             env["wayland"] = False
 
     if env["touch"]:


### PR DESCRIPTION
This prevents a wayland-scanner message from appearing every build when `wayland=yes` is used (the default). The error message when wayland-scanner is still printed as it's not printed by wayland-scanner itself.

wayland-scanner prints its version to stderr instead of stdout (at least in 1.22.0), so stderr needs to be redirected.
