### PR TITLE
Fix `CanvasItem`/`Node3D` editor plugin drag drop transform calculation

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5783,7 +5783,7 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 	target_position = canvas_item_editor->snap_point(target_position);
 
 	CanvasItem *parent_ci = Object::cast_to<CanvasItem>(parent);
-	Point2 local_target_pos = parent_ci ? parent_ci->get_global_transform().xform_inv(target_position) : target_position;
+	Point2 local_target_pos = parent_ci ? parent_ci->get_global_transform().affine_inverse().xform(target_position) : target_position;
 
 	undo_redo->add_do_method(child, "set_position", local_target_pos);
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3298,7 +3298,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 				}
 
 				Node3D *parent = sp->get_parent_node_3d();
-				Transform3D local_xform = parent ? parent->get_global_transform().inverse_xform(xform) : xform;
+				Transform3D local_xform = parent ? parent->get_global_transform().affine_inverse() * xform : xform;
 				undo_redo->add_do_method(sp, "set_transform", local_xform);
 				undo_redo->add_undo_method(sp, "set_transform", sp->get_local_gizmo_transform());
 			}
@@ -4371,7 +4371,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		}
 
 		Transform3D new_tf = node3d->get_transform();
-		new_tf.origin = parent_tf.xform_inv(preview_node_pos);
+		new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos);
 
 		undo_redo->add_do_method(instantiated_scene, "set_transform", new_tf);
 	}
@@ -6166,7 +6166,7 @@ void Node3DEditor::_xform_dialog_action() {
 		}
 
 		Node3D *parent = sp->get_parent_node_3d();
-		Transform3D local_tr = parent ? parent->get_global_transform().inverse_xform(tr) : tr;
+		Transform3D local_tr = parent ? parent->get_global_transform().affine_inverse() * tr : tr;
 		undo_redo->add_do_method(sp, "set_transform", local_tr);
 		undo_redo->add_undo_method(sp, "set_transform", sp->get_transform());
 	}
@@ -7517,7 +7517,7 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 					new_transform.origin = new_transform.origin - position_offset;
 
 					Node3D *parent = sp->get_parent_node_3d();
-					Transform3D new_local_xform = parent ? parent->get_global_transform().inverse_xform(new_transform) : new_transform;
+					Transform3D new_local_xform = parent ? parent->get_global_transform().affine_inverse() * new_transform : new_transform;
 					undo_redo->add_do_method(sp, "set_transform", new_local_xform);
 					undo_redo->add_undo_method(sp, "set_transform", sp->get_transform());
 				}


### PR DESCRIPTION
Fixes a regression from #86659/#88269 caused by using transform methods working only for orthonormal transforms.

| Before<br>(`master`) | After<br>(this PR) |
|--------|--------|
|![GHSAIEe1dz](https://github.com/godotengine/godot/assets/9283098/114009f4-3139-4a76-98fc-11cde2898326)|![jI2ldRoSyX](https://github.com/godotengine/godot/assets/9283098/129c0912-abca-4552-aa41-8693a00bf3ab)|
|![YjQtM2WRoi](https://github.com/godotengine/godot/assets/9283098/163396f9-1994-4e45-ab2a-6e6ab35fe0b2)|![Qr9ES9PfkR](https://github.com/godotengine/godot/assets/9283098/7b725382-cb29-4a95-be56-391720f08984)|
