### PR TITLE
Optimize when colliders are regenerated for imported meshes

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -430,24 +430,27 @@ void SceneImportSettingsDialog::_update_view_gizmos() {
 		return;
 	}
 	for (const KeyValue<String, NodeData> &e : node_map) {
+		// Skip import nodes that aren't MeshInstance3D.
+		const MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(e.value.node);
+		if (mesh_node == nullptr || mesh_node->get_mesh().is_null()) {
+			continue;
+		}
+
+		// Determine if the mesh collider should be visible.
 		bool show_collider_view = false;
 		if (e.value.settings.has(SNAME("generate/physics"))) {
 			show_collider_view = e.value.settings[SNAME("generate/physics")];
 		}
 
-		MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(e.value.node);
-		if (mesh_node == nullptr || mesh_node->get_mesh().is_null()) {
-			// Nothing to do.
-			continue;
-		}
-
+		// Get the collider_view MeshInstance3D.
 		TypedArray<Node> descendants = mesh_node->find_children("collider_view", "MeshInstance3D");
-
 		CRASH_COND_MSG(descendants.is_empty(), "This is unreachable, since the collider view is always created even when the collision is not used! If this is triggered there is a bug on the function `_fill_scene`.");
+		MeshInstance3D *collider_view = Object::cast_to<MeshInstance3D>(descendants[0].operator Object *());
 
-		MeshInstance3D *collider_view = static_cast<MeshInstance3D *>(descendants[0].operator Object *());
-		collider_view->set_visible(show_collider_view);
-		if (generate_collider) {
+		// Regenerate the physics collider for this MeshInstance3D if either:
+		// - A regeneration is requested for the selected import node.
+		// - The collider is being made visible.
+		if ((generate_collider && e.key == selected_id) || (show_collider_view && !collider_view->is_visible())) {
 			// This collider_view doesn't have a mesh so we need to generate a new one.
 			Ref<ImporterMesh> mesh;
 			mesh.instantiate();
@@ -511,6 +514,9 @@ void SceneImportSettingsDialog::_update_view_gizmos() {
 			collider_view->set_mesh(collider_view_mesh);
 			collider_view->set_transform(transform);
 		}
+
+		// Set the collider visibility.
+		collider_view->set_visible(show_collider_view);
 	}
 
 	generate_collider = false;


### PR DESCRIPTION
This pull request fixes unnecessary regeneration of collision shapes in the import dialog. The old logic recalculated the colliders for every mesh in the model - including for meshes that did not have physics colliders enabled, and for meshes with existing colliders whose settings had not been modified.

This was not a problem for simple models; however @yythlj encountered this attempting to import the [shop_house.zip](https://github.com/godotengine/godot/files/14188673/shop_house.zip) model which consists of:
- 68513 vertices
- 56289 triangles
- 1176 discrete objects/meshes

Changing physics settings on any mesh resulted in calculating colliders for all 1176 meshes, which takes so long I gave up trying to measure it. This behavior is now modified to only calculate the collider for a mesh under the following circumstances:
1. The collider is being made visible (ensures previously-enabled colliders are calculated for preview in the import dialog).
2. The currently selected mesh collider settings have been modified triggering a regeneration with different collision settings.

For the shop_house model described above; if collision happened to be enabled for all 1176 meshes there would still be an unavoidable enormous delay on opening the import dialog so the collider meshes could be calculated for preview.

The following video demonstrates opening the import settings on the shop_house model with a few colliders enabled, then toggling the collider-generation on a few meshes and re-importing.

https://github.com/godotengine/godot/assets/1863707/1393f472-2f5c-4101-9540-d3a69ddee79d
