### PR TITLE
Set `surface_override_material` to `RID()` when the `MeshInstance3D` is freed

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -530,4 +530,7 @@ MeshInstance3D::MeshInstance3D() {
 }
 
 MeshInstance3D::~MeshInstance3D() {
+	for (int surface_idx = 0; surface_idx < surface_override_materials.size(); surface_idx++) {
+		RS::get_singleton()->instance_set_surface_override_material(get_instance(), surface_idx, RID());
+	}
 }


### PR DESCRIPTION
For resources with `resource_local_to_scene` enabled, a copy of the original resource instance is usually used. When the node instance is freed, the copied resouce instance may be freed soon. However, the relevant data in `RenderingServer` may not be synchronized in time, which may cause some error messages to be output.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fix #88206. 
