### PR TITLE
Only update inspector if configuration warning change was relevant (reverted)

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -514,6 +514,7 @@ class EditorInspector : public ScrollContainer {
 	int property_focusable;
 	int update_scroll_request;
 
+	LocalVector<Dictionary> property_configuration_warnings;
 	HashMap<StringName, HashMap<StringName, String>> doc_path_cache;
 	HashSet<StringName> restart_request_props;
 
@@ -542,6 +543,7 @@ class EditorInspector : public ScrollContainer {
 
 	void _node_removed(Node *p_node);
 	void _warning_changed(Node *p_node);
+	bool _update_configuration_warnings();
 
 	HashMap<StringName, int> per_array_page;
 	void _page_change_request(int p_new_page, const StringName &p_array_prefix);


### PR DESCRIPTION
1. Keeps track of the node's property configuration warnings. If one got added, changed or removed by the latest `update_configuration_warnings()` call, only then will the inspector be forced to update.
2. Ignores config warnings that don't have a property associated, so these will never update the inspector.

This currently does another call to `Node::get_configuration_warnings()`. As a possible optimization, we could propagate this cached information from the EditorInspector to the EditorProperty as well. Not necessary for the fix though, and usually config warnings should be fast to evaluate.

Fixes #88176

* *Bugsquad edit, fixes: #88294*