### PR TITLE
Fix joypad triggers for web builds if the standard html5 gamepad mapping is used.

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -931,13 +931,7 @@ void DisplayServerWeb::process_joypads() {
 			continue;
 		}
 		for (int b = 0; b < s_btns_num; b++) {
-			// Buttons 6 and 7 in the standard mapping need to be
-			// axis to be handled as JoyAxis::TRIGGER by Godot.
-			if (s_standard && (b == 6 || b == 7)) {
-				input->joy_axis(idx, (JoyAxis)b, s_btns[b]);
-			} else {
-				input->joy_button(idx, (JoyButton)b, s_btns[b]);
-			}
+			input->joy_button(idx, (JoyButton)b, s_btns[b]);
 		}
 		for (int a = 0; a < s_axes_num; a++) {
 			input->joy_axis(idx, (JoyAxis)a, s_axes[a]);


### PR DESCRIPTION
The issue seemed to be that the devices were using the [Standard Gamepad](https://w3c.github.io/gamepad/#dfn-standard-gamepad) for HTML5 which defines the triggers as buttons rather than axes.

The logic for web builds appeared to attempt to remap these axes to correspond to the appropriate buttons, however the mapping between the engine and web library has already been done. Godot's build process already handles the defined input and maps it to the expected output.

- Gamepad controller triggers appeared to be broken for 4.2.1 web builds, but not on window builds.
  - Tested with XBox One Controller wired and PS5 Controller wired
  - All other buttons and axes worked as expected
  - Tested in Chrome 121.0.6167.185

Fixes https://github.com/godotengine/godot/issues/81758

Simple project to test with. I tested this both with 4.2.1 and master branch. Note that it will only respond to device 0.
[web-gamepad-trigger-fix (4.2.1).zip](https://github.com/godotengine/godot/files/14309377/web-gamepad-trigger-fix.4.2.1.zip)


The window builds will correctly show the axis values (tested with XBox One and PS5 controller)
![wgtf-1](https://github.com/godotengine/godot/assets/90439391/e48394a7-4678-4800-881c-e7349c9ae07b)
![wgtf-2](https://github.com/godotengine/godot/assets/90439391/40114d90-420c-44a2-949c-33a914a43de0)
![wgtf-3](https://github.com/godotengine/godot/assets/90439391/eec4e42b-e21b-4309-ab2b-7e40f59e180d)

But when doing a standard web build the values will always remain 0 and will never log out an event since the overridden mapping doesn't exist. 
![wgtf-4](https://github.com/godotengine/godot/assets/90439391/14a9c536-6380-4edf-af4a-d111adc91de8)


This fix corrects this behaviour, **though it will only report 0 or 1 since they are using the HTML5 Standard Gamepad.** Further investigation is needed in order to track down that issue, but at least input can be received from the triggers with this fix.