### PR TITLE
Rotary input for 3.x

### DIFF
--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Contains mouse click information. See [method Node._input].
+		[b]Note:[/b] On Wear OS devices, rotary input is mapped to [constant BUTTON_WHEEL_UP] and [constant BUTTON_WHEEL_DOWN]. This can be changed to [constant BUTTON_WHEEL_LEFT] and [constant BUTTON_WHEEL_RIGHT] with the [member ProjectSettings.input_devices/pointing/android/rotary_input_scroll_axis] setting.
 	</description>
 	<tutorials>
 		<link>$DOCS_URL/tutorials/inputs/mouse_and_input_coordinates.html</link>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -688,6 +688,9 @@
 		<member name="input_devices/pointing/emulate_touch_from_mouse" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], sends touch input events when clicking or dragging the mouse.
 		</member>
+		<member name="input_devices/pointing/android/rotary_input_scroll_axis" type="int" setter="" getter="" default="1">
+			On Wear OS devices, defines which axis of the mouse wheel rotary input is mapped to. This rotary input is usually performed by rotating the physical or virtual (touch-based) bezel on a smartwatch.
+		</member>
 		<member name="layer_names/2d_navigation/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 1. If left empty, the layer will display as "Layer 1".
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1329,6 +1329,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("display/window/ios/hide_status_bar", true);
 	GLOBAL_DEF("display/window/ios/suppress_ui_gesture", true);
 
+	GLOBAL_DEF("input_devices/pointing/android/rotary_input_scroll_axis", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pointing/android/rotary_input_scroll_axis",
+			PropertyInfo(Variant::INT,
+					"input_devices/pointing/android/rotary_input_scroll_axis",
+					PROPERTY_HINT_ENUM, "Horizontal,Vertical"));
+
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 
 #ifdef DEBUG_ENABLED

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -44,6 +44,7 @@ import org.godotengine.godot.utils.BenchmarkUtils;
 import org.godotengine.godot.utils.GodotNetUtils;
 import org.godotengine.godot.utils.PermissionsUtil;
 import org.godotengine.godot.xr.XRMode;
+import org.godotengine.godot.input.GodotInputHandler;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -352,6 +353,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		if (godotHost != null) {
 			godotHost.onGodotSetupCompleted();
 		}
+		GodotInputHandler.setRotaryInputAxis(GodotLib.getGlobal("input_devices/pointing/android/rotary_input_scroll_axis"));
 	}
 
 	/**

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -57,6 +57,9 @@ import java.util.Set;
 public class GodotInputHandler implements InputManager.InputDeviceListener {
 	private static final String TAG = GodotInputHandler.class.getSimpleName();
 
+	private static final int ROTARY_INPUT_VERTICAL_AXIS = 1;
+	private static final int ROTARY_INPUT_HORIZONTAL_AXIS = 0;
+
 	private final SparseIntArray mJoystickIds = new SparseIntArray(4);
 	private final SparseArray<Joystick> mJoysticksDevices = new SparseArray<>(4);
 
@@ -70,6 +73,8 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 	 * Used to decide whether mouse capture can be enabled.
 	 */
 	private int lastSeenToolType = MotionEvent.TOOL_TYPE_UNKNOWN;
+
+	private static int rotaryInputAxis = ROTARY_INPUT_VERTICAL_AXIS;
 
 	public GodotInputHandler(GodotView godotView) {
 		final Context context = godotView.getContext();
@@ -259,6 +264,8 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 				}
 				return true;
 			}
+		} else if (event.isFromSource(InputDevice.SOURCE_ROTARY_ENCODER)) {
+			return handleRotaryEvent(event);
 		} else {
 			return handleMouseEvent(event);
 		}
@@ -337,7 +344,6 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 					Log.w(TAG, " - DUPLICATE AXIS VALUE IN LIST: " + axis);
 				}
 			}
-		}
 		Collections.sort(joystick.axes);
 		for (int idx = 0; idx < joystick.axes.size(); idx++) {
 			//Helps with creating new joypad mappings.
@@ -467,6 +473,16 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 		return handleTouchEvent(eventAction, x, y, doubleTap);
 	}
 
+	/**
+	 * On Wear OS devices, sets which axis of the mouse wheel rotary input is mapped to. This is 1 (vertical axis) by default.
+	 */
+	public static void setRotaryInputAxis(String axis) {
+		if (axis != null && !axis.isEmpty() && !axis.equals("Null")) {
+			rotaryInputAxis = java.lang.Integer.parseInt(axis);
+		}
+	}
+
+
 	static boolean handleMouseEvent(final MotionEvent event) {
 		final int eventAction = event.getActionMasked();
 		final float x = event.getX();
@@ -558,6 +574,23 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 			case MotionEvent.ACTION_POINTER_DOWN: {
 				GodotLib.dispatchTouchEvent(eventAction, actionPointerId, pointerCount, positions, doubleTap);
 				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean handleRotaryEvent(final MotionEvent event) {
+		if (event.getAction() == MotionEvent.ACTION_SCROLL) {
+			final int buttonsMask = event.getButtonState();
+			final int action = event.getAction();
+			final float x = event.getX();
+			final float y = event.getY();
+			final float rotaryFactor = -event.getAxisValue(MotionEvent.AXIS_SCROLL);
+			if (rotaryInputAxis == ROTARY_INPUT_HORIZONTAL_AXIS) {
+				GodotLib.touch(InputDevice.SOURCE_MOUSE, action, 0, 1, new float[] { 0, x, y }, buttonsMask, 0, rotaryFactor);
+			} else {
+				// If rotaryInputAxis is not ROTARY_INPUT_HORIZONTAL_AXIS then use default ROTARY_INPUT_VERTICAL_AXIS axis.
+				GodotLib.touch(InputDevice.SOURCE_MOUSE, action, 0, 1, new float[] { 0, x, y }, buttonsMask, rotaryFactor, 0);
 			}
 		}
 		return false;


### PR DESCRIPTION
This PR adds Rotary input support for wear os devices. It converts RotaryInput to vertical mouse wheel event. Without it Godot does not recognise this event at all. The same feature wich implemented [here](https://github.com/godotengine/godot/pull/88130) , but for Godot 3.x.

Proposal: https://github.com/godotengine/godot-proposals/issues/9062