### PR TITLE
Tweak property order in the inspector for OptionButton

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -339,6 +339,13 @@ void OptionButton::set_item_count(int p_count) {
 		}
 	}
 
+	if (!initialized) {
+		if (queued_current != current) {
+			current = queued_current;
+		}
+		initialized = true;
+	}
+
 	_refresh_size_cache();
 	notify_property_list_changed();
 }
@@ -435,7 +442,13 @@ void OptionButton::_select(int p_which, bool p_emit) {
 }
 
 void OptionButton::_select_int(int p_which) {
-	if (p_which < NONE_SELECTED || p_which >= popup->get_item_count()) {
+	if (p_which < NONE_SELECTED) {
+		return;
+	}
+	if (p_which >= popup->get_item_count()) {
+		if (!initialized) {
+			queued_current = p_which;
+		}
 		return;
 	}
 	_select(p_which, false);
@@ -574,11 +587,10 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &OptionButton::get_allow_reselect);
 	ClassDB::bind_method(D_METHOD("set_disable_shortcuts", "disabled"), &OptionButton::set_disable_shortcuts);
 
-	// "selected" property must come after "item_count", otherwise GH-10213 occurs.
-	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "popup/item_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fit_to_longest_item"), "set_fit_to_longest_item", "is_fit_to_longest_item");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
+	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "popup/item_");
 
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "index")));

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -44,6 +44,8 @@ class OptionButton : public Button {
 	Vector2 _cached_size;
 	bool cache_refresh_pending = false;
 	bool allow_reselect = false;
+	bool initialized = false;
+	int queued_current = -1;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #88141. Moves the `items` property to below other properties.