### PR TITLE
Use highlighted version of the tab icon in the bottom file system dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -584,7 +584,7 @@ void FileSystemDock::_notification(int p_what) {
 			file_list_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			file_list_button_sort->set_icon(get_editor_theme_icon(SNAME("Sort")));
 
-			button_dock_placement->set_icon(get_editor_theme_icon(SNAME("GuiTabMenu")));
+			button_dock_placement->set_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 
 			if (is_layout_rtl()) {
 				button_hist_next->set_icon(get_editor_theme_icon(SNAME("Back")));


### PR DESCRIPTION
| Before: | After: |
|-|-|
| ![Screenshot_20240210_211900](https://github.com/godotengine/godot/assets/30739239/b86adcc3-d71b-4ca4-be3d-75c099300316) | ![Screenshot_20240210_210558](https://github.com/godotengine/godot/assets/30739239/e100ed0c-1ab1-4e14-b4e7-aa4c1e03906d)