### PR TITLE
C#: Improve dotnet sdk version detection

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -42,6 +42,7 @@ namespace GodotTools.Build
             startInfo.CreateNoWindow = true;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
+            startInfo.WorkingDirectory = Path.GetDirectoryName(buildInfo.Project)!;
 
             if (OperatingSystem.IsWindows())
             {
@@ -112,6 +113,7 @@ namespace GodotTools.Build
             startInfo.UseShellExecute = false;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
+            startInfo.WorkingDirectory = Path.GetDirectoryName(buildInfo.Project)!;
 
             if (OperatingSystem.IsWindows())
             {

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -52,6 +52,20 @@ namespace GodotTools.Build
             if (string.IsNullOrEmpty(dotNetExe))
                 return false;
 
+            // Detect default sdk installed in the system (the newest, usually).
+            if (!GetDotnetVersion(dotNetExe, null, out var systemSdkVersion))
+            {
+                // This should never happen, dotnet always has at least one sdk installed.
+                return false;
+            }
+
+            // Check whether the project requires a different sdk version from the default we detected above.
+            if (GetDotnetVersion(dotNetExe, Environment.CurrentDirectory, out version) && version != systemSdkVersion)
+            {
+                // The project has a required sdk version, use that one instead of the one we guessed.
+                expectedVersion = version;
+            }
+
             using Process process = new Process();
             process.StartInfo = new ProcessStartInfo(dotNetExe, "--list-sdks")
             {
@@ -100,7 +114,15 @@ namespace GodotTools.Build
                 if (!Version.TryParse(sdkLineParts[0], out var lineVersion))
                     continue;
 
-                // We're looking for the exact same major version
+                // This is the exact version we're looking for.
+                if (lineVersion == expectedVersion)
+                {
+                    latestVersionMatch = lineVersion;
+                    matchPath = sdkLineParts[1].TrimStart('[').TrimEnd(']');
+                    break;
+                }
+
+                // We're looking for the exact same major version.
                 if (lineVersion.Major != expectedVersion.Major)
                     continue;
 
@@ -118,6 +140,49 @@ namespace GodotTools.Build
             path = Path.Combine(matchPath!, version.ToString());
 
             return true;
+        }
+
+        private static bool GetDotnetVersion(string dotNetExe, [CanBeNull] string projectPath, out Version version)
+        {
+            version = null;
+
+            var lines = new List<string>();
+
+            using Process process = new Process();
+
+            process.StartInfo = new ProcessStartInfo(dotNetExe, "--version")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                WorkingDirectory = projectPath ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            };
+
+            if (OperatingSystem.IsWindows())
+            {
+                process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+            }
+
+            process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
+
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrWhiteSpace(e.Data))
+                    lines.Add(e.Data);
+            };
+
+            try
+            {
+                process.Start();
+            }
+            catch
+            {
+                return false;
+            }
+
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+
+            return lines.Count > 0 && Version.TryParse(lines[0].Trim(), out version);
         }
     }
 }


### PR DESCRIPTION
dotnet tooling picks up project-level configurations from a global.json file, if it exists in the project folder. The global.json file can specify required sdk versions, whether to allow roll forward (picking up newer sdk versions if the required one isn't installed), specific additional tools to be installed, etc. 

For nativeaot compilation scenarios, it's important that we pick up the correct sdk set by the project, and that we obey the requested version in the global.json file, if any. This PR checks what version dotnet reports in the project path vs the one reported outside the project path, and prioritizes the one that is reported in the project path over the one we're guessing based on the editor environment - if they're different, it's because the project has set a specific sdk version requirement, so that's the one we should be using.

I also set the working directory for the build and publish commands to be the project one, to be very clear that that's where these commands should be running from. The default working directory, if unset, is the current directory, which should be the project path - but it's better to be obvious about it.

/cc @raulsntos @RedworkDE 

*Contrbuted by W4Games ❤️*