### PR TITLE
C#: Fix crash when reloading scripts

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -727,20 +727,15 @@ void CSharpLanguage::reload_all_scripts() {
 }
 
 void CSharpLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload) {
+#ifdef GD_MONO_HOT_RELOAD
+	if (is_assembly_reloading_needed()) {
+		reload_assemblies(p_soft_reload);
+	}
+#endif
+}
+
+void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {
 	CRASH_COND(!Engine::get_singleton()->is_editor_hint());
-
-	bool has_csharp_script = false;
-	for (int i = 0; i < p_scripts.size(); ++i) {
-		Ref<CSharpScript> cs_script = p_scripts[i];
-		if (cs_script.is_valid()) {
-			has_csharp_script = true;
-			break;
-		}
-	}
-
-	if (!has_csharp_script) {
-		return;
-	}
 
 #ifdef TOOLS_ENABLED
 	get_godotsharp_editor()->get_node(NodePath("HotReloadAssemblyWatcher"))->call("RestartTimer");
@@ -751,12 +746,6 @@ void CSharpLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload) 
 		reload_assemblies(p_soft_reload);
 	}
 #endif
-}
-
-void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {
-	Array scripts;
-	scripts.push_back(p_script);
-	reload_scripts(scripts, p_soft_reload);
 }
 
 #ifdef GD_MONO_HOT_RELOAD


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/86676.
- Fixes https://github.com/godotengine/godot/issues/88022.

The crash cond was accidentally moved to the `reload_scripts` method when it was only meant to be in the `reload_tool_script` method. Same about restarting the HotReloadAssemblyWatcher timer.

Also removed the loop that checks if the script array contains a C# script because if we're in CSharpLanguage we can assume that at least one of them is.