### PR TITLE
C#: Run source generators tests in CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -169,6 +169,11 @@ jobs:
           ${{ matrix.bin }} --help
           ${{ matrix.bin }} --headless --test --force-colors
 
+      - name: .NET source generators tests
+        if: ${{ matrix.build-mono }}
+        run: |
+          dotnet test modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests
+
       # Check class reference
       - name: Check for class reference updates
         if: ${{ matrix.doc-test }}


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/82955

Runs the test project in CI so that changes to the C# source generators are tested. Not sure which job this should be added to but since it requires building the .NET assemblies, I chose the `w/ Mono` job.