### PR TITLE
Link `xid_start` and `xid_continue` externally to prevent data duplication in binary

### DIFF
--- a/core/string/char_range.inc
+++ b/core/string/char_range.inc
@@ -38,7 +38,7 @@ struct CharRange {
 	char32_t end;
 };
 
-static CharRange xid_start[] = {
+inline constexpr CharRange xid_start[] = {
 	{ 0x41, 0x5a },
 	{ 0x5f, 0x5f },
 	{ 0x61, 0x7a },
@@ -692,7 +692,7 @@ static CharRange xid_start[] = {
 	{ 0x0, 0x0 },
 };
 
-static CharRange xid_continue[] = {
+inline constexpr CharRange xid_continue[] = {
 	{ 0x30, 0x39 },
 	{ 0x41, 0x5a },
 	{ 0x5f, 0x5f },


### PR DESCRIPTION
Similarly to https://github.com/godotengine/godot/pull/88178 `xid_start` and `xid_continue` were reported in [SizeBench](https://devblogs.microsoft.com/performance-diagnostics/sizebench-a-new-tool-for-analyzing-windows-binary-size/).
![image](https://github.com/godotengine/godot/assets/1554127/360ec8ba-4b26-48df-8f79-0f4dd17e72d2)

Windows 11, Microsoft (R) C/C++ Optimizing Compiler Version 19.38.33133 for x64
`scons target=template_release` build size reduced by 22 KB.