### PR TITLE
Clean up and optimize BasisUniversal

### DIFF
--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -37,9 +37,6 @@
 #include <encoder/basisu_comp.h>
 #endif
 
-//workaround for lack of ETC2 RG
-#define USE_RG_AS_RGBA
-
 void basis_universal_init() {
 #ifdef TOOLS_ENABLED
 	basisu::basisu_encoder_init();
@@ -50,225 +47,205 @@ void basis_universal_init() {
 
 #ifdef TOOLS_ENABLED
 Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedChannels p_channels) {
-	Vector<uint8_t> budata;
-	{
-		basisu::basis_compressor_params params;
-		Ref<Image> image = p_image->duplicate();
-		if (image->get_format() != Image::FORMAT_RGBA8) {
-			image->convert(Image::FORMAT_RGBA8);
-		}
+	Ref<Image> image = p_image->duplicate();
+	image->convert(Image::FORMAT_RGBA8);
 
-		params.m_uastc = true;
-		params.m_quality_level = basisu::BASISU_QUALITY_MIN;
+	basisu::basis_compressor_params params;
 
-		params.m_pack_uastc_flags &= ~basisu::cPackUASTCLevelMask;
+	params.m_uastc = true;
+	params.m_quality_level = basisu::BASISU_QUALITY_MIN;
+	params.m_pack_uastc_flags &= ~basisu::cPackUASTCLevelMask;
+	params.m_pack_uastc_flags |= basisu::cPackUASTCLevelFastest;
 
-		static const uint32_t s_level_flags[basisu::TOTAL_PACK_UASTC_LEVELS] = { basisu::cPackUASTCLevelFastest, basisu::cPackUASTCLevelFaster, basisu::cPackUASTCLevelDefault, basisu::cPackUASTCLevelSlower, basisu::cPackUASTCLevelVerySlow };
-		params.m_pack_uastc_flags |= s_level_flags[0];
-		params.m_rdo_uastc = 0.0f;
-		params.m_rdo_uastc_quality_scalar = 0.0f;
-		params.m_rdo_uastc_dict_size = 1024;
+	params.m_rdo_uastc = 0.0f;
+	params.m_rdo_uastc_quality_scalar = 0.0f;
+	params.m_rdo_uastc_dict_size = 1024;
 
-		params.m_mip_fast = true;
-		params.m_multithreading = true;
+	params.m_mip_fast = true;
+	params.m_multithreading = true;
+	params.m_check_for_alpha = false;
 
-		basisu::job_pool jpool(OS::get_singleton()->get_processor_count());
-		params.m_pJob_pool = &jpool;
+	basisu::job_pool job_pool(OS::get_singleton()->get_processor_count());
+	params.m_pJob_pool = &job_pool;
 
-		BasisDecompressFormat decompress_format = BASIS_DECOMPRESS_RG;
-		params.m_check_for_alpha = false;
-
-		switch (p_channels) {
-			case Image::USED_CHANNELS_L: {
-				decompress_format = BASIS_DECOMPRESS_RGB;
-			} break;
-			case Image::USED_CHANNELS_LA: {
-				params.m_force_alpha = true;
-				decompress_format = BASIS_DECOMPRESS_RGBA;
-			} break;
-			case Image::USED_CHANNELS_R: {
-				decompress_format = BASIS_DECOMPRESS_RGB;
-			} break;
-			case Image::USED_CHANNELS_RG: {
-#ifdef USE_RG_AS_RGBA
-				params.m_force_alpha = true;
-				image->convert_rg_to_ra_rgba8();
-				decompress_format = BASIS_DECOMPRESS_RG_AS_RA;
-#else
-				params.m_seperate_rg_to_color_alpha = true;
-				decompress_format = BASIS_DECOMPRESS_RG;
-#endif
-			} break;
-			case Image::USED_CHANNELS_RGB: {
-				decompress_format = BASIS_DECOMPRESS_RGB;
-			} break;
-			case Image::USED_CHANNELS_RGBA: {
-				params.m_force_alpha = true;
-				decompress_format = BASIS_DECOMPRESS_RGBA;
-			} break;
-		}
-
-		if (!image->has_mipmaps()) {
-			basisu::image buimg(image->get_width(), image->get_height());
-			Vector<uint8_t> vec = image->get_data();
-			const uint8_t *r = vec.ptr();
-			memcpy(buimg.get_ptr(), r, vec.size());
-			params.m_source_images.push_back(buimg);
-		} else {
-			{
-				Ref<Image> base_image = image->get_image_from_mipmap(0);
-				Vector<uint8_t> image_vec = base_image->get_data();
-				basisu::image buimg_image(base_image->get_width(), base_image->get_height());
-				const uint8_t *r = image_vec.ptr();
-				memcpy(buimg_image.get_ptr(), r, image_vec.size());
-				params.m_source_images.push_back(buimg_image);
-			}
-			basisu::vector<basisu::image> images;
-			for (int32_t mip_map_i = 1; mip_map_i <= image->get_mipmap_count(); mip_map_i++) {
-				Ref<Image> mip_map = image->get_image_from_mipmap(mip_map_i);
-				Vector<uint8_t> mip_map_vec = mip_map->get_data();
-				basisu::image buimg_mipmap(mip_map->get_width(), mip_map->get_height());
-				const uint8_t *r = mip_map_vec.ptr();
-				memcpy(buimg_mipmap.get_ptr(), r, mip_map_vec.size());
-				images.push_back(buimg_mipmap);
-			}
-			params.m_source_mipmap_images.push_back(images);
-		}
-
-		basisu::basis_compressor c;
-		c.init(params);
-
-		int buerr = c.process();
-		ERR_FAIL_COND_V(buerr != basisu::basis_compressor::cECSuccess, budata);
-
-		const basisu::uint8_vec &buvec = c.get_output_basis_file();
-		budata.resize(buvec.size() + 4);
-
-		{
-			uint8_t *w = budata.ptrw();
-			uint32_t *decf = (uint32_t *)w;
-			*decf = decompress_format;
-			memcpy(w + 4, &buvec[0], buvec.size());
-		}
+	BasisDecompressFormat decompress_format = BASIS_DECOMPRESS_RG;
+	switch (p_channels) {
+		case Image::USED_CHANNELS_L: {
+			decompress_format = BASIS_DECOMPRESS_RGB;
+		} break;
+		case Image::USED_CHANNELS_LA: {
+			params.m_force_alpha = true;
+			decompress_format = BASIS_DECOMPRESS_RGBA;
+		} break;
+		case Image::USED_CHANNELS_R: {
+			decompress_format = BASIS_DECOMPRESS_RGB;
+		} break;
+		case Image::USED_CHANNELS_RG: {
+			// Currently RG textures are compressed as DXT5/ETC2_RGBA8 with a RA -> RG swizzle,
+			// as BasisUniversal didn't use to support ETC2_RG11 transcoding.
+			params.m_force_alpha = true;
+			image->convert_rg_to_ra_rgba8();
+			decompress_format = BASIS_DECOMPRESS_RG_AS_RA;
+		} break;
+		case Image::USED_CHANNELS_RGB: {
+			decompress_format = BASIS_DECOMPRESS_RGB;
+		} break;
+		case Image::USED_CHANNELS_RGBA: {
+			params.m_force_alpha = true;
+			decompress_format = BASIS_DECOMPRESS_RGBA;
+		} break;
 	}
 
-	return budata;
+	{
+		// Encode the image with mipmaps.
+		Vector<uint8_t> image_data = image->get_data();
+		basisu::vector<basisu::image> basisu_mipmaps;
+
+		for (int32_t i = 0; i <= image->get_mipmap_count(); i++) {
+			int ofs, size, width, height;
+			image->get_mipmap_offset_size_and_dimensions(i, ofs, size, width, height);
+
+			basisu::image basisu_image(width, height);
+			memcpy(basisu_image.get_ptr(), image_data.ptr() + ofs, size);
+
+			if (i == 0) {
+				params.m_source_images.push_back(basisu_image);
+			} else {
+				basisu_mipmaps.push_back(basisu_image);
+			}
+		}
+
+		params.m_source_mipmap_images.push_back(basisu_mipmaps);
+	}
+
+	// Encode the image data.
+	Vector<uint8_t> basisu_data;
+
+	basisu::basis_compressor compressor;
+	compressor.init(params);
+
+	int basisu_err = compressor.process();
+	ERR_FAIL_COND_V(basisu_err != basisu::basis_compressor::cECSuccess, basisu_data);
+
+	const basisu::uint8_vec &basisu_out = compressor.get_output_basis_file();
+	basisu_data.resize(basisu_out.size() + 4);
+
+	// Copy the encoded data to the buffer.
+	{
+		uint8_t *w = basisu_data.ptrw();
+		*(uint32_t *)w = decompress_format;
+
+		memcpy(w + 4, basisu_out.get_ptr(), basisu_out.size());
+	}
+
+	return basisu_data;
 }
 #endif // TOOLS_ENABLED
 
 Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 	Ref<Image> image;
+	ERR_FAIL_NULL_V_MSG(p_data, image, "Cannot unpack invalid BasisUniversal data.");
 
-	const uint8_t *ptr = p_data;
-	int size = p_size;
-	ERR_FAIL_NULL_V_MSG(p_data, image, "Cannot unpack invalid basis universal data.");
+	const uint8_t *src_ptr = p_data;
+	int src_size = p_size;
 
-	basist::transcoder_texture_format format = basist::transcoder_texture_format::cTFTotalTextureFormats;
-	Image::Format imgfmt = Image::FORMAT_MAX;
+	basist::transcoder_texture_format basisu_format = basist::transcoder_texture_format::cTFTotalTextureFormats;
+	Image::Format image_format = Image::FORMAT_MAX;
 
-	switch (*(uint32_t *)(ptr)) {
+	// Get supported compression formats.
+	bool bptc_supported = RS::get_singleton()->has_os_feature("bptc");
+	bool s3tc_supported = RS::get_singleton()->has_os_feature("s3tc");
+	bool etc2_supported = RS::get_singleton()->has_os_feature("etc2");
+
+	switch (*(uint32_t *)(src_ptr)) {
 		case BASIS_DECOMPRESS_RG: {
-			if (RS::get_singleton()->has_os_feature("rgtc")) {
-				format = basist::transcoder_texture_format::cTFBC5; // get this from renderer
-				imgfmt = Image::FORMAT_RGTC_RG;
-			} else if (RS::get_singleton()->has_os_feature("etc2")) {
-				//unfortunately, basis universal does not support
-				//
-				ERR_FAIL_V(image); //unimplemented here
-				//format = basist::transcoder_texture_format::cTFETC1; // get this from renderer
-				//imgfmt = Image::FORMAT_RGTC_RG;
-			} else {
-				// FIXME: There wasn't anything here, but then imgformat is used uninitialized.
-				ERR_FAIL_V(image);
-			}
+			// RGTC transcoding is currently performed with RG_AS_RA, fail.
+			ERR_FAIL_V(image);
 		} break;
 		case BASIS_DECOMPRESS_RGB: {
-			if (RS::get_singleton()->has_os_feature("bptc")) {
-				format = basist::transcoder_texture_format::cTFBC7_M6_OPAQUE_ONLY; // get this from renderer
-				imgfmt = Image::FORMAT_BPTC_RGBA;
-			} else if (RS::get_singleton()->has_os_feature("s3tc")) {
-				format = basist::transcoder_texture_format::cTFBC1; // get this from renderer
-				imgfmt = Image::FORMAT_DXT1;
-			} else if (RS::get_singleton()->has_os_feature("etc2")) {
-				format = basist::transcoder_texture_format::cTFETC1; // get this from renderer
-				imgfmt = Image::FORMAT_ETC2_RGB8;
+			if (bptc_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFBC7_M6_OPAQUE_ONLY;
+				image_format = Image::FORMAT_BPTC_RGBA;
+			} else if (s3tc_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFBC1;
+				image_format = Image::FORMAT_DXT1;
+			} else if (etc2_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFETC1;
+				image_format = Image::FORMAT_ETC2_RGB8;
 			} else {
-				format = basist::transcoder_texture_format::cTFBGR565; // get this from renderer
-				imgfmt = Image::FORMAT_RGB565;
+				// No supported VRAM compression formats, decompress.
+				basisu_format = basist::transcoder_texture_format::cTFRGBA32;
+				image_format = Image::FORMAT_RGBA8;
 			}
 
 		} break;
 		case BASIS_DECOMPRESS_RGBA: {
-			if (RS::get_singleton()->has_os_feature("bptc")) {
-				format = basist::transcoder_texture_format::cTFBC7_M5; // get this from renderer
-				imgfmt = Image::FORMAT_BPTC_RGBA;
-			} else if (RS::get_singleton()->has_os_feature("s3tc")) {
-				format = basist::transcoder_texture_format::cTFBC3; // get this from renderer
-				imgfmt = Image::FORMAT_DXT5;
-			} else if (RS::get_singleton()->has_os_feature("etc2")) {
-				format = basist::transcoder_texture_format::cTFETC2; // get this from renderer
-				imgfmt = Image::FORMAT_ETC2_RGBA8;
+			if (bptc_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFBC7_M5;
+				image_format = Image::FORMAT_BPTC_RGBA;
+			} else if (s3tc_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFBC3;
+				image_format = Image::FORMAT_DXT5;
+			} else if (etc2_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFETC2;
+				image_format = Image::FORMAT_ETC2_RGBA8;
 			} else {
-				//opengl most likely
-				format = basist::transcoder_texture_format::cTFRGBA4444; // get this from renderer
-				imgfmt = Image::FORMAT_RGBA4444;
+				// No supported VRAM compression formats, decompress.
+				basisu_format = basist::transcoder_texture_format::cTFRGBA32;
+				image_format = Image::FORMAT_RGBA8;
 			}
 		} break;
 		case BASIS_DECOMPRESS_RG_AS_RA: {
-			if (RS::get_singleton()->has_os_feature("s3tc")) {
-				format = basist::transcoder_texture_format::cTFBC3; // get this from renderer
-				imgfmt = Image::FORMAT_DXT5_RA_AS_RG;
-			} else if (RS::get_singleton()->has_os_feature("etc2")) {
-				format = basist::transcoder_texture_format::cTFETC2; // get this from renderer
-				imgfmt = Image::FORMAT_ETC2_RA_AS_RG;
+			if (s3tc_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFBC3;
+				image_format = Image::FORMAT_DXT5_RA_AS_RG;
+			} else if (etc2_supported) {
+				basisu_format = basist::transcoder_texture_format::cTFETC2;
+				image_format = Image::FORMAT_ETC2_RA_AS_RG;
 			} else {
-				//opengl most likely, bad for normal maps, nothing to do about this.
-				format = basist::transcoder_texture_format::cTFRGBA32;
-				imgfmt = Image::FORMAT_RGBA8;
+				// No supported VRAM compression formats, decompress.
+				basisu_format = basist::transcoder_texture_format::cTFRGBA32;
+				image_format = Image::FORMAT_RGBA8;
 			}
 		} break;
 	}
 
-	ptr += 4;
-	size -= 4;
+	src_ptr += 4;
+	src_size -= 4;
 
-	basist::basisu_transcoder tr;
+	basist::basisu_transcoder transcoder;
+	ERR_FAIL_COND_V(!transcoder.validate_header(src_ptr, src_size), image);
 
-	ERR_FAIL_COND_V(!tr.validate_header(ptr, size), image);
+	transcoder.start_transcoding(src_ptr, src_size);
 
-	tr.start_transcoding(ptr, size);
+	basist::basisu_image_info basisu_info;
+	transcoder.get_image_info(src_ptr, src_size, basisu_info, 0);
 
-	basist::basisu_image_info info;
-	tr.get_image_info(ptr, size, info, 0);
-	Vector<uint8_t> gpudata;
-	gpudata.resize(Image::get_image_data_size(info.m_width, info.m_height, imgfmt, info.m_total_levels > 1));
+	Vector<uint8_t> out_data;
+	out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels > 1));
 
-	uint8_t *w = gpudata.ptrw();
-	uint8_t *dst = w;
-	for (int i = 0; i < gpudata.size(); i++) {
-		dst[i] = 0x00;
-	}
-	uint32_t mip_count = Image::get_image_required_mipmaps(info.m_orig_width, info.m_orig_height, imgfmt);
-	for (uint32_t level_i = 0; level_i <= mip_count; level_i++) {
-		basist::basisu_image_level_info level;
-		tr.get_image_level_info(ptr, size, level, 0, level_i);
-		int ofs = Image::get_image_mipmap_offset(info.m_width, info.m_height, imgfmt, level_i);
-		bool ret = tr.transcode_image_level(ptr, size, 0, level_i, dst + ofs, level.m_total_blocks, format);
-		if (!ret) {
-			print_line(vformat("Basis universal cannot unpack level %d.", level_i));
+	uint8_t *dst = out_data.ptrw();
+	memset(dst, 0, out_data.size());
+
+	uint32_t mip_count = Image::get_image_required_mipmaps(basisu_info.m_orig_width, basisu_info.m_orig_height, image_format);
+	for (uint32_t i = 0; i <= mip_count; i++) {
+		basist::basisu_image_level_info basisu_level;
+		transcoder.get_image_level_info(src_ptr, src_size, basisu_level, 0, i);
+
+		int ofs = Image::get_image_mipmap_offset(basisu_info.m_width, basisu_info.m_height, image_format, i);
+		bool result = transcoder.transcode_image_level(src_ptr, src_size, 0, i, dst + ofs, basisu_level.m_total_blocks, basisu_format);
+
+		if (!result) {
+			print_line(vformat("BasisUniversal cannot unpack level %d.", i));
 			break;
-		};
+		}
 	}
 
-	image = Image::create_from_data(info.m_width, info.m_height, info.m_total_levels > 1, imgfmt, gpudata);
+	image = Image::create_from_data(basisu_info.m_width, basisu_info.m_height, basisu_info.m_total_levels > 1, image_format, out_data);
 
 	return image;
 }
 
 Ref<Image> basis_universal_unpacker(const Vector<uint8_t> &p_buffer) {
-	Ref<Image> image;
-
-	const uint8_t *r = p_buffer.ptr();
-	int size = p_buffer.size();
-	return basis_universal_unpacker_ptr(r, size);
+	return basis_universal_unpacker_ptr(p_buffer.ptr(), p_buffer.size());
 }

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -1,0 +1,274 @@
+/**************************************************************************/
+/*  image_compress_basisu.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "image_compress_basisu.h"
+
+#include "servers/rendering_server.h"
+
+#include <transcoder/basisu_transcoder.h>
+#ifdef TOOLS_ENABLED
+#include <encoder/basisu_comp.h>
+#endif
+
+//workaround for lack of ETC2 RG
+#define USE_RG_AS_RGBA
+
+void basis_universal_init() {
+#ifdef TOOLS_ENABLED
+	basisu::basisu_encoder_init();
+#endif
+
+	basist::basisu_transcoder_init();
+}
+
+#ifdef TOOLS_ENABLED
+Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedChannels p_channels) {
+	Vector<uint8_t> budata;
+	{
+		basisu::basis_compressor_params params;
+		Ref<Image> image = p_image->duplicate();
+		if (image->get_format() != Image::FORMAT_RGBA8) {
+			image->convert(Image::FORMAT_RGBA8);
+		}
+
+		params.m_uastc = true;
+		params.m_quality_level = basisu::BASISU_QUALITY_MIN;
+
+		params.m_pack_uastc_flags &= ~basisu::cPackUASTCLevelMask;
+
+		static const uint32_t s_level_flags[basisu::TOTAL_PACK_UASTC_LEVELS] = { basisu::cPackUASTCLevelFastest, basisu::cPackUASTCLevelFaster, basisu::cPackUASTCLevelDefault, basisu::cPackUASTCLevelSlower, basisu::cPackUASTCLevelVerySlow };
+		params.m_pack_uastc_flags |= s_level_flags[0];
+		params.m_rdo_uastc = 0.0f;
+		params.m_rdo_uastc_quality_scalar = 0.0f;
+		params.m_rdo_uastc_dict_size = 1024;
+
+		params.m_mip_fast = true;
+		params.m_multithreading = true;
+
+		basisu::job_pool jpool(OS::get_singleton()->get_processor_count());
+		params.m_pJob_pool = &jpool;
+
+		BasisDecompressFormat decompress_format = BASIS_DECOMPRESS_RG;
+		params.m_check_for_alpha = false;
+
+		switch (p_channels) {
+			case Image::USED_CHANNELS_L: {
+				decompress_format = BASIS_DECOMPRESS_RGB;
+			} break;
+			case Image::USED_CHANNELS_LA: {
+				params.m_force_alpha = true;
+				decompress_format = BASIS_DECOMPRESS_RGBA;
+			} break;
+			case Image::USED_CHANNELS_R: {
+				decompress_format = BASIS_DECOMPRESS_RGB;
+			} break;
+			case Image::USED_CHANNELS_RG: {
+#ifdef USE_RG_AS_RGBA
+				params.m_force_alpha = true;
+				image->convert_rg_to_ra_rgba8();
+				decompress_format = BASIS_DECOMPRESS_RG_AS_RA;
+#else
+				params.m_seperate_rg_to_color_alpha = true;
+				decompress_format = BASIS_DECOMPRESS_RG;
+#endif
+			} break;
+			case Image::USED_CHANNELS_RGB: {
+				decompress_format = BASIS_DECOMPRESS_RGB;
+			} break;
+			case Image::USED_CHANNELS_RGBA: {
+				params.m_force_alpha = true;
+				decompress_format = BASIS_DECOMPRESS_RGBA;
+			} break;
+		}
+
+		if (!image->has_mipmaps()) {
+			basisu::image buimg(image->get_width(), image->get_height());
+			Vector<uint8_t> vec = image->get_data();
+			const uint8_t *r = vec.ptr();
+			memcpy(buimg.get_ptr(), r, vec.size());
+			params.m_source_images.push_back(buimg);
+		} else {
+			{
+				Ref<Image> base_image = image->get_image_from_mipmap(0);
+				Vector<uint8_t> image_vec = base_image->get_data();
+				basisu::image buimg_image(base_image->get_width(), base_image->get_height());
+				const uint8_t *r = image_vec.ptr();
+				memcpy(buimg_image.get_ptr(), r, image_vec.size());
+				params.m_source_images.push_back(buimg_image);
+			}
+			basisu::vector<basisu::image> images;
+			for (int32_t mip_map_i = 1; mip_map_i <= image->get_mipmap_count(); mip_map_i++) {
+				Ref<Image> mip_map = image->get_image_from_mipmap(mip_map_i);
+				Vector<uint8_t> mip_map_vec = mip_map->get_data();
+				basisu::image buimg_mipmap(mip_map->get_width(), mip_map->get_height());
+				const uint8_t *r = mip_map_vec.ptr();
+				memcpy(buimg_mipmap.get_ptr(), r, mip_map_vec.size());
+				images.push_back(buimg_mipmap);
+			}
+			params.m_source_mipmap_images.push_back(images);
+		}
+
+		basisu::basis_compressor c;
+		c.init(params);
+
+		int buerr = c.process();
+		ERR_FAIL_COND_V(buerr != basisu::basis_compressor::cECSuccess, budata);
+
+		const basisu::uint8_vec &buvec = c.get_output_basis_file();
+		budata.resize(buvec.size() + 4);
+
+		{
+			uint8_t *w = budata.ptrw();
+			uint32_t *decf = (uint32_t *)w;
+			*decf = decompress_format;
+			memcpy(w + 4, &buvec[0], buvec.size());
+		}
+	}
+
+	return budata;
+}
+#endif // TOOLS_ENABLED
+
+Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
+	Ref<Image> image;
+
+	const uint8_t *ptr = p_data;
+	int size = p_size;
+	ERR_FAIL_NULL_V_MSG(p_data, image, "Cannot unpack invalid basis universal data.");
+
+	basist::transcoder_texture_format format = basist::transcoder_texture_format::cTFTotalTextureFormats;
+	Image::Format imgfmt = Image::FORMAT_MAX;
+
+	switch (*(uint32_t *)(ptr)) {
+		case BASIS_DECOMPRESS_RG: {
+			if (RS::get_singleton()->has_os_feature("rgtc")) {
+				format = basist::transcoder_texture_format::cTFBC5; // get this from renderer
+				imgfmt = Image::FORMAT_RGTC_RG;
+			} else if (RS::get_singleton()->has_os_feature("etc2")) {
+				//unfortunately, basis universal does not support
+				//
+				ERR_FAIL_V(image); //unimplemented here
+				//format = basist::transcoder_texture_format::cTFETC1; // get this from renderer
+				//imgfmt = Image::FORMAT_RGTC_RG;
+			} else {
+				// FIXME: There wasn't anything here, but then imgformat is used uninitialized.
+				ERR_FAIL_V(image);
+			}
+		} break;
+		case BASIS_DECOMPRESS_RGB: {
+			if (RS::get_singleton()->has_os_feature("bptc")) {
+				format = basist::transcoder_texture_format::cTFBC7_M6_OPAQUE_ONLY; // get this from renderer
+				imgfmt = Image::FORMAT_BPTC_RGBA;
+			} else if (RS::get_singleton()->has_os_feature("s3tc")) {
+				format = basist::transcoder_texture_format::cTFBC1; // get this from renderer
+				imgfmt = Image::FORMAT_DXT1;
+			} else if (RS::get_singleton()->has_os_feature("etc2")) {
+				format = basist::transcoder_texture_format::cTFETC1; // get this from renderer
+				imgfmt = Image::FORMAT_ETC2_RGB8;
+			} else {
+				format = basist::transcoder_texture_format::cTFBGR565; // get this from renderer
+				imgfmt = Image::FORMAT_RGB565;
+			}
+
+		} break;
+		case BASIS_DECOMPRESS_RGBA: {
+			if (RS::get_singleton()->has_os_feature("bptc")) {
+				format = basist::transcoder_texture_format::cTFBC7_M5; // get this from renderer
+				imgfmt = Image::FORMAT_BPTC_RGBA;
+			} else if (RS::get_singleton()->has_os_feature("s3tc")) {
+				format = basist::transcoder_texture_format::cTFBC3; // get this from renderer
+				imgfmt = Image::FORMAT_DXT5;
+			} else if (RS::get_singleton()->has_os_feature("etc2")) {
+				format = basist::transcoder_texture_format::cTFETC2; // get this from renderer
+				imgfmt = Image::FORMAT_ETC2_RGBA8;
+			} else {
+				//opengl most likely
+				format = basist::transcoder_texture_format::cTFRGBA4444; // get this from renderer
+				imgfmt = Image::FORMAT_RGBA4444;
+			}
+		} break;
+		case BASIS_DECOMPRESS_RG_AS_RA: {
+			if (RS::get_singleton()->has_os_feature("s3tc")) {
+				format = basist::transcoder_texture_format::cTFBC3; // get this from renderer
+				imgfmt = Image::FORMAT_DXT5_RA_AS_RG;
+			} else if (RS::get_singleton()->has_os_feature("etc2")) {
+				format = basist::transcoder_texture_format::cTFETC2; // get this from renderer
+				imgfmt = Image::FORMAT_ETC2_RA_AS_RG;
+			} else {
+				//opengl most likely, bad for normal maps, nothing to do about this.
+				format = basist::transcoder_texture_format::cTFRGBA32;
+				imgfmt = Image::FORMAT_RGBA8;
+			}
+		} break;
+	}
+
+	ptr += 4;
+	size -= 4;
+
+	basist::basisu_transcoder tr;
+
+	ERR_FAIL_COND_V(!tr.validate_header(ptr, size), image);
+
+	tr.start_transcoding(ptr, size);
+
+	basist::basisu_image_info info;
+	tr.get_image_info(ptr, size, info, 0);
+	Vector<uint8_t> gpudata;
+	gpudata.resize(Image::get_image_data_size(info.m_width, info.m_height, imgfmt, info.m_total_levels > 1));
+
+	uint8_t *w = gpudata.ptrw();
+	uint8_t *dst = w;
+	for (int i = 0; i < gpudata.size(); i++) {
+		dst[i] = 0x00;
+	}
+	uint32_t mip_count = Image::get_image_required_mipmaps(info.m_orig_width, info.m_orig_height, imgfmt);
+	for (uint32_t level_i = 0; level_i <= mip_count; level_i++) {
+		basist::basisu_image_level_info level;
+		tr.get_image_level_info(ptr, size, level, 0, level_i);
+		int ofs = Image::get_image_mipmap_offset(info.m_width, info.m_height, imgfmt, level_i);
+		bool ret = tr.transcode_image_level(ptr, size, 0, level_i, dst + ofs, level.m_total_blocks, format);
+		if (!ret) {
+			print_line(vformat("Basis universal cannot unpack level %d.", level_i));
+			break;
+		};
+	}
+
+	image = Image::create_from_data(info.m_width, info.m_height, info.m_total_levels > 1, imgfmt, gpudata);
+
+	return image;
+}
+
+Ref<Image> basis_universal_unpacker(const Vector<uint8_t> &p_buffer) {
+	Ref<Image> image;
+
+	const uint8_t *r = p_buffer.ptr();
+	int size = p_buffer.size();
+	return basis_universal_unpacker_ptr(r, size);
+}

--- a/modules/basis_universal/image_compress_basisu.h
+++ b/modules/basis_universal/image_compress_basisu.h
@@ -37,7 +37,7 @@ enum BasisDecompressFormat {
 	BASIS_DECOMPRESS_RG,
 	BASIS_DECOMPRESS_RGB,
 	BASIS_DECOMPRESS_RGBA,
-	BASIS_DECOMPRESS_RG_AS_RA
+	BASIS_DECOMPRESS_RG_AS_RA,
 };
 
 void basis_universal_init();

--- a/modules/basis_universal/image_compress_basisu.h
+++ b/modules/basis_universal/image_compress_basisu.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  image_compress_basisu.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,34 +28,25 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#ifndef IMAGE_COMPRESS_BASISU_H
+#define IMAGE_COMPRESS_BASISU_H
 
-#include "image_compress_basisu.h"
+#include "core/io/image.h"
 
-void initialize_basis_universal_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+enum BasisDecompressFormat {
+	BASIS_DECOMPRESS_RG,
+	BASIS_DECOMPRESS_RGB,
+	BASIS_DECOMPRESS_RGBA,
+	BASIS_DECOMPRESS_RG_AS_RA
+};
 
-	basis_universal_init();
-
-#ifdef TOOLS_ENABLED
-	Image::basis_universal_packer = basis_universal_packer;
-#endif
-
-	Image::basis_universal_unpacker = basis_universal_unpacker;
-	Image::basis_universal_unpacker_ptr = basis_universal_unpacker_ptr;
-}
-
-void uninitialize_basis_universal_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+void basis_universal_init();
 
 #ifdef TOOLS_ENABLED
-	Image::basis_universal_packer = nullptr;
+Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedChannels p_channels);
 #endif
 
-	Image::basis_universal_unpacker = nullptr;
-	Image::basis_universal_unpacker_ptr = nullptr;
-}
+Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size);
+Ref<Image> basis_universal_unpacker(const Vector<uint8_t> &p_buffer);
+
+#endif // IMAGE_COMPRESS_BASISU_H


### PR DESCRIPTION
This PR aims to clean up BasisUniversal's code to make it easier to read, as well as extracts the code from `register_types.cpp` into its own files.

It also slightly optimizes the memory usage and compression times by using the `get_mipmap_offset_size_and_dimensions()` function instead of copying each mipmap's data into a new image.

While it seems to function correctly, it still needs some testing, especially on mobile devices.