### PR TITLE
Fix regression where a tile's custom material was ignored

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -328,7 +328,7 @@ void TileMapLayer::_rendering_update() {
 							rs->canvas_item_set_material(ci, mat->get_rid());
 						}
 						rs->canvas_item_set_parent(ci, get_canvas_item());
-						rs->canvas_item_set_use_parent_material(ci, true);
+						rs->canvas_item_set_use_parent_material(ci, !mat.is_valid());
 
 						Transform2D xform(0, rendering_quadrant->canvas_items_position);
 						rs->canvas_item_set_transform(ci, xform);


### PR DESCRIPTION
Regression found via bisect; originates from commit 48bed5050b4a2d695953ace409c577bdfefe0038

Any material assigned to a tile via the TileSetEditor was ignored due to always using the parent material, even when a material is assigned to a tile.

I presume that the change I've made is close to the desired / expected behavior where a TileMap layer will only use a parent material if the material assigned is invalid. @groud Let me know if this is right. 

### Testing
- Checkout master or commit 48bed5050b4a2d695953ace409c577bdfefe0038 and compile.
- Try to assign a material to a tile via the TileSetEditor. The material will render properly in the editor directly.
- Try painting the tile onto a TileMap. You'll notice that the material does not work as expected. 
- Check out this PR and recompile.
- Materials should now work for individual tiles as well as TileMap/TileMapLayer(s).