### PR TITLE
Allow Ref `instantiate` to accept constructor args

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -665,7 +665,7 @@ RemoteDebugger::RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer) {
 	// Performance Profiler
 	Object *perf = Engine::get_singleton()->get_singleton_object("Performance");
 	if (perf) {
-		performance_profiler = Ref<PerformanceProfiler>(memnew(PerformanceProfiler(perf)));
+		performance_profiler.instantiate(perf);
 		performance_profiler->bind("performance");
 		profiler_enable("performance", true);
 	}

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -212,8 +212,9 @@ public:
 		reference = nullptr;
 	}
 
-	void instantiate() {
-		ref(memnew(T));
+	template <typename... VarArgs>
+	void instantiate(VarArgs... p_params) {
+		ref(memnew(T(p_params...)));
 	}
 
 	Ref() {}


### PR DESCRIPTION
Expands functionality of Ref `instantiate` function by adding a variable arguments parameter. In isolation, this doesn't affect existing functionality, but moving forward this will let that function accept constructor arguments for whatever class is being instantiated. This will give all forms of construction the same single-function convenience that `instantiate` previously provided for empty constructors. Implemented on one file as a proof-of-concept, with potential for a repo-wide sweep down the road.