### PR TITLE
Remove 3.x references in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,7 @@
 <!--
 Please target the `master` branch in priority.
-PRs can target `3.x` if the same change was done in `master`, or is not relevant there.
 
 Relevant fixes are cherry-picked for stable branches as needed by maintainers.
-You can mention in the description if the change is compatible with `3.x`.
 
 To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
 https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html


### PR DESCRIPTION
As 98% of the PRs target 4.x (don't quote me for this) and as these 3.x reference where something critical when we were developing 3.x and 4.x (on `master`) fully in parallel, we should remove these references as they are not relevant (for the great majority of users) anymore.

This PR was suggested in part by Nat from the comms after a review of the issues/PR workflow.