### PR TITLE
Visual Studio: Don't override user options. Add additional vs hint information

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1380,14 +1380,18 @@ def generate_vs_project(env, original_args, project_name="godot"):
 
         props_template = props_template.replace("%%OUTPUT%%", output)
 
-        props_template = props_template.replace(
-            "%%DEFINES%%", ";".join([format_key_value(v) for v in list(env["CPPDEFINES"])])
-        )
-        props_template = props_template.replace("%%INCLUDES%%", ";".join([str(j) for j in env["CPPPATH"]]))
-        props_template = props_template.replace(
-            "%%OPTIONS%%",
-            " ".join(env["CCFLAGS"]) + " " + " ".join([x for x in env["CXXFLAGS"] if not x.startswith("$")]),
-        )
+        proplist = [format_key_value(v) for v in list(env["CPPDEFINES"])]
+        proplist += [format_key_value(j) for j in env.get("VSHINT_DEFINES", [])]
+        props_template = props_template.replace("%%DEFINES%%", ";".join(proplist))
+
+        proplist = [str(j) for j in env["CPPPATH"]]
+        proplist += [str(j) for j in env.get("VSHINT_INCLUDES", [])]
+        props_template = props_template.replace("%%INCLUDES%%", ";".join(proplist))
+
+        proplist = env["CCFLAGS"]
+        proplist += [x for x in env["CXXFLAGS"] if not x.startswith("$")]
+        proplist += [str(j) for j in env.get("VSHINT_OPTIONS", [])]
+        props_template = props_template.replace("%%OPTIONS%%", " ".join(proplist))
 
         # Windows allows us to have spaces in paths, so we need
         # to double quote off the directory. However, the path ends

--- a/misc/msvs/props.template
+++ b/misc/msvs/props.template
@@ -4,13 +4,13 @@
     <NMakeBuildCommandLine>%%BUILD%%</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>%%REBUILD%%</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>%%CLEAN%%</NMakeCleanCommandLine>
-    <NMakeOutput>%%OUTPUT%%</NMakeOutput>
-    <NMakePreprocessorDefinitions>%%DEFINES%%</NMakePreprocessorDefinitions>
-    <NMakeIncludeSearchPath>%%INCLUDES%%</NMakeIncludeSearchPath>
+    <NMakeOutput Condition="'$(NMakeOutput)' == ''">%%OUTPUT%%</NMakeOutput>
+    <NMakePreprocessorDefinitions>%%DEFINES%%;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>%%INCLUDES%%;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
     <NMakeForcedIncludes>$(NMakeForcedIncludes)</NMakeForcedIncludes>
     <NMakeAssemblySearchPath>$(NMakeAssemblySearchPath)</NMakeAssemblySearchPath>
     <NMakeForcedUsingAssemblies>$(NMakeForcedUsingAssemblies)</NMakeForcedUsingAssemblies>
-    <AdditionalOptions>%%OPTIONS%%</AdditionalOptions>
+    <AdditionalOptions>%%OPTIONS%% $(AdditionalOptions)</AdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition="%%CONDITION%%">
     %%PROPERTIES%%


### PR DESCRIPTION
All of `NMakePreprocessorDefinitions`/`NMakeIncludeSearchPath`/`AdditionalOptions` entries that we generate are hints to VS about where to find things, what defines are active, etc, and they're generated based on what scons knows about a particular build configuration. However, there's a lot of implicit compiler settings (like default include paths, default defines, etc), that the compiler adds automatically and that scons can't tell us about. For VS to resolve things more accurately in the editor, either the user or the platform (or both!) need to add some extra information.

This PR makes sure both users and our build system can add additional information to VS about where things are found and what things are defined. It also lets users customize the binary name, in case they want to debug or deploy from VS and the final deployed binary name differs from the default one.

/cc @akien-mga @bruvzg @mhilbrunner 

*Contrbuted by W4Games ❤️*