### PR TITLE
[3.x] Add a `get_or_add` method to Dictionary

### DIFF
--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -116,6 +116,15 @@ Variant Dictionary::get(const Variant &p_key, const Variant &p_default) const {
 	return *result;
 }
 
+Variant Dictionary::get_or_add(const Variant &p_key, const Variant &p_default) {
+	const Variant *result = getptr(p_key);
+	if (!result) {
+		operator[](p_key) = p_default;
+		return p_default;
+	}
+	return *result;
+}
+
 int Dictionary::size() const {
 	return _p->variant_map.size();
 }

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -58,6 +58,7 @@ public:
 
 	Variant get_valid(const Variant &p_key) const;
 	Variant get(const Variant &p_key, const Variant &p_default) const;
+	Variant get_or_add(const Variant &p_key, const Variant &p_default);
 
 	int size() const;
 	bool empty() const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -559,6 +559,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Dictionary, values);
 	VCALL_LOCALMEM1R(Dictionary, duplicate);
 	VCALL_LOCALMEM2R(Dictionary, get);
+	VCALL_LOCALMEM2R(Dictionary, get_or_add);
 
 	VCALL_LOCALMEM2(Array, set);
 	VCALL_LOCALMEM1R(Array, get);
@@ -1944,6 +1945,7 @@ void register_variant_methods() {
 	ADDFUNC0R(DICTIONARY, ARRAY, Dictionary, values, varray());
 	ADDFUNC1R(DICTIONARY, DICTIONARY, Dictionary, duplicate, BOOL, "deep", varray(false));
 	ADDFUNC2R(DICTIONARY, NIL, Dictionary, get, NIL, "key", NIL, "default", varray(Variant()));
+	ADDFUNC2R(DICTIONARY, NIL, Dictionary, get_or_add, NIL, "key", NIL, "default", varray(Variant()));
 
 	ADDFUNC0R(ARRAY, INT, Array, size, varray());
 	ADDFUNC0R(ARRAY, BOOL, Array, empty, varray());

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -131,6 +131,14 @@
 				Returns the current value for the specified key in the [Dictionary]. If the key does not exist, the method returns the value of the optional default argument, or [code]null[/code] if it is omitted.
 			</description>
 		</method>
+		<method name="get_or_add">
+			<return type="Variant" />
+			<argument index="0" name="key" type="Variant" />
+			<argument index="1" name="default" type="Variant" default="null" />
+			<description>
+				Gets a value and ensures the key is set. If the [code]key[/code] exists in the dictionary, this behaves like [method get]. Otherwise, the [code]default[/code] value is inserted into the dictionary and returned.
+			</description>
+		</method>
 		<method name="has">
 			<return type="bool" />
 			<argument index="0" name="key" type="Variant" />


### PR DESCRIPTION
This follows #78095 that adds `get_or_add` method to `Dictionary` for 3.x branch. This is a very useful function for setting up new parameters into the dictionary or keep using old values from it.