### PR TITLE
[3.x] Fix `Mesh::get_face_count()`

### DIFF
--- a/editor/plugins/merge_group_editor_plugin.cpp
+++ b/editor/plugins/merge_group_editor_plugin.cpp
@@ -324,7 +324,7 @@ void MergeGroupEditorPlugin::_remove_queue_deleted_nodes_recursive(Node *p_node)
 uint32_t MergeGroupEditorPlugin::_get_mesh_poly_count(const MeshInstance &p_mi) const {
 	Ref<Mesh> rmesh = p_mi.get_mesh();
 	if (rmesh.is_valid()) {
-		return rmesh->get_face_count();
+		return rmesh->get_triangle_count();
 	}
 
 	return 0;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -42,7 +42,7 @@
 
 Mesh::ConvexDecompositionFunc Mesh::convex_decomposition_function = nullptr;
 
-int Mesh::surface_get_face_count(int p_idx) const {
+int Mesh::surface_get_triangle_count(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, get_surface_count(), 0);
 
 	switch (surface_get_primitive_type(p_idx)) {
@@ -50,14 +50,14 @@ int Mesh::surface_get_face_count(int p_idx) const {
 			int len = (surface_get_format(p_idx) & ARRAY_FORMAT_INDEX) ? surface_get_array_index_len(p_idx) : surface_get_array_len(p_idx);
 			// Don't error if zero, it's valid (we'll just skip it later).
 			ERR_FAIL_COND_V_MSG((len % 3) != 0, 0, vformat("Ignoring surface %d, incorrect %s count: %d (for PRIMITIVE_TRIANGLES).", p_idx, (surface_get_format(p_idx) & ARRAY_FORMAT_INDEX) ? "index" : "vertex", len));
-			return len;
+			return len / 3;
 		} break;
 		case PRIMITIVE_TRIANGLE_FAN:
 		case PRIMITIVE_TRIANGLE_STRIP: {
 			int len = (surface_get_format(p_idx) & ARRAY_FORMAT_INDEX) ? surface_get_array_index_len(p_idx) : surface_get_array_len(p_idx);
 			// Don't error if zero, it's valid (we'll just skip it later).
 			ERR_FAIL_COND_V_MSG(len != 0 && len < 3, 0, vformat("Ignoring surface %d, incorrect %s count: %d (for %s).", p_idx, (surface_get_format(p_idx) & ARRAY_FORMAT_INDEX) ? "index" : "vertex", len, (surface_get_primitive_type(p_idx) == PRIMITIVE_TRIANGLE_FAN) ? "PRIMITIVE_TRIANGLE_FAN" : "PRIMITIVE_TRIANGLE_STRIP"));
-			return (len == 0) ? 0 : (len - 2) * 3;
+			return (len == 0) ? 0 : (len - 2);
 		} break;
 		default: {
 		} break;
@@ -66,14 +66,14 @@ int Mesh::surface_get_face_count(int p_idx) const {
 	return 0;
 }
 
-int Mesh::get_face_count() const {
-	int faces_size = 0;
+int Mesh::get_triangle_count() const {
+	int triangle_count = 0;
 
 	for (int i = 0; i < get_surface_count(); i++) {
-		faces_size += surface_get_face_count(i);
+		triangle_count += surface_get_triangle_count(i);
 	}
 
-	return faces_size;
+	return triangle_count;
 }
 
 Ref<TriangleMesh> Mesh::generate_triangle_mesh_from_aabb() const {
@@ -151,14 +151,14 @@ Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 		return triangle_mesh;
 	}
 
-	int faces_size = get_face_count();
+	int faces_vertex_count = get_triangle_count() * 3;
 
-	if (faces_size == 0) {
+	if (faces_vertex_count == 0) {
 		return triangle_mesh;
 	}
 
 	PoolVector<Vector3> faces;
-	faces.resize(faces_size);
+	faces.resize(faces_vertex_count);
 	PoolVector<Vector3>::Write facesw = faces.write();
 
 	int widx = 0;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -137,11 +137,11 @@ public:
 	virtual void surface_set_material(int p_idx, const Ref<Material> &p_material) = 0;
 	virtual Ref<Material> surface_get_material(int p_idx) const = 0;
 	virtual int get_blend_shape_count() const = 0;
-	int surface_get_face_count(int p_idx) const;
+	int surface_get_triangle_count(int p_idx) const;
 	virtual StringName get_blend_shape_name(int p_index) const = 0;
 	virtual void set_blend_shape_name(int p_index, const StringName &p_name) = 0;
 
-	int get_face_count() const;
+	int get_triangle_count() const;
 	PoolVector<Face3> get_faces() const;
 	Ref<TriangleMesh> generate_triangle_mesh() const;
 	Ref<TriangleMesh> generate_triangle_mesh_from_aabb() const;


### PR DESCRIPTION
This fixes a minor bug whereby facecount was actually returning the facecount * 3. There were no major problems from this, but it did mean the optional threshold poly count used when merging was out by a factor of 3.

I've also taken the opportunity to rename it to `triangle count` rather than face, because `generate_triangle_mesh()` currently relies on it being triangles.

## Notes
* `get_face_count()` has only been present in 3.x for a few days since #61568 so there is little likelihood of any knockon problems fixing this.
* I managed to track down why I had inadvertently introduced this during `MergeGroup` PR: it was due to some rather dodgy naming *cough* by the previous author :grin: (that I copy pasted code from) where `faces_size` was not the face count, but the number of vertices used by the faces.
* I have improved the naming of the variable in `Mesh::generate_triangle_mesh()` to prevent this happening again.
* It was only used in 2 places: In `Mesh::generate_triangle_mesh()` (where it caused no problems due to the aforementioned naming), and optionally when merging if the user had set a threshold poly count for splitting (where the threshold would have been out by 3, which is no big problem).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
