### PR TITLE
[3.x] Fix X11/Server cross-bits compilation non-x86

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -2,6 +2,7 @@ import os
 import platform
 import sys
 from methods import get_compiler_version, using_gcc
+from platform_methods import detect_arch
 
 # This file is mostly based on platform/x11/detect.py.
 # If editing this file, make sure to apply relevant changes here too.
@@ -85,14 +86,21 @@ def configure(env):
     # Cross-compilation
     # TODO: Support cross-compilation on architectures other than x86.
     host_is_64_bit = sys.maxsize > 2**32
+    is_x86_target = "x86" in env["arch"] if env["arch"] else "x86" in detect_arch()
+
+    if env["arch"] == "" and not is_x86_target:
+        env["arch"] = detect_arch()
+
     if env["bits"] == "default":
         env["bits"] = "64" if host_is_64_bit else "32"
-    if host_is_64_bit and (env["bits"] == "32" or env["arch"] == "x86"):
-        env.Append(CCFLAGS=["-m32"])
-        env.Append(LINKFLAGS=["-m32"])
-    elif not host_is_64_bit and (env["bits"] == "64" or env["arch"] == "x86_64"):
-        env.Append(CCFLAGS=["-m64"])
-        env.Append(LINKFLAGS=["-m64"])
+
+    if is_x86_target:
+        if env["bits"] == "32":
+            env.Append(CCFLAGS=["-m32"])
+            env.Append(LINKFLAGS=["-m32"])
+        elif env["bits"] == "64":
+            env.Append(CCFLAGS=["-m64"])
+            env.Append(LINKFLAGS=["-m64"])
 
     if env["arch"] == "" and platform.machine() == "riscv64":
         env["arch"] = "rv64"

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -4,6 +4,7 @@ import json
 import uuid
 import functools
 import subprocess
+import platform
 
 # NOTE: The multiprocessing module is not compatible with SCons due to conflict on cPickle
 
@@ -11,6 +12,39 @@ if sys.version_info[0] < 3:
     JSON_SERIALIZABLE_TYPES = (bool, int, long, float, basestring)
 else:
     JSON_SERIALIZABLE_TYPES = (bool, int, float, str)
+
+# CPU architecture options.
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
+architecture_aliases = {
+    "x86": "x86_32",
+    "x64": "x86_64",
+    "amd64": "x86_64",
+    "armv7": "arm32",
+    "armv8": "arm64",
+    "arm64v8": "arm64",
+    "aarch64": "arm64",
+    "rv": "rv64",
+    "riscv": "rv64",
+    "riscv64": "rv64",
+    "ppcle": "ppc32",
+    "ppc": "ppc32",
+    "ppc64le": "ppc64",
+}
+
+
+def detect_arch():
+    host_machine = platform.machine().lower()
+    if host_machine in architectures:
+        return host_machine
+    elif host_machine in architecture_aliases.keys():
+        return architecture_aliases[host_machine]
+    elif "86" in host_machine:
+        # Catches x86, i386, i486, i586, i686, etc.
+        return "x86_32"
+    else:
+        print("Unsupported CPU architecture: " + host_machine)
+        print("Falling back to x86_64.")
+        return "x86_64"
 
 
 def run_in_subprocess(builder_function):


### PR DESCRIPTION
When making a 32 bits build from 64 machine (and vice versa) the built system assumed x86 (forcing `-m32` or `-m64`).

This commit backports the arch detection function from 4.x and only use it in the X11 and server platforms to avoid adding the incorrect flags.

I believe that unlike the whole "arch" refactor, this change is more likely to be backported to 3.5, so we can cross compile for arm32 without having to edit the build system.

Based on #55778 (but not a true back-port). I can also look into doing a full back-port if there is interest, but that is kind of a braking as it will also change the name of all binaries (while this PR leaves the behavior of only changing the binary names when specifying an `arch`)