### PR TITLE
Fix `ColorPicker`'s RAW mode colors and values

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -45,8 +45,12 @@ String ColorModeRGB::get_slider_label(int idx) const {
 
 float ColorModeRGB::get_slider_max(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider max value.");
-	Color color = color_picker->get_pick_color();
-	return next_power_of_2(MAX(255, color.components[idx] * 255.0)) - 1;
+	return slider_max[idx];
+}
+
+float ColorModeRGB::get_spinbox_max(int idx) const {
+	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get spinbox max value.");
+	return spinbox_max[idx];
 }
 
 float ColorModeRGB::get_slider_value(int idx) const {
@@ -219,6 +223,11 @@ float ColorModeRAW::get_slider_max(int idx) const {
 	return slider_max[idx];
 }
 
+float ColorModeRAW::get_spinbox_max(int idx) const {
+	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get spinbox max value.");
+	return spinbox_max[idx];
+}
+
 float ColorModeRAW::get_slider_value(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider value.");
 	return color_picker->get_pick_color().components[idx];
@@ -252,30 +261,27 @@ void ColorModeRAW::slider_draw(int p_which) {
 		left_color.a = 0;
 		right_color = color;
 		right_color.a = 1;
-
-		col.set(0, left_color);
-		col.set(1, right_color);
-		col.set(2, right_color);
-		col.set(3, left_color);
-		pos.set(0, Vector2(0, 0));
-		pos.set(1, Vector2(size.x, 0));
-		pos.set(2, Vector2(size.x, margin));
-		pos.set(3, Vector2(0, margin));
-
-		slider->draw_polygon(pos, col);
-	}
-}
-
-bool ColorModeRAW::apply_theme() const {
-	for (int i = 0; i < 4; i++) {
-		HSlider *slider = color_picker->get_slider(i);
-		slider->remove_theme_icon_override("grabber");
-		slider->remove_theme_icon_override("grabber_highlight");
-		slider->remove_theme_style_override("slider");
-		slider->remove_theme_constant_override("grabber_offset");
+	} else {
+		left_color = Color(
+				p_which == 0 ? 0 : color.r,
+				p_which == 1 ? 0 : color.g,
+				p_which == 2 ? 0 : color.b);
+		right_color = Color(
+				p_which == 0 ? 1 : color.r,
+				p_which == 1 ? 1 : color.g,
+				p_which == 2 ? 1 : color.b);
 	}
 
-	return true;
+	col.set(0, left_color);
+	col.set(1, right_color);
+	col.set(2, right_color);
+	col.set(3, left_color);
+	pos.set(0, Vector2(0, 0));
+	pos.set(1, Vector2(size.x, 0));
+	pos.set(2, Vector2(size.x, margin));
+	pos.set(3, Vector2(0, margin));
+
+	slider->draw_polygon(pos, col);
 }
 
 void ColorModeOKHSL::_value_changed() {

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -46,6 +46,8 @@ public:
 	virtual float get_spinbox_arrow_step() const { return get_slider_step(); }
 	virtual String get_slider_label(int idx) const = 0;
 	virtual float get_slider_max(int idx) const = 0;
+	virtual float get_spinbox_max(int idx) const = 0;
+	virtual bool can_allow_greater() const { return false; }
 	virtual float get_slider_value(int idx) const = 0;
 
 	virtual Color get_color() const = 0;
@@ -54,7 +56,6 @@ public:
 
 	virtual void slider_draw(int p_which) = 0;
 	virtual bool apply_theme() const { return false; }
-	virtual ColorPicker::PickerShapeType get_shape_override() const { return ColorPicker::SHAPE_MAX; }
 
 	ColorMode(ColorPicker *p_color_picker);
 	virtual ~ColorMode() {}
@@ -72,6 +73,7 @@ public:
 	virtual float get_slider_step() const override { return 1.0; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual float get_spinbox_max(int idx) const override { return get_slider_max(idx); }
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
@@ -87,12 +89,16 @@ public:
 class ColorModeRGB : public ColorMode {
 public:
 	String labels[3] = { "R", "G", "B" };
+	float slider_max[4] = { 255, 255, 255, 255 };
+	float spinbox_max[4] = { 2550, 2550, 2550, 255 };
 
 	virtual String get_name() const override { return "RGB"; }
 
 	virtual float get_slider_step() const override { return 1; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual float get_spinbox_max(int idx) const override;
+	virtual bool can_allow_greater() const override { return true; }
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
@@ -106,20 +112,21 @@ public:
 class ColorModeRAW : public ColorMode {
 public:
 	String labels[3] = { "R", "G", "B" };
-	float slider_max[4] = { 100, 100, 100, 1 };
+	float slider_max[4] = { 1, 1, 1, 1 };
+	float spinbox_max[4] = { 10, 10, 10, 255 };
 
 	virtual String get_name() const override { return "RAW"; }
 
-	virtual float get_slider_step() const override { return 0.001; }
-	virtual float get_spinbox_arrow_step() const override { return 0.01; }
+	virtual float get_slider_step() const override { return 1.0 / 255.0; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual float get_spinbox_max(int idx) const override;
+	virtual bool can_allow_greater() const override { return true; }
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
 
 	virtual void slider_draw(int p_which) override;
-	virtual bool apply_theme() const override;
 
 	ColorModeRAW(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker) {}
@@ -138,6 +145,7 @@ public:
 	virtual float get_slider_step() const override { return 1.0; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual float get_spinbox_max(int idx) const override { return get_slider_max(idx); }
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
@@ -145,7 +153,6 @@ public:
 	virtual void _value_changed() override;
 
 	virtual void slider_draw(int p_which) override;
-	virtual ColorPicker::PickerShapeType get_shape_override() const override { return ColorPicker::SHAPE_OKHSL_CIRCLE; }
 
 	ColorModeOKHSL(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker) {}

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -34,6 +34,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/popup.h"
+#include "scene/gui/spin_box.h"
 
 class AspectRatioContainer;
 class ColorMode;
@@ -47,7 +48,6 @@ class MarginContainer;
 class MenuButton;
 class OptionButton;
 class PopupMenu;
-class SpinBox;
 class StyleBoxFlat;
 class TextureRect;
 
@@ -276,7 +276,6 @@ private:
 	void _copy_color_to_hsv();
 	void _copy_hsv_to_color();
 
-	PickerShapeType _get_actual_shape() const;
 	void create_slider(GridContainer *gc, int idx);
 	void _reset_sliders_theme();
 	void _html_submitted(const String &p_html);
@@ -459,5 +458,19 @@ public:
 
 VARIANT_ENUM_CAST(ColorPicker::PickerShapeType);
 VARIANT_ENUM_CAST(ColorPicker::ColorModeType);
+
+class OverbrightSpinBox : public SpinBox {
+	GDCLASS(OverbrightSpinBox, SpinBox)
+
+	HSlider *slider = nullptr;
+
+	void _update();
+
+protected:
+	virtual void _value_changed(double p_value) override;
+
+public:
+	OverbrightSpinBox(HSlider *p_slider);
+};
 
 #endif // COLOR_PICKER_H


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/62894

- Makes RAW sliders colored same as RGB mode.
- Fix RAW mode maximum values, from 100 to 1.0.
- Allow RGB and RAW modes to have greater values for overbright.
- Changes RAW step value to 1.0 / 255.0, to match the RGB mode values when changed.
- Prevent OKHSL mode from overriding the picker shape.
- Fix conversion between RAW and RGB modes when color is overbright.