### PR TITLE
Fixed binary representation typo in comment

### DIFF
--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -98,7 +98,7 @@ public:
 
 	// This is the mask that will be used to extract the command.
 	enum {
-		CMD_MASK = 7, // 0x7 -> 0b00001111
+		CMD_MASK = 7, // 0x7 -> 0b00000111
 	};
 
 private:


### PR DESCRIPTION
Digging around in scene_multiplayer.h, I saw a couple comments that contradicted each other.

```
// Extract the `packet_type` from the LSB three bits:
uint8_t packet_type = p_packet[0] & CMD_MASK;
...
enum {
   CMD_MASK = 7, // 0x7 -> 0b00001111
};
```
The packet_type comment mentions "packet_type" is extracted from 3 bits, however the corresponding mask had a comment claiming 4 bits are set high. Looks like the CMD_MASK comment has a simple typo/off by one error, 0x7 is 0b0111 not 0b1111.

Feel free to ignore this if it is too nit-picky.