### PR TITLE
Enable getting suggested tracker names from OpenXR extensions

### DIFF
--- a/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
@@ -23,6 +23,12 @@
 				- If the [code]bool *[/code] points to a boolean, the boolean will be updated to [code]true[/code] if the extension is enabled.
 			</description>
 		</method>
+		<method name="_get_suggested_tracker_names" qualifiers="virtual">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a [PackedStringArray] of positional tracker names that are used within the extension wrapper.
+			</description>
+		</method>
 		<method name="_on_before_instance_created" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -35,6 +35,7 @@
 #include "core/math/projection.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/rid.h"
+#include "core/variant/variant.h"
 
 #include <openxr/openxr.h>
 
@@ -61,6 +62,8 @@ public:
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; } // Add additional data structures when we create our OpenXR session.
 	virtual void *set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; } // Add additional data structures when creating OpenXR swap chains.
 	virtual void *set_hand_joint_locations_and_get_next_pointer(int p_hand_index, void *p_next_pointer) { return p_next_pointer; }
+
+	virtual PackedStringArray get_suggested_tracker_names() { return PackedStringArray(); }
 
 	// `on_register_metadata` allows extensions to register additional controller metadata.
 	// This function is called even when OpenXRApi is not constructured as the metadata

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
@@ -40,6 +40,7 @@ void OpenXRExtensionWrapperExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_set_swapchain_create_info_and_get_next_pointer, "next_pointer");
 	GDVIRTUAL_BIND(_set_hand_joint_locations_and_get_next_pointer, "hand_index", "next_pointer");
 	GDVIRTUAL_BIND(_get_composition_layer);
+	GDVIRTUAL_BIND(_get_suggested_tracker_names);
 	GDVIRTUAL_BIND(_on_register_metadata);
 	GDVIRTUAL_BIND(_on_before_instance_created);
 	GDVIRTUAL_BIND(_on_instance_created, "instance");
@@ -127,6 +128,16 @@ void *OpenXRExtensionWrapperExtension::set_hand_joint_locations_and_get_next_poi
 	}
 
 	return nullptr;
+}
+
+PackedStringArray OpenXRExtensionWrapperExtension::get_suggested_tracker_names() {
+	PackedStringArray ret;
+
+	if (GDVIRTUAL_CALL(_get_suggested_tracker_names, ret)) {
+		return ret;
+	}
+
+	return PackedStringArray();
 }
 
 XrCompositionLayerBaseHeader *OpenXRExtensionWrapperExtension::get_composition_layer() {

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.h
@@ -69,6 +69,10 @@ public:
 	GDVIRTUAL2R(uint64_t, _set_hand_joint_locations_and_get_next_pointer, int, GDExtensionPtr<void>);
 	GDVIRTUAL0R(uint64_t, _get_composition_layer);
 
+	virtual PackedStringArray get_suggested_tracker_names() override;
+
+	GDVIRTUAL0R(PackedStringArray, _get_suggested_tracker_names);
+
 	virtual void on_register_metadata() override;
 	virtual void on_before_instance_created() override;
 	virtual void on_instance_created(const XrInstance p_instance) override;

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
@@ -69,6 +69,11 @@ void *OpenXREyeGazeInteractionExtension::set_system_properties_and_get_next_poin
 	return &properties;
 }
 
+PackedStringArray OpenXREyeGazeInteractionExtension::get_suggested_tracker_names() {
+	PackedStringArray arr = { "/user/eyes_ext" };
+	return arr;
+}
+
 bool OpenXREyeGazeInteractionExtension::is_available() {
 	return available;
 }

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.h
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.h
@@ -43,6 +43,8 @@ public:
 	virtual HashMap<String, bool *> get_requested_extensions() override;
 	virtual void *set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
 
+	PackedStringArray get_suggested_tracker_names() override;
+
 	bool is_available();
 	bool supports_eye_gaze_interaction();
 

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
@@ -42,6 +42,25 @@ HashMap<String, bool *> OpenXRHTCViveTrackerExtension::get_requested_extensions(
 	return request_extensions;
 }
 
+PackedStringArray OpenXRHTCViveTrackerExtension::get_suggested_tracker_names() {
+	PackedStringArray arr = {
+		"/user/vive_tracker_htcx/role/handheld_object",
+		"/user/vive_tracker_htcx/role/left_foot",
+		"/user/vive_tracker_htcx/role/right_foot",
+		"/user/vive_tracker_htcx/role/left_shoulder",
+		"/user/vive_tracker_htcx/role/right_shoulder",
+		"/user/vive_tracker_htcx/role/left_elbow",
+		"/user/vive_tracker_htcx/role/right_elbow",
+		"/user/vive_tracker_htcx/role/left_knee",
+		"/user/vive_tracker_htcx/role/right_knee",
+		"/user/vive_tracker_htcx/role/waist",
+		"/user/vive_tracker_htcx/role/chest",
+		"/user/vive_tracker_htcx/role/camera",
+		"/user/vive_tracker_htcx/role/keyboard",
+	};
+	return arr;
+}
+
 bool OpenXRHTCViveTrackerExtension::is_available() {
 	return available;
 }

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.h
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.h
@@ -37,6 +37,8 @@ class OpenXRHTCViveTrackerExtension : public OpenXRExtensionWrapper {
 public:
 	virtual HashMap<String, bool *> get_requested_extensions() override;
 
+	PackedStringArray get_suggested_tracker_names() override;
+
 	bool is_available();
 
 	virtual void on_register_metadata() override;

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -156,26 +156,11 @@ PackedStringArray OpenXRInterface::get_suggested_tracker_names() const {
 		"left_hand", // /user/hand/left is mapped to our defaults
 		"right_hand", // /user/hand/right is mapped to our defaults
 		"/user/treadmill",
-
-		// Even though these are only available if you have the tracker extension,
-		// we add these as we may be deploying on a different platform than our
-		// editor is running on.
-		"/user/vive_tracker_htcx/role/handheld_object",
-		"/user/vive_tracker_htcx/role/left_foot",
-		"/user/vive_tracker_htcx/role/right_foot",
-		"/user/vive_tracker_htcx/role/left_shoulder",
-		"/user/vive_tracker_htcx/role/right_shoulder",
-		"/user/vive_tracker_htcx/role/left_elbow",
-		"/user/vive_tracker_htcx/role/right_elbow",
-		"/user/vive_tracker_htcx/role/left_knee",
-		"/user/vive_tracker_htcx/role/right_knee",
-		"/user/vive_tracker_htcx/role/waist",
-		"/user/vive_tracker_htcx/role/chest",
-		"/user/vive_tracker_htcx/role/camera",
-		"/user/vive_tracker_htcx/role/keyboard",
-
-		"/user/eyes_ext",
 	};
+
+	for (OpenXRExtensionWrapper *wrapper : OpenXRAPI::get_singleton()->get_registered_extension_wrappers()) {
+		arr.append_array(wrapper->get_suggested_tracker_names());
+	}
 
 	return arr;
 }


### PR DESCRIPTION
Moves some of the hard-coded positional tracker names into their corresponding extension wrappers, and exposes them with their own `get_suggested_tracker_names()` function. Necessary if any vendor specific extensions like the one in GodotVR/godot_openxr_vendors#81 want to add suggested names.