### PR TITLE
Fix invalid file path handling in Windows when there is dot in the file name

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -60,7 +60,12 @@ void FileAccessWindows::check_errors() const {
 
 bool FileAccessWindows::is_path_invalid(const String &p_path) {
 	// Check for invalid operating system file.
-	String fname = p_path.get_file().get_basename().to_lower();
+	String fname = p_path.get_file().to_lower();
+
+	int dot = fname.find(".");
+	if (dot != -1) {
+		fname = fname.substr(0, dot);
+	}
 	return invalid_files.has(fname);
 }
 


### PR DESCRIPTION
This basically re-adds the dot-removal removed by the previous commit (PR https://github.com/godotengine/godot/pull/88129). It looks like get_basename() (that was meant to replace the old "dot-removal" part?) doesn't actually remove the dot from the filename. Therefore "con.png" etc. becomes "con." and this still froze the editor.

Not sure if the dot-removal should be actually done in get_basename() instead(?) If so, feel free to discard this PR.

@bruvzg