### PR TITLE
Shorten the bug report template in order to maximize attention

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,24 +5,31 @@ body:
 - type: markdown
   attributes:
     value: |
-      When reporting bugs, please follow the guidelines in this template. This helps identify the problem precisely and thus enables contributors to fix it faster.
-      - Write a descriptive issue title above.
-      - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
-      - Search [open](https://github.com/godotengine/godot/issues) and [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
-      - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
-      - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
+      Follow the guidelines. It will take longer to fix your issue if you don't.
+
+      *Golden rules:*
+      1. Search for [open](https://github.com/godotengine/godot/issues) and
+         [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed)
+         before submitting your own.
+      2. Make sure you are using a
+         [supported Godot version](https://docs.godotengine.org/en/latest/about/release_policy.html).
+      3. One issue for one bug.
+      4. Write a descriptive title.
+      5. Confirm the bug with a minimal reproductive project (MRP). (see below)
 
 - type: textarea
   attributes:
     label: Tested versions
     description: |
-      To properly fix a bug, we need to identify if the bug was recently introduced in the engine, or if it was always present.
-      - Please specify the Godot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
-      - If you can, **please test earlier Godot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Godot releases in our [download archive](https://godotengine.org/download/archive/).
-      - The aim is for us to identify whether a bug is a **regression**, i.e. an issue that didn't exist in a previous version, but was introduced later on, breaking existing functionality. For example, if a bug is reproducible in 4.2.stable but not in 4.1.stable, we would like you to test intermediate 4.2 dev and beta snapshots to find which snapshot is the first one where the issue can be reproduced.
+      We need to identify if the bug was recently introduced in the engine, or
+      if it was always present.
+      - Copy and paste the version by clicking the version shown in the editor
+        (bottom bar) or in the project manager (top bar).
+      - **Please test earlier Godot versions.** You can find all Godot releases
+        in our [download archive](https://godotengine.org/download/archive/).
     placeholder: |
-
-      - Reproducible in: 4.3.dev [d76c1d0e5], 4.2.stable, 4.2.dev5 and later 4.2 snapshots.
+      - Reproducible in: 4.3.dev [d76c1d0e5], 4.2.stable, 4.2.dev5 and later 4.2
+        snapshots.
       - Not reproducible in: 4.1.3.stable, 4.2.dev4 and earlier 4.2 snapshots.
   validations:
     required: true
@@ -31,12 +38,13 @@ body:
   attributes:
     label: System information
     description: |
-      - Specify the OS version, and when relevant hardware information.
-      - For issues that are likely OS-specific and/or graphics-related, please specify the CPU model and architecture.
-      - For graphics-related issues, specify the GPU model, driver version, and the rendering backend (GLES2, GLES3, Vulkan).
-      - **Bug reports not including the required information may be closed at the maintainers' discretion.** If in doubt, always include all the requested information; it's better to include too much information than not enough information.
-      - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
-    placeholder: Windows 10 - Godot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
+      - Copy and paste system information by clicking on
+        *Help > Copy System Info* at the top of the editor window.
+      - For Godot 4.0 and prior, see [sharing system information](https://github.com/godotengine/godot/blob/master/CONTRIBUTING.md#sharing-system-information).
+    placeholder: |
+      Godot v4.2.1.stable - Windows 11 - Vulkan (Forward+) - dedicated AMD
+      Radeon RX Vega (RADV VEGA10) () - AMD Ryzen 7 5800X 8-Core Processor
+      (16 Threads)
   validations:
     required: true
 
@@ -44,9 +52,15 @@ body:
   attributes:
     label: Issue description
     description: |
-      Describe your issue briefly. What doesn't work, and how do you expect it to work instead?
-      You can include images or videos with drag and drop, and format code blocks or logs with <code>\`\`\`</code> tags, on separate lines before and after the text. (Use <code>\`\`\`gdscript</code> to add GDScript syntax highlighting.)
-      Please do not add code examples or error messages as screenshots, but as text, this helps searching for issues and testing the code. If you are reporting a bug in the editor interface, like the script editor, please provide both a screenshot *and* the text of the code to help with testing.
+      Describe your issue briefly.
+
+      You can include images or videos with drag and drop, and format code
+      blocks or logs with <code>```</code> tags, on separate lines before and
+      after the text. (Use <code>```gdscript</code> to add GDScript syntax
+      highlighting.)
+
+      > [!IMPORTANT]
+      >  Please do **not** add code examples or error messages as screenshots
   validations:
     required: true
 
@@ -54,8 +68,8 @@ body:
   attributes:
     label: Steps to reproduce
     description: |
-      List of steps or sample code that reproduces the issue. Having reproducible issues is a prerequisite for contributors to be able to solve them.
-      If you include a minimal reproduction project below, you can detail how to use it here.
+      List of steps or sample code that reproduces the issue. Contributors need
+      to reproduce issues in order to fix them.
   validations:
     required: true
 
@@ -63,10 +77,22 @@ body:
   attributes:
     label: Minimal reproduction project (MRP)
     description: |
-      - A small Godot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
-      - Having an MRP is very important for contributors to be able to reproduce the bug in the same way that you are experiencing it. When testing a potential fix for the issue, contributors will use the MRP to validate that the fix is working as intended.
-      - If the reproduction steps are not project dependent (e.g. the bug is visible in a brand new project), you can write "N/A" in the field.
-      - Drag and drop a ZIP archive to upload it (max 10 MB). **Do not select another field until the project is done uploading.**
-      - **Note for C# users:** If your issue is *not* C#-specific, please upload a minimal reproduction project written in GDScript. This will make it easier for contributors to reproduce the issue locally as not everyone has a .NET setup available.
+      Contributors will use the MRP to validate that the fix is working as
+      intended.
+      - Drag and drop a ZIP archive containing a small Godot project which
+        reproduces the issue to upload it (max 10 MB). **Do not select another
+        field until the project is done uploading.**
+      - Make sure that the project contains the minimal amount of assets or
+        code.
+      - Be sure to not include the `.godot` folder in the archive (but keep
+        `project.godot`).
+      - We encourage the use of GDScript.
+      - Detail how to use your MRP if needed.
+
+      ---
+
+      If you are **absolutely sure** that the reproduction steps are not
+      project-dependent (the bug can be also seen in a brand new project), you
+      can write "N/A" in the field.
   validations:
     required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,33 @@ If you run into a bug which wasn't present in an earlier Godot version (what we
 call a _regression_), please mention it and clarify which versions you tested
 (both the one(s) working and the one(s) exhibiting the bug).
 
+### Sharing system information
+
+In the bug report, it's important to share your system information, specifically
+the OS version, and when relevant hardware information.
+
+**Bug reports not including the required information may be closed at the 
+maintainers' discretion.** If in doubt, always include all the requested 
+information; it's better to include too much information than not enough 
+information.
+
+Since Godot 4.1, you just have to copy and paste system information by clicking 
+on *Help > Copy System Info* at the top of the editor window.
+
+<details>
+  <summary>For Godot 4.0 and prior</summary>
+
+  Prior to Godot 4.1, the *Help > Copy System Info* button doesn't exist. So you
+  must manually collect and share the following with us:
+
+  - your Godot version
+  - your OS (e.g. Windows 11, macOS Sonoma, Ubuntu 23.10)
+    - if you're using Linux, please specify if you're using X11 or Wayland
+  - the rendering backend you're using (GLES2, GLES3, Vulkan)
+  - the GPU model, driver version
+  - the CPU model and architecture
+</details>
+
 ## Proposing features or improvements
 
 **The main issue tracker is for bug reports and does not accept feature proposals.**
@@ -201,9 +228,9 @@ or a bug you want to fix), the following channels can be used:
   for an overview of public channels focusing on various engine areas which you
   might be interested in.
 - [Bug tracker](https://github.com/godotengine/godot/issues): If there is an
-  existing issue about a topic you want to discuss, you can participate directly.
-  If not, you can open a new issue. Please mind the guidelines outlined above
-  for bug reporting.
+  existing issue about a topic you want to discuss, you can participate 
+	directly. If not, you can open a new issue. Please mind the guidelines 
+	outlined above for bug reporting.
 - [Feature proposals](https://github.com/godotengine/godot-proposals/issues):
   To propose a new feature, we have a dedicated issue tracker for that. Don't
   hesitate to start by talking about your idea on the Godot Contributors Chat


### PR DESCRIPTION
Had a discussion with Nat from the comms team. She underlined how verbose is the current bug report template.

This PR aims to correct verbosity by removing explanations on why we need files or some info. We need it because contributors need that to fix the issues.

This PR removes too the idea to ask C# users to create a project in GDScript, as C# is fully supported.

- [x] Add link on how to report system information for versions 4.0 and prior
- [x] Validate the new content with her