### PR TITLE
Fix the fetching of images in `CF_DIB` format in `DisplayServerWindows::clipboard_get_image`

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -760,8 +760,7 @@ Ref<Image> DisplayServerWindows::clipboard_get_image() const {
 						pba.append(rgbquad->rgbReserved);
 					}
 				}
-				image.instantiate();
-				image->create_from_data(info->biWidth, info->biHeight, false, Image::Format::FORMAT_RGBA8, pba);
+				image = Image::create_from_data(info->biWidth, info->biHeight, false, Image::Format::FORMAT_RGBA8, pba);
 
 				GlobalUnlock(mem);
 			}


### PR DESCRIPTION
A bug was occuring when trying to import an image from the windows clipbpoard, if it's in CF_DIB format (e. g. by taking screenshots). No image was returned.

It comes from a tiny error : in `DisplayServerWindows::clipboard_get_image`, `Image::create_from_data` was used with an instance of `Image`, but since it's a static function, it returns a new instance instead of modifying the 'called' one.
Correcting this fixes the importation.

### Testing with a GDScript

```
extends TextureRect

func _ready() -> void:
	if DisplayServer.clipboard_has_image() :
		var image = DisplayServer.clipboard_get_image()
		texture = ImageTexture.create_from_image(image)
```

This script was attached to a TextureRect node in the testing scene.
(At the start, the clipboard must contains an image in CF_DIB format, for instance a screenshot, or some images coming from a web navigator, in the right format, copied with the right-click context menu.)

PS : I apologies if my PR isn't conform to godot contributor's workflow, or for any other problem.