### PR TITLE
ThorVG: update from v0.12.4 to v0.12.5

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -856,13 +856,13 @@ instead of `miniz.h` as an external dependency.
 ## thorvg
 
 - Upstream: https://github.com/thorvg/thorvg
-- Version: 0.12.4 (331839d49368e19ca15f35abee5ac541dbf23637, 2024)
+- Version: 0.12.5 (9c8eeaab9629b5d241b1092a3398fe6351c259cd, 2024)
 - License: MIT
 
 Files extracted from upstream source:
 
 See `thorvg/update-thorvg.sh` for extraction instructions. Set the version
-number and run the script.
+number and run the script and apply patches from the `patches` folder.
 
 
 ## vhacd

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -10,5 +10,5 @@
 // For internal debugging:
 //#define THORVG_LOG_ENABLED
 
-#define THORVG_VERSION_STRING "0.12.4"
+#define THORVG_VERSION_STRING "0.12.5"
 #endif

--- a/thirdparty/thorvg/patches/Fix_compiler_shadowing_warning.patch
+++ b/thirdparty/thorvg/patches/Fix_compiler_shadowing_warning.patch
@@ -1,0 +1,23 @@
+diff --git a/thirdparty/thorvg/src/common/tvgLock.h b/thirdparty/thorvg/src/common/tvgLock.h
+index e6d993a41e..5dd3d5a624 100644
+--- a/thirdparty/thorvg/src/common/tvgLock.h
++++ b/thirdparty/thorvg/src/common/tvgLock.h
+@@ -38,10 +38,10 @@ namespace tvg {
+     {
+         Key* key = nullptr;
+
+-        ScopedLock(Key& key)
++        ScopedLock(Key& k)
+         {
+-            key.mtx.lock();
+-            this->key = &key;
++            k.mtx.lock();
++            key = &k;
+         }
+
+         ~ScopedLock()
+@@ -68,3 +68,4 @@ namespace tvg {
+ #endif //THORVG_THREAD_SUPPORT
+
+ #endif //_TVG_LOCK_H_
++

--- a/thirdparty/thorvg/src/common/tvgLock.h
+++ b/thirdparty/thorvg/src/common/tvgLock.h
@@ -38,10 +38,10 @@ namespace tvg {
     {
         Key* key = nullptr;
 
-        ScopedLock(Key& p_key)
+        ScopedLock(Key& k)
         {
-            p_key.mtx.lock();
-            key = &p_key;
+            k.mtx.lock();
+            key = &k;
         }
 
         ~ScopedLock()

--- a/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/external_png/tvgPngLoader.cpp
@@ -84,14 +84,15 @@ bool PngLoader::read()
 
     if (w == 0 || h == 0) return false;
 
-    png_bytep buffer;
-    image->format = PNG_FORMAT_BGRA;
-    buffer = static_cast<png_bytep>(malloc(PNG_IMAGE_SIZE((*image))));
-    if (!buffer) {
-        //out of memory, only time when libpng doesnt free its data
-        png_image_free(image);
-        return false;
+    if (cs == ColorSpace::ARGB8888 || cs == ColorSpace::ARGB8888S) {
+        image->format = PNG_FORMAT_BGRA;
+        surface.cs = ColorSpace::ARGB8888;
+    } else {
+        image->format = PNG_FORMAT_RGBA;
+        surface.cs = ColorSpace::ABGR8888;
     }
+
+    auto buffer = static_cast<png_bytep>(malloc(PNG_IMAGE_SIZE((*image))));
     if (!png_image_finish_read(image, NULL, buffer, 0, NULL)) {
         free(buffer);
         return false;
@@ -103,7 +104,7 @@ bool PngLoader::read()
     surface.w = (uint32_t)w;
     surface.h = (uint32_t)h;
     surface.channelSize = sizeof(uint32_t);
-    surface.cs = ColorSpace::ARGB8888;
+    //TODO: we can acquire a pre-multiplied image. See "png_structrp"
     surface.premultiplied = false;
 
     clear();

--- a/thirdparty/thorvg/src/loaders/png/tvgPngLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/png/tvgPngLoader.cpp
@@ -35,6 +35,8 @@ void PngLoader::run(unsigned tid)
     auto width = static_cast<unsigned>(w);
     auto height = static_cast<unsigned>(h);
 
+    state.info_raw.colortype = LCT_RGBA;   //request this image format
+
     if (lodepng_decode(&surface.buf8, &width, &height, &state, data, size)) {
         TVGERR("PNG", "Failed to decode image");
     }
@@ -43,8 +45,11 @@ void PngLoader::run(unsigned tid)
     surface.stride = width;
     surface.w = width;
     surface.h = height;
+    surface.cs = ColorSpace::ABGR8888;
     surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = false;
+
+    if (state.info_png.color.colortype == LCT_RGBA) surface.premultiplied = false;
+    else surface.premultiplied = true;
 }
 
 
@@ -93,9 +98,6 @@ bool PngLoader::open(const string& path)
     w = static_cast<float>(width);
     h = static_cast<float>(height);
 
-    if (state.info_png.color.colortype == LCT_RGBA) surface.cs = ColorSpace::ABGR8888;
-    else surface.cs = ColorSpace::ARGB8888;
-
     ret = true;
 
     goto finalize;
@@ -124,8 +126,6 @@ bool PngLoader::open(const char* data, uint32_t size, bool copy)
     w = static_cast<float>(width);
     h = static_cast<float>(height);
     this->size = size;
-
-    surface.cs = ColorSpace::ABGR8888;
 
     return true;
 }

--- a/thirdparty/thorvg/src/renderer/tvgCommon.h
+++ b/thirdparty/thorvg/src/renderer/tvgCommon.h
@@ -63,7 +63,7 @@ using namespace tvg;
 #define TVG_CLASS_ID_RADIAL    5
 #define TVG_CLASS_ID_TEXT      6
 
-enum class FileType { Tvg = 0, Svg, Ttf, Lottie, Raw, Png, Jpg, Webp, Gif, Unknown };
+enum class FileType { Png = 0, Jpg, Webp, Tvg, Svg, Lottie, Ttf, Raw, Gif, Unknown };
 
 using Size = Point;
 

--- a/thirdparty/thorvg/src/renderer/tvgLoadModule.h
+++ b/thirdparty/thorvg/src/renderer/tvgLoadModule.h
@@ -68,6 +68,8 @@ struct LoadModule
 
 struct ImageLoader : LoadModule
 {
+    static ColorSpace cs;                           //desired value
+
     float w = 0, h = 0;                             //default image size
     Surface surface;
 

--- a/thirdparty/thorvg/src/renderer/tvgScene.h
+++ b/thirdparty/thorvg/src/renderer/tvgScene.h
@@ -128,6 +128,7 @@ struct Scene::Impl
     bool render(RenderMethod* renderer)
     {
         Compositor* cmp = nullptr;
+        auto ret = true;
 
         if (needComp) {
             cmp = renderer->target(bounds(renderer), renderer->colorSpace());
@@ -136,12 +137,12 @@ struct Scene::Impl
         }
 
         for (auto paint : paints) {
-            if (!paint->pImpl->render(renderer)) return false;
+            ret &= paint->pImpl->render(renderer);
         }
 
         if (cmp) renderer->endComposite(cmp);
 
-        return true;
+        return ret;
     }
 
     RenderRegion bounds(RenderMethod* renderer) const

--- a/thirdparty/thorvg/src/renderer/tvgSwCanvas.cpp
+++ b/thirdparty/thorvg/src/renderer/tvgSwCanvas.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "tvgCanvas.h"
+#include "tvgLoadModule.h"
 
 #ifdef THORVG_SW_RASTER_SUPPORT
     #include "tvgSwRenderer.h"
@@ -89,6 +90,9 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 
     //Paints must be updated again with this new target.
     Canvas::pImpl->needRefresh();
+
+    //FIXME: The value must be associated with an individual canvas instance.
+    ImageLoader::cs = static_cast<ColorSpace>(cs);
 
     return Result::Success;
 #endif

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION=0.12.4
+VERSION=0.12.5
 
 cd thirdparty/thorvg/ || true
 rm -rf AUTHORS LICENSE inc/ src/ *.zip *.tar.gz tmp/


### PR DESCRIPTION
https://github.com/thorvg/thorvg/releases/tag/v0.12.5

+ Full Changelog:
      https://github.com/thorvg/thorvg/compare/v0.12.4...v0.12.5

Godot-related SVG bug fixes:

+ sw_engine: Improve image up-scaler quality.
      thorvg/thorvg#1960

+ renderer: Ensure canvas rendering continues
      despite invalid scene parts.
      thorvg/thorvg#1957

+ Portability: Fix compiler shadowing warning (patch)
      thorvg/thorvg#1975

Thanks to @lostminds for helping fix the embedded bitmap issues and a special YOLO rocket for @akien-mga .

![editor_screenshot_2024-02-08T110616](https://github.com/godotengine/godot/assets/4047289/1bcd8fb2-b389-4a81-ba59-3010192e11a2)
