### PR TITLE
Extend `NavigationMeshSourceGeometryData[23]D` to allow data merging

### DIFF
--- a/doc/classes/NavigationMeshSourceGeometryData2D.xml
+++ b/doc/classes/NavigationMeshSourceGeometryData2D.xml
@@ -47,6 +47,13 @@
 				Returns [code]true[/code] when parsed source geometry data exists.
 			</description>
 		</method>
+		<method name="merge">
+			<return type="void" />
+			<param index="0" name="other_geometry" type="NavigationMeshSourceGeometryData2D" />
+			<description>
+				Adds the geometry data of another [NavigationMeshSourceGeometryData2D] to the navigation mesh baking data.
+			</description>
+		</method>
 		<method name="set_obstruction_outlines">
 			<return type="void" />
 			<param index="0" name="obstruction_outlines" type="PackedVector2Array[]" />

--- a/doc/classes/NavigationMeshSourceGeometryData3D.xml
+++ b/doc/classes/NavigationMeshSourceGeometryData3D.xml
@@ -57,6 +57,13 @@
 				Returns [code]true[/code] when parsed source geometry data exists.
 			</description>
 		</method>
+		<method name="merge">
+			<return type="void" />
+			<param index="0" name="other_geometry" type="NavigationMeshSourceGeometryData3D" />
+			<description>
+				Adds the geometry data of another [NavigationMeshSourceGeometryData3D] to the navigation mesh baking data.
+			</description>
+		</method>
 		<method name="set_indices">
 			<return type="void" />
 			<param index="0" name="indices" type="PackedInt32Array" />

--- a/scene/resources/navigation_mesh_source_geometry_data_2d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_2d.cpp
@@ -113,6 +113,12 @@ void NavigationMeshSourceGeometryData2D::add_obstruction_outline(const PackedVec
 	}
 }
 
+void NavigationMeshSourceGeometryData2D::merge(const Ref<NavigationMeshSourceGeometryData2D> &p_other_geometry) {
+	// No need to worry about `root_node_transform` here as the data is already xformed.
+	traversable_outlines.append_array(p_other_geometry->traversable_outlines);
+	obstruction_outlines.append_array(p_other_geometry->obstruction_outlines);
+}
+
 void NavigationMeshSourceGeometryData2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &NavigationMeshSourceGeometryData2D::clear);
 	ClassDB::bind_method(D_METHOD("has_data"), &NavigationMeshSourceGeometryData2D::has_data);
@@ -125,6 +131,8 @@ void NavigationMeshSourceGeometryData2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_traversable_outline", "shape_outline"), &NavigationMeshSourceGeometryData2D::add_traversable_outline);
 	ClassDB::bind_method(D_METHOD("add_obstruction_outline", "shape_outline"), &NavigationMeshSourceGeometryData2D::add_obstruction_outline);
+
+	ClassDB::bind_method(D_METHOD("merge", "other_geometry"), &NavigationMeshSourceGeometryData2D::merge);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "traversable_outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_traversable_outlines", "get_traversable_outlines");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "obstruction_outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_obstruction_outlines", "get_obstruction_outlines");

--- a/scene/resources/navigation_mesh_source_geometry_data_2d.h
+++ b/scene/resources/navigation_mesh_source_geometry_data_2d.h
@@ -71,6 +71,8 @@ public:
 	bool has_data() { return traversable_outlines.size(); };
 	void clear();
 
+	void merge(const Ref<NavigationMeshSourceGeometryData2D> &p_other_geometry);
+
 	NavigationMeshSourceGeometryData2D() {}
 	~NavigationMeshSourceGeometryData2D() { clear(); }
 };

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
@@ -165,6 +165,17 @@ void NavigationMeshSourceGeometryData3D::add_faces(const PackedVector3Array &p_f
 	_add_faces(p_faces, root_node_transform * p_xform);
 }
 
+void NavigationMeshSourceGeometryData3D::merge(const Ref<NavigationMeshSourceGeometryData3D> &p_other_geometry) {
+	// No need to worry about `root_node_transform` here as the vertices are already xformed.
+	const int64_t number_of_vertices_before_merge = vertices.size();
+	const int64_t number_of_indices_before_merge = indices.size();
+	vertices.append_array(p_other_geometry->vertices);
+	indices.append_array(p_other_geometry->indices);
+	for (int64_t i = number_of_indices_before_merge; i < indices.size(); i++) {
+		indices.set(i, indices[i] + number_of_vertices_before_merge / 3);
+	}
+}
+
 void NavigationMeshSourceGeometryData3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vertices", "vertices"), &NavigationMeshSourceGeometryData3D::set_vertices);
 	ClassDB::bind_method(D_METHOD("get_vertices"), &NavigationMeshSourceGeometryData3D::get_vertices);
@@ -178,6 +189,7 @@ void NavigationMeshSourceGeometryData3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_mesh", "mesh", "xform"), &NavigationMeshSourceGeometryData3D::add_mesh);
 	ClassDB::bind_method(D_METHOD("add_mesh_array", "mesh_array", "xform"), &NavigationMeshSourceGeometryData3D::add_mesh_array);
 	ClassDB::bind_method(D_METHOD("add_faces", "faces", "xform"), &NavigationMeshSourceGeometryData3D::add_faces);
+	ClassDB::bind_method(D_METHOD("merge", "other_geometry"), &NavigationMeshSourceGeometryData3D::merge);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "indices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_indices", "get_indices");

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.h
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.h
@@ -68,6 +68,8 @@ public:
 	void add_mesh_array(const Array &p_mesh_array, const Transform3D &p_xform);
 	void add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform);
 
+	void merge(const Ref<NavigationMeshSourceGeometryData3D> &p_other_geometry);
+
 	NavigationMeshSourceGeometryData3D() {}
 	~NavigationMeshSourceGeometryData3D() { clear(); }
 };


### PR DESCRIPTION
This PR adds `merge` method to `NavigationMeshSourceGeometryData3D`

This PR therefore adds a way to avoid boilerplate code such as https://github.com/lampe-games/godot-open-rts/commit/487e995ac47811627e9a0324906111a09990230d#diff-0291eaa88b59eec77f3d1546e6404bea1391d58eec1ee646874dded17f0bfe16R60-R71