### PR TITLE
Implement more `_v` shorthands

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -317,4 +317,35 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 #define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
 #define GD_IS_DEFINED(x) ___gd_is_defined(x)
 
+template <bool B, typename T = void>
+struct EnableIf {
+	typedef T type;
+};
+
+template <typename T>
+struct EnableIf<false, T> {};
+
+template <bool B, typename T = void>
+using enable_if_t = typename EnableIf<B, T>::type;
+
+template <typename, typename>
+inline constexpr bool types_are_same_v = false;
+
+template <typename T>
+inline constexpr bool types_are_same_v<T, T> = true;
+
+template <typename B, typename D>
+struct TypeInherits {
+	static D *get_d();
+
+	static char (&test(B *))[1];
+	static char (&test(...))[2];
+
+	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
+			!types_are_same_v<B volatile const, void volatile const>;
+};
+
+template <typename B, typename D>
+inline constexpr bool type_inherits_v = TypeInherits<B, D>::value;
+
 #endif // TYPEDEFS_H

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -33,32 +33,6 @@
 
 #include "core/typedefs.h"
 
-template <bool C, typename T = void>
-struct EnableIf {
-	typedef T type;
-};
-
-template <typename T>
-struct EnableIf<false, T> {
-};
-
-template <typename, typename>
-inline constexpr bool types_are_same_v = false;
-
-template <typename T>
-inline constexpr bool types_are_same_v<T, T> = true;
-
-template <typename B, typename D>
-struct TypeInherits {
-	static D *get_d();
-
-	static char (&test(B *))[1];
-	static char (&test(...))[2];
-
-	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
-			!types_are_same_v<B volatile const, void volatile const>;
-};
-
 namespace GodotTypeInfo {
 enum Metadata {
 	METADATA_NONE,
@@ -223,7 +197,7 @@ MAKE_TEMPLATE_TYPE_INFO(Vector, Face3, Variant::PACKED_VECTOR3_ARRAY)
 MAKE_TEMPLATE_TYPE_INFO(Vector, StringName, Variant::PACKED_STRING_ARRAY)
 
 template <typename T>
-struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
+struct GetTypeInfo<T *, enable_if_t<type_inherits_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
@@ -232,7 +206,7 @@ struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type>
 };
 
 template <typename T>
-struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
+struct GetTypeInfo<const T *, enable_if_t<type_inherits_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {


### PR DESCRIPTION
Adds two new `_v` shorthands from existing structs: `enable_if_t`[^1] and `type_inherits_v`. These changes should strictly be refactors, not affecting codebase functionality whatsoever. These two new shorthands & the previously introduced shorthand `types_are_same_v` were all migrated from `type_info.h` to `typedefs.h`; this is because they're *very* broadly applicable, contrasting the majority of functions/definitions in `type_info.h` being tailor-made for Variants

[^1]: Okay, technically this one is a `_t`, but they're in the same camp