### PR TITLE
Prevent some internal nodes being duplicated in Controls

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1741,6 +1741,7 @@ void ColorPicker::_pick_button_pressed() {
 		picker_preview_color->add_theme_style_override(SceneStringName(panel), picker_preview_style_box_color);
 
 		add_child(picker_window, false, INTERNAL_MODE_FRONT);
+		picker_window->force_parent_owned();
 	}
 	set_process_internal(true);
 
@@ -1889,6 +1890,7 @@ void ColorPicker::_pick_button_pressed_legacy() {
 		picker_window->hide();
 		picker_window->set_transient(true);
 		add_child(picker_window, false, INTERNAL_MODE_FRONT);
+		picker_window->force_parent_owned();
 
 		picker_texture_rect = memnew(TextureRect);
 		picker_texture_rect->set_anchors_preset(Control::PRESET_FULL_RECT);
@@ -2562,6 +2564,7 @@ void ColorPickerButton::_update_picker() {
 		picker->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 		popup->add_child(picker);
 		add_child(popup, false, INTERNAL_MODE_FRONT);
+		popup->force_parent_owned();
 		picker->connect("color_changed", callable_mp(this, &ColorPickerButton::_color_changed));
 		popup->connect("about_to_popup", callable_mp(this, &ColorPickerButton::_about_to_popup));
 		popup->connect("popup_hide", callable_mp(this, &ColorPickerButton::_modal_closed));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2701,6 +2701,7 @@ Key LineEdit::_get_menu_action_accelerator(const String &p_action) {
 void LineEdit::_generate_context_menu() {
 	menu = memnew(PopupMenu);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
+	menu->force_parent_owned();
 
 	menu_dir = memnew(PopupMenu);
 	menu_dir->add_radio_check_item(ETR("Same as Layout Direction"), MENU_DIR_INHERITED);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -6834,6 +6834,7 @@ Size2 RichTextLabel::get_minimum_size() const {
 void RichTextLabel::_generate_context_menu() {
 	menu = memnew(PopupMenu);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
+	menu->force_parent_owned();
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &RichTextLabel::menu_option));
 
 	menu->add_item(ETR("Copy"), MENU_COPY);

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -761,6 +761,7 @@ void TabContainer::set_all_tabs_in_front(bool p_in_front) {
 
 	remove_child(tab_bar);
 	add_child(tab_bar, false, all_tabs_in_front ? INTERNAL_MODE_FRONT : INTERNAL_MODE_BACK);
+	tab_bar->force_parent_owned();
 }
 
 bool TabContainer::is_all_tabs_in_front() const {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7364,6 +7364,7 @@ Key TextEdit::_get_menu_action_accelerator(const String &p_action) {
 void TextEdit::_generate_context_menu() {
 	menu = memnew(PopupMenu);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
+	menu->force_parent_owned();
 
 	menu_dir = memnew(PopupMenu);
 	menu_dir->add_radio_check_item(ETR("Same as Layout Direction"), MENU_DIR_INHERITED);


### PR DESCRIPTION
Caused by duplication of on-demand created children, for example:
```gdscript
var cpb := ColorPickerButton.new()
print(cpb.get_child_count(true))
print(cpb.get_popup())
print(cpb.get_child_count(true))

var cpb2 := cpb.duplicate()
print(cpb2.get_child_count(true))
print(cpb2.get_popup())
print(cpb2.get_child_count(true))
```
Will print:
```
0
@PopupPanel@...:<PopupPanel#...>
1
1
@PopupPanel@...:<PopupPanel#...>
2
```
This fixes these

There are probably some other potential cases but unsure how to apply each, but keeping these specific menu cases for now

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
