### PR TITLE
Unbind GDExtension methods that can't reasonably be used

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -807,12 +807,8 @@ void GDExtension::deinitialize_library(InitializationLevel p_level) {
 }
 
 void GDExtension::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::open_library);
-	ClassDB::bind_method(D_METHOD("close_library"), &GDExtension::close_library);
 	ClassDB::bind_method(D_METHOD("is_library_open"), &GDExtension::is_library_open);
-
 	ClassDB::bind_method(D_METHOD("get_minimum_library_initialization_level"), &GDExtension::get_minimum_library_initialization_level);
-	ClassDB::bind_method(D_METHOD("initialize_library", "level"), &GDExtension::initialize_library);
 
 	BIND_ENUM_CONSTANT(INITIALIZATION_LEVEL_CORE);
 	BIND_ENUM_CONSTANT(INITIALIZATION_LEVEL_SERVERS);

--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -12,40 +12,16 @@
 		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/gdextension/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>
-		<method name="close_library">
-			<return type="void" />
-			<description>
-				Closes the current library.
-				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.unload_extension].
-			</description>
-		</method>
 		<method name="get_minimum_library_initialization_level" qualifiers="const">
 			<return type="int" enum="GDExtension.InitializationLevel" />
 			<description>
 				Returns the lowest level required for this extension to be properly initialized (see the [enum InitializationLevel] enum).
 			</description>
 		</method>
-		<method name="initialize_library">
-			<return type="void" />
-			<param index="0" name="level" type="int" enum="GDExtension.InitializationLevel" />
-			<description>
-				Initializes the library bound to this GDextension at the given initialization [param level].
-				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.load_extension].
-			</description>
-		</method>
 		<method name="is_library_open" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this extension's library has been opened.
-			</description>
-		</method>
-		<method name="open_library">
-			<return type="int" enum="Error" />
-			<param index="0" name="path" type="String" />
-			<param index="1" name="entry_symbol" type="String" />
-			<description>
-				Opens the library at the specified [param path].
-				[b]Note:[/b] You normally should not call this method directly. This is handled automatically by [method GDExtensionManager.load_extension].
 			</description>
 		</method>
 	</methods>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -120,3 +120,12 @@ GH-87340
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/RenderingDevice/methods/screen_get_framebuffer_format': arguments
 
 screen_get_framebuffer_format can now specify the screen it should get the format from. The argument defaults to the main window to emulate the behavior of the old function.
+
+
+GH-88418
+--------
+Validate extension JSON: API was removed: classes/GDExtension/methods/close_library
+Validate extension JSON: API was removed: classes/GDExtension/methods/initialize_library
+Validate extension JSON: API was removed: classes/GDExtension/methods/open_library
+
+Since it was basically impossible to use these methods in any useful way, the GDExtension team agreed that breaking compatibility by removing them was OK.


### PR DESCRIPTION
At the GDExtension meeting on January 26th, 2024 (see [notes](https://docs.google.com/document/d/1B1ffNeNX5u24C8Oh3SF2vRrnEsurrithrFBgUZRHHCo/edit#heading=h.5hxx7gcgdphy)) we agreed to unbind a number of methods on the `GDExtension` class that can't reasonably be used by developers.

These methods include:

- `GDExtension::open_library()`
- `GDExtension::initialize_library()`
- `GDExtension::close_library()`

A developer could _maybe_ have partially correctly loaded and initialized a GDExtension using `open_library()` and then calling `initialize_library()` with each initialization level. However, a number of other important things are managed by using `GDExtensionManager::load_extension()`, which this would bypass. Strangely, we never bound `deinitialize_library()` (the opposite to `initialize_library()`), so a developer could not have closed a GDExtension properly using these APIs.

Anyway, developers should be using `GDExtensionManager::load_extension()` and `GDExtensionManager::unload_extension()` to _correctly_ load and unload a GDExtension.

Since it's basically impossible to use the methods being unbound by this PR in any useful way, we agreed at the meeting that we didn't need to provide compatibility methods for them.

This discussion started from PR https://github.com/godotengine/godot/pull/86968 which was attempting to document the methods in question