### PR TITLE
Fix a regression that selects popup menu items on mouse down.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -598,7 +598,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	if ((b.is_valid() && b->is_pressed()) || (!mouse_is_pressed && drag_to_press)) {
+	if ((b.is_valid() && !b->is_pressed()) || (!mouse_is_pressed && drag_to_press)) {
 		if (b.is_valid()) {
 			MouseButton button_idx = b->get_button_index();
 			if (button_idx != MouseButton::LEFT && button_idx != MouseButton::RIGHT) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -587,15 +587,16 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	if (m.is_valid() && drag_to_press) {
-		BitField<MouseButtonMask> initial_button_mask = m->get_button_mask();
-		if (!initial_button_mask.has_flag(mouse_button_to_mask(MouseButton::LEFT)) && !initial_button_mask.has_flag(mouse_button_to_mask(MouseButton::RIGHT))) {
-			mouse_is_pressed = false;
-		}
+	Rect2 item_clickable_area_global = scroll_container->get_global_rect();
 
-		if (!item_clickable_area.has_point(m->get_position()) && !mouse_is_pressed) {
-			drag_to_press = false;
-		}
+	DisplayServer *ds = DisplayServer::get_singleton();
+
+	if (!ds->mouse_get_button_state().has_flag(mouse_button_to_mask(MouseButton::LEFT)) && !ds->mouse_get_button_state().has_flag(mouse_button_to_mask(MouseButton::RIGHT))) {
+		mouse_is_pressed = false;
+	}
+
+	if (item_clickable_area_global.has_point(ds->mouse_get_position()) && !mouse_is_pressed) {
+		drag_to_press = false;
 	}
 
 	if ((b.is_valid() && !b->is_pressed()) || (!mouse_is_pressed && drag_to_press)) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Selection should be on mouse up, not down as discussed here: https://github.com/godotengine/godot/issues/88324#issuecomment-1944670206

This does not fix the mentioned issue, just addresses that specific comment. 
