### PR TITLE
Separate and unify iterators from `Vector` and `LocalVector`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -35,6 +35,7 @@
 #include "core/os/memory.h"
 #include "core/templates/sort_array.h"
 #include "core/templates/vector.h"
+#include "core/templates/vector_iterator.h"
 
 #include <initializer_list>
 #include <type_traits>
@@ -49,6 +50,9 @@ private:
 	T *data = nullptr;
 
 public:
+	using Iterator = VectorIterator<T>;
+	using ConstIterator = ConstVectorIterator<T>;
+
 	T *ptr() {
 		return data;
 	}
@@ -162,69 +166,11 @@ public:
 		return data[p_index];
 	}
 
-	struct Iterator {
-		_FORCE_INLINE_ T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ Iterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ Iterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
+	_FORCE_INLINE_ Iterator begin() { return Iterator(data); }
+	_FORCE_INLINE_ Iterator end() { return Iterator(data + size()); }
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
-		Iterator() {}
-		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		T *elem_ptr = nullptr;
-	};
-
-	struct ConstIterator {
-		_FORCE_INLINE_ const T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ const T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ ConstIterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ ConstIterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
-
-		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
-		ConstIterator() {}
-		ConstIterator(const ConstIterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		const T *elem_ptr = nullptr;
-	};
-
-	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(data);
-	}
-	_FORCE_INLINE_ Iterator end() {
-		return Iterator(data + size());
-	}
-
-	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(ptr());
-	}
-	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(ptr() + size());
-	}
+	_FORCE_INLINE_ ConstIterator begin() const { return ConstIterator(ptr()); }
+	_FORCE_INLINE_ ConstIterator end() const { return ConstIterator(ptr() + size()); }
 
 	void insert(U p_pos, T p_val) {
 		ERR_FAIL_UNSIGNED_INDEX(p_pos, count + 1);

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -41,6 +41,7 @@
 #include "core/templates/cowdata.h"
 #include "core/templates/search_array.h"
 #include "core/templates/sort_array.h"
+#include "core/templates/vector_iterator.h"
 
 #include <climits>
 #include <initializer_list>
@@ -61,7 +62,9 @@ class Vector {
 
 public:
 	VectorWriteProxy<T> write;
-	typedef typename CowData<T>::Size Size;
+	using Size = typename CowData<T>::Size;
+	using Iterator = VectorIterator<T>;
+	using ConstIterator = ConstVectorIterator<T>;
 
 private:
 	CowData<T> _cowdata;
@@ -100,7 +103,7 @@ public:
 	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
 	Size count(const T &p_val) const { return _cowdata.count(p_val); }
 
-	void append_array(const Vector<T> &p_other);
+	void append_array(Vector<T> p_other);
 
 	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
@@ -212,69 +215,11 @@ public:
 		return false;
 	}
 
-	struct Iterator {
-		_FORCE_INLINE_ T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ Iterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ Iterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
+	_FORCE_INLINE_ Iterator begin() { return Iterator(ptrw()); }
+	_FORCE_INLINE_ Iterator end() { return Iterator(ptrw() + size()); }
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
-		Iterator() {}
-		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		T *elem_ptr = nullptr;
-	};
-
-	struct ConstIterator {
-		_FORCE_INLINE_ const T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ const T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ ConstIterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ ConstIterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
-
-		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
-		ConstIterator() {}
-		ConstIterator(const ConstIterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		const T *elem_ptr = nullptr;
-	};
-
-	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(ptrw());
-	}
-	_FORCE_INLINE_ Iterator end() {
-		return Iterator(ptrw() + size());
-	}
-
-	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(ptr());
-	}
-	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(ptr() + size());
-	}
+	_FORCE_INLINE_ ConstIterator begin() const { return ConstIterator(ptr()); }
+	_FORCE_INLINE_ ConstIterator end() const { return ConstIterator(ptr() + size()); }
 
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) {
@@ -300,7 +245,7 @@ void Vector<T>::reverse() {
 }
 
 template <class T>
-void Vector<T>::append_array(const Vector<T> &p_other) {
+void Vector<T>::append_array(Vector<T> p_other) {
 	const Size ds = p_other.size();
 	if (ds == 0) {
 		return;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -103,7 +103,7 @@ public:
 	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
 	Size count(const T &p_val) const { return _cowdata.count(p_val); }
 
-	void append_array(Vector<T> p_other);
+	void append_array(const Vector<T> &p_other);
 
 	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
@@ -245,7 +245,7 @@ void Vector<T>::reverse() {
 }
 
 template <class T>
-void Vector<T>::append_array(Vector<T> p_other) {
+void Vector<T>::append_array(const Vector<T> &p_other) {
 	const Size ds = p_other.size();
 	if (ds == 0) {
 		return;

--- a/core/templates/vector_iterator.h
+++ b/core/templates/vector_iterator.h
@@ -98,6 +98,7 @@ template <class T>
 struct VectorIterator : ConstVectorIterator<T> {
 	using _base = ConstVectorIterator<T>;
 	using _base::_base;
+	using _base::elem_ptr;
 
 	using value_type = T;
 	using difference_type = ptrdiff_t;

--- a/core/templates/vector_iterator.h
+++ b/core/templates/vector_iterator.h
@@ -1,0 +1,148 @@
+/**************************************************************************/
+/*  vector_iterator.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef VECTOR_ITERATOR_H
+#define VECTOR_ITERATOR_H
+
+#include <cstddef>
+
+/**
+ * @class VectorIterator
+ * Iterator for Vector and LocalVector.
+ */
+
+template <class T>
+struct ConstVectorIterator {
+	using value_type = T;
+	using difference_type = ptrdiff_t;
+	using pointer = const value_type *;
+	using reference = const value_type &;
+
+	reference operator*() const { return *elem_ptr; }
+	pointer operator->() const { return elem_ptr; }
+
+	ConstVectorIterator &operator++() {
+		++elem_ptr;
+		return *this;
+	}
+	ConstVectorIterator operator++(int) {
+		ConstVectorIterator tmp = *this;
+		++*this;
+		return tmp;
+	}
+
+	ConstVectorIterator &operator--() {
+		--elem_ptr;
+		return *this;
+	}
+	ConstVectorIterator operator--(int) {
+		ConstVectorIterator tmp = *this;
+		--*this;
+		return tmp;
+	}
+
+	bool operator==(const ConstVectorIterator &p_it) const { return elem_ptr == p_it.elem_ptr; }
+	bool operator!=(const ConstVectorIterator &p_it) const { return elem_ptr != p_it.elem_ptr; }
+
+	bool operator<(const ConstVectorIterator &p_it) const { return this->elem_ptr < p_it.elem_ptr; }
+	bool operator>(const ConstVectorIterator &p_it) const { return this->elem_ptr > p_it.elem_ptr; }
+	bool operator>=(const ConstVectorIterator &p_it) const { return !(this->elem_ptr < p_it.elem_ptr); }
+	bool operator<=(const ConstVectorIterator &p_it) const { return !(this->elem_ptr > p_it.elem_ptr); }
+
+	difference_type operator-(const ConstVectorIterator &p_it) const { return elem_ptr - p_it.elem_ptr; }
+
+	ConstVectorIterator operator+(const difference_type &p_diff) const { return ConstVectorIterator(elem_ptr + p_diff); }
+	ConstVectorIterator operator-(const difference_type &p_diff) const { return ConstVectorIterator(elem_ptr - p_diff); }
+
+	reference operator[](const difference_type &p_offset) const { return *(*this + p_offset); }
+
+	ConstVectorIterator(const T *p_ptr) :
+			elem_ptr{ const_cast<T *>(p_ptr) } {}
+	ConstVectorIterator(T *p_ptr) :
+			elem_ptr{ p_ptr } {}
+	ConstVectorIterator() {}
+	ConstVectorIterator(const ConstVectorIterator &p_it) = default;
+
+protected:
+	T *elem_ptr = nullptr;
+};
+
+template <class T>
+struct VectorIterator : ConstVectorIterator<T> {
+	using _base = ConstVectorIterator<T>;
+	using _base::_base;
+
+	using value_type = T;
+	using difference_type = ptrdiff_t;
+	using pointer = value_type *;
+	using reference = value_type &;
+
+	reference operator*() const { return *elem_ptr; }
+	pointer operator->() const { return elem_ptr; }
+
+	VectorIterator &operator++() {
+		++elem_ptr;
+		return *this;
+	}
+	VectorIterator operator++(int) {
+		VectorIterator tmp = *this;
+		++*this;
+		return tmp;
+	}
+
+	VectorIterator &operator--() {
+		--elem_ptr;
+		return *this;
+	}
+	VectorIterator operator--(int) {
+		VectorIterator tmp = *this;
+		--*this;
+		return tmp;
+	}
+
+	bool operator==(const VectorIterator &p_it) const { return elem_ptr == p_it.elem_ptr; }
+	bool operator!=(const VectorIterator &p_it) const { return elem_ptr != p_it.elem_ptr; }
+
+	bool operator<(const VectorIterator &p_it) const { return this->elem_ptr < p_it.elem_ptr; }
+	bool operator>(const VectorIterator &p_it) const { return this->elem_ptr > p_it.elem_ptr; }
+	bool operator>=(const VectorIterator &p_it) const { return !(this->elem_ptr < p_it.elem_ptr); }
+	bool operator<=(const VectorIterator &p_it) const { return !(this->elem_ptr > p_it.elem_ptr); }
+
+	difference_type operator-(const VectorIterator &p_it) const { return elem_ptr - p_it.elem_ptr; }
+
+	VectorIterator operator+(const difference_type &p_diff) const { return VectorIterator(elem_ptr + p_diff); }
+	VectorIterator operator-(const difference_type &p_diff) const { return VectorIterator(elem_ptr - p_diff); }
+
+	reference operator[](const difference_type &p_offset) const { return *(*this + p_offset); }
+
+	VectorIterator(const T *p_ptr) = delete;
+};
+
+#endif // VECTOR_ITERATOR_H


### PR DESCRIPTION
A follow-up to [#87794](https://github.com/godotengine/godot/pull/87794).

Both `LocalVector` and `Vector` now use the same `VectorIterator` defined in `vector_iterator.h`. No other changes.
