### PR TITLE
Editor: Fix skipping normal category followed by custom one

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2892,7 +2892,9 @@ void EditorInspector::update_tree() {
 						(!filter.is_empty() || !restrict_to_basic || (N->get().usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
 					break;
 				}
-				if (N->get().usage & PROPERTY_USAGE_CATEGORY) {
+				// Treat custom categories as second-level ones. Do not skip a normal category if it is followed by a custom one.
+				// Skip in the other 3 cases (normal -> normal, custom -> custom, custom -> normal).
+				if ((N->get().usage & PROPERTY_USAGE_CATEGORY) && (p.hint_string.is_empty() || !N->get().hint_string.is_empty())) {
 					valid = false;
 					break;
 				}


### PR DESCRIPTION
Fix a bug described in https://github.com/godotengine/godot/issues/64432#issuecomment-1941676792.

Before:
![](https://github.com/godotengine/godot/assets/47700418/69debb1d-bfcf-4648-8104-f477d9f4863e)

After:
![](https://github.com/godotengine/godot/assets/47700418/ef55bcf9-4634-4b4b-b045-6fbdb1b412aa)