### PR TITLE
[Android 14] Fix GodotEditText white box showing during editor load

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -37,6 +37,7 @@ import android.content.*
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.graphics.Color
 import android.graphics.Rect
 import android.hardware.Sensor
 import android.hardware.SensorEvent
@@ -379,6 +380,8 @@ class Godot(private val context: Context) : SensorEventListener {
 							ViewGroup.LayoutParams.MATCH_PARENT,
 							activity.resources.getDimension(R.dimen.text_edit_height).toInt()
 					)
+			// Prevent GodotEditText from showing on splash screen on devices with Android 14 or newer.
+			editText.setBackgroundColor(Color.TRANSPARENT)
 			// ...add to FrameLayout
 			containerLayout?.addView(editText)
 			renderView = if (usesVulkan()) {


### PR DESCRIPTION
Prevent GodotEditText white box from showing at the top of the splash screen during Godot Android editor load on Android 14 devices.

This fix is related to the #87689 pull-request -- see https://github.com/godotengine/godot/pull/87689#pullrequestreview-1876635759.

Fixes https://github.com/godotengine/godot/issues/87059 for Godot Android editor for the master branch.