### PR TITLE
Fix `TabBar` size when theme changes

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -376,6 +376,7 @@ void TabBar::_notification(int p_what) {
 			}
 
 			queue_redraw();
+			update_minimum_size();
 
 			[[fallthrough]];
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/87511