### PR TITLE
Redirect mouse events to the window under cursor, simplify popup menu input processing.

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -374,9 +374,14 @@
 	}
 	ds->mouse_set_button_state(last_button_state);
 
+	DisplayServer::WindowID receiving_window_id = ds->get_window_at_screen_position(ds->mouse_get_position());
+	if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+		receiving_window_id = window_id;
+	}
+
 	Ref<InputEventMouseButton> mb;
 	mb.instantiate();
-	mb->set_window_id(window_id);
+	mb->set_window_id(receiving_window_id);
 	if (outofstream) {
 		ds->update_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream]);
 	} else {
@@ -392,6 +397,11 @@
 		mb->set_double_click([event clickCount] == 2);
 	}
 
+	if (receiving_window_id != window_id) {
+		// Adjust event position relative to window distance when event is sent to a different window.
+		mb->set_position(mb->get_position() - ds->window_get_position(receiving_window_id) + ds->window_get_position(window_id));
+		mb->set_global_position(mb->get_position());
+	}
 	Input::get_singleton()->parse_input_event(mb);
 }
 
@@ -432,10 +442,15 @@
 		return;
 	}
 
+	DisplayServer::WindowID receiving_window_id = ds->get_window_at_screen_position(ds->mouse_get_position());
+	if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+		receiving_window_id = window_id;
+	}
+
 	Ref<InputEventMouseMotion> mm;
 	mm.instantiate();
 
-	mm->set_window_id(window_id);
+	mm->set_window_id(receiving_window_id);
 	mm->set_button_mask(ds->mouse_get_button_state());
 	ds->update_mouse_pos(wd, mpos);
 	mm->set_position(wd.mouse_pos);
@@ -458,6 +473,11 @@
 	mm->set_relative_screen_position(relativeMotion);
 	ds->get_key_modifier_state([event modifierFlags], mm);
 
+	if (receiving_window_id != window_id) {
+		// Adjust event position relative to window distance when event is sent to a different window.
+		mm->set_position(mm->get_position() - ds->window_get_position(receiving_window_id) + ds->window_get_position(window_id));
+		mm->set_global_position(mm->get_position());
+	}
 	Input::get_singleton()->parse_input_event(mm);
 }
 
@@ -740,10 +760,15 @@
 	MouseButtonMask mask = mouse_button_to_mask(button);
 	BitField<MouseButtonMask> last_button_state = ds->mouse_get_button_state();
 
+	DisplayServer::WindowID receiving_window_id = ds->get_window_at_screen_position(ds->mouse_get_position());
+	if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+		receiving_window_id = window_id;
+	}
+
 	Ref<InputEventMouseButton> sc;
 	sc.instantiate();
 
-	sc->set_window_id(window_id);
+	sc->set_window_id(receiving_window_id);
 	ds->get_key_modifier_state([event modifierFlags], sc);
 	sc->set_button_index(button);
 	sc->set_factor(factor);
@@ -754,18 +779,16 @@
 	sc->set_button_mask(last_button_state);
 	ds->mouse_set_button_state(last_button_state);
 
+	if (receiving_window_id != window_id) {
+		// Adjust event position relative to window distance when event is sent to a different window.
+		sc->set_position(sc->get_position() - ds->window_get_position(receiving_window_id) + ds->window_get_position(window_id));
+		sc->set_global_position(sc->get_position());
+	}
+
 	Input::get_singleton()->parse_input_event(sc);
 
-	sc.instantiate();
-	sc->set_window_id(window_id);
-	sc->set_button_index(button);
-	sc->set_factor(factor);
+	sc = sc->duplicate();
 	sc->set_pressed(false);
-	sc->set_position(wd.mouse_pos);
-	sc->set_global_position(wd.mouse_pos);
-	last_button_state.clear_flag(mask);
-	sc->set_button_mask(last_button_state);
-	ds->mouse_set_button_state(last_button_state);
 
 	Input::get_singleton()->parse_input_event(sc);
 }

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3959,10 +3959,15 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					}
 				}
 			} else if (mouse_mode == MOUSE_MODE_CAPTURED && raw->header.dwType == RIM_TYPEMOUSE) {
+				DisplayServer::WindowID receiving_window_id = get_window_at_screen_position(mouse_get_position());
+				if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+					receiving_window_id = window_id;
+				}
+
 				Ref<InputEventMouseMotion> mm;
 				mm.instantiate();
 
-				mm->set_window_id(window_id);
+				mm->set_window_id(receiving_window_id);
 				mm->set_ctrl_pressed(control_mem);
 				mm->set_shift_pressed(shift_mem);
 				mm->set_alt_pressed(alt_mem);
@@ -4008,7 +4013,12 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 				mm->set_relative_screen_position(mm->get_relative());
 
-				if ((windows[window_id].window_focused || windows[window_id].is_popup) && mm->get_relative() != Vector2()) {
+				if (mm->get_relative() != Vector2()) {
+					if (receiving_window_id != window_id) {
+						// Adjust event position relative to window distance when event is sent to a different window.
+						mm->set_position(mm->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id));
+						mm->set_global_position(mm->get_position());
+					}
 					Input::get_singleton()->parse_input_event(mm);
 				}
 			}
@@ -4060,9 +4070,14 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 						break;
 					}
 
+					DisplayServer::WindowID receiving_window_id = get_window_at_screen_position(mouse_get_position());
+					if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+						receiving_window_id = window_id;
+					}
+
 					Ref<InputEventMouseMotion> mm;
 					mm.instantiate();
-					mm->set_window_id(window_id);
+					mm->set_window_id(receiving_window_id);
 					mm->set_ctrl_pressed(GetKeyState(VK_CONTROL) < 0);
 					mm->set_shift_pressed(GetKeyState(VK_SHIFT) < 0);
 					mm->set_alt_pressed(alt_mem);
@@ -4106,9 +4121,13 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					mm->set_relative_screen_position(mm->get_relative());
 					old_x = mm->get_position().x;
 					old_y = mm->get_position().y;
-					if (windows[window_id].window_focused || window_get_active_popup() == window_id) {
-						Input::get_singleton()->parse_input_event(mm);
+
+					if (receiving_window_id != window_id) {
+						// Adjust event position relative to window distance when event is sent to a different window.
+						mm->set_position(mm->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id));
+						mm->set_global_position(mm->get_position());
 					}
+					Input::get_singleton()->parse_input_event(mm);
 				}
 				return 0;
 			}
@@ -4196,10 +4215,15 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
+			DisplayServer::WindowID receiving_window_id = get_window_at_screen_position(mouse_get_position());
+			if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+				receiving_window_id = window_id;
+			}
+
 			Ref<InputEventMouseMotion> mm;
 			mm.instantiate();
 
-			mm->set_window_id(window_id);
+			mm->set_window_id(receiving_window_id);
 			if (pen_info.penMask & PEN_MASK_PRESSURE) {
 				mm->set_pressure((float)pen_info.pressure / 1024);
 			} else {
@@ -4255,9 +4279,13 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			mm->set_relative_screen_position(mm->get_relative());
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
-			if (windows[window_id].window_focused || window_get_active_popup() == window_id) {
-				Input::get_singleton()->parse_input_event(mm);
+
+			if (receiving_window_id != window_id) {
+				// Adjust event position relative to window distance when event is sent to a different window.
+				mm->set_position(mm->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id));
+				mm->set_global_position(mm->get_position());
 			}
+			Input::get_singleton()->parse_input_event(mm);
 
 			return 0; // Pointer event handled return 0 to avoid duplicate WM_MOUSEMOVE event.
 		} break;
@@ -4311,7 +4339,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
-			DisplayServer::WindowID receiving_window_id = _get_focused_window_or_popup();
+			DisplayServer::WindowID receiving_window_id = get_window_at_screen_position(mouse_get_position());
 			if (receiving_window_id == INVALID_WINDOW_ID) {
 				receiving_window_id = window_id;
 			}
@@ -4407,9 +4435,14 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		case WM_XBUTTONDBLCLK:
 		case WM_XBUTTONDOWN:
 		case WM_XBUTTONUP: {
+			DisplayServer::WindowID receiving_window_id = get_window_at_screen_position(mouse_get_position());
+			if (receiving_window_id == DisplayServer::INVALID_WINDOW_ID) {
+				receiving_window_id = window_id;
+			}
+
 			Ref<InputEventMouseButton> mb;
 			mb.instantiate();
-			mb->set_window_id(window_id);
+			mb->set_window_id(receiving_window_id);
 
 			switch (uMsg) {
 				case WM_LBUTTONDOWN: {
@@ -4552,11 +4585,15 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			mb->set_global_position(mb->get_position());
 
+			if (receiving_window_id != window_id) {
+				// Adjust event position relative to window distance when event is sent to a different window.
+				mb->set_position(mb->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id));
+				mb->set_global_position(mb->get_position());
+			}
 			Input::get_singleton()->parse_input_event(mb);
 			if (mb->is_pressed() && mb->get_button_index() >= MouseButton::WHEEL_UP && mb->get_button_index() <= MouseButton::WHEEL_RIGHT) {
 				// Send release for mouse wheel.
 				Ref<InputEventMouseButton> mbd = mb->duplicate();
-				mbd->set_window_id(window_id);
 				last_button_state.clear_flag(mouse_button_to_mask(mbd->get_button_index()));
 				mbd->set_button_mask(last_button_state);
 				mbd->set_pressed(false);


### PR DESCRIPTION
- Redirect all mouse events to the window under the cursor.
- Simplify `PopupMenu` input handling.

Fixes https://github.com/godotengine/godot/issues/88324
Fixes https://github.com/godotengine/godot/issues/70361
Fixes https://github.com/godotengine/godot/issues/77246
Fixes https://github.com/godotengine/godot/issues/66273
Fixes https://github.com/godotengine/godot/issues/73926

Supersede https://github.com/godotengine/godot/pull/85583
Supersede https://github.com/godotengine/godot/pull/88366
Supersede https://github.com/godotengine/godot/pull/88342