### PR TITLE
Export: Unify settings for PC texture formats, removed obsoleted ETC feature

### DIFF
--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -355,19 +355,16 @@ bool Utilities::has_os_feature(const String &p_feature) const {
 	if (p_feature == "rgtc") {
 		return config->rgtc_supported;
 	}
-
 	if (p_feature == "s3tc") {
 		return config->s3tc_supported;
 	}
-
 	if (p_feature == "bptc") {
 		return config->bptc_supported;
 	}
 	if (p_feature == "astc") {
 		return config->astc_supported;
 	}
-
-	if (p_feature == "etc" || p_feature == "etc2") {
+	if (p_feature == "etc2") {
 		return config->etc2_supported;
 	}
 

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -159,7 +159,6 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["dtls"] = "DTLS";
 	capitalize_string_remaps["eol"] = "EOL";
 	capitalize_string_remaps["erp"] = "ERP";
-	capitalize_string_remaps["etc"] = "ETC";
 	capitalize_string_remaps["etc2"] = "ETC2";
 	capitalize_string_remaps["fabrik"] = "FABRIK";
 	capitalize_string_remaps["fbx"] = "FBX";

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -34,14 +34,13 @@
 #include "scene/resources/image_texture.h"
 
 void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
-	if (p_preset->get("texture_format/bptc")) {
+	if (p_preset->get("texture_format/s3tc_bptc")) {
+		r_features->push_back("s3tc");
 		r_features->push_back("bptc");
 	}
-	if (p_preset->get("texture_format/s3tc")) {
-		r_features->push_back("s3tc");
-	}
-	if (p_preset->get("texture_format/etc2")) {
+	if (p_preset->get("texture_format/etc2_astc")) {
 		r_features->push_back("etc2");
+		r_features->push_back("astc");
 	}
 	// PC platforms only have one architecture per export, since
 	// we export a single executable instead of a bundle.
@@ -57,9 +56,8 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) c
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/embed_pck"), false));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/bptc"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc_bptc"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2_astc"), false));
 }
 
 String EditorExportPlatformPC::get_name() const {
@@ -98,6 +96,14 @@ bool EditorExportPlatformPC::has_valid_export_configuration(const Ref<EditorExpo
 
 	valid = dvalid || rvalid;
 	r_missing_templates = !valid;
+
+	bool uses_s3tc_bptc = p_preset->get("texture_format/s3tc_bptc");
+	bool uses_etc2_astc = p_preset->get("texture_format/etc2_astc");
+
+	if (!uses_s3tc_bptc && !uses_etc2_astc) {
+		valid = false;
+		err += TTR("A texture format must be selected to export the project. Please select at least one texture format.");
+	}
 
 	if (!err.is_empty()) {
 		r_error = err;
@@ -233,9 +239,8 @@ void EditorExportPlatformPC::set_logo(const Ref<Texture2D> &p_logo) {
 }
 
 void EditorExportPlatformPC::get_platform_features(List<String> *r_features) const {
-	r_features->push_back("pc"); //all pcs support "pc"
-	r_features->push_back("s3tc"); //all pcs support "s3tc" compression
-	r_features->push_back(get_os_name().to_lower()); //OS name is a feature
+	r_features->push_back("pc"); // Identify PC platforms as such.
+	r_features->push_back(get_os_name().to_lower()); // OS name is a feature.
 }
 
 void EditorExportPlatformPC::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -40,9 +40,6 @@ void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &
 	if (p_preset->get("texture_format/s3tc")) {
 		r_features->push_back("s3tc");
 	}
-	if (p_preset->get("texture_format/etc")) {
-		r_features->push_back("etc");
-	}
 	if (p_preset->get("texture_format/etc2")) {
 		r_features->push_back("etc2");
 	}
@@ -62,7 +59,6 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) c
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/bptc"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), false));
 }
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -280,7 +280,6 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 
 	presets.insert("bptc");
 	presets.insert("s3tc");
-	presets.insert("etc");
 	presets.insert("etc2");
 	presets.insert("editor");
 	presets.insert("template_debug");

--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -190,9 +190,9 @@ static Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size
 			} else if (RS::get_singleton()->has_os_feature("s3tc")) {
 				format = basist::transcoder_texture_format::cTFBC1; // get this from renderer
 				imgfmt = Image::FORMAT_DXT1;
-			} else if (RS::get_singleton()->has_os_feature("etc")) {
+			} else if (RS::get_singleton()->has_os_feature("etc2")) {
 				format = basist::transcoder_texture_format::cTFETC1; // get this from renderer
-				imgfmt = Image::FORMAT_ETC;
+				imgfmt = Image::FORMAT_ETC2_RGB8;
 			} else {
 				format = basist::transcoder_texture_format::cTFBGR565; // get this from renderer
 				imgfmt = Image::FORMAT_RGB565;

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -287,7 +287,7 @@ static Ref<Image> load_from_file_access(Ref<FileAccess> f, Error *r_error) {
 							ktxfmt = KTX_TTF_BC7_RGBA;
 						} else if (RS::get_singleton()->has_os_feature("s3tc")) {
 							ktxfmt = KTX_TTF_BC1_RGB;
-						} else if (RS::get_singleton()->has_os_feature("etc")) {
+						} else if (RS::get_singleton()->has_os_feature("etc2")) {
 							ktxfmt = KTX_TTF_ETC1_RGB;
 						} else {
 							ktxfmt = KTX_TTF_RGBA32;

--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -60,9 +60,6 @@
 		<member name="texture_format/bptc" type="bool" setter="" getter="">
 			If [code]true[/code], project textures are exported in the BPTC format.
 		</member>
-		<member name="texture_format/etc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the ETC format.
-		</member>
 		<member name="texture_format/etc2" type="bool" setter="" getter="">
 			If [code]true[/code], project textures are exported in the ETC2 format.
 		</member>

--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -57,14 +57,11 @@
 			- [code]{exe_name}[/code] - Name of application executable.
 			- [code]{cmd_args}[/code] - Array of the command line argument for the application.
 		</member>
-		<member name="texture_format/bptc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the BPTC format.
+		<member name="texture_format/etc2_astc" type="bool" setter="" getter="">
+			If [code]true[/code], project textures are exported in the ETC2/ASTC format.
 		</member>
-		<member name="texture_format/etc2" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the ETC2 format.
-		</member>
-		<member name="texture_format/s3tc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the S3TC format.
+		<member name="texture_format/s3tc_bptc" type="bool" setter="" getter="">
+			If [code]true[/code], project textures are exported in the S3TC/BPTC format.
 		</member>
 	</members>
 </class>

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -123,14 +123,11 @@
 			- [code]{exe_name}[/code] - Name of application executable.
 			- [code]{cmd_args}[/code] - Array of the command line argument for the application.
 		</member>
-		<member name="texture_format/bptc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the BPTC format.
+		<member name="texture_format/etc2_astc" type="bool" setter="" getter="">
+			If [code]true[/code], project textures are exported in the ETC2/ASTC format.
 		</member>
-		<member name="texture_format/etc2" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the ETC2 format.
-		</member>
-		<member name="texture_format/s3tc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the S3TC format.
+		<member name="texture_format/s3tc_bptc" type="bool" setter="" getter="">
+			If [code]true[/code], project textures are exported in the S3TC/BPTC format.
 		</member>
 	</members>
 </class>

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -126,9 +126,6 @@
 		<member name="texture_format/bptc" type="bool" setter="" getter="">
 			If [code]true[/code], project textures are exported in the BPTC format.
 		</member>
-		<member name="texture_format/etc" type="bool" setter="" getter="">
-			If [code]true[/code], project textures are exported in the ETC format.
-		</member>
 		<member name="texture_format/etc2" type="bool" setter="" getter="">
 			If [code]true[/code], project textures are exported in the ETC2 format.
 		</member>

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -108,7 +108,7 @@ public:
 	virtual void set_debug_generate_wireframes(bool p_generate) override {}
 
 	virtual bool has_os_feature(const String &p_feature) const override {
-		return p_feature == "rgtc" || p_feature == "bptc" || p_feature == "s3tc" || p_feature == "etc" || p_feature == "etc2";
+		return p_feature == "rgtc" || p_feature == "bptc" || p_feature == "s3tc" || p_feature == "etc2";
 	}
 
 	virtual void update_memory_info() override {}

--- a/servers/rendering/renderer_rd/storage_rd/utilities.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.cpp
@@ -278,7 +278,7 @@ bool Utilities::has_os_feature(const String &p_feature) const {
 		return true;
 	}
 
-	if ((p_feature == "etc" || p_feature == "etc2") && RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_ETC2_R8G8B8_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT)) {
+	if (p_feature == "etc2" && RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_ETC2_R8G8B8_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT)) {
 		return true;
 	}
 


### PR DESCRIPTION
S3TC and BPTC should always be used together, and likewise for ETC2 and ASTC.

Also removes obsolete ETC support code since we removed that format.

- Supersedes #84913, implementing https://github.com/godotengine/godot/pull/84913#issuecomment-1851613110.
- Fixes #81234.
- Fixes #86317.
- Closes https://github.com/godotengine/godot-proposals/issues/7230.

---

I didn't add compatibility code yet, it would be a bit convoluted in `EditorExportPreset::_set` which currently has its own logic for some visibility update. Could be done but I'm not sure it's worth the bother, when handling this minor compat breakage just requires ensuring that the proper formats are toggled in the settings. The default behavior for the new options is also to export S3TC/BPTC, which is the most likely combinations that users need.

Haven't tested much yet.

For a potential 4.2.x cherry-pick we might consider going with the approach in #84913 to be more conservative.