### PR TITLE
Fix swap chain errors when application starts minimized.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -169,7 +169,11 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 		return;
 	}
 
-	RD::get_singleton()->screen_prepare_for_drawing(DisplayServer::MAIN_WINDOW_ID);
+	Error err = RD::get_singleton()->screen_prepare_for_drawing(DisplayServer::MAIN_WINDOW_ID);
+	if (err != OK) {
+		// Window is minimized and does not have valid swapchain, skip drawing without printing errors.
+		return;
+	}
 
 	RID texture = texture_storage->texture_allocate();
 	texture_storage->texture_2d_initialize(texture, p_image);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3164,9 +3164,6 @@ Error RenderingDevice::screen_create(DisplayServer::WindowID p_screen) {
 	RDD::SwapChainID swap_chain = driver->swap_chain_create(surface);
 	ERR_FAIL_COND_V_MSG(swap_chain.id == 0, ERR_CANT_CREATE, "Unable to create swap chain.");
 
-	Error err = driver->swap_chain_resize(main_queue, swap_chain, _get_swap_chain_desired_count());
-	ERR_FAIL_COND_V_MSG(err != OK, ERR_CANT_CREATE, "Unable to resize the new swap chain.");
-
 	screen_swap_chains[p_screen] = swap_chain;
 
 	return OK;


### PR DESCRIPTION
This effectively supersedes https://github.com/godotengine/godot/pull/85256, as it moves the error checking earlier to be consistent with the other method. It also removes an unnecessary resize call during screen creation which the bug made me realize is not actually necessary at all because resizing is delegated already to the first acquisition of the frame buffer image that is performed.

I think it's a fairly low risk merge but it might be a good idea to double-check on other platforms that taking out the resize doesn't break anything (it shouldn't as no drawing code goes through without preparing the screen for drawing first, which performs the resize if needed).

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/84905