### PR TITLE
Fix Remote Nodes missing custom icons

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -277,11 +277,14 @@ Variant EditorDebuggerTree::get_drag_data(const Point2 &p_point) {
 	}
 
 	String path = selected->get_text(0);
+	const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	TextureRect *tf = memnew(TextureRect);
 	tf->set_texture(selected->get_icon(0));
-	tf->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	tf->set_custom_minimum_size(Size2(icon_size, icon_size));
+	tf->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+	tf->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	hb->add_child(tf);
 	Label *label = memnew(Label(path));
 	hb->add_child(label);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4771,7 +4771,13 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 			// Look for the native base type in the editor theme. This is relevant for
 			// scripts extending other scripts and for built-in classes.
 			String script_class_name = p_script->get_language()->get_global_class_name(p_script->get_path());
-			String base_type = ScriptServer::get_global_class_native_base(script_class_name);
+			String base_type;
+			if (script_class_name.is_empty()) {
+				base_type = p_script->get_instance_base_type();
+			} else {
+				base_type = ScriptServer::get_global_class_native_base(script_class_name);
+			}
+
 			if (theme.is_valid() && theme->has_icon(base_type, EditorStringName(EditorIcons))) {
 				return theme->get_icon(base_type, EditorStringName(EditorIcons));
 			}
@@ -4836,6 +4842,8 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	Ref<Script> scr;
 	if (ScriptServer::is_global_class(p_class)) {
 		scr = EditorNode::get_editor_data().script_class_load_script(p_class);
+	} else if (ResourceLoader::exists(p_class)) { // If the script is not a class_name we check if the script resource exists.
+		scr = ResourceLoader::load(p_class);
 	}
 
 	return _get_class_or_script_icon(p_class, scr, p_fallback, true);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -535,7 +535,21 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 				}
 			}
 		}
-		nodes.push_back(RemoteNode(count, n->get_name(), n->get_class(), n->get_instance_id(), n->get_scene_file_path(), view_flags));
+
+		String class_name;
+		ScriptInstance *script_instance = n->get_script_instance();
+		if (script_instance) {
+			Ref<Script> script = script_instance->get_script();
+			if (script.is_valid()) {
+				class_name = script->get_global_name();
+
+				if (class_name.is_empty()) {
+					// If there is no class_name in this script we just take the script path.
+					class_name = script->get_path();
+				}
+			}
+		}
+		nodes.push_back(RemoteNode(count, n->get_name(), class_name.is_empty() ? n->get_class() : class_name, n->get_instance_id(), n->get_scene_file_path(), view_flags));
 	}
 }
 


### PR DESCRIPTION
# BEFORE:
![image](https://github.com/godotengine/godot/assets/38570835/1794f4fd-4e42-4fd1-b2c3-41d7566ee5a1)
# AFTER: 
![image](https://github.com/godotengine/godot/assets/38570835/ba24b4ef-02c9-4f57-b039-4fbd13674c3c)


This PR also fixes the type hint for Remote Nodes:
![image](https://github.com/godotengine/godot/assets/38570835/152bbabe-0cd4-4483-88e6-db94ab3e472a)

Closes https://github.com/godotengine/godot-proposals/issues/2084
Fixes #95209