### PR TITLE
Refactor templates and code duplication

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -36,9 +36,6 @@
 #include "core/templates/list.h"
 #include "core/templates/vector.h"
 
-template <typename T>
-class TypedArray;
-
 class Engine {
 public:
 	struct Singleton {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -37,9 +37,6 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_set.h"
 
-template <typename T>
-class TypedArray;
-
 class ProjectSettings : public Object {
 	GDCLASS(ProjectSettings, Object);
 	_THREAD_SAFE_CLASS_

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -42,8 +42,6 @@
 #include "core/templates/safe_refcount.h"
 
 class MainLoop;
-template <typename T>
-class TypedArray;
 
 namespace core_bind {
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -36,9 +36,6 @@
 #include "core/object/object.h"
 #include "core/templates/hash_map.h"
 
-template <typename T>
-class TypedArray;
-
 class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -34,9 +34,6 @@
 #include "core/io/ip_address.h"
 #include "core/os/os.h"
 
-template <typename T>
-class TypedArray;
-
 struct _IP_ResolverPrivate;
 
 class IP : public Object {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -40,8 +40,6 @@
 #include "core/variant/typed_array.h"
 
 class ScriptLanguage;
-template <typename T>
-class TypedArray;
 
 typedef void (*ScriptEditRequestFunction)(const String &p_path);
 

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -61,6 +61,7 @@ class Vector {
 
 public:
 	VectorWriteProxy<T> write;
+	typedef T Type;
 	typedef typename CowData<T>::Size Size;
 
 private:

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -99,6 +99,7 @@ template <class T>
 struct GetTypeInfo<GDExtensionConstPtr<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline String get_type_name() { return get_class_info().class_name; }
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionConstPtr<T>::get_name());
 	}
@@ -108,6 +109,7 @@ template <class T>
 struct GetTypeInfo<GDExtensionPtr<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline String get_type_name() { return get_class_info().class_name; }
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionPtr<T>::get_name());
 	}

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -33,32 +33,6 @@
 
 #include "core/typedefs.h"
 
-template <bool C, typename T = void>
-struct EnableIf {
-	typedef T type;
-};
-
-template <typename T>
-struct EnableIf<false, T> {
-};
-
-template <typename, typename>
-inline constexpr bool types_are_same_v = false;
-
-template <typename T>
-inline constexpr bool types_are_same_v<T, T> = true;
-
-template <typename B, typename D>
-struct TypeInherits {
-	static D *get_d();
-
-	static char (&test(B *))[1];
-	static char (&test(...))[2];
-
-	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
-			!types_are_same_v<B volatile const, void volatile const>;
-};
-
 namespace GodotTypeInfo {
 enum Metadata {
 	METADATA_NONE,
@@ -83,41 +57,29 @@ enum Metadata {
 template <class T, typename = void>
 struct GetTypeInfo;
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                                            \
-	template <>                                                                       \
-	struct GetTypeInfo<m_type> {                                                      \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
-	};                                                                                \
-	template <>                                                                       \
-	struct GetTypeInfo<const m_type &> {                                              \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+template <typename T>
+struct GetTypeInfo<T, EnableIf_t<TypeInherits_v<Object, RemoveRefPointerConst_t<T>>>> {
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline String get_type_name() { return get_class_info().class_name; }
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(StringName(RemoveRefPointerConst_t<T>::get_class_static()));
+	}
+};
+
+#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)                              \
+	template <typename T>                                                                     \
+	struct GetTypeInfo<T, EnableIf_t<types_are_same_v<m_type, RemoveRefPointerConst_t<T>>>> { \
+		static const Variant::Type VARIANT_TYPE = m_var_type;                                 \
+		static const GodotTypeInfo::Metadata METADATA = m_metadata;                           \
+		static inline String get_type_name() { return Variant::get_type_name(VARIANT_TYPE); } \
+		static inline PropertyInfo get_class_info() {                                         \
+			return PropertyInfo(VARIANT_TYPE, String());                                      \
+		}                                                                                     \
 	};
 
-#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)    \
-	template <>                                                     \
-	struct GetTypeInfo<m_type> {                                    \
-		static const Variant::Type VARIANT_TYPE = m_var_type;       \
-		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {               \
-			return PropertyInfo(VARIANT_TYPE, String());            \
-		}                                                           \
-	};                                                              \
-	template <>                                                     \
-	struct GetTypeInfo<const m_type &> {                            \
-		static const Variant::Type VARIANT_TYPE = m_var_type;       \
-		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {               \
-			return PropertyInfo(VARIANT_TYPE, String());            \
-		}                                                           \
-	};
+#define MAKE_TYPE_INFO(m_type, m_var_type) \
+	MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, GodotTypeInfo::METADATA_NONE)
 
 MAKE_TYPE_INFO(bool, Variant::BOOL)
 MAKE_TYPE_INFO_WITH_META(uint8_t, Variant::INT, GodotTypeInfo::METADATA_INT_IS_UINT8)
@@ -170,75 +132,32 @@ MAKE_TYPE_INFO(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
 MAKE_TYPE_INFO(IPAddress, Variant::STRING)
 
 //objectID
-template <>
-struct GetTypeInfo<ObjectID> {
+template <typename T>
+struct GetTypeInfo<T, EnableIf_t<types_are_same_v<ObjectID, RemoveRefPointerConst_t<T>>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::INT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_INT_IS_UINT64;
+	static inline String get_type_name() { return Variant::get_type_name(VARIANT_TYPE); }
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_OBJECTID);
 	}
 };
 
 //for variant
-template <>
-struct GetTypeInfo<Variant> {
+template <typename T>
+struct GetTypeInfo<T, EnableIf_t<types_are_same_v<Variant, RemoveRefPointerConst_t<T>>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline String get_type_name() { return Variant::get_type_name(VARIANT_TYPE); }
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
 
-template <>
-struct GetTypeInfo<const Variant &> {
-	static const Variant::Type VARIANT_TYPE = Variant::NIL;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
-	}
-};
-
-#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
-	template <>                                                                       \
-	struct GetTypeInfo<m_template<m_type>> {                                          \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
-	};                                                                                \
-	template <>                                                                       \
-	struct GetTypeInfo<const m_template<m_type> &> {                                  \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
-	};
-
-MAKE_TEMPLATE_TYPE_INFO(Vector, Variant, Variant::ARRAY)
-MAKE_TEMPLATE_TYPE_INFO(Vector, RID, Variant::ARRAY)
-MAKE_TEMPLATE_TYPE_INFO(Vector, Plane, Variant::ARRAY)
-MAKE_TEMPLATE_TYPE_INFO(Vector, Face3, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TEMPLATE_TYPE_INFO(Vector, StringName, Variant::PACKED_STRING_ARRAY)
-
-template <typename T>
-struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(StringName(T::get_class_static()));
-	}
-};
-
-template <typename T>
-struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(StringName(T::get_class_static()));
-	}
-};
+MAKE_TYPE_INFO(Vector<Variant>, Variant::ARRAY)
+MAKE_TYPE_INFO(Vector<RID>, Variant::ARRAY)
+MAKE_TYPE_INFO(Vector<Plane>, Variant::ARRAY)
+MAKE_TYPE_INFO(Vector<Face3>, Variant::PACKED_VECTOR3_ARRAY)
+MAKE_TYPE_INFO(Vector<StringName>, Variant::PACKED_STRING_ARRAY)
 
 namespace godot {
 namespace details {
@@ -253,22 +172,17 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 } // namespace details
 } // namespace godot
 
-#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                            \
-	template <>                                                                                                                              \
-	struct GetTypeInfo<m_impl> {                                                                                                             \
+#define MAKE_ENUM_TYPE_INFO(m_enum)                                                                                                          \
+	template <typename T>                                                                                                                    \
+	struct GetTypeInfo<T, EnableIf_t<types_are_same_v<m_enum, RemoveRefPointerConst_t<T>>>> {                                                \
 		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
+		static inline String get_type_name() { return Variant::get_type_name(VARIANT_TYPE); }                                                \
 		static inline PropertyInfo get_class_info() {                                                                                        \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
 					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                \
 		}                                                                                                                                    \
 	};
-
-#define MAKE_ENUM_TYPE_INFO(m_enum)                 \
-	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum)       \
-	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum const) \
-	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_enum &)     \
-	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, const m_enum &)
 
 template <typename T>
 inline StringName __constant_get_enum_name(T param, const String &p_constant) {
@@ -298,31 +212,27 @@ public:
 	_FORCE_INLINE_ operator Variant() const { return value; }
 };
 
-#define TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_impl)                                                                                            \
-	template <>                                                                                                                                  \
-	struct GetTypeInfo<m_impl> {                                                                                                                 \
+#define MAKE_BITFIELD_TYPE_INFO(m_enum)                                                                                                          \
+	template <typename T>                                                                                                                        \
+	struct GetTypeInfo<T, EnableIf_t<types_are_same_v<m_enum, RemoveRefPointerConst_t<T>>>> {                                                    \
 		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
+		static inline String get_type_name() { return Variant::get_type_name(VARIANT_TYPE); }                                                    \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
 					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                    \
 		}                                                                                                                                        \
 	};                                                                                                                                           \
-	template <>                                                                                                                                  \
-	struct GetTypeInfo<BitField<m_impl>> {                                                                                                       \
+	template <typename T>                                                                                                                        \
+	struct GetTypeInfo<BitField<T>, EnableIf_t<types_are_same_v<BitField<m_enum>, BitField<RemoveRefPointerConst_t<T>>>>> {                      \
 		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
+		static inline String get_type_name() { return Variant::get_type_name(VARIANT_TYPE); }                                                    \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
 					godot::details::enum_qualified_name_to_class_info_name(String(#m_enum)));                                                    \
 		}                                                                                                                                        \
 	};
-
-#define MAKE_BITFIELD_TYPE_INFO(m_enum)                 \
-	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum)       \
-	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum const) \
-	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_enum &)     \
-	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, const m_enum &)
 
 template <typename T>
 inline StringName __constant_get_bitfield_name(T param, const String &p_constant) {

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -41,203 +41,48 @@
 template <class T>
 class TypedArray : public Array {
 public:
+	typedef T Type;
 	_FORCE_INLINE_ void operator=(const Array &p_array) {
 		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
 		_ref(p_array);
 	}
 	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
-			Array(Array(p_variant), Variant::OBJECT, T::get_class_static(), Variant()) {
+			Array(Array(p_variant), GetTypeInfo<T>::VARIANT_TYPE, GetTypeInfo<T>::get_class_info().class_name, Variant()) {
 	}
 	_FORCE_INLINE_ TypedArray(const Array &p_array) :
-			Array(p_array, Variant::OBJECT, T::get_class_static(), Variant()) {
+			Array(p_array, GetTypeInfo<T>::VARIANT_TYPE, GetTypeInfo<T>::get_class_info().class_name, Variant()) {
 	}
 	_FORCE_INLINE_ TypedArray() {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+		set_typed(GetTypeInfo<T>::VARIANT_TYPE, GetTypeInfo<T>::get_class_info().class_name, Variant());
 	}
 };
 
 template <class T>
-struct VariantInternalAccessor<TypedArray<T>> {
-	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
-	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
-};
-template <class T>
-struct VariantInternalAccessor<const TypedArray<T> &> {
-	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
-	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
+struct VariantInternalAccessor<T, EnableIf_t<types_are_same_v<TypedArray<typename RemoveRefPointerConst_t<T>::Type>, RemoveRefPointerConst_t<T>>>> {
+	typedef RemoveRefPointerConst_t<T> TStripped;
+	static _FORCE_INLINE_ TStripped get(const Variant *v) { return *VariantInternal::get_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const TStripped &p_array) { *VariantInternal::get_array(v) = p_array; }
 };
 
-//specialization for the rest of variant types
-
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
-	template <>                                                                                                  \
-	class TypedArray<m_type> : public Array {                                                                    \
-	public:                                                                                                      \
-		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
-			_ref(p_array);                                                                                       \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
-				Array(Array(p_variant), m_variant_type, StringName(), Variant()) {                               \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Array &p_array) :                                                        \
-				Array(p_array, m_variant_type, StringName(), Variant()) {                                        \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-		}                                                                                                        \
-	};
-
-// All Variant::OBJECT types are intentionally omitted from this list because they are handled by
-// the unspecialized TypedArray definition.
-MAKE_TYPED_ARRAY(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY(String, Variant::STRING)
-MAKE_TYPED_ARRAY(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY(RID, Variant::RID)
-MAKE_TYPED_ARRAY(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY(IPAddress, Variant::STRING)
-
 template <class T>
-struct PtrToArg<TypedArray<T>> {
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
-		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
+struct PtrToArg<T, EnableIf_t<types_are_same_v<TypedArray<typename RemoveRefPointerConst_t<T>::Type>, RemoveRefPointerConst_t<T>>>> {
+	typedef RemoveRefPointerConst_t<T> TStripped;
+	_FORCE_INLINE_ static TStripped convert(const void *p_ptr) {
+		return TStripped(*reinterpret_cast<const Array *>(p_ptr));
 	}
 	typedef Array EncodeT;
-	_FORCE_INLINE_ static void encode(TypedArray<T> p_val, void *p_ptr) {
+	_FORCE_INLINE_ static void encode(TStripped p_val, void *p_ptr) {
 		*(Array *)p_ptr = p_val;
 	}
 };
 
 template <class T>
-struct PtrToArg<const TypedArray<T> &> {
-	typedef Array EncodeT;
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
-		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
-	}
-};
-
-template <class T>
-struct GetTypeInfo<TypedArray<T>> {
+struct GetTypeInfo<T, EnableIf_t<types_are_same_v<TypedArray<typename RemoveRefPointerConst_t<T>::Type>, RemoveRefPointerConst_t<T>>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, GetTypeInfo<typename RemoveRefPointerConst_t<T>::Type>::get_type_name());
 	}
 };
-
-template <class T>
-struct GetTypeInfo<const TypedArray<T> &> {
-	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
-	}
-};
-
-#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type)                                                                        \
-	template <>                                                                                                              \
-	struct GetTypeInfo<TypedArray<m_type>> {                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};                                                                                                                       \
-	template <>                                                                                                              \
-	struct GetTypeInfo<const TypedArray<m_type> &> {                                                                         \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};
-
-MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY_INFO(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(String, Variant::STRING)
-MAKE_TYPED_ARRAY_INFO(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY_INFO(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY_INFO(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY_INFO(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY_INFO(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY_INFO(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY_INFO(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY_INFO(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY_INFO(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY_INFO(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY_INFO(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY_INFO(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY_INFO(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY_INFO(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY_INFO(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY_INFO(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY_INFO(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY_INFO(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY_INFO(RID, Variant::RID)
-MAKE_TYPED_ARRAY_INFO(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY_INFO(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY_INFO(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY_INFO(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY_INFO(IPAddress, Variant::STRING)
-
-#undef MAKE_TYPED_ARRAY
-#undef MAKE_TYPED_ARRAY_INFO
 
 #endif // TYPED_ARRAY_H

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1050,7 +1050,7 @@ bool Variant::is_null() const {
 }
 
 bool Variant::initialize_ref(Object *p_object) {
-	RefCounted *ref_counted = const_cast<RefCounted *>(static_cast<const RefCounted *>(p_object));
+	RefCounted *ref_counted = static_or_reinterpret_cast<RefCounted *>(p_object);
 	if (!ref_counted->init_ref()) {
 		return false;
 	}
@@ -2610,7 +2610,7 @@ Variant::Variant(const Object *p_object) {
 
 	if (p_object) {
 		if (p_object->is_ref_counted()) {
-			RefCounted *ref_counted = const_cast<RefCounted *>(static_cast<const RefCounted *>(p_object));
+			RefCounted *ref_counted = static_or_reinterpret_cast<RefCounted *>(p_object);
 			if (!ref_counted->init_ref()) {
 				_get_obj().obj = nullptr;
 				_get_obj().id = ObjectID();

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -218,7 +218,7 @@ private:
 			return static_cast<PackedArrayRef<T> *>(p_base)->array;
 		}
 		static _FORCE_INLINE_ Vector<T> *get_array_ptr(const PackedArrayRefBase *p_base) {
-			return &const_cast<PackedArrayRef<T> *>(static_cast<const PackedArrayRef<T> *>(p_base))->array;
+			return &static_or_reinterpret_cast<PackedArrayRef<T> *>(p_base)->array;
 		}
 
 		_FORCE_INLINE_ PackedArrayRef(const Vector<T> &p_from) {

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -331,7 +331,7 @@ void VariantInternal::refcounted_object_assign(Variant *v, const RefCounted *rc)
 void VariantInternal::object_assign(Variant *v, const Object *o) {
 	if (o) {
 		if (o->is_ref_counted()) {
-			RefCounted *ref_counted = const_cast<RefCounted *>(static_cast<const RefCounted *>(o));
+			RefCounted *ref_counted = static_or_reinterpret_cast<RefCounted *>(o);
 			if (!ref_counted->init_ref()) {
 				v->_get_obj().obj = nullptr;
 				v->_get_obj().id = ObjectID();

--- a/main/performance.h
+++ b/main/performance.h
@@ -37,9 +37,6 @@
 #define PERF_WARN_OFFLINE_FUNCTION
 #define PERF_WARN_PROCESS_SYNC
 
-template <typename T>
-class TypedArray;
-
 class Performance : public Object {
 	GDCLASS(Performance, Object);
 

--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -38,9 +38,6 @@
 
 #include <enet/enet.h>
 
-template <typename T>
-class TypedArray;
-
 class ENetConnection : public RefCounted {
 	GDCLASS(ENetConnection, RefCounted);
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -833,7 +833,7 @@ void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)(b
 	}
 
 #ifdef TOOLS_ENABLED
-	if constexpr (std::is_same_v<T, ClassNode>) {
+	if constexpr (types_are_same_v<T, ClassNode>) {
 		if (has_comment(member->start_line, true)) {
 			// Inline doc comment.
 			member->doc_data = parse_class_doc_comment(member->start_line, true);

--- a/modules/gdscript/gdscript_utility_functions.h
+++ b/modules/gdscript/gdscript_utility_functions.h
@@ -34,9 +34,6 @@
 #include "core/string/string_name.h"
 #include "core/variant/variant.h"
 
-template <typename T>
-class TypedArray;
-
 class GDScriptUtilityFunctions {
 public:
 	typedef void (*FunctionPtr)(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error);

--- a/modules/gltf/structures/gltf_skin.h
+++ b/modules/gltf/structures/gltf_skin.h
@@ -36,9 +36,6 @@
 #include "core/io/resource.h"
 #include "scene/resources/skin.h"
 
-template <typename T>
-class TypedArray;
-
 class GLTFSkin : public Resource {
 	GDCLASS(GLTFSkin, Resource);
 	friend class GLTFDocument;

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -35,9 +35,6 @@
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 
-template <typename T>
-class TypedArray;
-
 class BitMap : public Resource {
 	GDCLASS(BitMap, Resource);
 	OBJ_SAVE_TYPE(BitMap);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2848,7 +2848,7 @@ Ref<Font> FontVariation::get_base_font() const {
 
 Ref<Font> FontVariation::_get_base_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(static_or_reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -2877,7 +2877,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 			}
 			if (f.is_valid()) {
 				theme_font = f;
-				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+				theme_font->connect_changed(callable_mp(static_or_reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
@@ -2887,7 +2887,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 	if (f != this) {
 		if (f.is_valid()) {
 			theme_font = f;
-			theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+			theme_font->connect_changed(callable_mp(static_or_reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 		}
 		return f;
 	}
@@ -3206,7 +3206,7 @@ void SystemFont::reset_state() {
 
 Ref<Font> SystemFont::_get_base_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(static_or_reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -3235,7 +3235,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 			}
 			if (f.is_valid()) {
 				theme_font = f;
-				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+				theme_font->connect_changed(callable_mp(static_or_reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
@@ -3245,7 +3245,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 	if (f != this) {
 		if (f.is_valid()) {
 			theme_font = f;
-			theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+			theme_font->connect_changed(callable_mp(static_or_reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 		}
 		return f;
 	}

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -43,8 +43,6 @@
 **/
 
 class CameraFeed;
-template <typename T>
-class TypedArray;
 
 class CameraServer : public Object {
 	GDCLASS(CameraServer, Object);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -36,8 +36,6 @@
 #include "core/object/ref_counted.h"
 
 class PhysicsDirectSpaceState2D;
-template <typename T>
-class TypedArray;
 
 class PhysicsDirectBodyState2D : public Object {
 	GDCLASS(PhysicsDirectBodyState2D, Object);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -37,8 +37,6 @@
 #include "core/variant/native_ptr.h"
 
 class PhysicsDirectSpaceState3D;
-template <typename T>
-class TypedArray;
 
 class PhysicsDirectBodyState3D : public Object {
 	GDCLASS(PhysicsDirectBodyState3D, Object);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -41,9 +41,6 @@
 #include "servers/display_server.h"
 #include "servers/rendering/rendering_device.h"
 
-template <typename T>
-class TypedArray;
-
 class RenderingServer : public Object {
 	GDCLASS(RenderingServer, Object);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -37,9 +37,6 @@
 #include "core/variant/native_ptr.h"
 #include "core/variant/variant.h"
 
-template <typename T>
-class TypedArray;
-
 struct Glyph;
 struct CaretInfo;
 


### PR DESCRIPTION
So I was searching for `bind_static_vararg_method` (which sadly doesn't exist), and ended up reading Godot's template code.  I noticed that there was a lot of duplication and decided to see if I could reduce the duplication.
I've summarized the changes and how I tested it below since template code is often difficult to read without knowing the context.

* Collapse multiple, duplicate, specializations into single specializations (with the help of enable-if).
    For example, this
    ``` C++
    template<typename T> struct MyStruct;
    template<> struct MyStruct<MyType> { /* some specialization */ };
    template<> struct MyStruct<const MyType&> { /* identical specialization as just "MyType"*/ };
    ```
    Becomes
    ``` C++
    template<typename T, typename = void> struct MyStruct;
    template<typename T> struct MyStruct<T, EnableIf_t<types_are_same_v<MyType, RemoveRefPointerConst_t<T>>> {
      /* some specialization */
    };
    ```
* Move existing templates to typedefs.h since one file couldn't include core/typedefs.  Figure it doesn't hurt to move them since it increases visibility
* Add `get_type_name()` to `GetTypeInfo` due to the refactor in typed_array.h.  I think the correct place to put this string is in `PropertyInfo`, but wanted to see what others thought first.
* I'm assuming `GetTypeInfo<T>::get_class_info().class_name` is `T::get_class_static()` for Objects and empty string otherwise.
* `VariantObjectClassChecker` was not collapsed, but instead was generalized to handle const and non-const Ref.  I figured this was necessary since the place its used (`VariantCasterAndValidate`), can pass in any type.
* Add a few new template types to core/typedefs.h that are similar, but not the same, as stl templates:
    * `is_void_v` returns void if the base type is void, instead of exactly void
        Test:
        ``` C++
        print_line("std::is_void_v",
                   std::is_void_v<void>,
                   std::is_void_v<void*>,
                   std::is_void_v<void*&>,
                   std::is_void_v<void**>,
                   std::is_void_v<const void*>,
                   std::is_void_v<const void*&>,
                   std::is_void_v<const void**>,
                   std::is_void_v<const void**&>);
        print_line("is_void_v",
                   is_void_v<void>,
                   is_void_v<void*>,
                   is_void_v<void*&>,
                   is_void_v<void**>,
                   is_void_v<const void*>,
                   is_void_v<const void*&>,
                   is_void_v<const void**>,
                   is_void_v<const void**&>);
        ```
        Output:
        ```
        std::is_void_v true false false false false false false false
        is_void_v true true true true true true true true
        ```
    * `RemoveRefPointerConst_t` removes const, ref, and pointer(s) from a type, leaving you with the base type.
        I tried `std::decay` too, but it returned `false` for every case.
        Test:
        ``` C++
        print_line("std",
                   std::is_same_v<int, std::remove_cv_t<std::remove_reference_t<int>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int&>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int*>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int*&>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int**>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int**&>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int&>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int*>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int*&>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int**>>>>,
                   std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int**&>>>>);

        print_line("custom",
                   std::is_same_v<int, RemoveRefPointerConst_t<int>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<int&>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<int*>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<int*&>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<int**>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<int**&>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<const int&>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<const int*>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<const int*&>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<const int**>>,
                   std::is_same_v<int, RemoveRefPointerConst_t<const int**&>>);
        ```
        Output:
        ```
        std true true true true false false true true true false false
        custom true true true true true true true true true true true
        ```
    * `static_or_reinterpret_cast` (for lack of a better name, considering it optionally calls `const_cast` too) to simplify otherwise complex expressions.

       For example, this
       ``` C++
       T *ret1 = const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr));
       RefCounted *ret2 = const_cast<RefCounted *>(static_cast<const RefCounted *>(o));
       ```
       Becomes
       ``` C++
       T *ret1 = static_or_reinterpret_cast<T*>(p_ptr);
       RefCounted *ret2 = static_or_reinterpret_cast<RefCounted *>(o);
       ```

      Test code to verify that the correct casts were taking place (I also put printfs in `static_or_reinterpret_cast` so I can see which one is being called)
      ``` C++
      Label* l = memnew(Label);
      Node* n0 = static_or_reinterpret_cast<Node*>(l);
      Node* n1 = static_or_reinterpret_cast<Node*>((const Label*)l);
      Node* n2 = static_or_reinterpret_cast<Node*>((void*)l);
      Node* n3 = static_or_reinterpret_cast<Node*>((const void*)l);
      const Node* n4 = static_or_reinterpret_cast<const Node*>(l);
      const Node* n5 = static_or_reinterpret_cast<const Node*>((void*)l);
      const Node* n6 = static_or_reinterpret_cast<const Node*>((const Label*)l);
      const Node* n7 = static_or_reinterpret_cast<const Node*>((const void*)l);
      ```
      The original reason for this function is that collapsing some duplicate template specializations didn't result in identical code.  In particular, `const_cast` was always called instead of conditionally called.  `struct PtrToArg<T, EnableIf_t<std::is_pointer_v<T>>>` in method_ptrcall.h is a good example of this.
    * `is_ptr_to_const_v` determines if a pointer is a pointer-to-const (like `const int*`).
       This template was needed for `static_or_reinterpret_cast` since using `const_cast` is dependent on whether it is working on a pointer-to-const or not.  This does not return true for ref-to-const.
       Test:
       ``` C++
        print_line("is_ptr_to_const_v",
                   is_ptr_to_const_v<int>,
                   is_ptr_to_const_v<int&>,
                   is_ptr_to_const_v<int*>,
                   is_ptr_to_const_v<int*&>,
                   is_ptr_to_const_v<int**>,
                   is_ptr_to_const_v<int**&>,
                   is_ptr_to_const_v<const int&>,
                   is_ptr_to_const_v<const int*>,
                   is_ptr_to_const_v<const int*&>,
                   is_ptr_to_const_v<const int**>,
                   is_ptr_to_const_v<const int**&>);
       ```
       Output:
       ```
       is_ptr_to_const_v false false false false false false false true true true true
       ```