### PR TITLE
Add KHR_audio_emitter support to the GLTF module

### DIFF
--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -4,6 +4,23 @@ from misc.utility.scons_hints import *
 Import("env")
 Import("env_modules")
 
+# For MP3 support in the GLTFDocumentExtensionAudio.
+if env["module_mp3_enabled"]:
+    thirdparty_dir = "#thirdparty/dr_libs/"
+    if not env.msvc:
+        env_modules.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
+    else:
+        env_modules.Prepend(CPPPATH=[thirdparty_dir])
+    if not env["mp3_extra_formats"]:
+        env_modules.Append(CPPDEFINES=["DR_MP3_ONLY_MP3"])
+
+# For OGG Vorbis support in the GLTFDocumentExtensionAudio.
+if env["module_vorbis_enabled"]:
+    thirdparty_dir = "#thirdparty/libvorbis/"
+    env_modules.Prepend(CPPPATH=[thirdparty_dir])
+    if env["builtin_libogg"]:
+        env_modules.Prepend(CPPPATH=["#thirdparty/libogg"])
+
 env_gltf = env_modules.Clone()
 
 # Godot source files

--- a/modules/gltf/config.py
+++ b/modules/gltf/config.py
@@ -13,6 +13,7 @@ def get_doc_classes():
         "EditorSceneFormatImporterGLTF",
         "GLTFAccessor",
         "GLTFAnimation",
+        "GLTFAudioPlayer",
         "GLTFBufferView",
         "GLTFCamera",
         "GLTFDocument",

--- a/modules/gltf/doc_classes/GLTFAudioPlayer.xml
+++ b/modules/gltf/doc_classes/GLTFAudioPlayer.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GLTFAudioPlayer" inherits="Resource" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Represents a GLTF audio player.
+	</brief_description>
+	<description>
+		GLTFAudioPlayer is an intermediary between GLTF audio and Godot's audio player nodes.
+		The KHR_audio_emitter GLTF extension includes the MP3 format in the base spec. Godot supports saving and loading MP3 when Godot is compiled with the MP3 module enabled (default). Additionally, Godot can load and save WAV files always, and can load Ogg Vorbis audio files but not save them when Godot is compiled with the Vorbis module enabled (default).
+	</description>
+	<tutorials>
+		<link title="KHR_audio_emitter GLTF extension">https://github.com/omigroup/gltf-extensions/tree/main/extensions/2.0/KHR_audio_emitter</link>
+	</tutorials>
+	<methods>
+		<method name="from_dictionary" qualifiers="static">
+			<return type="GLTFAudioPlayer" />
+			<param index="0" name="dictionary" type="Dictionary" />
+			<description>
+				Creates a new GLTFAudioPlayer instance from the given [Dictionary] containing GLTF audio emitter data as defined by KHR_audio_emitter.
+			</description>
+		</method>
+		<method name="from_node" qualifiers="static">
+			<return type="GLTFAudioPlayer" />
+			<param index="0" name="audio_node" type="Node" />
+			<description>
+				Creates a new GLTFAudioPlayer instance from the given Godot [AudioStreamPlayer] or [AudioStreamPlayer3D] node.
+			</description>
+		</method>
+		<method name="from_node_0d" qualifiers="static">
+			<return type="GLTFAudioPlayer" />
+			<param index="0" name="audio_node" type="AudioStreamPlayer" />
+			<description>
+				Creates a new GLTFAudioPlayer instance from the given Godot [AudioStreamPlayer] node.
+			</description>
+		</method>
+		<method name="from_node_3d" qualifiers="static">
+			<return type="GLTFAudioPlayer" />
+			<param index="0" name="audio_node" type="AudioStreamPlayer3D" />
+			<description>
+				Creates a new GLTFAudioPlayer instance from the given Godot [AudioStreamPlayer3D] node.
+			</description>
+		</method>
+		<method name="to_dictionary" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Converts this GLTFAudioPlayer to a [Dictionary] containing GLTF audio emitter data as defined by KHR_audio_emitter.
+			</description>
+		</method>
+		<method name="to_node">
+			<return type="Node" />
+			<description>
+				Converts this GLTFAudioPlayer to a Godot [AudioStreamPlayer] or [AudioStreamPlayer3D] node.
+			</description>
+		</method>
+		<method name="to_node_0d">
+			<return type="AudioStreamPlayer" />
+			<description>
+				Converts this GLTFAudioPlayer to a Godot [AudioStreamPlayer] node.
+			</description>
+		</method>
+		<method name="to_node_3d">
+			<return type="AudioStreamPlayer3D" />
+			<description>
+				Converts this GLTFAudioPlayer to a Godot [AudioStreamPlayer3D] node.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="audio_sources" type="PackedInt32Array" setter="set_audio_sources" getter="get_audio_sources" default="PackedInt32Array()">
+			Indices of the audio sources in the GLTF file that are used by this player. This property is used by the [Dictionary] conversion methods, but not the [Node] conversion methods.
+		</member>
+		<member name="audio_stream" type="AudioStream" setter="set_audio_stream" getter="get_audio_stream">
+			The audio stream used by this player. This property is used by the [Node] conversion methods, but not the [Dictionary] conversion methods.
+		</member>
+		<member name="autoplay" type="bool" setter="set_autoplay" getter="get_autoplay" default="false">
+			If [code]true[/code], the audio will automatically start playing when the audio player node is added to the scene tree. This corresponds to the [code skip-lint]autoplay[/code] property of the audio source in the GLTF file (not the audio emitter).
+		</member>
+		<member name="cone_inner_angle" type="float" setter="set_cone_inner_angle" getter="get_cone_inner_angle" default="6.2831855">
+			The inner angle of the audio cone's angular diameter in radians. An angle of [constant @GDScript.TAU] or greater means the audio is emitted in all directions. This corresponds to the [code]coneInnerAngle[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="cone_outer_angle" type="float" setter="set_cone_outer_angle" getter="get_cone_outer_angle" default="6.2831855">
+			The outer angle of the audio cone's angular diameter in radians. This corresponds to the [code]coneOuterAngle[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="cone_outer_gain" type="float" setter="set_cone_outer_gain" getter="get_cone_outer_gain" default="0.0">
+			The linear volume gain multiplier of the audio applied when outside the outer cone angle. This is multiplied with [member volume_gain]. This corresponds to the [code]coneOuterGain[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="distance_model" type="String" setter="set_distance_model" getter="get_distance_model" default="&quot;inverse&quot;">
+			The distance model used to calculate the volume of the audio. Godot only supports the [code]"inverse"[/code] distance model. This corresponds to the [code]distanceModel[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="emitter_type" type="int" setter="set_emitter_type" getter="get_emitter_type" enum="GLTFAudioPlayer.EmitterType" default="1">
+			The emitter type of the audio player. This corresponds to the [code]type[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">
+			The maximum distance from the audio source, beyond which the audio cannot be heard. This corresponds to the [code]maxDistance[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="pitch_playback_rate" type="float" setter="set_pitch_playback_rate" getter="get_pitch_playback_rate" default="1.0">
+			The combined pitch and playback rate without resampling, as a multiplier of the audio sample's sample rate. This corresponds to the [code]playbackRate[/code] property of the audio source in the GLTF file (not the audio emitter), and the [member AudioStreamPlayer.pitch_scale] and [member AudioStreamPlayer3D.pitch_scale] properties in Godot.
+		</member>
+		<member name="rolloff_factor" type="float" setter="set_rolloff_factor" getter="get_rolloff_factor" default="1.0">
+			The rate at which the volume decreases between [member unit_distance] and [member max_distance]. Godot only supports values of [code]0.0[/code] (no distance attenuation), [code]1.0[/code] (inverse distance), and [code]2.0[/code] (inverse squared distance). This corresponds to the [code]rolloffFactor[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="shape_type" type="String" setter="set_shape_type" getter="get_shape_type" default="&quot;omnidirectional&quot;">
+			The shape of the audio emitter. May be [code]"omnidirectional"[/code] or [code]"cone"[/code]. This corresponds to the [code]shapeType[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="unit_distance" type="float" setter="set_unit_distance" getter="get_unit_distance" default="1.0">
+			The distance in meters where the volume is heard at 100% of its original volume. If closer than this distance, the volume will be [member volume_gain]. If between this distance and [member max_distance], the volume will decrease at a rate determined by [member rolloff_factor]. This corresponds to the [code]refDistance[/code] property of the audio emitter in the GLTF file.
+		</member>
+		<member name="volume_gain" type="float" setter="set_volume_gain" getter="get_volume_gain" default="1.0">
+			The linear volume gain multiplier of the audio. This value is linear, a value of [code]0.0[/code] means silence, [code]1.0[/code] is the original volume, [code]2.0[/code] is twice the volume, etc. This corresponds to the [code]gain[/code] property of the audio source in the GLTF file (not the audio emitter).
+		</member>
+	</members>
+	<constants>
+		<constant name="EMITTER_TYPE_GLOBAL" value="0" enum="EmitterType">
+			Global emitter type, played everywhere. Audio players with the global emitter type will be imported as [AudioStreamPlayer] nodes, or exported as [code]"type": "global"[/code] in the GLTF file.
+		</constant>
+		<constant name="EMITTER_TYPE_POSITIONAL" value="1" enum="EmitterType">
+			Positional emitter type, played at a specific position, either omnidirectionally or in a cone. Audio players with the positional emitter type will be imported as [AudioStreamPlayer3D] nodes, or exported as [code]"type": "positional"[/code] in the GLTF file.
+		</constant>
+	</constants>
+</class>

--- a/modules/gltf/extensions/SCsub
+++ b/modules/gltf/extensions/SCsub
@@ -9,5 +9,6 @@ env_gltf = env_modules.Clone()
 # Godot source files
 
 env_gltf.add_source_files(env.modules_sources, "*.cpp")
+env_gltf.add_source_files(env.modules_sources, "audio/*.cpp")
 if not env["disable_physics_3d"]:
     env_gltf.add_source_files(env.modules_sources, "physics/*.cpp")

--- a/modules/gltf/extensions/audio/gltf_audio_player.cpp
+++ b/modules/gltf/extensions/audio/gltf_audio_player.cpp
@@ -1,0 +1,456 @@
+/**************************************************************************/
+/*  gltf_audio_player.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gltf_audio_player.h"
+
+#include "../../gltf_template_convert.h"
+
+#include "core/object/class_db.h"
+#include "scene/3d/audio_stream_player_3d.h"
+#include "scene/audio/audio_stream_player.h"
+#include "scene/resources/audio/audio_stream.h"
+
+void GLTFAudioPlayer::_bind_methods() {
+	// Constructors and converters.
+	ClassDB::bind_static_method("GLTFAudioPlayer", D_METHOD("from_node_0d", "audio_node"), &GLTFAudioPlayer::from_node_0d);
+	ClassDB::bind_static_method("GLTFAudioPlayer", D_METHOD("from_node_3d", "audio_node"), &GLTFAudioPlayer::from_node_3d);
+	ClassDB::bind_static_method("GLTFAudioPlayer", D_METHOD("from_node", "audio_node"), &GLTFAudioPlayer::from_node);
+
+	ClassDB::bind_method(D_METHOD("to_node_0d"), &GLTFAudioPlayer::to_node_0d);
+	ClassDB::bind_method(D_METHOD("to_node_3d"), &GLTFAudioPlayer::to_node_3d);
+	ClassDB::bind_method(D_METHOD("to_node"), &GLTFAudioPlayer::to_node);
+
+	ClassDB::bind_static_method("GLTFAudioPlayer", D_METHOD("from_dictionary", "dictionary"), &GLTFAudioPlayer::from_dictionary);
+	ClassDB::bind_method(D_METHOD("to_dictionary"), &GLTFAudioPlayer::to_dictionary);
+
+	// General audio properties.
+	ClassDB::bind_method(D_METHOD("get_emitter_type"), &GLTFAudioPlayer::get_emitter_type);
+	ClassDB::bind_method(D_METHOD("set_emitter_type", "emitter_type"), &GLTFAudioPlayer::set_emitter_type);
+
+	ClassDB::bind_method(D_METHOD("get_audio_sources"), &GLTFAudioPlayer::get_audio_sources);
+	ClassDB::bind_method(D_METHOD("set_audio_sources", "audio_sources"), &GLTFAudioPlayer::set_audio_sources);
+
+	ClassDB::bind_method(D_METHOD("get_audio_stream"), &GLTFAudioPlayer::get_audio_stream);
+	ClassDB::bind_method(D_METHOD("set_audio_stream", "audio_stream"), &GLTFAudioPlayer::set_audio_stream);
+
+	ClassDB::bind_method(D_METHOD("get_pitch_playback_rate"), &GLTFAudioPlayer::get_pitch_playback_rate);
+	ClassDB::bind_method(D_METHOD("set_pitch_playback_rate", "pitch_playback_rate"), &GLTFAudioPlayer::set_pitch_playback_rate);
+
+	ClassDB::bind_method(D_METHOD("get_volume_gain"), &GLTFAudioPlayer::get_volume_gain);
+	ClassDB::bind_method(D_METHOD("set_volume_gain", "volume_gain"), &GLTFAudioPlayer::set_volume_gain);
+
+	ClassDB::bind_method(D_METHOD("get_autoplay"), &GLTFAudioPlayer::get_autoplay);
+	ClassDB::bind_method(D_METHOD("set_autoplay", "autoplay"), &GLTFAudioPlayer::set_autoplay);
+
+	// Distance attenuation.
+	ClassDB::bind_method(D_METHOD("get_distance_model"), &GLTFAudioPlayer::get_distance_model);
+	ClassDB::bind_method(D_METHOD("set_distance_model", "distance_model"), &GLTFAudioPlayer::set_distance_model);
+
+	ClassDB::bind_method(D_METHOD("get_max_distance"), &GLTFAudioPlayer::get_max_distance);
+	ClassDB::bind_method(D_METHOD("set_max_distance", "max_distance"), &GLTFAudioPlayer::set_max_distance);
+
+	ClassDB::bind_method(D_METHOD("get_unit_distance"), &GLTFAudioPlayer::get_unit_distance);
+	ClassDB::bind_method(D_METHOD("set_unit_distance", "unit_distance"), &GLTFAudioPlayer::set_unit_distance);
+
+	ClassDB::bind_method(D_METHOD("get_rolloff_factor"), &GLTFAudioPlayer::get_rolloff_factor);
+	ClassDB::bind_method(D_METHOD("set_rolloff_factor", "rolloff_factor"), &GLTFAudioPlayer::set_rolloff_factor);
+
+	// Cone attenuation. All angles are in radians.
+	ClassDB::bind_method(D_METHOD("get_shape_type"), &GLTFAudioPlayer::get_shape_type);
+	ClassDB::bind_method(D_METHOD("set_shape_type", "shape_type"), &GLTFAudioPlayer::set_shape_type);
+
+	ClassDB::bind_method(D_METHOD("get_cone_inner_angle"), &GLTFAudioPlayer::get_cone_inner_angle);
+	ClassDB::bind_method(D_METHOD("set_cone_inner_angle", "cone_inner_angle"), &GLTFAudioPlayer::set_cone_inner_angle);
+
+	ClassDB::bind_method(D_METHOD("get_cone_outer_angle"), &GLTFAudioPlayer::get_cone_outer_angle);
+	ClassDB::bind_method(D_METHOD("set_cone_outer_angle", "cone_outer_angle"), &GLTFAudioPlayer::set_cone_outer_angle);
+
+	ClassDB::bind_method(D_METHOD("get_cone_outer_gain"), &GLTFAudioPlayer::get_cone_outer_gain);
+	ClassDB::bind_method(D_METHOD("set_cone_outer_gain", "cone_outer_gain"), &GLTFAudioPlayer::set_cone_outer_gain);
+
+	// General audio properties.
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "emitter_type"), "set_emitter_type", "get_emitter_type");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "audio_sources"), "set_audio_sources", "get_audio_sources");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "audio_stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_audio_stream", "get_audio_stream");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "get_autoplay");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_playback_rate"), "set_pitch_playback_rate", "get_pitch_playback_rate");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_gain"), "set_volume_gain", "get_volume_gain");
+
+	// Distance attenuation.
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "distance_model"), "set_distance_model", "get_distance_model");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance"), "set_max_distance", "get_max_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_distance"), "set_unit_distance", "get_unit_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rolloff_factor"), "set_rolloff_factor", "get_rolloff_factor");
+
+	// Cone attenuation. All angles are in radians.
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "shape_type"), "set_shape_type", "get_shape_type");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cone_inner_angle"), "set_cone_inner_angle", "get_cone_inner_angle");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cone_outer_angle"), "set_cone_outer_angle", "get_cone_outer_angle");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cone_outer_gain"), "set_cone_outer_gain", "get_cone_outer_gain");
+
+	// Emitter type enum.
+	BIND_ENUM_CONSTANT(EMITTER_TYPE_GLOBAL);
+	BIND_ENUM_CONSTANT(EMITTER_TYPE_POSITIONAL);
+}
+
+// General audio properties.
+
+GLTFAudioPlayer::EmitterType GLTFAudioPlayer::get_emitter_type() const {
+	return emitter_type;
+}
+
+void GLTFAudioPlayer::set_emitter_type(EmitterType p_emitter_type) {
+	emitter_type = p_emitter_type;
+}
+
+Vector<GLTFAudioSourceIndex> GLTFAudioPlayer::get_audio_sources() const {
+	return audio_sources;
+}
+
+void GLTFAudioPlayer::set_audio_sources(const Vector<GLTFAudioSourceIndex> &p_audio_sources) {
+	audio_sources = p_audio_sources;
+}
+
+Ref<AudioStream> GLTFAudioPlayer::get_audio_stream() const {
+	return audio_stream;
+}
+
+void GLTFAudioPlayer::set_audio_stream(const Ref<AudioStream> p_audio_stream) {
+	audio_stream = p_audio_stream;
+}
+
+bool GLTFAudioPlayer::get_autoplay() const {
+	return autoplay;
+}
+
+void GLTFAudioPlayer::set_autoplay(bool p_autoplay) {
+	autoplay = p_autoplay;
+}
+
+real_t GLTFAudioPlayer::get_pitch_playback_rate() const {
+	return pitch_playback_rate;
+}
+
+void GLTFAudioPlayer::set_pitch_playback_rate(real_t p_pitch_playback_rate) {
+	pitch_playback_rate = p_pitch_playback_rate;
+}
+
+real_t GLTFAudioPlayer::get_volume_gain() const {
+	return volume_gain;
+}
+
+void GLTFAudioPlayer::set_volume_gain(real_t p_volume_gain) {
+	volume_gain = p_volume_gain;
+}
+
+// Distance attenuation.
+
+String GLTFAudioPlayer::get_distance_model() const {
+	return distance_model;
+}
+
+void GLTFAudioPlayer::set_distance_model(const String &p_distance_model) {
+	distance_model = p_distance_model;
+}
+
+real_t GLTFAudioPlayer::get_max_distance() const {
+	return max_distance;
+}
+
+void GLTFAudioPlayer::set_max_distance(real_t p_max_distance) {
+	max_distance = p_max_distance;
+}
+
+real_t GLTFAudioPlayer::get_unit_distance() const {
+	return unit_distance;
+}
+
+void GLTFAudioPlayer::set_unit_distance(real_t p_unit_distance) {
+	unit_distance = p_unit_distance;
+}
+
+real_t GLTFAudioPlayer::get_rolloff_factor() const {
+	return rolloff_factor;
+}
+
+void GLTFAudioPlayer::set_rolloff_factor(real_t p_rolloff_factor) {
+	rolloff_factor = p_rolloff_factor;
+}
+
+// Cone attenuation. All angles are in radians.
+
+String GLTFAudioPlayer::get_shape_type() const {
+	return shape_type;
+}
+
+void GLTFAudioPlayer::set_shape_type(const String &p_shape_type) {
+	shape_type = p_shape_type;
+}
+
+real_t GLTFAudioPlayer::get_cone_inner_angle() const {
+	return cone_inner_angle;
+}
+
+void GLTFAudioPlayer::set_cone_inner_angle(real_t p_cone_inner_angle) {
+	cone_inner_angle = p_cone_inner_angle;
+}
+
+real_t GLTFAudioPlayer::get_cone_outer_angle() const {
+	return cone_outer_angle;
+}
+
+void GLTFAudioPlayer::set_cone_outer_angle(real_t p_cone_outer_angle) {
+	cone_outer_angle = p_cone_outer_angle;
+}
+
+real_t GLTFAudioPlayer::get_cone_outer_gain() const {
+	return cone_outer_gain;
+}
+
+void GLTFAudioPlayer::set_cone_outer_gain(real_t p_cone_outer_gain) {
+	cone_outer_gain = p_cone_outer_gain;
+}
+
+Ref<GLTFAudioPlayer> GLTFAudioPlayer::from_node_0d(const AudioStreamPlayer *p_audio_player_node) {
+	Ref<GLTFAudioPlayer> audio_player;
+	audio_player.instantiate();
+	audio_player->set_emitter_type(GLTFAudioPlayer::EmitterType::EMITTER_TYPE_GLOBAL);
+	audio_player->set_audio_stream(p_audio_player_node->get_stream());
+	audio_player->set_pitch_playback_rate(p_audio_player_node->get_pitch_scale());
+	audio_player->set_volume_gain(Math::db_to_linear(p_audio_player_node->get_volume_db()));
+	audio_player->set_autoplay(p_audio_player_node->is_autoplay_enabled());
+	audio_player->set_name(p_audio_player_node->get_name());
+	return audio_player;
+}
+
+Ref<GLTFAudioPlayer> GLTFAudioPlayer::from_node_3d(const AudioStreamPlayer3D *p_audio_player_node) {
+	Ref<GLTFAudioPlayer> audio_player;
+	audio_player.instantiate();
+	audio_player->set_emitter_type(GLTFAudioPlayer::EmitterType::EMITTER_TYPE_POSITIONAL);
+	audio_player->set_audio_stream(p_audio_player_node->get_stream());
+	audio_player->set_pitch_playback_rate(p_audio_player_node->get_pitch_scale());
+	audio_player->set_volume_gain(Math::db_to_linear(p_audio_player_node->get_volume_db()));
+	audio_player->set_autoplay(p_audio_player_node->is_autoplay_enabled());
+	audio_player->set_name(p_audio_player_node->get_name());
+	// Distance attenuation.
+	audio_player->set_max_distance(p_audio_player_node->get_max_distance());
+	audio_player->set_unit_distance(p_audio_player_node->get_unit_size());
+	audio_player->set_distance_model("inverse");
+	const AudioStreamPlayer3D::AttenuationModel attenuation_model = p_audio_player_node->get_attenuation_model();
+	switch (attenuation_model) {
+		case AudioStreamPlayer3D::ATTENUATION_INVERSE_DISTANCE:
+			audio_player->set_rolloff_factor(1.0);
+			break;
+		case AudioStreamPlayer3D::ATTENUATION_INVERSE_SQUARE_DISTANCE:
+			audio_player->set_rolloff_factor(2.0);
+			break;
+		case AudioStreamPlayer3D::ATTENUATION_LOGARITHMIC:
+			ERR_PRINT("GLTF audio: Logarithmic attenuation is not supported by GLTF audio. Falling back to inverse.");
+			audio_player->set_rolloff_factor(1.0);
+			break;
+		case AudioStreamPlayer3D::ATTENUATION_DISABLED:
+			audio_player->set_rolloff_factor(0.0);
+			break;
+	}
+	// Cone attenuation. Godot only has one cone angle.
+	if (p_audio_player_node->is_emission_angle_enabled()) {
+		audio_player->set_shape_type("cone");
+		const real_t cone_angle = Math::deg_to_rad(p_audio_player_node->get_emission_angle()) * 2.0f;
+		audio_player->set_cone_inner_angle(cone_angle);
+		audio_player->set_cone_outer_angle(cone_angle);
+		audio_player->set_cone_outer_gain(Math::db_to_linear(p_audio_player_node->get_emission_angle_filter_attenuation_db()));
+	}
+	return audio_player;
+}
+
+Ref<GLTFAudioPlayer> GLTFAudioPlayer::from_node(const Node *p_audio_player_node) {
+	Ref<GLTFAudioPlayer> audio_player;
+	if (Object::cast_to<const AudioStreamPlayer>(p_audio_player_node)) {
+		audio_player = from_node_0d(cast_to<const AudioStreamPlayer>(p_audio_player_node));
+	} else if (cast_to<const AudioStreamPlayer3D>(p_audio_player_node)) {
+		audio_player = from_node_3d(cast_to<const AudioStreamPlayer3D>(p_audio_player_node));
+	} else {
+		ERR_PRINT("Tried to create a GLTFAudioPlayer from a node, but the given node was not an AudioStreamPlayer or AudioStreamPlayer3D.");
+	}
+	return audio_player;
+}
+
+AudioStreamPlayer *GLTFAudioPlayer::to_node_0d() {
+	AudioStreamPlayer *audio_node = memnew(AudioStreamPlayer);
+	audio_node->set_stream(audio_stream);
+	audio_node->set_pitch_scale(pitch_playback_rate);
+	audio_node->set_volume_db(Math::linear_to_db(volume_gain));
+	audio_node->set_autoplay(autoplay);
+	if (get_name().is_empty()) {
+		audio_node->set_name("GlobalAudioPlayer");
+	} else {
+		audio_node->set_name(get_name());
+	}
+	return audio_node;
+}
+
+AudioStreamPlayer3D *GLTFAudioPlayer::to_node_3d() {
+	AudioStreamPlayer3D *audio_node = memnew(AudioStreamPlayer3D);
+	audio_node->set_stream(audio_stream);
+	audio_node->set_pitch_scale(pitch_playback_rate);
+	audio_node->set_volume_db(Math::linear_to_db(volume_gain));
+	audio_node->set_max_db(Math::linear_to_db(volume_gain));
+	audio_node->set_autoplay(autoplay);
+	if (get_name().is_empty()) {
+		audio_node->set_name("PositionalAudioPlayer");
+	} else {
+		audio_node->set_name(get_name());
+	}
+	// Distance attenuation.
+	audio_node->set_max_distance(max_distance);
+	audio_node->set_unit_size(unit_distance);
+	if (distance_model != "inverse") {
+		WARN_PRINT("GLTF audio: A distance model of '" + distance_model + "' was specified in the GLTF data, but Godot only supports 'inverse'. Falling back to 'inverse'.");
+	}
+	if (rolloff_factor < 0.25f) {
+		audio_node->set_attenuation_model(AudioStreamPlayer3D::ATTENUATION_DISABLED);
+		if (!Math::is_zero_approx(rolloff_factor)) {
+			WARN_PRINT("GLTF audio: A rolloff factor of '" + rtos(rolloff_factor) + "' was specified in the GLTF data, but Godot only supports 0, 1, and 2. Falling back to 0 (no attenuation).");
+		}
+	} else if (rolloff_factor < 1.5f) {
+		audio_node->set_attenuation_model(AudioStreamPlayer3D::ATTENUATION_INVERSE_DISTANCE);
+		if (!Math::is_equal_approx(rolloff_factor, 1)) {
+			WARN_PRINT("GLTF audio: A rolloff factor of '" + rtos(rolloff_factor) + "' was specified in the GLTF data, but Godot only supports 0, 1, and 2. Falling back to 1 (inverse attenuation).");
+		}
+	} else {
+		audio_node->set_attenuation_model(AudioStreamPlayer3D::ATTENUATION_INVERSE_SQUARE_DISTANCE);
+		if (!Math::is_equal_approx(rolloff_factor, 2)) {
+			WARN_PRINT("GLTF audio: A rolloff factor of '" + rtos(rolloff_factor) + "' was specified in the GLTF data, but Godot only supports 0, 1, and 2. Falling back to 2 (inverse squared attenuation).");
+		}
+	}
+	// Cone attenuation. Godot only has one cone angle.
+	real_t emission_angle_radians = (cone_inner_angle + cone_outer_angle) / 4.0f;
+	// Note: Don't use TAU or PI in checks to account for floating point errors.
+	if (emission_angle_radians < 3.14f) {
+		if (emission_angle_radians > 1.58f) {
+			WARN_PRINT("GLTF audio: An emission angular radius of " + rtos(emission_angle_radians) + " radians was determined from the GLTF data (half the average of cone inner angular diameter " + rtos(cone_inner_angle) + " and cone outer angular diameter " + rtos(cone_outer_angle) + "), but Godot only supports 0 to 90 degrees (1.570796... radians). Falling back to 90 degrees.");
+		}
+		audio_node->set_emission_angle(MIN(Math::rad_to_deg(emission_angle_radians), 90.0f));
+		if (shape_type == "cone") {
+			audio_node->set_emission_angle_enabled(true);
+		}
+	}
+	audio_node->set_emission_angle_filter_attenuation_db(Math::linear_to_db(cone_outer_gain));
+	return audio_node;
+}
+
+Node *GLTFAudioPlayer::to_node() {
+	if (emitter_type == EmitterType::EMITTER_TYPE_GLOBAL) {
+		return to_node_0d();
+	}
+	return to_node_3d();
+}
+
+Ref<GLTFAudioPlayer> GLTFAudioPlayer::from_dictionary(const Dictionary &p_dictionary) {
+	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFAudioPlayer>(), "Failed to parse GLTF audio, missing required field 'type'.");
+	Ref<GLTFAudioPlayer> audio;
+	audio.instantiate();
+	const String &emitter_type_string = p_dictionary["type"];
+	// KHR_audio_emitter has "global" and "positional".
+	if (emitter_type_string == "global") {
+		audio->set_emitter_type(EmitterType::EMITTER_TYPE_GLOBAL);
+	} else if (emitter_type_string == "positional") {
+		audio->set_emitter_type(EmitterType::EMITTER_TYPE_POSITIONAL);
+	} else {
+		ERR_PRINT("Error parsing GLTF audio: Player type '" + emitter_type_string + "' is unknown.");
+	}
+	Vector<int> audio_sources;
+	Array sources = p_dictionary["sources"];
+	GLTFTemplateConvert::set_from_array(audio_sources, sources);
+	audio->set_audio_sources(audio_sources);
+	audio->set_volume_gain(p_dictionary.get("gain", 1.0));
+	audio->set_name(p_dictionary.get("name", ""));
+	if (p_dictionary.has("positional")) {
+		const Dictionary &positional = p_dictionary["positional"];
+		// Distance attenuation.
+		audio->set_distance_model(positional.get("distanceModel", "inverse"));
+		audio->set_max_distance(positional.get("maxDistance", 0.0));
+		audio->set_unit_distance(positional.get("refDistance", 1.0));
+		audio->set_rolloff_factor(positional.get("rolloffFactor", 1.0));
+		// Cone attenuation.
+		audio->set_cone_inner_angle(positional.get("coneInnerAngle", Math::TAU));
+		audio->set_cone_outer_angle(positional.get("coneOuterAngle", Math::TAU));
+		audio->set_cone_outer_gain(positional.get("coneOuterGain", 0.0));
+		if (positional.has("shapeType")) {
+			audio->set_shape_type(positional["shapeType"]);
+		} else if (audio->get_cone_outer_angle() < 6.28) {
+			audio->set_shape_type("cone");
+		}
+	}
+	return audio;
+}
+
+Dictionary GLTFAudioPlayer::to_dictionary() const {
+	Dictionary dict;
+	dict["sources"] = GLTFTemplateConvert::to_array(audio_sources);
+	dict["gain"] = volume_gain;
+	if (!get_name().is_empty()) {
+		dict["name"] = get_name();
+	}
+	if (emitter_type == EmitterType::EMITTER_TYPE_POSITIONAL) {
+		Dictionary positional;
+		if (cone_inner_angle < Math::TAU) {
+			positional["coneInnerAngle"] = cone_inner_angle;
+		}
+		if (cone_outer_angle < Math::TAU) {
+			positional["coneOuterAngle"] = cone_outer_angle;
+		}
+		if (cone_outer_gain != 0.0) {
+			positional["coneOuterGain"] = cone_outer_gain;
+		}
+		if (distance_model != "inverse") {
+			positional["distanceModel"] = distance_model;
+		}
+		if (max_distance > 0.0) {
+			positional["maxDistance"] = max_distance;
+		}
+		if (unit_distance != 1.0) {
+			positional["refDistance"] = unit_distance;
+		}
+		if (rolloff_factor != 1.0) {
+			positional["rolloffFactor"] = rolloff_factor;
+		}
+		if (shape_type != "omnidirectional") {
+			positional["shapeType"] = shape_type;
+		}
+		if (!positional.is_empty()) {
+			dict["positional"] = positional;
+		}
+		dict["type"] = "positional";
+	} else {
+		dict["type"] = "global";
+	}
+	return dict;
+}

--- a/modules/gltf/extensions/audio/gltf_audio_player.h
+++ b/modules/gltf/extensions/audio/gltf_audio_player.h
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/*  gltf_audio_player.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource.h"
+
+class AudioStream;
+class AudioStreamPlayer;
+class AudioStreamPlayer3D;
+
+using GLTFAudioSourceIndex = int;
+
+// GLTFAudioPlayer is an intermediary between GLTF audio and Godot's audio player nodes.
+// https://github.com/omigroup/gltf-extensions/tree/main/extensions/2.0/KHR_audio
+
+class GLTFAudioPlayer : public Resource {
+	GDCLASS(GLTFAudioPlayer, Resource)
+
+public:
+	enum EmitterType {
+		EMITTER_TYPE_GLOBAL,
+		EMITTER_TYPE_POSITIONAL,
+	};
+
+protected:
+	static void _bind_methods();
+
+private:
+	// General audio properties.
+	EmitterType emitter_type = EmitterType::EMITTER_TYPE_POSITIONAL;
+	Vector<GLTFAudioSourceIndex> audio_sources;
+	Ref<AudioStream> audio_stream;
+	real_t pitch_playback_rate = 1.0;
+	real_t volume_gain = 1.0;
+	bool autoplay = false;
+	// Distance attenuation.
+	String distance_model = "inverse";
+	real_t max_distance = 0.0;
+	real_t unit_distance = 1.0;
+	real_t rolloff_factor = 1.0;
+	// Cone attenuation. All angles are in radians.
+	String shape_type = "omnidirectional";
+	real_t cone_inner_angle = Math::TAU;
+	real_t cone_outer_angle = Math::TAU;
+	real_t cone_outer_gain = 0.0;
+
+public:
+	// General audio properties.
+	EmitterType get_emitter_type() const;
+	void set_emitter_type(EmitterType p_emitter_type);
+
+	Vector<GLTFAudioSourceIndex> get_audio_sources() const;
+	void set_audio_sources(const Vector<GLTFAudioSourceIndex> &p_audio_sources);
+
+	Ref<AudioStream> get_audio_stream() const;
+	void set_audio_stream(const Ref<AudioStream> p_audio_stream);
+
+	bool get_autoplay() const;
+	void set_autoplay(bool p_autoplay);
+
+	real_t get_pitch_playback_rate() const;
+	void set_pitch_playback_rate(real_t p_pitch_playback_rate);
+
+	real_t get_volume_gain() const;
+	void set_volume_gain(real_t p_volume_gain);
+
+	// Distance attenuation.
+	String get_distance_model() const;
+	void set_distance_model(const String &p_distance_model);
+
+	real_t get_max_distance() const;
+	void set_max_distance(real_t p_max_distance);
+
+	real_t get_unit_distance() const;
+	void set_unit_distance(real_t p_unit_distance);
+
+	real_t get_rolloff_factor() const;
+	void set_rolloff_factor(real_t p_rolloff_factor);
+
+	// Cone attenuation. All angles are in radians.
+	String get_shape_type() const;
+	void set_shape_type(const String &p_shape_type);
+
+	real_t get_cone_inner_angle() const;
+	void set_cone_inner_angle(real_t p_cone_inner_angle);
+
+	real_t get_cone_outer_angle() const;
+	void set_cone_outer_angle(real_t p_cone_outer_angle);
+
+	real_t get_cone_outer_gain() const;
+	void set_cone_outer_gain(real_t p_cone_outer_gain);
+
+	// Constructors and converters.
+	static Ref<GLTFAudioPlayer> from_node_0d(const AudioStreamPlayer *p_audio_node);
+	static Ref<GLTFAudioPlayer> from_node_3d(const AudioStreamPlayer3D *p_audio_node);
+	static Ref<GLTFAudioPlayer> from_node(const Node *p_audio_node);
+
+	AudioStreamPlayer *to_node_0d();
+	AudioStreamPlayer3D *to_node_3d();
+	Node *to_node();
+
+	static Ref<GLTFAudioPlayer> from_dictionary(const Dictionary &p_dictionary);
+	Dictionary to_dictionary() const;
+};
+
+VARIANT_ENUM_CAST(GLTFAudioPlayer::EmitterType);

--- a/modules/gltf/extensions/audio/gltf_document_extension_audio.cpp
+++ b/modules/gltf/extensions/audio/gltf_document_extension_audio.cpp
@@ -1,0 +1,668 @@
+/**************************************************************************/
+/*  gltf_document_extension_audio.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gltf_document_extension_audio.h"
+
+#include "gltf_audio_player.h"
+
+#include "core/core_bind.h"
+#include "core/io/file_access.h"
+#include "scene/3d/audio_stream_player_3d.h"
+#include "scene/audio/audio_stream_player.h"
+#include "scene/resources/audio/audio_stream_wav.h"
+
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_MP3_ENABLED
+#include "modules/mp3/audio_stream_mp3.h"
+#endif // MODULE_MP3_ENABLED
+
+#ifdef MODULE_VORBIS_ENABLED
+#include "modules/vorbis/audio_stream_ogg_vorbis.h"
+#endif // MODULE_VORBIS_ENABLED
+
+// Import process.
+Error GLTFDocumentExtensionAudio::import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) {
+	if (!p_extensions.has("KHR_audio_emitter")) {
+		return ERR_SKIP;
+	}
+	Dictionary state_json = p_state->get_json();
+	if (state_json.has("extensions")) {
+		Dictionary state_extensions = state_json["extensions"];
+		if (state_extensions.has("KHR_audio_emitter")) {
+			// KHR_audio_emitter's data is all defined in the document-level
+			// extensions and is designed to be highly reusable.
+			Dictionary khr_audio_ext = state_extensions["KHR_audio_emitter"];
+			if (khr_audio_ext.has("audio")) {
+				// TODO: Replace this with glTF 2.1 "files" array.
+				Array audio_data = khr_audio_ext["audio"];
+				p_state->set_additional_data(StringName("GLTFAudioData"), audio_data);
+			}
+			if (khr_audio_ext.has("sources")) {
+				Array audio_sources = khr_audio_ext["sources"];
+				p_state->set_additional_data(StringName("GLTFAudioSources"), audio_sources);
+			}
+			if (khr_audio_ext.has("emitters")) {
+				Array audio_emitter_dicts = khr_audio_ext["emitters"];
+				Array audio_emitters;
+				for (int emitter_index = 0; emitter_index < audio_emitter_dicts.size(); emitter_index++) {
+					Ref<GLTFAudioPlayer> audio_emitter = GLTFAudioPlayer::from_dictionary(audio_emitter_dicts[emitter_index]);
+					audio_emitters.append(audio_emitter);
+				}
+				p_state->set_additional_data(StringName("GLTFAudioEmitters"), audio_emitters);
+			}
+		}
+	}
+	return OK;
+}
+
+Vector<String> GLTFDocumentExtensionAudio::get_supported_extensions() {
+	Vector<String> ret;
+	ret.push_back("KHR_audio_emitter");
+	ret.push_back("OMI_audio_ogg_vorbis");
+	return ret;
+}
+
+Error GLTFDocumentExtensionAudio::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) {
+	if (p_extensions.has("KHR_audio_emitter")) {
+		Dictionary khr_audio_ext = p_extensions["KHR_audio_emitter"];
+		PackedInt32Array emitter_indices;
+		if (khr_audio_ext.has("emitters")) {
+			emitter_indices = khr_audio_ext["emitters"];
+			p_gltf_node->set_additional_data(StringName("GLTFAudioEmitterIndices"), emitter_indices);
+		}
+		if (khr_audio_ext.has("emitter")) {
+			int emitter_index = khr_audio_ext["emitter"];
+			emitter_indices.append(emitter_index);
+			p_gltf_node->set_additional_data(StringName("GLTFAudioEmitterIndices"), emitter_indices);
+		}
+	}
+	return OK;
+}
+
+// Helper methods for import_post_parse.
+static String _determine_mime_type_for_audio_dict(const Dictionary &p_audio_data_dict) {
+	String mime_type = p_audio_data_dict.get("mimeType", "");
+	if (!mime_type.is_empty()) {
+		return mime_type;
+	}
+	// Determine the MIME type from the URI.
+	String uri = p_audio_data_dict.get("uri", "");
+	if (uri.begins_with("data:")) {
+		return uri.substr(5, uri.find_char(';') - 5);
+	} else if (uri.ends_with(".mp3")) {
+		return "audio/mpeg";
+	} else if (uri.ends_with(".wav")) {
+		return "audio/wav";
+	} else if (uri.ends_with(".ogg")) {
+		return "audio/ogg";
+	}
+	// No MIME type was found, return an empty string.
+	return mime_type;
+}
+
+static Vector<uint8_t> _load_audio_bytes(Ref<GLTFState> p_state, const Dictionary &p_audio_data_dict) {
+	if (p_audio_data_dict.has("uri")) {
+		String uri = p_audio_data_dict["uri"];
+		if (uri.begins_with("data:")) {
+			int comma = uri.find_char(',');
+			ERR_FAIL_COND_V_MSG(comma == -1, Vector<uint8_t>(), "GLTF audio: Could not load audio URI data, no base64 data separator was found.");
+			return CoreBind::Marshalls::get_singleton()->base64_to_raw(uri.substr(comma + 1));
+		}
+		Error err;
+		Vector<uint8_t> bytes = FileAccess::get_file_as_bytes(p_state->get_base_path().path_join(uri), &err);
+		if (err == OK) {
+			return bytes;
+		}
+	}
+	if (p_audio_data_dict.has("bufferView")) {
+		const GLTFBufferViewIndex bvi = p_audio_data_dict["bufferView"];
+		const Vector<Ref<GLTFBufferView>> &buffer_views = p_state->get_buffer_views();
+		ERR_FAIL_INDEX_V(bvi, buffer_views.size(), Vector<uint8_t>());
+		Ref<GLTFBufferView> bv = buffer_views[bvi];
+		return bv->load_buffer_view_data(p_state);
+	}
+	ERR_FAIL_V_MSG(Vector<uint8_t>(), "GLTF audio: Could not load audio data, neither uri nor bufferView was valid.");
+}
+
+static void _load_audio_data(Ref<GLTFState> p_state, Dictionary &p_audio_data_dict, Dictionary &p_audio_source_dict) {
+	Ref<AudioStream> audio_stream;
+	String mime_type = _determine_mime_type_for_audio_dict(p_audio_data_dict);
+	ERR_FAIL_COND_MSG(mime_type.is_empty(), "GLTF audio: Unable to determine the MIME type for the audio data.");
+	Vector<uint8_t> audio_bytes = _load_audio_bytes(p_state, p_audio_data_dict);
+	ERR_FAIL_COND_MSG(audio_bytes.is_empty(), "GLTF audio: Unable to load audio data, no data bytes were found.");
+	const bool loop = p_audio_source_dict.get("loop", false);
+	if (mime_type == "audio/wav") {
+		Ref<AudioStreamWAV> audio_stream_wav;
+		audio_stream_wav.instantiate();
+		audio_stream_wav->set_data(audio_bytes);
+		audio_stream_wav->set_loop_mode(loop ? AudioStreamWAV::LoopMode::LOOP_FORWARD : AudioStreamWAV::LoopMode::LOOP_DISABLED);
+		audio_stream = audio_stream_wav;
+#ifdef MODULE_MP3_ENABLED
+	} else if (mime_type == "audio/mpeg") {
+		Ref<AudioStreamMP3> audio_stream_mp3;
+		audio_stream_mp3.instantiate();
+		audio_stream_mp3->set_data(audio_bytes);
+		audio_stream_mp3->set_loop(loop);
+		audio_stream = audio_stream_mp3;
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	} else if (mime_type == "audio/ogg") {
+		Ref<AudioStreamOggVorbis> audio_stream_ogg = AudioStreamOggVorbis::load_from_buffer(audio_bytes);
+		audio_stream_ogg->set_loop(loop);
+		audio_stream = audio_stream_ogg;
+#endif // MODULE_VORBIS_ENABLED
+	} else {
+		ERR_FAIL_MSG("GLTF audio: Unable to load audio data, the given MIME type is not supported: '" + mime_type + "'.");
+	}
+	ERR_FAIL_COND_MSG(audio_stream.is_null(), "GLTF audio: Unknown error loading audio with MIME type: '" + mime_type + "'.");
+	audio_stream->set_name(p_audio_source_dict.get("name", ""));
+	// Use snake_case because audio_stream only exists in memory, not in the exported JSON.
+	p_audio_data_dict["audio_stream"] = audio_stream;
+	p_audio_source_dict["audio_stream"] = audio_stream;
+}
+
+Array _generate_players_for_emitter(const Ref<GLTFAudioPlayer> p_audio_emitter, const Array &p_all_audio_sources) {
+	// Generate audio players for each audio source in this audio emitter.
+	Array audio_players;
+	const Vector<int> audio_source_indices = p_audio_emitter->get_audio_sources();
+	for (int audio_source_index : audio_source_indices) {
+		ERR_FAIL_INDEX_V_MSG(audio_source_index, p_all_audio_sources.size(), audio_players, "GLTF audio: Emitter source index " + itos(audio_source_index) + " is not in the sources array (size=" + itos(p_all_audio_sources.size()) + ").");
+		const Dictionary &audio_source_dict = p_all_audio_sources[audio_source_index];
+		Ref<GLTFAudioPlayer> audio_player = p_audio_emitter->duplicate();
+		if (likely(audio_source_dict.has("audio_stream"))) {
+			audio_player->set_audio_stream(audio_source_dict["audio_stream"]);
+		}
+		audio_player->set_autoplay(audio_source_dict.get("autoplay", false));
+		audio_player->set_pitch_playback_rate(audio_source_dict.get("playbackRate", 1.0));
+		const real_t source_gain = audio_source_dict.get("gain", 1.0);
+		audio_player->set_volume_gain(source_gain * audio_player->get_volume_gain());
+		audio_players.append(audio_player);
+	}
+	// If no audio source was present, still generate an empty audio player for this emitter.
+	if (audio_players.is_empty()) {
+		audio_players.append(p_audio_emitter->duplicate());
+	}
+	return audio_players;
+}
+
+Array _generate_players_for_all_emitters(Ref<GLTFState> p_state) {
+	// Generate audio players for each audio emitter + source pair.
+	Array audio_sources = p_state->get_additional_data(StringName("GLTFAudioSources"));
+	Array audio_emitters = p_state->get_additional_data(StringName("GLTFAudioEmitters"));
+	Array audio_players;
+	for (Ref<GLTFAudioPlayer> audio_emitter : audio_emitters) {
+		audio_players.append(_generate_players_for_emitter(audio_emitter, audio_sources));
+	}
+	p_state->set_additional_data(StringName("GLTFAudioPlayers"), audio_players);
+	return audio_players;
+}
+
+Dictionary _get_main_scene_dictionary(Ref<GLTFState> p_state) {
+	Dictionary state_json = p_state->get_json();
+	int scene_index = state_json.get("scene", 0);
+	Array scenes = state_json["scenes"];
+	ERR_FAIL_INDEX_V_MSG(scene_index, scenes.size(), Dictionary(), "GLTF audio: Scene index " + itos(scene_index) + " is not in the scenes array (size=" + itos(scenes.size()) + ").");
+	return scenes[scene_index];
+}
+
+Array _get_scene_level_audio_emitter_indices(Ref<GLTFState> p_state) {
+	Dictionary scene_dict = _get_main_scene_dictionary(p_state);
+	if (scene_dict.has("extensions")) {
+		Dictionary scene_extensions = scene_dict["extensions"];
+		if (scene_extensions.has("KHR_audio_emitter")) {
+			Dictionary scene_khr_audio_ext = scene_extensions["KHR_audio_emitter"];
+			if (scene_khr_audio_ext.has("emitters")) {
+				return scene_khr_audio_ext["emitters"];
+			}
+		}
+	}
+	return Array();
+}
+
+Error GLTFDocumentExtensionAudio::import_post_parse(Ref<GLTFState> p_state) {
+	// Load the audio bytes as audio streams and reference in the audio data and sources.
+	Array audio_data = p_state->get_additional_data(StringName("GLTFAudioData"));
+	Array audio_sources = p_state->get_additional_data(StringName("GLTFAudioSources"));
+	for (Dictionary audio_source_dict : audio_sources) {
+		int audio_data_index = audio_source_dict.get("audio", -1);
+		if (audio_source_dict.has("extensions")) {
+			Dictionary audio_source_extensions = audio_source_dict["extensions"];
+			if (audio_source_extensions.has("OMI_audio_ogg_vorbis")) {
+				Dictionary ogg_vorbis_ext = audio_source_extensions["OMI_audio_ogg_vorbis"];
+				if (ogg_vorbis_ext.has("audio")) {
+					audio_data_index = ogg_vorbis_ext["audio"];
+				}
+			}
+		}
+		if (audio_data_index == -1) {
+			continue;
+		}
+		ERR_FAIL_INDEX_V_MSG(audio_data_index, audio_data.size(), ERR_PARSE_ERROR, "GLTF audio: Audio data index " + itos(audio_data_index) + " is not in the audio data array (size=" + itos(audio_data.size()) + ").");
+		Dictionary audio_data_dict = audio_data[audio_data_index];
+		_load_audio_data(p_state, audio_data_dict, audio_source_dict);
+	}
+	Array audio_players = _generate_players_for_all_emitters(p_state);
+	// Set up audio players for the scene-level audio emitters.
+	Array scene_emitter_indices = _get_scene_level_audio_emitter_indices(p_state);
+	Array scene_audio_players;
+	for (int emitter_index : scene_emitter_indices) {
+		// Note: The size of the emitters array and players array will be the same.
+		ERR_FAIL_INDEX_V_MSG(emitter_index, audio_players.size(), ERR_PARSE_ERROR, "GLTF audio: Scene-level emitter index " + itos(emitter_index) + " is not in the emitters array (size=" + itos(audio_players.size()) + ").");
+		scene_audio_players.append_array(audio_players[emitter_index]);
+	}
+	p_state->set_additional_data(StringName("GLTFSceneAudioPlayers"), scene_audio_players);
+	return OK;
+}
+
+Node3D *GLTFDocumentExtensionAudio::generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) {
+	Variant emitter_index_variant = p_gltf_node->get_additional_data(StringName("GLTFAudioEmitterIndices"));
+	if (emitter_index_variant.get_type() != Variant::PACKED_INT32_ARRAY) {
+		return nullptr;
+	}
+	// Grab the audio players for this node's emitter index from the state.
+	PackedInt32Array emitter_indices = emitter_index_variant;
+	Array state_all_audio_emitter_players = p_state->get_additional_data(StringName("GLTFAudioPlayers"));
+	if (state_all_audio_emitter_players.is_empty()) {
+		state_all_audio_emitter_players = _generate_players_for_all_emitters(p_state);
+	}
+	// Generate Godot nodes for the audio players.
+	Node3D *ret = nullptr;
+	for (int32_t emitter_index : emitter_indices) {
+		ERR_FAIL_INDEX_V_MSG(emitter_index, state_all_audio_emitter_players.size(), nullptr, "GLTF audio: Node emitter index " + itos(emitter_index) + " is not in the GLTF emitters array (size=" + itos(state_all_audio_emitter_players.size()) + ").");
+		Array audio_players = state_all_audio_emitter_players[emitter_index];
+		for (Ref<GLTFAudioPlayer> audio_player : audio_players) {
+			if (audio_player.is_valid()) {
+				Node *audio_node = audio_player->to_node();
+				if (ret) {
+					ret->add_child(audio_node);
+				} else {
+					Node3D *audio_node_3d = Object::cast_to<Node3D>(audio_node);
+					if (audio_node_3d) {
+						ret = audio_node_3d;
+					} else {
+						// The generated node must be a Node3D to ensure it has a transform,
+						// otherwise the GLTF node transform hierarchy will be broken.
+						ret = memnew(Node3D);
+						ret->add_child(audio_node);
+					}
+				}
+			}
+		}
+	}
+	return ret;
+}
+
+Error GLTFDocumentExtensionAudio::import_post(Ref<GLTFState> p_state, Node *p_root_node) {
+	// Instantiate the scene-level audio players as children of the root node.
+	Array scene_audio_players = p_state->get_additional_data(StringName("GLTFSceneAudioPlayers"));
+	for (Ref<GLTFAudioPlayer> audio_player : scene_audio_players) {
+		if (audio_player.is_valid()) {
+			Node *audio_node = audio_player->to_node();
+			p_root_node->add_child(audio_node);
+			audio_node->set_owner(p_root_node);
+		}
+	}
+	return OK;
+}
+
+// Export process.
+Array _get_or_create_audio_data_in_state(Ref<GLTFState> p_state) {
+	Variant state_data_variant = p_state->get_additional_data(StringName("GLTFAudioData"));
+	if (state_data_variant.get_type() == Variant::ARRAY) {
+		return state_data_variant;
+	}
+	Array state_data;
+	p_state->set_additional_data(StringName("GLTFAudioData"), state_data);
+	return state_data;
+}
+
+Array _get_or_create_audio_sources_in_state(Ref<GLTFState> p_state) {
+	Variant state_sources_variant = p_state->get_additional_data(StringName("GLTFAudioSources"));
+	if (state_sources_variant.get_type() == Variant::ARRAY) {
+		return state_sources_variant;
+	}
+	Array state_sources;
+	p_state->set_additional_data(StringName("GLTFAudioSources"), state_sources);
+	return state_sources;
+}
+
+Array _get_or_create_audio_emitters_in_state(Ref<GLTFState> p_state) {
+	Variant state_emitters_variant = p_state->get_additional_data(StringName("GLTFAudioEmitters"));
+	if (state_emitters_variant.get_type() == Variant::ARRAY) {
+		return state_emitters_variant;
+	}
+	Array state_emitters;
+	p_state->set_additional_data(StringName("GLTFAudioEmitters"), state_emitters);
+	return state_emitters;
+}
+
+int _get_or_insert_audio_stream_in_state(Ref<GLTFState> p_state, Ref<AudioStream> p_audio_stream) {
+	Array audio_data = _get_or_create_audio_data_in_state(p_state);
+	for (int i = 0; i < audio_data.size(); i++) {
+		Dictionary audio_data_dict = audio_data[i];
+		if (audio_data_dict.get("audio_stream", Variant()) == p_audio_stream) {
+			return i;
+		}
+	}
+	const int new_index = audio_data.size();
+	Dictionary audio_data_dict;
+	// Use snake_case because audio_stream only exists in memory, not in the exported JSON.
+	audio_data_dict["audio_stream"] = p_audio_stream;
+	audio_data.push_back(audio_data_dict);
+	return new_index;
+}
+
+static int _get_or_insert_audio_source_in_state(Ref<GLTFState> p_state, const Dictionary &p_audio_source) {
+	Array state_sources = _get_or_create_audio_sources_in_state(p_state);
+	for (int i = 0; i < state_sources.size(); i++) {
+		Dictionary state_source = state_sources[i];
+		if (state_source == p_audio_source) {
+			return i;
+		}
+	}
+	const int new_index = state_sources.size();
+	state_sources.push_back(p_audio_source);
+	return new_index;
+}
+
+int _get_or_insert_audio_player_in_state(Ref<GLTFState> p_state, Ref<GLTFAudioPlayer> p_audio_player) {
+	Array state_emitters = _get_or_create_audio_emitters_in_state(p_state);
+	for (int i = 0; i < state_emitters.size(); i++) {
+		Ref<GLTFAudioPlayer> state_emitter = state_emitters[i];
+		if (state_emitter->to_dictionary() == p_audio_player->to_dictionary()) {
+			return i;
+		}
+	}
+	const int new_index = state_emitters.size();
+	state_emitters.push_back(p_audio_player);
+	return new_index;
+}
+
+static void _copy_audio_stream_properties_to_audio_source(const Ref<AudioStream> p_audio_stream, Dictionary &p_audio_source) {
+	Ref<AudioStreamWAV> audio_stream_wav = p_audio_stream;
+#ifdef MODULE_MP3_ENABLED
+	Ref<AudioStreamMP3> audio_stream_mp3 = p_audio_stream;
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	Ref<AudioStreamOggVorbis> audio_stream_ogg = p_audio_stream;
+#endif // MODULE_VORBIS_ENABLED
+	if (audio_stream_wav.is_valid()) {
+		const bool loop = audio_stream_wav->get_loop_mode() != AudioStreamWAV::LoopMode::LOOP_DISABLED;
+		if (loop) {
+			// If false, we don't need to write false, since that is the default value.
+			p_audio_source["loop"] = true;
+		}
+#ifdef MODULE_MP3_ENABLED
+	} else if (audio_stream_mp3.is_valid()) {
+		if (audio_stream_mp3->has_loop()) {
+			// If false, we don't need to write false, since that is the default value.
+			p_audio_source["loop"] = true;
+		}
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	} else if (audio_stream_ogg.is_valid()) {
+		if (audio_stream_ogg->has_loop()) {
+			// If false, we don't need to write false, since that is the default value.
+			p_audio_source["loop"] = true;
+		}
+#endif // MODULE_VORBIS_ENABLED
+	}
+	if (!p_audio_source.has("name")) {
+		if (!p_audio_stream->get_name().is_empty()) {
+			p_audio_source["name"] = p_audio_stream->get_name();
+		} else if (!p_audio_stream->get_path().is_empty()) {
+			p_audio_source["name"] = p_audio_stream->get_path().get_file();
+		}
+	}
+}
+
+void GLTFDocumentExtensionAudio::convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) {
+	Ref<GLTFAudioPlayer> audio_player;
+	Ref<AudioStream> audio_stream;
+	Dictionary audio_source;
+	if (Object::cast_to<AudioStreamPlayer>(p_scene_node)) {
+		AudioStreamPlayer *audio_player_node = Object::cast_to<AudioStreamPlayer>(p_scene_node);
+		audio_player = GLTFAudioPlayer::from_node_0d(audio_player_node);
+		if (audio_player_node->is_autoplay_enabled()) {
+			// If false, we don't need to write false, since that is the default value.
+			audio_source["autoplay"] = true;
+		}
+		if (audio_player_node->get_pitch_scale() != 1.0f) {
+			audio_source["playbackRate"] = audio_player_node->get_pitch_scale();
+		}
+		audio_stream = audio_player_node->get_stream();
+	} else if (cast_to<AudioStreamPlayer3D>(p_scene_node)) {
+		AudioStreamPlayer3D *audio_player_node = Object::cast_to<AudioStreamPlayer3D>(p_scene_node);
+		audio_player = GLTFAudioPlayer::from_node_3d(audio_player_node);
+		if (audio_player_node->is_autoplay_enabled()) {
+			// If false, we don't need to write false, since that is the default value.
+			audio_source["autoplay"] = true;
+		}
+		if (audio_player_node->get_pitch_scale() != 1.0f) {
+			audio_source["playbackRate"] = audio_player_node->get_pitch_scale();
+		}
+		audio_stream = audio_player_node->get_stream();
+	}
+	if (audio_player.is_null()) {
+		return; // Not an audio node or could not convert.
+	}
+	if (audio_stream.is_valid()) {
+		_copy_audio_stream_properties_to_audio_source(audio_stream, audio_source);
+		audio_source["audio"] = _get_or_insert_audio_stream_in_state(p_state, audio_stream);
+	}
+	if (!audio_source.is_empty()) {
+		const GLTFAudioSourceIndex source_index = _get_or_insert_audio_source_in_state(p_state, audio_source);
+		Vector<GLTFAudioSourceIndex> audio_sources;
+		audio_sources.push_back(source_index);
+		audio_player->set_audio_sources(audio_sources);
+	}
+	const int emitter_index = _get_or_insert_audio_player_in_state(p_state, audio_player);
+	PackedInt32Array emitter_indices = { emitter_index };
+	p_gltf_node->set_additional_data(StringName("GLTFAudioEmitterIndices"), emitter_indices);
+}
+
+GLTFBufferViewIndex _save_audio_data_to_buffer(Ref<GLTFState> p_state, Ref<AudioStream> p_audio_stream) {
+	// Save to bytes in memory. Assign Ref<> types to perform a cast.
+	Ref<AudioStreamWAV> audio_stream_wav = p_audio_stream;
+#ifdef MODULE_MP3_ENABLED
+	Ref<AudioStreamMP3> audio_stream_mp3 = p_audio_stream;
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	Ref<AudioStreamOggVorbis> audio_stream_ogg = p_audio_stream;
+#endif // MODULE_VORBIS_ENABLED
+	Vector<uint8_t> audio_bytes;
+	if (audio_stream_wav.is_valid()) {
+		audio_bytes = audio_stream_wav->get_data();
+#ifdef MODULE_MP3_ENABLED
+	} else if (audio_stream_mp3.is_valid()) {
+		audio_bytes = audio_stream_mp3->get_data();
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	} else if (audio_stream_ogg.is_valid()) {
+		ERR_FAIL_V_MSG(-1, "GLTF audio: Unable to export audio data, Godot is not capable of saving Ogg Vorbis files yet.");
+#endif // MODULE_VORBIS_ENABLED
+	} else {
+		ERR_FAIL_V_MSG(-1, "GLTF audio: Unable to export audio data, unknown AudioStream class '" + p_audio_stream->get_class() + "'.");
+	}
+	ERR_FAIL_COND_V_MSG(audio_bytes.is_empty(), -1, "GLTF audio: Unable to export audio data, no data bytes were found.");
+	// Write the bytes to a buffer.
+	return p_state->append_data_to_buffers(audio_bytes, true);
+}
+
+String _determine_mime_type_for_audio_stream(const Ref<AudioStream> p_audio_stream) {
+	Ref<AudioStreamWAV> audio_stream_wav = p_audio_stream;
+	if (audio_stream_wav.is_valid()) {
+		return "audio/wav";
+	}
+#ifdef MODULE_MP3_ENABLED
+	Ref<AudioStreamMP3> audio_stream_mp3 = p_audio_stream;
+	if (audio_stream_mp3.is_valid()) {
+		return "audio/mpeg";
+	}
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	Ref<AudioStreamOggVorbis> audio_stream_ogg = p_audio_stream;
+	if (audio_stream_ogg.is_valid()) {
+		return "audio/ogg";
+#endif // MODULE_VORBIS_ENABLED
+	}
+	ERR_FAIL_V_MSG(String(), "GLTF audio: Unable to determine MIME type for AudioStream, unknown class '" + p_audio_stream->get_class() + "'.");
+}
+
+Dictionary _save_audio_data(const Ref<GLTFState> p_state, const Dictionary &p_audio_data_dict, const int p_audio_data_index) {
+	Dictionary serialized_audio_data;
+	if (!p_audio_data_dict.has("audio_stream")) {
+		return serialized_audio_data;
+	}
+	// Use snake_case because audio_stream only exists in memory, not in the exported JSON.
+	Ref<AudioStream> audio_stream = p_audio_data_dict["audio_stream"];
+	serialized_audio_data["mimeType"] = _determine_mime_type_for_audio_stream(audio_stream);
+	String filename = p_state->get_filename();
+	String base_path = p_state->get_base_path();
+	// If .gltf, it's text, save audio to a separate file.
+	// If .glb, it's binary. If empty, it's a buffer, also binary.
+	if (!filename.ends_with(".gltf")) {
+		GLTFBufferViewIndex bvi = _save_audio_data_to_buffer(p_state, audio_stream);
+		if (bvi >= 0) {
+			serialized_audio_data["bufferView"] = bvi;
+		}
+		return serialized_audio_data;
+	}
+	String save_filename = p_audio_data_dict.get("uri", "");
+	if (save_filename.is_empty()) {
+		save_filename = audio_stream->get_name();
+		if (save_filename.is_empty()) {
+			save_filename = audio_stream->get_path().get_file().get_basename();
+			if (save_filename.is_empty()) {
+				save_filename = "audio_" + itos(p_audio_data_index);
+			}
+		}
+	}
+	// Save to a file. Assign Ref<> types to perform a cast.
+	Ref<AudioStreamWAV> audio_stream_wav = audio_stream;
+#ifdef MODULE_MP3_ENABLED
+	Ref<AudioStreamMP3> audio_stream_mp3 = audio_stream;
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	Ref<AudioStreamOggVorbis> audio_stream_ogg = audio_stream;
+#endif // MODULE_VORBIS_ENABLED
+	if (audio_stream_wav.is_valid()) {
+		if (!save_filename.ends_with(".wav")) {
+			save_filename += ".wav";
+		}
+		audio_stream_wav->save_to_wav(base_path + save_filename);
+		serialized_audio_data["uri"] = save_filename;
+#ifdef MODULE_MP3_ENABLED
+	} else if (audio_stream_mp3.is_valid()) {
+		if (!save_filename.ends_with(".mp3")) {
+			save_filename += ".mp3";
+		}
+		Ref<FileAccess> file = FileAccess::open(base_path.path_join(save_filename), FileAccess::WRITE);
+		file->store_buffer(audio_stream_mp3->get_data());
+		file->close();
+		serialized_audio_data["uri"] = save_filename;
+#endif // MODULE_MP3_ENABLED
+#ifdef MODULE_VORBIS_ENABLED
+	} else if (audio_stream_ogg.is_valid()) {
+		ERR_PRINT("GLTF audio: Unable to export audio data, Godot is not capable of saving Ogg Vorbis files yet.");
+#endif // MODULE_VORBIS_ENABLED
+	} else {
+		ERR_PRINT("GLTF audio: Unable to export audio data, unknown AudioStream class '" + audio_stream->get_class() + "'.");
+	}
+	return serialized_audio_data;
+}
+
+void _insert_scene_level_audio_emitters_if_any(Ref<GLTFState> p_state) {
+	Array scene_audio_players = p_state->get_additional_data(StringName("GLTFSceneAudioPlayers"));
+	Array scene_audio_emitter_indices;
+	for (int i = 0; i < scene_audio_players.size(); i++) {
+		const int emitter_index = _get_or_insert_audio_player_in_state(p_state, scene_audio_players[i]);
+		scene_audio_emitter_indices.push_back(emitter_index);
+	}
+	p_state->set_additional_data(StringName("GLTFSceneAudioEmitterIndices"), scene_audio_emitter_indices);
+}
+
+Error GLTFDocumentExtensionAudio::export_preserialize(Ref<GLTFState> p_state) {
+	_insert_scene_level_audio_emitters_if_any(p_state);
+	Array audio_data = p_state->get_additional_data(StringName("GLTFAudioData"));
+	Array audio_sources = p_state->get_additional_data(StringName("GLTFAudioSources"));
+	Array audio_emitters = p_state->get_additional_data(StringName("GLTFAudioEmitters"));
+	if (audio_sources.is_empty() && audio_emitters.is_empty()) {
+		return OK; // No audio data to export.
+	}
+	p_state->add_used_extension("KHR_audio_emitter");
+	Dictionary state_json = p_state->get_json();
+	Dictionary serialized_extensions = state_json.get_or_add("extensions", Dictionary());
+	Dictionary khr_audio_emitter_ext = serialized_extensions.get_or_add("KHR_audio_emitter", Dictionary());
+	Array serialized_audio_data;
+	Array serialized_sources;
+	Array serialized_emitters;
+	for (int i = 0; i < audio_data.size(); i++) {
+		Dictionary serialized = _save_audio_data(p_state, audio_data[i], i);
+		serialized_audio_data.push_back(serialized);
+	}
+	for (int i = 0; i < audio_sources.size(); i++) {
+		Dictionary serialized = Dictionary(audio_sources[i]).duplicate(false);
+		Ref<AudioStream> audio_stream = serialized["audio_stream"];
+		serialized.erase("audio_stream");
+		serialized_sources.push_back(serialized);
+	}
+	for (Ref<GLTFAudioPlayer> audio_emitter : audio_emitters) {
+		serialized_emitters.push_back(audio_emitter->to_dictionary());
+	}
+	khr_audio_emitter_ext["audio"] = serialized_audio_data;
+	khr_audio_emitter_ext["sources"] = serialized_sources;
+	khr_audio_emitter_ext["emitters"] = serialized_emitters;
+	return OK;
+}
+
+Error GLTFDocumentExtensionAudio::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_node_json, Node *p_node) {
+	Variant emitter_indices = p_gltf_node->get_additional_data(StringName("GLTFAudioEmitterIndices"));
+	if (emitter_indices.get_type() != Variant::PACKED_INT32_ARRAY) {
+		return OK;
+	}
+	Dictionary node_extensions = r_node_json["extensions"];
+	Dictionary khr_audio_emitter_ext = node_extensions.get_or_add("KHR_audio_emitter", Dictionary());
+	khr_audio_emitter_ext["emitters"] = emitter_indices;
+	return OK;
+}
+
+Error GLTFDocumentExtensionAudio::export_post(Ref<GLTFState> p_state) {
+	Array scene_audio_emitter_indices = p_state->get_additional_data(StringName("GLTFSceneAudioEmitterIndices"));
+	if (scene_audio_emitter_indices.is_empty()) {
+		return OK;
+	}
+	Dictionary scene_dictionary = _get_main_scene_dictionary(p_state);
+	Dictionary scene_extensions = scene_dictionary.get_or_add("extensions", Dictionary());
+	Dictionary khr_audio_emitter_ext = scene_extensions.get_or_add("KHR_audio_emitter", Dictionary());
+	khr_audio_emitter_ext["emitters"] = scene_audio_emitter_indices;
+	return OK;
+}

--- a/modules/gltf/extensions/audio/gltf_document_extension_audio.h
+++ b/modules/gltf/extensions/audio/gltf_document_extension_audio.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  gltf_document_extension_audio.h                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../gltf_document_extension.h"
+
+class GLTFDocumentExtensionAudio : public GLTFDocumentExtension {
+	GDCLASS(GLTFDocumentExtensionAudio, GLTFDocumentExtension);
+
+public:
+	// Import process.
+	virtual Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) override;
+	virtual Vector<String> get_supported_extensions() override;
+	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) override;
+	virtual Error import_post_parse(Ref<GLTFState> p_state) override;
+	virtual Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) override;
+	virtual Error import_post(Ref<GLTFState> p_state, Node *p_root_node) override;
+	// Export process.
+	virtual void convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) override;
+	virtual Error export_preserialize(Ref<GLTFState> p_state) override;
+	virtual Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_node_json, Node *p_scene_node) override;
+	virtual Error export_post(Ref<GLTFState> p_state) override;
+};

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -30,6 +30,8 @@
 
 #include "register_types.h"
 
+#include "extensions/audio/gltf_audio_player.h"
+#include "extensions/audio/gltf_document_extension_audio.h"
 #include "extensions/gltf_document_extension_convert_importer_mesh.h"
 #include "extensions/gltf_document_extension_texture_ktx.h"
 #include "extensions/gltf_document_extension_texture_webp.h"
@@ -113,6 +115,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		// glTF API available at runtime.
 		GDREGISTER_CLASS(GLTFAccessor);
 		GDREGISTER_CLASS(GLTFAnimation);
+		GDREGISTER_CLASS(GLTFAudioPlayer);
 		GDREGISTER_CLASS(GLTFBufferView);
 		GDREGISTER_CLASS(GLTFCamera);
 		GDREGISTER_CLASS(GLTFDocument);
@@ -137,6 +140,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		// Ensure physics is first in this list so that physics nodes are created before other nodes.
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionPhysics);
 #endif // PHYSICS_3D_DISABLED
+		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionAudio);
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureKTX);
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureWebP);
 		bool is_editor = Engine::get_singleton()->is_editor_hint();

--- a/modules/mp3/doc_classes/AudioStreamMP3.xml
+++ b/modules/mp3/doc_classes/AudioStreamMP3.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		MP3 audio stream driver. See [member data] if you want to load an MP3 file at run-time. More info can be found in [ResourceImporterMP3].
-		[b]Note:[/b] This class can optionally support legacy MP1 and MP2 formats, provided that the engine is compiled with the [code]minimp3_extra_formats=yes[/code] SCons option. These extra formats are not enabled by default.
+		[b]Note:[/b] This class can optionally support legacy MP1 and MP2 formats, provided that the engine is compiled with the [code]mp3_extra_formats=yes[/code] SCons option. These extra formats are not enabled by default.
 	</description>
 	<tutorials>
 		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>


### PR DESCRIPTION
Implements this proposal https://github.com/godotengine/godot-proposals/issues/8814

This PR adds support for audio import and export in the GLTF module using the not-yet-finalized [KHR_audio_emitter](https://github.com/omigroup/gltf-extensions/tree/main/extensions/2.0/KHR_audio_emitter) GLTF extension (https://github.com/KhronosGroup/glTF/pull/2137). This allows you to save audio inside of GLTF scenes, and load them back later. In the future this will also allow you to use GLTF as an interchange format between game engines.

You can try out a Three.js implementation here: https://omigroup.github.io/three-omi/

Some example use cases: a fountain that makes water noises, a gun that makes custom sounds when fired, the radio from Portal that plays music on a loop, or a tree that includes bird chirping noises or rustling leaves or something. For more details about the intended use cases, see the proposal.

Freely licensed example file: https://github.com/omigroup/gltf-extensions/tree/main/extensions/2.0/KHR_audio_emitter/examples/boom_box This file contains a boom box, a short looping music clip, OMI physics, and licensing information via `KHR_xmp_json_ld`. The model is CC0, created by The Khronos Group, and the music is CC-BY 3.0, created by Kevin MacLeod.

The code in this PR is ready for review, but note that the extension is not yet finalized. Usually my approach is for us to be pioneers with Godot and implement extensions that may not be finalized, like with OMI physics. However, for this extension, since it is using the `KHR_` namespace, we must tread carefully and avoid shipping features in Khronos's namespace into production without Khronos's approval. Don't put words in their mouth, so to speak.

_Production edit: closes godotengine/internal-team-priorities#44_