### PR TITLE
[macOS] Enabled secure restorable state.

### DIFF
--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -35,6 +35,10 @@
 
 @implementation GodotApplicationDelegate
 
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+	return YES;
+}
+
 - (void)forceUnbundledWindowActivationHackStep1 {
 	// Step 1: Switch focus to macOS SystemUIServer process.
 	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.


### PR DESCRIPTION
We aren't storing any custom data in it, but adding it prevents `WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application` warning on the app start.
