### PR TITLE
Fix exporting trigger shapes in GLTF

### DIFF
--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -360,7 +360,7 @@ void GLTFDocumentExtensionPhysics::convert_scene_node(Ref<GLTFState> p_state, Re
 				gltf_shape->set_mesh_index(_get_or_insert_mesh_in_state(p_state, importer_mesh));
 			}
 		}
-		if (cast_to<Area3D>(_get_ancestor_collision_object(p_scene_node))) {
+		if (cast_to<Area3D>(_get_ancestor_collision_object(p_scene_node->get_parent()))) {
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsTriggerShape"), gltf_shape);
 		} else {
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsColliderShape"), gltf_shape);


### PR DESCRIPTION
This is a minor but critical bug that broke exporting trigger shapes. It's a regression I introduced in #78967. This is only merged in master, so this PR is only relevant for master.

The intention of this internal helper method is to start with the parent, because it's used in places where the child may not even exist yet. However, in the export code, since there is no `p_scene_parent` like with the import code, I made a mistake of writing `p_scene_node` instead of `p_scene_node->get_parent()`.