### PR TITLE
C#: Fix missing CowData 64-bit promotion for `PackedInt32Array`.

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -962,7 +962,7 @@ namespace Godot.NativeInterop
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *(_ptr - 1) : 0;
+            get => _ptr != null ? (int)(*((ulong*)_ptr - 1)) : 0;
         }
     }
 


### PR DESCRIPTION
Fixes the missing `Size` promotion for `PackedInt32Array` after https://github.com/godotengine/godot/pull/86730

- Fixes #88215