### PR TITLE
Remove NavigationServerDummy warnings

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -347,7 +347,6 @@ void initialize_navigation_server() {
 
 	// Fall back to dummy if no default server has been registered.
 	if (!navigation_server_3d) {
-		WARN_PRINT_ONCE("No NavigationServer3D implementation has been registered! Falling back to a dummy implementation: navigation features will be unavailable.");
 		navigation_server_3d = memnew(NavigationServer3DDummy);
 	}
 
@@ -358,7 +357,6 @@ void initialize_navigation_server() {
 	// Init 2D Navigation Server
 	navigation_server_2d = NavigationServer2DManager::new_default_server();
 	if (!navigation_server_2d) {
-		WARN_PRINT_ONCE("No NavigationServer2D implementation has been registered! Falling back to a dummy implementation: navigation features will be unavailable.");
 		navigation_server_2d = memnew(NavigationServer2DDummy);
 	}
 


### PR DESCRIPTION
Removes NavigationServerDummy warnings.

Godot does not spam dummy warnings for anything else in the engine that uses a dummy implementation when certain features are disabled. The console is quiet with a Godot minimalist build while the NavigationServer is all spammy about it.

You only get those warnings and dummies when you use a build with disabled navigation module which you need to create deliberately so it is not as if you disabled them by accident. Those dummy warnings have no real informational value as it really only matters to know when the dummy fails to load as an error.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
