### PR TITLE
C#: Fix processing exclusions during export

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -389,10 +389,10 @@ namespace GodotTools.Export
                 if (filterDir(dir))
                 {
                     addEntry(dir, false);
-                }
-                else if (recurseDir(dir))
-                {
-                    RecursePublishContents(dir, filterDir, filterFile, recurseDir, addEntry);
+                    if (recurseDir(dir))
+                    {
+                        RecursePublishContents(dir, filterDir, filterFile, recurseDir, addEntry);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When I added the filtering logic to allow excluding files or directories from the export logic, I made a mistake in the logic around deciding whether to recurse into a directory or not - it was only called if the directory itself was ignored. The intended logic should be:

- `filterDir` - Process this directory?
  - if false: stop processing this directory tree
  - if true:
    - call `addEntry` to allow doing something with the directory entry itself
    - `recurseDir` - Process the contents of this directory?
      - if false: stop processing this directory tree
      - if true: recursively process this directory

This PR fixes that.

/cc @raulsntos @RedworkDE 

*Contrbuted by W4Games ❤️*