### PR TITLE
Assign missing surface data fields in dummy render server

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -87,6 +87,12 @@ public:
 		s->index_count = p_surface.index_count;
 		s->aabb = p_surface.aabb;
 		s->skin_data = p_surface.skin_data;
+		s->lods = p_surface.lods;
+		s->bone_aabbs = p_surface.bone_aabbs;
+		s->mesh_to_skeleton_xform = p_surface.mesh_to_skeleton_xform;
+		s->blend_shape_data = p_surface.blend_shape_data;
+		s->uv_scale = p_surface.uv_scale;
+		s->material = p_surface.material;
 	}
 
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override { return 0; }


### PR DESCRIPTION
# Issue
Doing headless resource imports and subsequent headless project exports causes the texture mapping of `gltf` meshes to be completely off. After some digging, I discovered that the `uv_scale` was missing in the imported scene of the `gltf` files when importing in headless mode.

# Solution
`MeshStorage::mesh_add_surface` does not assign all `p_surface_data` properties to the new `SurfaceData` instance.