### PR TITLE
Add first interaction action to better inform newcomers

### DIFF
--- a/.github/workflows/first_interaction.yml
+++ b/.github/workflows/first_interaction.yml
@@ -1,0 +1,48 @@
+name: 🔗 GHA
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    branches: [master]
+    types: [opened]
+
+jobs:
+  check_for_first_issue:
+    name: 🌱 Check for first interaction
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Hello from the maintainer team!
+
+            First of all, thank you for taking the time to report an issue here.
+
+            In case you haven't already, be sure to attach an MRP (minimal 
+            reproduction project) if **specific** steps or assets are needed in 
+            order to reproduce the issue. Contributors will use the MRP to
+            validate that the fix is working as intended.
+
+            The time it will take to assess and fix your issue may vary.
+            Follow the blog about our
+            [new releases](https://godotengine.org/blog/release/) and
+            [pre-releases](https://godotengine.org/blog/pre-release/) to track 
+            new fixes or go to
+            [our forum](https://forum.godotengine.org/) where users could help
+            you in the meantime.
+
+            Thank you for your patience.
+          pr-message: |
+            Hi there, fellow Godot contributor!
+
+            Thank you for your first PR.
+
+            Be sure to join us in the
+            [developers chat](https://chat.godotengine.org) to talk about your 
+            PR, especially if you need help or guidance. Don't forget to consult
+            the [contributing docs](https://docs.godotengine.org/en/stable/contributing/development/index.html)
+            too!
+
+            Thank you for your patience.


### PR DESCRIPTION
Creates a first interaction action.

https://github.com/actions/first-interaction

- [x] Add the first issue message.
- [x] Add the first PR message.
- [x] Ask the comms team input for the messages