### PR TITLE
Support setting 3.x `material/#` properties on MeshInstance3D

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -62,8 +62,19 @@ bool MeshInstance3D::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 
-	if (p_name.operator String().begins_with("surface_material_override/")) {
-		int idx = p_name.operator String().get_slicec('/', 1).to_int();
+	String name = p_name;
+
+#ifndef DISABLE_DEPRECATED
+	if (name.begins_with("material/")) {
+		WARN_DEPRECATED_MSG("This mesh uses an old deprecated parameter name. Consider re-saving this scene in order for it to continue working in future versions." +
+				(is_inside_tree() ? vformat(" Path: \"%s\"", get_path()) : (get_name().is_empty() ? String() : vformat(" Name: \"%s\"", get_name()))));
+	}
+	if (name.begins_with("surface_material_override/") || name.begins_with("material/"))
+#else
+	if (name.begins_with("surface_material_override/"))
+#endif
+	{
+		int idx = name.get_slicec('/', 1).to_int();
 
 		if (idx >= surface_override_materials.size() || idx < 0) {
 			return false;


### PR DESCRIPTION
This PR introduces support for setting the old `material/#` properties on MeshInstance3D, which were renamed to `surface_material_override/#` in 4.x. This is only supported when using `set()` (i.e. during the initial load) and emits a warning when doing so.

Note that this should not conflict with ImporterMesh; This will only trigger if the property is named `material/{num}`. I have checked, and MeshInstance3D was the only resource that stored a property named `material` INI style in either 3.x or 4.x.