### PR TITLE
[Editor] Hide Search Results by default and show it on first search.

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -566,6 +566,7 @@ void FindInFilesDialog::_bind_methods() {
 //-----------------------------------------------------------------------------
 const char *FindInFilesPanel::SIGNAL_RESULT_SELECTED = "result_selected";
 const char *FindInFilesPanel::SIGNAL_FILES_MODIFIED = "files_modified";
+const char *FindInFilesPanel::SIGNAL_CLOSE_BUTTON_CLICKED = "close_button_clicked";
 
 FindInFilesPanel::FindInFilesPanel() {
 	_finder = memnew(FindInFiles);
@@ -610,6 +611,11 @@ FindInFilesPanel::FindInFilesPanel() {
 		_cancel_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_cancel_button_clicked));
 		_cancel_button->hide();
 		hbc->add_child(_cancel_button);
+
+		_close_button = memnew(Button);
+		_close_button->set_text(TTR("Close"));
+		_close_button->connect("pressed", callable_mp(this, &FindInFilesPanel::_on_close_button_clicked));
+		hbc->add_child(_close_button);
 
 		vbc->add_child(hbc);
 	}
@@ -842,6 +848,10 @@ void FindInFilesPanel::_on_cancel_button_clicked() {
 	stop_search();
 }
 
+void FindInFilesPanel::_on_close_button_clicked() {
+	emit_signal(SNAME(SIGNAL_CLOSE_BUTTON_CLICKED));
+}
+
 void FindInFilesPanel::_on_result_selected() {
 	TreeItem *item = _results_display->get_selected();
 	HashMap<TreeItem *, Result>::Iterator E = _result_items.find(item);
@@ -1009,4 +1019,6 @@ void FindInFilesPanel::_bind_methods() {
 			PropertyInfo(Variant::INT, "end")));
 
 	ADD_SIGNAL(MethodInfo(SIGNAL_FILES_MODIFIED, PropertyInfo(Variant::STRING, "paths")));
+
+	ADD_SIGNAL(MethodInfo(SIGNAL_CLOSE_BUTTON_CLICKED));
 }

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -159,6 +159,7 @@ class FindInFilesPanel : public Control {
 public:
 	static const char *SIGNAL_RESULT_SELECTED;
 	static const char *SIGNAL_FILES_MODIFIED;
+	static const char *SIGNAL_CLOSE_BUTTON_CLICKED;
 
 	FindInFilesPanel();
 
@@ -180,6 +181,7 @@ private:
 	void _on_finished();
 	void _on_refresh_button_clicked();
 	void _on_cancel_button_clicked();
+	void _on_close_button_clicked();
 	void _on_result_selected();
 	void _on_item_edited();
 	void _on_replace_text_changed(const String &text);
@@ -207,6 +209,7 @@ private:
 	Label *_status_label = nullptr;
 	Button *_refresh_button = nullptr;
 	Button *_cancel_button = nullptr;
+	Button *_close_button = nullptr;
 	ProgressBar *_progress_bar = nullptr;
 	HashMap<String, TreeItem *> _file_items;
 	HashMap<TreeItem *, Result> _result_items;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1715,18 +1715,6 @@ void ScriptEditor::_notification(int p_what) {
 			_test_script_times_on_disk();
 			_update_modified_scripts_for_external_editor();
 		} break;
-
-		case CanvasItem::NOTIFICATION_VISIBILITY_CHANGED: {
-			if (is_visible()) {
-				find_in_files_button->show();
-			} else {
-				if (find_in_files->is_visible_in_tree()) {
-					EditorNode::get_bottom_panel()->hide_bottom_panel();
-				}
-				find_in_files_button->hide();
-			}
-
-		} break;
 	}
 }
 
@@ -3775,6 +3763,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 					ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
 
 					if (ste) {
+						EditorInterface::get_singleton()->set_main_screen_editor("Script");
 						ste->goto_line_selection(line_number, begin, end);
 					}
 				}
@@ -3789,6 +3778,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 
 				ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
 				if (ste) {
+					EditorInterface::get_singleton()->set_main_screen_editor("Script");
 					ste->goto_line_selection(line_number - 1, begin, end);
 				}
 				return;
@@ -3822,6 +3812,13 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	find_in_files->set_replace_text(find_in_files_dialog->get_replace_text());
 	find_in_files->start_search();
 
+	if (find_in_files_button->get_index() != find_in_files_button->get_parent()->get_child_count()) {
+		find_in_files_button->get_parent()->move_child(find_in_files_button, -1);
+	}
+	if (!find_in_files_button->is_visible()) {
+		find_in_files_button->show();
+	}
+
 	EditorNode::get_bottom_panel()->make_item_visible(find_in_files);
 }
 
@@ -3846,6 +3843,11 @@ void ScriptEditor::_set_zoom_factor(float p_zoom_factor) {
 			}
 		}
 	}
+}
+
+void ScriptEditor::_on_find_in_files_close_button_clicked() {
+	EditorNode::get_bottom_panel()->hide_bottom_panel();
+	find_in_files_button->hide();
 }
 
 void ScriptEditor::_window_changed(bool p_visible) {
@@ -4201,6 +4203,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
+	find_in_files->connect(FindInFilesPanel::SIGNAL_CLOSE_BUTTON_CLICKED, callable_mp(this, &ScriptEditor::_on_find_in_files_close_button_clicked));
 	find_in_files->hide();
 	find_in_files_button->hide();
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -496,6 +496,7 @@ class ScriptEditor : public PanelContainer {
 	void _on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end);
 	void _start_find_in_files(bool with_replace);
 	void _on_find_in_files_modified_files(const PackedStringArray &paths);
+	void _on_find_in_files_close_button_clicked();
 
 	void _set_zoom_factor(float p_zoom_factor);
 


### PR DESCRIPTION
_Bugsquad edit: fixes https://github.com/godotengine/godot-proposals/issues/9114_
This PR aims to implement this proposal : https://github.com/godotengine/godot-proposals/issues/9114

~~This add the _find_in_files_button_ only when the first search to find in files is made so that it is placed in the last position.~~
This shows the _find_in_files_button_ only when the first search to find in files is made and push it in the last position.
It also add a _Close_ button that hide the panel and its button when the user want it. I choose to keep the Search Results open even when switching away from the Script editor since the Close button is now available to hide it at will.
Also switch to the script editor when the user click on a line found.

This is my first PR on the editor and found the above proposal was fitting to be an easy first attempt. I tried to avoid doing stupid things and from my test I did not find any issue, but let me know if I did something stupid...