### PR TITLE
Add const lvalue ref to `editor/*` container parameters

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3828,7 +3828,7 @@ void AnimationTrackEditor::_insert_track(bool p_reset_wanted, bool p_create_bezi
 	}
 }
 
-void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant p_value) {
+void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant &p_value) {
 	ERR_FAIL_NULL(root);
 	ERR_FAIL_COND_MSG(
 			(p_type != Animation::TYPE_POSITION_3D && p_type != Animation::TYPE_ROTATION_3D && p_type != Animation::TYPE_SCALE_3D),
@@ -4986,7 +4986,7 @@ void AnimationTrackEditor::_fetch_value_track_options(const NodePath &p_path, An
 	}
 }
 
-void AnimationTrackEditor::_new_track_property_selected(String p_name) {
+void AnimationTrackEditor::_new_track_property_selected(const String &p_name) {
 	String full_path = String(adding_track_path) + ":" + p_name;
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -440,7 +440,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _add_track(int p_type);
 	void _new_track_node_selected(NodePath p_path);
-	void _new_track_property_selected(String p_name);
+	void _new_track_property_selected(const String &p_name);
 
 	void _update_step_spinbox();
 
@@ -699,7 +699,7 @@ public:
 	void set_anim_pos(float p_pos);
 	void insert_node_value_key(Node *p_node, const String &p_property, const Variant &p_value, bool p_only_if_exists = false);
 	void insert_value_key(const String &p_property, const Variant &p_value, bool p_advance);
-	void insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant p_value);
+	void insert_transform_key(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type, const Variant &p_value);
 	bool has_track(Node3D *p_node, const String &p_sub, const Animation::TrackType p_type);
 	void make_insert_queue();
 	void commit_insert_queue();

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -236,7 +236,7 @@ void ConnectDialog::_remove_bind() {
 /*
  * Automatically generates a name for the callback method.
  */
-StringName ConnectDialog::generate_method_callback_name(Node *p_source, String p_signal_name, Node *p_target) {
+StringName ConnectDialog::generate_method_callback_name(Node *p_source, const String &p_signal_name, Node *p_target) {
 	String node_name = p_source->get_name();
 	for (int i = 0; i < node_name.length(); i++) { // TODO: Regex filter may be cleaner.
 		char32_t c = node_name[i];
@@ -645,7 +645,7 @@ void ConnectDialog::init(const ConnectionData &p_cd, const PackedStringArray &p_
 	source_connection_data = p_cd;
 }
 
-void ConnectDialog::popup_dialog(const String p_for_signal) {
+void ConnectDialog::popup_dialog(const String &p_for_signal) {
 	from_signal->set_text(p_for_signal);
 	warning_label->add_theme_color_override("font_color", warning_label->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 	error_label->add_theme_color_override("font_color", error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -163,7 +163,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	static StringName generate_method_callback_name(Node *p_source, String p_signal_name, Node *p_target);
+	static StringName generate_method_callback_name(Node *p_source, const String &p_signal_name, Node *p_target);
 	Node *get_source() const;
 	ConnectionData get_source_connection_data() const;
 	StringName get_signal_name() const;
@@ -184,7 +184,7 @@ public:
 
 	void init(const ConnectionData &p_cd, const PackedStringArray &p_signal_args, bool p_edit = false);
 
-	void popup_dialog(const String p_for_signal);
+	void popup_dialog(const String &p_for_signal);
 	ConnectDialog();
 	~ConnectDialog();
 };

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -343,7 +343,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	}
 }
 
-String CreateDialog::_top_result(const Vector<String> p_candidates, const String &p_search_text) const {
+String CreateDialog::_top_result(const Vector<String> &p_candidates, const String &p_search_text) const {
 	float highest_score = 0;
 	int highest_index = 0;
 	for (int i = 0; i < p_candidates.size(); i++) {

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -71,7 +71,7 @@ class CreateDialog : public ConfirmationDialog {
 	bool _should_hide_type(const String &p_type) const;
 	void _add_type(const String &p_type, const TypeCategory p_type_category);
 	void _configure_search_option_item(TreeItem *r_item, const String &p_type, const TypeCategory p_type_category);
-	String _top_result(const Vector<String> p_candidates, const String &p_search_text) const;
+	String _top_result(const Vector<String> &p_candidates, const String &p_search_text) const;
 	float _score_type(const String &p_type, const String &p_search) const;
 	bool _is_type_preferred(const String &p_type) const;
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -557,7 +557,7 @@ void EditorDebuggerNode::_paused() {
 	});
 }
 
-void EditorDebuggerNode::_breaked(bool p_breaked, bool p_can_debug, String p_message, bool p_has_stackdump, int p_debugger) {
+void EditorDebuggerNode::_breaked(bool p_breaked, bool p_can_debug, const String &p_message, bool p_has_stackdump, int p_debugger) {
 	if (get_current_debugger() != get_debugger(p_debugger)) {
 		if (!p_breaked) {
 			return;
@@ -582,7 +582,7 @@ void EditorDebuggerNode::set_breakpoint(const String &p_path, int p_line, bool p
 	emit_signal(SNAME("breakpoint_toggled"), p_path, p_line, p_enabled);
 }
 
-void EditorDebuggerNode::set_breakpoints(const String &p_path, Array p_lines) {
+void EditorDebuggerNode::set_breakpoints(const String &p_path, const Array &p_lines) {
 	for (int i = 0; i < p_lines.size(); i++) {
 		set_breakpoint(p_path, p_lines[i], true);
 	}

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -149,7 +149,7 @@ protected:
 	void _text_editor_stack_clear(const ScriptEditorDebugger *p_debugger);
 	void _stack_frame_selected(int p_debugger);
 	void _error_selected(const String &p_file, int p_line, int p_debugger);
-	void _breaked(bool p_breaked, bool p_can_debug, String p_message, bool p_has_stackdump, int p_debugger);
+	void _breaked(bool p_breaked, bool p_can_debug, const String &p_message, bool p_has_stackdump, int p_debugger);
 	void _paused();
 	void _break_state_changed();
 	void _menu_option(int p_id);
@@ -186,7 +186,7 @@ public:
 
 	bool is_skip_breakpoints() const;
 	void set_breakpoint(const String &p_path, int p_line, bool p_enabled);
-	void set_breakpoints(const String &p_path, Array p_lines);
+	void set_breakpoints(const String &p_path, const Array &p_lines);
 	void reload_all_scripts();
 	void reload_scripts(const Vector<String> &p_script_paths);
 

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -98,7 +98,7 @@ void EditorFileServer::_scan_files_changed(EditorFileSystemDirectory *efd, const
 	}
 }
 
-static void _add_custom_file(const String f, HashMap<String, uint64_t> &files_to_send, HashMap<String, uint64_t> &cached_files) {
+static void _add_custom_file(const String &f, HashMap<String, uint64_t> &files_to_send, HashMap<String, uint64_t> &cached_files) {
 	if (!FileAccess::exists(f)) {
 		return;
 	}

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -38,7 +38,7 @@
 
 EditorPerformanceProfiler::Monitor::Monitor() {}
 
-EditorPerformanceProfiler::Monitor::Monitor(String p_name, String p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item) {
+EditorPerformanceProfiler::Monitor::Monitor(const String &p_name, const String &p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item) {
 	type = p_type;
 	item = p_item;
 	frame_index = p_frame_index;

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -54,7 +54,7 @@ private:
 		int frame_index = 0;
 
 		Monitor();
-		Monitor(String p_name, String p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item);
+		Monitor(const String &p_name, const String &p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item);
 		void update_value(float p_value);
 		void reset();
 	};

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -72,7 +72,7 @@
 
 using CameraOverride = EditorDebuggerNode::CameraOverride;
 
-void ScriptEditorDebugger::_put_msg(String p_message, Array p_data, uint64_t p_thread_id) {
+void ScriptEditorDebugger::_put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id) {
 	ERR_FAIL_COND(p_thread_id == Thread::UNASSIGNED_ID);
 	if (is_session_active()) {
 		Array msg;

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -222,7 +222,7 @@ private:
 	void _item_menu_id_pressed(int p_option);
 	void _tab_changed(int p_tab);
 
-	void _put_msg(String p_message, Array p_data, uint64_t p_thread_id = Thread::MAIN_ID);
+	void _put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id = Thread::MAIN_ID);
 	void _export_csv();
 
 	void _clear_execution();

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -382,17 +382,17 @@ void EditorAutoloadSettings::_autoload_file_callback(const String &p_path) {
 	add_autoload->set_disabled(false);
 }
 
-void EditorAutoloadSettings::_autoload_text_submitted(const String p_name) {
+void EditorAutoloadSettings::_autoload_text_submitted(const String &p_name) {
 	if (!autoload_add_path->get_text().is_empty() && _autoload_name_is_valid(p_name, nullptr)) {
 		_autoload_add();
 	}
 }
 
-void EditorAutoloadSettings::_autoload_path_text_changed(const String p_path) {
+void EditorAutoloadSettings::_autoload_path_text_changed(const String &p_path) {
 	add_autoload->set_disabled(!_autoload_name_is_valid(autoload_add_name->get_text(), nullptr));
 }
 
-void EditorAutoloadSettings::_autoload_text_changed(const String p_name) {
+void EditorAutoloadSettings::_autoload_text_changed(const String &p_name) {
 	String error_string;
 	bool is_name_valid = _autoload_name_is_valid(p_name, &error_string);
 	add_autoload->set_disabled(!is_name_valid);

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -83,9 +83,9 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _autoload_activated();
-	void _autoload_path_text_changed(const String p_path);
-	void _autoload_text_submitted(const String p_name);
-	void _autoload_text_changed(const String p_name);
+	void _autoload_path_text_changed(const String &p_path);
+	void _autoload_text_submitted(const String &p_name);
+	void _autoload_text_changed(const String &p_name);
 	void _autoload_open(const String &fpath);
 	void _autoload_file_callback(const String &p_path);
 	Node *_create_autoload(const String &p_path);

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -266,7 +266,7 @@ Vector<EditorPlugin *> EditorData::get_handling_sub_editors(Object *p_object) {
 	return sub_plugins;
 }
 
-EditorPlugin *EditorData::get_editor_by_name(String p_name) {
+EditorPlugin *EditorData::get_editor_by_name(const String &p_name) {
 	for (int i = editor_plugins.size() - 1; i > -1; i--) {
 		if (editor_plugins[i]->get_name() == p_name) {
 			return editor_plugins[i];

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -152,7 +152,7 @@ private:
 public:
 	EditorPlugin *get_handling_main_editor(Object *p_object);
 	Vector<EditorPlugin *> get_handling_sub_editors(Object *p_object);
-	EditorPlugin *get_editor_by_name(String p_name);
+	EditorPlugin *get_editor_by_name(const String &p_name);
 
 	void copy_object_params(Object *p_object);
 	void paste_object_params(Object *p_object);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -524,7 +524,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 	return false; //nothing changed
 }
 
-bool EditorFileSystem::_scan_import_support(Vector<String> reimports) {
+bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
 	if (import_support_queries.size() == 0) {
 		return false;
 	}
@@ -1161,7 +1161,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 	}
 }
 
-void EditorFileSystem::_delete_internal_files(String p_file) {
+void EditorFileSystem::_delete_internal_files(const String &p_file) {
 	if (FileAccess::exists(p_file + ".import")) {
 		List<String> paths;
 		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, &paths);

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -221,7 +221,7 @@ class EditorFileSystem : public Node {
 
 	void _scan_fs_changes(EditorFileSystemDirectory *p_dir, const ScanProgress &p_progress);
 
-	void _delete_internal_files(String p_file);
+	void _delete_internal_files(const String &p_file);
 
 	HashSet<String> textfile_extensions;
 	HashSet<String> valid_extensions;
@@ -298,7 +298,7 @@ class EditorFileSystem : public Node {
 	static ResourceUID::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
 
 	bool _scan_extensions();
-	bool _scan_import_support(Vector<String> reimports);
+	bool _scan_import_support(const Vector<String> &reimports);
 
 	Vector<Ref<EditorFileSystemImportFormatSupportQuery>> import_support_queries;
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2066,7 +2066,7 @@ void EditorInspectorArray::_new_size_spin_box_value_changed(float p_value) {
 	resize_dialog->get_ok_button()->set_disabled(int(p_value) == count);
 }
 
-void EditorInspectorArray::_new_size_spin_box_text_submitted(String p_text) {
+void EditorInspectorArray::_new_size_spin_box_text_submitted(const String &p_text) {
 	_resize_dialog_confirmed();
 }
 
@@ -2306,7 +2306,7 @@ void EditorInspectorArray::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("page_change_request"));
 }
 
-void EditorInspectorArray::setup_with_move_element_function(Object *p_object, String p_label, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable, bool p_numbered, int p_page_length, const String &p_add_item_text) {
+void EditorInspectorArray::setup_with_move_element_function(Object *p_object, const String &p_label, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable, bool p_numbered, int p_page_length, const String &p_add_item_text) {
 	count_property = "";
 	mode = MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION;
 	array_element_prefix = p_array_element_prefix;
@@ -2320,7 +2320,7 @@ void EditorInspectorArray::setup_with_move_element_function(Object *p_object, St
 	_setup();
 }
 
-void EditorInspectorArray::setup_with_count_property(Object *p_object, String p_label, const StringName &p_count_property, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable, bool p_numbered, int p_page_length, const String &p_add_item_text, const String &p_swap_method) {
+void EditorInspectorArray::setup_with_count_property(Object *p_object, const String &p_label, const StringName &p_count_property, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable, bool p_numbered, int p_page_length, const String &p_add_item_text, const String &p_swap_method) {
 	count_property = p_count_property;
 	mode = MODE_USE_COUNT_PROPERTY;
 	array_element_prefix = p_array_element_prefix;
@@ -2412,7 +2412,7 @@ void EditorPaginator::_prev_page_button_pressed() {
 	emit_signal("page_changed", MAX(0, page - 1));
 }
 
-void EditorPaginator::_page_line_edit_text_submitted(String p_text) {
+void EditorPaginator::_page_line_edit_text_submitted(const String &p_text) {
 	if (p_text.is_valid_int()) {
 		int new_page = p_text.to_int() - 1;
 		new_page = MIN(MAX(0, new_page), max_page);
@@ -3829,7 +3829,7 @@ void EditorInspector::_property_changed(const String &p_path, const Variant &p_v
 	}
 }
 
-void EditorInspector::_multiple_properties_changed(Vector<String> p_paths, Array p_values, bool p_changing) {
+void EditorInspector::_multiple_properties_changed(const Vector<String> &p_paths, const Array &p_values, bool p_changing) {
 	ERR_FAIL_COND(p_paths.is_empty() || p_values.is_empty());
 	ERR_FAIL_COND(p_paths.size() != p_values.size());
 	String names;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -406,7 +406,7 @@ class EditorInspectorArray : public EditorInspectorSection {
 	int _drop_position() const;
 
 	void _new_size_spin_box_value_changed(float p_value);
-	void _new_size_spin_box_text_submitted(String p_text);
+	void _new_size_spin_box_text_submitted(const String &p_text);
 	void _resize_dialog_confirmed();
 
 	void _update_elements_visibility();
@@ -423,8 +423,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void setup_with_move_element_function(Object *p_object, String p_label, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable = true, bool p_numbered = false, int p_page_length = 5, const String &p_add_item_text = "");
-	void setup_with_count_property(Object *p_object, String p_label, const StringName &p_count_property, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable = true, bool p_numbered = false, int p_page_length = 5, const String &p_add_item_text = "", const String &p_swap_method = "");
+	void setup_with_move_element_function(Object *p_object, const String &p_label, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable = true, bool p_numbered = false, int p_page_length = 5, const String &p_add_item_text = "");
+	void setup_with_count_property(Object *p_object, const String &p_label, const StringName &p_count_property, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable = true, bool p_numbered = false, int p_page_length = 5, const String &p_add_item_text = "", const String &p_swap_method = "");
 	VBoxContainer *get_vbox(int p_index);
 
 	EditorInspectorArray(bool p_read_only);
@@ -444,7 +444,7 @@ class EditorPaginator : public HBoxContainer {
 
 	void _first_page_button_pressed();
 	void _prev_page_button_pressed();
-	void _page_line_edit_text_submitted(String p_text);
+	void _page_line_edit_text_submitted(const String &p_text);
 	void _next_page_button_pressed();
 	void _last_page_button_pressed();
 
@@ -520,7 +520,7 @@ class EditorInspector : public ScrollContainer {
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
 	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false, bool p_update_all = false);
-	void _multiple_properties_changed(Vector<String> p_paths, Array p_values, bool p_changing = false);
+	void _multiple_properties_changed(const Vector<String> &p_paths, const Array &p_values, bool p_changing = false);
 	void _property_keyed(const String &p_path, bool p_advance);
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);
 	void _property_deleted(const String &p_path);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -64,7 +64,7 @@ private:
 
 		LogMessage() {}
 
-		LogMessage(const String p_text, MessageType p_type, bool p_clear) :
+		LogMessage(const String &p_text, MessageType p_type, bool p_clear) :
 				text(p_text),
 				type(p_type),
 				clear(p_clear) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -254,7 +254,7 @@ void EditorPropertyTextEnum::_set_read_only(bool p_read_only) {
 	edit_button->set_disabled(p_read_only);
 }
 
-void EditorPropertyTextEnum::_emit_changed_value(String p_string) {
+void EditorPropertyTextEnum::_emit_changed_value(const String &p_string) {
 	if (string_name) {
 		emit_changed(get_edited_property(), StringName(p_string));
 	} else {
@@ -272,7 +272,7 @@ void EditorPropertyTextEnum::_edit_custom_value() {
 	custom_value_edit->grab_focus();
 }
 
-void EditorPropertyTextEnum::_custom_value_submitted(String p_value) {
+void EditorPropertyTextEnum::_custom_value_submitted(const String &p_value) {
 	edit_custom_layout->hide();
 	default_layout->show();
 
@@ -2897,7 +2897,7 @@ void EditorPropertyNodePath::update_property() {
 	assign->set_icon(EditorNode::get_singleton()->get_object_icon(target_node, "Node"));
 }
 
-void EditorPropertyNodePath::setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types, bool p_use_path_from_scene_root, bool p_editing_node) {
+void EditorPropertyNodePath::setup(const NodePath &p_base_hint, const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root, bool p_editing_node) {
 	base_hint = p_base_hint;
 	valid_types = p_valid_types;
 	editing_node = p_editing_node;

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -116,11 +116,11 @@ class EditorPropertyTextEnum : public EditorProperty {
 	bool string_name = false;
 	bool loose_mode = false;
 
-	void _emit_changed_value(String p_string);
+	void _emit_changed_value(const String &p_string);
 	void _option_selected(int p_which);
 
 	void _edit_custom_value();
-	void _custom_value_submitted(String p_value);
+	void _custom_value_submitted(const String &p_value);
 	void _custom_value_accepted();
 	void _custom_value_canceled();
 
@@ -677,7 +677,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types, bool p_use_path_from_scene_root = true, bool p_editing_node = false);
+	void setup(const NodePath &p_base_hint, const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root = true, bool p_editing_node = false);
 	EditorPropertyNodePath();
 };
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1287,7 +1287,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 
 ///////////////////// LOCALIZABLE STRING ///////////////////////////
 
-void EditorPropertyLocalizableString::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void EditorPropertyLocalizableString::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("indices")) {
 		int index = p_property.get_slice("/", 1).to_int();
 

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -214,7 +214,7 @@ class EditorPropertyLocalizableString : public EditorProperty {
 	void _page_changed(int p_page);
 	void _edit_pressed();
 	void _remove_item(Object *p_button, int p_index);
-	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
+	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 
 	void _add_locale_popup();
 	void _add_locale(const String &p_locale);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -654,7 +654,7 @@ bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
 	return false;
 }
 
-bool EditorResourcePicker::_is_type_valid(const String p_type_name, const HashSet<StringName> &p_allowed_types) const {
+bool EditorResourcePicker::_is_type_valid(const String &p_type_name, const HashSet<StringName> &p_allowed_types) const {
 	for (const StringName &E : p_allowed_types) {
 		String at = E;
 		if (p_type_name == at || ClassDB::is_parent_class(p_type_name, at) || EditorNode::get_editor_data().script_class_is_parent(p_type_name, at)) {

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -99,7 +99,7 @@ class EditorResourcePicker : public HBoxContainer {
 	String _get_resource_type(const Ref<Resource> &p_resource) const;
 	void _get_allowed_types(bool p_with_convert, HashSet<StringName> *p_vector) const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
-	bool _is_type_valid(const String p_type_name, const HashSet<StringName> &p_allowed_types) const;
+	bool _is_type_valid(const String &p_type_name, const HashSet<StringName> &p_allowed_types) const;
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -351,7 +351,7 @@ void EditorResourcePreview::_iterate() {
 	_preview_ready(item.path, 0, texture, small_texture, item.id, item.function, item.userdata, preview_metadata);
 }
 
-void EditorResourcePreview::_write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, String p_hash, const Dictionary &p_metadata) {
+void EditorResourcePreview::_write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata) {
 	p_file->store_line(itos(p_thumbnail_size));
 	p_file->store_line(itos(p_has_small_texture));
 	p_file->store_line(itos(p_modified_time));

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -117,7 +117,7 @@ class EditorResourcePreview : public Node {
 	static void _idle_callback(); // For other rendering drivers (i.e., OpenGL).
 	void _iterate();
 
-	void _write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, String p_hash, const Dictionary &p_metadata);
+	void _write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata);
 	void _read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata);
 
 	Vector<Ref<EditorResourcePreviewGenerator>> preview_generators;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -934,7 +934,7 @@ void EditorSettings::_load_default_visual_shader_editor_theme() {
 	_initial_set("editors/visual_editors/category_colors/particle_color", Color(0.12, 0.358, 0.8));
 }
 
-bool EditorSettings::_save_text_editor_theme(String p_file) {
+bool EditorSettings::_save_text_editor_theme(const String &p_file) {
 	String theme_section = "color_theme";
 	Ref<ConfigFile> cf = memnew(ConfigFile); // hex is better?
 
@@ -957,7 +957,7 @@ bool EditorSettings::_save_text_editor_theme(String p_file) {
 	return err == OK;
 }
 
-bool EditorSettings::_is_default_text_editor_theme(String p_theme_name) {
+bool EditorSettings::_is_default_text_editor_theme(const String &p_theme_name) {
 	return p_theme_name == "default" || p_theme_name == "godot 2" || p_theme_name == "custom";
 }
 
@@ -1251,7 +1251,7 @@ void EditorSettings::add_property_hint(const PropertyInfo &p_hint) {
 
 // Metadata
 
-void EditorSettings::set_project_metadata(const String &p_section, const String &p_key, Variant p_data) {
+void EditorSettings::set_project_metadata(const String &p_section, const String &p_key, const Variant &p_data) {
 	const String path = _get_project_metadata_path();
 
 	if (project_metadata.is_null()) {
@@ -1268,7 +1268,7 @@ void EditorSettings::set_project_metadata(const String &p_section, const String 
 	ERR_FAIL_COND_MSG(err != OK, "Cannot save project metadata to file '" + path + "'.");
 }
 
-Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const {
+Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, const Variant &p_default) const {
 	if (project_metadata.is_null()) {
 		project_metadata.instantiate();
 
@@ -1409,7 +1409,7 @@ void EditorSettings::load_text_editor_theme() {
 	// if it doesn't load just use what is currently loaded
 }
 
-bool EditorSettings::import_text_editor_theme(String p_file) {
+bool EditorSettings::import_text_editor_theme(const String &p_file) {
 	if (!p_file.ends_with(".tet")) {
 		return false;
 	} else {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -111,8 +111,8 @@ private:
 	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());
 	void _load_godot2_text_editor_theme();
 	void _load_default_visual_shader_editor_theme();
-	bool _save_text_editor_theme(String p_file);
-	bool _is_default_text_editor_theme(String p_theme_name);
+	bool _save_text_editor_theme(const String &p_file);
+	bool _is_default_text_editor_theme(const String &p_theme_name);
 	const String _get_project_metadata_path() const;
 
 protected:
@@ -155,8 +155,8 @@ public:
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
 
-	void set_project_metadata(const String &p_section, const String &p_key, Variant p_data);
-	Variant get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const;
+	void set_project_metadata(const String &p_section, const String &p_key, const Variant &p_data);
+	Variant get_project_metadata(const String &p_section, const String &p_key, const Variant &p_default) const;
 
 	void set_favorites(const Vector<String> &p_favorites);
 	Vector<String> get_favorites() const;
@@ -166,7 +166,7 @@ public:
 
 	void list_text_editor_themes();
 	void load_text_editor_theme();
-	bool import_text_editor_theme(String p_file);
+	bool import_text_editor_theme(const String &p_file);
 	bool save_text_editor_theme();
 	bool save_text_editor_theme_as(String p_file);
 	bool is_default_text_editor_theme();

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -34,18 +34,18 @@
 
 EditorVCSInterface *EditorVCSInterface::singleton = nullptr;
 
-void EditorVCSInterface::popup_error(String p_msg) {
+void EditorVCSInterface::popup_error(const String &p_msg) {
 	// TRANSLATORS: %s refers to the name of a version control system (e.g. "Git").
 	EditorNode::get_singleton()->show_warning(p_msg.strip_edges(), vformat(TTR("%s Error"), get_vcs_name()));
 }
 
-bool EditorVCSInterface::initialize(String p_project_path) {
+bool EditorVCSInterface::initialize(const String &p_project_path) {
 	bool result = false;
 	GDVIRTUAL_REQUIRED_CALL(_initialize, p_project_path, result);
 	return result;
 }
 
-void EditorVCSInterface::set_credentials(String p_username, String p_password, String p_ssh_public_key, String p_ssh_private_key, String p_ssh_passphrase) {
+void EditorVCSInterface::set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key, const String &p_ssh_private_key, const String &p_ssh_passphrase) {
 	GDVIRTUAL_REQUIRED_CALL(_set_credentials, p_username, p_password, p_ssh_public_key, p_ssh_private_key, p_ssh_passphrase);
 }
 
@@ -75,23 +75,23 @@ List<EditorVCSInterface::StatusFile> EditorVCSInterface::get_modified_files_data
 	return status_files;
 }
 
-void EditorVCSInterface::stage_file(String p_file_path) {
+void EditorVCSInterface::stage_file(const String &p_file_path) {
 	GDVIRTUAL_REQUIRED_CALL(_stage_file, p_file_path);
 }
 
-void EditorVCSInterface::unstage_file(String p_file_path) {
+void EditorVCSInterface::unstage_file(const String &p_file_path) {
 	GDVIRTUAL_REQUIRED_CALL(_unstage_file, p_file_path);
 }
 
-void EditorVCSInterface::discard_file(String p_file_path) {
+void EditorVCSInterface::discard_file(const String &p_file_path) {
 	GDVIRTUAL_REQUIRED_CALL(_discard_file, p_file_path);
 }
 
-void EditorVCSInterface::commit(String p_msg) {
+void EditorVCSInterface::commit(const String &p_msg) {
 	GDVIRTUAL_REQUIRED_CALL(_commit, p_msg);
 }
 
-List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(String p_identifier, TreeArea p_area) {
+List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(const String &p_identifier, TreeArea p_area) {
 	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_REQUIRED_CALL(_get_diff, p_identifier, int(p_area), result)) {
 		return {};
@@ -130,19 +130,19 @@ List<String> EditorVCSInterface::get_branch_list() {
 	return branch_list;
 }
 
-void EditorVCSInterface::create_branch(String p_branch_name) {
+void EditorVCSInterface::create_branch(const String &p_branch_name) {
 	GDVIRTUAL_REQUIRED_CALL(_create_branch, p_branch_name);
 }
 
-void EditorVCSInterface::create_remote(String p_remote_name, String p_remote_url) {
+void EditorVCSInterface::create_remote(const String &p_remote_name, const String &p_remote_url) {
 	GDVIRTUAL_REQUIRED_CALL(_create_remote, p_remote_name, p_remote_url);
 }
 
-void EditorVCSInterface::remove_branch(String p_branch_name) {
+void EditorVCSInterface::remove_branch(const String &p_branch_name) {
 	GDVIRTUAL_REQUIRED_CALL(_remove_branch, p_branch_name);
 }
 
-void EditorVCSInterface::remove_remote(String p_remote_name) {
+void EditorVCSInterface::remove_remote(const String &p_remote_name) {
 	GDVIRTUAL_REQUIRED_CALL(_remove_remote, p_remote_name);
 }
 
@@ -152,25 +152,25 @@ String EditorVCSInterface::get_current_branch_name() {
 	return result;
 }
 
-bool EditorVCSInterface::checkout_branch(String p_branch_name) {
+bool EditorVCSInterface::checkout_branch(const String &p_branch_name) {
 	bool result = false;
 	GDVIRTUAL_REQUIRED_CALL(_checkout_branch, p_branch_name, result);
 	return result;
 }
 
-void EditorVCSInterface::pull(String p_remote) {
+void EditorVCSInterface::pull(const String &p_remote) {
 	GDVIRTUAL_REQUIRED_CALL(_pull, p_remote);
 }
 
-void EditorVCSInterface::push(String p_remote, bool p_force) {
+void EditorVCSInterface::push(const String &p_remote, bool p_force) {
 	GDVIRTUAL_REQUIRED_CALL(_push, p_remote, p_force);
 }
 
-void EditorVCSInterface::fetch(String p_remote) {
+void EditorVCSInterface::fetch(const String &p_remote) {
 	GDVIRTUAL_REQUIRED_CALL(_fetch, p_remote);
 }
 
-List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(String p_file_path, String p_text) {
+List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(const String &p_file_path, const String &p_text) {
 	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_REQUIRED_CALL(_get_line_diff, p_file_path, p_text, result)) {
 		return {};
@@ -195,7 +195,7 @@ String EditorVCSInterface::get_vcs_name() {
 	return result;
 }
 
-Dictionary EditorVCSInterface::create_diff_line(int p_new_line_no, int p_old_line_no, String p_content, String p_status) {
+Dictionary EditorVCSInterface::create_diff_line(int p_new_line_no, int p_old_line_no, const String &p_content, const String &p_status) {
 	Dictionary diff_line;
 	diff_line["new_line_no"] = p_new_line_no;
 	diff_line["old_line_no"] = p_old_line_no;
@@ -220,7 +220,7 @@ Dictionary EditorVCSInterface::add_line_diffs_into_diff_hunk(Dictionary p_diff_h
 	return p_diff_hunk;
 }
 
-Dictionary EditorVCSInterface::create_diff_file(String p_new_file, String p_old_file) {
+Dictionary EditorVCSInterface::create_diff_file(const String &p_new_file, const String &p_old_file) {
 	Dictionary file_diff;
 	file_diff["new_file"] = p_new_file;
 	file_diff["old_file"] = p_old_file;
@@ -228,7 +228,7 @@ Dictionary EditorVCSInterface::create_diff_file(String p_new_file, String p_old_
 	return file_diff;
 }
 
-Dictionary EditorVCSInterface::create_commit(String p_msg, String p_author, String p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes) {
+Dictionary EditorVCSInterface::create_commit(const String &p_msg, const String &p_author, const String &p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes) {
 	Dictionary commit_info;
 	commit_info["message"] = p_msg;
 	commit_info["author"] = p_author;
@@ -243,7 +243,7 @@ Dictionary EditorVCSInterface::add_diff_hunks_into_diff_file(Dictionary p_diff_f
 	return p_diff_file;
 }
 
-Dictionary EditorVCSInterface::create_status_file(String p_file_path, ChangeType p_change, TreeArea p_area) {
+Dictionary EditorVCSInterface::create_status_file(const String &p_file_path, ChangeType p_change, TreeArea p_area) {
 	Dictionary sf;
 	sf["file_path"] = p_file_path;
 	sf["change_type"] = p_change;
@@ -251,7 +251,7 @@ Dictionary EditorVCSInterface::create_status_file(String p_file_path, ChangeType
 	return sf;
 }
 
-EditorVCSInterface::DiffLine EditorVCSInterface::_convert_diff_line(Dictionary p_diff_line) {
+EditorVCSInterface::DiffLine EditorVCSInterface::_convert_diff_line(const Dictionary &p_diff_line) {
 	DiffLine d;
 	d.new_line_no = p_diff_line["new_line_no"];
 	d.old_line_no = p_diff_line["old_line_no"];
@@ -260,7 +260,7 @@ EditorVCSInterface::DiffLine EditorVCSInterface::_convert_diff_line(Dictionary p
 	return d;
 }
 
-EditorVCSInterface::DiffHunk EditorVCSInterface::_convert_diff_hunk(Dictionary p_diff_hunk) {
+EditorVCSInterface::DiffHunk EditorVCSInterface::_convert_diff_hunk(const Dictionary &p_diff_hunk) {
 	DiffHunk dh;
 	dh.new_lines = p_diff_hunk["new_lines"];
 	dh.old_lines = p_diff_hunk["old_lines"];
@@ -274,7 +274,7 @@ EditorVCSInterface::DiffHunk EditorVCSInterface::_convert_diff_hunk(Dictionary p
 	return dh;
 }
 
-EditorVCSInterface::DiffFile EditorVCSInterface::_convert_diff_file(Dictionary p_diff_file) {
+EditorVCSInterface::DiffFile EditorVCSInterface::_convert_diff_file(const Dictionary &p_diff_file) {
 	DiffFile df;
 	df.new_file = p_diff_file["new_file"];
 	df.old_file = p_diff_file["old_file"];
@@ -286,7 +286,7 @@ EditorVCSInterface::DiffFile EditorVCSInterface::_convert_diff_file(Dictionary p
 	return df;
 }
 
-EditorVCSInterface::Commit EditorVCSInterface::_convert_commit(Dictionary p_commit) {
+EditorVCSInterface::Commit EditorVCSInterface::_convert_commit(const Dictionary &p_commit) {
 	EditorVCSInterface::Commit c;
 	c.msg = p_commit["message"];
 	c.author = p_commit["author"];
@@ -296,7 +296,7 @@ EditorVCSInterface::Commit EditorVCSInterface::_convert_commit(Dictionary p_comm
 	return c;
 }
 
-EditorVCSInterface::StatusFile EditorVCSInterface::_convert_status_file(Dictionary p_status_file) {
+EditorVCSInterface::StatusFile EditorVCSInterface::_convert_status_file(const Dictionary &p_status_file) {
 	StatusFile sf;
 	sf.file_path = p_status_file["file_path"];
 	sf.change_type = (ChangeType)(int)p_status_file["change_type"];

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -99,11 +99,11 @@ protected:
 
 	static void _bind_methods();
 
-	DiffLine _convert_diff_line(Dictionary p_diff_line);
-	DiffHunk _convert_diff_hunk(Dictionary p_diff_hunk);
-	DiffFile _convert_diff_file(Dictionary p_diff_file);
-	Commit _convert_commit(Dictionary p_commit);
-	StatusFile _convert_status_file(Dictionary p_status_file);
+	DiffLine _convert_diff_line(const Dictionary &p_diff_line);
+	DiffHunk _convert_diff_hunk(const Dictionary &p_diff_hunk);
+	DiffFile _convert_diff_file(const Dictionary &p_diff_file);
+	Commit _convert_commit(const Dictionary &p_commit);
+	StatusFile _convert_status_file(const Dictionary &p_status_file);
 
 	// Proxy endpoints for extensions to implement
 	GDVIRTUAL1R(bool, _initialize, String);
@@ -141,40 +141,40 @@ public:
 	static void create_vcs_metadata_files(VCSMetadata p_vcs_metadata_type, String &p_dir);
 
 	// Proxies to the editor for use
-	bool initialize(String p_project_path);
-	void set_credentials(String p_username, String p_password, String p_ssh_public_key_path, String p_ssh_private_key_path, String p_ssh_passphrase);
+	bool initialize(const String &p_project_path);
+	void set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key_path, const String &p_ssh_private_key_path, const String &p_ssh_passphrase);
 	List<StatusFile> get_modified_files_data();
-	void stage_file(String p_file_path);
-	void unstage_file(String p_file_path);
-	void discard_file(String p_file_path);
-	void commit(String p_msg);
-	List<DiffFile> get_diff(String p_identifier, TreeArea p_area);
+	void stage_file(const String &p_file_path);
+	void unstage_file(const String &p_file_path);
+	void discard_file(const String &p_file_path);
+	void commit(const String &p_msg);
+	List<DiffFile> get_diff(const String &p_identifier, TreeArea p_area);
 	bool shut_down();
 	String get_vcs_name();
 	List<Commit> get_previous_commits(int p_max_commits);
 	List<String> get_branch_list();
 	List<String> get_remotes();
-	void create_branch(String p_branch_name);
-	void remove_branch(String p_branch_name);
-	void create_remote(String p_remote_name, String p_remote_url);
-	void remove_remote(String p_remote_name);
+	void create_branch(const String &p_branch_name);
+	void remove_branch(const String &p_branch_name);
+	void create_remote(const String &p_remote_name, const String &p_remote_url);
+	void remove_remote(const String &p_remote_name);
 	String get_current_branch_name();
-	bool checkout_branch(String p_branch_name);
-	void pull(String p_remote);
-	void push(String p_remote, bool p_force);
-	void fetch(String p_remote);
-	List<DiffHunk> get_line_diff(String p_file_path, String p_text);
+	bool checkout_branch(const String &p_branch_name);
+	void pull(const String &p_remote);
+	void push(const String &p_remote, bool p_force);
+	void fetch(const String &p_remote);
+	List<DiffHunk> get_line_diff(const String &p_file_path, const String &p_text);
 
 	// Helper functions to create and convert Dictionary into data structures
-	Dictionary create_diff_line(int p_new_line_no, int p_old_line_no, String p_content, String p_status);
+	Dictionary create_diff_line(int p_new_line_no, int p_old_line_no, const String &p_content, const String &p_status);
 	Dictionary create_diff_hunk(int p_old_start, int p_new_start, int p_old_lines, int p_new_lines);
-	Dictionary create_diff_file(String p_new_file, String p_old_file);
-	Dictionary create_commit(String p_msg, String p_author, String p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes);
-	Dictionary create_status_file(String p_file_path, ChangeType p_change, TreeArea p_area);
+	Dictionary create_diff_file(const String &p_new_file, const String &p_old_file);
+	Dictionary create_commit(const String &p_msg, const String &p_author, const String &p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes);
+	Dictionary create_status_file(const String &p_file_path, ChangeType p_change, TreeArea p_area);
 	Dictionary add_line_diffs_into_diff_hunk(Dictionary p_diff_hunk, TypedArray<Dictionary> p_line_diffs);
 	Dictionary add_diff_hunks_into_diff_file(Dictionary p_diff_file, TypedArray<Dictionary> p_diff_hunks);
 
-	void popup_error(String p_msg);
+	void popup_error(const String &p_msg);
 };
 
 VARIANT_ENUM_CAST(EditorVCSInterface::ChangeType);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -329,7 +329,7 @@ Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 	}
 }
 
-String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
+String EditorExportPlatform::find_export_template(const String &template_file_name, String *err) const {
 	String current_version = VERSION_FULL_CONFIG;
 	String template_path = EditorPaths::get_singleton()->get_export_templates_dir().path_join(current_version).path_join(template_file_name);
 
@@ -344,7 +344,7 @@ String EditorExportPlatform::find_export_template(String template_file_name, Str
 	return String();
 }
 
-bool EditorExportPlatform::exists_export_template(String template_file_name, String *err) const {
+bool EditorExportPlatform::exists_export_template(const String &template_file_name, String *err) const {
 	return find_export_template(template_file_name, err) != "";
 }
 

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -132,8 +132,8 @@ protected:
 
 	HashSet<String> get_features(const Ref<EditorExportPreset> &p_preset, bool p_debug) const;
 
-	bool exists_export_template(String template_file_name, String *err) const;
-	String find_export_template(String template_file_name, String *err = nullptr) const;
+	bool exists_export_template(const String &template_file_name, String *err) const;
+	String find_export_template(const String &template_file_name, String *err = nullptr) const;
 	void gen_export_flags(Vector<String> &r_flags, int p_flags);
 	void gen_debug_flags(Vector<String> &r_flags, int p_flags);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -80,7 +80,7 @@ Control *FileSystemList::make_custom_tooltip(const String &p_text) const {
 	return FileSystemDock::get_singleton()->create_tooltip_for_path(get_item_metadata(idx));
 }
 
-void FileSystemList::_line_editor_submit(String p_text) {
+void FileSystemList::_line_editor_submit(const String &p_text) {
 	popup_editor->hide();
 
 	emit_signal(SNAME("item_edited"));
@@ -173,7 +173,7 @@ FileSystemList::FileSystemList() {
 
 FileSystemDock *FileSystemDock::singleton = nullptr;
 
-Ref<Texture2D> FileSystemDock::_get_tree_item_icon(bool p_is_valid, String p_file_type) {
+Ref<Texture2D> FileSystemDock::_get_tree_item_icon(bool p_is_valid, const String &p_file_type) {
 	Ref<Texture2D> file_icon;
 	if (!p_is_valid) {
 		file_icon = get_editor_theme_icon(SNAME("ImportFail"));
@@ -1678,7 +1678,7 @@ void FileSystemDock::_resource_removed(const Ref<Resource> &p_resource) {
 	emit_signal(SNAME("resource_removed"), p_resource);
 }
 
-void FileSystemDock::_file_removed(String p_file) {
+void FileSystemDock::_file_removed(const String &p_file) {
 	emit_signal(SNAME("file_removed"), p_file);
 
 	// Find the closest parent directory available, in case multiple items were deleted along the same path.
@@ -1691,7 +1691,7 @@ void FileSystemDock::_file_removed(String p_file) {
 	current_path_line_edit->set_text(current_path);
 }
 
-void FileSystemDock::_folder_removed(String p_folder) {
+void FileSystemDock::_folder_removed(const String &p_folder) {
 	emit_signal(SNAME("folder_removed"), p_folder);
 
 	// Find the closest parent directory available, in case multiple items were deleted along the same path.
@@ -2986,7 +2986,7 @@ void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu)
 	_update_file_list(true);
 }
 
-void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options) {
+void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vector<String> &p_paths, bool p_display_path_dependent_options) {
 	// Add options for files and folders.
 	ERR_FAIL_COND_MSG(p_paths.is_empty(), "Path cannot be empty.");
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -64,7 +64,7 @@ class FileSystemList : public ItemList {
 	LineEdit *line_editor = nullptr;
 
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
-	void _line_editor_submit(String p_text);
+	void _line_editor_submit(const String &p_text);
 	void _text_editor_popup_modal_close();
 
 protected:
@@ -245,7 +245,7 @@ private:
 	void _tree_mouse_exited();
 	void _reselect_items_selected_on_drag_begin(bool reset = false);
 
-	Ref<Texture2D> _get_tree_item_icon(bool p_is_valid, String p_file_type);
+	Ref<Texture2D> _get_tree_item_icon(bool p_is_valid, const String &p_file_type);
 	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false);
 	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_select_in_favorites = false, bool p_unfold_path = false);
 	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false);
@@ -281,8 +281,8 @@ private:
 	void _update_folder_colors_setting();
 
 	void _resource_removed(const Ref<Resource> &p_resource);
-	void _file_removed(String p_file);
-	void _folder_removed(String p_folder);
+	void _file_removed(const String &p_file);
+	void _folder_removed(const String &p_folder);
 
 	void _resource_created();
 	void _make_scene_confirm();
@@ -313,7 +313,7 @@ private:
 	void _file_sort_popup(int p_id);
 
 	void _folder_color_index_pressed(int p_index, PopupMenu *p_menu);
-	void _file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options = true);
+	void _file_and_folders_fill_popup(PopupMenu *p_popup, const Vector<String> &p_paths, bool p_display_path_dependent_options = true);
 	void _tree_rmb_select(const Vector2 &p_pos, MouseButton p_button);
 	void _file_list_item_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _file_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -55,7 +55,7 @@ inline void pop_back(T &container) {
 	container.resize(container.size() - 1);
 }
 
-static bool find_next(const String &line, String pattern, int from, bool match_case, bool whole_words, int &out_begin, int &out_end) {
+static bool find_next(const String &line, const String &pattern, int from, bool match_case, bool whole_words, int &out_begin, int &out_end) {
 	int end = from;
 
 	while (true) {
@@ -84,7 +84,7 @@ static bool find_next(const String &line, String pattern, int from, bool match_c
 
 //--------------------------------------------------------------------------------
 
-void FindInFiles::set_search_text(String p_pattern) {
+void FindInFiles::set_search_text(const String &p_pattern) {
 	_pattern = p_pattern;
 }
 
@@ -96,7 +96,7 @@ void FindInFiles::set_match_case(bool p_match_case) {
 	_match_case = p_match_case;
 }
 
-void FindInFiles::set_folder(String folder) {
+void FindInFiles::set_folder(const String &folder) {
 	_root_dir = folder;
 }
 
@@ -213,7 +213,7 @@ float FindInFiles::get_progress() const {
 	return 0;
 }
 
-void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan) {
+void FindInFiles::_scan_dir(const String &path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan) {
 	Ref<DirAccess> dir = DirAccess::open(path);
 	if (dir.is_null()) {
 		print_verbose("Cannot open directory! " + path);
@@ -258,7 +258,7 @@ void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders, PackedS
 	}
 }
 
-void FindInFiles::_scan_file(String fpath) {
+void FindInFiles::_scan_file(const String &fpath) {
 	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
 	if (f.is_null()) {
 		print_verbose(String("Cannot open file ") + fpath);
@@ -397,12 +397,12 @@ FindInFilesDialog::FindInFilesDialog() {
 	_mode = SEARCH_MODE;
 }
 
-void FindInFilesDialog::set_search_text(String text) {
+void FindInFilesDialog::set_search_text(const String &text) {
 	_search_text_line_edit->set_text(text);
 	_on_search_text_modified(text);
 }
 
-void FindInFilesDialog::set_replace_text(String text) {
+void FindInFilesDialog::set_replace_text(const String &text) {
 	_replace_text_line_edit->set_text(text);
 }
 
@@ -505,7 +505,7 @@ void FindInFilesDialog::custom_action(const String &p_action) {
 	}
 }
 
-void FindInFilesDialog::_on_search_text_modified(String text) {
+void FindInFilesDialog::_on_search_text_modified(const String &text) {
 	ERR_FAIL_NULL(_find_button);
 	ERR_FAIL_NULL(_replace_button);
 
@@ -513,7 +513,7 @@ void FindInFilesDialog::_on_search_text_modified(String text) {
 	_replace_button->set_disabled(get_search_text().is_empty());
 }
 
-void FindInFilesDialog::_on_search_text_submitted(String text) {
+void FindInFilesDialog::_on_search_text_submitted(const String &text) {
 	// This allows to trigger a global search without leaving the keyboard.
 	if (!_find_button->is_disabled()) {
 		if (_mode == SEARCH_MODE) {
@@ -528,7 +528,7 @@ void FindInFilesDialog::_on_search_text_submitted(String text) {
 	}
 }
 
-void FindInFilesDialog::_on_replace_text_submitted(String text) {
+void FindInFilesDialog::_on_replace_text_submitted(const String &text) {
 	// This allows to trigger a global search without leaving the keyboard.
 	if (!_replace_button->is_disabled()) {
 		if (_mode == REPLACE_MODE) {
@@ -653,7 +653,7 @@ void FindInFilesPanel::set_with_replace(bool with_replace) {
 	}
 }
 
-void FindInFilesPanel::set_replace_text(String text) {
+void FindInFilesPanel::set_replace_text(const String &text) {
 	_replace_line_edit->set_text(text);
 }
 
@@ -710,7 +710,7 @@ void FindInFilesPanel::_notification(int p_what) {
 	}
 }
 
-void FindInFilesPanel::_on_result_found(String fpath, int line_number, int begin, int end, String text) {
+void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, int begin, int end, String text) {
 	TreeItem *file_item;
 	HashMap<String, TreeItem *>::Iterator E = _file_items.find(fpath);
 
@@ -844,7 +844,7 @@ void FindInFilesPanel::_on_result_selected() {
 	emit_signal(SNAME(SIGNAL_RESULT_SELECTED), fpath, r.line_number, r.begin, r.end);
 }
 
-void FindInFilesPanel::_on_replace_text_changed(String text) {
+void FindInFilesPanel::_on_replace_text_changed(const String &text) {
 	update_replace_buttons();
 }
 
@@ -914,7 +914,7 @@ private:
 	Vector<char> _line_buffer;
 };
 
-void FindInFilesPanel::apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text) {
+void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text) {
 	// If the file is already open, I assume the editor will reload it.
 	// If there are unsaved changes, the user will be asked on focus,
 	// however that means either losing changes or losing replaces.

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -42,10 +42,10 @@ public:
 	static const char *SIGNAL_RESULT_FOUND;
 	static const char *SIGNAL_FINISHED;
 
-	void set_search_text(String p_pattern);
+	void set_search_text(const String &p_pattern);
 	void set_whole_words(bool p_whole_word);
 	void set_match_case(bool p_match_case);
-	void set_folder(String folder);
+	void set_folder(const String &folder);
 	void set_filter(const HashSet<String> &exts);
 
 	String get_search_text() const { return _pattern; }
@@ -67,8 +67,8 @@ protected:
 private:
 	void _process();
 	void _iterate();
-	void _scan_dir(String path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan);
-	void _scan_file(String fpath);
+	void _scan_dir(const String &path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan);
+	void _scan_file(const String &fpath);
 
 	// Config
 	String _pattern;
@@ -105,8 +105,8 @@ public:
 
 	FindInFilesDialog();
 
-	void set_search_text(String text);
-	void set_replace_text(String text);
+	void set_search_text(const String &text);
+	void set_replace_text(const String &text);
 
 	void set_find_in_files_mode(FindInFilesMode p_mode);
 
@@ -127,9 +127,9 @@ protected:
 private:
 	void _on_folder_button_pressed();
 	void _on_folder_selected(String path);
-	void _on_search_text_modified(String text);
-	void _on_search_text_submitted(String text);
-	void _on_replace_text_submitted(String text);
+	void _on_search_text_modified(const String &text);
+	void _on_search_text_submitted(const String &text);
+	void _on_replace_text_submitted(const String &text);
 
 	FindInFilesMode _mode;
 	LineEdit *_search_text_line_edit = nullptr;
@@ -165,7 +165,7 @@ public:
 	FindInFiles *get_finder() const { return _finder; }
 
 	void set_with_replace(bool with_replace);
-	void set_replace_text(String text);
+	void set_replace_text(const String &text);
 
 	void start_search();
 	void stop_search();
@@ -176,13 +176,13 @@ protected:
 	void _notification(int p_what);
 
 private:
-	void _on_result_found(String fpath, int line_number, int begin, int end, String text);
+	void _on_result_found(const String &fpath, int line_number, int begin, int end, String text);
 	void _on_finished();
 	void _on_refresh_button_clicked();
 	void _on_cancel_button_clicked();
 	void _on_result_selected();
 	void _on_item_edited();
-	void _on_replace_text_changed(String text);
+	void _on_replace_text_changed(const String &text);
 	void _on_replace_all_clicked();
 
 	struct Result {
@@ -192,7 +192,7 @@ private:
 		int begin_trimmed = 0;
 	};
 
-	void apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text);
+	void apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text);
 	void update_replace_buttons();
 	String get_replace_text();
 

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -287,7 +287,7 @@ void EditorFileDialog::update_dir() {
 	}
 }
 
-void EditorFileDialog::_dir_submitted(String p_dir) {
+void EditorFileDialog::_dir_submitted(const String &p_dir) {
 	dir_access->change_dir(p_dir);
 	invalidate();
 	update_dir();

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -199,7 +199,7 @@ private:
 	void _item_menu_id_pressed(int p_option);
 
 	void _select_drive(int p_idx);
-	void _dir_submitted(String p_dir);
+	void _dir_submitted(const String &p_dir);
 	void _action_pressed();
 	void _save_confirm_pressed();
 	void _cancel_pressed();

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -342,7 +342,7 @@ void EditorToaster::_repop_old() {
 	}
 }
 
-Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_time, String p_tooltip) {
+Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_time, const String &p_tooltip) {
 	// Create the panel according to the severity.
 	PanelContainer *panel = memnew(PanelContainer);
 	panel->set_tooltip_text(p_tooltip);
@@ -398,7 +398,7 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 	return panel;
 }
 
-void EditorToaster::popup_str(String p_message, Severity p_severity, String p_tooltip) {
+void EditorToaster::popup_str(const String &p_message, Severity p_severity, const String &p_tooltip) {
 	if (is_processing_error) {
 		return;
 	}
@@ -410,7 +410,7 @@ void EditorToaster::popup_str(String p_message, Severity p_severity, String p_to
 	is_processing_error = false;
 }
 
-void EditorToaster::_popup_str(String p_message, Severity p_severity, String p_tooltip) {
+void EditorToaster::_popup_str(const String &p_message, Severity p_severity, const String &p_tooltip) {
 	is_processing_error = true;
 	// Check if we already have a popup with the given message.
 	Control *control = nullptr;

--- a/editor/gui/editor_toaster.h
+++ b/editor/gui/editor_toaster.h
@@ -100,7 +100,7 @@ private:
 
 	void _set_notifications_enabled(bool p_enabled);
 	void _repop_old();
-	void _popup_str(String p_message, Severity p_severity, String p_tooltip);
+	void _popup_str(const String &p_message, Severity p_severity, const String &p_tooltip);
 	void _close_button_theme_changed(Control *p_close_button);
 
 protected:
@@ -111,8 +111,8 @@ protected:
 public:
 	static EditorToaster *get_singleton();
 
-	Control *popup(Control *p_control, Severity p_severity = SEVERITY_INFO, double p_time = 0.0, String p_tooltip = String());
-	void popup_str(String p_message, Severity p_severity = SEVERITY_INFO, String p_tooltip = String());
+	Control *popup(Control *p_control, Severity p_severity = SEVERITY_INFO, double p_time = 0.0, const String &p_tooltip = String());
+	void popup_str(const String &p_message, Severity p_severity = SEVERITY_INFO, const String &p_tooltip = String());
 	void close(Control *p_control);
 
 	EditorToaster();

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -750,7 +750,7 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 	return p_parent->is_visible();
 }
 
-bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, PackedStringArray p_terms) {
+bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms) {
 	if (p_terms.is_empty()) {
 		return true;
 	}

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -79,7 +79,7 @@ class SceneTreeEditor : public Control {
 	void _add_nodes(Node *p_node, TreeItem *p_parent);
 	void _test_update_tree();
 	bool _update_filter(TreeItem *p_parent = nullptr, bool p_scroll_to_selected = false);
-	bool _item_matches_all_terms(TreeItem *p_item, PackedStringArray p_terms);
+	bool _item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms);
 	void _tree_changed();
 	void _tree_process_mode_changed();
 	void _node_removed(Node *p_node);

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -834,7 +834,7 @@ void Collada::_parse_light(XMLParser &p_parser) {
 	COLLADA_PRINT("Light ID:" + id);
 }
 
-void Collada::_parse_curve_geometry(XMLParser &p_parser, String p_id, String p_name) {
+void Collada::_parse_curve_geometry(XMLParser &p_parser, const String &p_id, const String &p_name) {
 	if (!(state.import_flags & IMPORT_FLAG_SCENE)) {
 		if (!p_parser.is_empty()) {
 			p_parser.skip_section();
@@ -916,7 +916,7 @@ void Collada::_parse_curve_geometry(XMLParser &p_parser, String p_id, String p_n
 	}
 }
 
-void Collada::_parse_mesh_geometry(XMLParser &p_parser, String p_id, String p_name) {
+void Collada::_parse_mesh_geometry(XMLParser &p_parser, const String &p_id, const String &p_name) {
 	if (!(state.import_flags & IMPORT_FLAG_SCENE)) {
 		if (!p_parser.is_empty()) {
 			p_parser.skip_section();
@@ -1070,7 +1070,7 @@ void Collada::_parse_mesh_geometry(XMLParser &p_parser, String p_id, String p_na
 	}
 }
 
-void Collada::_parse_skin_controller(XMLParser &p_parser, String p_id) {
+void Collada::_parse_skin_controller(XMLParser &p_parser, const String &p_id) {
 	state.skin_controller_data_map[p_id] = SkinControllerData();
 	SkinControllerData &skindata = state.skin_controller_data_map[p_id];
 
@@ -1224,7 +1224,7 @@ void Collada::_parse_skin_controller(XMLParser &p_parser, String p_id) {
 	}
 }
 
-void Collada::_parse_morph_controller(XMLParser &p_parser, String p_id) {
+void Collada::_parse_morph_controller(XMLParser &p_parser, const String &p_id) {
 	state.morph_controller_data_map[p_id] = MorphControllerData();
 	MorphControllerData &morphdata = state.morph_controller_data_map[p_id];
 
@@ -2311,7 +2311,7 @@ void Collada::_optimize() {
 	}
 }
 
-int Collada::get_uv_channel(String p_name) {
+int Collada::get_uv_channel(const String &p_name) {
 	if (!channel_map.has(p_name)) {
 		ERR_FAIL_COND_V(channel_map.size() == 2, 0);
 

--- a/editor/import/3d/collada.h
+++ b/editor/import/3d/collada.h
@@ -521,7 +521,7 @@ public:
 
 	Transform3D get_root_transform() const;
 
-	int get_uv_channel(String p_name);
+	int get_uv_channel(const String &p_name);
 
 private: // private stuff
 	HashMap<String, int> channel_map;
@@ -535,11 +535,11 @@ private: // private stuff
 	void _parse_light(XMLParser &p_parser);
 	void _parse_animation_clip(XMLParser &p_parser);
 
-	void _parse_mesh_geometry(XMLParser &p_parser, String p_id, String p_name);
-	void _parse_curve_geometry(XMLParser &p_parser, String p_id, String p_name);
+	void _parse_mesh_geometry(XMLParser &p_parser, const String &p_id, const String &p_name);
+	void _parse_curve_geometry(XMLParser &p_parser, const String &p_id, const String &p_name);
 
-	void _parse_skin_controller(XMLParser &p_parser, String p_id);
-	void _parse_morph_controller(XMLParser &p_parser, String p_id);
+	void _parse_skin_controller(XMLParser &p_parser, const String &p_id);
+	void _parse_morph_controller(XMLParser &p_parser, const String &p_id);
 	void _parse_controller(XMLParser &p_parser);
 
 	Node *_parse_visual_instance_geometry(XMLParser &p_parser);

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -88,7 +88,7 @@ struct ColladaImport {
 	Error _create_scene(Collada::Node *p_node, Node3D *p_parent);
 	Error _create_resources(Collada::Node *p_node, bool p_use_compression);
 	Error _create_material(const String &p_target);
-	Error _create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p_mesh, const HashMap<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform3D &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, Vector<Ref<ImporterMesh>> p_morph_meshes = Vector<Ref<ImporterMesh>>(), bool p_use_compression = false, bool p_use_mesh_material = false);
+	Error _create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p_mesh, const HashMap<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform3D &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, const Vector<Ref<ImporterMesh>> &p_morph_meshes = Vector<Ref<ImporterMesh>>(), bool p_use_compression = false, bool p_use_mesh_material = false);
 	Error load(const String &p_path, int p_flags, bool p_force_make_tangents = false, bool p_use_compression = false);
 	void _fix_param_animation_tracks();
 	void create_animation(int p_clip, bool p_import_value_tracks);
@@ -467,7 +467,7 @@ Error ColladaImport::_create_material(const String &p_target) {
 	return OK;
 }
 
-Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p_mesh, const HashMap<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform3D &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, Vector<Ref<ImporterMesh>> p_morph_meshes, bool p_use_compression, bool p_use_mesh_material) {
+Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p_mesh, const HashMap<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform3D &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, const Vector<Ref<ImporterMesh>> &p_morph_meshes, bool p_use_compression, bool p_use_mesh_material) {
 	bool local_xform_mirror = p_local_xform.basis.determinant() < 0;
 
 	if (p_morph_data) {

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -156,11 +156,11 @@ Variant EditorScenePostImportPlugin::get_option_value(const StringName &p_name) 
 	}
 	return Variant();
 }
-void EditorScenePostImportPlugin::add_import_option(const String &p_name, Variant p_default_value) {
+void EditorScenePostImportPlugin::add_import_option(const String &p_name, const Variant &p_default_value) {
 	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option() can only be called from get_import_options().");
 	add_import_option_advanced(p_default_value.get_type(), p_name, p_default_value);
 }
-void EditorScenePostImportPlugin::add_import_option_advanced(Variant::Type p_type, const String &p_name, Variant p_default_value, PropertyHint p_hint, const String &p_hint_string, int p_usage_flags) {
+void EditorScenePostImportPlugin::add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint, const String &p_hint_string, int p_usage_flags) {
 	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option_advanced() can only be called from get_import_options().");
 	current_option_list->push_back(ResourceImporter::ImportOption(PropertyInfo(p_type, p_name, p_hint, p_hint_string, p_usage_flags), p_default_value));
 }
@@ -1445,7 +1445,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 	return p_node;
 }
 
-Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, String p_save_to_path, bool p_keep_custom_tracks) {
+Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, const String &p_save_to_path, bool p_keep_custom_tracks) {
 	if (!p_save_to_file || !p_save_to_path.is_resource_file()) {
 		return anim;
 	}

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -54,8 +54,8 @@ class EditorSceneFormatImporter : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	Node *import_scene_wrapper(const String &p_path, uint32_t p_flags, Dictionary p_options);
-	Ref<Animation> import_animation_wrapper(const String &p_path, uint32_t p_flags, Dictionary p_options);
+	Node *import_scene_wrapper(const String &p_path, uint32_t p_flags, const Dictionary &p_options);
+	Ref<Animation> import_animation_wrapper(const String &p_path, uint32_t p_flags, const Dictionary &p_options);
 
 	GDVIRTUAL0RC(uint32_t, _get_import_flags)
 	GDVIRTUAL0RC(Vector<String>, _get_extensions)
@@ -136,8 +136,8 @@ protected:
 
 public:
 	Variant get_option_value(const StringName &p_name) const;
-	void add_import_option(const String &p_name, Variant p_default_value);
-	void add_import_option_advanced(Variant::Type p_type, const String &p_name, Variant p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
+	void add_import_option(const String &p_name, const Variant &p_default_value);
+	void add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
 
 	virtual void get_internal_import_options(InternalImportCategory p_category, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_internal_option_visibility(InternalImportCategory p_category, bool p_for_animation, const String &p_option, const HashMap<StringName, Variant> &p_options) const;
@@ -287,7 +287,7 @@ public:
 	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps, float p_applied_root_scale);
 	Node *_post_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps);
 
-	Ref<Animation> _save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, String p_save_to_path, bool p_keep_custom_tracks);
+	Ref<Animation> _save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, const String &p_save_to_path, bool p_keep_custom_tracks);
 	void _create_slices(AnimationPlayer *ap, Ref<Animation> anim, const Array &p_clips, bool p_bake_all);
 	void _optimize_animations(AnimationPlayer *anim, float p_max_vel_error, float p_max_ang_error, int p_prc_error);
 	void _compress_animations(AnimationPlayer *anim, int p_page_size_kb);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -694,7 +694,7 @@ Node *SceneImportSettingsDialog::get_selected_node() {
 	return node_map[selected_id].node;
 }
 
-void SceneImportSettingsDialog::_select(Tree *p_from, String p_type, String p_id) {
+void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, const String &p_id) {
 	selecting = true;
 	scene_import_settings_data->hide_options = false;
 

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -162,7 +162,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	void _update_view_gizmos();
 	void _update_camera();
-	void _select(Tree *p_from, String p_type, String p_id);
+	void _select(Tree *p_from, const String &p_type, const String &p_id);
 	void _inspector_property_edited(const String &p_name);
 	void _reset_bone_transforms();
 	void _play_animation();

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -244,7 +244,7 @@ void InspectorDock::_load_resource(const String &p_type) {
 	load_resource_dialog->popup_file_dialog();
 }
 
-void InspectorDock::_resource_file_selected(String p_file) {
+void InspectorDock::_resource_file_selected(const String &p_file) {
 	Ref<Resource> res;
 	if (ResourceLoader::exists(p_file, "")) {
 		res = ResourceLoader::load(p_file);

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -114,7 +114,7 @@ class InspectorDock : public VBoxContainer {
 	void _new_resource();
 	void _load_resource(const String &p_type = "");
 	void _open_resource_selector() { _load_resource(); }; // just used to call from arg-less signal
-	void _resource_file_selected(String p_file);
+	void _resource_file_selected(const String &p_file);
 	void _save_resource(bool save_as);
 	void _unref_resource();
 	void _copy_resource();

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -233,7 +233,7 @@ void AbstractPolygon2DEditor::_wip_close() {
 	selected_point = Vertex();
 }
 
-void AbstractPolygon2DEditor::disable_polygon_editing(bool p_disable, String p_reason) {
+void AbstractPolygon2DEditor::disable_polygon_editing(bool p_disable, const String &p_reason) {
 	_polygon_editing_enabled = !p_disable;
 
 	button_create->set_disabled(p_disable);
@@ -766,7 +766,7 @@ void AbstractPolygon2DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-AbstractPolygon2DEditorPlugin::AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, String p_class) :
+AbstractPolygon2DEditorPlugin::AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, const String &p_class) :
 		polygon_editor(p_polygon_editor),
 		klass(p_class) {
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(polygon_editor);

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -137,7 +137,7 @@ protected:
 	virtual void _create_resource();
 
 public:
-	void disable_polygon_editing(bool p_disable, String p_reason);
+	void disable_polygon_editing(bool p_disable, const String &p_reason);
 
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
@@ -162,7 +162,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, String p_class);
+	AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, const String &p_class);
 	~AbstractPolygon2DEditorPlugin();
 };
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -494,7 +494,7 @@ void AnimationNodeBlendTreeEditor::_disconnection_request(const String &p_from, 
 	updating = false;
 }
 
-void AnimationNodeBlendTreeEditor::_anim_selected(int p_index, Array p_options, const String &p_node) {
+void AnimationNodeBlendTreeEditor::_anim_selected(int p_index, const Array &p_options, const String &p_node) {
 	String option = p_options[p_index];
 
 	Ref<AnimationNodeAnimation> anim = blend_tree->get_node(p_node);

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -111,7 +111,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _scroll_changed(const Vector2 &p_scroll);
 	void _node_selected(Object *p_node);
 	void _open_in_editor(const String &p_which);
-	void _anim_selected(int p_index, Array p_options, const String &p_node);
+	void _anim_selected(int p_index, const Array &p_options, const String &p_node);
 	void _delete_node_request(const String &p_which);
 	void _delete_nodes_request(const TypedArray<StringName> &p_nodes);
 

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -300,7 +300,7 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 	}
 }
 
-void AnimationLibraryEditor::_load_file(String p_path) {
+void AnimationLibraryEditor::_load_file(const String &p_path) {
 	switch (file_dialog_action) {
 		case FILE_DIALOG_ACTION_SAVE_LIBRARY: {
 			Ref<AnimationLibrary> al = mixer->get_animation_library(file_dialog_library);

--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -100,7 +100,7 @@ class AnimationLibraryEditor : public AcceptDialog {
 	void _add_library_validate(const String &p_name);
 	void _add_library_confirm();
 	void _load_library();
-	void _load_file(String p_path);
+	void _load_file(const String &p_path);
 	void _load_files(const PackedStringArray &p_paths);
 
 	void _item_renamed();

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1184,7 +1184,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	state_machine_play_pos->queue_redraw();
 }
 
-void AnimationNodeStateMachineEditor::_state_machine_pos_draw_individual(String p_name, float p_ratio) {
+void AnimationNodeStateMachineEditor::_state_machine_pos_draw_individual(const String &p_name, float p_ratio) {
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
 		return;

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -134,7 +134,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	void _state_machine_draw();
 
-	void _state_machine_pos_draw_individual(String p_name, float p_ratio);
+	void _state_machine_pos_draw_individual(const String &p_name, float p_ratio);
 	void _state_machine_pos_draw_all();
 
 	void _update_graph();

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
@@ -43,7 +43,7 @@ bool AudioStreamRandomizerEditorPlugin::handles(Object *p_object) const {
 void AudioStreamRandomizerEditorPlugin::make_visible(bool p_visible) {
 }
 
-void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos) {
+void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos) {
 	EditorUndoRedoManager *undo_redo_man = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo_man);
 

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.h
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.h
@@ -38,7 +38,7 @@ class AudioStreamRandomizerEditorPlugin : public EditorPlugin {
 	GDCLASS(AudioStreamRandomizerEditorPlugin, EditorPlugin);
 
 private:
-	void _move_stream_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos);
+	void _move_stream_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos);
 
 public:
 	virtual String get_name() const override { return "AudioStreamRandomizer"; }

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -136,7 +136,7 @@ void BoneMapperItem::_open_picker() {
 	emit_signal(SNAME("pick"), profile_bone_name);
 }
 
-void BoneMapperItem::_value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void BoneMapperItem::_value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	bone_map->set(p_property, p_value);
 }
 
@@ -534,12 +534,12 @@ void BoneMapper::_clear_mapping_current_group() {
 }
 
 #ifdef MODULE_REGEX_ENABLED
-bool BoneMapper::is_match_with_bone_name(String p_bone_name, String p_word) {
+bool BoneMapper::is_match_with_bone_name(const String &p_bone_name, const String &p_word) {
 	RegEx re = RegEx(p_word);
 	return !re.search(p_bone_name.to_lower()).is_null();
 }
 
-int BoneMapper::search_bone_by_name(Skeleton3D *p_skeleton, Vector<String> p_picklist, BoneSegregation p_segregation, int p_parent, int p_child, int p_children_count) {
+int BoneMapper::search_bone_by_name(Skeleton3D *p_skeleton, const Vector<String> &p_picklist, BoneSegregation p_segregation, int p_parent, int p_child, int p_children_count) {
 	// There may be multiple candidates hit by existing the subsidiary bone.
 	// The one with the shortest name is probably the original.
 	LocalVector<String> hit_list;
@@ -617,7 +617,7 @@ int BoneMapper::search_bone_by_name(Skeleton3D *p_skeleton, Vector<String> p_pic
 	return skeleton->find_bone(shortest);
 }
 
-BoneMapper::BoneSegregation BoneMapper::guess_bone_segregation(String p_bone_name) {
+BoneMapper::BoneSegregation BoneMapper::guess_bone_segregation(const String &p_bone_name) {
 	String fixed_bn = p_bone_name.to_snake_case();
 
 	LocalVector<String> left_words;
@@ -1279,12 +1279,12 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 }
 #endif // MODULE_REGEX_ENABLED
 
-void BoneMapper::_value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void BoneMapper::_value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	set(p_property, p_value);
 	recreate_editor();
 }
 
-void BoneMapper::_profile_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void BoneMapper::_profile_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	bone_map->set(p_property, p_value);
 
 	// Run auto mapping when setting SkeletonProfileHumanoid by GUI Editor.

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -99,7 +99,7 @@ class BoneMapperItem : public VBoxContainer {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual void _value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing);
+	virtual void _value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
 	virtual void create_editor();
 
 public:
@@ -179,9 +179,9 @@ class BoneMapper : public VBoxContainer {
 		BONE_SEGREGATION_LEFT,
 		BONE_SEGREGATION_RIGHT
 	};
-	bool is_match_with_bone_name(String p_bone_name, String p_word);
-	int search_bone_by_name(Skeleton3D *p_skeleton, Vector<String> p_picklist, BoneSegregation p_segregation = BONE_SEGREGATION_NONE, int p_parent = -1, int p_child = -1, int p_children_count = -1);
-	BoneSegregation guess_bone_segregation(String p_bone_name);
+	bool is_match_with_bone_name(const String &p_bone_name, const String &p_word);
+	int search_bone_by_name(Skeleton3D *p_skeleton, const Vector<String> &p_picklist, BoneSegregation p_segregation = BONE_SEGREGATION_NONE, int p_parent = -1, int p_child = -1, int p_children_count = -1);
+	BoneSegregation guess_bone_segregation(const String &p_bone_name);
 	void auto_mapping_process(Ref<BoneMap> &p_bone_map);
 	void _run_auto_mapping();
 #endif // MODULE_REGEX_ENABLED
@@ -189,8 +189,8 @@ class BoneMapper : public VBoxContainer {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual void _value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing);
-	virtual void _profile_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing);
+	virtual void _value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
+	virtual void _profile_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
 
 public:
 	void set_current_group_idx(int p_group_idx);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -861,7 +861,7 @@ void CanvasItemEditor::_restore_canvas_item_state(const List<CanvasItem *> &p_ca
 	}
 }
 
-void CanvasItemEditor::_commit_canvas_item_state(const List<CanvasItem *> &p_canvas_items, String action_name, bool commit_bones) {
+void CanvasItemEditor::_commit_canvas_item_state(const List<CanvasItem *> &p_canvas_items, const String &action_name, bool commit_bones) {
 	List<CanvasItem *> modified_canvas_items;
 	for (CanvasItem *ci : p_canvas_items) {
 		Dictionary old_state = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(ci)->undo_state;
@@ -2708,7 +2708,7 @@ Control::CursorShape CanvasItemEditor::get_cursor_shape(const Point2 &p_pos) con
 	return c;
 }
 
-void CanvasItemEditor::_draw_text_at_position(Point2 p_position, String p_string, Side p_side) {
+void CanvasItemEditor::_draw_text_at_position(Point2 p_position, const String &p_string, Side p_side) {
 	Color color = get_theme_color(SNAME("font_color"), EditorStringName(Editor));
 	color.a = 0.8;
 	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -394,7 +394,7 @@ private:
 
 	void _save_canvas_item_state(const List<CanvasItem *> &p_canvas_items, bool save_bones = false);
 	void _restore_canvas_item_state(const List<CanvasItem *> &p_canvas_items, bool restore_bones = false);
-	void _commit_canvas_item_state(const List<CanvasItem *> &p_canvas_items, String action_name, bool commit_bones = false);
+	void _commit_canvas_item_state(const List<CanvasItem *> &p_canvas_items, const String &action_name, bool commit_bones = false);
 
 	Vector2 _anchor_to_position(const Control *p_control, Vector2 anchor);
 	Vector2 _position_to_anchor(const Control *p_control, Vector2 position);
@@ -440,7 +440,7 @@ private:
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_ev) override;
 
-	void _draw_text_at_position(Point2 p_position, String p_string, Side p_side);
+	void _draw_text_at_position(Point2 p_position, const String &p_string, Side p_side);
 	void _draw_margin_at_position(int p_value, Point2 p_position, Side p_side);
 	void _draw_percentage_at_position(real_t p_value, Point2 p_position, Side p_side);
 	void _draw_straight_line(Point2 p_from, Point2 p_to, Color p_color);

--- a/editor/plugins/editor_debugger_plugin.cpp
+++ b/editor/plugins/editor_debugger_plugin.cpp
@@ -32,7 +32,7 @@
 
 #include "editor/debugger/script_editor_debugger.h"
 
-void EditorDebuggerSession::_breaked(bool p_really_did, bool p_can_debug, String p_message, bool p_has_stackdump) {
+void EditorDebuggerSession::_breaked(bool p_really_did, bool p_can_debug, const String &p_message, bool p_has_stackdump) {
 	if (p_really_did) {
 		emit_signal(SNAME("breaked"), p_can_debug);
 	} else {

--- a/editor/plugins/editor_debugger_plugin.h
+++ b/editor/plugins/editor_debugger_plugin.h
@@ -43,7 +43,7 @@ private:
 
 	ScriptEditorDebugger *debugger = nullptr;
 
-	void _breaked(bool p_really_did, bool p_can_debug, String p_message, bool p_has_stackdump);
+	void _breaked(bool p_really_did, bool p_can_debug, const String &p_message, bool p_has_stackdump);
 	void _started();
 	void _stopped();
 	void _debugger_gone_away();

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -163,7 +163,7 @@ void EditorPropertyFontMetaOverride::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyFontMetaOverride::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void EditorPropertyFontMetaOverride::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
 		String key = p_property.get_slice("/", 1);
@@ -391,7 +391,7 @@ void EditorPropertyOTVariation::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyOTVariation::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void EditorPropertyOTVariation::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
 		Dictionary defaults_dict = object->get_defaults();
@@ -559,7 +559,7 @@ void EditorPropertyOTFeatures::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyOTFeatures::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void EditorPropertyOTFeatures::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
 		int key = p_property.get_slice("/", 1).to_int();

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -108,7 +108,7 @@ protected:
 
 	void _edit_pressed();
 	void _page_changed(int p_page);
-	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
+	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 	void _remove(Object *p_button, const String &p_key);
 	void _add_menu();
 	void _add_script(int p_option);
@@ -144,7 +144,7 @@ protected:
 
 	void _edit_pressed();
 	void _page_changed(int p_page);
-	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
+	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
 public:
@@ -193,7 +193,7 @@ protected:
 
 	void _edit_pressed();
 	void _page_changed(int p_page);
-	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
+	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 	void _remove(Object *p_button, int p_key);
 	void _add_menu();
 	void _add_feature(int p_option);

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -93,7 +93,7 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 	for (const String &arch_tag : archs) {
 		PackedStringArray tags;
 		String library_path = GDExtension::find_extension_library(
-				p_path, config, [features_wo_arch, arch_tag](String p_feature) { return features_wo_arch.has(p_feature) || (p_feature == arch_tag); }, &tags);
+				p_path, config, [features_wo_arch, arch_tag](const String &p_feature) { return features_wo_arch.has(p_feature) || (p_feature == arch_tag); }, &tags);
 		if (libs_added.has(library_path)) {
 			continue; // Universal library, already added for another arch, do not duplicate.
 		}

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -303,7 +303,7 @@ void EditorInspectorPluginMaterial::parse_begin(Object *p_object) {
 	add_custom_control(editor);
 }
 
-void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value) {
+void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value) {
 	EditorUndoRedoManager *undo_redo = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo);
 

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -110,7 +110,7 @@ public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_begin(Object *p_object) override;
 
-	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
+	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value);
 
 	EditorInspectorPluginMaterial();
 };

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
@@ -348,7 +348,7 @@ PackedVector2Array NavigationObstacle3DEditor::_get_polygon() {
 	return PackedVector2Array(obstacle_node->call("get_polygon"));
 }
 
-void NavigationObstacle3DEditor::_set_polygon(PackedVector2Array p_poly) {
+void NavigationObstacle3DEditor::_set_polygon(const PackedVector2Array &p_poly) {
 	ERR_FAIL_NULL_MSG(obstacle_node, "Edited object is not valid.");
 	obstacle_node->call("set_polygon", p_poly);
 }

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.h
@@ -82,7 +82,7 @@ class NavigationObstacle3DEditor : public HBoxContainer {
 	void _menu_option(int p_option);
 
 	PackedVector2Array _get_polygon();
-	void _set_polygon(PackedVector2Array p_poly);
+	void _set_polygon(const PackedVector2Array &p_poly);
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2663,7 +2663,7 @@ void Node3DEditorViewport::_update_freelook(real_t delta) {
 	cursor.eye_pos += motion;
 }
 
-void Node3DEditorViewport::set_message(String p_message, float p_time) {
+void Node3DEditorViewport::set_message(const String &p_message, float p_time) {
 	message = p_message;
 	message_time = p_time;
 }

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -400,7 +400,7 @@ private:
 	String message;
 	double message_time;
 
-	void set_message(String p_message, float p_time = 5);
+	void set_message(const String &p_message, float p_time = 5);
 
 	void _view_settings_confirmed(real_t p_interp_delta);
 	void _update_camera(real_t p_interp_delta);

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -364,7 +364,7 @@ PackedVector2Array Polygon3DEditor::_get_polygon() {
 	return PackedVector2Array(obj->call("get_polygon"));
 }
 
-void Polygon3DEditor::_set_polygon(PackedVector2Array p_poly) {
+void Polygon3DEditor::_set_polygon(const PackedVector2Array &p_poly) {
 	Object *obj = node_resource.is_valid() ? (Object *)node_resource.ptr() : node;
 	ERR_FAIL_NULL_MSG(obj, "Edited object is not valid.");
 	obj->call("set_polygon", p_poly);

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -82,7 +82,7 @@ class Polygon3DEditor : public HBoxContainer {
 
 	float _get_depth();
 	PackedVector2Array _get_polygon();
-	void _set_polygon(PackedVector2Array p_poly);
+	void _set_polygon(const PackedVector2Array &p_poly);
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -696,7 +696,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	_update_help_overview_visibility();
 }
 
-void ScriptEditor::_add_recent_script(String p_path) {
+void ScriptEditor::_add_recent_script(const String &p_path) {
 	if (p_path.is_empty()) {
 		return;
 	}
@@ -790,7 +790,7 @@ void ScriptEditor::_open_recent_script(int p_idx) {
 	_show_error_dialog(path);
 }
 
-void ScriptEditor::_show_error_dialog(String p_path) {
+void ScriptEditor::_show_error_dialog(const String &p_path) {
 	error_dialog->set_text(vformat(TTR("Can't open '%s'. The file could have been moved or deleted."), p_path));
 	error_dialog->popup_centered();
 }
@@ -1109,7 +1109,7 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Resource> p_for_script) {
 	return need_reload;
 }
 
-void ScriptEditor::_file_dialog_action(String p_file) {
+void ScriptEditor::_file_dialog_action(const String &p_file) {
 	switch (file_dialog_option) {
 		case FILE_NEW_TEXTFILE: {
 			Error err;
@@ -3628,7 +3628,7 @@ void ScriptEditor::set_live_auto_reload_running_scripts(bool p_enabled) {
 	auto_reload_running_scripts = p_enabled;
 }
 
-void ScriptEditor::_help_search(String p_text) {
+void ScriptEditor::_help_search(const String &p_text) {
 	help_search_dialog->popup_dialog(p_text);
 }
 
@@ -3679,20 +3679,20 @@ void ScriptEditor::_script_changed() {
 	NodeDock::get_singleton()->update_lists();
 }
 
-void ScriptEditor::_on_find_in_files_requested(String text) {
+void ScriptEditor::_on_find_in_files_requested(const String &text) {
 	find_in_files_dialog->set_find_in_files_mode(FindInFilesDialog::SEARCH_MODE);
 	find_in_files_dialog->set_search_text(text);
 	find_in_files_dialog->popup_centered();
 }
 
-void ScriptEditor::_on_replace_in_files_requested(String text) {
+void ScriptEditor::_on_replace_in_files_requested(const String &text) {
 	find_in_files_dialog->set_find_in_files_mode(FindInFilesDialog::REPLACE_MODE);
 	find_in_files_dialog->set_search_text(text);
 	find_in_files_dialog->set_replace_text("");
 	find_in_files_dialog->popup_centered();
 }
 
-void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_number, int begin, int end) {
+void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end) {
 	if (ResourceLoader::exists(fpath)) {
 		Ref<Resource> res = ResourceLoader::load(fpath);
 
@@ -3814,7 +3814,7 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	EditorNode::get_bottom_panel()->make_item_visible(find_in_files);
 }
 
-void ScriptEditor::_on_find_in_files_modified_files(PackedStringArray paths) {
+void ScriptEditor::_on_find_in_files_modified_files(const PackedStringArray &paths) {
 	_test_script_times_on_disk();
 	_update_modified_scripts_for_external_editor();
 }
@@ -4217,7 +4217,7 @@ void ScriptEditorPlugin::_focus_another_editor() {
 	}
 }
 
-void ScriptEditorPlugin::_save_last_editor(String p_editor) {
+void ScriptEditorPlugin::_save_last_editor(const String &p_editor) {
 	if (p_editor != get_name()) {
 		last_editor = p_editor;
 	}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -179,7 +179,7 @@ public:
 	virtual PackedInt32Array get_breakpoints() = 0;
 	virtual void set_breakpoint(int p_line, bool p_enabled) = 0;
 	virtual void clear_breakpoints() = 0;
-	virtual void add_callback(const String &p_function, PackedStringArray p_args) = 0;
+	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) = 0;
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
 	virtual bool can_lose_focus_on_node_selection() { return true; }
@@ -362,11 +362,11 @@ class ScriptEditor : public PanelContainer {
 
 	bool _test_script_times_on_disk(Ref<Resource> p_for_script = Ref<Resource>());
 
-	void _add_recent_script(String p_path);
+	void _add_recent_script(const String &p_path);
 	void _update_recent_scripts();
 	void _open_recent_script(int p_idx);
 
-	void _show_error_dialog(String p_path);
+	void _show_error_dialog(const String &p_path);
 
 	void _close_tab(int p_idx, bool p_save = true, bool p_history_back = true);
 	void _update_find_replace_bar();
@@ -462,7 +462,7 @@ class ScriptEditor : public PanelContainer {
 	void _script_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index);
 	void _make_script_list_context_menu();
 
-	void _help_search(String p_text);
+	void _help_search(const String &p_text);
 
 	void _history_forward();
 	void _history_back();
@@ -481,7 +481,7 @@ class ScriptEditor : public PanelContainer {
 
 	void _script_changed();
 	int file_dialog_option;
-	void _file_dialog_action(String p_file);
+	void _file_dialog_action(const String &p_file);
 
 	Ref<Script> _get_current_script();
 	TypedArray<Script> _get_open_scripts() const;
@@ -490,11 +490,11 @@ class ScriptEditor : public PanelContainer {
 	Ref<TextFile> _load_text_file(const String &p_path, Error *r_error) const;
 	Error _save_text_file(Ref<TextFile> p_text_file, const String &p_path);
 
-	void _on_find_in_files_requested(String text);
-	void _on_replace_in_files_requested(String text);
-	void _on_find_in_files_result_selected(String fpath, int line_number, int begin, int end);
+	void _on_find_in_files_requested(const String &text);
+	void _on_replace_in_files_requested(const String &text);
+	void _on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end);
 	void _start_find_in_files(bool with_replace);
-	void _on_find_in_files_modified_files(PackedStringArray paths);
+	void _on_find_in_files_modified_files(const PackedStringArray &paths);
 
 	void _set_zoom_factor(float p_zoom_factor);
 
@@ -579,7 +579,7 @@ class ScriptEditorPlugin : public EditorPlugin {
 
 	void _focus_another_editor();
 
-	void _save_last_editor(String p_editor);
+	void _save_last_editor(const String &p_editor);
 	void _window_visibility_changed(bool p_visible);
 
 protected:

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -46,7 +46,7 @@
 void ConnectionInfoDialog::ok_pressed() {
 }
 
-void ConnectionInfoDialog::popup_connections(String p_method, Vector<Node *> p_nodes) {
+void ConnectionInfoDialog::popup_connections(const String &p_method, const Vector<Node *> &p_nodes) {
 	method->set_text(p_method);
 
 	tree->clear();
@@ -269,7 +269,7 @@ void ScriptTextEditor::_show_warnings_panel(bool p_show) {
 	warnings_panel->set_visible(p_show);
 }
 
-void ScriptTextEditor::_warning_clicked(Variant p_line) {
+void ScriptTextEditor::_warning_clicked(const Variant &p_line) {
 	if (p_line.get_type() == Variant::INT) {
 		goto_line_centered(p_line.operator int64_t());
 	} else if (p_line.get_type() == Variant::DICTIONARY) {
@@ -300,7 +300,7 @@ void ScriptTextEditor::_warning_clicked(Variant p_line) {
 	}
 }
 
-void ScriptTextEditor::_error_clicked(Variant p_line) {
+void ScriptTextEditor::_error_clicked(const Variant &p_line) {
 	if (p_line.get_type() == Variant::INT) {
 		code_editor->get_text_editor()->remove_secondary_carets();
 		code_editor->get_text_editor()->set_caret_line(p_line.operator int64_t());
@@ -344,7 +344,7 @@ void ScriptTextEditor::reload_text() {
 	_validate_script();
 }
 
-void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray p_args) {
+void ScriptTextEditor::add_callback(const String &p_function, const PackedStringArray &p_args) {
 	ScriptLanguage *language = script->get_language();
 	if (!language->can_make_function()) {
 		return;

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -49,7 +49,7 @@ class ConnectionInfoDialog : public AcceptDialog {
 	virtual void ok_pressed() override;
 
 public:
-	void popup_connections(String p_method, Vector<Node *> p_nodes);
+	void popup_connections(const String &p_method, const Vector<Node *> &p_nodes);
 
 	ConnectionInfoDialog();
 };
@@ -177,8 +177,8 @@ protected:
 	void _set_theme_for_script();
 	void _show_errors_panel(bool p_show);
 	void _show_warnings_panel(bool p_show);
-	void _error_clicked(Variant p_line);
-	void _warning_clicked(Variant p_line);
+	void _error_clicked(const Variant &p_line);
+	void _warning_clicked(const Variant &p_line);
 
 	void _notification(int p_what);
 
@@ -240,7 +240,7 @@ public:
 	virtual void set_breakpoint(int p_line, bool p_enabled) override;
 	virtual void clear_breakpoints() override;
 
-	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;
+	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) override;
 	virtual void update_settings() override;
 
 	virtual bool show_members_overview() override;

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -113,7 +113,7 @@ void BoneTransformEditor::_notification(int p_what) {
 	}
 }
 
-void BoneTransformEditor::_value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
+void BoneTransformEditor::_value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (updating) {
 		return;
 	}

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -75,7 +75,7 @@ class BoneTransformEditor : public VBoxContainer {
 
 	void create_editors();
 
-	void _value_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing);
+	void _value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing);
 
 	void _property_keyed(const String &p_path, bool p_advance);
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -140,7 +140,7 @@ void TextEditor::enable_editor(Control *p_shortcut_context) {
 	}
 }
 
-void TextEditor::add_callback(const String &p_function, PackedStringArray p_args) {
+void TextEditor::add_callback(const String &p_function, const PackedStringArray &p_args) {
 }
 
 void TextEditor::set_debugger_active(bool p_active) {

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -142,7 +142,7 @@ public:
 	virtual bool can_lose_focus_on_node_selection() override { return true; }
 	virtual void set_debugger_active(bool p_active) override;
 	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) override;
-	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;
+	virtual void add_callback(const String &p_function, const PackedStringArray &p_args) override;
 	void update_toggle_scripts_button() override;
 
 	virtual Control *get_edit_menu() override;

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -758,7 +758,7 @@ void TextShaderEditor::_show_warnings_panel(bool p_show) {
 	warnings_panel->set_visible(p_show);
 }
 
-void TextShaderEditor::_warning_clicked(Variant p_line) {
+void TextShaderEditor::_warning_clicked(const Variant &p_line) {
 	if (p_line.get_type() == Variant::INT) {
 		code_editor->get_text_editor()->set_caret_line(p_line.operator int64_t());
 	}

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -165,7 +165,7 @@ class TextShaderEditor : public MarginContainer {
 	void _reload_shader_include_from_disk();
 	void _reload();
 	void _show_warnings_panel(bool p_show);
-	void _warning_clicked(Variant p_line);
+	void _warning_clicked(const Variant &p_line);
 	void _update_warnings(bool p_validate);
 
 	void _script_validated(bool p_valid) {

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -42,7 +42,7 @@ void AtlasMergingDialog::_property_changed(const StringName &p_property, const V
 	_set(p_property, p_value);
 }
 
-void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atlas_sources, int p_max_columns) {
+void AtlasMergingDialog::_generate_merged(const Vector<Ref<TileSetAtlasSource>> &p_atlas_sources, int p_max_columns) {
 	merged.instantiate();
 	merged_mapping.clear();
 
@@ -177,7 +177,7 @@ void AtlasMergingDialog::_update_texture() {
 	}
 }
 
-void AtlasMergingDialog::_merge_confirmed(String p_path) {
+void AtlasMergingDialog::_merge_confirmed(const String &p_path) {
 	ERR_FAIL_COND(!merged.is_valid());
 
 	Ref<ImageTexture> output_image_texture = merged->get_texture();

--- a/editor/plugins/tiles/atlas_merging_dialog.h
+++ b/editor/plugins/tiles/atlas_merging_dialog.h
@@ -64,9 +64,9 @@ private:
 
 	void _property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
 
-	void _generate_merged(Vector<Ref<TileSetAtlasSource>> p_atlas_sources, int p_max_columns);
+	void _generate_merged(const Vector<Ref<TileSetAtlasSource>> &p_atlas_sources, int p_max_columns);
 	void _update_texture();
-	void _merge_confirmed(String p_path);
+	void _merge_confirmed(const String &p_path);
 
 protected:
 	virtual void ok_pressed() override;

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -750,7 +750,7 @@ int GenericTilePolygonEditor::get_polygon_count() {
 	return polygons.size();
 }
 
-int GenericTilePolygonEditor::add_polygon(Vector<Point2> p_polygon, int p_index) {
+int GenericTilePolygonEditor::add_polygon(const Vector<Point2> &p_polygon, int p_index) {
 	ERR_FAIL_COND_V(p_polygon.size() < 3, -1);
 	ERR_FAIL_COND_V(!multiple_polygon_mode && polygons.size() >= 1, -1);
 
@@ -782,7 +782,7 @@ void GenericTilePolygonEditor::clear_polygons() {
 	base_control->queue_redraw();
 }
 
-void GenericTilePolygonEditor::set_polygon(int p_polygon_index, Vector<Point2> p_polygon) {
+void GenericTilePolygonEditor::set_polygon(int p_polygon_index, const Vector<Point2> &p_polygon) {
 	ERR_FAIL_INDEX(p_polygon_index, (int)polygons.size());
 	ERR_FAIL_COND(p_polygon.size() < 3);
 	polygons[p_polygon_index] = p_polygon;
@@ -954,7 +954,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	_set_snap_option(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_snap_option", SNAP_NONE));
 }
 
-void TileDataDefaultEditor::_property_value_changed(const StringName &p_property, Variant p_value, const StringName &p_field) {
+void TileDataDefaultEditor::_property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field) {
 	ERR_FAIL_NULL(dummy_object);
 	dummy_object->set(p_property, p_value);
 	emit_signal(SNAME("needs_redraw"));
@@ -975,7 +975,7 @@ void TileDataDefaultEditor::_set_painted_value(TileSetAtlasSource *p_tile_set_at
 	}
 }
 
-void TileDataDefaultEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) {
+void TileDataDefaultEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_NULL(tile_data);
 	tile_data->set(property, p_value);
@@ -987,7 +987,7 @@ Variant TileDataDefaultEditor::_get_value(TileSetAtlasSource *p_tile_set_atlas_s
 	return tile_data->get(property);
 }
 
-void TileDataDefaultEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) {
+void TileDataDefaultEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
 		Vector2i coords = E.key.get_atlas_coords();
@@ -1250,7 +1250,7 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 	}
 }
 
-void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, String p_property, String p_label, Variant p_default_value) {
+void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, const String &p_property, const String &p_label, const Variant &p_default_value) {
 	ERR_FAIL_COND_MSG(!property.is_empty(), "Cannot setup TileDataDefaultEditor twice");
 	property = p_property;
 	property_type = p_type;
@@ -1446,7 +1446,7 @@ void TileDataOcclusionShapeEditor::_set_painted_value(TileSetAtlasSource *p_tile
 	polygon_editor->set_background(p_tile_set_atlas_source->get_texture(), p_tile_set_atlas_source->get_tile_texture_region(p_coords), tile_data->get_texture_origin(), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
 }
 
-void TileDataOcclusionShapeEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) {
+void TileDataOcclusionShapeEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_NULL(tile_data);
 	Ref<OccluderPolygon2D> occluder_polygon = p_value;
@@ -1461,7 +1461,7 @@ Variant TileDataOcclusionShapeEditor::_get_value(TileSetAtlasSource *p_tile_set_
 	return tile_data->get_occluder(occlusion_layer);
 }
 
-void TileDataOcclusionShapeEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) {
+void TileDataOcclusionShapeEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
 		Vector2i coords = E.key.get_atlas_coords();
@@ -1487,7 +1487,7 @@ TileDataOcclusionShapeEditor::TileDataOcclusionShapeEditor() {
 	add_child(polygon_editor);
 }
 
-void TileDataCollisionEditor::_property_value_changed(const StringName &p_property, Variant p_value, const StringName &p_field) {
+void TileDataCollisionEditor::_property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field) {
 	dummy_object->set(p_property, p_value);
 }
 
@@ -1602,7 +1602,7 @@ void TileDataCollisionEditor::_set_painted_value(TileSetAtlasSource *p_tile_set_
 	polygon_editor->set_background(p_tile_set_atlas_source->get_texture(), p_tile_set_atlas_source->get_tile_texture_region(p_coords), tile_data->get_texture_origin(), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
 }
 
-void TileDataCollisionEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) {
+void TileDataCollisionEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_NULL(tile_data);
 
@@ -1640,7 +1640,7 @@ Variant TileDataCollisionEditor::_get_value(TileSetAtlasSource *p_tile_set_atlas
 	return dict;
 }
 
-void TileDataCollisionEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) {
+void TileDataCollisionEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) {
 	Dictionary new_dict = p_new_value;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
@@ -1808,7 +1808,7 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 	}
 }
 
-void TileDataTerrainsEditor::_property_value_changed(const StringName &p_property, Variant p_value, const StringName &p_field) {
+void TileDataTerrainsEditor::_property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field) {
 	Variant old_value = dummy_object->get(p_property);
 	dummy_object->set(p_property, p_value);
 	if (p_property == "terrain_set") {
@@ -2862,7 +2862,7 @@ void TileDataNavigationEditor::_set_painted_value(TileSetAtlasSource *p_tile_set
 	polygon_editor->set_background(p_tile_set_atlas_source->get_texture(), p_tile_set_atlas_source->get_tile_texture_region(p_coords), tile_data->get_texture_origin(), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
 }
 
-void TileDataNavigationEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) {
+void TileDataNavigationEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_NULL(tile_data);
 	Ref<NavigationPolygon> nav_polygon = p_value;
@@ -2877,7 +2877,7 @@ Variant TileDataNavigationEditor::_get_value(TileSetAtlasSource *p_tile_set_atla
 	return tile_data->get_navigation_polygon(navigation_layer);
 }
 
-void TileDataNavigationEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) {
+void TileDataNavigationEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
 		Vector2i coords = E.key.get_atlas_coords();

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -185,10 +185,10 @@ public:
 	void set_background(Ref<Texture2D> p_texture, Rect2 p_region = Rect2(), Vector2 p_offset = Vector2(), bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, Color p_modulate = Color(1.0, 1.0, 1.0, 0.0));
 
 	int get_polygon_count();
-	int add_polygon(Vector<Point2> p_polygon, int p_index = -1);
+	int add_polygon(const Vector<Point2> &p_polygon, int p_index = -1);
 	void remove_polygon(int p_index);
 	void clear_polygons();
-	void set_polygon(int p_polygon_index, Vector<Point2> p_polygon);
+	void set_polygon(int p_polygon_index, const Vector<Point2> &p_polygon);
 	Vector<Point2> get_polygon(int p_polygon_index);
 
 	void set_polygons_color(Color p_color);
@@ -224,7 +224,7 @@ private:
 	HashMap<TileMapCell, Variant, TileMapCell> drag_modified;
 	Variant drag_painted_value;
 
-	void _property_value_changed(const StringName &p_property, Variant p_value, const StringName &p_field);
+	void _property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field);
 
 protected:
 	DummyObject *dummy_object = memnew(DummyObject);
@@ -236,9 +236,9 @@ protected:
 
 	virtual Variant _get_painted_value();
 	virtual void _set_painted_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile);
-	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value);
+	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value);
 	virtual Variant _get_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile);
-	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value);
+	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value);
 
 public:
 	virtual Control *get_toolbar() override { return toolbar; };
@@ -248,7 +248,7 @@ public:
 	virtual void forward_painting_alternatives_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) override;
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;
 
-	void setup_property_editor(Variant::Type p_type, String p_property, String p_label = "", Variant p_default_value = Variant());
+	void setup_property_editor(Variant::Type p_type, const String &p_property, const String &p_label = "", const Variant &p_default_value = Variant());
 	Variant::Type get_property_type();
 
 	TileDataDefaultEditor();
@@ -285,13 +285,13 @@ private:
 	// UI
 	GenericTilePolygonEditor *polygon_editor = nullptr;
 
-	void _polygon_changed(PackedVector2Array p_polygon);
+	void _polygon_changed(const PackedVector2Array &p_polygon);
 
 	virtual Variant _get_painted_value() override;
 	virtual void _set_painted_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) override;
-	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) override;
+	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) override;
 	virtual Variant _get_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) override;
-	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) override;
+	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) override;
 
 protected:
 	virtual void _tile_set_changed() override;
@@ -316,15 +316,15 @@ class TileDataCollisionEditor : public TileDataDefaultEditor {
 	DummyObject *dummy_object = memnew(DummyObject);
 	HashMap<StringName, EditorProperty *> property_editors;
 
-	void _property_value_changed(const StringName &p_property, Variant p_value, const StringName &p_field);
+	void _property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field);
 	void _property_selected(const StringName &p_path, int p_focusable);
 	void _polygons_changed();
 
 	virtual Variant _get_painted_value() override;
 	virtual void _set_painted_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) override;
-	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) override;
+	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) override;
 	virtual Variant _get_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) override;
-	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) override;
+	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) override;
 
 protected:
 	virtual void _tile_set_changed() override;
@@ -368,7 +368,7 @@ private:
 	EditorPropertyEnum *terrain_set_property_editor = nullptr;
 	EditorPropertyEnum *terrain_property_editor = nullptr;
 
-	void _property_value_changed(const StringName &p_property, Variant p_value, const StringName &p_field);
+	void _property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field);
 
 	void _update_terrain_selector();
 
@@ -399,13 +399,13 @@ private:
 	// UI
 	GenericTilePolygonEditor *polygon_editor = nullptr;
 
-	void _polygon_changed(PackedVector2Array p_polygon);
+	void _polygon_changed(const PackedVector2Array &p_polygon);
 
 	virtual Variant _get_painted_value() override;
 	virtual void _set_painted_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) override;
-	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) override;
+	virtual void _set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, const Variant &p_value) override;
 	virtual Variant _get_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) override;
-	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, Variant p_new_value) override;
+	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value) override;
 
 protected:
 	virtual void _tile_set_changed() override;

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -445,7 +445,7 @@ void TileMapLayerEditorTilesPlugin::_update_scenes_collection_view() {
 	scene_tiles_list->set_fixed_icon_size(Vector2(int_size, int_size));
 }
 
-void TileMapLayerEditorTilesPlugin::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Variant p_ud) {
+void TileMapLayerEditorTilesPlugin::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud) {
 	int index = p_ud;
 
 	if (index >= 0 && index < scene_tiles_list->get_item_count()) {
@@ -3874,7 +3874,7 @@ void TileMapLayerEditor::_update_highlighting_toggle() {
 	}
 }
 
-void TileMapLayerEditor::_move_tile_map_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos) {
+void TileMapLayerEditor::_move_tile_map_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos) {
 	EditorUndoRedoManager *undo_redo_man = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo_man);
 

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -209,7 +209,7 @@ private:
 	ItemList *scene_tiles_list = nullptr;
 
 	void _update_scenes_collection_view();
-	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Variant p_ud);
+	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud);
 	void _scenes_list_multi_selected(int p_index, bool p_selected);
 	void _scenes_list_lmb_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 
@@ -382,7 +382,7 @@ private:
 	void _update_highlighting_toggle();
 
 	// Inspector undo/redo callback.
-	void _move_tile_map_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos);
+	void _move_tile_map_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos);
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -551,7 +551,7 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("changed", PropertyInfo(Variant::STRING, "what")));
 }
 
-void TileSetAtlasSourceEditor::_inspector_property_selected(String p_property) {
+void TileSetAtlasSourceEditor::_inspector_property_selected(const String &p_property) {
 	selected_property = p_property;
 	_update_atlas_view();
 	_update_current_tile_data_editor();
@@ -1701,7 +1701,7 @@ void TileSetAtlasSourceEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void TileSetAtlasSourceEditor::_set_selection_from_array(Array p_selection) {
+void TileSetAtlasSourceEditor::_set_selection_from_array(const Array &p_selection) {
 	ERR_FAIL_COND((p_selection.size() % 2) != 0);
 	selection.clear();
 	for (int i = 0; i < p_selection.size() / 2; i++) {
@@ -2100,12 +2100,12 @@ void TileSetAtlasSourceEditor::_tile_set_changed() {
 	tile_set_changed_needs_update = true;
 }
 
-void TileSetAtlasSourceEditor::_tile_proxy_object_changed(String p_what) {
+void TileSetAtlasSourceEditor::_tile_proxy_object_changed(const String &p_what) {
 	tile_set_changed_needs_update = false; // Avoid updating too many things.
 	_update_atlas_view();
 }
 
-void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(String p_what) {
+void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(const String &p_what) {
 	if (p_what == "texture" && !atlas_source_proxy_object->get("texture").is_null()) {
 		atlases_to_auto_create_tiles.clear();
 		atlases_to_auto_create_tiles.append(tile_set_atlas_source);
@@ -2115,7 +2115,7 @@ void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(String p_what)
 	}
 }
 
-void TileSetAtlasSourceEditor::_undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value) {
+void TileSetAtlasSourceEditor::_undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value) {
 	EditorUndoRedoManager *undo_redo_man = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo_man);
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -153,7 +153,7 @@ private:
 	EditorInspector *tile_inspector = nullptr;
 	Label *tile_inspector_no_tile_selected_label = nullptr;
 	String selected_property;
-	void _inspector_property_selected(String p_property);
+	void _inspector_property_selected(const String &p_property);
 
 	TileSetAtlasSourceProxyObject *atlas_source_proxy_object = nullptr;
 	EditorInspector *atlas_source_inspector = nullptr;
@@ -229,7 +229,7 @@ private:
 	// Selection.
 	RBSet<TileSelection> selection;
 
-	void _set_selection_from_array(Array p_selection);
+	void _set_selection_from_array(const Array &p_selection);
 	Array _get_selection_as_array();
 
 	// A control on the tile atlas to draw and handle input events.
@@ -283,10 +283,10 @@ private:
 	void _cleanup_outside_tiles();
 
 	void _tile_set_changed();
-	void _tile_proxy_object_changed(String p_what);
-	void _atlas_source_proxy_object_changed(String p_what);
+	void _tile_proxy_object_changed(const String &p_what);
+	void _atlas_source_proxy_object_changed(const String &p_what);
 
-	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
+	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value);
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -458,7 +458,7 @@ void TileSetEditor::_tab_changed(int p_tab_changed) {
 	patterns_item_list->set_visible(p_tab_changed == 1);
 }
 
-void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos) {
+void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos) {
 	EditorUndoRedoManager *undo_redo_man = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo_man);
 
@@ -668,7 +668,7 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 	}
 }
 
-void TileSetEditor::_undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value) {
+void TileSetEditor::_undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value) {
 	EditorUndoRedoManager *undo_redo_man = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo_man);
 

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -108,8 +108,8 @@ private:
 	void _tile_set_changed();
 	void _tab_changed(int p_tab_changed);
 
-	void _move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos);
-	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
+	void _move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos);
+	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value);
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -214,7 +214,7 @@ void TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_bind_methods() 
 	ADD_SIGNAL(MethodInfo("changed", PropertyInfo(Variant::STRING, "what")));
 }
 
-void TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed(String p_what) {
+void TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed(const String &p_what) {
 	if (p_what == "id") {
 		emit_signal(SNAME("source_id_changed"), scenes_collection_source_proxy_object->get_id());
 	}
@@ -224,7 +224,7 @@ void TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_cha
 	tile_set_scenes_collection_source_changed_needs_update = true;
 }
 
-void TileSetScenesCollectionSourceEditor::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Variant p_ud) {
+void TileSetScenesCollectionSourceEditor::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud) {
 	int index = p_ud;
 
 	if (index >= 0 && index < scene_tiles_list->get_item_count()) {

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -118,8 +118,8 @@ private:
 	EditorFileDialog *scene_select_dialog = nullptr;
 
 	void _tile_set_scenes_collection_source_changed();
-	void _scenes_collection_source_proxy_object_changed(String p_what);
-	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Variant p_ud);
+	void _scenes_collection_source_proxy_object_changed(const String &p_what);
+	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud);
 	void _scenes_list_item_activated(int p_index);
 
 	void _source_add_pressed();

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -144,7 +144,7 @@ void VersionControlEditorPlugin::_set_credentials() {
 	EditorSettings::get_singleton()->set_setting("version_control/ssh_private_key_path", ssh_private_key);
 }
 
-bool VersionControlEditorPlugin::_load_plugin(String p_name) {
+bool VersionControlEditorPlugin::_load_plugin(const String &p_name) {
 	Object *extension_instance = ClassDB::instantiate(p_name);
 	ERR_FAIL_NULL_V_MSG(extension_instance, false, "Received a nullptr VCS extension instance during construction.");
 
@@ -168,7 +168,7 @@ bool VersionControlEditorPlugin::_load_plugin(String p_name) {
 	return true;
 }
 
-void VersionControlEditorPlugin::_update_set_up_warning(String p_new_text) {
+void VersionControlEditorPlugin::_update_set_up_warning(const String &p_new_text) {
 	bool empty_settings = set_up_username->get_text().strip_edges().is_empty() &&
 			set_up_password->get_text().is_empty() &&
 			set_up_ssh_public_key_path->get_text().strip_edges().is_empty() &&
@@ -305,15 +305,15 @@ void VersionControlEditorPlugin::_remote_selected(int p_index) {
 	_refresh_remote_list();
 }
 
-void VersionControlEditorPlugin::_ssh_public_key_selected(String p_path) {
+void VersionControlEditorPlugin::_ssh_public_key_selected(const String &p_path) {
 	set_up_ssh_public_key_path->set_text(p_path);
 }
 
-void VersionControlEditorPlugin::_ssh_private_key_selected(String p_path) {
+void VersionControlEditorPlugin::_ssh_private_key_selected(const String &p_path) {
 	set_up_ssh_private_key_path->set_text(p_path);
 }
 
-void VersionControlEditorPlugin::_popup_file_dialog(Variant p_file_dialog_variant) {
+void VersionControlEditorPlugin::_popup_file_dialog(const Variant &p_file_dialog_variant) {
 	FileDialog *file_dialog = Object::cast_to<FileDialog>(p_file_dialog_variant);
 	ERR_FAIL_NULL(file_dialog);
 
@@ -345,11 +345,11 @@ void VersionControlEditorPlugin::_create_remote() {
 	_refresh_remote_list();
 }
 
-void VersionControlEditorPlugin::_update_branch_create_button(String p_new_text) {
+void VersionControlEditorPlugin::_update_branch_create_button(const String &p_new_text) {
 	branch_create_ok->set_disabled(p_new_text.strip_edges().is_empty());
 }
 
-void VersionControlEditorPlugin::_update_remote_create_button(String p_new_text) {
+void VersionControlEditorPlugin::_update_remote_create_button(const String &p_new_text) {
 	remote_create_ok->set_disabled(p_new_text.strip_edges().is_empty());
 }
 
@@ -384,7 +384,7 @@ void VersionControlEditorPlugin::_refresh_stage_area() {
 	version_commit_dock->set_name(commit_tab_title);
 }
 
-void VersionControlEditorPlugin::_discard_file(String p_file_path, EditorVCSInterface::ChangeType p_change) {
+void VersionControlEditorPlugin::_discard_file(const String &p_file_path, EditorVCSInterface::ChangeType p_change) {
 	CHECK_PLUGIN_INITIALIZED();
 
 	if (p_change == EditorVCSInterface::CHANGE_TYPE_NEW) {
@@ -414,7 +414,7 @@ void VersionControlEditorPlugin::_discard_all() {
 	_refresh_stage_area();
 }
 
-void VersionControlEditorPlugin::_add_new_item(Tree *p_tree, String p_file_path, EditorVCSInterface::ChangeType p_change) {
+void VersionControlEditorPlugin::_add_new_item(Tree *p_tree, const String &p_file_path, EditorVCSInterface::ChangeType p_change) {
 	String change_text = p_file_path + " (" + change_type_to_strings[p_change] + ")";
 
 	TreeItem *new_item = p_tree->create_item();

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -142,15 +142,15 @@ private:
 	void _initialize_vcs();
 	void _set_vcs_ui_state(bool p_enabled);
 	void _set_credentials();
-	void _ssh_public_key_selected(String p_path);
-	void _ssh_private_key_selected(String p_path);
+	void _ssh_public_key_selected(const String &p_path);
+	void _ssh_private_key_selected(const String &p_path);
 	void _populate_available_vcs_names();
 	void _update_remotes_list();
-	void _update_set_up_warning(String p_new_text);
+	void _update_set_up_warning(const String &p_new_text);
 	void _update_opened_tabs();
 	void _update_extra_options();
 
-	bool _load_plugin(String p_name);
+	bool _load_plugin(const String &p_name);
 
 	void _pull();
 	void _push();
@@ -172,8 +172,8 @@ private:
 	void _item_activated(Object *p_tree);
 	void _create_branch();
 	void _create_remote();
-	void _update_branch_create_button(String p_new_text);
-	void _update_remote_create_button(String p_new_text);
+	void _update_branch_create_button(const String &p_new_text);
+	void _update_remote_create_button(const String &p_new_text);
 	void _branch_item_selected(int p_index);
 	void _remote_selected(int p_index);
 	void _remove_branch();
@@ -183,16 +183,16 @@ private:
 	void _move_item(Tree *p_tree, TreeItem *p_itme);
 	void _display_diff_split_view(List<EditorVCSInterface::DiffLine> &p_diff_content);
 	void _display_diff_unified_view(List<EditorVCSInterface::DiffLine> &p_diff_content);
-	void _discard_file(String p_file_path, EditorVCSInterface::ChangeType p_change);
+	void _discard_file(const String &p_file_path, EditorVCSInterface::ChangeType p_change);
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, int p_mouse_button_index);
-	void _add_new_item(Tree *p_tree, String p_file_path, EditorVCSInterface::ChangeType p_change);
+	void _add_new_item(Tree *p_tree, const String &p_file_path, EditorVCSInterface::ChangeType p_change);
 	void _update_commit_button();
 	void _commit_message_gui_input(const Ref<InputEvent> &p_event);
 	void _extra_option_selected(int p_index);
 	bool _is_staging_area_empty();
 	String _get_date_string_from(int64_t p_unix_timestamp, int64_t p_offset_minutes) const;
 	void _create_vcs_metadata_files();
-	void _popup_file_dialog(Variant p_file_dialog_variant);
+	void _popup_file_dialog(const Variant &p_file_dialog_variant);
 	void _toggle_vcs_integration(bool p_toggled);
 
 	friend class EditorVCSInterface;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -194,7 +194,7 @@ void VisualShaderGraphPlugin::update_node(VisualShader::Type p_type, int p_node_
 	add_node(p_type, p_node_id, true);
 }
 
-void VisualShaderGraphPlugin::set_input_port_default_value(VisualShader::Type p_type, int p_node_id, int p_port_id, Variant p_value) {
+void VisualShaderGraphPlugin::set_input_port_default_value(VisualShader::Type p_type, int p_node_id, int p_port_id, const Variant &p_value) {
 	if (p_type != visual_shader->get_shader_type() || !links.has(p_node_id)) {
 		return;
 	}
@@ -1211,7 +1211,7 @@ void VisualShaderEditedProperty::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "edited_property", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_edited_property", "get_edited_property");
 }
 
-void VisualShaderEditedProperty::set_edited_property(Variant p_variant) {
+void VisualShaderEditedProperty::set_edited_property(const Variant &p_variant) {
 	edited_property = p_variant;
 }
 
@@ -3116,7 +3116,7 @@ void VisualShaderEditor::_setup_node(VisualShaderNode *p_node, const Vector<Vari
 	}
 }
 
-void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, String p_resource_path, int p_node_idx) {
+void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, const String &p_resource_path, int p_node_idx) {
 	ERR_FAIL_INDEX(p_idx, add_options.size());
 
 	VisualShader::Type type = get_current_shader_type();
@@ -3799,7 +3799,7 @@ void VisualShaderEditor::_replace_node(VisualShader::Type p_type_id, int p_node_
 	undo_redo->add_undo_method(visual_shader.ptr(), "replace_node", p_type_id, p_node_id, p_from);
 }
 
-void VisualShaderEditor::_update_constant(VisualShader::Type p_type_id, int p_node_id, Variant p_var, int p_preview_port) {
+void VisualShaderEditor::_update_constant(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port) {
 	Ref<VisualShaderNode> node = visual_shader->get_node(p_type_id, p_node_id);
 	ERR_FAIL_COND(!node.is_valid());
 	ERR_FAIL_COND(!node->has_method("set_constant"));
@@ -3809,7 +3809,7 @@ void VisualShaderEditor::_update_constant(VisualShader::Type p_type_id, int p_no
 	}
 }
 
-void VisualShaderEditor::_update_parameter(VisualShader::Type p_type_id, int p_node_id, Variant p_var, int p_preview_port) {
+void VisualShaderEditor::_update_parameter(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port) {
 	Ref<VisualShaderNodeParameter> parameter = visual_shader->get_node(p_type_id, p_node_id);
 	ERR_FAIL_COND(!parameter.is_valid());
 
@@ -4715,7 +4715,7 @@ void VisualShaderEditor::_custom_mode_toggled(bool p_enabled) {
 	_update_graph();
 }
 
-void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, String p_name) {
+void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, const String &p_name) {
 	String prev_name = p_input->get_input_name();
 
 	if (p_name == prev_name) {
@@ -4787,7 +4787,7 @@ void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, 
 	undo_redo_man->commit_action();
 }
 
-void VisualShaderEditor::_parameter_ref_select_item(Ref<VisualShaderNodeParameterRef> p_parameter_ref, String p_name) {
+void VisualShaderEditor::_parameter_ref_select_item(Ref<VisualShaderNodeParameterRef> p_parameter_ref, const String &p_name) {
 	String prev_name = p_parameter_ref->get_parameter_name();
 
 	if (p_name == prev_name) {
@@ -4831,7 +4831,7 @@ void VisualShaderEditor::_parameter_ref_select_item(Ref<VisualShaderNodeParamete
 	undo_redo_man->commit_action();
 }
 
-void VisualShaderEditor::_varying_select_item(Ref<VisualShaderNodeVarying> p_varying, String p_name) {
+void VisualShaderEditor::_varying_select_item(Ref<VisualShaderNodeVarying> p_varying, const String &p_name) {
 	String prev_name = p_varying->get_varying_name();
 
 	if (p_name == prev_name) {
@@ -6780,7 +6780,7 @@ public:
 		}
 	}
 
-	void setup(VisualShaderEditor *p_editor, Ref<Resource> p_parent_resource, Vector<EditorProperty *> p_properties, const Vector<StringName> &p_names, const HashMap<StringName, String> &p_overrided_names, Ref<VisualShaderNode> p_node) {
+	void setup(VisualShaderEditor *p_editor, Ref<Resource> p_parent_resource, const Vector<EditorProperty *> &p_properties, const Vector<StringName> &p_names, const HashMap<StringName, String> &p_overrided_names, Ref<VisualShaderNode> p_node) {
 		editor = p_editor;
 		parent_resource = p_parent_resource;
 		updating = false;

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -127,7 +127,7 @@ public:
 	void show_port_preview(VisualShader::Type p_type, int p_node_id, int p_port_id, bool p_is_valid);
 	void set_node_position(VisualShader::Type p_type, int p_id, const Vector2 &p_position);
 	void refresh_node_ports(VisualShader::Type p_type, int p_node);
-	void set_input_port_default_value(VisualShader::Type p_type, int p_node_id, int p_port_id, Variant p_value);
+	void set_input_port_default_value(VisualShader::Type p_type, int p_node_id, int p_port_id, const Variant &p_value);
 	void update_parameter_refs();
 	void set_parameter_name(VisualShader::Type p_type, int p_node_id, const String &p_name);
 	void update_curve(int p_node_id);
@@ -154,7 +154,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_edited_property(Variant p_variant);
+	void set_edited_property(const Variant &p_variant);
 	Variant get_edited_property() const;
 
 	VisualShaderEditedProperty() {}
@@ -360,7 +360,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _draw_color_over_button(Object *p_obj, Color p_color);
 
 	void _setup_node(VisualShaderNode *p_node, const Vector<Variant> &p_ops);
-	void _add_node(int p_idx, const Vector<Variant> &p_ops, String p_resource_path = "", int p_node_idx = -1);
+	void _add_node(int p_idx, const Vector<Variant> &p_ops, const String &p_resource_path = "", int p_node_idx = -1);
 	void _add_varying(const String &p_name, VisualShader::VaryingMode p_mode, VisualShader::VaryingType p_type);
 	void _remove_varying(const String &p_name);
 	void _update_options_menu();
@@ -416,8 +416,8 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _convert_constants_to_parameters(bool p_vice_versa);
 	void _replace_node(VisualShader::Type p_type_id, int p_node_id, const StringName &p_from, const StringName &p_to);
-	void _update_constant(VisualShader::Type p_type_id, int p_node_id, Variant p_var, int p_preview_port);
-	void _update_parameter(VisualShader::Type p_type_id, int p_node_id, Variant p_var, int p_preview_port);
+	void _update_constant(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port);
+	void _update_parameter(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port);
 
 	void _connection_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_position);
 	void _connection_from_empty(const String &p_to, int p_to_slot, const Vector2 &p_release_position);
@@ -470,9 +470,9 @@ class VisualShaderEditor : public VBoxContainer {
 	void _mode_selected(int p_id);
 	void _custom_mode_toggled(bool p_enabled);
 
-	void _input_select_item(Ref<VisualShaderNodeInput> p_input, String p_name);
-	void _parameter_ref_select_item(Ref<VisualShaderNodeParameterRef> p_parameter_ref, String p_name);
-	void _varying_select_item(Ref<VisualShaderNodeVarying> p_varying, String p_name);
+	void _input_select_item(Ref<VisualShaderNodeInput> p_input, const String &p_name);
+	void _parameter_ref_select_item(Ref<VisualShaderNodeParameterRef> p_parameter_ref, const String &p_name);
+	void _varying_select_item(Ref<VisualShaderNodeVarying> p_varying, const String &p_name);
 
 	void _float_constant_selected(int p_which);
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -47,15 +47,15 @@
 #include "modules/regex/regex.h"
 
 // Find "OS.set_property(x)", capturing x into $1.
-static String make_regex_gds_os_property_set(String name_set) {
+static String make_regex_gds_os_property_set(const String &name_set) {
 	return String("\\bOS\\.") + name_set + "\\s*\\((.*)\\)";
 }
 // Find "OS.property = x", capturing x into $1 or $2.
-static String make_regex_gds_os_property_assign(String name) {
+static String make_regex_gds_os_property_assign(const String &name) {
 	return String("\\bOS\\.") + name + "\\s*=\\s*([^#]+)";
 }
 // Find "OS.property" OR "OS.get_property()" / "OS.is_property()".
-static String make_regex_gds_os_property_get(String name, String get) {
+static String make_regex_gds_os_property_get(const String &name, const String &get) {
 	return String("\\bOS\\.(") + get + "_)?" + name + "(\\s*\\(\\s*\\))?";
 }
 
@@ -746,7 +746,7 @@ Vector<SourceLine> ProjectConverter3To4::split_lines(const String &text) {
 }
 
 // Test expected results of gdscript
-bool ProjectConverter3To4::test_conversion_gdscript_builtin(String name, String expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &, bool), String what, const RegExContainer &reg_container, bool builtin_script) {
+bool ProjectConverter3To4::test_conversion_gdscript_builtin(const String &name, const String &expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &, bool), const String &what, const RegExContainer &reg_container, bool builtin_script) {
 	Vector<SourceLine> got = split_lines(name);
 
 	(this->*func)(got, reg_container, builtin_script);
@@ -756,7 +756,7 @@ bool ProjectConverter3To4::test_conversion_gdscript_builtin(String name, String 
 	return true;
 }
 
-bool ProjectConverter3To4::test_conversion_with_regex(String name, String expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &), String what, const RegExContainer &reg_container) {
+bool ProjectConverter3To4::test_conversion_with_regex(const String &name, const String &expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &), const String &what, const RegExContainer &reg_container) {
 	Vector<SourceLine> got = split_lines(name);
 
 	(this->*func)(got, reg_container);
@@ -766,7 +766,7 @@ bool ProjectConverter3To4::test_conversion_with_regex(String name, String expect
 	return true;
 }
 
-bool ProjectConverter3To4::test_conversion_basic(String name, String expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, String what) {
+bool ProjectConverter3To4::test_conversion_basic(const String &name, const String &expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, const String &what) {
 	Vector<SourceLine> got = split_lines(name);
 
 	rename_common(array, regex_cache, got);
@@ -1638,7 +1638,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_functions(Vector<
 	return found_renames;
 }
 
-bool ProjectConverter3To4::contains_function_call(String &line, String function) const {
+bool ProjectConverter3To4::contains_function_call(const String &line, const String &function) const {
 	// We want to convert the function only if it is completely standalone.
 	// For example, when we search for "connect(", we don't want to accidentally convert "reconnect(".
 	if (!line.contains(function)) {
@@ -2834,7 +2834,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_input_map_scancode(Vector<
 	return found_renames;
 }
 
-void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, String from, String to) {
+void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to) {
 	RegEx reg = RegEx(String("\\b") + from + "\\b");
 	CRASH_COND(!reg.is_valid());
 	for (SourceLine &source_line : source_lines) {
@@ -2849,7 +2849,7 @@ void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, Strin
 	}
 };
 
-Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lines, String from, String to) {
+Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lines, const String &from, const String &to) {
 	Vector<String> found_renames;
 
 	RegEx reg = RegEx(String("\\b") + from + "\\b");

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -101,8 +101,8 @@ class ProjectConverter3To4 {
 	void rename_joypad_buttons_and_axes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_joypad_buttons_and_axes(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void custom_rename(Vector<SourceLine> &source_lines, String from, String to);
-	Vector<String> check_for_custom_rename(Vector<String> &lines, String from, String to);
+	void custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to);
+	Vector<String> check_for_custom_rename(Vector<String> &lines, const String &from, const String &to);
 
 	void rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<SourceLine> &source_lines);
 	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);
@@ -114,7 +114,7 @@ class ProjectConverter3To4 {
 	String connect_arguments(const Vector<String> &line, int from, int to = -1) const;
 	String get_starting_space(const String &line) const;
 	String get_object_of_execution(const String &line) const;
-	bool contains_function_call(String &line, String function) const;
+	bool contains_function_call(const String &line, const String &function) const;
 
 	String line_formatter(int current_line, String from, String to, String line);
 	String simple_line_formatter(int current_line, String old_line, String line);
@@ -122,9 +122,9 @@ class ProjectConverter3To4 {
 	Vector<SourceLine> split_lines(const String &text);
 
 	bool test_single_array(const char *array[][2], bool ignore_second_check = false);
-	bool test_conversion_gdscript_builtin(String name, String expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &, bool), String what, const RegExContainer &reg_container, bool builtin);
-	bool test_conversion_with_regex(String name, String expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &), String what, const RegExContainer &reg_container);
-	bool test_conversion_basic(String name, String expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, String what);
+	bool test_conversion_gdscript_builtin(const String &name, const String &expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &, bool), const String &what, const RegExContainer &reg_container, bool builtin);
+	bool test_conversion_with_regex(const String &name, const String &expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &), const String &what, const RegExContainer &reg_container);
+	bool test_conversion_basic(const String &name, const String &expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, const String &what);
 	bool test_array_names();
 	bool test_conversion(RegExContainer &reg_container);
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -380,7 +380,7 @@ void RenameDialog::_update_preview_int(int new_value) {
 	_update_preview();
 }
 
-void RenameDialog::_update_preview(String new_text) {
+void RenameDialog::_update_preview(const String &new_text) {
 	if (lock_preview_update || preview_node == nullptr) {
 		return;
 	}
@@ -637,7 +637,7 @@ bool RenameDialog::_is_main_field(LineEdit *line_edit) {
 			(line_edit == lne_search || line_edit == lne_replace || line_edit == lne_prefix || line_edit == lne_suffix);
 }
 
-void RenameDialog::_insert_text(String text) {
+void RenameDialog::_insert_text(const String &text) {
 	LineEdit *focus_owner = Object::cast_to<LineEdit>(get_viewport()->gui_get_focus_owner());
 
 	if (_is_main_field(focus_owner)) {

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -52,7 +52,7 @@ class RenameDialog : public ConfirmationDialog {
 	virtual void ok_pressed() override { rename(); };
 	void _cancel_pressed() {}
 	void _features_toggled(bool pressed);
-	void _insert_text(String text);
+	void _insert_text(const String &text);
 	void _update_substitute();
 	bool _is_main_field(LineEdit *line_edit);
 
@@ -61,7 +61,7 @@ class RenameDialog : public ConfirmationDialog {
 	String _substitute(const String &subject, const Node *node, int count);
 	String _regex(const String &pattern, const String &subject, const String &replacement);
 	String _postprocess(const String &subject);
-	void _update_preview(String new_text = "");
+	void _update_preview(const String &new_text = "");
 	void _update_preview_int(int new_value = 0);
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1356,7 +1356,7 @@ void SceneTreeDock::_property_selected(int p_idx) {
 	property_drop_node = nullptr;
 }
 
-void SceneTreeDock::_perform_property_drop(Node *p_node, String p_property, Ref<Resource> p_res) {
+void SceneTreeDock::_perform_property_drop(Node *p_node, const String &p_property, Ref<Resource> p_res) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(TTR("Set %s"), p_property));
 	undo_redo->add_do_property(p_node, p_property, p_res);
@@ -2957,7 +2957,7 @@ void SceneTreeDock::set_selected(Node *p_node, bool p_emit_selected) {
 	scene_tree->set_selected(p_node, p_emit_selected);
 }
 
-void SceneTreeDock::_new_scene_from(String p_file) {
+void SceneTreeDock::_new_scene_from(const String &p_file) {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
 	if (selection.size() != 1) {
@@ -3105,7 +3105,7 @@ void SceneTreeDock::_normalize_drop(Node *&to_node, int &to_pos, int p_type) {
 	}
 }
 
-void SceneTreeDock::_files_dropped(Vector<String> p_files, NodePath p_to, int p_type) {
+void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to, int p_type) {
 	Node *node = get_node(p_to);
 	ERR_FAIL_NULL(node);
 
@@ -3156,7 +3156,7 @@ void SceneTreeDock::_files_dropped(Vector<String> p_files, NodePath p_to, int p_
 	}
 }
 
-void SceneTreeDock::_script_dropped(String p_file, NodePath p_to) {
+void SceneTreeDock::_script_dropped(const String &p_file, NodePath p_to) {
 	Ref<Script> scr = ResourceLoader::load(p_file);
 	ERR_FAIL_COND(!scr.is_valid());
 	Node *n = get_node(p_to);
@@ -3206,7 +3206,7 @@ void SceneTreeDock::_script_dropped(String p_file, NodePath p_to) {
 	}
 }
 
-void SceneTreeDock::_nodes_dragged(Array p_nodes, NodePath p_to, int p_type) {
+void SceneTreeDock::_nodes_dragged(const Array &p_nodes, NodePath p_to, int p_type) {
 	if (!_validate_no_foreign()) {
 		return;
 	}
@@ -3581,7 +3581,7 @@ void SceneTreeDock::set_filter(const String &p_filter) {
 	scene_tree->set_filter(p_filter);
 }
 
-void SceneTreeDock::save_branch_to_file(String p_directory) {
+void SceneTreeDock::save_branch_to_file(const String &p_directory) {
 	new_scene_from_dialog->set_current_dir(p_directory);
 	_tool_selected(TOOL_NEW_SCENE_FROM);
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -139,7 +139,7 @@ class SceneTreeDock : public VBoxContainer {
 
 	Node *property_drop_node = nullptr;
 	String resource_drop_path;
-	void _perform_property_drop(Node *p_node, String p_property, Ref<Resource> p_res);
+	void _perform_property_drop(Node *p_node, const String &p_property, Ref<Resource> p_res);
 
 	EditorData *editor_data = nullptr;
 	EditorSelection *editor_selection = nullptr;
@@ -238,7 +238,7 @@ class SceneTreeDock : public VBoxContainer {
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _scene_tree_gui_input(Ref<InputEvent> p_event);
 
-	void _new_scene_from(String p_file);
+	void _new_scene_from(const String &p_file);
 	void _set_node_owner_recursive(Node *p_node, Node *p_owner, const HashMap<const Node *, Node *> &p_inverse_duplimap);
 
 	bool _validate_no_foreign();
@@ -251,9 +251,9 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _normalize_drop(Node *&to_node, int &to_pos, int p_type);
 
-	void _nodes_dragged(Array p_nodes, NodePath p_to, int p_type);
-	void _files_dropped(Vector<String> p_files, NodePath p_to, int p_type);
-	void _script_dropped(String p_file, NodePath p_to);
+	void _nodes_dragged(const Array &p_nodes, NodePath p_to, int p_type);
+	void _files_dropped(const Vector<String> &p_files, NodePath p_to, int p_type);
+	void _script_dropped(const String &p_file, NodePath p_to);
 	void _quick_open();
 
 	void _tree_rmb(const Vector2 &p_menu_pos);
@@ -306,7 +306,7 @@ protected:
 public:
 	String get_filter();
 	void set_filter(const String &p_filter);
-	void save_branch_to_file(String p_directory);
+	void save_branch_to_file(const String &p_directory);
 
 	void _focus_node();
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -46,7 +46,7 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
 
-static String _get_parent_class_of_script(String p_path) {
+static String _get_parent_class_of_script(const String &p_path) {
 	if (!ResourceLoader::exists(p_path, "Script")) {
 		return "Object"; // A script eventually inherits from Object.
 	}
@@ -73,7 +73,7 @@ static String _get_parent_class_of_script(String p_path) {
 	return _get_parent_class_of_script(base->get_path());
 }
 
-static Vector<String> _get_hierarchy(String p_class_name) {
+static Vector<String> _get_hierarchy(const String &p_class_name) {
 	Vector<String> hierarchy;
 
 	String class_name = p_class_name;

--- a/editor/themes/editor_color_map.cpp
+++ b/editor/themes/editor_color_map.cpp
@@ -33,7 +33,7 @@
 HashMap<Color, Color> EditorColorMap::color_conversion_map;
 HashSet<StringName> EditorColorMap::color_conversion_exceptions;
 
-void EditorColorMap::add_conversion_color_pair(const String p_from_color, const String p_to_color) {
+void EditorColorMap::add_conversion_color_pair(const String &p_from_color, const String &p_to_color) {
 	color_conversion_map[Color::html(p_from_color)] = Color::html(p_to_color);
 }
 

--- a/editor/themes/editor_color_map.h
+++ b/editor/themes/editor_color_map.h
@@ -47,7 +47,7 @@ class EditorColorMap {
 	static HashSet<StringName> color_conversion_exceptions;
 
 public:
-	static void add_conversion_color_pair(const String p_from_color, const String p_to_color);
+	static void add_conversion_color_pair(const String &p_from_color, const String &p_to_color);
 	static void add_conversion_exception(const StringName &p_icon_name);
 
 	static HashMap<Color, Color> &get_color_conversion_map() { return color_conversion_map; };

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -286,7 +286,7 @@ void WindowWrapper::enable_window_on_screen(int p_screen, bool p_auto_scale) {
 	}
 }
 
-void WindowWrapper::set_window_title(const String p_title) {
+void WindowWrapper::set_window_title(const String &p_title) {
 	if (!is_window_available()) {
 		return;
 	}

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -78,7 +78,7 @@ public:
 	void restore_window_from_saved_position(const Rect2 p_window_rect, int p_screen, const Rect2 p_screen_rect);
 	void enable_window_on_screen(int p_screen = -1, bool p_auto_scale = false);
 
-	void set_window_title(const String p_title);
+	void set_window_title(const String &p_title);
 	void set_margins_enabled(bool p_enabled);
 
 	WindowWrapper();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds const lvalue reference to the core container types specified in the [documentation](https://docs.godotengine.org/en/stable/development/cpp/core_types.html) that are declared in function parameters in `editor/*` files

initial: https://github.com/godotengine/godot/pull/51156
`core/*`: https://github.com/godotengine/godot/pull/86966
`modules/*`: https://github.com/godotengine/godot/pull/88915
`platform/*`: https://github.com/godotengine/godot/pull/88971
`servers/*`: https://github.com/godotengine/godot/pull/88972
`scene/*`: https://github.com/godotengine/godot/pull/88974
others: https://github.com/godotengine/godot/pull/88975