### PR TITLE
Visual Studio: Fix user workflows with custom user VS configurations

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1367,7 +1367,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
                 vsconf = f'{target}|{a["platform"]}'
                 break
 
-        condition = "'$(Configuration)|$(Platform)'=='" + vsconf + "'"
+        condition = "'$(GodotConfiguration)|$(GodotPlatform)'=='" + vsconf + "'"
         properties.append("<ActiveProjectItemList>;" + ";".join(activeItems) + ";</ActiveProjectItemList>")
         output = f'bin\\godot{env["PROGSUFFIX"]}'
 
@@ -1482,12 +1482,26 @@ def generate_vs_project(env, original_args, project_name="godot"):
                     "</ProjectConfiguration>",
                 ]
 
+                properties += [
+                    f"<PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='{godot_target}|{proj_plat}'\">",
+                    f"  <GodotConfiguration>{godot_target}</GodotConfiguration>",
+                    f"  <GodotPlatform>{proj_plat}</GodotPlatform>",
+                    "</PropertyGroup>",
+                ]
+
                 if godot_platform != "windows":
                     configurations += [
                         f'<ProjectConfiguration Include="editor|{proj_plat}">',
                         f"  <Configuration>editor</Configuration>",
                         f"  <Platform>{proj_plat}</Platform>",
                         "</ProjectConfiguration>",
+                    ]
+
+                    properties += [
+                        f"<PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='editor|{proj_plat}'\">",
+                        f"  <GodotConfiguration>editor</GodotConfiguration>",
+                        f"  <GodotPlatform>{proj_plat}</GodotPlatform>",
+                        "</PropertyGroup>",
                     ]
 
                 p = f"{project_name}.{godot_platform}.{godot_target}.{godot_arch}.generated.props"
@@ -1502,6 +1516,10 @@ def generate_vs_project(env, original_args, project_name="godot"):
                     f"{{{proj_uuid}}}.{godot_target}|{sln_plat}.Build.0 = {godot_target}|{proj_plat}",
                 ]
 
+    # Add an extra import for a local user props file at the end, so users can add more overrides.
+    imports += [
+        f'<Import Project="$(MSBuildProjectDirectory)\\{project_name}.vs.user.props" Condition="Exists(\'$(MSBuildProjectDirectory)\\{project_name}.vs.user.props\')"/>'
+    ]
     section1 = sorted(section1)
     section2 = sorted(section2)
 

--- a/misc/msvs/props.template
+++ b/misc/msvs/props.template
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='%%VSCONF%%'">
+  <PropertyGroup Condition="'$(GodotConfiguration)|$(GodotPlatform)'=='%%VSCONF%%'">
     <NMakeBuildCommandLine>%%BUILD%%</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>%%REBUILD%%</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>%%CLEAN%%</NMakeCleanCommandLine>

--- a/misc/msvs/vcxproj.template
+++ b/misc/msvs/vcxproj.template
@@ -9,23 +9,21 @@
     <Keyword>MakeFileProj</Keyword>
     <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
-  <PropertyGroup>
-    %%PROPERTIES%%
-  </PropertyGroup>
+  %%PROPERTIES%%
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <PlatformToolset>v143</PlatformToolset>
-    <OutDir>$(SolutionDir)\bin\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\bin\$(GodotPlatform)\$(GodotConfiguration)\</OutDir>
+    <IntDir>obj\$(GodotPlatform)\$(GodotConfiguration)\</IntDir>
     <LayoutDir>$(OutDir)\Layout</LayoutDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(GodotPlatform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(GodotPlatform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>


### PR DESCRIPTION
Users can add additional VS project configurations with their own custom settings, but to support this workflow, we can't rely directly on `$(Platform)` and `$(Configuration)`, because VS needs Configuration|Platform to be a unique combo in the ProjectConfiguration section, and we need to allow for different combos of Configuration|Platform to point to the same scons build configuration.

GodotPlatform and GodotConfiguration properties lets us decouple from the magic VS properties that we don't control, so users can add however many Platform|Configuration combos they want and still point to a specific GodotPlatform|GodotConfiguration build config.

How to test:
- Run `scons target=editor vsproj=yes` to generate a vcxproj file and the build-specific `godot.windows.editor.x86_64.generated.props` file
- In the VS, add a new project configuration and copy settings from the `editor` configuration (let it create the solution configurations)
- Once VS has created this new configuration, do a build with this new configuration. Verify that the output window says `1>Building for platform "windows", architecture "x86_64", target "editor".`

/cc @anvilfolk who reported this on rocketchat (https://chat.godotengine.org/channel/buildsystem?msg=ZMZ3tjFBsDTsNAC8K)
/cc @akien-mga @mhilbrunner @bruvzg 