### PR TITLE
Fix import crash due to multiple data races

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -119,9 +119,8 @@ void StringName::cleanup() {
 void StringName::unref() {
 	ERR_FAIL_COND(!configured);
 
+	MutexLock lock(mutex);
 	if (_data && _data->refcount.unref()) {
-		MutexLock lock(mutex);
-
 		if (CoreGlobals::leak_reporting_enabled && _data->static_count.get() > 0) {
 			if (_data->cname) {
 				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->cname));

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -92,7 +92,10 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr; }
+	operator const void *() const {
+		MutexLock lock(mutex);
+		return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr;
+	}
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1779,6 +1779,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 	} else {
 		//the file exists and it was updated, and was not added in this step.
 		//this means we must force upon next restart to scan it again, to get proper type and dependencies
+		MutexLock lock(late_update_files_mutex);
 		late_update_files.insert(p_file);
 		_save_late_updated_files(); //files need to be updated in the re-scan
 	}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -173,6 +173,7 @@ class EditorFileSystem : public Node {
 
 	void _scan_filesystem();
 
+	Mutex late_update_files_mutex;
 	HashSet<String> late_update_files;
 
 	void _save_late_updated_files();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -177,6 +177,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 		return instance;
 	}
 
+	MutexLock initializer_lock(GDScriptLanguage::singleton->mutex);
 	initializer = _super_constructor(this);
 	if (initializer != nullptr) {
 		initializer->call(instance, p_args, p_argcount, r_error);
@@ -185,7 +186,6 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 			instance->script = Ref<GDScript>();
 			instance->owner->set_script_instance(nullptr);
 			{
-				MutexLock lock(GDScriptLanguage::singleton->mutex);
 				instances.erase(p_owner);
 			}
 			ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance: " + error_text);


### PR DESCRIPTION
The import process currently has multiple race conditions which can lead to wildly different crashes. This patch aims to alleviate issues related to importing multiple files that need to be late-updated (i.e. stored within `EditorFileSystem.late_updated_files`), and issues related to `GDScriptInstance` objects for which ThreadSanitizer found  race conditions when initializing these.

I've included the sanitizer reports I followed below, each of which correspond to each commit in order. The reports can be generated by using the MRP from #84364, which I include here for convenience if anyone would like to test (which would be great): [custom_resource_import_crash.zip](https://github.com/godotengine/godot/files/13239181/custom_resource_import_crash.zip)

For anyone who'd like to test, you might want to add an additional [rough patch](https://github.com/godotengine/godot/files/14216013/0001-Fix-lock-order-inversion-in-TextServer.patch.txt) to silence the `TextServerAdvance` warnings by ThreadSanitizer which is documented in #87990.

Fixes:
* #84364

*Reports*:

<details>
<summary> Click to show StringName._data ThreadSanitizer report</summary>

```
==================
WARNING: ThreadSanitizer: data race (pid=63162)
  Write of size 8 at 0x555561239d48 by thread T22 (mutexes: write M0):
    #0 StringName::unref() /opt/godot/core/string/string_name.cpp:147:8 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e3f87) (BuildId: 4908b8b50aab2496)
    #1 StringName::operator=(StringName const&) /opt/godot/core/string/string_name.cpp:185:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e4673) (BuildId: 4908b8b50aab2496)
    #2 StringName::assign_static_unique_class_name(StringName*, char const*) /opt/godot/core/string/string_name.cpp:205:8 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e4673)
    #3 RegEx::_get_class_namev() const /opt/godot/modules/regex/regex.h:73:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x524a205) (BuildId: 4908b8b50aab2496)
    #4 Object::_postinitialize() /opt/godot/core/object/object.cpp:211:20 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa166d72) (BuildId: 4908b8b50aab2496)
    #5 postinitialize_handler(Object*) /opt/godot/core/object/object.cpp:2052:12 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa166d72)
    #6 RegEx* _post_initialize<RegEx>(RegEx*) /opt/godot/./core/os/memory.h:97:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5302b3e) (BuildId: 4908b8b50aab2496)
    #7 Object* ClassDB::creator<RegEx>() /opt/godot/./core/object/class_db.h:144:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5302b3e)
    #8 ClassDB::instantiate(StringName const&) /opt/godot/core/object/class_db.cpp:378:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa12392c) (BuildId: 4908b8b50aab2496)
    #9 GDScriptNativeClass::instantiate() /opt/godot/modules/gdscript/gdscript.cpp:97:9 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ab737) (BuildId: 4908b8b50aab2496)
    #10 GDScriptNativeClass::_new() /opt/godot/modules/gdscript/gdscript.cpp:85:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ab737)
    #11 void call_with_validated_variant_args_ret_helper<__UnexistingClass, Variant>(__UnexistingClass*, Variant (__UnexistingClass::*)(), Variant const**, Variant*, IndexSequence<>) /opt/godot/./core/variant/binder_common.h:375:74 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45dc829) (BuildId: 4908b8b50aab2496)
    #12 void call_with_validated_object_instance_args_ret<__UnexistingClass, Variant>(__UnexistingClass*, Variant (__UnexistingClass::*)(), Variant const**, Variant*) /opt/godot/./core/variant/binder_common.h:662:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45dc829)
    #13 MethodBindTR<Variant>::validated_call(Object*, Variant const**, Variant*) const /opt/godot/./core/object/method_bind.h:505:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45dc829)
    #14 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:1986:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47b8183) (BuildId: 4908b8b50aab2496)
    #15 GDScript::_super_implicit_constructor(GDScript*, GDScriptInstance*, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:137:34 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45abc39) (BuildId: 4908b8b50aab2496)
    #16 GDScript::_create_instance(Variant const**, int, Object*, bool, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:163:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac06a) (BuildId: 4908b8b50aab2496)
    #17 GDScript::_new(Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:227:31 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac7b6) (BuildId: 4908b8b50aab2496)
    #18 MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const /opt/godot/./core/object/method_bind.h:264:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45e6a6a) (BuildId: 4908b8b50aab2496)
    #19 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:1828:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47b82cc) (BuildId: 4908b8b50aab2496)
    #20 GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:1907:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45c3580) (BuildId: 4908b8b50aab2496)
    #21 bool EditorImportPlugin::_gdvirtual__import_call<false>(String, String, Dictionary, TypedArray<String>, TypedArray<String>, Error&) const /opt/godot/editor/import/editor_import_plugin.h:54:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63ebd35) (BuildId: 4908b8b50aab2496)
    #22 EditorImportPlugin::import(String const&, String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, List<String, DefaultAllocator>*, List<String, DefaultAllocator>*, Variant*) /opt/godot/editor/import/editor_import_plugin.cpp:177:6 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63e5765) (BuildId: 4908b8b50aab2496)
    #23 EditorFileSystem::_reimport_file(String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, String const&, Variant*) /opt/godot/editor/editor_file_system.cpp:2132:24 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58958d7) (BuildId: 4908b8b50aab2496)
    #24 EditorFileSystem::_reimport_thread(unsigned int, EditorFileSystem::ImportThreadData*) /opt/godot/editor/editor_file_system.cpp:2302:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5899eaa) (BuildId: 4908b8b50aab2496)
    #25 WorkerThreadPool::GroupUserData<EditorFileSystem, void (EditorFileSystem::*)(unsigned int, EditorFileSystem::ImportThreadData*), EditorFileSystem::ImportThreadData*>::callback_indexed(unsigned int) /opt/godot/./core/object/worker_thread_pool.h:176:4 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58af8d8) (BuildId: 4908b8b50aab2496)
    #26 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) /opt/godot/core/object/worker_thread_pool.cpp:88:32 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c1a38) (BuildId: 4908b8b50aab2496)
    #27 WorkerThreadPool::_thread_function(void*) /opt/godot/core/object/worker_thread_pool.cpp:189:15 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c294f) (BuildId: 4908b8b50aab2496)
    #28 Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) /opt/godot/core/os/thread.cpp:64:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a81d8) (BuildId: 4908b8b50aab2496)
    #29 void std::__invoke_impl<void, void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(std::__invoke_other, void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3) (BuildId: 4908b8b50aab2496)
    #30 std::__invoke_result<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>::type std::__invoke<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #31 void std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #32 std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #33 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #34 execute_native_thread_routine msdf-error-correction.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6753f2) (BuildId: 4908b8b50aab2496)

  Previous read of size 8 at 0x555561239d48 by thread T23:
    #0 StringName::operator void const*() const /opt/godot/./core/string/string_name.h:100:42 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x524a1b2) (BuildId: 4908b8b50aab2496)
    #1 RegEx::_get_class_namev() const /opt/godot/modules/regex/regex.h:73:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x524a1b2)
    #2 Object::_postinitialize() /opt/godot/core/object/object.cpp:211:20 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa166d72) (BuildId: 4908b8b50aab2496)
    #3 postinitialize_handler(Object*) /opt/godot/core/object/object.cpp:2052:12 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa166d72)
    #4 RegEx* _post_initialize<RegEx>(RegEx*) /opt/godot/./core/os/memory.h:97:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5302b3e) (BuildId: 4908b8b50aab2496)
    #5 Object* ClassDB::creator<RegEx>() /opt/godot/./core/object/class_db.h:144:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5302b3e)
    #6 ClassDB::instantiate(StringName const&) /opt/godot/core/object/class_db.cpp:378:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa12392c) (BuildId: 4908b8b50aab2496)
    #7 GDScriptNativeClass::instantiate() /opt/godot/modules/gdscript/gdscript.cpp:97:9 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ab737) (BuildId: 4908b8b50aab2496)
    #8 GDScriptNativeClass::_new() /opt/godot/modules/gdscript/gdscript.cpp:85:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ab737)
    #9 void call_with_validated_variant_args_ret_helper<__UnexistingClass, Variant>(__UnexistingClass*, Variant (__UnexistingClass::*)(), Variant const**, Variant*, IndexSequence<>) /opt/godot/./core/variant/binder_common.h:375:74 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45dc829) (BuildId: 4908b8b50aab2496)
    #10 void call_with_validated_object_instance_args_ret<__UnexistingClass, Variant>(__UnexistingClass*, Variant (__UnexistingClass::*)(), Variant const**, Variant*) /opt/godot/./core/variant/binder_common.h:662:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45dc829)
    #11 MethodBindTR<Variant>::validated_call(Object*, Variant const**, Variant*) const /opt/godot/./core/object/method_bind.h:505:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45dc829)
    #12 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:1986:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47b8183) (BuildId: 4908b8b50aab2496)
    #13 GDScript::_super_implicit_constructor(GDScript*, GDScriptInstance*, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:137:34 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45abc39) (BuildId: 4908b8b50aab2496)
    #14 GDScript::_create_instance(Variant const**, int, Object*, bool, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:163:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac06a) (BuildId: 4908b8b50aab2496)
    #15 GDScript::_new(Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:227:31 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac7b6) (BuildId: 4908b8b50aab2496)
    #16 MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const /opt/godot/./core/object/method_bind.h:264:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45e6a6a) (BuildId: 4908b8b50aab2496)
    #17 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:1828:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47b82cc) (BuildId: 4908b8b50aab2496)
    #18 GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:1907:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45c3580) (BuildId: 4908b8b50aab2496)
    #19 bool EditorImportPlugin::_gdvirtual__import_call<false>(String, String, Dictionary, TypedArray<String>, TypedArray<String>, Error&) const /opt/godot/editor/import/editor_import_plugin.h:54:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63ebd35) (BuildId: 4908b8b50aab2496)
    #20 EditorImportPlugin::import(String const&, String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, List<String, DefaultAllocator>*, List<String, DefaultAllocator>*, Variant*) /opt/godot/editor/import/editor_import_plugin.cpp:177:6 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63e5765) (BuildId: 4908b8b50aab2496)
    #21 EditorFileSystem::_reimport_file(String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, String const&, Variant*) /opt/godot/editor/editor_file_system.cpp:2132:24 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58958d7) (BuildId: 4908b8b50aab2496)
    #22 EditorFileSystem::_reimport_thread(unsigned int, EditorFileSystem::ImportThreadData*) /opt/godot/editor/editor_file_system.cpp:2302:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5899eaa) (BuildId: 4908b8b50aab2496)
    #23 WorkerThreadPool::GroupUserData<EditorFileSystem, void (EditorFileSystem::*)(unsigned int, EditorFileSystem::ImportThreadData*), EditorFileSystem::ImportThreadData*>::callback_indexed(unsigned int) /opt/godot/./core/object/worker_thread_pool.h:176:4 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58af8d8) (BuildId: 4908b8b50aab2496)
    #24 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) /opt/godot/core/object/worker_thread_pool.cpp:88:32 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c1a38) (BuildId: 4908b8b50aab2496)
    #25 WorkerThreadPool::_thread_function(void*) /opt/godot/core/object/worker_thread_pool.cpp:189:15 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c294f) (BuildId: 4908b8b50aab2496)
    #26 Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) /opt/godot/core/os/thread.cpp:64:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a81d8) (BuildId: 4908b8b50aab2496)
    #27 void std::__invoke_impl<void, void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(std::__invoke_other, void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3) (BuildId: 4908b8b50aab2496)
    #28 std::__invoke_result<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>::type std::__invoke<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #29 void std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #30 std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #31 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #32 execute_native_thread_routine msdf-error-correction.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6753f2) (BuildId: 4908b8b50aab2496)

  Location is global 'RegEx::_get_class_namev() const::_class_name_static' of size 8 at 0x555561239d48 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xbce5d48)

  Mutex M0 (0x55555fe15a28) created at:
    #0 pthread_mutex_lock <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b20631) (BuildId: 4908b8b50aab2496)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:749:12 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d) (BuildId: 4908b8b50aab2496)
    #2 __gthread_recursive_mutex_lock(pthread_mutex_t*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:811:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d)
    #3 std::recursive_mutex::lock() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/mutex:120:17 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d)
    #4 std::unique_lock<std::recursive_mutex>::lock() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/unique_lock.h:141:17 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d)
    #5 std::unique_lock<std::recursive_mutex>::unique_lock(std::recursive_mutex&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/unique_lock.h:71:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d)
    #6 MutexLock<MutexImpl<std::recursive_mutex>>::MutexLock(MutexImpl<std::recursive_mutex> const&) /opt/godot/./core/os/mutex.h:81:4 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d)
    #7 StringName::StringName(String const&, bool) /opt/godot/core/string/string_name.cpp:338:12 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1e532d)
    #8 GetTypeInfo<Side, void>::get_class_info() /opt/godot/./core/variant/binder_common.h:155:1 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x7308e69) (BuildId: 4908b8b50aab2496)
    #9 StringName __constant_get_enum_name<Side>(Side, String const&) /opt/godot/./core/variant/type_info.h:278:9 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x9767892) (BuildId: 4908b8b50aab2496)
    #10 register_global_constants() /opt/godot/core/core_constants.cpp:256:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x9767892)
    #11 register_core_types() /opt/godot/core/register_core_types.cpp:133:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x97d3b33) (BuildId: 4908b8b50aab2496)
    #12 Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp:867:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3cb71fc) (BuildId: 4908b8b50aab2496)
    #13 main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3ba46b7) (BuildId: 4908b8b50aab2496)

  Thread T22 (tid=63188, running) created by main thread at:
    #0 pthread_create <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b20336) (BuildId: 4908b8b50aab2496)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6754d9) (BuildId: 4908b8b50aab2496)
    #2 WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c5176) (BuildId: 4908b8b50aab2496)
    #3 Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3cbc31b) (BuildId: 4908b8b50aab2496)
    #4 main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3ba46b7) (BuildId: 4908b8b50aab2496)

  Thread T23 (tid=63189, running) created by main thread at:
    #0 pthread_create <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b20336) (BuildId: 4908b8b50aab2496)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6754d9) (BuildId: 4908b8b50aab2496)
    #2 WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c5176) (BuildId: 4908b8b50aab2496)
    #3 Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3cbc31b) (BuildId: 4908b8b50aab2496)
    #4 main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3ba46b7) (BuildId: 4908b8b50aab2496)

SUMMARY: ThreadSanitizer: data race /opt/godot/core/string/string_name.cpp:147:8 in StringName::unref()
==================
```
</details>

<details>

<summary>Click to show EditorFileSystem AddressSanitizer report</summary>

```
=================================================================                                                                                               ????????????????=                                                                                                                                              
==102593==ERROR: AddressSanitizer: heap-use-after-free on address 0x518000032cc8 at pc 0x555566fb7531 bp 0x7fffeb5fc8f0 sp 0x7fffeb5fc8e8                     fa??????????????????????????????????8    ?                                                                                                                       
READ of size 8 at 0x518000032cc8 thread T13                                                                                                                   ts???????????                            ?                                                                                                                       
    #0 0x555566fb7530 in CowData<char32_t>::_get_size() const /opt/godot/./core/templates/cowdata.h:128:8                                                     6_??????????????????????????8            ?                                                                                                                       
    #1 0x555566fb7530 in CowData<char32_t>::size() const /opt/godot/./core/templates/cowdata.h:181:26                                                         7 ?????????????????????????6             ?                                                                                                                       
    #2 0x555566fb7530 in String::size() const /opt/godot/./core/string/ustring.h:217:52                                                                       2.??????????????????????                 ?                                                                                                                       
    #3 0x555566fb7530 in String::length() const /opt/godot/./core/string/ustring.h:273:11                                                                     de??????????????????????1                ?                                                                                                                       
    #4 0x555566fb7530 in FileAccess::store_string(String const&) /opt/godot/core/io/file_access.cpp:656:15                                                      ???????????????????????????                                                                                                                                    
    #5 0x555566fb7c24 in FileAccess::store_line(String const&) /opt/godot/core/io/file_access.cpp:683:2                                                       d:??????????????????????????             ?                                                                                                                       
    #6 0x55555f173a46 in EditorFileSystem::_save_late_updated_files() /opt/godot/editor/editor_file_system.cpp:1523:6                                         x9?????????????????????????????6         ?                                                                                                                       
    #7 0x55555f177908 in EditorFileSystem::update_file(String const&) /opt/godot/editor/editor_file_system.cpp:1788:3                                           ?????????????????????????????3                                                                                                                                 
    #8 0x55555f454940 in EditorNode::_resource_saved(Ref<Resource>, String const&) /opt/godot/editor/editor_node.cpp:6075:38                                    ???????????????????????????????                                                                                                                                
    #9 0x55556722cbe3 in ResourceSaver::save(Ref<Resource> const&, String const&, unsigned int) /opt/godot/core/io/resource_saver.cpp:145:5                   b2???????????????????????????????????    ?                                                                                                                       
    #10 0x555566c8fd46 in core_bind::ResourceSaver::save(Ref<Resource> const&, String const&, BitField<core_bind::ResourceSaver::SaverFlags>) /opt/godot/core/  ????????????????????????????????????????                                                                                                                       core_bind.cpp:154:9                                                                                                                                             ?????                                                                       
    #11 0x555566cfc963 in void call_with_variant_args_ret_helper<__UnexistingClass, Error, Ref<Resource> const&, String const&, BitField<core_bind::ResourceSa  ????????????????????????????????????????                                                                                                                       ver::SaverFlags>, 0ul, 1ul, 2ul>(__UnexistingClass*, Error (__UnexistingClass::*)(Ref<Resource> const&, String const&, BitField<core_bind::ResourceSaver::Save  ????????????????????????????????????????                                                                                                                       rFlags>), Variant const**, Variant&, Callable::CallError&, IndexSequence<0ul, 1ul, 2ul>) /opt/godot/./core/variant/binder_common.h:756:10                     de??????????????????????????????????0    ?                                                                                                                       
    #12 0x555566cfc3cd in void call_with_variant_args_ret_dv<__UnexistingClass, Error, Ref<Resource> const&, String const&, BitField<core_bind::ResourceSaver: 4????????????????????????????????????????                                                                                                                       :SaverFlags>>(__UnexistingClass*, Error (__UnexistingClass::*)(Ref<Resource> const&, String const&, BitField<core_bind::ResourceSaver::SaverFlags>), Variant c  ????????????????????????????????????????                                                                                                                       onst**, int, Variant&, Callable::CallError&, Vector<Variant> const&) /opt/godot/./core/variant/binder_common.h:535:2                                            ?????????????????????????????                                                                                                                                  
    #13 0x555566cfb93d in MethodBindTR<Error, Ref<Resource> const&, String const&, BitField<core_bind::ResourceSaver::SaverFlags>>::call(Object*, Variant cons  ????????????????????????????????????????                                                                                                                       t**, int, Callable::CallError&) const /opt/godot/./core/object/method_bind.h:496:3                                                                              ?????????????????????                                                                                                                                          
    #14 0x55555d0b164e in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modul  ????????????????????????????????????????                                                                                                                       es/gdscript/gdscript_vm.cpp:1828:21                                                                                                                           de?????????                              ?                                                                                                    
    #15 0x55555ccbd5e9 in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:1906 4????????????????????????????????????????                                                                                                                       :21                                                                                                                                                             ?           
    #16 0x55556067f29d in bool EditorImportPlugin::_gdvirtual__import_call<false>(String, String, Dictionary, TypedArray<String>, TypedArray<String>, Error&)   ????????????????????????????????????????                                                                                                                       const /opt/godot/editor/import/editor_import_plugin.h:54:2                                                                                                      ???????????????                                                                                                                                                
    #17 0x555560671d3d in EditorImportPlugin::import(String const&, String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault  ????????????????????????????????????????                                                                                                                       <StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, List<String, DefaultAllocator>*, List<String, DefaultAllocator>*, Variant*)   ????????????????????????????????????????                                                                                                                       /opt/godot/editor/import/editor_import_plugin.cpp:177:6                                                                                                         ??????????????                         ?                                                                                                                       
    #18 0x55555f186f3e in EditorFileSystem::_reimport_file(String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, String const&, Variant*) /opt/godot/editor/editor_file_system.cpp:2134:24
    #19 0x55555f18f16c in EditorFileSystem::_reimport_thread(unsigned int, EditorFileSystem::ImportThreadData*) /opt/godot/editor/editor_file_system.cpp:2304:2
    #20 0x555567dc1a74 in WorkerThreadPool::_process_task(WorkerThreadPool::Task*) /opt/godot/core/object/worker_thread_pool.cpp:88:32
    #21 0x555567dc3818 in WorkerThreadPool::_thread_function(void*) /opt/godot/core/object/worker_thread_pool.cpp:189:15
    #22 0x555566d87684 in Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) /opt/godot/core/os/thread.cpp:64:3
    #23 0x5555686b0442 in execute_native_thread_routine msdf-error-correction.cpp                                                                             fa
    #24 0x7ffff7d29559  (/usr/lib/libc.so.6+0x8b559) (BuildId: c0caa0b7709d3369ee575fcd7d7d0b0fc48733af)                                                      ts
    #25 0x7ffff7da6a3b  (/usr/lib/libc.so.6+0x108a3b) (BuildId: c0caa0b7709d3369ee575fcd7d7d0b0fc48733af)                                                     6_
                                                                                                                                                              7 
0x518000032cc8 is located 72 bytes inside of 792-byte region [0x518000032c80,0x518000032f98)                                                                  2.
freed by thread T24 here:                                                                                                                                     de
    #0 0x55555b7dcb1a in __interceptor_realloc.part.0 (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x6288b1a) (BuildId: d9131251223f5910)
    #1 0x555566d78b42 in Memory::realloc_static(void*, unsigned long, bool) /opt/godot/core/os/memory.cpp:129:21                                              d:
                                                                                                                                                              x9
previously allocated by thread T9 here:
    #0 0x55555b7dcb1a in __interceptor_realloc.part.0 (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x6288b1a) (BuildId: d9131251223f5910)
    #1 0x555566d78b42 in Memory::realloc_static(void*, unsigned long, bool) /opt/godot/core/os/memory.cpp:129:21                                              b2

Thread T13 created by T0 here:
    #0 0x55555b7166c8 in pthread_create (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x61c26c8) (BuildId: d9131251223f5910)
    #1 0x5555686b0529 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1315c529) (BuildId: d9131251223f5910)                                                                         de
    #2 0x555567dc85ed in WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21                                               4
    #3 0x55555ba051b7 in Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp
    #4 0x55555b8286f2 in main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14
    #5 0x7ffff7cc3ccf  (/usr/lib/libc.so.6+0x25ccf) (BuildId: c0caa0b7709d3369ee575fcd7d7d0b0fc48733af)

Thread T24 created by T0 here:
    #0 0x55555b7166c8 in pthread_create (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x61c26c8) (BuildId: d9131251223f5910)                      de
    #1 0x5555686b0529 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/opt/godot/ 4bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1315c529) (BuildId: d9131251223f5910)
    #2 0x555567dc85ed in WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21
    #3 0x55555ba051b7 in Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp
    #4 0x55555b8286f2 in main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14
    #5 0x7ffff7cc3ccf  (/usr/lib/libc.so.6+0x25ccf) (BuildId: c0caa0b7709d3369ee575fcd7d7d0b0fc48733af)

Thread T9 created by T0 here:
    #0 0x55555b7166c8 in pthread_create (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x61c26c8) (BuildId: d9131251223f5910)
    #1 0x5555686b0529 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/opt/godot/bin/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x1315c529) (BuildId: d9131251223f5910)
    #2 0x555567dc85ed in WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21
    #3 0x55555ba051b7 in Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp
    #4 0x55555b8286f2 in main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14
    #5 0x7ffff7cc3ccf  (/usr/lib/libc.so.6+0x25ccf) (BuildId: c0caa0b7709d3369ee575fcd7d7d0b0fc48733af)                                                       fa
                                                                                                                                                              ts
SUMMARY: AddressSanitizer: heap-use-after-free /opt/godot/./core/templates/cowdata.h:128:8 in CowData<char32_t>::_get_size() const                            6_
Shadow bytes around the buggy address:                                                                                                                        7 
  0x518000032a00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                                             2.
  0x518000032a80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                                             de
  0x518000032b00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x518000032b80: 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa                                                                                             d:
  0x518000032c00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                                             x9
=>0x518000032c80: fa fa fa fa fa fa fa fa fa[fa]fa fa fa fa fa fa
  0x518000032d00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x518000032d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa                                                                                             b2
  0x518000032e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x518000032e80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x518000032f00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00                                                                                                                                   de
  Partially addressable: 01 02 03 04 05 06 07                                                                                                                  4
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5                                                                                                                                 de
  Stack use after scope:   f8                                                                                                                                  4
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==102593==ABORTING

```

</details>


<details>
<summary>Click to show GDScriptInstance.initializer ThreadSanitizer report</summary>

```
==================
WARNING: ThreadSanitizer: data race (pid=63162)
  Read of size 8 at 0x7b6c001a0000 by thread T18:
    #0 GDScript::_super_constructor(GDScript*) /opt/godot/modules/gdscript/gdscript.cpp:116:16 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45abb5b) (BuildId: 4908b8b50aab2496)
    #1 GDScript::_create_instance(Variant const**, int, Object*, bool, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:179:16 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac22d) (BuildId: 4908b8b50aab2496)
    #2 GDScript::_new(Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:227:31 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac7b6) (BuildId: 4908b8b50aab2496)
    #3 MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const /opt/godot/./core/object/method_bind.h:264:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45e6a6a) (BuildId: 4908b8b50aab2496)
    #4 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:1828:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47b82cc) (BuildId: 4908b8b50aab2496)
    #5 GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:1907:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45c3580) (BuildId: 4908b8b50aab2496)
    #6 bool EditorImportPlugin::_gdvirtual__import_call<false>(String, String, Dictionary, TypedArray<String>, TypedArray<String>, Error&) const /opt/godot/editor/import/editor_import_plugin.h:54:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63ebd35) (BuildId: 4908b8b50aab2496)
    #7 EditorImportPlugin::import(String const&, String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, List<String, DefaultAllocator>*, List<String, DefaultAllocator>*, Variant*) /opt/godot/editor/import/editor_import_plugin.cpp:177:6 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63e5765) (BuildId: 4908b8b50aab2496)
    #8 EditorFileSystem::_reimport_file(String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, String const&, Variant*) /opt/godot/editor/editor_file_system.cpp:2132:24 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58958d7) (BuildId: 4908b8b50aab2496)
    #9 EditorFileSystem::_reimport_thread(unsigned int, EditorFileSystem::ImportThreadData*) /opt/godot/editor/editor_file_system.cpp:2302:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5899eaa) (BuildId: 4908b8b50aab2496)
    #10 WorkerThreadPool::GroupUserData<EditorFileSystem, void (EditorFileSystem::*)(unsigned int, EditorFileSystem::ImportThreadData*), EditorFileSystem::ImportThreadData*>::callback_indexed(unsigned int) /opt/godot/./core/object/worker_thread_pool.h:176:4 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58af8d8) (BuildId: 4908b8b50aab2496)
    #11 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) /opt/godot/core/object/worker_thread_pool.cpp:88:32 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c1a38) (BuildId: 4908b8b50aab2496)
    #12 WorkerThreadPool::_thread_function(void*) /opt/godot/core/object/worker_thread_pool.cpp:189:15 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c294f) (BuildId: 4908b8b50aab2496)
    #13 Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) /opt/godot/core/os/thread.cpp:64:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a81d8) (BuildId: 4908b8b50aab2496)
    #14 void std::__invoke_impl<void, void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(std::__invoke_other, void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3) (BuildId: 4908b8b50aab2496)
    #15 std::__invoke_result<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>::type std::__invoke<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #16 void std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #17 std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #18 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #19 execute_native_thread_routine msdf-error-correction.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6753f2) (BuildId: 4908b8b50aab2496)

  Previous write of size 8 at 0x7b6c001a0000 by thread T10:
    #0 GDScript::_create_instance(Variant const**, int, Object*, bool, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:179:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac23c) (BuildId: 4908b8b50aab2496)
    #1 GDScript::_new(Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:227:31 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45ac7b6) (BuildId: 4908b8b50aab2496)
    #2 MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const /opt/godot/./core/object/method_bind.h:264:10 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45e6a6a) (BuildId: 4908b8b50aab2496)
    #3 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:1828:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47b82cc) (BuildId: 4908b8b50aab2496)
    #4 GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:1907:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45c3580) (BuildId: 4908b8b50aab2496)
    #5 bool EditorImportPlugin::_gdvirtual__import_call<false>(String, String, Dictionary, TypedArray<String>, TypedArray<String>, Error&) const /opt/godot/editor/import/editor_import_plugin.h:54:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63ebd35) (BuildId: 4908b8b50aab2496)
    #6 EditorImportPlugin::import(String const&, String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, List<String, DefaultAllocator>*, List<String, DefaultAllocator>*, Variant*) /opt/godot/editor/import/editor_import_plugin.cpp:177:6 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63e5765) (BuildId: 4908b8b50aab2496)
    #7 EditorFileSystem::_reimport_file(String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, String const&, Variant*) /opt/godot/editor/editor_file_system.cpp:2132:24 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58958d7) (BuildId: 4908b8b50aab2496)
    #8 EditorFileSystem::_reimport_thread(unsigned int, EditorFileSystem::ImportThreadData*) /opt/godot/editor/editor_file_system.cpp:2302:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5899eaa) (BuildId: 4908b8b50aab2496)
    #9 WorkerThreadPool::GroupUserData<EditorFileSystem, void (EditorFileSystem::*)(unsigned int, EditorFileSystem::ImportThreadData*), EditorFileSystem::ImportThreadData*>::callback_indexed(unsigned int) /opt/godot/./core/object/worker_thread_pool.h:176:4 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58af8d8) (BuildId: 4908b8b50aab2496)
    #10 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) /opt/godot/core/object/worker_thread_pool.cpp:88:32 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c1a38) (BuildId: 4908b8b50aab2496)
    #11 WorkerThreadPool::_thread_function(void*) /opt/godot/core/object/worker_thread_pool.cpp:189:15 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c294f) (BuildId: 4908b8b50aab2496)
    #12 Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) /opt/godot/core/os/thread.cpp:64:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a81d8) (BuildId: 4908b8b50aab2496)
    #13 void std::__invoke_impl<void, void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(std::__invoke_other, void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3) (BuildId: 4908b8b50aab2496)
    #14 std::__invoke_result<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>::type std::__invoke<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #15 void std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #16 std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #17 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #18 execute_native_thread_routine msdf-error-correction.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6753f2) (BuildId: 4908b8b50aab2496)

  Location is heap block of size 1792 at 0x7b6c0019fa00 allocated by thread T19:
    #0 malloc <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b35463) (BuildId: 4908b8b50aab2496)
    #1 Memory::alloc_static(unsigned long, bool) /opt/godot/core/os/memory.cpp:75:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x989f70d) (BuildId: 4908b8b50aab2496)
    #2 operator new(unsigned long, char const*) /opt/godot/core/os/memory.cpp:40:9 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x989f70d)
    #3 Ref<GDScript>::instantiate() /opt/godot/./core/object/ref_counted.h:216:7 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45d3a52) (BuildId: 4908b8b50aab2496)
    #4 GDScriptCache::get_shallow_script(String const&, Error&, String const&) /opt/godot/modules/gdscript/gdscript_cache.cpp:255:9 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x464336e) (BuildId: 4908b8b50aab2496)
    #5 GDScriptCache::get_full_script(String const&, Error&, String const&, bool) /opt/godot/modules/gdscript/gdscript_cache.cpp:289:12 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x46438ee) (BuildId: 4908b8b50aab2496)
    #6 ResourceFormatLoaderGDScript::load(String const&, String const&, Error*, bool, float*, ResourceFormatLoader::CacheMode) /opt/godot/modules/gdscript/gdscript.cpp:2791:22 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45cc5c3) (BuildId: 4908b8b50aab2496)
    #7 ResourceLoader::_load(String const&, String const&, String const&, ResourceFormatLoader::CacheMode, Error*, bool, float*) /opt/godot/core/io/resource_loader.cpp:262:20 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x9af02c9) (BuildId: 4908b8b50aab2496)
    #8 ResourceLoader::_thread_load_function(void*) /opt/godot/core/io/resource_loader.cpp:320:22 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x9af1167) (BuildId: 4908b8b50aab2496)
    #9 ResourceLoader::_load_start(String const&, String const&, ResourceLoader::LoadThreadMode, ResourceFormatLoader::CacheMode) /opt/godot/core/io/resource_loader.cpp:501:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x9af2ddc) (BuildId: 4908b8b50aab2496)
    #10 ResourceLoader::load(String const&, String const&, ResourceFormatLoader::CacheMode, Error*) /opt/godot/core/io/resource_loader.cpp:418:30 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x9af302f) (BuildId: 4908b8b50aab2496)
    #11 GDScriptUtilityFunctionsDefinitions::load(Variant*, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript_utility_functions.cpp:241:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47a374b) (BuildId: 4908b8b50aab2496)
    #12 GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /opt/godot/modules/gdscript/gdscript_vm.cpp:2147:5 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x47abf2b) (BuildId: 4908b8b50aab2496)
    #13 GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /opt/godot/modules/gdscript/gdscript.cpp:1907:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x45c3580) (BuildId: 4908b8b50aab2496)
    #14 bool EditorImportPlugin::_gdvirtual__import_call<false>(String, String, Dictionary, TypedArray<String>, TypedArray<String>, Error&) const /opt/godot/editor/import/editor_import_plugin.h:54:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63ebd35) (BuildId: 4908b8b50aab2496)
    #15 EditorImportPlugin::import(String const&, String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, List<String, DefaultAllocator>*, List<String, DefaultAllocator>*, Variant*) /opt/godot/editor/import/editor_import_plugin.cpp:177:6 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x63e5765) (BuildId: 4908b8b50aab2496)
    #16 EditorFileSystem::_reimport_file(String const&, HashMap<StringName, Variant, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, Variant>>> const&, String const&, Variant*) /opt/godot/editor/editor_file_system.cpp:2132:24 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58958d7) (BuildId: 4908b8b50aab2496)
    #17 EditorFileSystem::_reimport_thread(unsigned int, EditorFileSystem::ImportThreadData*) /opt/godot/editor/editor_file_system.cpp:2302:2 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x5899eaa) (BuildId: 4908b8b50aab2496)
    #18 WorkerThreadPool::GroupUserData<EditorFileSystem, void (EditorFileSystem::*)(unsigned int, EditorFileSystem::ImportThreadData*), EditorFileSystem::ImportThreadData*>::callback_indexed(unsigned int) /opt/godot/./core/object/worker_thread_pool.h:176:4 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x58af8d8) (BuildId: 4908b8b50aab2496)
    #19 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) /opt/godot/core/object/worker_thread_pool.cpp:88:32 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c1a38) (BuildId: 4908b8b50aab2496)
    #20 WorkerThreadPool::_thread_function(void*) /opt/godot/core/object/worker_thread_pool.cpp:189:15 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c294f) (BuildId: 4908b8b50aab2496)
    #21 Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) /opt/godot/core/os/thread.cpp:64:3 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a81d8) (BuildId: 4908b8b50aab2496)
    #22 void std::__invoke_impl<void, void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(std::__invoke_other, void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3) (BuildId: 4908b8b50aab2496)
    #23 std::__invoke_result<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>::type std::__invoke<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #24 void std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #25 std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #26 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x98a86e3)
    #27 execute_native_thread_routine msdf-error-correction.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6753f2) (BuildId: 4908b8b50aab2496)

  Thread T18 (tid=63184, running) created by main thread at:
    #0 pthread_create <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b20336) (BuildId: 4908b8b50aab2496)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6754d9) (BuildId: 4908b8b50aab2496)
    #2 WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c5176) (BuildId: 4908b8b50aab2496)
    #3 Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3cbc31b) (BuildId: 4908b8b50aab2496)
    #4 main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3ba46b7) (BuildId: 4908b8b50aab2496)

  Thread T10 (tid=63176, running) created by main thread at:
    #0 pthread_create <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b20336) (BuildId: 4908b8b50aab2496)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6754d9) (BuildId: 4908b8b50aab2496)
    #2 WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c5176) (BuildId: 4908b8b50aab2496)
    #3 Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3cbc31b) (BuildId: 4908b8b50aab2496)
    #4 main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3ba46b7) (BuildId: 4908b8b50aab2496)

  Thread T19 (tid=63185, running) created by main thread at:
    #0 pthread_create <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3b20336) (BuildId: 4908b8b50aab2496)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa6754d9) (BuildId: 4908b8b50aab2496)
    #2 WorkerThreadPool::init(int, float) /opt/godot/core/object/worker_thread_pool.cpp:612:21 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0xa1c5176) (BuildId: 4908b8b50aab2496)
    #3 Main::setup(char const*, int, char**, bool) /opt/godot/main/main.cpp (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3cbc31b) (BuildId: 4908b8b50aab2496)
    #4 main /opt/godot/platform/linuxbsd/godot_linuxbsd.cpp:74:14 (godot.linuxbsd.editor.dev.x86_64.llvm.san+0x3ba46b7) (BuildId: 4908b8b50aab2496)

SUMMARY: ThreadSanitizer: data race /opt/godot/modules/gdscript/gdscript.cpp:116:16 in GDScript::_super_constructor(GDScript*)
==================
```

</details>