### PR TITLE
[3.x] Backport code snippet correct usage of shape index in class docs

### DIFF
--- a/doc/classes/Area.xml
+++ b/doc/classes/Area.xml
@@ -122,8 +122,16 @@
 				Emitted when one of another Area's [Shape]s enters one of this Area's [Shape]s. Requires [member monitoring] to be set to [code]true[/code].
 				[code]area_rid[/code] the [RID] of the other Area's [CollisionObject] used by the [PhysicsServer].
 				[code]area[/code] the other Area.
-				[code]area_shape_index[/code] the index of the [Shape] of the other Area used by the [PhysicsServer]. Get the [CollisionShape] node with [code]area.shape_owner_get_owner(area_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape] of this Area used by the [PhysicsServer]. Get the [CollisionShape] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]area_shape_index[/code] the index of the [Shape] from the other Area.
+				[code]local_shape_index[/code] the index of the [Shape] from this Area.
+				[b]Example of getting the[/b] [CollisionShape] [b]node from the shape index:[/b]
+				[codeblock]
+				var other_shape_owner = area.shape_find_owner(area_shape_index)
+				var other_shape_node = area.shape_owner_get_owner(other_shape_owner)
+
+				var local_shape_owner = shape_find_owner(local_shape_index)
+				var local_shape_node = shape_owner_get_owner(local_shape_owner)
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="area_shape_exited">
@@ -135,8 +143,9 @@
 				Emitted when one of another Area's [Shape]s enters one of this Area's [Shape]s. Requires [member monitoring] to be set to [code]true[/code].
 				[code]area_rid[/code] the [RID] of the other Area's [CollisionObject] used by the [PhysicsServer].
 				[code]area[/code] the other Area.
-				[code]area_shape_index[/code] the index of the [Shape] of the other Area used by the [PhysicsServer]. Get the [CollisionShape] node with [code]area.shape_owner_get_owner(area_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape] of this Area used by the [PhysicsServer]. Get the [CollisionShape] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]area_shape_index[/code] the index of the [Shape] from the other Area.
+				[code]local_shape_index[/code] the index of the [Shape] from this Area.
+				See also [signal area_shape_entered].
 			</description>
 		</signal>
 		<signal name="body_entered">
@@ -162,8 +171,16 @@
 				Emitted when one of a [PhysicsBody] or [GridMap]'s [Shape]s enters one of this Area's [Shape]s. Requires [member monitoring] to be set to [code]true[/code]. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape]s.
 				[code]body_rid[/code] the [RID] of the [PhysicsBody] or [MeshLibrary]'s [CollisionObject] used by the [PhysicsServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape] of the [PhysicsBody] or [GridMap] used by the [PhysicsServer]. Get the [CollisionShape] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape] of this Area used by the [PhysicsServer]. Get the [CollisionShape] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape] from the [PhysicsBody] or [GridMap].
+				[code]local_shape_index[/code] the index of the [Shape] from this Area.
+				[b]Example of getting the[/b] [CollisionShape] [b]node from the shape index:[/b]
+				[codeblock]
+				var body_shape_owner = body.shape_find_owner(body_shape_index)
+				var body_shape_node = body.shape_owner_get_owner(body_shape_owner)
+
+				var local_shape_owner = shape_find_owner(local_shape_index)
+				var local_shape_node = shape_owner_get_owner(local_shape_owner)
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -175,8 +192,9 @@
 				Emitted when one of a [PhysicsBody] or [GridMap]'s [Shape]s enters one of this Area's [Shape]s. Requires [member monitoring] to be set to [code]true[/code]. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape]s.
 				[code]body_rid[/code] the [RID] of the [PhysicsBody] or [MeshLibrary]'s [CollisionObject] used by the [PhysicsServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape] of the [PhysicsBody] or [GridMap] used by the [PhysicsServer]. Get the [CollisionShape] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape] of this Area used by the [PhysicsServer]. Get the [CollisionShape] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape] from the [PhysicsBody] or [GridMap].
+				[code]local_shape_index[/code] the index of the [Shape] from this Area.
+				See also [signal body_shape_entered].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -111,8 +111,16 @@
 				Emitted when one of another Area2D's [Shape2D]s enters one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code].
 				[code]area_rid[/code] the [RID] of the other Area2D's [CollisionObject2D] used by the [Physics2DServer].
 				[code]area[/code] the other Area2D.
-				[code]area_shape_index[/code] the index of the [Shape2D] of the other Area2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]area.shape_owner_get_owner(area_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]area_shape_index[/code] the index of the [Shape2D] from the other Area2D.
+				[code]local_shape_index[/code] the index of the [Shape2D] from this Area2D.
+				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
+				[codeblock]
+				var other_shape_owner = area.shape_find_owner(area_shape_index)
+				var other_shape_node = area.shape_owner_get_owner(other_shape_owner)
+
+				var local_shape_owner = shape_find_owner(local_shape_index)
+				var local_shape_node = shape_owner_get_owner(local_shape_owner)
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="area_shape_exited">
@@ -124,8 +132,9 @@
 				Emitted when one of another Area2D's [Shape2D]s exits one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code].
 				[code]area_rid[/code] the [RID] of the other Area2D's [CollisionObject2D] used by the [Physics2DServer].
 				[code]area[/code] the other Area2D.
-				[code]area_shape_index[/code] the index of the [Shape2D] of the other Area2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]area.shape_owner_get_owner(area_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]area_shape_index[/code] the index of the [Shape2D] from the other Area2D.
+				[code]local_shape_index[/code] the index of the [Shape2D] from this Area2D.
+				See also [signal area_shape_entered].
 			</description>
 		</signal>
 		<signal name="body_entered">
@@ -151,8 +160,16 @@
 				Emitted when one of a [PhysicsBody2D] or [TileMap]'s [Shape2D]s enters one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code]. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
 				[code]body_rid[/code] the [RID] of the [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [Physics2DServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the [PhysicsBody2D] or [TileMap] used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape2D] from the [PhysicsBody2D] or [TileMap].
+				[code]local_shape_index[/code] the index of the [Shape2D] from this Area2D.
+				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
+				[codeblock]
+				var body_shape_owner = body.shape_find_owner(body_shape_index)
+				var body_shape_node = body.shape_owner_get_owner(body_shape_owner)
+
+				var local_shape_owner = shape_find_owner(local_shape_index)
+				var local_shape_node = shape_owner_get_owner(local_shape_owner)
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -164,8 +181,9 @@
 				Emitted when one of a [PhysicsBody2D] or [TileMap]'s [Shape2D]s exits one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code]. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
 				[code]body_rid[/code] the [RID] of the [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [Physics2DServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the [PhysicsBody2D] or [TileMap] used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape2D] from the [PhysicsBody2D] or [TileMap].
+				[code]local_shape_index[/code] the index of the [Shape2D] from this Area2D.
+				See also [signal body_shape_entered].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -210,8 +210,16 @@
 				Emitted when one of this RigidBody's [Shape]s collides with another [PhysicsBody] or [GridMap]'s [Shape]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape]s.
 				[code]body_rid[/code] the [RID] of the other [PhysicsBody] or [MeshLibrary]'s [CollisionObject] used by the [PhysicsServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape] of the other [PhysicsBody] or [GridMap] used by the [PhysicsServer]. Get the [CollisionShape] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape] of this RigidBody used by the [PhysicsServer]. Get the [CollisionShape] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape] of the other [PhysicsBody] or [GridMap].
+				[code]local_shape_index[/code] the index of the [Shape] of this RigidBody.
+				[b]Example of getting the[/b] [CollisionShape] [b]node from the shape index:[/b]
+				[codeblock]
+				var body_shape_owner = body.shape_find_owner(body_shape_index)
+				var body_shape_node = body.shape_owner_get_owner(body_shape_owner)
+
+				var local_shape_owner = shape_find_owner(local_shape_index)
+				var local_shape_node = shape_owner_get_owner(local_shape_owner)
+				[/codeblock]
 				[b]Note:[/b] Bullet physics cannot identify the shape index when using a [ConcavePolygonShape]. Don't use multiple [CollisionShape]s when using a [ConcavePolygonShape] with Bullet physics if you need shape indices.
 			</description>
 		</signal>
@@ -224,9 +232,10 @@
 				Emitted when the collision between one of this RigidBody's [Shape]s and another [PhysicsBody] or [GridMap]'s [Shape]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape]s.
 				[code]body_rid[/code] the [RID] of the other [PhysicsBody] or [MeshLibrary]'s [CollisionObject] used by the [PhysicsServer]. [GridMap]s are detected if the Meshes have [Shape]s.
 				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape] of the other [PhysicsBody] or [GridMap] used by the [PhysicsServer]. Get the [CollisionShape] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape] of this RigidBody used by the [PhysicsServer]. Get the [CollisionShape] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape] of the other [PhysicsBody] or [GridMap].
+				[code]local_shape_index[/code] the index of the [Shape] of this RigidBody.
 				[b]Note:[/b] Bullet physics cannot identify the shape index when using a [ConcavePolygonShape]. Don't use multiple [CollisionShape]s when using a [ConcavePolygonShape] with Bullet physics if you need shape indices.
+				See also [signal body_shape_entered].
 			</description>
 		</signal>
 		<signal name="sleeping_state_changed">

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -186,8 +186,16 @@
 				Emitted when one of this RigidBody2D's [Shape2D]s collides with another [PhysicsBody2D] or [TileMap]'s [Shape2D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
 				[code]body_rid[/code] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [Physics2DServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this RigidBody2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap].
+				[code]local_shape_index[/code] the index of the [Shape2D] of this RigidBody2D.
+				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
+				[codeblock]
+				var body_shape_owner = body.shape_find_owner(body_shape_index)
+				var body_shape_node = body.shape_owner_get_owner(body_shape_owner)
+
+				var local_shape_owner = shape_find_owner(local_shape_index)
+				var local_shape_node = shape_owner_get_owner(local_shape_owner)
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -199,8 +207,9 @@
 				Emitted when the collision between one of this RigidBody2D's [Shape2D]s and another [PhysicsBody2D] or [TileMap]'s [Shape2D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
 				[code]body_rid[/code] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [Physics2DServer].
 				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body_shape_index)[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this RigidBody2D used by the [Physics2DServer]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(local_shape_index)[/code].
+				[code]body_shape_index[/code] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap].
+				[code]local_shape_index[/code] the index of the [Shape2D] of this RigidBody2D.
+				See also [signal body_shape_entered].
 			</description>
 		</signal>
 		<signal name="sleeping_state_changed">


### PR DESCRIPTION
Fixes #57369
Backported from #57478 but with more readable format from a rework of the area docs since that PR in 4.x

