### PR TITLE
SCons: Use r-strings for wayland-scanner builder command

### DIFF
--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -11,14 +11,14 @@ if env["use_sowrap"]:
     WAYLAND_BUILDERS_SOWRAP = {
         "WAYLAND_API_HEADER": Builder(
             action=Action(
-                "wayland-scanner -c client-header < ${SOURCE} | sed 's:wayland-client-core\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
+                r"wayland-scanner -c client-header < ${SOURCE} | sed 's:wayland-client-core\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
                 'Generating Wayland client header: "${TARGET}"',
             ),
             single_source=True,
         ),
         "WAYLAND_API_CODE": Builder(
             action=Action(
-                "wayland-scanner -c private-code < ${SOURCE} | sed 's:wayland-util\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
+                r"wayland-scanner -c private-code < ${SOURCE} | sed 's:wayland-util\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
                 'Generating Wayland protocol marshaling code: "${TARGET}"',
             ),
             single_source=True,
@@ -29,14 +29,14 @@ else:
     WAYLAND_BUILDERS = {
         "WAYLAND_API_HEADER": Builder(
             action=Action(
-                "wayland-scanner -c client-header < ${SOURCE} > ${TARGET}",
+                r"wayland-scanner -c client-header < ${SOURCE} > ${TARGET}",
                 'Generating Wayland client header: "${TARGET}"',
             ),
             single_source=True,
         ),
         "WAYLAND_API_CODE": Builder(
             action=Action(
-                "wayland-scanner -c private-code < ${SOURCE} > ${TARGET}",
+                r"wayland-scanner -c private-code < ${SOURCE} > ${TARGET}",
                 'Generating Wayland protocol marshaling code: "${TARGET}"',
             ),
             single_source=True,


### PR DESCRIPTION
I wonder if there's a static check we could do to spot this without this trial and error?