### PR TITLE
[TextServer] Improve text server interlocking.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -388,42 +388,41 @@ int64_t TextServerAdvanced::_get_features() const {
 }
 
 void TextServerAdvanced::_free_rid(const RID &p_rid) {
-	_THREAD_SAFE_METHOD_
+	rid_lock.lock();
 	if (font_owner.owns(p_rid)) {
 		MutexLock ftlock(ft_mutex);
 
 		FontAdvanced *fd = font_owner.get_or_null(p_rid);
-		{
-			MutexLock lock(fd->mutex);
-			font_owner.free(p_rid);
+		font_owner.free(p_rid);
+		if (fd && fd->unreference()) {
+			memdelete(fd);
 		}
-		memdelete(fd);
 	} else if (font_var_owner.owns(p_rid)) {
 		MutexLock ftlock(ft_mutex);
 
 		FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_rid);
-		{
-			font_var_owner.free(p_rid);
+		font_var_owner.free(p_rid);
+		if (fdv && fdv->unreference()) {
+			memdelete(fdv);
 		}
-		memdelete(fdv);
 	} else if (shaped_owner.owns(p_rid)) {
 		ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_rid);
-		{
-			MutexLock lock(sd->mutex);
-			shaped_owner.free(p_rid);
+		shaped_owner.free(p_rid);
+		if (sd && sd->unreference()) {
+			memdelete(sd);
 		}
-		memdelete(sd);
 	}
+	rid_lock.unlock();
 }
 
 bool TextServerAdvanced::_has(const RID &p_rid) {
-	_THREAD_SAFE_METHOD_
-	return font_owner.owns(p_rid) || font_var_owner.owns(p_rid) || shaped_owner.owns(p_rid);
+	rid_lock.lock();
+	bool has = font_owner.owns(p_rid) || font_var_owner.owns(p_rid) || shaped_owner.owns(p_rid);
+	rid_lock.unlock();
+	return has;
 }
 
 bool TextServerAdvanced::_load_support_data(const String &p_filename) {
-	_THREAD_SAFE_METHOD_
-
 #ifdef ICU_STATIC_DATA
 	if (!icu_data_loaded) {
 		UErrorCode err = U_ZERO_ERROR;
@@ -467,7 +466,6 @@ String TextServerAdvanced::_get_support_data_info() const {
 }
 
 bool TextServerAdvanced::_save_support_data(const String &p_filename) const {
-	_THREAD_SAFE_METHOD_
 #ifdef ICU_STATIC_DATA
 
 	// Store data to the res file if it's available.
@@ -952,7 +950,7 @@ void TextServerAdvanced::_generateMTSDF_threaded(void *p_td, uint32_t p_y) {
 	}
 }
 
-_FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const {
+_FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(Ref<FontAdvanced> &p_font_data, FontForSizeAdvanced *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const {
 	msdfgen::Shape shape;
 
 	shape.contours.clear();
@@ -1166,7 +1164,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitma
 /* Font Cache                                                            */
 /*************************************************************************/
 
-_FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph) const {
+_FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(Ref<FontAdvanced> &p_font_data, const Vector2i &p_size, int32_t p_glyph) const {
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(p_font_data, p_size), false);
 
 	int32_t glyph_index = p_glyph & 0xffffff; // Remove subpixel shifts.
@@ -1325,7 +1323,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data,
 	return false;
 }
 
-_FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size) const {
+_FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(Ref<FontAdvanced> &p_font_data, const Vector2i &p_size) const {
 	ERR_FAIL_COND_V(p_size.x <= 0, false);
 	if (p_font_data->cache.has(p_size)) {
 		return true;
@@ -1806,7 +1804,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 	return true;
 }
 
-_FORCE_INLINE_ void TextServerAdvanced::_font_clear_cache(FontAdvanced *p_font_data) {
+_FORCE_INLINE_ void TextServerAdvanced::_font_clear_cache(Ref<FontAdvanced> &p_font_data) {
 	MutexLock ftlock(ft_mutex);
 
 	for (const KeyValue<Vector2i, FontForSizeAdvanced *> &E : p_font_data->cache) {
@@ -1820,7 +1818,7 @@ _FORCE_INLINE_ void TextServerAdvanced::_font_clear_cache(FontAdvanced *p_font_d
 }
 
 hb_font_t *TextServerAdvanced::_font_get_hb_handle(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, nullptr);
 
 	MutexLock lock(fd->mutex);
@@ -1832,31 +1830,38 @@ hb_font_t *TextServerAdvanced::_font_get_hb_handle(const RID &p_font_rid, int64_
 }
 
 RID TextServerAdvanced::_create_font() {
-	_THREAD_SAFE_METHOD_
-
 	FontAdvanced *fd = memnew(FontAdvanced);
+	fd->init_ref();
 
-	return font_owner.make_rid(fd);
+	rid_lock.lock();
+	RID rid = font_owner.make_rid(fd);
+	rid_lock.unlock();
+	return rid;
 }
 
 RID TextServerAdvanced::_create_font_linked_variation(const RID &p_font_rid) {
-	_THREAD_SAFE_METHOD_
-
+	rid_lock.lock();
 	RID rid = p_font_rid;
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(rid);
 	if (unlikely(fdv)) {
 		rid = fdv->base_font;
 	}
-	ERR_FAIL_COND_V(!font_owner.owns(rid), RID());
+	if (!font_owner.owns(rid)) {
+		rid_lock.unlock();
+		ERR_FAIL_V(RID());
+	}
 
 	FontAdvancedLinkedVariation *new_fdv = memnew(FontAdvancedLinkedVariation);
+	new_fdv->init_ref();
 	new_fdv->base_font = rid;
 
-	return font_var_owner.make_rid(new_fdv);
+	rid = font_var_owner.make_rid(new_fdv);
+	rid_lock.unlock();
+	return rid;
 }
 
 void TextServerAdvanced::_font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1867,7 +1872,7 @@ void TextServerAdvanced::_font_set_data(const RID &p_font_rid, const PackedByteA
 }
 
 void TextServerAdvanced::_font_set_data_ptr(const RID &p_font_rid, const uint8_t *p_data_ptr, int64_t p_data_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1881,7 +1886,7 @@ void TextServerAdvanced::_font_set_face_index(const RID &p_font_rid, int64_t p_f
 	ERR_FAIL_COND(p_face_index < 0);
 	ERR_FAIL_COND(p_face_index >= 0x7FFF);
 
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1892,7 +1897,7 @@ void TextServerAdvanced::_font_set_face_index(const RID &p_font_rid, int64_t p_f
 }
 
 int64_t TextServerAdvanced::_font_get_face_index(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -1900,7 +1905,7 @@ int64_t TextServerAdvanced::_font_get_face_index(const RID &p_font_rid) const {
 }
 
 int64_t TextServerAdvanced::_font_get_face_count(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -1946,7 +1951,7 @@ int64_t TextServerAdvanced::_font_get_face_count(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_style(const RID &p_font_rid, BitField<FontStyle> p_style) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1956,7 +1961,7 @@ void TextServerAdvanced::_font_set_style(const RID &p_font_rid, BitField<FontSty
 }
 
 BitField<TextServer::FontStyle> TextServerAdvanced::_font_get_style(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -1966,7 +1971,7 @@ BitField<TextServer::FontStyle> TextServerAdvanced::_font_get_style(const RID &p
 }
 
 void TextServerAdvanced::_font_set_style_name(const RID &p_font_rid, const String &p_name) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1976,7 +1981,7 @@ void TextServerAdvanced::_font_set_style_name(const RID &p_font_rid, const Strin
 }
 
 String TextServerAdvanced::_font_get_style_name(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
@@ -1986,7 +1991,7 @@ String TextServerAdvanced::_font_get_style_name(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_weight(const RID &p_font_rid, int64_t p_weight) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1996,7 +2001,7 @@ void TextServerAdvanced::_font_set_weight(const RID &p_font_rid, int64_t p_weigh
 }
 
 int64_t TextServerAdvanced::_font_get_weight(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 400);
 
 	MutexLock lock(fd->mutex);
@@ -2006,7 +2011,7 @@ int64_t TextServerAdvanced::_font_get_weight(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_stretch(const RID &p_font_rid, int64_t p_stretch) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2016,7 +2021,7 @@ void TextServerAdvanced::_font_set_stretch(const RID &p_font_rid, int64_t p_stre
 }
 
 int64_t TextServerAdvanced::_font_get_stretch(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 100);
 
 	MutexLock lock(fd->mutex);
@@ -2026,7 +2031,7 @@ int64_t TextServerAdvanced::_font_get_stretch(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_name(const RID &p_font_rid, const String &p_name) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2036,7 +2041,7 @@ void TextServerAdvanced::_font_set_name(const RID &p_font_rid, const String &p_n
 }
 
 String TextServerAdvanced::_font_get_name(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
@@ -2046,7 +2051,7 @@ String TextServerAdvanced::_font_get_name(const RID &p_font_rid) const {
 }
 
 Dictionary TextServerAdvanced::_font_get_ot_name_strings(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -2159,7 +2164,7 @@ Dictionary TextServerAdvanced::_font_get_ot_name_strings(const RID &p_font_rid) 
 }
 
 void TextServerAdvanced::_font_set_antialiasing(const RID &p_font_rid, TextServer::FontAntialiasing p_antialiasing) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2170,7 +2175,7 @@ void TextServerAdvanced::_font_set_antialiasing(const RID &p_font_rid, TextServe
 }
 
 TextServer::FontAntialiasing TextServerAdvanced::_font_get_antialiasing(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TextServer::FONT_ANTIALIASING_NONE);
 
 	MutexLock lock(fd->mutex);
@@ -2178,7 +2183,7 @@ TextServer::FontAntialiasing TextServerAdvanced::_font_get_antialiasing(const RI
 }
 
 void TextServerAdvanced::_font_set_generate_mipmaps(const RID &p_font_rid, bool p_generate_mipmaps) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2194,7 +2199,7 @@ void TextServerAdvanced::_font_set_generate_mipmaps(const RID &p_font_rid, bool 
 }
 
 bool TextServerAdvanced::_font_get_generate_mipmaps(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2202,7 +2207,7 @@ bool TextServerAdvanced::_font_get_generate_mipmaps(const RID &p_font_rid) const
 }
 
 void TextServerAdvanced::_font_set_multichannel_signed_distance_field(const RID &p_font_rid, bool p_msdf) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2213,7 +2218,7 @@ void TextServerAdvanced::_font_set_multichannel_signed_distance_field(const RID 
 }
 
 bool TextServerAdvanced::_font_is_multichannel_signed_distance_field(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2221,7 +2226,7 @@ bool TextServerAdvanced::_font_is_multichannel_signed_distance_field(const RID &
 }
 
 void TextServerAdvanced::_font_set_msdf_pixel_range(const RID &p_font_rid, int64_t p_msdf_pixel_range) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2232,7 +2237,7 @@ void TextServerAdvanced::_font_set_msdf_pixel_range(const RID &p_font_rid, int64
 }
 
 int64_t TextServerAdvanced::_font_get_msdf_pixel_range(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2240,7 +2245,7 @@ int64_t TextServerAdvanced::_font_get_msdf_pixel_range(const RID &p_font_rid) co
 }
 
 void TextServerAdvanced::_font_set_msdf_size(const RID &p_font_rid, int64_t p_msdf_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2251,7 +2256,7 @@ void TextServerAdvanced::_font_set_msdf_size(const RID &p_font_rid, int64_t p_ms
 }
 
 int64_t TextServerAdvanced::_font_get_msdf_size(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -2259,7 +2264,7 @@ int64_t TextServerAdvanced::_font_get_msdf_size(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2267,7 +2272,7 @@ void TextServerAdvanced::_font_set_fixed_size(const RID &p_font_rid, int64_t p_f
 }
 
 int64_t TextServerAdvanced::_font_get_fixed_size(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -2275,7 +2280,7 @@ int64_t TextServerAdvanced::_font_get_fixed_size(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_fixed_size_scale_mode(const RID &p_font_rid, TextServer::FixedSizeScaleMode p_fixed_size_scale_mode) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2283,7 +2288,7 @@ void TextServerAdvanced::_font_set_fixed_size_scale_mode(const RID &p_font_rid, 
 }
 
 TextServer::FixedSizeScaleMode TextServerAdvanced::_font_get_fixed_size_scale_mode(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, FIXED_SIZE_SCALE_DISABLE);
 
 	MutexLock lock(fd->mutex);
@@ -2291,7 +2296,7 @@ TextServer::FixedSizeScaleMode TextServerAdvanced::_font_get_fixed_size_scale_mo
 }
 
 void TextServerAdvanced::_font_set_allow_system_fallback(const RID &p_font_rid, bool p_allow_system_fallback) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2299,7 +2304,7 @@ void TextServerAdvanced::_font_set_allow_system_fallback(const RID &p_font_rid, 
 }
 
 bool TextServerAdvanced::_font_is_allow_system_fallback(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2307,7 +2312,7 @@ bool TextServerAdvanced::_font_is_allow_system_fallback(const RID &p_font_rid) c
 }
 
 void TextServerAdvanced::_font_set_force_autohinter(const RID &p_font_rid, bool p_force_autohinter) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2318,7 +2323,7 @@ void TextServerAdvanced::_font_set_force_autohinter(const RID &p_font_rid, bool 
 }
 
 bool TextServerAdvanced::_font_is_force_autohinter(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2326,7 +2331,7 @@ bool TextServerAdvanced::_font_is_force_autohinter(const RID &p_font_rid) const 
 }
 
 void TextServerAdvanced::_font_set_hinting(const RID &p_font_rid, TextServer::Hinting p_hinting) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2337,7 +2342,7 @@ void TextServerAdvanced::_font_set_hinting(const RID &p_font_rid, TextServer::Hi
 }
 
 TextServer::Hinting TextServerAdvanced::_font_get_hinting(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, HINTING_NONE);
 
 	MutexLock lock(fd->mutex);
@@ -2345,7 +2350,7 @@ TextServer::Hinting TextServerAdvanced::_font_get_hinting(const RID &p_font_rid)
 }
 
 void TextServerAdvanced::_font_set_subpixel_positioning(const RID &p_font_rid, TextServer::SubpixelPositioning p_subpixel) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2353,7 +2358,7 @@ void TextServerAdvanced::_font_set_subpixel_positioning(const RID &p_font_rid, T
 }
 
 TextServer::SubpixelPositioning TextServerAdvanced::_font_get_subpixel_positioning(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, SUBPIXEL_POSITIONING_DISABLED);
 
 	MutexLock lock(fd->mutex);
@@ -2361,7 +2366,7 @@ TextServer::SubpixelPositioning TextServerAdvanced::_font_get_subpixel_positioni
 }
 
 void TextServerAdvanced::_font_set_embolden(const RID &p_font_rid, double p_strength) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2372,7 +2377,7 @@ void TextServerAdvanced::_font_set_embolden(const RID &p_font_rid, double p_stre
 }
 
 double TextServerAdvanced::_font_get_embolden(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2381,13 +2386,14 @@ double TextServerAdvanced::_font_get_embolden(const RID &p_font_rid) const {
 
 void TextServerAdvanced::_font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) {
 	ERR_FAIL_INDEX((int)p_spacing, 4);
-	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
-	if (fdv) {
+	Ref<FontAdvancedLinkedVariation> fdv = _get_font_var_data(p_font_rid);
+	if (fdv.is_valid()) {
+		MutexLock lock(fdv->mutex);
 		if (fdv->extra_spacing[p_spacing] != p_value) {
 			fdv->extra_spacing[p_spacing] = p_value;
 		}
 	} else {
-		FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
+		Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 		ERR_FAIL_NULL(fd);
 
 		MutexLock lock(fd->mutex);
@@ -2399,11 +2405,12 @@ void TextServerAdvanced::_font_set_spacing(const RID &p_font_rid, SpacingType p_
 
 int64_t TextServerAdvanced::_font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const {
 	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
-	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
-	if (fdv) {
+	Ref<FontAdvancedLinkedVariation> fdv = _get_font_var_data(p_font_rid);
+	if (fdv.is_valid()) {
+		MutexLock lock(fdv->mutex);
 		return fdv->extra_spacing[p_spacing];
 	} else {
-		FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
+		Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 		ERR_FAIL_NULL_V(fd, 0);
 
 		MutexLock lock(fd->mutex);
@@ -2412,13 +2419,14 @@ int64_t TextServerAdvanced::_font_get_spacing(const RID &p_font_rid, SpacingType
 }
 
 void TextServerAdvanced::_font_set_baseline_offset(const RID &p_font_rid, float p_baseline_offset) {
-	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
-	if (fdv) {
+	Ref<FontAdvancedLinkedVariation> fdv = _get_font_var_data(p_font_rid);
+	if (fdv.is_valid()) {
+		MutexLock lock(fdv->mutex);
 		if (fdv->baseline_offset != p_baseline_offset) {
 			fdv->baseline_offset = p_baseline_offset;
 		}
 	} else {
-		FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
+		Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 		ERR_FAIL_NULL(fd);
 
 		MutexLock lock(fd->mutex);
@@ -2430,11 +2438,12 @@ void TextServerAdvanced::_font_set_baseline_offset(const RID &p_font_rid, float 
 }
 
 float TextServerAdvanced::_font_get_baseline_offset(const RID &p_font_rid) const {
-	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
-	if (fdv) {
+	Ref<FontAdvancedLinkedVariation> fdv = _get_font_var_data(p_font_rid);
+	if (fdv.is_valid()) {
+		MutexLock lock(fdv->mutex);
 		return fdv->baseline_offset;
 	} else {
-		FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
+		Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 		ERR_FAIL_NULL_V(fd, 0.0);
 
 		MutexLock lock(fd->mutex);
@@ -2443,7 +2452,7 @@ float TextServerAdvanced::_font_get_baseline_offset(const RID &p_font_rid) const
 }
 
 void TextServerAdvanced::_font_set_transform(const RID &p_font_rid, const Transform2D &p_transform) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2454,7 +2463,7 @@ void TextServerAdvanced::_font_set_transform(const RID &p_font_rid, const Transf
 }
 
 Transform2D TextServerAdvanced::_font_get_transform(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Transform2D());
 
 	MutexLock lock(fd->mutex);
@@ -2462,7 +2471,7 @@ Transform2D TextServerAdvanced::_font_get_transform(const RID &p_font_rid) const
 }
 
 void TextServerAdvanced::_font_set_variation_coordinates(const RID &p_font_rid, const Dictionary &p_variation_coordinates) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2473,7 +2482,7 @@ void TextServerAdvanced::_font_set_variation_coordinates(const RID &p_font_rid, 
 }
 
 Dictionary TextServerAdvanced::_font_get_variation_coordinates(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -2481,7 +2490,7 @@ Dictionary TextServerAdvanced::_font_get_variation_coordinates(const RID &p_font
 }
 
 void TextServerAdvanced::_font_set_oversampling(const RID &p_font_rid, double p_oversampling) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2492,7 +2501,7 @@ void TextServerAdvanced::_font_set_oversampling(const RID &p_font_rid, double p_
 }
 
 double TextServerAdvanced::_font_get_oversampling(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2500,7 +2509,7 @@ double TextServerAdvanced::_font_get_oversampling(const RID &p_font_rid) const {
 }
 
 TypedArray<Vector2i> TextServerAdvanced::_font_get_size_cache_list(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
@@ -2512,7 +2521,7 @@ TypedArray<Vector2i> TextServerAdvanced::_font_get_size_cache_list(const RID &p_
 }
 
 void TextServerAdvanced::_font_clear_size_cache(const RID &p_font_rid) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2524,7 +2533,7 @@ void TextServerAdvanced::_font_clear_size_cache(const RID &p_font_rid) {
 }
 
 void TextServerAdvanced::_font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2536,7 +2545,7 @@ void TextServerAdvanced::_font_remove_size_cache(const RID &p_font_rid, const Ve
 }
 
 void TextServerAdvanced::_font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2547,7 +2556,7 @@ void TextServerAdvanced::_font_set_ascent(const RID &p_font_rid, int64_t p_size,
 }
 
 double TextServerAdvanced::_font_get_ascent(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2569,9 +2578,10 @@ double TextServerAdvanced::_font_get_ascent(const RID &p_font_rid, int64_t p_siz
 }
 
 void TextServerAdvanced::_font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
+	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
@@ -2579,7 +2589,7 @@ void TextServerAdvanced::_font_set_descent(const RID &p_font_rid, int64_t p_size
 }
 
 double TextServerAdvanced::_font_get_descent(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2601,7 +2611,7 @@ double TextServerAdvanced::_font_get_descent(const RID &p_font_rid, int64_t p_si
 }
 
 void TextServerAdvanced::_font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2612,7 +2622,7 @@ void TextServerAdvanced::_font_set_underline_position(const RID &p_font_rid, int
 }
 
 double TextServerAdvanced::_font_get_underline_position(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2634,7 +2644,7 @@ double TextServerAdvanced::_font_get_underline_position(const RID &p_font_rid, i
 }
 
 void TextServerAdvanced::_font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2645,7 +2655,7 @@ void TextServerAdvanced::_font_set_underline_thickness(const RID &p_font_rid, in
 }
 
 double TextServerAdvanced::_font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2667,7 +2677,7 @@ double TextServerAdvanced::_font_get_underline_thickness(const RID &p_font_rid, 
 }
 
 void TextServerAdvanced::_font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2683,7 +2693,7 @@ void TextServerAdvanced::_font_set_scale(const RID &p_font_rid, int64_t p_size, 
 }
 
 double TextServerAdvanced::_font_get_scale(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2705,7 +2715,7 @@ double TextServerAdvanced::_font_get_scale(const RID &p_font_rid, int64_t p_size
 }
 
 int64_t TextServerAdvanced::_font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -2717,7 +2727,7 @@ int64_t TextServerAdvanced::_font_get_texture_count(const RID &p_font_rid, const
 }
 
 void TextServerAdvanced::_font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
@@ -2727,7 +2737,7 @@ void TextServerAdvanced::_font_clear_textures(const RID &p_font_rid, const Vecto
 }
 
 void TextServerAdvanced::_font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2739,7 +2749,7 @@ void TextServerAdvanced::_font_remove_texture(const RID &p_font_rid, const Vecto
 }
 
 void TextServerAdvanced::_font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 	ERR_FAIL_COND(p_image.is_null());
 
@@ -2767,7 +2777,7 @@ void TextServerAdvanced::_font_set_texture_image(const RID &p_font_rid, const Ve
 }
 
 Ref<Image> TextServerAdvanced::_font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Ref<Image>());
 
 	MutexLock lock(fd->mutex);
@@ -2781,7 +2791,7 @@ Ref<Image> TextServerAdvanced::_font_get_texture_image(const RID &p_font_rid, co
 
 void TextServerAdvanced::_font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offsets) {
 	ERR_FAIL_COND(p_offsets.size() % 4 != 0);
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2800,7 +2810,7 @@ void TextServerAdvanced::_font_set_texture_offsets(const RID &p_font_rid, const 
 }
 
 PackedInt32Array TextServerAdvanced::_font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
@@ -2825,7 +2835,7 @@ PackedInt32Array TextServerAdvanced::_font_get_texture_offsets(const RID &p_font
 }
 
 PackedInt32Array TextServerAdvanced::_font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
@@ -2841,7 +2851,7 @@ PackedInt32Array TextServerAdvanced::_font_get_glyph_list(const RID &p_font_rid,
 }
 
 void TextServerAdvanced::_font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2852,7 +2862,7 @@ void TextServerAdvanced::_font_clear_glyphs(const RID &p_font_rid, const Vector2
 }
 
 void TextServerAdvanced::_font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2863,7 +2873,7 @@ void TextServerAdvanced::_font_remove_glyph(const RID &p_font_rid, const Vector2
 }
 
 double TextServerAdvanced::_get_extra_advance(RID p_font_rid, int p_font_size) const {
-	const FontAdvanced *fd = _get_font_data(p_font_rid);
+	const Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -2877,7 +2887,7 @@ double TextServerAdvanced::_get_extra_advance(RID p_font_rid, int p_font_size) c
 }
 
 Vector2 TextServerAdvanced::_font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -2921,7 +2931,7 @@ Vector2 TextServerAdvanced::_font_get_glyph_advance(const RID &p_font_rid, int64
 }
 
 void TextServerAdvanced::_font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2936,7 +2946,7 @@ void TextServerAdvanced::_font_set_glyph_advance(const RID &p_font_rid, int64_t 
 }
 
 Vector2 TextServerAdvanced::_font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -2972,7 +2982,7 @@ Vector2 TextServerAdvanced::_font_get_glyph_offset(const RID &p_font_rid, const 
 }
 
 void TextServerAdvanced::_font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2987,7 +2997,7 @@ void TextServerAdvanced::_font_set_glyph_offset(const RID &p_font_rid, const Vec
 }
 
 Vector2 TextServerAdvanced::_font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -3023,7 +3033,7 @@ Vector2 TextServerAdvanced::_font_get_glyph_size(const RID &p_font_rid, const Ve
 }
 
 void TextServerAdvanced::_font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3038,7 +3048,7 @@ void TextServerAdvanced::_font_set_glyph_size(const RID &p_font_rid, const Vecto
 }
 
 Rect2 TextServerAdvanced::_font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Rect2());
 
 	MutexLock lock(fd->mutex);
@@ -3063,7 +3073,7 @@ Rect2 TextServerAdvanced::_font_get_glyph_uv_rect(const RID &p_font_rid, const V
 }
 
 void TextServerAdvanced::_font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3078,7 +3088,7 @@ void TextServerAdvanced::_font_set_glyph_uv_rect(const RID &p_font_rid, const Ve
 }
 
 int64_t TextServerAdvanced::_font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, -1);
 
 	MutexLock lock(fd->mutex);
@@ -3103,7 +3113,7 @@ int64_t TextServerAdvanced::_font_get_glyph_texture_idx(const RID &p_font_rid, c
 }
 
 void TextServerAdvanced::_font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3118,7 +3128,7 @@ void TextServerAdvanced::_font_set_glyph_texture_idx(const RID &p_font_rid, cons
 }
 
 RID TextServerAdvanced::_font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, RID());
 
 	MutexLock lock(fd->mutex);
@@ -3165,7 +3175,7 @@ RID TextServerAdvanced::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 }
 
 Size2 TextServerAdvanced::_font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Size2());
 
 	MutexLock lock(fd->mutex);
@@ -3212,7 +3222,7 @@ Size2 TextServerAdvanced::_font_get_glyph_texture_size(const RID &p_font_rid, co
 }
 
 Dictionary TextServerAdvanced::_font_get_glyph_contours(const RID &p_font_rid, int64_t p_size, int64_t p_index) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -3268,7 +3278,7 @@ Dictionary TextServerAdvanced::_font_get_glyph_contours(const RID &p_font_rid, i
 }
 
 TypedArray<Vector2i> TextServerAdvanced::_font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
@@ -3284,7 +3294,7 @@ TypedArray<Vector2i> TextServerAdvanced::_font_get_kerning_list(const RID &p_fon
 }
 
 void TextServerAdvanced::_font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3295,7 +3305,7 @@ void TextServerAdvanced::_font_clear_kerning_map(const RID &p_font_rid, int64_t 
 }
 
 void TextServerAdvanced::_font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3306,7 +3316,7 @@ void TextServerAdvanced::_font_remove_kerning(const RID &p_font_rid, int64_t p_s
 }
 
 void TextServerAdvanced::_font_set_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair, const Vector2 &p_kerning) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3317,7 +3327,7 @@ void TextServerAdvanced::_font_set_kerning(const RID &p_font_rid, int64_t p_size
 }
 
 Vector2 TextServerAdvanced::_font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -3362,7 +3372,7 @@ Vector2 TextServerAdvanced::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 }
 
 int64_t TextServerAdvanced::_font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 	ERR_FAIL_COND_V_MSG((p_char >= 0xd800 && p_char <= 0xdfff) || (p_char > 0x10ffff), 0, "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_char, 16) + ".");
 	ERR_FAIL_COND_V_MSG((p_variation_selector >= 0xd800 && p_variation_selector <= 0xdfff) || (p_variation_selector > 0x10ffff), 0, "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_variation_selector, 16) + ".");
@@ -3387,7 +3397,7 @@ int64_t TextServerAdvanced::_font_get_glyph_index(const RID &p_font_rid, int64_t
 }
 
 int64_t TextServerAdvanced::_font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -3418,9 +3428,9 @@ int64_t TextServerAdvanced::_font_get_char_from_glyph_index(const RID &p_font_ri
 }
 
 bool TextServerAdvanced::_font_has_char(const RID &p_font_rid, int64_t p_char) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_COND_V_MSG((p_char >= 0xd800 && p_char <= 0xdfff) || (p_char > 0x10ffff), false, "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_char, 16) + ".");
-	if (!fd) {
+	if (fd.is_null()) {
 		return false;
 	}
 
@@ -3439,7 +3449,7 @@ bool TextServerAdvanced::_font_has_char(const RID &p_font_rid, int64_t p_char) c
 }
 
 String TextServerAdvanced::_font_get_supported_chars(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
@@ -3472,7 +3482,7 @@ String TextServerAdvanced::_font_get_supported_chars(const RID &p_font_rid) cons
 }
 
 void TextServerAdvanced::_font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 	ERR_FAIL_COND_MSG((p_start >= 0xd800 && p_start <= 0xdfff) || (p_start > 0x10ffff), "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_start, 16) + ".");
 	ERR_FAIL_COND_MSG((p_end >= 0xd800 && p_end <= 0xdfff) || (p_end > 0x10ffff), "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_end, 16) + ".");
@@ -3507,7 +3517,7 @@ void TextServerAdvanced::_font_render_range(const RID &p_font_rid, const Vector2
 }
 
 void TextServerAdvanced::_font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3541,7 +3551,7 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	if (p_index == 0) {
 		return; // Non visual character, skip.
 	}
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3652,7 +3662,7 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	if (p_index == 0) {
 		return; // Non visual character, skip.
 	}
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3760,7 +3770,7 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 }
 
 bool TextServerAdvanced::_font_is_language_supported(const RID &p_font_rid, const String &p_language) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -3772,7 +3782,7 @@ bool TextServerAdvanced::_font_is_language_supported(const RID &p_font_rid, cons
 }
 
 void TextServerAdvanced::_font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3780,7 +3790,7 @@ void TextServerAdvanced::_font_set_language_support_override(const RID &p_font_r
 }
 
 bool TextServerAdvanced::_font_get_language_support_override(const RID &p_font_rid, const String &p_language) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -3788,7 +3798,7 @@ bool TextServerAdvanced::_font_get_language_support_override(const RID &p_font_r
 }
 
 void TextServerAdvanced::_font_remove_language_support_override(const RID &p_font_rid, const String &p_language) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3796,7 +3806,7 @@ void TextServerAdvanced::_font_remove_language_support_override(const RID &p_fon
 }
 
 PackedStringArray TextServerAdvanced::_font_get_language_support_overrides(const RID &p_font_rid) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedStringArray());
 
 	MutexLock lock(fd->mutex);
@@ -3808,7 +3818,7 @@ PackedStringArray TextServerAdvanced::_font_get_language_support_overrides(const
 }
 
 bool TextServerAdvanced::_font_is_script_supported(const RID &p_font_rid, const String &p_script) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -3822,7 +3832,7 @@ bool TextServerAdvanced::_font_is_script_supported(const RID &p_font_rid, const 
 }
 
 void TextServerAdvanced::_font_set_script_support_override(const RID &p_font_rid, const String &p_script, bool p_supported) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3830,7 +3840,7 @@ void TextServerAdvanced::_font_set_script_support_override(const RID &p_font_rid
 }
 
 bool TextServerAdvanced::_font_get_script_support_override(const RID &p_font_rid, const String &p_script) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -3838,7 +3848,7 @@ bool TextServerAdvanced::_font_get_script_support_override(const RID &p_font_rid
 }
 
 void TextServerAdvanced::_font_remove_script_support_override(const RID &p_font_rid, const String &p_script) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3846,7 +3856,7 @@ void TextServerAdvanced::_font_remove_script_support_override(const RID &p_font_
 }
 
 PackedStringArray TextServerAdvanced::_font_get_script_support_overrides(const RID &p_font_rid) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedStringArray());
 
 	MutexLock lock(fd->mutex);
@@ -3858,7 +3868,7 @@ PackedStringArray TextServerAdvanced::_font_get_script_support_overrides(const R
 }
 
 void TextServerAdvanced::_font_set_opentype_feature_overrides(const RID &p_font_rid, const Dictionary &p_overrides) {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -3868,7 +3878,7 @@ void TextServerAdvanced::_font_set_opentype_feature_overrides(const RID &p_font_
 }
 
 Dictionary TextServerAdvanced::_font_get_opentype_feature_overrides(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -3876,7 +3886,7 @@ Dictionary TextServerAdvanced::_font_get_opentype_feature_overrides(const RID &p
 }
 
 Dictionary TextServerAdvanced::_font_supported_feature_list(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -3886,7 +3896,7 @@ Dictionary TextServerAdvanced::_font_supported_feature_list(const RID &p_font_ri
 }
 
 Dictionary TextServerAdvanced::_font_supported_variation_list(const RID &p_font_rid) const {
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	Ref<FontAdvanced> fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -3900,7 +3910,6 @@ double TextServerAdvanced::_font_get_global_oversampling() const {
 }
 
 void TextServerAdvanced::_font_set_global_oversampling(double p_oversampling) {
-	_THREAD_SAFE_METHOD_
 	if (oversampling != p_oversampling) {
 		oversampling = p_oversampling;
 		List<RID> fonts;
@@ -3917,7 +3926,11 @@ void TextServerAdvanced::_font_set_global_oversampling(double p_oversampling) {
 			List<RID> text_bufs;
 			shaped_owner.get_owned_list(&text_bufs);
 			for (const RID &E : text_bufs) {
-				invalidate(shaped_owner.get_or_null(E), false);
+				Ref<ShapedTextDataAdvanced> sd = _get_shaped(E);
+				if (sd.is_valid()) {
+					MutexLock lock(sd->mutex);
+					invalidate(sd, false);
+				}
 			}
 		}
 	}
@@ -3940,7 +3953,7 @@ int64_t TextServerAdvanced::_convert_pos(const String &p_utf32, const Char16Stri
 	return limit;
 }
 
-int64_t TextServerAdvanced::_convert_pos(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const {
+int64_t TextServerAdvanced::_convert_pos(const Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_pos) const {
 	int64_t limit = p_pos;
 	if (p_sd->text.length() != p_sd->utf16.length()) {
 		const UChar *data = p_sd->utf16.get_data();
@@ -3953,7 +3966,7 @@ int64_t TextServerAdvanced::_convert_pos(const ShapedTextDataAdvanced *p_sd, int
 	return limit;
 }
 
-int64_t TextServerAdvanced::_convert_pos_inv(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const {
+int64_t TextServerAdvanced::_convert_pos_inv(const Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_pos) const {
 	int64_t limit = p_pos;
 	if (p_sd->text.length() != p_sd->utf16.length()) {
 		for (int i = 0; i < p_pos; i++) {
@@ -3965,7 +3978,7 @@ int64_t TextServerAdvanced::_convert_pos_inv(const ShapedTextDataAdvanced *p_sd,
 	return limit;
 }
 
-void TextServerAdvanced::invalidate(TextServerAdvanced::ShapedTextDataAdvanced *p_shaped, bool p_text) {
+void TextServerAdvanced::invalidate(Ref<ShapedTextDataAdvanced> &p_shaped, bool p_text) {
 	p_shaped->valid = false;
 	p_shaped->sort_valid = false;
 	p_shaped->line_breaks_valid = false;
@@ -3996,8 +4009,8 @@ void TextServerAdvanced::invalidate(TextServerAdvanced::ShapedTextDataAdvanced *
 	}
 }
 
-void TextServerAdvanced::full_copy(ShapedTextDataAdvanced *p_shaped) {
-	ShapedTextDataAdvanced *parent = shaped_owner.get_or_null(p_shaped->parent);
+void TextServerAdvanced::full_copy(Ref<ShapedTextDataAdvanced> &p_shaped) {
+	Ref<ShapedTextDataAdvanced> parent = _get_shaped(p_shaped->parent);
 
 	for (const KeyValue<Variant, ShapedTextDataAdvanced::EmbeddedObject> &E : parent->objects) {
 		if (E.value.pos >= p_shaped->start && E.value.pos < p_shaped->end) {
@@ -4019,18 +4032,22 @@ void TextServerAdvanced::full_copy(ShapedTextDataAdvanced *p_shaped) {
 }
 
 RID TextServerAdvanced::_create_shaped_text(TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
-	_THREAD_SAFE_METHOD_
 	ERR_FAIL_COND_V_MSG(p_direction == DIRECTION_INHERITED, RID(), "Invalid text direction.");
 
 	ShapedTextDataAdvanced *sd = memnew(ShapedTextDataAdvanced);
+	sd->init_ref();
 	sd->hb_buffer = hb_buffer_create();
 	sd->direction = p_direction;
 	sd->orientation = p_orientation;
-	return shaped_owner.make_rid(sd);
+
+	rid_lock.lock();
+	RID rid = shaped_owner.make_rid(sd);
+	rid_lock.unlock();
+	return rid;
 }
 
 void TextServerAdvanced::_shaped_text_clear(const RID &p_shaped) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
 	MutexLock lock(sd->mutex);
@@ -4045,7 +4062,7 @@ void TextServerAdvanced::_shaped_text_clear(const RID &p_shaped) {
 }
 
 void TextServerAdvanced::_shaped_text_set_direction(const RID &p_shaped, TextServer::Direction p_direction) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_COND_MSG(p_direction == DIRECTION_INHERITED, "Invalid text direction.");
 	ERR_FAIL_NULL(sd);
 
@@ -4060,7 +4077,7 @@ void TextServerAdvanced::_shaped_text_set_direction(const RID &p_shaped, TextSer
 }
 
 TextServer::Direction TextServerAdvanced::_shaped_text_get_direction(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, TextServer::DIRECTION_LTR);
 
 	MutexLock lock(sd->mutex);
@@ -4068,7 +4085,7 @@ TextServer::Direction TextServerAdvanced::_shaped_text_get_direction(const RID &
 }
 
 TextServer::Direction TextServerAdvanced::_shaped_text_get_inferred_direction(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, TextServer::DIRECTION_LTR);
 
 	MutexLock lock(sd->mutex);
@@ -4076,10 +4093,10 @@ TextServer::Direction TextServerAdvanced::_shaped_text_get_inferred_direction(co
 }
 
 void TextServerAdvanced::_shaped_text_set_custom_punctuation(const RID &p_shaped, const String &p_punct) {
-	_THREAD_SAFE_METHOD_
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
+	MutexLock lock(sd->mutex);
 	if (sd->custom_punct != p_punct) {
 		if (sd->parent != RID()) {
 			full_copy(sd);
@@ -4090,28 +4107,31 @@ void TextServerAdvanced::_shaped_text_set_custom_punctuation(const RID &p_shaped
 }
 
 String TextServerAdvanced::_shaped_text_get_custom_punctuation(const RID &p_shaped) const {
-	_THREAD_SAFE_METHOD_
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, String());
+
+	MutexLock lock(sd->mutex);
 	return sd->custom_punct;
 }
 
 void TextServerAdvanced::_shaped_text_set_custom_ellipsis(const RID &p_shaped, int64_t p_char) {
-	_THREAD_SAFE_METHOD_
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
+
+	MutexLock lock(sd->mutex);
 	sd->el_char = p_char;
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_custom_ellipsis(const RID &p_shaped) const {
-	_THREAD_SAFE_METHOD_
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);
+
+	MutexLock lock(sd->mutex);
 	return sd->el_char;
 }
 
 void TextServerAdvanced::_shaped_text_set_bidi_override(const RID &p_shaped, const Array &p_override) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
 	MutexLock lock(sd->mutex);
@@ -4132,7 +4152,7 @@ void TextServerAdvanced::_shaped_text_set_bidi_override(const RID &p_shaped, con
 }
 
 void TextServerAdvanced::_shaped_text_set_orientation(const RID &p_shaped, TextServer::Orientation p_orientation) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
 	MutexLock lock(sd->mutex);
@@ -4146,7 +4166,7 @@ void TextServerAdvanced::_shaped_text_set_orientation(const RID &p_shaped, TextS
 }
 
 void TextServerAdvanced::_shaped_text_set_preserve_invalid(const RID &p_shaped, bool p_enabled) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
 	MutexLock lock(sd->mutex);
@@ -4158,7 +4178,7 @@ void TextServerAdvanced::_shaped_text_set_preserve_invalid(const RID &p_shaped, 
 }
 
 bool TextServerAdvanced::_shaped_text_get_preserve_invalid(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -4166,7 +4186,7 @@ bool TextServerAdvanced::_shaped_text_get_preserve_invalid(const RID &p_shaped) 
 }
 
 void TextServerAdvanced::_shaped_text_set_preserve_control(const RID &p_shaped, bool p_enabled) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
 	MutexLock lock(sd->mutex);
@@ -4180,7 +4200,7 @@ void TextServerAdvanced::_shaped_text_set_preserve_control(const RID &p_shaped, 
 }
 
 bool TextServerAdvanced::_shaped_text_get_preserve_control(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -4189,7 +4209,7 @@ bool TextServerAdvanced::_shaped_text_get_preserve_control(const RID &p_shaped) 
 
 void TextServerAdvanced::_shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) {
 	ERR_FAIL_INDEX((int)p_spacing, 4);
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 
 	MutexLock lock(sd->mutex);
@@ -4205,7 +4225,7 @@ void TextServerAdvanced::_shaped_text_set_spacing(const RID &p_shaped, SpacingTy
 int64_t TextServerAdvanced::_shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const {
 	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
 
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);
 
 	MutexLock lock(sd->mutex);
@@ -4213,7 +4233,7 @@ int64_t TextServerAdvanced::_shaped_text_get_spacing(const RID &p_shaped, Spacin
 }
 
 TextServer::Orientation TextServerAdvanced::_shaped_text_get_orientation(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, TextServer::ORIENTATION_HORIZONTAL);
 
 	MutexLock lock(sd->mutex);
@@ -4221,20 +4241,20 @@ TextServer::Orientation TextServerAdvanced::_shaped_text_get_orientation(const R
 }
 
 int64_t TextServerAdvanced::_shaped_get_span_count(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);
 	return sd->spans.size();
 }
 
 Variant TextServerAdvanced::_shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, Variant());
 	ERR_FAIL_INDEX_V(p_index, sd->spans.size(), Variant());
 	return sd->spans[p_index].meta;
 }
 
 void TextServerAdvanced::_shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL(sd);
 	ERR_FAIL_INDEX(p_index, sd->spans.size());
 
@@ -4247,7 +4267,7 @@ void TextServerAdvanced::_shaped_set_span_update_font(const RID &p_shaped, int64
 }
 
 bool TextServerAdvanced::_shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 	ERR_FAIL_COND_V(p_size <= 0, false);
 
@@ -4282,12 +4302,12 @@ bool TextServerAdvanced::_shaped_text_add_string(const RID &p_shaped, const Stri
 }
 
 bool TextServerAdvanced::_shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int64_t p_length, double p_baseline) {
-	_THREAD_SAFE_METHOD_
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 	ERR_FAIL_COND_V(p_key == Variant(), false);
 	ERR_FAIL_COND_V(sd->objects.has(p_key), false);
 
+	MutexLock lock(sd->mutex);
 	if (sd->parent != RID()) {
 		full_copy(sd);
 	}
@@ -4313,7 +4333,7 @@ bool TextServerAdvanced::_shaped_text_add_object(const RID &p_shaped, const Vari
 }
 
 bool TextServerAdvanced::_shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, double p_baseline) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -4381,7 +4401,7 @@ bool TextServerAdvanced::_shaped_text_resize_object(const RID &p_shaped, const V
 	return true;
 }
 
-void TextServerAdvanced::_realign(ShapedTextDataAdvanced *p_sd) const {
+void TextServerAdvanced::_realign(Ref<ShapedTextDataAdvanced> &p_sd) const {
 	// Align embedded objects to baseline.
 	double full_ascent = p_sd->ascent;
 	double full_descent = p_sd->descent;
@@ -4457,8 +4477,7 @@ void TextServerAdvanced::_realign(ShapedTextDataAdvanced *p_sd) const {
 }
 
 RID TextServerAdvanced::_shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const {
-	_THREAD_SAFE_METHOD_
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, RID());
 
 	MutexLock lock(sd->mutex);
@@ -4473,6 +4492,7 @@ RID TextServerAdvanced::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 	ERR_FAIL_COND_V(sd->end < p_start + p_length, RID());
 
 	ShapedTextDataAdvanced *new_sd = memnew(ShapedTextDataAdvanced);
+	new_sd->init_ref();
 	new_sd->parent = p_shaped;
 	new_sd->start = p_start;
 	new_sd->end = p_start + p_length;
@@ -4485,14 +4505,19 @@ RID TextServerAdvanced::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 		new_sd->extra_spacing[i] = sd->extra_spacing[i];
 	}
 
-	if (!_shape_substr(new_sd, sd, p_start, p_length)) {
+	Ref<ShapedTextDataAdvanced> new_sd_ref = new_sd;
+	if (!_shape_substr(new_sd_ref, sd, p_start, p_length)) {
 		memdelete(new_sd);
 		return RID();
 	}
-	return shaped_owner.make_rid(new_sd);
+
+	rid_lock.lock();
+	RID rid = shaped_owner.make_rid(new_sd);
+	rid_lock.unlock();
+	return rid;
 }
 
-bool TextServerAdvanced::_shape_substr(ShapedTextDataAdvanced *p_new_sd, const ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_length) const {
+bool TextServerAdvanced::_shape_substr(Ref<ShapedTextDataAdvanced> &p_new_sd, const Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_start, int64_t p_length) const {
 	if (p_new_sd->valid) {
 		return true;
 	}
@@ -4642,7 +4667,7 @@ bool TextServerAdvanced::_shape_substr(ShapedTextDataAdvanced *p_new_sd, const S
 }
 
 RID TextServerAdvanced::_shaped_text_get_parent(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, RID());
 
 	MutexLock lock(sd->mutex);
@@ -4650,7 +4675,7 @@ RID TextServerAdvanced::_shaped_text_get_parent(const RID &p_shaped) const {
 }
 
 double TextServerAdvanced::_shaped_text_fit_to_width(const RID &p_shaped, double p_width, BitField<TextServer::JustificationFlag> p_jst_flags) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -4807,7 +4832,7 @@ double TextServerAdvanced::_shaped_text_fit_to_width(const RID &p_shaped, double
 }
 
 double TextServerAdvanced::_shaped_text_tab_align(const RID &p_shaped, const PackedFloat32Array &p_tab_stops) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -5023,7 +5048,7 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 }
 
 void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_line, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped_line);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped_line);
 	ERR_FAIL_NULL_MSG(sd, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
@@ -5053,7 +5078,7 @@ void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 
 	Vector<ShapedTextDataAdvanced::Span> &spans = sd->spans;
 	if (sd->parent != RID()) {
-		ShapedTextDataAdvanced *parent_sd = shaped_owner.get_or_null(sd->parent);
+		Ref<ShapedTextDataAdvanced> parent_sd = _get_shaped(sd->parent);
 		ERR_FAIL_COND(!parent_sd->valid);
 		spans = parent_sd->spans;
 	}
@@ -5222,7 +5247,7 @@ void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_trim_pos(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V_MSG(sd, -1, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
@@ -5230,7 +5255,7 @@ int64_t TextServerAdvanced::_shaped_text_get_trim_pos(const RID &p_shaped) const
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_ellipsis_pos(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V_MSG(sd, -1, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
@@ -5238,7 +5263,7 @@ int64_t TextServerAdvanced::_shaped_text_get_ellipsis_pos(const RID &p_shaped) c
 }
 
 const Glyph *TextServerAdvanced::_shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V_MSG(sd, nullptr, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
@@ -5246,14 +5271,14 @@ const Glyph *TextServerAdvanced::_shaped_text_get_ellipsis_glyphs(const RID &p_s
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V_MSG(sd, 0, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
 	return sd->overrun_trim_data.ellipsis_glyph_buf.size();
 }
 
-void TextServerAdvanced::_update_chars(ShapedTextDataAdvanced *p_sd) const {
+void TextServerAdvanced::_update_chars(Ref<ShapedTextDataAdvanced> &p_sd) const {
 	if (!p_sd->chars_valid) {
 		p_sd->chars.clear();
 
@@ -5264,7 +5289,7 @@ void TextServerAdvanced::_update_chars(ShapedTextDataAdvanced *p_sd) const {
 
 		Vector<ShapedTextDataAdvanced::Span> &spans = p_sd->spans;
 		if (p_sd->parent != RID()) {
-			ShapedTextDataAdvanced *parent_sd = shaped_owner.get_or_null(p_sd->parent);
+			Ref<ShapedTextDataAdvanced> parent_sd = _get_shaped(p_sd->parent);
 			ERR_FAIL_COND(!parent_sd->valid);
 			spans = parent_sd->spans;
 		}
@@ -5309,7 +5334,7 @@ void TextServerAdvanced::_update_chars(ShapedTextDataAdvanced *p_sd) const {
 }
 
 PackedInt32Array TextServerAdvanced::_shaped_text_get_character_breaks(const RID &p_shaped) const {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, PackedInt32Array());
 
 	MutexLock lock(sd->mutex);
@@ -5323,7 +5348,7 @@ PackedInt32Array TextServerAdvanced::_shaped_text_get_character_breaks(const RID
 }
 
 bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -5588,7 +5613,7 @@ _FORCE_INLINE_ int64_t _generate_kashida_justification_opportunies(const String 
 }
 
 bool TextServerAdvanced::_shaped_text_update_justification_ops(const RID &p_shaped) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -5739,7 +5764,7 @@ bool TextServerAdvanced::_shaped_text_update_justification_ops(const RID &p_shap
 	return sd->justification_ops_valid;
 }
 
-Glyph TextServerAdvanced::_shape_single_glyph(ShapedTextDataAdvanced *p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size) {
+Glyph TextServerAdvanced::_shape_single_glyph(Ref<ShapedTextDataAdvanced> &p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size) {
 	hb_font_t *hb_font = _font_get_hb_handle(p_font, p_font_size);
 	double scale = _font_get_scale(p_font, p_font_size);
 	bool subpos = (scale != 1.0) || (_font_get_subpixel_positioning(p_font) == SUBPIXEL_POSITIONING_ONE_HALF) || (_font_get_subpixel_positioning(p_font) == SUBPIXEL_POSITIONING_ONE_QUARTER) || (_font_get_subpixel_positioning(p_font) == SUBPIXEL_POSITIONING_AUTO && p_font_size <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE);
@@ -5819,7 +5844,7 @@ _FORCE_INLINE_ void TextServerAdvanced::_add_featuers(const Dictionary &p_source
 	}
 }
 
-void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, RID p_prev_font) {
+void TextServerAdvanced::_shape_run(Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, RID p_prev_font) {
 	RID f;
 	int fs = p_sd->spans[p_span].font_size;
 
@@ -5922,7 +5947,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 		return;
 	}
 
-	FontAdvanced *fd = _get_font_data(f);
+	Ref<FontAdvanced> fd = _get_font_data(f);
 	ERR_FAIL_NULL(fd);
 	MutexLock lock(fd->mutex);
 
@@ -6128,8 +6153,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 }
 
 bool TextServerAdvanced::_shaped_text_shape(const RID &p_shaped) {
-	_THREAD_SAFE_METHOD_
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -6140,7 +6164,7 @@ bool TextServerAdvanced::_shaped_text_shape(const RID &p_shaped) {
 	invalidate(sd, false);
 	if (sd->parent != RID()) {
 		_shaped_text_shape(sd->parent);
-		ShapedTextDataAdvanced *parent_sd = shaped_owner.get_or_null(sd->parent);
+		Ref<ShapedTextDataAdvanced> parent_sd = _get_shaped(sd->parent);
 		ERR_FAIL_COND_V(!parent_sd->valid, false);
 		ERR_FAIL_COND_V(!_shape_substr(sd, parent_sd, sd->start, sd->end - sd->start), false);
 		return true;
@@ -6345,7 +6369,7 @@ bool TextServerAdvanced::_shaped_text_shape(const RID &p_shaped) {
 }
 
 bool TextServerAdvanced::_shaped_text_is_ready(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, false);
 
 	MutexLock lock(sd->mutex);
@@ -6353,7 +6377,7 @@ bool TextServerAdvanced::_shaped_text_is_ready(const RID &p_shaped) const {
 }
 
 const Glyph *TextServerAdvanced::_shaped_text_get_glyphs(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, nullptr);
 
 	MutexLock lock(sd->mutex);
@@ -6364,7 +6388,7 @@ const Glyph *TextServerAdvanced::_shaped_text_get_glyphs(const RID &p_shaped) co
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_glyph_count(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);
 
 	MutexLock lock(sd->mutex);
@@ -6375,7 +6399,7 @@ int64_t TextServerAdvanced::_shaped_text_get_glyph_count(const RID &p_shaped) co
 }
 
 const Glyph *TextServerAdvanced::_shaped_text_sort_logical(const RID &p_shaped) {
-	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, nullptr);
 
 	MutexLock lock(sd->mutex);
@@ -6393,7 +6417,7 @@ const Glyph *TextServerAdvanced::_shaped_text_sort_logical(const RID &p_shaped) 
 }
 
 Vector2i TextServerAdvanced::_shaped_text_get_range(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, Vector2i());
 
 	MutexLock lock(sd->mutex);
@@ -6402,7 +6426,7 @@ Vector2i TextServerAdvanced::_shaped_text_get_range(const RID &p_shaped) const {
 
 Array TextServerAdvanced::_shaped_text_get_objects(const RID &p_shaped) const {
 	Array ret;
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, ret);
 
 	MutexLock lock(sd->mutex);
@@ -6414,7 +6438,7 @@ Array TextServerAdvanced::_shaped_text_get_objects(const RID &p_shaped) const {
 }
 
 Rect2 TextServerAdvanced::_shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, Rect2());
 
 	MutexLock lock(sd->mutex);
@@ -6426,7 +6450,7 @@ Rect2 TextServerAdvanced::_shaped_text_get_object_rect(const RID &p_shaped, cons
 }
 
 Size2 TextServerAdvanced::_shaped_text_get_size(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, Size2());
 
 	MutexLock lock(sd->mutex);
@@ -6441,7 +6465,7 @@ Size2 TextServerAdvanced::_shaped_text_get_size(const RID &p_shaped) const {
 }
 
 double TextServerAdvanced::_shaped_text_get_ascent(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -6452,7 +6476,7 @@ double TextServerAdvanced::_shaped_text_get_ascent(const RID &p_shaped) const {
 }
 
 double TextServerAdvanced::_shaped_text_get_descent(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -6463,7 +6487,7 @@ double TextServerAdvanced::_shaped_text_get_descent(const RID &p_shaped) const {
 }
 
 double TextServerAdvanced::_shaped_text_get_width(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -6474,7 +6498,7 @@ double TextServerAdvanced::_shaped_text_get_width(const RID &p_shaped) const {
 }
 
 double TextServerAdvanced::_shaped_text_get_underline_position(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -6486,7 +6510,7 @@ double TextServerAdvanced::_shaped_text_get_underline_position(const RID &p_shap
 }
 
 double TextServerAdvanced::_shaped_text_get_underline_thickness(const RID &p_shaped) const {
-	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	const Ref<ShapedTextDataAdvanced> sd = _get_shaped(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0.0);
 
 	MutexLock lock(sd->mutex);
@@ -7227,7 +7251,6 @@ TextServerAdvanced::TextServerAdvanced() {
 }
 
 void TextServerAdvanced::_cleanup() {
-	_THREAD_SAFE_METHOD_
 	for (const KeyValue<SystemFontKey, SystemFontCache> &E : system_fonts) {
 		const Vector<SystemFontCacheRec> &sysf_cache = E.value.var;
 		for (const SystemFontCacheRec &F : sysf_cache) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87990, supersede https://github.com/godotengine/godot/pull/72646

- Makes internal TextServer resources ref-counted (since acquired object can be in use when `free` is called for other thread).
- Instead of locking the whole TextServer (via `_THREAD_SAFE_CLASS_` mutex), only lock RID operation (creation, deletion, and reference acquisition).
- Individual internal objects already have own mutexes.