### PR TITLE
Fix data race regarding `server_quit` in `EditorExportPlatformWeb`

### DIFF
--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -676,7 +676,7 @@ Ref<Texture2D> EditorExportPlatformWeb::get_run_icon() const {
 
 void EditorExportPlatformWeb::_server_thread_poll(void *data) {
 	EditorExportPlatformWeb *ej = static_cast<EditorExportPlatformWeb *>(data);
-	while (!ej->server_quit) {
+	while (!ej->server_quit.get()) {
 		OS::get_singleton()->delay_usec(6900);
 		{
 			MutexLock lock(ej->server_lock);
@@ -714,7 +714,7 @@ EditorExportPlatformWeb::~EditorExportPlatformWeb() {
 	if (server.is_valid()) {
 		server->stop();
 	}
-	server_quit = true;
+	server_quit.set(true);
 	if (server_thread.is_started()) {
 		server_thread.wait_to_finish();
 	}

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -52,7 +52,7 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 	int menu_options = 0;
 
 	Ref<EditorHTTPServer> server;
-	bool server_quit = false;
+	SafeNumeric<bool> server_quit;
 	Mutex server_lock;
 	Thread server_thread;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87995

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
