### PR TITLE
Fix Curve min/max limits being bypassed on first assignment.

### DIFF
--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -88,8 +88,8 @@ protected:
 	GDVIRTUAL0(_setup_local_to_scene);
 
 public:
-	static Node *(*_get_local_scene_func)(); //used by editor
-	static void (*_update_configuration_warning)(); //used by editor
+	static Node *(*_get_local_scene_func)(); // Used by editor.
+	static void (*_update_configuration_warning)(); // Used by editor.
 
 	void update_configuration_warning();
 	virtual bool editor_can_reload_from_file();
@@ -123,6 +123,8 @@ public:
 
 	Node *get_local_scene() const;
 
+	virtual void _finish_loading() {}
+
 #ifdef TOOLS_ENABLED
 
 	uint32_t hash_edited_version() const;
@@ -150,6 +152,14 @@ public:
 
 	Resource();
 	~Resource();
+};
+
+class LoadHooksResource : public Resource {
+	GDCLASS(LoadHooksResource, Resource);
+
+public:
+	virtual void _start_load() = 0;
+	virtual void _finish_load() = 0;
 };
 
 class ResourceCache {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -261,6 +261,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 		found = true;
 		res = loader[i]->load(p_path, !p_original_path.is_empty() ? p_original_path : p_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
 		if (!res.is_null()) {
+			res->_finish_loading();
 			break;
 		}
 	}

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -166,6 +166,7 @@ void register_core_types() {
 	GDREGISTER_CLASS(RefCounted);
 	GDREGISTER_CLASS(WeakRef);
 	GDREGISTER_CLASS(Resource);
+	GDREGISTER_ABSTRACT_CLASS(LoadHooksResource);
 	GDREGISTER_VIRTUAL_CLASS(MissingResource);
 	GDREGISTER_CLASS(Image);
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -308,11 +308,11 @@ void Curve::update_auto_tangents(int p_index) {
 #define MIN_Y_RANGE 0.01
 
 void Curve::set_min_value(real_t p_min) {
-	if (_minmax_set_once & 0b11 && p_min > _max_value - MIN_Y_RANGE) {
-		_min_value = _max_value - MIN_Y_RANGE;
-	} else {
-		_minmax_set_once |= 0b10; // first bit is "min set"
+	// Bypass min < max when loading Curve since stored values may conflict with default values.
+	if (p_min <= _max_value - MIN_Y_RANGE || _is_loading) {
 		_min_value = p_min;
+	} else {
+		_min_value = _max_value - MIN_Y_RANGE;
 	}
 	// Note: min and max are indicative values,
 	// it's still possible that existing points are out of range at this point.
@@ -320,11 +320,10 @@ void Curve::set_min_value(real_t p_min) {
 }
 
 void Curve::set_max_value(real_t p_max) {
-	if (_minmax_set_once & 0b11 && p_max < _min_value + MIN_Y_RANGE) {
-		_max_value = _min_value + MIN_Y_RANGE;
-	} else {
-		_minmax_set_once |= 0b01; // second bit is "max set"
+	if (p_max >= _min_value + MIN_Y_RANGE || _is_loading) {
 		_max_value = p_max;
+	} else {
+		_max_value = _min_value + MIN_Y_RANGE;
 	}
 	emit_signal(SNAME(SIGNAL_RANGE_CHANGED));
 }

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -34,8 +34,8 @@
 #include "core/io/resource.h"
 
 // y(x) curve
-class Curve : public Resource {
-	GDCLASS(Curve, Resource);
+class Curve : public LoadHooksResource {
+	GDCLASS(Curve, LoadHooksResource);
 
 public:
 	static const int MIN_X = 0.f;
@@ -138,10 +138,15 @@ public:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	virtual void _start_load() override { _is_loading = true; }
+	virtual void _finish_load() override { _is_loading = false; }
+
 protected:
 	static void _bind_methods();
 
 private:
+	bool _is_loading = false; // Used to bypass min < max setter restrictions during deserialization.
+
 	void mark_dirty();
 	int _add_point(Vector2 p_position,
 			real_t left_tangent = 0,
@@ -156,7 +161,6 @@ private:
 	int _bake_resolution = 100;
 	real_t _min_value = 0.0;
 	real_t _max_value = 1.0;
-	int _minmax_set_once = 0b00; // Encodes whether min and max have been set a first time, first bit for min and second for max.
 };
 
 VARIANT_ENUM_CAST(Curve::TangentMode)

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -115,6 +115,8 @@ class ResourceLoaderText {
 
 	Ref<PackedScene> _parse_node_tag(VariantParser::ResourceParser &parser);
 
+	Error _parse_resource_properties(Ref<Resource> res, bool do_assign, bool missing_resource);
+
 public:
 	Ref<Resource> get_resource();
 	Error load();


### PR DESCRIPTION
This is an alternative PR to #78931 - see that PR for problem description. It does add a step to resource loading in general, but in doing so provides a simple hook for post-loading logic to be executed in any resource.

This enables `Curve` - or any other resource with mutually dependent variables - to have a simple `_is_loading` variable, which toggles whether setters enforce dependencies/restrictions (no during loading, yes otherwise). This means we don't need workaround "fake" properties like in #78931, which increase code complexity & number of properties.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
