### PR TITLE
Add fallback argument hints for default values

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -778,18 +778,24 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 					const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(par->initializer);
 					if (call->is_constant && call->reduced) {
 						def_val = call->function_name.operator String() + call->reduced_value.operator String();
+					} else {
+						def_val = call->function_name.operator String() + (call->arguments.is_empty() ? "()" : "(...)");
 					}
 				} break;
 				case GDScriptParser::Node::ARRAY: {
 					const GDScriptParser::ArrayNode *arr = static_cast<const GDScriptParser::ArrayNode *>(par->initializer);
 					if (arr->is_constant && arr->reduced) {
 						def_val = arr->reduced_value.operator String();
+					} else {
+						def_val = arr->elements.is_empty() ? "[]" : "[...]";
 					}
 				} break;
 				case GDScriptParser::Node::DICTIONARY: {
 					const GDScriptParser::DictionaryNode *dict = static_cast<const GDScriptParser::DictionaryNode *>(par->initializer);
 					if (dict->is_constant && dict->reduced) {
 						def_val = dict->reduced_value.operator String();
+					} else {
+						def_val = dict->elements.is_empty() ? "{}" : "{...}";
 					}
 				} break;
 				case GDScriptParser::Node::SUBSCRIPT: {


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/78191

In lieu of having constexpr, this solution proposes a fallback to provide a better hint to developers about what the default value of a method is. 

I've used a similar approach to generating a default as [GDScriptDocGen::_docvalue_from_variant](https://github.com/godotengine/godot/blob/4e990cd7e51d17cf24f854cc33b2715eaa27200f/modules/gdscript/editor/gdscript_docgen.cpp#L148), but assuming recursion depth is always met. 

This provides value to developers by now being able to know if there is an array to be expected and if it is empty or not at a glance instead of going to look at the source for a method. 

It could possibly be extended a little to include a small recursion depth, but I think that this is a good first step towards QOL. 

https://github.com/godotengine/godot/assets/60748675/1d441ee2-b0d1-4e1c-b840-a291cc796b78

^ All forms of defaults are now in line with how `constant` and `variable` defaults are created.