### PR TITLE
Implement Cut Selected Keys in AnimationPlayer

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -842,7 +842,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		if (ED_GET_SHORTCUT("animation_editor/copy_selected_keys")->matches_event(p_event)) {
 			if (!read_only) {
-				copy_selected_keys();
+				copy_selected_keys(false);
 			}
 			accept_event();
 		}
@@ -959,6 +959,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				if (selected || selection.size()) {
 					menu->add_separator();
 					menu->add_icon_item(get_editor_theme_icon(SNAME("Duplicate")), TTR("Duplicate Selected Key(s)"), MENU_KEY_DUPLICATE);
+					menu->add_icon_item(get_editor_theme_icon(SNAME("ActionCut")), TTR("Cut Selected Key(s)"), MENU_KEY_CUT);
 					menu->add_icon_item(get_editor_theme_icon(SNAME("ActionCopy")), TTR("Copy Selected Key(s)"), MENU_KEY_COPY);
 				}
 
@@ -1600,8 +1601,11 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 		case MENU_KEY_DELETE: {
 			delete_selection();
 		} break;
+		case MENU_KEY_CUT: {
+			copy_selected_keys(true);
+		} break;
 		case MENU_KEY_COPY: {
-			copy_selected_keys();
+			copy_selected_keys(false);
 		} break;
 		case MENU_KEY_PASTE: {
 			paste_keys(time);
@@ -1681,7 +1685,7 @@ void AnimationBezierTrackEdit::duplicate_selected_keys(real_t p_ofs) {
 	undo_redo->commit_action();
 }
 
-void AnimationBezierTrackEdit::copy_selected_keys() {
+void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 	if (selection.is_empty()) {
 		return;
 	}
@@ -1704,6 +1708,25 @@ void AnimationBezierTrackEdit::copy_selected_keys() {
 		keys.insert(sk, ki);
 	}
 	editor->_set_key_clipboard(selected_track, top_time, keys);
+
+	if (p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Animation Cut Keys"), UndoRedo::MERGE_DISABLE, animation.ptr());
+		undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
+		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+		for (RBMap<AnimationTrackEditor::SelectedKey, AnimationTrackEditor::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+			int track_idx = E->key().track;
+			int key_idx = E->key().key;
+			float time = E->value().pos;
+			undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", track_idx, time);
+			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track_idx, time, animation->track_get_key_value(track_idx, key_idx), animation->track_get_key_transition(track_idx, key_idx));
+			undo_redo->add_undo_method(this, "_select_at_anim", animation, track_idx, time);
+		}
+		for (RBMap<AnimationTrackEditor::SelectedKey, AnimationTrackEditor::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+			undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos);
+		}
+		undo_redo->commit_action();
+	}
 }
 
 void AnimationBezierTrackEdit::paste_keys(real_t p_ofs) {

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -42,6 +42,7 @@ class AnimationBezierTrackEdit : public Control {
 	enum {
 		MENU_KEY_INSERT,
 		MENU_KEY_DUPLICATE,
+		MENU_KEY_CUT,
 		MENU_KEY_COPY,
 		MENU_KEY_PASTE,
 		MENU_KEY_DELETE,
@@ -212,7 +213,7 @@ public:
 	void update_play_position();
 
 	void duplicate_selected_keys(real_t p_ofs);
-	void copy_selected_keys();
+	void copy_selected_keys(bool p_cut);
 	void paste_keys(real_t p_ofs);
 	void delete_selection();
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2692,6 +2692,12 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 			accept_event();
 		}
+		if (ED_GET_SHORTCUT("animation_editor/cut_selected_keys")->matches_event(p_event)) {
+			if (!read_only) {
+				emit_signal(SNAME("cut_request"));
+			}
+			accept_event();
+		}
 		if (ED_GET_SHORTCUT("animation_editor/copy_selected_keys")->matches_event(p_event)) {
 			if (!read_only) {
 				emit_signal(SNAME("copy_request"));
@@ -2852,6 +2858,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				if (selected || editor->is_selection_active()) {
 					menu->add_separator();
 					menu->add_icon_item(get_editor_theme_icon(SNAME("Duplicate")), TTR("Duplicate Key(s)"), MENU_KEY_DUPLICATE);
+					menu->add_icon_item(get_editor_theme_icon(SNAME("ActionCut")), TTR("Cut Key(s)"), MENU_KEY_CUT);
 					menu->add_icon_item(get_editor_theme_icon(SNAME("ActionCopy")), TTR("Copy Key(s)"), MENU_KEY_COPY);
 				}
 				if (editor->is_key_clipboard_active()) {
@@ -3177,10 +3184,12 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 		case MENU_KEY_DUPLICATE: {
 			emit_signal(SNAME("duplicate_request"), insert_at_pos);
 		} break;
+		case MENU_KEY_CUT: {
+			emit_signal(SNAME("cut_request"));
+		} break;
 		case MENU_KEY_COPY: {
 			emit_signal(SNAME("copy_request"));
 		} break;
-
 		case MENU_KEY_PASTE: {
 			emit_signal(SNAME("paste_request"), insert_at_pos);
 		} break;
@@ -3259,6 +3268,7 @@ void AnimationTrackEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("duplicate_request", PropertyInfo(Variant::FLOAT, "offset")));
 	ADD_SIGNAL(MethodInfo("create_reset_request"));
 	ADD_SIGNAL(MethodInfo("copy_request"));
+	ADD_SIGNAL(MethodInfo("cut_request"));
 	ADD_SIGNAL(MethodInfo("paste_request", PropertyInfo(Variant::FLOAT, "offset")));
 	ADD_SIGNAL(MethodInfo("delete_request"));
 }
@@ -4608,6 +4618,7 @@ void AnimationTrackEditor::_update_tracks() {
 		track_edit->connect("move_selection_cancel", callable_mp(this, &AnimationTrackEditor::_move_selection_cancel));
 
 		track_edit->connect("duplicate_request", callable_mp(this, &AnimationTrackEditor::_anim_duplicate_keys).bind(i), CONNECT_DEFERRED);
+		track_edit->connect("cut_request", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed).bind(EDIT_CUT_KEYS), CONNECT_DEFERRED);
 		track_edit->connect("copy_request", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed).bind(EDIT_COPY_KEYS), CONNECT_DEFERRED);
 		track_edit->connect("paste_request", callable_mp(this, &AnimationTrackEditor::_anim_paste_keys).bind(i), CONNECT_DEFERRED);
 		track_edit->connect("create_reset_request", callable_mp(this, &AnimationTrackEditor::_edit_menu_pressed).bind(EDIT_ADD_RESET_KEY), CONNECT_DEFERRED);
@@ -5720,10 +5731,11 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, int p_track) {
 	}
 }
 
-void AnimationTrackEditor::_anim_copy_keys() {
+void AnimationTrackEditor::_anim_copy_keys(bool p_cut) {
 	if (is_selection_active() && animation.is_valid()) {
 		int top_track = 0x7FFFFFFF;
 		float top_time = 1e10;
+
 		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 			const SelectedKey &sk = E->key();
 
@@ -5739,6 +5751,24 @@ void AnimationTrackEditor::_anim_copy_keys() {
 		ERR_FAIL_COND(top_track == 0x7FFFFFFF || top_time == 1e10);
 
 		_set_key_clipboard(top_track, top_time, selection);
+
+		if (p_cut) {
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Animation Cut Keys"), UndoRedo::MERGE_DISABLE, animation.ptr());
+			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
+			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+				int track_idx = E->key().track;
+				int key_idx = E->key().key;
+				float time = E->value().pos;
+				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", track_idx, time);
+				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track_idx, time, animation->track_get_key_value(track_idx, key_idx), animation->track_get_key_transition(track_idx, key_idx));
+			}
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+				undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos);
+			}
+			undo_redo->commit_action();
+		}
 	}
 }
 
@@ -6328,12 +6358,19 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			}
 			_anim_duplicate_keys(-1.0, -1.0);
 		} break;
-		case EDIT_COPY_KEYS: {
+		case EDIT_CUT_KEYS: {
 			if (bezier_edit->is_visible()) {
-				bezier_edit->copy_selected_keys();
+				bezier_edit->copy_selected_keys(true);
 				break;
 			}
-			_anim_copy_keys();
+			_anim_copy_keys(true);
+		} break;
+		case EDIT_COPY_KEYS: {
+			if (bezier_edit->is_visible()) {
+				bezier_edit->copy_selected_keys(false);
+				break;
+			}
+			_anim_copy_keys(false);
 		} break;
 		case EDIT_PASTE_KEYS: {
 			_anim_paste_keys(-1.0, -1.0);
@@ -6981,6 +7018,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	edit->get_popup()->add_item(TTR("Make Easing Selection"), EDIT_EASE_SELECTION);
 	edit->get_popup()->add_separator();
 	edit->get_popup()->add_shortcut(ED_SHORTCUT("animation_editor/duplicate_selected_keys", TTR("Duplicate Selected Keys"), KeyModifierMask::CMD_OR_CTRL | Key::D), EDIT_DUPLICATE_SELECTED_KEYS);
+	edit->get_popup()->add_shortcut(ED_SHORTCUT("animation_editor/cut_selected_keys", TTR("Cut Selected Keys"), KeyModifierMask::CMD_OR_CTRL | Key::X), EDIT_CUT_KEYS);
 	edit->get_popup()->add_shortcut(ED_SHORTCUT("animation_editor/copy_selected_keys", TTR("Copy Selected Keys"), KeyModifierMask::CMD_OR_CTRL | Key::C), EDIT_COPY_KEYS);
 	edit->get_popup()->add_shortcut(ED_SHORTCUT("animation_editor/paste_keys", TTR("Paste Keys"), KeyModifierMask::CMD_OR_CTRL | Key::V), EDIT_PASTE_KEYS);
 	edit->get_popup()->add_shortcut(ED_SHORTCUT("animation_editor/add_reset_value", TTR("Add RESET Value(s)")));

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -231,6 +231,7 @@ class AnimationTrackEdit : public Control {
 		MENU_LOOP_CLAMP,
 		MENU_KEY_INSERT,
 		MENU_KEY_DUPLICATE,
+		MENU_KEY_CUT,
 		MENU_KEY_COPY,
 		MENU_KEY_PASTE,
 		MENU_KEY_ADD_RESET,
@@ -578,7 +579,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _anim_duplicate_keys(float p_ofs, int p_track);
 
-	void _anim_copy_keys();
+	void _anim_copy_keys(bool p_cut);
 
 	bool _is_track_compatible(int p_target_track_idx, Variant::Type p_source_value_type, Animation::TrackType p_source_track_type);
 
@@ -649,6 +650,7 @@ public:
 		EDIT_COPY_TRACKS,
 		EDIT_COPY_TRACKS_CONFIRM,
 		EDIT_PASTE_TRACKS,
+		EDIT_CUT_KEYS,
 		EDIT_COPY_KEYS,
 		EDIT_PASTE_KEYS,
 		EDIT_SCALE_SELECTION,


### PR DESCRIPTION
Following up on #87250, I added an additional option to "cut" the selected keys, i.e. both copy and remove them at once. This follows the way that cutting is implemented in the SceneTree. 
Same as copy and paste, the option is accessible both through the right-click menu and the Edit menu, as well as with the usual shortcut of CTRL+X.
While not necessarily a complex feature, the lack thereof would definitely confound some users, especially since pressing the familiar CTRL+X in hopes of cutting the selected keys (since CTRL+C, CTRL+V work as well) would remove the currently selected node in the scene if this shortcut were not implemented in the AnimationPlayer. 
The implementation works both in the default and the Bezier editor.
![AnimationPlayerCutKeys](https://github.com/godotengine/godot/assets/53947784/d0d5da39-f40c-4b0f-a128-6eebefd38ff3)
