### PR TITLE
[3.x] GDNative: Fix Linux arm32 warning about ignored sysv_abi attribute

### DIFF
--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -47,7 +47,7 @@ extern "C" {
 #endif
 
 #else // Linux/BSD/Web
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__arm__)
 #define GDCALLINGCONV
 #else
 #define GDCALLINGCONV __attribute__((sysv_abi))


### PR DESCRIPTION
Apply the fix in #85916 to `arm32`.

I've confirmed the same issue as #41160 when building gdnative linux arm32 (for the webrtc plugin godotengine/webrtc-native#138).

Note: To build for arm32 I used the godot toolchain (arm32), and had to modify the `platform/x11/detect.py` to avoid adding the `-m32` flag (I'll make another PR with a possible solution for that. *Edit: See #88369*).