### PR TITLE
[4.2] Clarify that LightmapGI is not supported in compatibility renderer

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -9,7 +9,7 @@
 		[b]Performance:[/b] [LightmapGI] provides the best possible run-time performance for global illumination. It is suitable for low-end hardware including integrated graphics and mobile devices.
 		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 		[b]Note:[/b] Lightmap baking on [CSGShape3D]s and [PrimitiveMesh]es is not supported, as these cannot store UV2 data required for baking.
-		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked when using the Vulkan backend (Forward+ or Mobile), not OpenGL.
+		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked when using the Vulkan backend (Forward+ or Mobile), not OpenGL. Additionally, [LightmapGI] rendering is not currently supported when using the OpenGL backend (Compatibility).
 	</description>
 	<tutorials>
 		<link title="Using Lightmap global illumination">$DOCS_URL/tutorials/3d/global_illumination/using_lightmap_gi.html</link>


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/88406 but targeted at the 4.2 branch

> The documentation currently does not mention that LightmapGI rendering is not supported in the compatibility renderer. It only states the fact that baking it is not supported (thus it is possible to make an assumption that rendering it is supported, while baking isn't).