### PR TITLE
Make user accessible internal controls safe by using ObjectIDs instead of pointers.

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -213,7 +213,7 @@
 			<return type="HBoxContainer" />
 			<description>
 				Gets the [HBoxContainer] that contains the zooming and grid snap controls in the top left of the graph. You can use this method to reposition the toolbar or to add your own custom controls to it.
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [GraphEdit] functionality. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="is_node_connected">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -169,7 +169,7 @@
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar.
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [ItemList] functionality. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="is_anything_selected">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -125,7 +125,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break some [LineEdit] functionality. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_scroll_offset" qualifiers="const">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -14,7 +14,7 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] contained in this button.
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [MenuButton] functionality. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="set_disable_shortcuts">

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -88,7 +88,7 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] contained in this button.
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [OptionButton] functionality. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_selectable_item" qualifiers="const">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -153,7 +153,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it some [RichTextLabel] functionality. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_paragraph_count" qualifiers="const">
@@ -204,7 +204,7 @@
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar.
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it some [RichTextLabel] functionality. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 		<method name="get_visible_line_count" qualifiers="const">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -27,14 +27,14 @@
 			<return type="HScrollBar" />
 			<description>
 				Returns the horizontal scrollbar [HScrollBar] of this [ScrollContainer].
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable or hide a scrollbar, you can use [member horizontal_scroll_mode].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [ScrollContainer] functionality. If you wish to disable or hide a scrollbar, you can use [member horizontal_scroll_mode].
 			</description>
 		</method>
 		<method name="get_v_scroll_bar">
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar [VScrollBar] of this [ScrollContainer].
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable or hide a scrollbar, you can use [member vertical_scroll_mode].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [ScrollContainer] functionality. If you wish to disable or hide a scrollbar, you can use [member vertical_scroll_mode].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -40,7 +40,7 @@
 			<return type="LineEdit" />
 			<description>
 				Returns the [LineEdit] instance from this [SpinBox]. You can use it to access properties and methods of [LineEdit].
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break [SpinBox] functionality. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -21,7 +21,7 @@
 			<return type="Popup" />
 			<description>
 				Returns the [Popup] node instance if one has been set already with [method set_popup].
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break some [TabContainer] functionality. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_previous_tab" qualifiers="const">
@@ -34,7 +34,7 @@
 			<return type="TabBar" />
 			<description>
 				Returns the [TabBar] contained in this container.
-				[b]Warning:[/b] This is a required internal node, removing and freeing it or editing its tabs may cause a crash. If you wish to edit the tabs, use the methods provided in [TabContainer].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it or editing its tabs will break [TabContainer] functionality. If you wish to edit the tabs, use the methods provided in [TabContainer].
 			</description>
 		</method>
 		<method name="get_tab_button_icon" qualifiers="const">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -488,7 +488,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it will break some [TextEdit] functionality. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
 		<method name="get_minimap_line_at_pos" qualifiers="const">

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -733,16 +733,40 @@ void GraphEdit::_update_theme_item_cache() {
 void GraphEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			zoom_minus_button->set_icon(theme_cache.zoom_out);
-			zoom_reset_button->set_icon(theme_cache.zoom_reset);
-			zoom_plus_button->set_icon(theme_cache.zoom_in);
+			Button *zoom_minus_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_minus_button_id));
+			if (zoom_minus_button) {
+				zoom_minus_button->set_icon(theme_cache.zoom_out);
+			}
+			Button *zoom_reset_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_reset_button_id));
+			if (zoom_reset_button) {
+				zoom_reset_button->set_icon(theme_cache.zoom_reset);
+			}
+			Button *zoom_plus_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_plus_button_id));
+			if (zoom_plus_button) {
+				zoom_plus_button->set_icon(theme_cache.zoom_in);
+			}
 
-			toggle_snapping_button->set_icon(theme_cache.snapping_toggle);
-			toggle_grid_button->set_icon(theme_cache.grid_toggle);
-			minimap_button->set_icon(theme_cache.minimap_toggle);
-			arrange_button->set_icon(theme_cache.layout);
+			Button *toggle_snapping_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_snapping_button_id));
+			if (toggle_snapping_button) {
+				toggle_snapping_button->set_icon(theme_cache.snapping_toggle);
+			}
+			Button *toggle_grid_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_grid_button_id));
+			if (toggle_grid_button) {
+				toggle_grid_button->set_icon(theme_cache.grid_toggle);
+			}
+			Button *minimap_button = Object::cast_to<Button>(ObjectDB::get_instance(minimap_button_id));
+			if (minimap_button) {
+				minimap_button->set_icon(theme_cache.minimap_toggle);
+			}
+			Button *arrange_button = Object::cast_to<Button>(ObjectDB::get_instance(arrange_button_id));
+			if (arrange_button) {
+				arrange_button->set_icon(theme_cache.layout);
+			}
 
-			zoom_label->set_custom_minimum_size(Size2(48, 0) * theme_cache.base_scale);
+			Label *zoom_label = Object::cast_to<Label>(ObjectDB::get_instance(zoom_label_id));
+			if (zoom_label) {
+				zoom_label->set_custom_minimum_size(Size2(48, 0) * theme_cache.base_scale);
+			}
 
 			menu_panel->add_theme_style_override(SceneStringName(panel), theme_cache.menu_panel);
 		} break;
@@ -2156,8 +2180,14 @@ void GraphEdit::set_zoom_custom(float p_zoom, const Vector2 &p_center) {
 
 	callable_mp(this, &GraphEdit::_update_top_connection_layer).call_deferred();
 
-	zoom_minus_button->set_disabled(zoom == zoom_min);
-	zoom_plus_button->set_disabled(zoom == zoom_max);
+	Button *zoom_minus_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_minus_button_id));
+	if (zoom_minus_button) {
+		zoom_minus_button->set_disabled(zoom == zoom_min);
+	}
+	Button *zoom_plus_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_plus_button_id));
+	if (zoom_plus_button) {
+		zoom_plus_button->set_disabled(zoom == zoom_max);
+	}
 
 	_update_scroll();
 	minimap->queue_redraw();
@@ -2303,7 +2333,10 @@ void GraphEdit::_zoom_plus() {
 void GraphEdit::_update_zoom_label() {
 	int zoom_percent = static_cast<int>(Math::round(zoom * 100));
 	String zoom_text = itos(zoom_percent) + "%";
-	zoom_label->set_text(zoom_text);
+	Label *zoom_label = Object::cast_to<Label>(ObjectDB::get_instance(zoom_label_id));
+	if (zoom_label) {
+		zoom_label->set_text(zoom_text);
+	}
 }
 
 void GraphEdit::_invalidate_connection_line_cache() {
@@ -2389,7 +2422,10 @@ void GraphEdit::set_snapping_enabled(bool p_enable) {
 	}
 
 	snapping_enabled = p_enable;
-	toggle_snapping_button->set_pressed(p_enable);
+	Button *toggle_snapping_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_snapping_button_id));
+	if (toggle_snapping_button) {
+		toggle_snapping_button->set_pressed(p_enable);
+	}
 	queue_redraw();
 }
 
@@ -2401,7 +2437,10 @@ void GraphEdit::set_snapping_distance(int p_snapping_distance) {
 	ERR_FAIL_COND_MSG(p_snapping_distance < GRID_MIN_SNAPPING_DISTANCE || p_snapping_distance > GRID_MAX_SNAPPING_DISTANCE,
 			vformat("GraphEdit's snapping distance must be between %d and %d (inclusive)", GRID_MIN_SNAPPING_DISTANCE, GRID_MAX_SNAPPING_DISTANCE));
 	snapping_distance = p_snapping_distance;
-	snapping_distance_spinbox->set_value(p_snapping_distance);
+	SpinBox *snapping_distance_spinbox = Object::cast_to<SpinBox>(ObjectDB::get_instance(snapping_distance_spinbox_id));
+	if (snapping_distance_spinbox) {
+		snapping_distance_spinbox->set_value(p_snapping_distance);
+	}
 	queue_redraw();
 }
 
@@ -2415,7 +2454,10 @@ void GraphEdit::set_show_grid(bool p_show) {
 	}
 
 	show_grid = p_show;
-	toggle_grid_button->set_pressed(p_show);
+	Button *toggle_grid_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_grid_button_id));
+	if (toggle_grid_button) {
+		toggle_grid_button->set_pressed(p_show);
+	}
 	queue_redraw();
 }
 
@@ -2437,16 +2479,25 @@ GraphEdit::GridPattern GraphEdit::get_grid_pattern() const {
 }
 
 void GraphEdit::_snapping_toggled() {
-	snapping_enabled = toggle_snapping_button->is_pressed();
+	Button *toggle_snapping_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_snapping_button_id));
+	if (toggle_snapping_button) {
+		snapping_enabled = toggle_snapping_button->is_pressed();
+	}
 }
 
 void GraphEdit::_snapping_distance_changed(double) {
-	snapping_distance = snapping_distance_spinbox->get_value();
+	SpinBox *snapping_distance_spinbox = Object::cast_to<SpinBox>(ObjectDB::get_instance(snapping_distance_spinbox_id));
+	if (snapping_distance_spinbox) {
+		snapping_distance = snapping_distance_spinbox->get_value();
+	}
 	queue_redraw();
 }
 
 void GraphEdit::_show_grid_toggled() {
-	show_grid = toggle_grid_button->is_pressed();
+	Button *toggle_grid_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_grid_button_id));
+	if (toggle_grid_button) {
+		show_grid = toggle_grid_button->is_pressed();
+	}
 	queue_redraw();
 }
 
@@ -2480,6 +2531,10 @@ float GraphEdit::get_minimap_opacity() const {
 }
 
 void GraphEdit::set_minimap_enabled(bool p_enable) {
+	Button *minimap_button = Object::cast_to<Button>(ObjectDB::get_instance(minimap_button_id));
+	if (!minimap_button) {
+		return;
+	}
 	if (minimap_button->is_pressed() == p_enable) {
 		return;
 	}
@@ -2489,7 +2544,8 @@ void GraphEdit::set_minimap_enabled(bool p_enable) {
 }
 
 bool GraphEdit::is_minimap_enabled() const {
-	return minimap_button->is_pressed();
+	Button *minimap_button = Object::cast_to<Button>(ObjectDB::get_instance(minimap_button_id));
+	return minimap_button && minimap_button->is_pressed();
 }
 
 void GraphEdit::set_show_menu(bool p_hidden) {
@@ -2503,7 +2559,10 @@ bool GraphEdit::is_showing_menu() const {
 
 void GraphEdit::set_show_zoom_label(bool p_hidden) {
 	show_zoom_label = p_hidden;
-	zoom_label->set_visible(show_zoom_label);
+	Label *zoom_label = Object::cast_to<Label>(ObjectDB::get_instance(zoom_label_id));
+	if (zoom_label) {
+		zoom_label->set_visible(show_zoom_label);
+	}
 }
 
 bool GraphEdit::is_showing_zoom_label() const {
@@ -2513,9 +2572,18 @@ bool GraphEdit::is_showing_zoom_label() const {
 void GraphEdit::set_show_zoom_buttons(bool p_hidden) {
 	show_zoom_buttons = p_hidden;
 
-	zoom_minus_button->set_visible(show_zoom_buttons);
-	zoom_reset_button->set_visible(show_zoom_buttons);
-	zoom_plus_button->set_visible(show_zoom_buttons);
+	Button *zoom_minus_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_minus_button_id));
+	if (zoom_minus_button) {
+		zoom_minus_button->set_visible(show_zoom_buttons);
+	}
+	Button *zoom_reset_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_reset_button_id));
+	if (zoom_reset_button) {
+		zoom_reset_button->set_visible(show_zoom_buttons);
+	}
+	Button *zoom_plus_button = Object::cast_to<Button>(ObjectDB::get_instance(zoom_plus_button_id));
+	if (zoom_plus_button) {
+		zoom_plus_button->set_visible(show_zoom_buttons);
+	}
 }
 
 bool GraphEdit::is_showing_zoom_buttons() const {
@@ -2525,9 +2593,18 @@ bool GraphEdit::is_showing_zoom_buttons() const {
 void GraphEdit::set_show_grid_buttons(bool p_hidden) {
 	show_grid_buttons = p_hidden;
 
-	toggle_grid_button->set_visible(show_grid_buttons);
-	toggle_snapping_button->set_visible(show_grid_buttons);
-	snapping_distance_spinbox->set_visible(show_grid_buttons);
+	Button *toggle_grid_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_grid_button_id));
+	if (toggle_grid_button) {
+		toggle_grid_button->set_visible(show_grid_buttons);
+	}
+	Button *toggle_snapping_button = Object::cast_to<Button>(ObjectDB::get_instance(toggle_snapping_button_id));
+	if (toggle_snapping_button) {
+		toggle_snapping_button->set_visible(show_grid_buttons);
+	}
+	SpinBox *snapping_distance_spinbox = Object::cast_to<SpinBox>(ObjectDB::get_instance(snapping_distance_spinbox_id));
+	if (snapping_distance_spinbox) {
+		snapping_distance_spinbox->set_visible(show_grid_buttons);
+	}
 }
 
 bool GraphEdit::is_showing_grid_buttons() const {
@@ -2536,7 +2613,10 @@ bool GraphEdit::is_showing_grid_buttons() const {
 
 void GraphEdit::set_show_minimap_button(bool p_hidden) {
 	show_minimap_button = p_hidden;
-	minimap_button->set_visible(show_minimap_button);
+	Button *minimap_button = Object::cast_to<Button>(ObjectDB::get_instance(minimap_button_id));
+	if (minimap_button) {
+		minimap_button->set_visible(show_minimap_button);
+	}
 }
 
 bool GraphEdit::is_showing_minimap_button() const {
@@ -2545,7 +2625,10 @@ bool GraphEdit::is_showing_minimap_button() const {
 
 void GraphEdit::set_show_arrange_button(bool p_hidden) {
 	show_arrange_button = p_hidden;
-	arrange_button->set_visible(show_arrange_button);
+	Button *arrange_button = Object::cast_to<Button>(ObjectDB::get_instance(arrange_button_id));
+	if (arrange_button) {
+		arrange_button->set_visible(show_arrange_button);
+	}
 }
 
 bool GraphEdit::is_showing_arrange_button() const {
@@ -2619,6 +2702,9 @@ bool GraphEdit::is_connection_lines_antialiased() const {
 }
 
 HBoxContainer *GraphEdit::get_menu_hbox() {
+	HBoxContainer *menu_hbox = Object::cast_to<HBoxContainer>(ObjectDB::get_instance(menu_hbox_id));
+	ERR_FAIL_NULL_V(menu_hbox, nullptr);
+
 	return menu_hbox;
 }
 
@@ -2891,46 +2977,51 @@ GraphEdit::GraphEdit() {
 	top_layer->add_child(menu_panel);
 	menu_panel->set_position(Vector2(10, 10));
 
-	menu_hbox = memnew(HBoxContainer);
+	HBoxContainer *menu_hbox = memnew(HBoxContainer);
 	menu_panel->add_child(menu_hbox);
+	menu_hbox_id = menu_hbox->get_instance_id();
 
 	// Zoom label and controls.
 
-	zoom_label = memnew(Label);
+	Label *zoom_label = memnew(Label);
 	zoom_label->set_visible(show_zoom_label);
 	zoom_label->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	zoom_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	zoom_label->set_custom_minimum_size(Size2(48, 0));
 	menu_hbox->add_child(zoom_label);
+	zoom_label_id = zoom_label->get_instance_id();
 	_update_zoom_label();
 
-	zoom_minus_button = memnew(Button);
+	Button *zoom_minus_button = memnew(Button);
 	zoom_minus_button->set_theme_type_variation("FlatButton");
 	zoom_minus_button->set_visible(show_zoom_buttons);
 	zoom_minus_button->set_tooltip_text(ETR("Zoom Out"));
 	zoom_minus_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(zoom_minus_button);
 	zoom_minus_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_zoom_minus));
+	zoom_minus_button_id = zoom_minus_button->get_instance_id();
 
-	zoom_reset_button = memnew(Button);
+	Button *zoom_reset_button = memnew(Button);
 	zoom_reset_button->set_theme_type_variation("FlatButton");
 	zoom_reset_button->set_visible(show_zoom_buttons);
 	zoom_reset_button->set_tooltip_text(ETR("Zoom Reset"));
 	zoom_reset_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(zoom_reset_button);
 	zoom_reset_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_zoom_reset));
+	zoom_reset_button_id = zoom_reset_button->get_instance_id();
 
-	zoom_plus_button = memnew(Button);
+	Button *zoom_plus_button = memnew(Button);
 	zoom_plus_button->set_theme_type_variation("FlatButton");
 	zoom_plus_button->set_visible(show_zoom_buttons);
 	zoom_plus_button->set_tooltip_text(ETR("Zoom In"));
 	zoom_plus_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(zoom_plus_button);
 	zoom_plus_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_zoom_plus));
+	zoom_plus_button_id = zoom_plus_button->get_instance_id();
 
 	// Grid controls.
 
-	toggle_grid_button = memnew(Button);
+	Button *toggle_grid_button = memnew(Button);
 	toggle_grid_button->set_theme_type_variation("FlatButton");
 	toggle_grid_button->set_visible(show_grid_buttons);
 	toggle_grid_button->set_toggle_mode(true);
@@ -2939,8 +3030,9 @@ GraphEdit::GraphEdit() {
 	toggle_grid_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(toggle_grid_button);
 	toggle_grid_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_show_grid_toggled));
+	toggle_grid_button_id = toggle_grid_button->get_instance_id();
 
-	toggle_snapping_button = memnew(Button);
+	Button *toggle_snapping_button = memnew(Button);
 	toggle_snapping_button->set_theme_type_variation("FlatButton");
 	toggle_snapping_button->set_visible(show_grid_buttons);
 	toggle_snapping_button->set_toggle_mode(true);
@@ -2949,8 +3041,9 @@ GraphEdit::GraphEdit() {
 	toggle_snapping_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(toggle_snapping_button);
 	toggle_snapping_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_snapping_toggled));
+	toggle_snapping_button_id = toggle_snapping_button->get_instance_id();
 
-	snapping_distance_spinbox = memnew(SpinBox);
+	SpinBox *snapping_distance_spinbox = memnew(SpinBox);
 	snapping_distance_spinbox->set_visible(show_grid_buttons);
 	snapping_distance_spinbox->set_min(GRID_MIN_SNAPPING_DISTANCE);
 	snapping_distance_spinbox->set_max(GRID_MAX_SNAPPING_DISTANCE);
@@ -2959,10 +3052,11 @@ GraphEdit::GraphEdit() {
 	snapping_distance_spinbox->set_tooltip_text(ETR("Change the snapping distance."));
 	menu_hbox->add_child(snapping_distance_spinbox);
 	snapping_distance_spinbox->connect(SceneStringName(value_changed), callable_mp(this, &GraphEdit::_snapping_distance_changed));
+	snapping_distance_spinbox_id = snapping_distance_spinbox->get_instance_id();
 
 	// Extra controls.
 
-	minimap_button = memnew(Button);
+	Button *minimap_button = memnew(Button);
 	minimap_button->set_theme_type_variation("FlatButton");
 	minimap_button->set_visible(show_minimap_button);
 	minimap_button->set_toggle_mode(true);
@@ -2971,14 +3065,16 @@ GraphEdit::GraphEdit() {
 	minimap_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(minimap_button);
 	minimap_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::_minimap_toggled));
+	minimap_button_id = minimap_button->get_instance_id();
 
-	arrange_button = memnew(Button);
+	Button *arrange_button = memnew(Button);
 	arrange_button->set_theme_type_variation("FlatButton");
 	arrange_button->set_visible(show_arrange_button);
 	arrange_button->connect(SceneStringName(pressed), callable_mp(this, &GraphEdit::arrange_nodes));
 	arrange_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(arrange_button);
 	arrange_button->set_tooltip_text(ETR("Automatically arrange selected nodes."));
+	arrange_button_id = arrange_button->get_instance_id();
 
 	// Minimap.
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -169,16 +169,16 @@ private:
 		}
 	};
 
-	Label *zoom_label = nullptr;
-	Button *zoom_minus_button = nullptr;
-	Button *zoom_reset_button = nullptr;
-	Button *zoom_plus_button = nullptr;
+	ObjectID zoom_label_id;
+	ObjectID zoom_minus_button_id;
+	ObjectID zoom_reset_button_id;
+	ObjectID zoom_plus_button_id;
 
-	Button *toggle_snapping_button = nullptr;
-	SpinBox *snapping_distance_spinbox = nullptr;
-	Button *toggle_grid_button = nullptr;
-	Button *minimap_button = nullptr;
-	Button *arrange_button = nullptr;
+	ObjectID toggle_snapping_button_id;
+	ObjectID snapping_distance_spinbox_id;
+	ObjectID toggle_grid_button_id;
+	ObjectID minimap_button_id;
+	ObjectID arrange_button_id;
 
 	HScrollBar *h_scrollbar = nullptr;
 	VScrollBar *v_scrollbar = nullptr;
@@ -247,7 +247,7 @@ private:
 	bool lines_antialiased = true;
 
 	PanelContainer *menu_panel = nullptr;
-	HBoxContainer *menu_hbox = nullptr;
+	ObjectID menu_hbox_id;
 	Control *connections_layer = nullptr;
 
 	GraphEditFilter *top_connection_layer = nullptr; // Draws a dragged connection. Necessary since the connection line shader can't be applied to the whole top layer.

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -671,6 +671,9 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 #define CAN_SELECT(i) (items[i].selectable && !items[i].disabled)
 #define IS_SAME_ROW(i, row) (i / current_columns == row)
 
+	VScrollBar *scroll_bar = Object::cast_to<VScrollBar>(ObjectDB::get_instance(scroll_bar_id));
+	ERR_FAIL_NULL(scroll_bar);
+
 	double prev_scroll = scroll_bar->get_value();
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -1047,6 +1050,9 @@ void ItemList::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
+			VScrollBar *scroll_bar = Object::cast_to<VScrollBar>(ObjectDB::get_instance(scroll_bar_id));
+			ERR_FAIL_NULL(scroll_bar);
+
 			force_update_list_size();
 
 			int scroll_bar_minwidth = scroll_bar->get_minimum_size().x;
@@ -1373,6 +1379,9 @@ void ItemList::force_update_list_size() {
 		return;
 	}
 
+	VScrollBar *scroll_bar = Object::cast_to<VScrollBar>(ObjectDB::get_instance(scroll_bar_id));
+	ERR_FAIL_NULL(scroll_bar);
+
 	int scroll_bar_minwidth = scroll_bar->get_minimum_size().x;
 	Size2 size = get_size();
 	float max_column_width = 0.0;
@@ -1524,6 +1533,13 @@ void ItemList::force_update_list_size() {
 	shape_changed = false;
 }
 
+VScrollBar *ItemList::get_v_scroll_bar() {
+	VScrollBar *scroll_bar = Object::cast_to<VScrollBar>(ObjectDB::get_instance(scroll_bar_id));
+	ERR_FAIL_NULL_V(scroll_bar, nullptr);
+
+	return scroll_bar;
+}
+
 void ItemList::_scroll_changed(double) {
 	queue_redraw();
 }
@@ -1553,6 +1569,9 @@ String ItemList::_atr(int p_idx, const String &p_text) const {
 }
 
 int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
+	VScrollBar *scroll_bar = Object::cast_to<VScrollBar>(ObjectDB::get_instance(scroll_bar_id));
+	ERR_FAIL_NULL_V(scroll_bar, -1);
+
 	Vector2 pos = p_pos;
 	pos -= theme_cache.panel_style->get_offset();
 	pos.y += scroll_bar->get_value();
@@ -1587,6 +1606,9 @@ int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 }
 
 bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
+	VScrollBar *scroll_bar = Object::cast_to<VScrollBar>(ObjectDB::get_instance(scroll_bar_id));
+	ERR_FAIL_NULL_V(scroll_bar, false);
+
 	if (items.is_empty()) {
 		return true;
 	}
@@ -1978,9 +2000,10 @@ void ItemList::_bind_methods() {
 }
 
 ItemList::ItemList() {
-	scroll_bar = memnew(VScrollBar);
+	VScrollBar *scroll_bar = memnew(VScrollBar);
 	add_child(scroll_bar, false, INTERNAL_MODE_FRONT);
 	scroll_bar->connect(SceneStringName(value_changed), callable_mp(this, &ItemList::_scroll_changed));
+	scroll_bar_id = scroll_bar->get_instance_id();
 
 	connect(SceneStringName(mouse_exited), callable_mp(this, &ItemList::_mouse_exited));
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -111,7 +111,7 @@ private:
 
 	SelectMode select_mode = SELECT_SINGLE;
 	IconMode icon_mode = ICON_MODE_LEFT;
-	VScrollBar *scroll_bar = nullptr;
+	ObjectID scroll_bar_id;
 	TextServer::OverrunBehavior text_overrun_behavior = TextServer::OVERRUN_TRIM_ELLIPSIS;
 
 	uint64_t search_time_msec = 0;
@@ -306,7 +306,7 @@ public:
 
 	void force_update_list_size();
 
-	VScrollBar *get_v_scroll_bar() { return scroll_bar; }
+	VScrollBar *get_v_scroll_bar();
 
 	ItemList();
 	~ItemList();

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -111,9 +111,9 @@ private:
 	bool drag_and_drop_selection_enabled = true;
 
 	bool context_menu_enabled = true;
-	PopupMenu *menu = nullptr;
-	PopupMenu *menu_dir = nullptr;
-	PopupMenu *menu_ctl = nullptr;
+	ObjectID menu_id;
+	ObjectID menu_dir_id;
+	ObjectID menu_ctl_id;
 
 	bool caret_mid_grapheme_enabled = false;
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -40,6 +40,9 @@ void MenuButton::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	if (p_event->is_pressed() && !is_disabled() && is_visible_in_tree() && popup->activate_item_by_event(p_event, false)) {
 		accept_event();
 		return;
@@ -62,6 +65,9 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 }
 
 void MenuButton::pressed() {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	if (popup->is_visible()) {
 		popup->hide();
 		return;
@@ -71,6 +77,9 @@ void MenuButton::pressed() {
 }
 
 PopupMenu *MenuButton::get_popup() const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, nullptr);
+
 	return popup;
 }
 
@@ -78,6 +87,9 @@ void MenuButton::show_popup() {
 	if (!get_viewport()) {
 		return;
 	}
+
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
 
 	emit_signal(SNAME("about_to_popup"));
 	Rect2 rect = get_screen_rect();
@@ -111,6 +123,9 @@ bool MenuButton::is_switch_on_hover() {
 }
 
 void MenuButton::set_item_count(int p_count) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	ERR_FAIL_COND(p_count < 0);
 
 	if (popup->get_item_count() == p_count) {
@@ -122,24 +137,35 @@ void MenuButton::set_item_count(int p_count) {
 }
 
 int MenuButton::get_item_count() const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, 0);
+
 	return popup->get_item_count();
 }
 
 void MenuButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+			ERR_FAIL_NULL(popup);
+
 			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible_in_tree()) {
+				PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+				ERR_FAIL_NULL(popup);
+
 				popup->hide();
 			}
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_find_control(get_viewport()->get_mouse_position()));
+			PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+			ERR_FAIL_NULL(popup);
 
+			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_find_control(get_viewport()->get_mouse_position()));
 			if (menu_btn_other && menu_btn_other != this && menu_btn_other->is_switch_on_hover() && !menu_btn_other->is_disabled() &&
 					(get_parent()->is_ancestor_of(menu_btn_other) || menu_btn_other->get_parent()->is_ancestor_of(popup))) {
 				popup->hide();
@@ -155,6 +181,9 @@ void MenuButton::_notification(int p_what) {
 bool MenuButton::_set(const StringName &p_name, const Variant &p_value) {
 	const String sname = p_name;
 	if (property_helper.is_property_valid(sname)) {
+		PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+		ERR_FAIL_NULL_V(popup, false);
+
 		bool valid;
 		popup->set(sname.trim_prefix("popup/"), p_value, &valid);
 		return valid;
@@ -165,6 +194,9 @@ bool MenuButton::_set(const StringName &p_name, const Variant &p_value) {
 bool MenuButton::_get(const StringName &p_name, Variant &r_ret) const {
 	const String sname = p_name;
 	if (property_helper.is_property_valid(sname)) {
+		PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+		ERR_FAIL_NULL_V(popup, false);
+
 		bool valid;
 		r_ret = popup->get(sname.trim_prefix("popup/"), &valid);
 		return valid;
@@ -214,13 +246,14 @@ MenuButton::MenuButton(const String &p_text) :
 	set_focus_mode(FOCUS_NONE);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
-	popup = memnew(PopupMenu);
+	PopupMenu *popup = memnew(PopupMenu);
 	popup->hide();
 	add_child(popup, false, INTERNAL_MODE_FRONT);
 	popup->connect("about_to_popup", callable_mp(this, &MenuButton::_popup_visibility_changed).bind(true));
 	popup->connect("popup_hide", callable_mp(this, &MenuButton::_popup_visibility_changed).bind(false));
 
 	property_helper.setup_for_instance(base_property_helper, this);
+	popup_id = popup->get_instance_id();
 }
 
 MenuButton::~MenuButton() {

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -41,7 +41,7 @@ class MenuButton : public Button {
 	bool clicked = false;
 	bool switch_on_hover = false;
 	bool disable_shortcuts = false;
-	PopupMenu *popup = nullptr;
+	ObjectID popup_id;
 
 	static inline PropertyListHelper base_property_helper;
 	PropertyListHelper property_helper;

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -43,6 +43,9 @@ void OptionButton::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	if (p_event->is_pressed() && !p_event->is_echo() && !is_disabled() && is_visible_in_tree() && popup->activate_item_by_event(p_event, false)) {
 		accept_event();
 		return;
@@ -129,6 +132,9 @@ void OptionButton::_notification(int p_what) {
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+			ERR_FAIL_NULL(popup);
+
 			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
 			[[fallthrough]];
 		}
@@ -147,6 +153,9 @@ void OptionButton::_notification(int p_what) {
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible_in_tree()) {
+				PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+				ERR_FAIL_NULL(popup);
+
 				popup->hide();
 			}
 		} break;
@@ -158,6 +167,9 @@ bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 	const String sname = p_name;
 
 	if (property_helper.is_property_valid(sname, &index)) {
+		PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+		ERR_FAIL_NULL_V(popup, false);
+
 		bool valid;
 		popup->set(sname.trim_prefix("popup/"), p_value, &valid);
 
@@ -186,6 +198,9 @@ void OptionButton::_selected(int p_which) {
 }
 
 void OptionButton::pressed() {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	if (popup->is_visible()) {
 		popup->hide();
 		return;
@@ -195,6 +210,9 @@ void OptionButton::pressed() {
 }
 
 void OptionButton::add_icon_item(const Ref<Texture2D> &p_icon, const String &p_label, int p_id) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	bool first_selectable = !has_selectable_items();
 	popup->add_icon_radio_check_item(p_icon, p_label, p_id);
 	if (first_selectable) {
@@ -204,6 +222,9 @@ void OptionButton::add_icon_item(const Ref<Texture2D> &p_icon, const String &p_l
 }
 
 void OptionButton::add_item(const String &p_label, int p_id) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	bool first_selectable = !has_selectable_items();
 	popup->add_radio_check_item(p_label, p_id);
 	if (first_selectable) {
@@ -213,6 +234,9 @@ void OptionButton::add_item(const String &p_label, int p_id) {
 }
 
 void OptionButton::set_item_text(int p_idx, const String &p_text) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->set_item_text(p_idx, p_text);
 
 	if (current == p_idx) {
@@ -222,6 +246,9 @@ void OptionButton::set_item_text(int p_idx, const String &p_text) {
 }
 
 void OptionButton::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->set_item_icon(p_idx, p_icon);
 
 	if (current == p_idx) {
@@ -231,30 +258,51 @@ void OptionButton::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
 }
 
 void OptionButton::set_item_id(int p_idx, int p_id) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->set_item_id(p_idx, p_id);
 }
 
 void OptionButton::set_item_metadata(int p_idx, const Variant &p_metadata) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->set_item_metadata(p_idx, p_metadata);
 }
 
 void OptionButton::set_item_tooltip(int p_idx, const String &p_tooltip) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->set_item_tooltip(p_idx, p_tooltip);
 }
 
 void OptionButton::set_item_disabled(int p_idx, bool p_disabled) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->set_item_disabled(p_idx, p_disabled);
 }
 
 String OptionButton::get_item_text(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, String());
+
 	return popup->get_item_text(p_idx);
 }
 
 Ref<Texture2D> OptionButton::get_item_icon(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, Ref<Texture2D>());
+
 	return popup->get_item_icon(p_idx);
 }
 
 int OptionButton::get_item_id(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, NONE_SELECTED);
+
 	if (p_idx == NONE_SELECTED) {
 		return NONE_SELECTED;
 	}
@@ -263,25 +311,43 @@ int OptionButton::get_item_id(int p_idx) const {
 }
 
 int OptionButton::get_item_index(int p_id) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, 0);
+
 	return popup->get_item_index(p_id);
 }
 
 Variant OptionButton::get_item_metadata(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, Variant());
+
 	return popup->get_item_metadata(p_idx);
 }
 
 String OptionButton::get_item_tooltip(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, String());
+
 	return popup->get_item_tooltip(p_idx);
 }
 
 bool OptionButton::is_item_disabled(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, false);
+
 	return popup->is_item_disabled(p_idx);
 }
 
 bool OptionButton::is_item_separator(int p_idx) const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, false);
+
 	return popup->is_item_separator(p_idx);
 }
 void OptionButton::set_item_count(int p_count) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	ERR_FAIL_COND(p_count < 0);
 
 	int count_old = get_item_count();
@@ -334,6 +400,9 @@ int OptionButton::get_selectable_item(bool p_from_last) const {
 }
 
 int OptionButton::get_item_count() const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, 0);
+
 	return popup->get_item_count();
 }
 
@@ -359,10 +428,16 @@ bool OptionButton::get_allow_reselect() const {
 }
 
 void OptionButton::add_separator(const String &p_text) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->add_separator(p_text);
 }
 
 void OptionButton::clear() {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->clear();
 	set_text("");
 	current = NONE_SELECTED;
@@ -370,6 +445,9 @@ void OptionButton::clear() {
 }
 
 void OptionButton::_select(int p_which, bool p_emit) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	if (p_which == current && !allow_reselect) {
 		return;
 	}
@@ -400,6 +478,9 @@ void OptionButton::_select(int p_which, bool p_emit) {
 }
 
 void OptionButton::_select_int(int p_which) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	if (p_which < NONE_SELECTED) {
 		return;
 	}
@@ -413,6 +494,9 @@ void OptionButton::_select_int(int p_which) {
 }
 
 void OptionButton::_refresh_size_cache() {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	cache_refresh_pending = false;
 
 	if (fit_to_longest_item) {
@@ -454,6 +538,9 @@ Variant OptionButton::get_selected_metadata() const {
 }
 
 void OptionButton::remove_item(int p_idx) {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
+
 	popup->remove_item(p_idx);
 	if (current == p_idx) {
 		_select(NONE_SELECTED);
@@ -462,6 +549,9 @@ void OptionButton::remove_item(int p_idx) {
 }
 
 PopupMenu *OptionButton::get_popup() const {
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL_V(popup, nullptr);
+
 	return popup;
 }
 
@@ -469,6 +559,9 @@ void OptionButton::show_popup() {
 	if (!get_viewport()) {
 		return;
 	}
+
+	PopupMenu *popup = Object::cast_to<PopupMenu>(ObjectDB::get_instance(popup_id));
+	ERR_FAIL_NULL(popup);
 
 	Rect2 rect = get_screen_rect();
 	rect.position.y += rect.size.height;
@@ -591,7 +684,7 @@ OptionButton::OptionButton(const String &p_text) :
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
-	popup = memnew(PopupMenu);
+	PopupMenu *popup = memnew(PopupMenu);
 	popup->hide();
 	add_child(popup, false, INTERNAL_MODE_FRONT);
 	popup->connect("index_pressed", callable_mp(this, &OptionButton::_selected));
@@ -599,6 +692,7 @@ OptionButton::OptionButton(const String &p_text) :
 	popup->connect("popup_hide", callable_mp((BaseButton *)this, &BaseButton::set_pressed).bind(false));
 
 	property_helper.setup_for_instance(base_property_helper, this);
+	popup_id = popup->get_instance_id();
 }
 
 OptionButton::~OptionButton() {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -39,7 +39,7 @@ class OptionButton : public Button {
 	GDCLASS(OptionButton, Button);
 
 	bool disable_shortcuts = false;
-	PopupMenu *popup = nullptr;
+	ObjectID popup_id;
 	int current = -1;
 	bool fit_to_longest_item = true;
 	Vector2 _cached_size;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -459,7 +459,7 @@ private:
 	uint64_t loading_started = 0;
 	int progress_delay = 1000;
 
-	VScrollBar *vscroll = nullptr;
+	ObjectID vscroll_id;
 
 	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_WORD_SMART;
 
@@ -539,7 +539,7 @@ private:
 	bool shortcut_keys_enabled = true;
 
 	// Context menu.
-	PopupMenu *menu = nullptr;
+	ObjectID menu_id;
 	void _generate_context_menu();
 	void _update_context_menu();
 	Key _get_menu_action_accelerator(const String &p_action);
@@ -768,7 +768,7 @@ public:
 
 	void scroll_to_selection();
 
-	VScrollBar *get_v_scroll_bar() { return vscroll; }
+	VScrollBar *get_v_scroll_bar();
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual Variant get_drag_data(const Point2 &p_point) override;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -39,6 +39,9 @@ Size2 ScrollContainer::get_minimum_size() const {
 	// and needs to be calculated before being used by update_scrollbars().
 	largest_child_min_size = Size2();
 
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
@@ -94,15 +97,26 @@ void ScrollContainer::_cancel_drag() {
 
 bool ScrollContainer::_is_h_scroll_visible() const {
 	// Scrolls may have been moved out for reasons.
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL_V(h_scroll, false);
+
 	return h_scroll->is_visible() && h_scroll->get_parent() == this;
 }
 
 bool ScrollContainer::_is_v_scroll_visible() const {
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL_V(v_scroll, false);
+
 	return v_scroll->is_visible() && v_scroll->get_parent() == this;
 }
 
 void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 	ERR_FAIL_COND(p_gui_input.is_null());
+
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
 
 	double prev_v_scroll = v_scroll->get_value();
 	double prev_h_scroll = h_scroll->get_value();
@@ -258,6 +272,11 @@ void ScrollContainer::_update_scrollbar_position() {
 		return;
 	}
 
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
+
 	Size2 hmin = h_scroll->is_visible() ? h_scroll->get_combined_minimum_size() : Size2();
 	Size2 vmin = v_scroll->is_visible() ? v_scroll->get_combined_minimum_size() : Size2();
 
@@ -286,6 +305,11 @@ void ScrollContainer::_gui_focus_changed(Control *p_control) {
 void ScrollContainer::ensure_control_visible(Control *p_control) {
 	ERR_FAIL_COND_MSG(!is_ancestor_of(p_control), "Must be an ancestor of the control.");
 
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
+
 	Rect2 global_rect = get_global_rect();
 	Rect2 other_rect = p_control->get_global_rect();
 	float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x : 0.0f;
@@ -299,6 +323,11 @@ void ScrollContainer::ensure_control_visible(Control *p_control) {
 }
 
 void ScrollContainer::_reposition_children() {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
+
 	update_scrollbars();
 	Size2 size = get_size();
 	Point2 ofs;
@@ -371,6 +400,11 @@ void ScrollContainer::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (drag_touching) {
 				if (drag_touching_deaccel) {
+					HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+					ERR_FAIL_NULL(h_scroll);
+					VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+					ERR_FAIL_NULL(v_scroll);
+
 					Vector2 pos = Vector2(h_scroll->get_value(), v_scroll->get_value());
 					pos += drag_speed * get_physics_process_delta_time();
 
@@ -439,6 +473,11 @@ void ScrollContainer::_notification(int p_what) {
 }
 
 void ScrollContainer::update_scrollbars() {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
+
 	Size2 size = get_size();
 	size -= theme_cache.panel_style->get_minimum_size();
 
@@ -464,36 +503,60 @@ void ScrollContainer::_scroll_moved(float) {
 };
 
 void ScrollContainer::set_h_scroll(int p_pos) {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+
 	h_scroll->set_value(p_pos);
 	_cancel_drag();
 }
 
 int ScrollContainer::get_h_scroll() const {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL_V(h_scroll, 0);
+
 	return h_scroll->get_value();
 }
 
 void ScrollContainer::set_v_scroll(int p_pos) {
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
+
 	v_scroll->set_value(p_pos);
 	_cancel_drag();
 }
 
 int ScrollContainer::get_v_scroll() const {
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL_V(v_scroll, 0);
+
 	return v_scroll->get_value();
 }
 
 void ScrollContainer::set_horizontal_custom_step(float p_custom_step) {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL(h_scroll);
+
 	h_scroll->set_custom_step(p_custom_step);
 }
 
 float ScrollContainer::get_horizontal_custom_step() const {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL_V(h_scroll, 0.0);
+
 	return h_scroll->get_custom_step();
 }
 
 void ScrollContainer::set_vertical_custom_step(float p_custom_step) {
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL(v_scroll);
+
 	v_scroll->set_custom_step(p_custom_step);
 }
 
 float ScrollContainer::get_vertical_custom_step() const {
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL_V(v_scroll, 0.0);
+
 	return v_scroll->get_custom_step();
 }
 
@@ -546,6 +609,9 @@ PackedStringArray ScrollContainer::get_configuration_warnings() const {
 
 	int found = 0;
 
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i), SortableVisbilityMode::VISIBLE);
 		if (!c) {
@@ -566,10 +632,16 @@ PackedStringArray ScrollContainer::get_configuration_warnings() const {
 }
 
 HScrollBar *ScrollContainer::get_h_scroll_bar() {
+	HScrollBar *h_scroll = Object::cast_to<HScrollBar>(ObjectDB::get_instance(h_scroll_id));
+	ERR_FAIL_NULL_V(h_scroll, nullptr);
+
 	return h_scroll;
 }
 
 VScrollBar *ScrollContainer::get_v_scroll_bar() {
+	VScrollBar *v_scroll = Object::cast_to<VScrollBar>(ObjectDB::get_instance(v_scroll_id));
+	ERR_FAIL_NULL_V(v_scroll, nullptr);
+
 	return v_scroll;
 }
 
@@ -628,15 +700,19 @@ void ScrollContainer::_bind_methods() {
 };
 
 ScrollContainer::ScrollContainer() {
-	h_scroll = memnew(HScrollBar);
+	HScrollBar *h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
 	add_child(h_scroll, false, INTERNAL_MODE_BACK);
-	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &ScrollContainer::_scroll_moved));
 
-	v_scroll = memnew(VScrollBar);
+	h_scroll->connect("value_changed", callable_mp(this, &ScrollContainer::_scroll_moved));
+	h_scroll_id = h_scroll->get_instance_id();
+
+	VScrollBar *v_scroll = memnew(VScrollBar);
 	v_scroll->set_name("_v_scroll");
 	add_child(v_scroll, false, INTERNAL_MODE_BACK);
+
 	v_scroll->connect(SceneStringName(value_changed), callable_mp(this, &ScrollContainer::_scroll_moved));
+	v_scroll_id = v_scroll->get_instance_id();
 
 	deadzone = GLOBAL_GET("gui/common/default_scroll_deadzone");
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -48,8 +48,8 @@ public:
 	};
 
 private:
-	HScrollBar *h_scroll = nullptr;
-	VScrollBar *v_scroll = nullptr;
+	ObjectID h_scroll_id;
+	ObjectID v_scroll_id;
 
 	mutable Size2 largest_child_min_size; // The largest one among the min sizes of all available child controls.
 

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -35,12 +35,18 @@
 #include "scene/theme/theme_db.h"
 
 Size2 SpinBox::get_minimum_size() const {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL_V(line_edit, Size2(sizing_cache.buttons_block_width, 0));
+
 	Size2 ms = line_edit->get_combined_minimum_size();
 	ms.width += sizing_cache.buttons_block_width;
 	return ms;
 }
 
 void SpinBox::_update_text(bool p_keep_line_edit) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	String value = String::num(get_value(), Math::range_step_decimals(get_step()));
 	if (is_localizing_numeral_system()) {
 		value = TS->format_number(value);
@@ -96,6 +102,9 @@ void SpinBox::_text_submitted(const String &p_string) {
 }
 
 void SpinBox::_text_changed(const String &p_string) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	int cursor_pos = line_edit->get_caret_column();
 
 	_text_submitted(p_string);
@@ -105,6 +114,9 @@ void SpinBox::_text_changed(const String &p_string) {
 }
 
 LineEdit *SpinBox::get_line_edit() {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL_V(line_edit, nullptr);
+
 	return line_edit;
 }
 
@@ -151,6 +163,9 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 	if (!is_editable()) {
 		return;
 	}
+
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
 
 	Ref<InputEventMouse> me = p_event;
 	Ref<InputEventMouseButton> mb = p_event;
@@ -254,6 +269,9 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void SpinBox::_line_edit_editing_toggled(bool p_toggled_on) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	if (p_toggled_on) {
 		int col = line_edit->get_caret_column();
 		_update_text();
@@ -276,6 +294,9 @@ void SpinBox::_line_edit_editing_toggled(bool p_toggled_on) {
 }
 
 inline void SpinBox::_compute_sizes() {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	int buttons_block_wanted_width = theme_cache.buttons_width + theme_cache.field_and_buttons_separation;
 	int buttons_block_icon_enforced_width = _get_widest_button_icon_width() + theme_cache.field_and_buttons_separation;
 
@@ -412,8 +433,11 @@ void SpinBox::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
+			LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+			ERR_FAIL_NULL(line_edit);
+
 			callable_mp((Control *)this, &Control::update_minimum_size).call_deferred();
-			callable_mp((Control *)get_line_edit(), &Control::update_minimum_size).call_deferred();
+			callable_mp((Control *)line_edit, &Control::update_minimum_size).call_deferred();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
@@ -423,10 +447,16 @@ void SpinBox::_notification(int p_what) {
 }
 
 void SpinBox::set_horizontal_alignment(HorizontalAlignment p_alignment) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	line_edit->set_horizontal_alignment(p_alignment);
 }
 
 HorizontalAlignment SpinBox::get_horizontal_alignment() const {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL_V(line_edit, HORIZONTAL_ALIGNMENT_LEFT);
+
 	return line_edit->get_horizontal_alignment();
 }
 
@@ -457,6 +487,9 @@ String SpinBox::get_prefix() const {
 }
 
 void SpinBox::set_update_on_text_changed(bool p_enabled) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	if (update_on_text_changed == p_enabled) {
 		return;
 	}
@@ -471,27 +504,45 @@ void SpinBox::set_update_on_text_changed(bool p_enabled) {
 }
 
 bool SpinBox::get_update_on_text_changed() const {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL_V(line_edit, false);
+
 	return update_on_text_changed;
 }
 
 void SpinBox::set_select_all_on_focus(bool p_enabled) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	line_edit->set_select_all_on_focus(p_enabled);
 }
 
 bool SpinBox::is_select_all_on_focus() const {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL_V(line_edit, false);
+
 	return line_edit->is_select_all_on_focus();
 }
 
 void SpinBox::set_editable(bool p_enabled) {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	line_edit->set_editable(p_enabled);
 	queue_redraw();
 }
 
 bool SpinBox::is_editable() const {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL_V(line_edit, false);
+
 	return line_edit->is_editable();
 }
 
 void SpinBox::apply() {
+	LineEdit *line_edit = Object::cast_to<LineEdit>(ObjectDB::get_instance(line_edit_id));
+	ERR_FAIL_NULL(line_edit);
+
 	_text_submitted(line_edit->get_text());
 }
 
@@ -585,7 +636,7 @@ void SpinBox::_bind_methods() {
 }
 
 SpinBox::SpinBox() {
-	line_edit = memnew(LineEdit);
+	LineEdit *line_edit = memnew(LineEdit);
 	add_child(line_edit, false, INTERNAL_MODE_FRONT);
 
 	line_edit->set_theme_type_variation("SpinBoxInnerLineEdit");
@@ -596,6 +647,8 @@ SpinBox::SpinBox() {
 	line_edit->connect("text_submitted", callable_mp(this, &SpinBox::_text_submitted), CONNECT_DEFERRED);
 	line_edit->connect("editing_toggled", callable_mp(this, &SpinBox::_line_edit_editing_toggled), CONNECT_DEFERRED);
 	line_edit->connect(SceneStringName(gui_input), callable_mp(this, &SpinBox::_line_edit_input));
+
+	line_edit_id = line_edit->get_instance_id();
 
 	range_click_timer = memnew(Timer);
 	range_click_timer->connect("timeout", callable_mp(this, &SpinBox::_range_click_timeout));

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -38,7 +38,7 @@
 class SpinBox : public Range {
 	GDCLASS(SpinBox, Range);
 
-	LineEdit *line_edit = nullptr;
+	ObjectID line_edit_id;
 	bool update_on_text_changed = false;
 
 	struct SizingCache {

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -46,7 +46,7 @@ public:
 	};
 
 private:
-	TabBar *tab_bar = nullptr;
+	ObjectID tab_bar_id;
 	bool tabs_visible = true;
 	bool all_tabs_in_front = false;
 	TabPosition tabs_position = POSITION_TOP;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -614,8 +614,11 @@ void TextEdit::_notification(int p_what) {
 
 			Size2 size = get_size();
 			bool rtl = is_layout_rtl();
-			if ((!has_focus() && !(menu && menu->has_focus())) || !window_has_focus) {
-				draw_caret = false;
+			if (menu_id.is_valid()) {
+				PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
+				if ((!has_focus() && !(menu && menu->has_focus())) || !window_has_focus) {
+					draw_caret = false;
+				}
 			}
 
 			_update_scrollbars();
@@ -1969,10 +1972,14 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				if (context_menu_enabled) {
 					_update_context_menu();
-					menu->set_position(get_screen_position() + mpos);
-					menu->reset_size();
-					menu->popup();
-					grab_focus();
+
+					PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
+					if (menu) {
+						menu->set_position(get_screen_position() + mpos);
+						menu->reset_size();
+						menu->popup();
+						grab_focus();
+					}
 				}
 			}
 		} else {
@@ -2271,10 +2278,14 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (context_menu_enabled) {
 				_update_context_menu();
 				adjust_viewport_to_caret();
-				menu->set_position(get_screen_position() + get_caret_draw_pos());
-				menu->reset_size();
-				menu->popup();
-				menu->grab_focus();
+
+				PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
+				if (menu) {
+					menu->set_position(get_screen_position() + get_caret_draw_pos());
+					menu->reset_size();
+					menu->popup();
+					menu->grab_focus();
+				}
 			}
 			accept_event();
 			return;
@@ -3228,11 +3239,14 @@ void TextEdit::set_text_direction(Control::TextDirection p_text_direction) {
 		text.invalidate_font();
 		_update_placeholder();
 
-		if (menu_dir) {
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_INHERITED), text_direction == TEXT_DIRECTION_INHERITED);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_AUTO), text_direction == TEXT_DIRECTION_AUTO);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), text_direction == TEXT_DIRECTION_LTR);
-			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), text_direction == TEXT_DIRECTION_RTL);
+		if (menu_dir_id.is_valid()) {
+			PopupMenu *menu_dir = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_dir_id));
+			if (menu_dir) {
+				menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_INHERITED), text_direction == TEXT_DIRECTION_INHERITED);
+				menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_AUTO), text_direction == TEXT_DIRECTION_AUTO);
+				menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), text_direction == TEXT_DIRECTION_LTR);
+				menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), text_direction == TEXT_DIRECTION_RTL);
+			}
 		}
 		queue_redraw();
 	}
@@ -3888,13 +3902,21 @@ void TextEdit::paste_primary_clipboard(int p_caret) {
 
 // Context menu.
 PopupMenu *TextEdit::get_menu() const {
-	if (!menu) {
+	if (menu_id.is_null()) {
 		const_cast<TextEdit *>(this)->_generate_context_menu();
 	}
+
+	PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
+	ERR_FAIL_NULL_V(menu, nullptr);
 	return menu;
 }
 
 bool TextEdit::is_menu_visible() const {
+	if (menu_id.is_null()) {
+		return false;
+	}
+
+	PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
 	return menu && menu->is_visible();
 }
 
@@ -6490,7 +6512,10 @@ String TextEdit::get_default_word_separators() const {
 void TextEdit::set_draw_control_chars(bool p_enabled) {
 	if (draw_control_chars != p_enabled) {
 		draw_control_chars = p_enabled;
-		if (menu) {
+		if (menu_id.is_valid()) {
+			PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
+			ERR_FAIL_NULL(menu);
+
 			menu->set_item_checked(menu->get_item_index(MENU_DISPLAY_UCC), draw_control_chars);
 		}
 		text.set_draw_control_chars(draw_control_chars);
@@ -7385,16 +7410,18 @@ Key TextEdit::_get_menu_action_accelerator(const String &p_action) {
 }
 
 void TextEdit::_generate_context_menu() {
-	menu = memnew(PopupMenu);
+	PopupMenu *menu = memnew(PopupMenu);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
+	menu_id = menu->get_instance_id();
 
-	menu_dir = memnew(PopupMenu);
+	PopupMenu *menu_dir = memnew(PopupMenu);
 	menu_dir->add_radio_check_item(ETR("Same as Layout Direction"), MENU_DIR_INHERITED);
 	menu_dir->add_radio_check_item(ETR("Auto-Detect Direction"), MENU_DIR_AUTO);
 	menu_dir->add_radio_check_item(ETR("Left-to-Right"), MENU_DIR_LTR);
 	menu_dir->add_radio_check_item(ETR("Right-to-Left"), MENU_DIR_RTL);
+	menu_dir_id = menu_dir->get_instance_id();
 
-	menu_ctl = memnew(PopupMenu);
+	PopupMenu *menu_ctl = memnew(PopupMenu);
 	menu_ctl->add_item(ETR("Left-to-Right Mark (LRM)"), MENU_INSERT_LRM);
 	menu_ctl->add_item(ETR("Right-to-Left Mark (RLM)"), MENU_INSERT_RLM);
 	menu_ctl->add_item(ETR("Start of Left-to-Right Embedding (LRE)"), MENU_INSERT_LRE);
@@ -7413,6 +7440,7 @@ void TextEdit::_generate_context_menu() {
 	menu_ctl->add_item(ETR("Zero-Width Non-Joiner (ZWNJ)"), MENU_INSERT_ZWNJ);
 	menu_ctl->add_item(ETR("Word Joiner (WJ)"), MENU_INSERT_WJ);
 	menu_ctl->add_item(ETR("Soft Hyphen (SHY)"), MENU_INSERT_SHY);
+	menu_ctl_id = menu_ctl->get_instance_id();
 
 	menu->add_item(ETR("Cut"), MENU_CUT);
 	menu->add_item(ETR("Copy"), MENU_COPY);
@@ -7435,9 +7463,15 @@ void TextEdit::_generate_context_menu() {
 }
 
 void TextEdit::_update_context_menu() {
-	if (!menu) {
+	if (menu_id.is_null()) {
 		_generate_context_menu();
 	}
+
+	PopupMenu *menu = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_id));
+	ERR_FAIL_NULL(menu);
+
+	PopupMenu *menu_dir = Object::cast_to<PopupMenu>(ObjectDB::get_instance(menu_dir_id));
+	ERR_FAIL_NULL(menu_dir);
 
 	int idx = -1;
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -325,9 +325,9 @@ private:
 	String cut_copy_line = "";
 
 	// Context menu.
-	PopupMenu *menu = nullptr;
-	PopupMenu *menu_dir = nullptr;
-	PopupMenu *menu_ctl = nullptr;
+	ObjectID menu_id;
+	ObjectID menu_dir_id;
+	ObjectID menu_ctl_id;
 
 	Key _get_menu_action_accelerator(const String &p_action);
 	void _generate_context_menu();


### PR DESCRIPTION
Should prevent crashes is internal sub-nodes (popup menus / scroll bars) are deleted by user.
