### PR TITLE
Avoid unqualified-id "near" and "far" in Node3DEditor/Viewport

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -117,11 +117,6 @@ AABB AABB::intersection(const AABB &p_aabb) const {
 	return AABB(min, max - min);
 }
 
-#ifdef MINGW_ENABLED
-#undef near
-#undef far
-#endif
-
 bool AABB::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *r_clip, Vector3 *r_normal) const {
 #ifdef MATH_CHECKS
 	if (unlikely(size.x < 0 || size.y < 0 || size.z < 0)) {
@@ -130,8 +125,8 @@ bool AABB::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *
 #endif
 	Vector3 c1, c2;
 	Vector3 end = position + size;
-	real_t near = -1e20;
-	real_t far = 1e20;
+	real_t depth_near = -1e20;
+	real_t depth_far = 1e20;
 	int axis = 0;
 
 	for (int i = 0; i < 3; i++) {
@@ -146,14 +141,14 @@ bool AABB::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *
 			if (c1[i] > c2[i]) {
 				SWAP(c1, c2);
 			}
-			if (c1[i] > near) {
-				near = c1[i];
+			if (c1[i] > depth_near) {
+				depth_near = c1[i];
 				axis = i;
 			}
-			if (c2[i] < far) {
-				far = c2[i];
+			if (c2[i] < depth_far) {
+				depth_far = c2[i];
 			}
-			if ((near > far) || (far < 0)) {
+			if ((depth_near > depth_far) || (depth_far < 0)) {
 				return false;
 			}
 		}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -943,13 +943,13 @@ void Node3DEditorViewport::_select_region() {
 		}
 	}
 
-	Plane near(-_get_camera_normal(), cam_pos);
-	near.d -= get_znear();
-	frustum.push_back(near);
+	Plane near_plane = Plane(-_get_camera_normal(), cam_pos);
+	near_plane.d -= get_znear();
+	frustum.push_back(near_plane);
 
-	Plane far = -near;
-	far.d += get_zfar();
-	frustum.push_back(far);
+	Plane far_plane = -near_plane;
+	far_plane.d += get_zfar();
+	frustum.push_back(far_plane);
 
 	if (spatial_editor->get_single_selected_node()) {
 		Node3D *single_selected = spatial_editor->get_single_selected_node();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -254,7 +254,7 @@ namespace Godot
         /// <param name="near">The near clipping distance.</param>
         /// <param name="far">The far clipping distance.</param>
         /// <returns>The created projection.</returns>
-        public static Projection CreateFrustum(real_t left, real_t right, real_t bottom, real_t top, real_t near, real_t far)
+        public static Projection CreateFrustum(real_t left, real_t right, real_t bottom, real_t top, real_t depth_near, real_t depth_far)
         {
             if (right <= left)
             {
@@ -264,18 +264,18 @@ namespace Godot
             {
                 throw new ArgumentException("top is less or equal to bottom.");
             }
-            if (far <= near)
+            if (depth_far <= depth_near)
             {
                 throw new ArgumentException("far is less or equal to near.");
             }
 
-            real_t x = 2 * near / (right - left);
-            real_t y = 2 * near / (top - bottom);
+            real_t x = 2 * depth_near / (right - left);
+            real_t y = 2 * depth_near / (top - bottom);
 
             real_t a = (right + left) / (right - left);
             real_t b = (top + bottom) / (top - bottom);
-            real_t c = -(far + near) / (far - near);
-            real_t d = -2 * far * near / (far - near);
+            real_t c = -(depth_far + depth_near) / (depth_far - depth_near);
+            real_t d = -2 * depth_far * depth_near / (depth_far - depth_near);
 
             return new Projection(
                 new Vector4(x, 0, 0, 0),
@@ -297,13 +297,13 @@ namespace Godot
         /// <param name="far">The far clipping distance.</param>
         /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
         /// <returns>The created projection.</returns>
-        public static Projection CreateFrustumAspect(real_t size, real_t aspect, Vector2 offset, real_t near, real_t far, bool flipFov)
+        public static Projection CreateFrustumAspect(real_t size, real_t aspect, Vector2 offset, real_t depth_near, real_t depth_far, bool flipFov)
         {
             if (!flipFov)
             {
                 size *= aspect;
             }
-            return CreateFrustum(-size / 2 + offset.X, +size / 2 + offset.X, -size / aspect / 2 + offset.Y, +size / aspect / 2 + offset.Y, near, far);
+            return CreateFrustum(-size / 2 + offset.X, +size / 2 + offset.X, -size / aspect / 2 + offset.Y, +size / aspect / 2 + offset.Y, depth_near, depth_far);
         }
 
         /// <summary>

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -72,11 +72,6 @@ void SceneDebugger::deinitialize() {
 	}
 }
 
-#ifdef MINGW_ENABLED
-#undef near
-#undef far
-#endif
-
 #ifdef DEBUG_ENABLED
 Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured) {
 	SceneTree *scene_tree = SceneTree::get_singleton();
@@ -124,12 +119,12 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 		Transform3D transform = p_args[0];
 		bool is_perspective = p_args[1];
 		float size_or_fov = p_args[2];
-		float near = p_args[3];
-		float far = p_args[4];
+		float depth_near = p_args[3];
+		float depth_far = p_args[4];
 		if (is_perspective) {
-			scene_tree->get_root()->set_camera_3d_override_perspective(size_or_fov, near, far);
+			scene_tree->get_root()->set_camera_3d_override_perspective(size_or_fov, depth_near, depth_far);
 		} else {
-			scene_tree->get_root()->set_camera_3d_override_orthogonal(size_or_fov, near, far);
+			scene_tree->get_root()->set_camera_3d_override_orthogonal(size_or_fov, depth_near, depth_far);
 		}
 		scene_tree->get_root()->set_camera_3d_override_transform(transform);
 #endif // _3D_DISABLED

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -896,13 +896,13 @@ void Viewport::_process_picking() {
 			if (camera_3d) {
 				Vector3 from = camera_3d->project_ray_origin(pos);
 				Vector3 dir = camera_3d->project_ray_normal(pos);
-				real_t far = camera_3d->get_far();
+				real_t depth_far = camera_3d->get_far();
 
 				PhysicsDirectSpaceState3D *space = PhysicsServer3D::get_singleton()->space_get_direct_state(find_world_3d()->get_space());
 				if (space) {
 					PhysicsDirectSpaceState3D::RayParameters ray_params;
 					ray_params.from = from;
-					ray_params.to = from + dir * far;
+					ray_params.to = from + dir * depth_far;
 					ray_params.collide_with_areas = true;
 					ray_params.pick_ray = true;
 

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -373,11 +373,6 @@ real_t CameraAttributesPhysical::get_fov() const {
 	return frustum_fov;
 }
 
-#ifdef MINGW_ENABLED
-#undef near
-#undef far
-#endif
-
 void CameraAttributesPhysical::_update_frustum() {
 	//https://en.wikipedia.org/wiki/Circle_of_confusion#Circle_of_confusion_diameter_limit_based_on_d/1500
 	Vector2i sensor_size = Vector2i(36, 24); // Matches high-end DSLR, could be made variable if there is demand.
@@ -393,12 +388,12 @@ void CameraAttributesPhysical::_update_frustum() {
 	// that it is not picked up by the camera sensors.
 	// To be properly physically-based, we would run the DoF shader at all depths. To be efficient, we are only running it where the CoC
 	// will be visible, this introduces some value shifts in the near field that we have to compensate for below.
-	float near = ((hyperfocal_length * u) / (hyperfocal_length + (u - frustum_focal_length))) / 1000.0; // In meters.
-	float far = ((hyperfocal_length * u) / (hyperfocal_length - (u - frustum_focal_length))) / 1000.0; // In meters.
+	float depth_near = ((hyperfocal_length * u) / (hyperfocal_length + (u - frustum_focal_length))) / 1000.0; // In meters.
+	float depth_far = ((hyperfocal_length * u) / (hyperfocal_length - (u - frustum_focal_length))) / 1000.0; // In meters.
 	float scale = (frustum_focal_length / (u - frustum_focal_length)) * (frustum_focal_length / exposure_aperture);
 
-	bool use_far = (far < frustum_far) && (far > 0.0);
-	bool use_near = near > frustum_near;
+	bool use_far = (depth_far < frustum_far) && (depth_far > 0.0);
+	bool use_near = depth_near > frustum_near;
 #ifdef DEBUG_ENABLED
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 		// Force disable DoF in editor builds to suppress warnings.

--- a/tests/scene/test_camera_3d.h
+++ b/tests/scene/test_camera_3d.h
@@ -65,17 +65,17 @@ TEST_CASE("[SceneTree][Camera3D] Getters and setters") {
 	}
 
 	SUBCASE("Camera frustum properties") {
-		constexpr float near = 0.2f;
-		constexpr float far = 995.0f;
+		constexpr float depth_near = 0.2f;
+		constexpr float depth_far = 995.0f;
 		constexpr float fov = 120.0f;
 		constexpr float size = 7.0f;
 		constexpr float h_offset = 1.1f;
 		constexpr float v_offset = -1.6f;
 		const Vector2 frustum_offset(5, 7);
-		test_camera->set_near(near);
-		CHECK(test_camera->get_near() == near);
-		test_camera->set_far(far);
-		CHECK(test_camera->get_far() == far);
+		test_camera->set_near(depth_near);
+		CHECK(test_camera->get_near() == depth_near);
+		test_camera->set_far(depth_far);
+		CHECK(test_camera->get_far() == depth_far);
 		test_camera->set_fov(fov);
 		CHECK(test_camera->get_fov() == fov);
 		test_camera->set_size(size);


### PR DESCRIPTION
Follow up https://github.com/godotengine/godot/pull/87164.

Current master build is failed by unqualified-id.

Previously this problem avoid by [undef](https://github.com/godotengine/godot/pull/87164/files#diff-0ee50480f71f1736de08b61f004f9b4e1867ace0dad25b3da8d29e9f8306dce0L39-L43), but "near" and "far" are now reserved words generally, and that PR changed the reserved words in some files.

However other files also contained reserved words that needed to be changed.

(Although I feel `Windows.h` is too arrogant to use those common noun words as reserved words...🤔)