### PR TITLE
Allow GDExtensions to set a `compatibility_maximum`

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -914,6 +914,35 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 		return ERR_INVALID_DATA;
 	}
 
+	// Optionally check maximum compatibility.
+	if (config->has_section_key("configuration", "compatibility_maximum")) {
+		uint32_t compatibility_maximum[3] = { 0, 0, 0 };
+		String compat_string = config->get_value("configuration", "compatibility_maximum");
+		Vector<int> parts = compat_string.split_ints(".");
+		for (int i = 0; i < 3; i++) {
+			if (i < parts.size() && parts[i] >= 0) {
+				compatibility_maximum[i] = parts[i];
+			} else {
+				// If a version part is missing, set the maximum to an arbitrary high value.
+				compatibility_maximum[i] = 9999;
+			}
+		}
+
+		compatible = true;
+		if (VERSION_MAJOR != compatibility_maximum[0]) {
+			compatible = VERSION_MAJOR < compatibility_maximum[0];
+		} else if (VERSION_MINOR != compatibility_maximum[1]) {
+			compatible = VERSION_MINOR < compatibility_maximum[1];
+		} else {
+			compatible = VERSION_PATCH <= compatibility_maximum[2];
+		}
+
+		if (!compatible) {
+			ERR_PRINT(vformat("GDExtension only compatible with Godot version %s or earlier: %s", compat_string, p_path));
+			return ERR_INVALID_DATA;
+		}
+	}
+
 	String library_path = GDExtension::find_extension_library(p_path, config, [](const String &p_feature) { return OS::get_singleton()->has_feature(p_feature); });
 
 	if (library_path.is_empty()) {


### PR DESCRIPTION
At the GDExtension meeting on December 1st, 2023 (see [notes](https://docs.google.com/document/d/1B1ffNeNX5u24C8Oh3SF2vRrnEsurrithrFBgUZRHHCo/edit#heading=h.5hxx7gcgdphy)), we agreed on a number of changes to help with upgrading Godot on projects using GDExtensions.

One of those changes was implementing a `compatibility_maximum` that can be used in .gdextension files - which is what this PR adds!

While this doesn't solve all the problems, it is simple to add, and is another tool in the toolbox for use by the maintainers of GDExtensions.

In fact, Godot Jolt is already implementing a custom version of this in its [register_types.cpp](https://github.com/godot-jolt/godot-jolt/blob/master/src/register_types.cpp):

```c++
	if (internal::godot_version.major != GDJ_GODOT_VERSION_MAJOR ||
		internal::godot_version.minor != GDJ_GODOT_VERSION_MINOR)
	{
		char error_message[4096] = {'\0'};

		snprintf(
			error_message,
			(size_t)count_of(error_message),
			"Godot Jolt failed to load due to not supporting Godot %d.%d. "
			"This version of Godot Jolt (%d.%d.%d) only supports Godot %d.%d.",
			internal::godot_version.major,
			internal::godot_version.minor,
			GDJ_VERSION_MAJOR,
			GDJ_VERSION_MINOR,
			GDJ_VERSION_PATCH,
			GDJ_GODOT_VERSION_MAJOR,
			GDJ_GODOT_VERSION_MINOR
		);

		ERR_PRINT_EARLY(error_message);

		success = 0;
	}
```

So, this is a pretty good sign that this feature would be useful.

However, I think it would actually be even better if Godot Jolt used `compatibility_maximum` instead of hard-coding this in the C++, because that would make it easier for advanced users to test it with new versions.

_(Selfishly, I would like to be able to grab old binary releases of Godot Jolt and try them with Godot `master` during development, as a way to test that we didn't break GDExtension's binary compatibility - if it used `compatibility_maximum`, I could just delete that line ;-))_

Please let me know what you think!

/cc @mihe 