### PR TITLE
Editor: Focus value editor on type change in Dictionary and Array editors

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -652,6 +652,19 @@ void EditorProperty::add_focusable(Control *p_control) {
 	focusables.push_back(p_control);
 }
 
+void EditorProperty::grab_focus(int p_focusable) {
+	if (focusables.is_empty()) {
+		return;
+	}
+
+	if (p_focusable >= 0) {
+		ERR_FAIL_INDEX(p_focusable, focusables.size());
+		focusables[p_focusable]->grab_focus();
+	} else {
+		focusables[0]->grab_focus();
+	}
+}
+
 void EditorProperty::select(int p_focusable) {
 	bool already_selected = selected;
 	if (!selectable) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -192,6 +192,7 @@ public:
 	void set_deletable(bool p_enable);
 	bool is_deletable() const;
 	void add_focusable(Control *p_control);
+	void grab_focus(int p_focusable = -1);
 	void select(int p_focusable = -1);
 	void deselect();
 	bool is_selected() const;

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -49,6 +49,10 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 
 public:
+	enum {
+		NOT_CHANGING_TYPE = -1,
+	};
+
 	void set_array(const Variant &p_array);
 	Variant get_array();
 
@@ -68,7 +72,8 @@ protected:
 
 public:
 	enum {
-		NEW_KEY_INDEX = -2,
+		NOT_CHANGING_TYPE = -3,
+		NEW_KEY_INDEX,
 		NEW_VALUE_INDEX,
 	};
 
@@ -111,7 +116,7 @@ class EditorPropertyArray : public EditorProperty {
 
 	int page_length = 20;
 	int page_index = 0;
-	int changing_type_index;
+	int changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -206,7 +211,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	Ref<EditorPropertyDictionaryObject> object;
 	int page_length = 20;
 	int page_index = 0;
-	int changing_type_index;
+	int changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;


### PR DESCRIPTION
In the inspector, when editing an exported `Dictionary` property, the focus is lost once a type is chosen for the new key, the new value or an existing value.


https://github.com/godotengine/godot/assets/3855602/4055f3f5-cd4e-4fd6-a839-a19de3051806

This PR is fixing this by focusing the editor property after changing the type:

https://github.com/godotengine/godot/assets/3855602/f51e19b4-3706-4dbc-8f73-4ee6fa10c25d


