### PR TITLE
Fix `SoftBody3D` for double-precision builds

### DIFF
--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -82,7 +82,10 @@ void SoftBodyRenderingServerHandler::commit_changes() {
 }
 
 void SoftBodyRenderingServerHandler::set_vertex(int p_vertex_id, const Vector3 &p_vertex) {
-	memcpy(&write_buffer[p_vertex_id * stride + offset_vertices], &p_vertex, sizeof(Vector3));
+	float *vertex_buffer = reinterpret_cast<float *>(write_buffer + p_vertex_id * stride + offset_vertices);
+	*vertex_buffer++ = (float)p_vertex.x;
+	*vertex_buffer++ = (float)p_vertex.y;
+	*vertex_buffer++ = (float)p_vertex.z;
 }
 
 void SoftBodyRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &p_normal) {


### PR DESCRIPTION
Forgive the issue-and-PR-rolled-into-one, but I figured this was pretty straight-forward.

It turns out that my previous PR (#81298) that changed the interface for `PhysicsServer3DRenderingServerHandler` also broke `SoftBody3D` for `precision=double` builds entirely.

The issue is that #81298 changed the `memcpy` that happens in `PhysicsServer3DRenderingServerHandler::set_vertex` to copy the incoming vertex position by `sizeof(Vector3)`, which obviously changes depending on the `precision` of the build, but the vertex buffer itself is always single-precision, leading to the `memcpy` writing nonsense (and eventually onto the normals part of the vertex buffer) in `precision=double` builds, which in turn leads to the mesh "exploding" as soon as the `SoftBody3D` updates the rendering server with the new particle positions.

This PR fixes this by explicitly casting each vector component to `float` instead of doing a `memcpy`.