### PR TITLE
Link hash table primes externally to prevent data duplication in binary

### DIFF
--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -429,7 +429,7 @@ struct HashMapComparatorDefault<Vector3> {
 
 constexpr uint32_t HASH_TABLE_SIZE_MAX = 29;
 
-const uint32_t hash_table_size_primes[HASH_TABLE_SIZE_MAX] = {
+inline constexpr uint32_t hash_table_size_primes[HASH_TABLE_SIZE_MAX] = {
 	5,
 	13,
 	23,
@@ -462,7 +462,7 @@ const uint32_t hash_table_size_primes[HASH_TABLE_SIZE_MAX] = {
 };
 
 // Computed with elem_i = UINT64_C (0 x FFFFFFFF FFFFFFFF ) / d_i + 1, where d_i is the i-th element of the above array.
-const uint64_t hash_table_size_primes_inv[HASH_TABLE_SIZE_MAX] = {
+inline constexpr uint64_t hash_table_size_primes_inv[HASH_TABLE_SIZE_MAX] = {
 	3689348814741910324,
 	1418980313362273202,
 	802032351030850071,


### PR DESCRIPTION
I've started analyzing Godot binaries on Windows using [SizeBench](https://devblogs.microsoft.com/performance-diagnostics/sizebench-a-new-tool-for-analyzing-windows-binary-size/) and on top of the duplicate data results were `hash_table_size_primes` and `hash_table_size_primes_inv`.  
![SizeBench](https://github.com/godotengine/godot/assets/1554127/967788be-ca54-47c7-943a-246610c66b97)

As visible above the tool shows around 168KB of wasted memory (tested on commit 36e943b6b20cb7a8a89bc30489c4a81c3e149d74 `scons target=template_release debug_symbols=yes`)

This PR reduces build size by 547KB ( `scons target=template_release`).

File scoped const arrays are linked internally which means each time `hashfuncs.h` are included, those two arrays are not merged into single data point (which would be fine and expected for const, read only data). ~I've moved their initialization to `hashfuncs.cpp` and marked `extern` in `hashfuncs.h`.~ Thanks to @Malcolmnixon suggestion I've made it simpler by using `inline constexpr` from C++17 standard.

I've not benchmarked it yet. In theory it can improve the CPU cache, because all of the hash_maps and hash_sets reuse the data from the same address in memory (meaning - there is higher chance that it will be still present in cache when needed).