### PR TITLE
Fix glTF buffer size check

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -884,14 +884,14 @@ Error GLTFDocument::_parse_buffer_views(Ref<GLTFState> p_state) {
 		if (d.has("byteStride")) {
 			buffer_view->byte_stride = d["byteStride"];
 
-			// Magic numbers from gltf bufferview schema
+			// Some magic numbers from the gltf bufferview schema.
 			ERR_FAIL_COND_V_MSG((buffer_view->byte_stride % 4 != 0) || (buffer_view->byte_stride < 4) || (buffer_view->byte_stride > 252),
 					ERR_PARSE_ERROR, "glTF: Incorrect byte_stride (" + itos(buffer_view->byte_stride) + ")");
 		}
-		// bufferview can't point to something outside the actual data
+		// The bufferview can't point to something outside the actual data.
 		ERR_FAIL_COND_V_MSG((buffer_view->byte_length + buffer_view->byte_offset) > buffersData[buffer_view->buffer].size(),
 				ERR_PARSE_ERROR, "glTF: length+offset > size (" + itos(buffersData[buffer_view->buffer].size()) + ")");
-		// TODO: check the combination of byte_stride, offset and byte_length
+		// TODO: Check the combination of byte_stride, offset and byte_length for bounds.
 
 		if (d.has("target")) {
 			const int target = d["target"];

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -811,7 +811,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 
 				ERR_FAIL_COND_V(!buffer.has("byteLength"), ERR_PARSE_ERROR);
 				int byteLength = buffer["byteLength"];
-				ERR_FAIL_COND_V(byteLength < buffer_data.size(), ERR_PARSE_ERROR);
+				ERR_FAIL_COND_V_MSG(buffer_data.size() < byteLength, ERR_PARSE_ERROR, "glTF: Buffer data smaller than expected: " + uri);
 				p_state->buffers.push_back(buffer_data);
 			}
 		}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -811,7 +811,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 
 				ERR_FAIL_COND_V(!buffer.has("byteLength"), ERR_PARSE_ERROR);
 				int byteLength = buffer["byteLength"];
-				ERR_FAIL_COND_V_MSG(buffer_data.size() < byteLength, ERR_PARSE_ERROR, "glTF: Buffer data smaller than expected: " + uri);
+				ERR_FAIL_COND_V_MSG((buffer_data.size() < byteLength) || (byteLength <= 0), ERR_PARSE_ERROR, "glTF: Buffer data smaller than expected: " + uri);
 				p_state->buffers.push_back(buffer_data);
 			}
 		}
@@ -857,6 +857,7 @@ Error GLTFDocument::_parse_buffer_views(Ref<GLTFState> p_state) {
 	if (!p_state->json.has("bufferViews")) {
 		return OK;
 	}
+	const Vector<Vector<uint8_t>> &buffersData = p_state->buffers;
 	const Array &buffers = p_state->json["bufferViews"];
 	for (GLTFBufferViewIndex i = 0; i < buffers.size(); i++) {
 		const Dictionary &d = buffers[i];
@@ -866,16 +867,31 @@ Error GLTFDocument::_parse_buffer_views(Ref<GLTFState> p_state) {
 
 		ERR_FAIL_COND_V(!d.has("buffer"), ERR_PARSE_ERROR);
 		buffer_view->buffer = d["buffer"];
+
+		// Check if the buffer actually exists.
+		// ! This assumes that we've parsed the buffers (p_state->buffers) before!
+		ERR_FAIL_COND_V_MSG((buffersData.size() < buffer_view->buffer), ERR_PARSE_ERROR,
+				"glTF: Missing buffer at index referenced by bufferview (" + itos(buffer_view->buffer) + ")");
+
 		ERR_FAIL_COND_V(!d.has("byteLength"), ERR_PARSE_ERROR);
 		buffer_view->byte_length = d["byteLength"];
 
 		if (d.has("byteOffset")) {
 			buffer_view->byte_offset = d["byteOffset"];
+			ERR_FAIL_COND_V_MSG(buffer_view->byte_offset < 0, ERR_PARSE_ERROR, "glTF: Bufferview byte_offset < 0 (" + itos(buffer_view->byte_offset) + ")");
 		}
 
 		if (d.has("byteStride")) {
 			buffer_view->byte_stride = d["byteStride"];
+
+			// Magic numbers from gltf bufferview schema
+			ERR_FAIL_COND_V_MSG((buffer_view->byte_stride % 4 != 0) || (buffer_view->byte_stride < 4) || (buffer_view->byte_stride > 252),
+					ERR_PARSE_ERROR, "glTF: Incorrect byte_stride (" + itos(buffer_view->byte_stride) + ")");
 		}
+		// bufferview can't point to something outside the actual data
+		ERR_FAIL_COND_V_MSG((buffer_view->byte_length + buffer_view->byte_offset) > buffersData[buffer_view->buffer].size(),
+				ERR_PARSE_ERROR, "glTF: length+offset > size (" + itos(buffersData[buffer_view->buffer].size()) + ")");
+		// TODO: check the combination of byte_stride, offset and byte_length
 
 		if (d.has("target")) {
 			const int target = d["target"];


### PR DESCRIPTION
A crash (possibly) occurs while importing a glTF file pointing to a buffer with a smaller size than expected (`byteLength` in gltf file is greater than the real size).

This can crash the application and, since the file gets reimported, on the subsequent startups too.
The only way to fix this at the moment is deleting the problematic files from the project folder.

To reproduce the issue:

1. Create new project
2. Import `Gem.gltf` with `buffer.bin` (from `Gem.zip`) into the project

[Gem.zip](https://github.com/godotengine/godot/files/14316860/Gem.zip)

Seems like a simple oversight(?)