### PR TITLE
Fix resource previews not created in compatibility rendering

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -476,6 +476,7 @@ void EditorResourcePreview::start() {
 	} else {
 		SceneTree *st = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 		ERR_FAIL_NULL_MSG(st, "Editor's MainLoop is not a SceneTree. This is a bug.");
+		st->add_idle_callback(&_idle_callback);
 	}
 }
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/commit/e5454cd6603ca01bdf47f69cafbb1ef755525a12#r138705235.

Fixes #88170.