### PR TITLE
[UX] Renamed 'quick load' to 'search', to make it more User friendly 

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -194,7 +194,7 @@ void EditorResourcePicker::_update_menu_items() {
 		set_create_options(edit_menu);
 
 		// Add an option to load a resource from a file using the QuickOpen dialog.
-		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Quick Load"), OBJ_MENU_QUICKLOAD);
+		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Search")), TTR("Search"), OBJ_MENU_QUICKLOAD);
 
 		// Add an option to load a resource from a file using the regular file dialog.
 		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Load"), OBJ_MENU_LOAD);


### PR DESCRIPTION
# Preview
![Scene](https://github.com/godotengine/godot/assets/16447282/b0e48c26-3677-442a-aae0-b08bd67c4a9a)
## About
My goal is making godot more User friendly to new users. So i changed something that caused me a lot of confusion to me at the start. 
I assumed Quick Load meant a different type of loading (like preload). That's its somehow faster and completely different operation from the Load option. To my surprise, i did not expect it to be an asset search dialog. This happened because I didn't know about the quick open dialogs.
## Why
 **Since then I realized that to properly understand what Quick Load does from its name alone, I needed to know already what quick open was. So I made it simpler to eliminate this barrier of entry. that's why I renamed it to 'search' since that's the only action you can do when the dialog pops up.** 
## Requires Minimal Doc Changes
From what i can tell changes to the docs would be minimal (like 2 lines approx) since its rarely mentioned there.
Here's a screenshot where i look up every mention of quick load in the docs
![image](https://github.com/godotengine/godot/assets/16447282/bab6252f-d62f-4760-acb8-d180047c6e73)

Feel free to leave some feedback on this change. 

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9112*