### PR TITLE
fixed issue where you can't select secondary handles (in/out) for curve 3d in top view mode

### DIFF
--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -150,9 +150,10 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 	// Define a tolerance - sometimes the camera's direction vector is not exactly (0, 1, 0) or (1, 0, 0).
 	const float TOLERANCE = 0.00001;
 	// Check if the camera is facing directly down or up and set the is_top_view flag.
-	is_top_view = Math::abs(dir.x) < TOLERANCE &&
+	const bool is_camera_in_top_view = Math::abs(dir.x) < TOLERANCE &&
 					Math::abs(dir.y) > (1.0 - TOLERANCE) &&
 					Math::abs(dir.z) < TOLERANCE;
+	set_is_top_view(is_camera_in_top_view);
 
 	// If the handle clicked is a tilt handle and the camera is in top view, we will use handle in/out instead.
 	if (is_top_view && _secondary_handles_info[p_id].type == HandleType::HANDLE_TYPE_TILT) {
@@ -250,6 +251,14 @@ void Path3DGizmo::commit_handle(int p_id, bool p_secondary, const Variant &p_res
 		ur->commit_action();
 
 		return;
+	}
+
+	// If the handle clicked is a tilt handle and the camera is in top view, we will use handle in/out instead.
+	if (is_top_view && _secondary_handles_info[p_id].type == HandleType::HANDLE_TYPE_TILT) {
+		// handle in has id-2 and handle out has id-1
+		// if p_id is 2 it means that it's a beginning of the curve, so we will use handle out instead.
+		const int modified_p_id = p_id == 2 ? p_id - 1 : p_id - 2;
+		return commit_handle(modified_p_id, true, p_restore, p_cancel);
 	}
 
 	// Secondary handles: in, out, tilt.

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -66,14 +66,6 @@ String Path3DGizmo::get_handle_name(int p_id, bool p_secondary) const {
 		return get_handle_name(get_modified_p_id(_secondary_handles_info[p_id].type, p_id), true);
 	}
 
-	// If the handle clicked is a tilt handle and the camera is in top view, we will use handle in/out instead.
-	if (is_top_view && _secondary_handles_info[p_id].type == HandleType::HANDLE_TYPE_TILT) {
-		// handle in has id-2 and handle out has id-1
-		// if p_id is 2 it means that it's a beginning of the curve, so we will use handle out instead.
-		const int modified_p_id = p_id == 2 ? p_id - 1 : p_id - 2;
-		return get_handle_name(modified_p_id, true);
-	}
-
 	// Secondary handles: in, out, tilt.
 	const HandleInfo info = _secondary_handles_info[p_id];
 	switch (info.type) {

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -41,9 +41,6 @@
 #include "scene/gui/menu_button.h"
 #include "scene/resources/curve.h"
 
-// A flag to indicate if the camera is top view.
-bool is_top_view = false;
-
 String Path3DGizmo::get_handle_name(int p_id, bool p_secondary) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -151,8 +151,8 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 	const float TOLERANCE = 0.00001;
 	// Check if the camera is facing directly down or up and set the is_top_view flag.
 	const bool is_camera_in_top_view = Math::abs(dir.x) < TOLERANCE &&
-					Math::abs(dir.y) > (1.0 - TOLERANCE) &&
-					Math::abs(dir.z) < TOLERANCE;
+			Math::abs(dir.y) > (1.0 - TOLERANCE) &&
+			Math::abs(dir.z) < TOLERANCE;
 	set_is_top_view(is_camera_in_top_view);
 
 	// If the handle clicked is a tilt handle and the camera is in top view, we will use handle in/out instead.

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -70,6 +70,7 @@ public:
 	virtual Variant get_handle_value(int p_id, bool p_secondary) const override;
 	virtual void set_handle(int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) override;
 	virtual void commit_handle(int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
+	virtual int get_modified_p_id(int secondary_handle_type, int p_id) const;
 
 	virtual void redraw() override;
 	Path3DGizmo(Path3D *p_path = nullptr, float p_disk_size = 0.8);

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -63,6 +63,8 @@ class Path3DGizmo : public EditorNode3DGizmo {
 	// Cache information of secondary handles.
 	Vector<HandleInfo> _secondary_handles_info;
 
+	bool is_top_view = false;
+
 public:
 	virtual String get_handle_name(int p_id, bool p_secondary) const override;
 	virtual Variant get_handle_value(int p_id, bool p_secondary) const override;
@@ -71,6 +73,8 @@ public:
 
 	virtual void redraw() override;
 	Path3DGizmo(Path3D *p_path = nullptr, float p_disk_size = 0.8);
+
+    void set_is_top_view(bool value) { is_top_view = value;}
 };
 
 class Path3DGizmoPlugin : public EditorNode3DGizmoPlugin {

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -75,7 +75,7 @@ public:
 	virtual void redraw() override;
 	Path3DGizmo(Path3D *p_path = nullptr, float p_disk_size = 0.8);
 
-    void set_is_top_view(bool value) { is_top_view = value; }
+	void set_is_top_view(bool value) { is_top_view = value; }
 };
 
 class Path3DGizmoPlugin : public EditorNode3DGizmoPlugin {

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -74,7 +74,7 @@ public:
 	virtual void redraw() override;
 	Path3DGizmo(Path3D *p_path = nullptr, float p_disk_size = 0.8);
 
-    void set_is_top_view(bool value) { is_top_view = value;}
+    void set_is_top_view(bool value) { is_top_view = value; }
 };
 
 class Path3DGizmoPlugin : public EditorNode3DGizmoPlugin {


### PR DESCRIPTION
The issue: you can't modify 3d curve using secondary handles in top view mode. It's because there's no way to click on handle in/out because handle tilt is on top of them and you are always clicking on handle tilt

https://github.com/godotengine/godot/assets/32012330/cb2e1d97-374b-41b6-95fb-8c423705b117

The solution:
When you are in top view, and you click on handle tilt, treat it like you have clicked handle in or handle out for the beginning of the curve


https://github.com/godotengine/godot/assets/32012330/d9e405ff-c6f6-4d4e-911b-87daecf34d3f

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/85795*
