### PR TITLE
[Export] Add support for adding shebang to the PCK files.

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -196,6 +196,8 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		return false;
 	}
 
+	int64_t pck_start_pos = f->get_position() - 4;
+
 	uint32_t version = f->get_32();
 	uint32_t ver_major = f->get_32();
 	uint32_t ver_minor = f->get_32();
@@ -208,6 +210,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	uint64_t file_base = f->get_64();
 
 	bool enc_directory = (pack_flags & PACK_DIR_ENCRYPTED);
+	bool rel_filebase = (pack_flags & PACK_REL_FILEBASE);
 
 	for (int i = 0; i < 16; i++) {
 		//reserved
@@ -215,6 +218,10 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	}
 
 	int file_count = f->get_32();
+
+	if (rel_filebase) {
+		file_base += pck_start_pos;
+	}
 
 	if (enc_directory) {
 		Ref<FileAccessEncrypted> fae;

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -44,7 +44,8 @@
 #define PACK_FORMAT_VERSION 2
 
 enum PackFlags {
-	PACK_DIR_ENCRYPTED = 1 << 0
+	PACK_DIR_ENCRYPTED = 1 << 0,
+	PACK_REL_FILEBASE = 1 << 1
 };
 
 enum PackFileFlags {

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -78,6 +78,7 @@ void EditorExport::_save() {
 			Vector<String> export_files = preset->get_files_to_export();
 			config->set_value(section, "export_files", export_files);
 		}
+		config->set_value(section, "shebang", preset->get_shebang());
 		config->set_value(section, "include_filter", preset->get_include_filter());
 		config->set_value(section, "exclude_filter", preset->get_exclude_filter());
 		config->set_value(section, "export_path", preset->get_export_path());
@@ -265,6 +266,10 @@ void EditorExport::load_config() {
 					preset->add_export_file(files[i]);
 				}
 			}
+		}
+
+		if (config->has_section_key(section, "shebang")) {
+			preset->set_shebang(config->get_value(section, "shebang"));
 		}
 
 		preset->set_include_filter(config->get_value(section, "include_filter"));

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1552,6 +1552,8 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 	Error err = export_project_files(p_preset, p_debug, _save_pack_file, &pd, _add_shared_object);
 
+	String shebang = p_preset->get_shebang();
+
 	// Close temp file.
 	pd.f.unref();
 	ftmp.unref();
@@ -1597,6 +1599,17 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		}
 	}
 
+	if (!shebang.is_empty() && !p_embed) {
+		String stub = shebang + vformat("\n\n# GODOT VERSION: %d.%d.%d\n# BINARY PAYLOAD START, DO NOT EDIT\n\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+		uint32_t string_len = stub.utf8().length();
+		uint32_t pad = _get_pad(4, string_len);
+
+		f->store_buffer((const uint8_t *)stub.utf8().get_data(), string_len);
+		for (uint32_t j = 0; j < pad; j++) {
+			f->store_8(0);
+		}
+	}
+
 	int64_t pck_start_pos = f->get_position();
 
 	f->store_32(PACK_HEADER_MAGIC);
@@ -1610,6 +1623,9 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 	bool enc_directory = p_preset->get_enc_directory();
 	if (enc_pck && enc_directory) {
 		pack_flags |= PACK_DIR_ENCRYPTED;
+	}
+	if (p_embed || !shebang.is_empty()) {
+		pack_flags |= PACK_REL_FILEBASE;
 	}
 	f->store_32(pack_flags); // flags
 
@@ -1701,8 +1717,12 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 	}
 
 	uint64_t file_base = f->get_position();
+	uint64_t file_base_store = file_base;
+	if (pack_flags & PACK_REL_FILEBASE) {
+		file_base_store -= pck_start_pos;
+	}
 	f->seek(file_base_ofs);
-	f->store_64(file_base); // update files base
+	f->store_64(file_base_store); // update files base
 	f->seek(file_base);
 
 	// Save the rest of the data.
@@ -1727,7 +1747,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 	ftmp.unref(); // Close temp file.
 
-	if (p_embed) {
+	if (p_embed || !shebang.is_empty()) {
 		// Ensure embedded data ends at a 64-bit multiple
 		uint64_t embed_end = f->get_position() - embed_pos + 12;
 		uint64_t pad = embed_end % 8;
@@ -1743,7 +1763,13 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 			*r_embedded_size = f->get_position() - embed_pos;
 		}
 	}
+	f->close();
 
+#if defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED)
+	if (!p_embed && !shebang.is_empty()) {
+		FileAccess::set_unix_permissions(p_path, 0755);
+	}
+#endif
 	DirAccess::remove_file_or_error(tmppath);
 
 	return OK;

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -332,6 +332,15 @@ int EditorExportPreset::get_script_export_mode() const {
 	return script_mode;
 }
 
+void EditorExportPreset::set_shebang(const String &p_shebang) {
+	shebang = p_shebang;
+	EditorExport::singleton->save_presets();
+}
+
+String EditorExportPreset::get_shebang() const {
+	return shebang;
+}
+
 Variant EditorExportPreset::get_or_env(const StringName &p_name, const String &p_env_var, bool *r_valid) const {
 	const String from_env = OS::get_singleton()->get_environment(p_env_var);
 	if (!from_env.is_empty()) {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -91,6 +91,7 @@ private:
 
 	String script_key;
 	int script_mode = MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
+	String shebang;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -161,6 +162,9 @@ public:
 
 	void set_script_export_mode(int p_mode);
 	int get_script_export_mode() const;
+
+	void set_shebang(const String &p_shebang);
+	String get_shebang() const;
 
 	Variant get_or_env(const StringName &p_name, const String &p_env_var, bool *r_valid = nullptr) const;
 

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -386,6 +386,11 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	int script_export_mode = current->get_script_export_mode();
 	script_mode->select(script_export_mode);
 
+	String shebang_value = current->get_shebang();
+	if (!updating_shebang) {
+		shebang->set_text(shebang_value);
+	}
+
 	updating = false;
 }
 
@@ -596,6 +601,21 @@ void ProjectExportDialog::_script_export_mode_changed(int p_mode) {
 	current->set_script_export_mode(p_mode);
 
 	_update_current_preset();
+}
+
+void ProjectExportDialog::_shebang_changed(const String &p_text) {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_shebang(p_text);
+
+	updating_shebang = true;
+	_update_current_preset();
+	updating_shebang = false;
 }
 
 void ProjectExportDialog::_duplicate_preset() {
@@ -1331,6 +1351,12 @@ ProjectExportDialog::ProjectExportDialog() {
 			TTR("Filters to exclude files/folders from project\n(comma-separated, e.g: *.json, *.txt, docs/*)"),
 			exclude_filters);
 	exclude_filters->connect("text_changed", callable_mp(this, &ProjectExportDialog::_filter_changed));
+
+	shebang = memnew(LineEdit);
+	resources_vb->add_margin_child(
+			TTR("Add sheband to the exported PCK file\n(e.g: \"#!/usr/bin/env godot4 --main-pack\")"),
+			shebang);
+	shebang->connect("text_changed", callable_mp(this, &ProjectExportDialog::_shebang_changed));
 
 	// Feature tags.
 

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -161,6 +161,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	LineEdit *enc_ex_filters = nullptr;
 
 	OptionButton *script_mode = nullptr;
+	LineEdit *shebang = nullptr;
 
 	void _open_export_template_manager();
 
@@ -179,6 +180,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 
 	bool updating_script_key = false;
 	bool updating_enc_filters = false;
+	bool updating_shebang = false;
 	void _enc_pck_changed(bool p_pressed);
 	void _enc_directory_changed(bool p_pressed);
 	void _enc_filters_changed(const String &p_text);
@@ -186,6 +188,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	bool _validate_script_encryption_key(const String &p_key);
 
 	void _script_export_mode_changed(int p_mode);
+	void _shebang_changed(const String &p_text);
 
 	void _open_key_help_link();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/9066

Not sure how useful it is for Linux distros, but can be a convenient way to run local tools.
Also, should improve embedded PCK robustness by removing global file base offset.