### PR TITLE
Use `SafeFlag` for `EditorHTTPServer.server_quit`

### DIFF
--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -32,7 +32,7 @@
 
 void EditorHTTPServer::_server_thread_poll(void *data) {
 	EditorHTTPServer *web_server = static_cast<EditorHTTPServer *>(data);
-	while (!web_server->server_quit.get()) {
+	while (!web_server->server_quit.is_set()) {
 		OS::get_singleton()->delay_usec(6900);
 		{
 			MutexLock lock(web_server->server_lock);
@@ -193,7 +193,7 @@ void EditorHTTPServer::_poll() {
 }
 
 void EditorHTTPServer::stop() {
-	server_quit.set(true);
+	server_quit.set();
 	if (server_thread.is_started()) {
 		server_thread.wait_to_finish();
 	}
@@ -227,7 +227,7 @@ Error EditorHTTPServer::listen(int p_port, IPAddress p_address, bool p_use_tls, 
 	}
 	Error err = server->listen(p_port, p_address);
 	if (err == OK) {
-		server_quit.set(false);
+		server_quit.clear();
 		server_thread.start(_server_thread_poll, this);
 	}
 	return err;

--- a/platform/web/export/editor_http_server.h
+++ b/platform/web/export/editor_http_server.h
@@ -51,7 +51,7 @@ private:
 	uint8_t req_buf[4096];
 	int req_pos = 0;
 
-	SafeNumeric<bool> server_quit;
+	SafeFlag server_quit;
 	Mutex server_lock;
 	Thread server_thread;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
