### PR TITLE
Fix C# "out of sync" notice with external editors

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -24,6 +24,20 @@ namespace GodotTools.Build
         public static event Action<string> StdOutputReceived;
         public static event Action<string> StdErrorReceived;
 
+        public static DateTime LastValidBuildDateTime { get; private set; }
+
+        static BuildManager()
+        {
+            UpdateLastValidBuildDateTime();
+        }
+
+        public static void UpdateLastValidBuildDateTime()
+        {
+            var dllName = $"{GodotSharpDirs.ProjectAssemblyName}.dll";
+            var path = Path.Combine(GodotSharpDirs.ProjectBaseOutputPath, "Debug", dllName);
+            LastValidBuildDateTime = File.GetLastWriteTime(path);
+        }
+
         private static void RemoveOldIssuesFile(BuildInfo buildInfo)
         {
             string issuesFile = GetIssuesFilePath(buildInfo);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -89,7 +89,10 @@ namespace GodotTools.Build
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
 
             if (Internal.IsAssembliesReloadingNeeded())
+            {
+                BuildManager.UpdateLastValidBuildDateTime();
                 Internal.ReloadAssemblies(softReload: false);
+            }
         }
 
         private void RebuildProject()
@@ -107,7 +110,10 @@ namespace GodotTools.Build
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
 
             if (Internal.IsAssembliesReloadingNeeded())
+            {
+                BuildManager.UpdateLastValidBuildDateTime();
                 Internal.ReloadAssemblies(softReload: false);
+            }
         }
 
         private void CleanProject()

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -54,8 +54,6 @@ namespace GodotTools
 
         public bool SkipBuildBeforePlaying { get; set; } = false;
 
-        public DateTime LastValidBuildDateTime { get; private set; }
-
         [UsedImplicitly]
         private bool CreateProjectSolutionIfNeeded()
         {
@@ -441,21 +439,6 @@ namespace GodotTools
             }
         }
 
-        private void UpdateLastValidBuildDateTime()
-        {
-            var dllName = $"{GodotSharpDirs.ProjectAssemblyName}.dll";
-            var path = Path.Combine(GodotSharpDirs.ProjectBaseOutputPath, "Debug", dllName);
-            LastValidBuildDateTime = File.GetLastWriteTime(path);
-        }
-
-        private void BuildFinished(BuildResult buildResult)
-        {
-            if (buildResult == BuildResult.Success)
-            {
-                UpdateLastValidBuildDateTime();
-            }
-        }
-
         private void BuildStateChanged()
         {
             if (_bottomPanelBtn != null)
@@ -465,8 +448,6 @@ namespace GodotTools
         public override void _EnablePlugin()
         {
             base._EnablePlugin();
-
-            UpdateLastValidBuildDateTime();
 
             ProjectSettings.SettingsChanged += GodotSharpDirs.DetermineProjectLocation;
 
@@ -640,7 +621,6 @@ namespace GodotTools
             var inspectorPlugin = new InspectorPlugin();
             AddInspectorPlugin(inspectorPlugin);
             _inspectorPluginWeak = WeakRef(inspectorPlugin);
-            BuildManager.BuildFinished += BuildFinished;
 
             BuildManager.Initialize();
             RiderPathManager.Initialize();
@@ -657,7 +637,6 @@ namespace GodotTools
 
             // Custom signals aren't automatically disconnected currently.
             MSBuildPanel.BuildStateChanged -= BuildStateChanged;
-            BuildManager.BuildFinished -= BuildFinished;
         }
 
         public override void _ExitTree()

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -1,7 +1,7 @@
 using Godot;
+using GodotTools.Build;
 using GodotTools.Internals;
 using JetBrains.Annotations;
-using static GodotTools.Internals.Globals;
 
 namespace GodotTools
 {
@@ -16,14 +16,20 @@ namespace GodotTools
                 RestartTimer();
 
                 if (Internal.IsAssembliesReloadingNeeded())
+                {
+                    BuildManager.UpdateLastValidBuildDateTime();
                     Internal.ReloadAssemblies(softReload: false);
+                }
             }
         }
 
         private void TimerTimeout()
         {
             if (Internal.IsAssembliesReloadingNeeded())
+            {
+                BuildManager.UpdateLastValidBuildDateTime();
                 Internal.ReloadAssemblies(softReload: false);
+            }
         }
 
         [UsedImplicitly]

--- a/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorPlugin.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Godot;
+using GodotTools.Build;
 using GodotTools.Utils;
 
 namespace GodotTools.Inspector
@@ -24,7 +25,7 @@ namespace GodotTools.Inspector
             {
                 if (script is not CSharpScript) continue;
 
-                if (File.GetLastWriteTime(script.ResourcePath) > GodotSharpEditor.Instance.LastValidBuildDateTime)
+                if (File.GetLastWriteTime(script.ResourcePath) > BuildManager.LastValidBuildDateTime)
                 {
                     AddCustomControl(new InspectorOutOfSyncWarning());
                     break;


### PR DESCRIPTION
The notice introduced in #85869 wasn't being dequeued when building from an external IDE. This PR fixes it by changing what triggers our reevaluation of the last valid build time. We used to react only to Godot's internal build process. We're now reacting to assembly reload, which is triggered both by building from Godot, and from the watcher. 

Thanks @Delsin-Yu @zaevi for pointing out the issue.