### PR TITLE
[3.x] Fix crash on mat creation after ORM refactor

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -643,7 +643,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 
 				if (at == "SpatialMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Texture")) {
 					// Use existing resource if possible and only replace its data.
-					Ref<Material3D> mat = edited_resource;
+					Ref<SpatialMaterial> mat = edited_resource;
 					if (mat.is_null()) {
 						mat.instance();
 					}

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -637,9 +637,8 @@ private:
 	RID indicators_instance;
 	RID cursor_mesh;
 	RID cursor_instance;
-	Ref<Material3D> indicator_mat;
+	Ref<SpatialMaterial> indicator_mat;
 	Ref<ShaderMaterial> grid_mat[3];
-	Ref<Material3D> cursor_material;
 
 	// Scene drag and drop support
 	Spatial *preview_node;

--- a/modules/fbx/data/fbx_material.cpp
+++ b/modules/fbx/data/fbx_material.cpp
@@ -253,7 +253,7 @@ Ref<Material3D> FBXMaterial::import_material(ImportState &state) {
 
 	const String p_fbx_current_directory = state.path;
 
-	Ref<Material3D> spatial_material;
+	Ref<SpatialMaterial> spatial_material;
 
 	// read the material file
 	// is material two sided

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2919,7 +2919,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 
 			//just add it
 
-			Ref<Material3D> mat;
+			Ref<Material> mat;
 			if (p.has("material")) {
 				const int material = p["material"];
 				ERR_FAIL_INDEX_V(material, p_state->materials.size(), ERR_FILE_CORRUPT);
@@ -2930,7 +2930,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				mat = mat3d;
 
 			} else if (has_vertex_color) {
-				Ref<Material3D> mat3d;
+				Ref<SpatialMaterial> mat3d;
 				mat3d.instance();
 				mat3d->set_flag(Material3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 				mat = mat3d;
@@ -3669,7 +3669,7 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 	for (GLTFMaterialIndex i = 0; i < materials.size(); i++) {
 		const Dictionary &d = materials[i];
 
-		Ref<Material3D> material;
+		Ref<SpatialMaterial> material;
 		material.instance();
 		if (d.has("name") && !String(d["name"]).empty()) {
 			material->set_name(d["name"]);

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -124,10 +124,10 @@ class GridMapEditor : public VBoxContainer {
 
 	List<ClipboardItem> clipboard_items;
 
-	Ref<Material3D> indicator_mat;
-	Ref<Material3D> inner_mat;
-	Ref<Material3D> outer_mat;
-	Ref<Material3D> selection_floor_mat;
+	Ref<SpatialMaterial> indicator_mat;
+	Ref<SpatialMaterial> inner_mat;
+	Ref<SpatialMaterial> outer_mat;
+	Ref<SpatialMaterial> selection_floor_mat;
 
 	bool updating;
 

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -822,7 +822,7 @@ void MeshInstance::create_debug_tangents() {
 	}
 
 	if (lines.size()) {
-		Ref<Material3D> sm;
+		Ref<SpatialMaterial> sm;
 		sm.instance();
 
 		sm->set_flag(Material3D::FLAG_UNSHADED, true);

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -421,7 +421,7 @@ void RayCast::_create_debug_shape() {
 
 void RayCast::_update_debug_shape_material(bool p_check_collision) {
 	if (!debug_material.is_valid()) {
-		Ref<Material3D> material = memnew(Material3D);
+		Ref<SpatialMaterial> material = memnew(SpatialMaterial);
 		debug_material = material;
 
 		material->set_flag(Material3D::FLAG_UNSHADED, true);

--- a/scene/3d/shape_cast.cpp
+++ b/scene/3d/shape_cast.cpp
@@ -539,7 +539,7 @@ void ShapeCast::_create_debug_shape() {
 
 void ShapeCast::_update_debug_shape_material(bool p_check_collision) {
 	if (!debug_material.is_valid()) {
-		Ref<Material3D> material = memnew(Material3D);
+		Ref<SpatialMaterial> material = memnew(SpatialMaterial);
 		debug_material = material;
 
 		material->set_flag(Material3D::FLAG_UNSHADED, true);

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1507,7 +1507,7 @@ Ref<MultiMesh> VoxelLightBaker::create_debug_multimesh(DebugMode p_mode) {
 	}
 
 	{
-		Ref<Material3D> fsm;
+		Ref<SpatialMaterial> fsm;
 		fsm.instance();
 		fsm->set_flag(Material3D::FLAG_SRGB_VERTEX_COLOR, true);
 		fsm->set_flag(Material3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1826,7 +1826,7 @@ RID Material3D::get_material_rid_for_2d(bool p_shaded, bool p_transparent, bool 
 		return materials_for_2d[hash]->get_rid();
 	}
 
-	Ref<Material3D> material;
+	Ref<SpatialMaterial> material;
 	material.instance();
 
 	material->set_flag(FLAG_UNSHADED, !p_shaded);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -458,6 +458,8 @@ protected:
 	void _validate_property(PropertyInfo &property) const;
 	virtual bool _can_do_next_pass() const { return true; }
 
+	Material3D(bool p_orm = false);
+
 public:
 	void set_albedo(const Color &p_albedo);
 	Color get_albedo() const;
@@ -643,7 +645,6 @@ public:
 
 	virtual Shader::Mode get_shader_mode() const;
 
-	Material3D(bool p_orm = false);
 	virtual ~Material3D();
 };
 


### PR DESCRIPTION
This fixes an issue with the recent ORM PR which caused the creation of new materials failed.

Fixes #88232