### PR TITLE
[D3D12] Improve shader validation handling.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -977,6 +977,8 @@ public:
 	virtual String get_pipeline_cache_uuid() const override final;
 	virtual const Capabilities &get_capabilities() const override final;
 
+	static bool is_in_developer_mode();
+
 private:
 	/*********************/
 	/**** BOOKKEEPING ****/


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot-nir-static/pull/8

- Allow running without validation if developer mode is enabled.
- Show error message if DXIL.dll is not found instead of silently crashing.