### PR TITLE
Make `RID_Owner<Texture>` threadsafe in `TextureStorage` for GLES3

### DIFF
--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -404,8 +404,8 @@ private:
 	RID_Owner<CanvasTexture, true> canvas_texture_owner;
 
 	/* Texture API */
-
-	mutable RID_Owner<Texture> texture_owner;
+	// Textures can be created from threads, so this RID_Owner is thread safe.
+	mutable RID_Owner<Texture, true> texture_owner;
 
 	Ref<Image> _get_gl_image_and_format(const Ref<Image> &p_image, Image::Format p_format, Image::Format &r_real_format, GLenum &r_gl_format, GLenum &r_gl_internal_format, GLenum &r_gl_type, bool &r_compressed, bool p_force_decompress) const;
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -172,7 +172,7 @@ private:
 		void cleanup();
 	};
 
-	//textures can be created from threads, so this RID_Owner is thread safe
+	// Textures can be created from threads, so this RID_Owner is thread safe.
 	mutable RID_Owner<Texture, true> texture_owner;
 	Texture *get_texture(RID p_rid) { return texture_owner.get_or_null(p_rid); };
 


### PR DESCRIPTION
This seems to fix https://github.com/godotengine/godot/issues/88195. In the Vulkan driver the `RID_Owner<Texture>` is already thread safe and indeed, textures might be created from threads. Also the `RID_Owner<CanvasTexture>` for gles3 is thread safe as well. I think this was just forgotten to add for the `Texture` one in a refactor.