### PR TITLE
Make dummy rendering server appear as a high end platform to fix vulkan shader compile error when exporting

### DIFF
--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -104,7 +104,7 @@ public:
 
 	static void make_current() {
 		_create_func = _create_current;
-		low_end = true;
+		low_end = false;
 	}
 
 	uint64_t get_frame_number() const override { return frame; }


### PR DESCRIPTION
 Fixes https://github.com/godotengine/godot/issues/88187 as https://github.com/godotengine/godot/issues/88187#issuecomment-1937400961 suggested, tested locally it eliminates the shader compilation error reported.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
