### PR TITLE
Tweak error and warning colors and fix `StatusWarning` icon visibility on light themes

### DIFF
--- a/editor/themes/editor_color_map.cpp
+++ b/editor/themes/editor_color_map.cpp
@@ -169,9 +169,7 @@ void EditorColorMap::create() {
 	add_conversion_exception("ZoomReset");
 	add_conversion_exception("LockViewport");
 	add_conversion_exception("GroupViewport");
-	add_conversion_exception("StatusError");
 	add_conversion_exception("StatusSuccess");
-	add_conversion_exception("StatusWarning");
 	add_conversion_exception("OverbrightIndicator");
 	add_conversion_exception("MaterialPreviewCube");
 	add_conversion_exception("MaterialPreviewSphere");

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -436,8 +436,8 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 		if (!p_config.dark_theme) {
 			// Darken some colors to be readable on a light background.
 			p_config.success_color = p_config.success_color.lerp(p_config.mono_color, 0.35);
-			p_config.warning_color = p_config.warning_color.lerp(p_config.mono_color, 0.35);
-			p_config.error_color = p_config.error_color.lerp(p_config.mono_color, 0.25);
+			p_config.warning_color = Color(0.82, 0.56, 0.1);
+			p_config.error_color = Color(0.8, 0.22, 0.22);
 		}
 
 		p_theme->set_color("mono_color", EditorStringName(Editor), p_config.mono_color);
@@ -1901,14 +1901,20 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 			// When pressed, don't tint the icons with the accent color, just leave them normal.
 			p_theme->set_color("icon_pressed_color", "EditorLogFilterButton", p_config.icon_normal_color);
 			// When unpressed, dim the icons.
-			p_theme->set_color("icon_normal_color", "EditorLogFilterButton", p_config.icon_disabled_color);
+			Color icon_normal_color = Color(p_config.icon_normal_color, (p_config.dark_theme ? 0.4 : 0.8));
+			p_theme->set_color("icon_normal_color", "EditorLogFilterButton", icon_normal_color);
+			Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.0);
+			icon_hover_color.a = 1.0;
+			p_theme->set_color("icon_hover_color", "EditorLogFilterButton", icon_hover_color);
 
 			// When pressed, add a small bottom border to the buttons to better show their active state,
 			// similar to active tabs.
 			Ref<StyleBoxFlat> editor_log_button_pressed = style_flat_button_pressed->duplicate();
 			editor_log_button_pressed->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
 			editor_log_button_pressed->set_border_color(p_config.accent_color);
-
+			if (!p_config.dark_theme) {
+				editor_log_button_pressed->set_bg_color(flat_pressed_color.lightened(0.5));
+			}
 			p_theme->set_stylebox("normal", "EditorLogFilterButton", style_flat_button);
 			p_theme->set_stylebox("hover", "EditorLogFilterButton", style_flat_button_hover);
 			p_theme->set_stylebox("pressed", "EditorLogFilterButton", editor_log_button_pressed);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #87987

Originally this PR focused on fixing visibility of the `StatusWarning`, but after successive iterations and positive feedback, a few more relevant alterations were made:

- Removed `StatusWarning` and `StatusError` icons from the exclusion list to be able to convert its colors
- Set `error_color` to the same color used in `Node3D` (`#BF5A50` -> `#CD3838`)
- Shift `warning_color` to a more orange saturated hue (`#A69042` -> `#D18F19`)
- Tweak `EditorLogFilterButton` appearance (more comparison screenshots at https://github.com/godotengine/godot/pull/88058#issuecomment-1935833345):
    - Increased icon `normal` color opacity from 40% to 80%
    - Removed icon `hover` color modulate, making it now the original color, *aka* 100%
    - Lightened gray brackground on `pressed` state by 50%

---

<details><summary><b>Comparison screenshots</b></summary>

| Before | After |
| - | - |
|![1_old](https://github.com/godotengine/godot/assets/6501975/2ad2b80e-bfeb-4408-bb2a-8e48837ab113) |![1_new](https://github.com/godotengine/godot/assets/6501975/bba4d9c8-609b-4fb6-9252-db8c486a7078) |
|![2_old](https://github.com/godotengine/godot/assets/6501975/406c7c6b-4d68-4afd-90c4-889f9ae0ce6b) |![2_new](https://github.com/godotengine/godot/assets/6501975/b4bf4c6b-a561-473b-be44-a621b3a0ec2d) |
|![3_old](https://github.com/godotengine/godot/assets/6501975/72afa890-ad5b-4e21-907b-6c5e16714913) |![3_new](https://github.com/godotengine/godot/assets/6501975/e5e0ecfd-9891-4bb0-b917-ae760037e27e) |
|![4_old](https://github.com/godotengine/godot/assets/6501975/47f2ff07-b639-4b1c-8f2c-7a2a57464198) |![4_new](https://github.com/godotengine/godot/assets/6501975/24c28a0a-1cce-49c7-b8a5-d071a7a755c8) |
|![5_old](https://github.com/godotengine/godot/assets/6501975/d8a87965-5672-4a0a-b586-995b8c4c86b0) |![5_new](https://github.com/godotengine/godot/assets/6501975/3f640cb4-0e3b-435d-8f85-81b33a77b683) |
|![6_old](https://github.com/godotengine/godot/assets/6501975/a82a1f5e-3bd7-4c61-ac76-3a2e888ccaeb) |![6_new](https://github.com/godotengine/godot/assets/6501975/bb4767e7-c3d7-4d8b-a8d8-cad7a5e94a93) |
|![7_old](https://github.com/godotengine/godot/assets/6501975/ba13f2b6-fc7a-4b81-a375-9641f1ba83c9) |![7_new](https://github.com/godotengine/godot/assets/6501975/8cb453b0-5fe3-420b-8539-57fceaad17c4) |

</details>