### PR TITLE
Fix Animation Bezier Editor key selection bugs

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -840,16 +840,27 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 			accept_event();
 		}
+		if (ED_IS_SHORTCUT("animation_editor/cut_selected_keys", p_event)) {
+			if (!read_only) {
+				copy_selected_keys(true);
+			}
+			accept_event();
+		}
 		if (ED_IS_SHORTCUT("animation_editor/copy_selected_keys", p_event)) {
 			if (!read_only) {
 				copy_selected_keys(false);
 			}
 			accept_event();
 		}
-
 		if (ED_IS_SHORTCUT("animation_editor/paste_keys", p_event)) {
 			if (!read_only) {
 				paste_keys(-1.0);
+			}
+			accept_event();
+		}
+		if (ED_IS_SHORTCUT("animation_editor/delete_selection", p_event)) {
+			if (!read_only) {
+				delete_selection();
 			}
 			accept_event();
 		}
@@ -1247,7 +1258,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (moving_selection_attempt && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		if (!read_only) {
-			if (moving_selection) {
+			if (moving_selection && (abs(moving_selection_offset.x) > 0 || abs(moving_selection_offset.y) > 0)) {
 				//combit it
 
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -1504,7 +1515,7 @@ bool AnimationBezierTrackEdit::_try_select_at_ui_pos(const Point2 &p_pos, bool p
 				}
 
 				set_animation_and_track(animation, pair.first, read_only);
-				if (p_deselectable || !selection.has(pair)) {
+				if (!selection.has(pair)) {
 					selection.clear();
 					selection.insert(pair);
 				}


### PR DESCRIPTION
This bugs fixes a regression introduced with #87250, which resulted in not being able to move multiple keys in Bezier editor at once anymore. It re-adds the accidentally removed delete shortcut and the cut shortcut, which interestingly kept working, as the shortcuts were still covered by the AnimationTrackEditor, but I thought to be safe they should be put back. Finally, this PR also fixes an old bug that snapped keys in the Bezier editor upon selection, which is not desirable, by adding a check if the mouse has been moved or not.