### PR TITLE
Add an `Advanced Options` toggle to the editor export preset

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -47,6 +47,7 @@ void EditorExport::_save() {
 		config->set_value(section, "name", preset->get_name());
 		config->set_value(section, "platform", preset->get_platform()->get_name());
 		config->set_value(section, "runnable", preset->is_runnable());
+		config->set_value(section, "advanced_options", preset->are_advanced_options_enabled());
 		config->set_value(section, "dedicated_server", preset->is_dedicated_server());
 		config->set_value(section, "custom_features", preset->get_custom_features());
 
@@ -227,6 +228,7 @@ void EditorExport::load_config() {
 		}
 
 		preset->set_name(config->get_value(section, "name"));
+		preset->set_advanced_options_enabled(config->get_value(section, "advanced_options", false));
 		preset->set_runnable(config->get_value(section, "runnable"));
 		preset->set_dedicated_server(config->get_value(section, "dedicated_server", false));
 

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -228,6 +228,19 @@ bool EditorExportPreset::is_runnable() const {
 	return runnable;
 }
 
+void EditorExportPreset::set_advanced_options_enabled(bool p_enabled) {
+	if (advanced_options_enabled == p_enabled) {
+		return;
+	}
+	advanced_options_enabled = p_enabled;
+	EditorExport::singleton->save_presets();
+	notify_property_list_changed();
+}
+
+bool EditorExportPreset::are_advanced_options_enabled() const {
+	return advanced_options_enabled;
+}
+
 void EditorExportPreset::set_dedicated_server(bool p_enable) {
 	dedicated_server = p_enable;
 	EditorExport::singleton->save_presets();

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -71,6 +71,7 @@ private:
 	HashSet<String> selected_files;
 	HashMap<String, FileExportMode> customized_files;
 	bool runnable = false;
+	bool advanced_options_enabled = false;
 	bool dedicated_server = false;
 
 	friend class EditorExport;
@@ -127,6 +128,9 @@ public:
 
 	void set_runnable(bool p_enable);
 	bool is_runnable() const;
+
+	void set_advanced_options_enabled(bool p_enabled);
+	bool are_advanced_options_enabled() const;
 
 	void set_dedicated_server(bool p_enable);
 	bool is_dedicated_server() const;

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -81,6 +81,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	EditorPropertyPath *export_path = nullptr;
 	EditorInspector *parameters = nullptr;
 	CheckButton *runnable = nullptr;
+	CheckButton *advanced_options = nullptr;
 
 	Button *button_export = nullptr;
 	bool updating = false;
@@ -119,6 +120,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 
 	bool exporting = false;
 
+	void _advanced_options_pressed();
 	void _runnable_pressed();
 	void _update_parameters(const String &p_edited_property);
 	void _name_changed(const String &p_string);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1883,13 +1883,22 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 }
 
 bool EditorExportPlatformAndroid::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
+	if (p_preset == nullptr) {
+		return true;
+	}
+
+	bool advanced_options_enabled = p_preset->are_advanced_options_enabled();
+	if (p_option == "graphics/opengl_debug" ||
+			p_option == "command_line/extra_args" ||
+			p_option == "permissions/custom_permissions") {
+		return advanced_options_enabled;
+	}
 	if (p_option == "gradle_build/gradle_build_directory" || p_option == "gradle_build/android_source_template") {
-		// @todo These are experimental options - keep them hidden for now.
-		//return (bool)p_preset->get("gradle_build/use_gradle_build");
-		return false;
-	} else if (p_option == "custom_template/debug" || p_option == "custom_template/release") {
+		return advanced_options_enabled && bool(p_preset->get("gradle_build/use_gradle_build"));
+	}
+	if (p_option == "custom_template/debug" || p_option == "custom_template/release") {
 		// The APK templates are ignored if Gradle build is enabled.
-		return !p_preset->get("gradle_build/use_gradle_build");
+		return advanced_options_enabled && !bool(p_preset->get("gradle_build/use_gradle_build"));
 	}
 	return true;
 }


### PR DESCRIPTION
Similar to the `Project Settings`, add an `Advanced Options` toggle to the editor export presets to allow hiding advanced options and simplify the UI.

Follow up of the discussion with @dsnopek on https://github.com/godotengine/godot/pull/88297#issuecomment-1949301682.
This PR sets up the infra and hides Android advanced options; other platform maintainers can leverage the same logic to hide options they deem advanced for their platform.


![Screenshot_20240216_141141_Godot Editor 4 (debug)](https://github.com/godotengine/godot/assets/914968/50bacae4-7f45-481d-af3a-9bbcd872c52b)



https://github.com/godotengine/godot/assets/914968/2cbe5e00-286b-454a-a159-7a03ee17d06c



<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
