### PR TITLE
Use indeterminate progressbars for editor downloads (export templates & assets)

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -146,6 +146,9 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 
 	install_options_vb->hide();
 	download_progress_hb->show();
+	download_progress_bar->show();
+	download_progress_bar->set_indeterminate(true);
+
 	_set_current_progress_status(TTR("Starting the download..."));
 
 	download_templates->set_download_file(EditorPaths::get_singleton()->get_cache_dir().path_join("tmp_templates.tpz"));
@@ -159,6 +162,7 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 	Error err = download_templates->request(p_url);
 	if (err != OK) {
 		_set_current_progress_status(TTR("Error requesting URL:") + " " + p_url, true);
+		download_progress_hb->hide();
 		return;
 	}
 
@@ -357,10 +361,10 @@ bool ExportTemplateManager::_humanize_http_status(HTTPRequest *p_request, String
 }
 
 void ExportTemplateManager::_set_current_progress_status(const String &p_status, bool p_error) {
-	download_progress_bar->hide();
 	download_progress_label->set_text(p_status);
 
 	if (p_error) {
+		download_progress_bar->hide();
 		download_progress_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 	} else {
 		download_progress_label->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("Label")));
@@ -369,6 +373,7 @@ void ExportTemplateManager::_set_current_progress_status(const String &p_status,
 
 void ExportTemplateManager::_set_current_progress_value(float p_value, const String &p_status) {
 	download_progress_bar->show();
+	download_progress_bar->set_indeterminate(false);
 	download_progress_bar->set_value(p_value);
 	download_progress_label->set_text(p_status);
 }
@@ -955,6 +960,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	download_progress_bar->set_max(1);
 	download_progress_bar->set_value(0);
 	download_progress_bar->set_step(0.01);
+	download_progress_bar->set_editor_preview_indeterminate(true);
 	download_progress_hb->add_child(download_progress_bar);
 
 	download_progress_label = memnew(Label);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -384,6 +384,10 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 		} break;
 	}
 
+	// Make the progress bar invisible but don't reflow other Controls around it.
+	progress->set_modulate(Color(0, 0, 0, 0));
+	progress->set_indeterminate(false);
+
 	if (!error_text.is_empty()) {
 		download_error->set_text(TTR("Asset Download Error:") + "\n" + error_text);
 		download_error->popup_centered();
@@ -394,8 +398,6 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 
 	install_button->set_disabled(false);
 	status->set_text(TTR("Ready to install!"));
-	// Make the progress bar invisible but don't reflow other Controls around it.
-	progress->set_modulate(Color(0, 0, 0, 0));
 
 	set_process(false);
 
@@ -436,13 +438,13 @@ void EditorAssetLibraryItemDownload::_notification(int p_what) {
 
 			if (cstatus == HTTPClient::STATUS_BODY) {
 				if (download->get_body_size() > 0) {
+					progress->set_indeterminate(false);
 					status->set_text(vformat(
 							TTR("Downloading (%s / %s)..."),
 							String::humanize_size(download->get_downloaded_bytes()),
 							String::humanize_size(download->get_body_size())));
 				} else {
-					// Total file size is unknown, so it cannot be displayed.
-					progress->set_modulate(Color(0, 0, 0, 0));
+					progress->set_indeterminate(true);
 					status->set_text(vformat(
 							TTR("Downloading...") + " (%s)",
 							String::humanize_size(download->get_downloaded_bytes())));
@@ -508,6 +510,7 @@ void EditorAssetLibraryItemDownload::_make_request() {
 	if (err != OK) {
 		status->set_text(TTR("Error making request"));
 	} else {
+		progress->set_indeterminate(true);
 		set_process(true);
 	}
 }
@@ -548,6 +551,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	status = memnew(Label(TTR("Idle")));
 	vb->add_child(status);
 	progress = memnew(ProgressBar);
+	progress->set_editor_preview_indeterminate(true);
 	vb->add_child(progress);
 
 	HBoxContainer *hb2 = memnew(HBoxContainer);


### PR DESCRIPTION
Now that we have [indeterminate progress bars](https://github.com/godotengine/godot/pull/87318), I've implemented their use for the most obvious case: downloads.
There might be other places that could use them but it'd involve changes to `ProgressDialog` and tasks, haven't looked through that as of yet.

Before & After:

https://github.com/godotengine/godot/assets/138269/7643d5d1-dd94-441d-8a95-30d5211db6fb

https://github.com/godotengine/godot/assets/138269/1184a474-176f-4311-b7ab-0de7bd8de632

---

https://github.com/godotengine/godot/assets/138269/5eab6a2d-7eef-43d3-8613-63170d2ea826

https://github.com/godotengine/godot/assets/138269/ddec0abd-18a9-4813-a286-e7f791e2d575


(I was connected to a slow VPN for testing I swear I'm not on dial-up or something 😅)
