### PR TITLE
Disable ReShade in the editor and project manager (if run via Vulkan)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2208,11 +2208,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->set_environment("DISABLE_MANGOHUD", "1"); // GH-57403.
 		OS::get_singleton()->set_environment("DISABLE_RTSS_LAYER", "1"); // GH-57937.
 		OS::get_singleton()->set_environment("DISABLE_VKBASALT", "1");
+		OS::get_singleton()->set_environment("DISABLE_VK_LAYER_reshade_1", "1"); // GH-70849.
 	} else {
 		// Re-allow using Vulkan overlays, disabled while using the editor.
 		OS::get_singleton()->unset_environment("DISABLE_MANGOHUD");
 		OS::get_singleton()->unset_environment("DISABLE_RTSS_LAYER");
 		OS::get_singleton()->unset_environment("DISABLE_VKBASALT");
+		OS::get_singleton()->unset_environment("DISABLE_VK_LAYER_reshade_1");
 	}
 #endif
 


### PR DESCRIPTION
ReShade can still be used on projects run from the editor as well as exported projects.

This avoids several issues:

- ReShade doesn't play well with low-processor mode, making it hard to use unless the Update Continuously editor setting is enabled.
- The ReShade overlay appears on every popup opened, which made popups unusable.
- If you use a ReShade configuration that heavily affects the image, it won't affect the editor UI which may become unreadable as a result.

This doesn't affect the editor being run via OpenGL or Direct3D 12 as ReShade is injected in a different manner when using those graphics APIs.

- This closes https://github.com/godotengine/godot/issues/70849.

## Preview

*Before this PR, this could happen if ReShade was installed for the Godot editor:*

![Screenshot 2024-02-14 081640](https://github.com/godotengine/godot/assets/180032/697bfb86-02f7-4e07-8784-3b730695c7ac)

![Screenshot 2024-02-14 082003](https://github.com/godotengine/godot/assets/180032/f7465444-7629-4d68-a0dd-953f28d82820)

*With this PR, you can still run ReShade on projects run from the editor - it just won't apply to the editor itself:*

![Screenshot 2024-02-14 081845](https://github.com/godotengine/godot/assets/180032/102e7108-2952-45b7-ac5b-fbea35b49e76)

