### PR TITLE
[Windows] Fix windows `is_path_invalid`, and apply it to directory creation.

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -31,6 +31,7 @@
 #if defined(WINDOWS_ENABLED)
 
 #include "dir_access_windows.h"
+#include "file_access_windows.h"
 
 #include "core/config/project_settings.h"
 #include "core/os/memory.h"
@@ -175,6 +176,13 @@ Error DirAccessWindows::make_dir(String p_dir) {
 	if (p_dir.is_relative_path()) {
 		p_dir = current_dir.path_join(p_dir);
 		p_dir = fix_path(p_dir);
+	}
+
+	if (FileAccessWindows::is_path_invalid(p_dir)) {
+#ifdef DEBUG_ENABLED
+		WARN_PRINT("The path :" + p_dir + " is a reserved Windows system pipe, so it can't be used for creating directories.");
+#endif
+		return ERR_INVALID_PARAMETER;
 	}
 
 	p_dir = p_dir.simplify_path().replace("/", "\\");

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -60,12 +60,7 @@ void FileAccessWindows::check_errors() const {
 
 bool FileAccessWindows::is_path_invalid(const String &p_path) {
 	// Check for invalid operating system file.
-	String fname = p_path;
-	int dot = fname.find(".");
-	if (dot != -1) {
-		fname = fname.substr(0, dot);
-	}
-	fname = fname.to_lower();
+	String fname = p_path.get_file().get_basename().to_lower();
 	return invalid_files.has(fname);
 }
 

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -50,10 +50,11 @@ class FileAccessWindows : public FileAccess {
 
 	void _close();
 
-	static bool is_path_invalid(const String &p_path);
 	static HashSet<String> invalid_files;
 
 public:
+	static bool is_path_invalid(const String &p_path);
+
 	virtual String fix_path(const String &p_path) const override;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88120 and applies validity checks to the directory creation. 