### PR TITLE
Fix function description for `Font.get_char_size()`

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -136,7 +136,7 @@
 			<param index="0" name="char" type="int" />
 			<param index="1" name="font_size" type="int" />
 			<description>
-				Returns the size of a character, optionally taking kerning into account if the next character is provided.
+				Returns the size of a character. Does not take kerning into account.
 				[b]Note:[/b] Do not use this function to calculate width of the string character by character, use [method get_string_size] or [TextLine] instead. The height returned is the font height (see also [method get_height]) and has no relation to the glyph height.
 			</description>
 		</method>


### PR DESCRIPTION
_Bugsquad edit: closes https://github.com/godotengine/godot/issues/88348_

Removed description implying you can pass a second char in order to account for kerning