### PR TITLE
Add support for search shortcut to signal connection dialog

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -573,6 +573,18 @@ bool ConnectDialog::is_editing() const {
 	return edit_mode;
 }
 
+void ConnectDialog::shortcut_input(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventKey> &key = p_event;
+
+	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
+		if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
+			filter_nodes->grab_focus();
+			filter_nodes->select_all();
+			filter_nodes->accept_event();
+		}
+	}
+}
+
 /*
  * Initialize ConnectDialog and populate fields with expected data.
  * If creating a connection from scratch, sensible defaults are used.
@@ -1531,6 +1543,7 @@ ConnectionsDock::ConnectionsDock() {
 
 	connect_dialog = memnew(ConnectDialog);
 	connect_dialog->connect("connected", callable_mp(NodeDock::get_singleton(), &NodeDock::restore_last_valid_node), CONNECT_DEFERRED);
+	connect_dialog->set_process_shortcut_input(true);
 	add_child(connect_dialog);
 
 	disconnect_all_dialog = memnew(ConfirmationDialog);

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -178,6 +178,8 @@ public:
 	bool get_one_shot() const;
 	bool is_editing() const;
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 	void init(const ConnectionData &p_cd, const PackedStringArray &p_signal_args, bool p_edit = false);
 
 	void popup_dialog(const String p_for_signal);


### PR DESCRIPTION
Adds `Ctrl+F` to signal connection popup, a follow-up to https://github.com/godotengine/godot/pull/87200#pullrequestreview-1836697932

https://github.com/godotengine/godot/assets/60579014/f2764711-9eeb-4a23-ab2d-eca7a0bc953d