### PR TITLE
Add colors to SCons error/warning messages

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -16,6 +16,29 @@ base_folder_only = os.path.basename(os.path.normpath(base_folder_path))
 # for SCU in scu_builders.py
 _scu_folders = set()
 
+colors = {}
+# Colors are disabled in non-TTY environments such as pipes. This means
+# that if output is redirected to a file, it won't contain color codes.
+# Colors are always enabled on continuous integration.
+if sys.stdout.isatty() or os.environ.get("CI"):
+    colors["gray"] = "\033[90m"
+    colors["regular_blue"] = "\033[0;94m"
+    colors["bold_red"] = "\033[1;91m"
+    colors["bold_yellow"] = "\033[1;93m"
+    colors["bold_blue"] = "\033[1;94m"
+    colors["bold"] = "\033[1m"
+    colors["regular"] = "\033[22m"
+    colors["reset"] = "\033[0m"
+else:
+    colors["gray"] = ""
+    colors["regular_blue"] = ""
+    colors["bold_red"] = ""
+    colors["bold_yellow"] = ""
+    colors["bold_blue"] = ""
+    colors["bold"] = ""
+    colors["regular"] = ""
+    colors["reset"] = ""
+
 
 def set_scu_folders(scu_folders):
     global _scu_folders
@@ -311,6 +334,27 @@ def get_cmdline_bool(option, default):
         return default
 
 
+def print_info(message):
+    """
+    Prints an informational message with formatting.
+    """
+    print(f"{colors['bold']}INFO:{colors['regular']} {message}{colors['reset']}")
+
+
+def print_warning(message):
+    """
+    Prints a warning message with formatting.
+    """
+    print(f"{colors['bold_yellow']}WARNING:{colors['regular']} {message}{colors['reset']}")
+
+
+def print_error(message):
+    """
+    Prints an error message with formatting.
+    """
+    print(f"{colors['bold_red']}ERROR:{colors['regular']} {message}{colors['reset']}")
+
+
 def detect_modules(search_path, recursive=False):
     """Detects and collects a list of C++ modules at specified path
 
@@ -569,44 +613,31 @@ def use_windows_spawn_fix(self, platform=None):
 
 
 def no_verbose(sys, env):
-    colors = {}
-
-    # Colors are disabled in non-TTY environments such as pipes. This means
-    # that if output is redirected to a file, it will not contain color codes
-    if sys.stdout.isatty():
-        colors["blue"] = "\033[0;94m"
-        colors["bold_blue"] = "\033[1;94m"
-        colors["reset"] = "\033[0m"
-    else:
-        colors["blue"] = ""
-        colors["bold_blue"] = ""
-        colors["reset"] = ""
-
     # There is a space before "..." to ensure that source file names can be
     # Ctrl + clicked in the VS Code terminal.
     compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     java_compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     compile_shared_source_message = "{}Compiling shared {}$SOURCE{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     link_program_message = "{}Linking Program {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     link_library_message = "{}Linking Static Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     ranlib_library_message = "{}Ranlib Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     link_shared_library_message = "{}Linking Shared Library {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
-        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+        colors["regular_blue"], colors["bold_blue"], colors["regular_blue"], colors["reset"]
     )
     compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
         colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
@@ -961,9 +992,9 @@ def show_progress(env):
     from SCons.Script import Progress, Command, AlwaysBuild
 
     screen = sys.stdout
-    # Progress reporting is not available in non-TTY environments since it
-    # messes with the output (for example, when writing to a file)
-    show_progress = env["progress"] and sys.stdout.isatty()
+    # Progress reporting is not available in non-TTY environments unless it's continuous integration,
+    # since it messes with the output (for example, when writing to a file).
+    show_progress = env["progress"] and (sys.stdout.isatty() or os.environ.get("CI"))
     node_count = 0
     node_count_max = 0
     node_count_interval = 1

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -2,6 +2,7 @@ import os
 import sys
 import platform
 import subprocess
+from methods import print_error, print_info, print_warning
 
 from typing import TYPE_CHECKING
 
@@ -76,24 +77,24 @@ def get_flags():
 # Check if Android NDK version is installed
 # If not, install it.
 def install_ndk_if_needed(env: "SConsEnvironment"):
-    print("Checking for Android NDK...")
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
         sdkmanager = sdk_root + "/cmdline-tools/latest/bin/sdkmanager" + extension
         if os.path.exists(sdkmanager):
             # Install the Android NDK
-            print("Installing Android NDK...")
+            print_info("Installing Android NDK...")
             ndk_download_args = "ndk;" + get_ndk_version()
             subprocess.check_call([sdkmanager, ndk_download_args])
         else:
-            print("Cannot find " + sdkmanager)
-            print(
-                "Please ensure ANDROID_HOME is correct and cmdline-tools are installed, or install NDK version "
+            print_error(
+                "Cannot find "
+                + sdkmanager
+                + "Please ensure ANDROID_HOME is correct and cmdline-tools are installed, or install NDK version "
                 + get_ndk_version()
                 + " manually."
             )
-            sys.exit()
+            sys.exit(200)
     env["ANDROID_NDK_ROOT"] = get_android_ndk_root(env)
 
 
@@ -101,15 +102,15 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for Android. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     if get_min_sdk_version(env["ndk_platform"]) < get_min_target_api():
-        print(
-            "WARNING: minimum supported Android target api is %d. Forcing target api %d."
+        print_warning(
+            "Minimum supported Android target API is %d. Forcing target API %d."
             % (get_min_target_api(), get_min_target_api())
         )
         env["ndk_platform"] = "android-" + str(get_min_target_api())

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from methods import detect_darwin_sdk_path
+from methods import detect_darwin_sdk_path, print_error
 
 from typing import TYPE_CHECKING
 
@@ -59,11 +59,11 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for iOS. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     ## LTO
 
@@ -117,7 +117,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["arch"] == "x86_64":
         if not env["ios_simulator"]:
-            print("ERROR: Building for iOS with 'arch=x86_64' requires 'ios_simulator=yes'.")
+            print_error("Building for iOS with 'arch=x86_64' requires 'ios_simulator=yes'.")
             sys.exit(255)
 
         env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "10.9"

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import sys
-from methods import get_compiler_version, using_gcc
+from methods import get_compiler_version, using_gcc, print_error, print_info, print_warning
 from platform_methods import detect_arch
 
 from typing import TYPE_CHECKING
@@ -20,7 +20,7 @@ def can_build():
 
     pkgconf_error = os.system("pkg-config --version > /dev/null")
     if pkgconf_error:
-        print("Error: pkg-config not found. Aborting.")
+        print_error("pkg-config not found. Aborting.")
         return False
 
     return True
@@ -75,7 +75,7 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for Linux / *BSD. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
@@ -128,7 +128,9 @@ def configure(env: "SConsEnvironment"):
                         found_wrapper = True
                         break
                 if not found_wrapper:
-                    print("Couldn't locate mold installation path. Make sure it's installed in /usr or /usr/local.")
+                    print_error(
+                        "Couldn't locate mold installation path. Make sure it's installed in /usr or /usr/local."
+                    )
                     sys.exit(255)
             else:
                 env.Append(LINKFLAGS=["-fuse-ld=mold"])
@@ -185,7 +187,7 @@ def configure(env: "SConsEnvironment"):
     if env["lto"] != "none":
         if env["lto"] == "thin":
             if not env["use_llvm"]:
-                print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
+                print_error("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
                 sys.exit(255)
             env.Append(CCFLAGS=["-flto=thin"])
             env.Append(LINKFLAGS=["-flto=thin"])
@@ -209,7 +211,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["wayland"]:
         if os.system("wayland-scanner -v 2>/dev/null") != 0:
-            print("wayland-scanner not found. Disabling Wayland support.")
+            print_warning("wayland-scanner not found. Disabling Wayland support.")
             env["wayland"] = False
 
     if env["touch"]:
@@ -227,7 +229,7 @@ def configure(env: "SConsEnvironment"):
         env["builtin_harfbuzz"],
     ]
     if (not all(ft_linked_deps)) and any(ft_linked_deps):  # All or nothing.
-        print(
+        print_error(
             "These libraries should be either all builtin, or all system provided:\n"
             "freetype, libpng, zlib, graphite, harfbuzz.\n"
             "Please specify `builtin_<name>=no` for all of them, or none."
@@ -318,7 +320,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config fontconfig --cflags --libs")
                 env.Append(CPPDEFINES=["FONTCONFIG_ENABLED"])
             else:
-                print("Warning: fontconfig development libraries not found. Disabling the system fonts support.")
+                print_warning("fontconfig development libraries not found. Disabling the system fonts support.")
                 env["fontconfig"] = False
         else:
             env.Append(CPPDEFINES=["FONTCONFIG_ENABLED"])
@@ -329,7 +331,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config alsa --cflags --libs")
                 env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
             else:
-                print("Warning: ALSA development libraries not found. Disabling the ALSA audio driver.")
+                print_warning("ALSA development libraries not found. Disabling the ALSA audio driver.")
                 env["alsa"] = False
         else:
             env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
@@ -340,7 +342,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config libpulse --cflags --libs")
                 env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
             else:
-                print("Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
+                print_warning("PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
                 env["pulseaudio"] = False
         else:
             env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED", "_REENTRANT"])
@@ -351,7 +353,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config dbus-1 --cflags --libs")
                 env.Append(CPPDEFINES=["DBUS_ENABLED"])
             else:
-                print("Warning: D-Bus development libraries not found. Disabling screensaver prevention.")
+                print_warning("D-Bus development libraries not found. Disabling screensaver prevention.")
                 env["dbus"] = False
         else:
             env.Append(CPPDEFINES=["DBUS_ENABLED"])
@@ -362,7 +364,7 @@ def configure(env: "SConsEnvironment"):
                 env.ParseConfig("pkg-config speech-dispatcher --cflags --libs")
                 env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
             else:
-                print("Warning: speech-dispatcher development libraries not found. Disabling text to speech support.")
+                print_warning("speech-dispatcher development libraries not found. Disabling text to speech support.")
                 env["speechd"] = False
         else:
             env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
@@ -373,11 +375,11 @@ def configure(env: "SConsEnvironment"):
             env.Append(CPPDEFINES=["XKB_ENABLED"])
         else:
             if env["wayland"]:
-                print("Error: libxkbcommon development libraries required by Wayland not found. Aborting.")
+                print_error("libxkbcommon development libraries required by Wayland not found. Aborting.")
                 sys.exit(255)
             else:
-                print(
-                    "Warning: libxkbcommon development libraries not found. Disabling dead key composition and key label support."
+                print_warning(
+                    "libxkbcommon development libraries not found. Disabling dead key composition and key label support."
                 )
     else:
         env.Append(CPPDEFINES=["XKB_ENABLED"])
@@ -390,7 +392,7 @@ def configure(env: "SConsEnvironment"):
                     env.ParseConfig("pkg-config libudev --cflags --libs")
                     env.Append(CPPDEFINES=["UDEV_ENABLED"])
                 else:
-                    print("Warning: libudev development libraries not found. Disabling controller hotplugging support.")
+                    print_warning("libudev development libraries not found. Disabling controller hotplugging support.")
                     env["udev"] = False
             else:
                 env.Append(CPPDEFINES=["UDEV_ENABLED"])
@@ -416,31 +418,31 @@ def configure(env: "SConsEnvironment"):
     if env["x11"]:
         if not env["use_sowrap"]:
             if os.system("pkg-config --exists x11"):
-                print("Error: X11 libraries not found. Aborting.")
+                print_error("X11 libraries not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config x11 --cflags --libs")
             if os.system("pkg-config --exists xcursor"):
-                print("Error: Xcursor library not found. Aborting.")
+                print_error("Xcursor library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xcursor --cflags --libs")
             if os.system("pkg-config --exists xinerama"):
-                print("Error: Xinerama library not found. Aborting.")
+                print_error("Xinerama library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xinerama --cflags --libs")
             if os.system("pkg-config --exists xext"):
-                print("Error: Xext library not found. Aborting.")
+                print_error("Xext library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xext --cflags --libs")
             if os.system("pkg-config --exists xrandr"):
-                print("Error: XrandR library not found. Aborting.")
+                print_error("XrandR library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xrandr --cflags --libs")
             if os.system("pkg-config --exists xrender"):
-                print("Error: XRender library not found. Aborting.")
+                print_error("XRender library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xrender --cflags --libs")
             if os.system("pkg-config --exists xi"):
-                print("Error: Xi library not found. Aborting.")
+                print_error("Xi library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xi --cflags --libs")
         env.Append(CPPDEFINES=["X11_ENABLED"])
@@ -448,20 +450,20 @@ def configure(env: "SConsEnvironment"):
     if env["wayland"]:
         if not env["use_sowrap"]:
             if os.system("pkg-config --exists libdecor-0"):
-                print("Warning: libdecor development libraries not found. Disabling client-side decorations.")
+                print_warning("libdecor development libraries not found. Disabling client-side decorations.")
                 env["libdecor"] = False
             else:
                 env.ParseConfig("pkg-config libdecor-0 --cflags --libs")
             if os.system("pkg-config --exists wayland-client"):
-                print("Error: Wayland client library not found. Aborting.")
+                print_error("Wayland client library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-client --cflags --libs")
             if os.system("pkg-config --exists wayland-cursor"):
-                print("Error: Wayland cursor library not found. Aborting.")
+                print_error("Wayland cursor library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-cursor --cflags --libs")
             if os.system("pkg-config --exists wayland-egl"):
-                print("Error: Wayland EGL library not found. Aborting.")
+                print_error("Wayland EGL library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-egl --cflags --libs")
 
@@ -492,7 +494,7 @@ def configure(env: "SConsEnvironment"):
         # The default crash handler depends on glibc, so if the host uses
         # a different libc (BSD libc, musl), fall back to libexecinfo.
         if not "execinfo" in env:
-            print("Note: Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.")
+            print_info("Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.")
             env["execinfo"] = True
 
         if env["execinfo"]:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from methods import detect_darwin_sdk_path, get_compiler_version, is_vanilla_clang
+from methods import detect_darwin_sdk_path, get_compiler_version, is_vanilla_clang, print_error
 from platform_methods import detect_arch, detect_mvk
 
 from typing import TYPE_CHECKING
@@ -64,11 +64,11 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for macOS. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     ## Build type
 
@@ -86,12 +86,10 @@ def configure(env: "SConsEnvironment"):
 
     # CPU architecture.
     if env["arch"] == "arm64":
-        print("Building for macOS 11.0+.")
         env.Append(ASFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
         env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
     elif env["arch"] == "x86_64":
-        print("Building for macOS 10.13+.")
         env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
@@ -254,7 +252,7 @@ def configure(env: "SConsEnvironment"):
             if mvk_path != "":
                 env.Append(LINKFLAGS=["-L" + mvk_path])
             else:
-                print(
-                    "MoltenVK SDK installation directory not found, use 'vulkan_sdk_path' SCons parameter to specify SDK path."
+                print_error(
+                    "MoltenVK SDK installation directory not found. Use the `vulkan_sdk_path=<path>` SCons option to specify the path to the SDK folder."
                 )
                 sys.exit(255)

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -10,7 +10,7 @@ from emscripten_helpers import (
     create_template_zip,
     get_template_zip_path,
 )
-from methods import get_compiler_version
+from methods import get_compiler_version, print_error, print_info, print_warning
 from SCons.Util import WhereIs
 from typing import TYPE_CHECKING
 
@@ -85,16 +85,16 @@ def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["wasm32"]
     if env["arch"] not in supported_arches:
-        print(
+        print_error(
             'Unsupported CPU architecture "%s" for iOS. Supported architectures are: %s.'
             % (env["arch"], ", ".join(supported_arches))
         )
-        sys.exit()
+        sys.exit(255)
 
     try:
         env["initial_memory"] = int(env["initial_memory"])
     except Exception:
-        print("Initial memory must be a valid integer")
+        print_error("Initial memory must be a valid integer")
         sys.exit(255)
 
     ## Build type
@@ -109,7 +109,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-s", "ASSERTIONS=1"])
 
     if env.editor_build and env["initial_memory"] < 64:
-        print('Note: Forcing "initial_memory=64" as it is required for the web editor.')
+        print_info("Forcing `initial_memory=64` as it is required for the web editor.")
         env["initial_memory"] = 64
 
     env.Append(LINKFLAGS=["-s", "INITIAL_MEMORY=%sMB" % env["initial_memory"]])
@@ -227,7 +227,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-s", "PTHREAD_POOL_SIZE=8"])
         env.Append(LINKFLAGS=["-s", "WASM_MEM_MAX=2048MB"])
     elif env["proxy_to_pthread"]:
-        print('"threads=no" support requires "proxy_to_pthread=no", disabling proxy to pthread.')
+        print_warning('"threads=no" support requires "proxy_to_pthread=no", disabling proxy to pthread.')
         env["proxy_to_pthread"] = False
 
     if env["lto"] != "none":
@@ -240,11 +240,11 @@ def configure(env: "SConsEnvironment"):
 
     if env["dlink_enabled"]:
         if env["proxy_to_pthread"]:
-            print("GDExtension support requires proxy_to_pthread=no, disabling proxy to pthread.")
+            print_warning("GDExtension support requires proxy_to_pthread=no, disabling proxy to pthread.")
             env["proxy_to_pthread"] = False
 
         if cc_semver < (3, 1, 14):
-            print("GDExtension support requires emscripten >= 3.1.14, detected: %s.%s.%s" % cc_semver)
+            print_error("GDExtension support requires emscripten >= 3.1.14, detected: %s.%s.%s" % cc_semver)
             sys.exit(255)
 
         env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])


### PR DESCRIPTION
This also includes various improvements to the messages:

- Remove some "success" messages that were printed on every build, such as the macOS minimum supported version (which is already mentioned in the documentation. Only the "error" variants of these messages are kept.
- Use gray color for the build timer printed at the end of each build, and only display 2 decimals.
- Use non-zero exit codes when exiting after some error messages that previously exited with a zero (success) exit code.
- Improve formatting of the Direct3D 12 missing dependencies message.
- Clarify how MSVC is detected in the message printed when it's detected.
- Force colored output on CI (it's non-interactive but can still display colors).

___

- This closes https://github.com/godotengine/godot-proposals/issues/9291.

## Preview

![Screenshot_20240207_202104](https://github.com/godotengine/godot/assets/180032/e58d6e24-c80f-4e2e-9d56-00b1453b8207)

![Screenshot_20240207_202502](https://github.com/godotengine/godot/assets/180032/9ac733b7-358c-4cca-8788-a24d793ad718)

![Screenshot_20240207_202726](https://github.com/godotengine/godot/assets/180032/32095b6c-b1ac-4e05-b2f9-0e67384472a8)

I also had automatic underlining of backticked text at some point, but I removed it for now. Let me know if you'd like me to readd it:

![Screenshot_20240207_201931](https://github.com/godotengine/godot/assets/180032/c629b62f-f5e2-408d-8700-1c1c5ed106ec)