### PR TITLE
C#: Detect Directory.Build.props for folder-based customization

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -38,6 +38,8 @@ namespace GodotTools.ProjectEditor
             if (sanitizedName != name)
                 mainGroup.AddProperty("RootNamespace", sanitizedName);
 
+            var import = root.AddImport(@"$(MSBuildProjectDirectory)\**\Directory.Build.props");
+
             return root;
         }
 


### PR DESCRIPTION
Adds the `Import` task in generating the C# solution to import any `Directory.Builds.props` files within the project ([as detailed in this Microsoft concept tutorial](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022)). This allows for addons to reference nuget packages without the developers having to tweak the project's `.csproj` file manually every time.