### PR TITLE
[3.x] Fix EditorPropertyLocale connecting to inexistent signal `text_submitted`.

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -370,7 +370,7 @@ EditorPropertyLocale::EditorPropertyLocale() {
 	add_child(locale_hb);
 	locale = memnew(LineEdit);
 	locale_hb->add_child(locale);
-	locale->connect("text_submitted", this, "_locale_selected");
+	locale->connect("text_entered", this, "_locale_selected");
 	locale->connect("focus_exited", this, "_locale_focus_exited");
 	locale->set_h_size_flags(SIZE_EXPAND_FILL);
 


### PR DESCRIPTION
This fixes a bug in the Internalization section of the project properties, which tries to connect the signal text_submitted insetad of text_entered.

Doesn't seem to have ill effects, apart from errors in the output panel.