### PR TITLE
[GDExtension] Add config option to specify custom library lookup paths.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -67,6 +67,10 @@ String ProjectSettings::get_resource_path() const {
 	return resource_path;
 }
 
+String ProjectSettings::get_main_pack_path() const {
+	return main_pack_path;
+}
+
 String ProjectSettings::get_imported_files_path() const {
 	return get_project_data_path().path_join("imported");
 }
@@ -475,6 +479,10 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 
 	if (!ok) {
 		return false;
+	}
+
+	if (main_pack_path.is_empty()) {
+		main_pack_path = p_pack.get_base_dir();
 	}
 
 	//if data.pck is found, all directory access will be from here

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -96,6 +96,7 @@ protected:
 
 	RBMap<StringName, VariantContainer> props; // NOTE: Key order is used e.g. in the save_custom method.
 	String resource_path;
+	String main_pack_path;
 	HashMap<StringName, PropertyInfo> custom_prop_info;
 	bool using_datapack = false;
 	bool project_loaded = false;
@@ -176,6 +177,7 @@ public:
 	String get_project_data_dir_name() const;
 	String get_project_data_path() const;
 	String get_resource_path() const;
+	String get_main_pack_path() const;
 	String get_imported_files_path() const;
 
 	static ProjectSettings *get_singleton();

--- a/core/extension/gdextension.compat.inc
+++ b/core/extension/gdextension.compat.inc
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  gdextension.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "gdextension.h"
+
+Error GDExtension::_open_library_bind_compat_88049(const String &p_path, const String &p_entry_symbol) {
+	return open_library(p_path, p_entry_symbol, Vector<String>());
+}
+
+void GDExtension::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::_open_library_bind_compat_88049);
+}
+
+#endif

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -110,6 +110,12 @@ class GDExtension : public Resource {
 	static HashMap<StringName, GDExtensionInterfaceFunctionPtr> gdextension_interface_functions;
 
 protected:
+#ifndef DISABLE_DEPRECATED
+	Error _open_library_bind_compat_88049(const String &p_path, const String &p_entry_symbol);
+
+	static void _bind_compatibility_methods();
+#endif
+
 	static void _bind_methods();
 
 public:
@@ -120,7 +126,7 @@ public:
 	static String get_extension_list_config_file();
 	static String find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags = nullptr);
 
-	Error open_library(const String &p_path, const String &p_entry_symbol);
+	Error open_library(const String &p_path, const String &p_entry_symbol, const Vector<String> &p_lookup_paths = Vector<String>());
 	void close_library();
 
 #if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)

--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -43,6 +43,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="entry_symbol" type="String" />
+			<param index="2" name="lookup_paths" type="PackedStringArray" default="PackedStringArray()" />
 			<description>
 				Opens the library at the specified [param path].
 				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.load_extension].

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -82,3 +82,10 @@ Validate extension JSON: Error: Field 'classes/GPUParticles3D/properties/process
 Validate extension JSON: Error: Field 'classes/Sky/properties/sky_material': type changed value in new API, from "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial" to "PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial,ShaderMaterial".
 
 Property hints reordered to improve editor usability. The types allowed are still the same as before. No adjustments should be necessary.
+
+
+GH-88049
+--------
+Validate extension JSON: Error: Field 'classes/GDExtension/methods/open_library/arguments': size changed value in new API, from 2 to 3.
+
+Added optional "lookup_paths" argument. Compatibility method registered.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87761

Add an optional `lookup_paths` GDExtension config file parameter to specify a list of custom library lookup paths. Paths can be relative `res://` path, absolute path, or relative to the other special project locations (`bundle_dir://`, `pck_dir://`, `exe_dir://`).

In case of #87761, the issue can be resolved by adding this line to the config:
```diff
 compatibility_minimum = "4.1"
+lookup_paths = [ ""pck_dir://" ]

 [libraries]
```