### PR TITLE
C#: Let platforms signal if they support the mono module or not

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,8 +1,3 @@
-# Prior to .NET Core, we supported these: ["windows", "macos", "linuxbsd", "android", "web", "ios"]
-# Eventually support for each them should be added back.
-supported_platforms = ["windows", "macos", "linuxbsd", "android", "ios"]
-
-
 def can_build(env, platform):
     if env["arch"].startswith("rv"):
         return False
@@ -14,9 +9,10 @@ def can_build(env, platform):
 
 
 def configure(env):
-    platform = env["platform"]
+    # Check if the platform has marked mono as supported.
+    supported = env.get("supported", [])
 
-    if platform not in supported_platforms:
+    if not "mono" in supported:
         raise RuntimeError("This module does not currently support building for this platform")
 
     env.add_module_version_string("mono")

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -68,6 +68,7 @@ def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
         ("target", "template_debug"),
+        ("supported", ["mono"]),
     ]
 
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -49,6 +49,7 @@ def get_flags():
         ("arch", "arm64"),  # Default for convenience.
         ("target", "template_debug"),
         ("use_volk", False),
+        ("supported", ["mono"]),
     ]
 
 

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -65,6 +65,7 @@ def get_doc_path():
 def get_flags():
     return [
         ("arch", detect_arch()),
+        ("supported", ["mono"]),
     ]
 
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -50,6 +50,7 @@ def get_flags():
     return [
         ("arch", detect_arch()),
         ("use_volk", False),
+        ("supported", ["mono"]),
     ]
 
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -215,6 +215,7 @@ def get_flags():
 
     return [
         ("arch", arch),
+        ("supported", ["mono"]),
     ]
 
 


### PR DESCRIPTION
Instead of hardcoding platform names that support C#, let platforms set a flag indicating if they support it or not. All public platforms except web already support it, and it's a pain to maintain a patch for this list just to add additional names of proprietary console platforms, or when adding new platforms in general.

It will make it much easier to add new platforms or variants of existing platforms if we prefer having the platform signal what it supports instead of having hardcoded "if env.platform == X" checks. Platform flag checking scales much better in the long run and lets us keep both platforms and modules more clean and portable.

/cc @akien-mga @raulsntos @mhilbrunner 

*Contrbuted by W4Games ❤️*