### PR TITLE
Fix LineEdit behavior for deleting all the way to the left/right

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -140,7 +140,9 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 
 	if (p_all_to_left) {
 		deselect();
-		text = text.substr(0, caret_column);
+		text = text.substr(caret_column);
+		_shape();
+		set_caret_column(0);
 		_text_changed();
 		return;
 	}
@@ -176,9 +178,8 @@ void LineEdit::_delete(bool p_word, bool p_all_to_right) {
 
 	if (p_all_to_right) {
 		deselect();
-		text = text.substr(caret_column, text.length() - caret_column);
+		text = text.substr(0, caret_column);
 		_shape();
-		set_caret_column(0);
 		_text_changed();
 		return;
 	}


### PR DESCRIPTION
"Backspace all to left" and "Delete all to right" were swapped in `LineEdit`
Now they behave correctly like in `TextEdit`
Closes #70793