### PR TITLE
Asset Library author link, description popup size and UX details

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -60,7 +60,6 @@ class EditorAssetLibraryItem : public PanelContainer {
 	LinkButton *title = nullptr;
 	LinkButton *category = nullptr;
 	LinkButton *author = nullptr;
-	TextureRect *stars[5];
 	Label *price = nullptr;
 
 	int asset_id = 0;
@@ -82,7 +81,7 @@ public:
 
 	void clamp_width(int p_max_width);
 
-	EditorAssetLibraryItem();
+	EditorAssetLibraryItem(bool p_clickable = false);
 };
 
 class EditorAssetLibraryItemDescription : public ConfirmationDialog {
@@ -90,6 +89,7 @@ class EditorAssetLibraryItemDescription : public ConfirmationDialog {
 
 	EditorAssetLibraryItem *item = nullptr;
 	RichTextLabel *description = nullptr;
+	VBoxContainer *previews_vbox = nullptr;
 	ScrollContainer *previews = nullptr;
 	HBoxContainer *preview_hb = nullptr;
 	PanelContainer *previews_bg = nullptr;
@@ -294,7 +294,7 @@ class EditorAssetLibrary : public PanelContainer {
 
 	void _install_asset();
 
-	void _select_author(int p_id);
+	void _select_author(const String &p_author);
 	void _select_category(int p_id);
 	void _select_asset(int p_id);
 


### PR DESCRIPTION
I noticed that the asset library had some weird UI stuff, especially LinkButtons that didn't do anything when clicked, so I've made some minor visual and UX adjustments, mainly:

 * The items are more compact and the license label is no longer misaligned with the image/text
 * The asset name is no longer clickable without it having any effect when the same Item node is used inside of the description window
 * Added tooltips to the asset author and license labels
 * The preview UI in the description window is now hidden when the asset does not have any preview media to show, like code-only assets.
 * Clicking on the author now redirects to the asset store web, filtering by it. This is the one that I'd need some maintainer feedback on: I made it so that it would do nothing (like before) when the repository is not the default Godot one, since I'm not entirely sure if alternate repositories would benefit from linking to the main asset library. The alternative to this implementation could be just making this a label like the license one, since right now it's a confusing that it's clickable but nothing happens.

Before/After:

![asset_library_item_before](https://github.com/godotengine/godot/assets/138269/02d698ce-611c-4dee-90c5-5607c8f72138)
![asset_library_item_after](https://github.com/godotengine/godot/assets/138269/8d679526-e58f-487a-bae9-ad0de1c04c25)

![asset_library_description_before](https://github.com/godotengine/godot/assets/138269/a5fc1063-f340-4f9c-8d43-ba353d8951a7)
![asset_library_description_after](https://github.com/godotengine/godot/assets/138269/1a73c385-d1ae-443d-b8c8-1e83c46b8fb2)


