### PR TITLE
Add method to get current stream from `AudioStreamPlaybackRandomizer`

### DIFF
--- a/doc/classes/AudioStreamPlaybackRandomizer.xml
+++ b/doc/classes/AudioStreamPlaybackRandomizer.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamPlaybackRandomizer" inherits="AudioStreamPlayback" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Playback instance for [AudioStreamRandomizer].
+	</brief_description>
+	<description>
+		Playback instance for [AudioStreamRandomizer]. After setting the [code]stream[/code] property of [AudioStreamPlayer], [AudioStreamPlayer2D], or [AudioStreamPlayer3D], the playback instance can be obtained by calling [method AudioStreamPlayer.get_stream_playback], [method AudioStreamPlayer2D.get_stream_playback], or [method AudioStreamPlayer3D.get_stream_playback] methods.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_stream" qualifiers="const">
+			<return type="AudioStream" />
+			<description>
+				Returns the current stream.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -762,6 +762,14 @@ int AudioStreamPlaybackRandomizer::get_loop_count() const {
 	return 0;
 }
 
+Ref<AudioStream> AudioStreamPlaybackRandomizer::get_stream() const {
+	if (randomizer.is_valid()) {
+		return randomizer->last_playback;
+	}
+
+	return nullptr;
+}
+
 double AudioStreamPlaybackRandomizer::get_playback_position() const {
 	if (playing.is_valid()) {
 		return playing->get_playback_position();
@@ -797,6 +805,10 @@ int AudioStreamPlaybackRandomizer::mix(AudioFrame *p_buffer, float p_rate_scale,
 		}
 		return p_frames;
 	}
+}
+
+void AudioStreamPlaybackRandomizer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_stream"), &AudioStreamPlaybackRandomizer::get_stream);
 }
 
 AudioStreamPlaybackRandomizer::~AudioStreamPlaybackRandomizer() {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -306,6 +306,9 @@ class AudioStreamPlaybackRandomizer : public AudioStreamPlayback {
 	float pitch_scale;
 	float volume_scale;
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
@@ -313,6 +316,7 @@ public:
 
 	virtual int get_loop_count() const override; //times it looped
 
+	Ref<AudioStream> get_stream() const;
 	virtual double get_playback_position() const override;
 	virtual void seek(double p_time) override;
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -176,6 +176,7 @@ void register_server_types() {
 	GDREGISTER_VIRTUAL_CLASS(AudioStreamPlaybackResampled);
 	GDREGISTER_CLASS(AudioStreamMicrophone);
 	GDREGISTER_CLASS(AudioStreamRandomizer);
+	GDREGISTER_VIRTUAL_CLASS(AudioStreamPlaybackRandomizer);
 	GDREGISTER_VIRTUAL_CLASS(AudioEffect);
 	GDREGISTER_VIRTUAL_CLASS(AudioEffectInstance);
 	GDREGISTER_CLASS(AudioEffectEQ);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/9079.

This PR adds function that allows to get the currently selected stream from `AudioStreamPlaybackRandomizer`