### PR TITLE
[3.x] Editor 3D view mesh stats

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -204,6 +204,7 @@ class SpatialEditorViewport : public Control {
 		VIEW_AUDIO_DOPPLER,
 		VIEW_GIZMOS,
 		VIEW_INFORMATION,
+		VIEW_SELECTED_INFO,
 		VIEW_FPS,
 		VIEW_DISPLAY_NORMAL,
 		VIEW_DISPLAY_WIREFRAME,
@@ -283,6 +284,7 @@ private:
 	Vector2 previous_mouse_position;
 
 	Label *info_label;
+	Label *selected_info_label;
 	Label *cinema_label;
 	Label *locked_label;
 	Label *zoom_limit_label;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -126,6 +126,14 @@ public:
 		STORAGE_MODE_CPU_AND_GPU,
 	};
 
+	struct CachedStats {
+		bool dirty = true;
+		uint32_t triangle_count = 0;
+		uint32_t vertex_count = 0;
+		uint32_t index_count = 0;
+		uint32_t array_format = 0;
+	};
+
 	virtual int get_surface_count() const = 0;
 	virtual int surface_get_array_len(int p_idx) const = 0;
 	virtual int surface_get_array_index_len(int p_idx) const = 0;
@@ -138,11 +146,15 @@ public:
 	virtual Ref<Material> surface_get_material(int p_idx) const = 0;
 	virtual int get_blend_shape_count() const = 0;
 	int surface_get_triangle_count(int p_idx) const;
+	int surface_get_index_count(int p_idx) const;
 	virtual StringName get_blend_shape_name(int p_index) const = 0;
 	virtual void set_blend_shape_name(int p_index, const StringName &p_name) = 0;
 
 	int get_triangle_count() const;
 	PoolVector<Face3> get_faces() const;
+#ifdef TOOLS_ENABLED
+	const CachedStats &get_cached_stats() const;
+#endif
 	Ref<TriangleMesh> generate_triangle_mesh() const;
 	Ref<TriangleMesh> generate_triangle_mesh_from_aabb() const;
 	void generate_debug_mesh_lines(Vector<Vector3> &r_lines);
@@ -167,6 +179,13 @@ public:
 	Vector<Ref<Shape>> convex_decompose(int p_max_convex_hulls = -1) const;
 
 	Mesh();
+
+private:
+#ifdef TOOLS_ENABLED
+	// Only for use in the editor.
+	// No need to bloat exports.
+	mutable CachedStats _cached_stats;
+#endif
 };
 
 class ArrayMesh : public Mesh {


### PR DESCRIPTION
Similar to information window, add a small optional window to display face count and other stats.

Implements https://github.com/godotengine/godot-proposals/issues/248 

![stats4](https://github.com/godotengine/godot/assets/21999379/0377c350-7d59-4935-9930-f9d61001bae2)

## Vertex Format
Is supported internally but display of the line is commented out for now in the source code so we can leave to a follow up PR. See discussion in later comments.

## Notes
* Switched on an off via `View Selected Info` in the 3D window (defaults to off).
* This is pretty simple, but is super useful for performance optimizing scenes.
* The standard information window is useful, but it doesn't allow us to easily examine individual meshes.
* Supports `MeshInstance` and `MultiMeshInstance` so far.
* Information is hidden unless relevant. If one mesh is selected, that line is hidden, etc.
* Counts are added when multiple objects are selected.
* Vertex format is ORed when multiple objects are selected. This was best compromise I could think of. 
* I did try various options for displaying vertex format - all caps, capital first letter only etc. This version looked best so far but happy to hear ideas.
* Drawcalls can be inferred from number of surfaces, material swaps might be nice for a followup.
* Index count can currently be inferred from tri count, but might still be useful for non-tri based geometry (could arguably be hidden though)
* Index count / Vertex count determines vertex sharing measure. This could be displayed also, but it's usually obvious from the figures.

## Discussion
One thing that could be worth improving is that it currently doesn't have a label to tell you this box is for the selected objects. I'm hoping it's kind of obvious, once you have it switched on. Colors could be changed to distinguish it from the Information label. Position wise I don't know if anything else uses the lower left :grinning: , I don't use anything else regularly that does.

Also I'm happy to hear other suggestions where to put this info in the editor, am happy to change. This seemed to work pretty well so far though.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
