### PR TITLE
Clarify that LightmapGI is not supported in compatibility renderer

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -9,7 +9,7 @@
 		[b]Performance:[/b] [LightmapGI] provides the best possible run-time performance for global illumination. It is suitable for low-end hardware including integrated graphics and mobile devices.
 		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 		[b]Note:[/b] Lightmap baking on [CSGShape3D]s and [PrimitiveMesh]es is not supported, as these cannot store UV2 data required for baking.
-		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked from devices that support the Forward+ or Mobile rendering backends.
+		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked from devices that support the Forward+ or Mobile rendering backends. Additionally, [LightmapGI] rendering is not currently supported in the Compatibility rendering method.
 	</description>
 	<tutorials>
 		<link title="Using Lightmap global illumination">$DOCS_URL/tutorials/3d/global_illumination/using_lightmap_gi.html</link>


### PR DESCRIPTION
The documentation currently does not mention that LightmapGI _rendering_ is not supported in the compatibility renderer. It only states the fact that baking it is not supported (thus it is possible to make an assumption that _rendering_ it is supported, while baking isn't).

I'd originally wanted to reply in https://github.com/godotengine/godot/issues/75726#issuecomment-1499752607 but appening this to documentation seemed fairly easy to do myself.