### PR TITLE
Fix `LineEdit` delete all the way to the left/right when something is selected

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -138,17 +138,20 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 		return;
 	}
 
+	if (selection.enabled) {
+		selection_delete();
+		return;
+	}
+
+	if (caret_column == 0) {
+		return; // Nothing to do.
+	}
+
 	if (p_all_to_left) {
-		deselect();
 		text = text.substr(caret_column);
 		_shape();
 		set_caret_column(0);
 		_text_changed();
-		return;
-	}
-
-	if (selection.enabled) {
-		selection_delete();
 		return;
 	}
 
@@ -176,23 +179,20 @@ void LineEdit::_delete(bool p_word, bool p_all_to_right) {
 		return;
 	}
 
-	if (p_all_to_right) {
-		deselect();
-		text = text.substr(0, caret_column);
-		_shape();
-		_text_changed();
-		return;
-	}
-
 	if (selection.enabled) {
 		selection_delete();
 		return;
 	}
 
-	int text_len = text.length();
-
-	if (caret_column == text_len) {
+	if (caret_column == text.length()) {
 		return; // Nothing to do.
+	}
+
+	if (p_all_to_right) {
+		text = text.substr(0, caret_column);
+		_shape();
+		_text_changed();
+		return;
 	}
 
 	if (p_word) {


### PR DESCRIPTION
When something is selected in `TextEdit`, using "delete all the way to the left/right" on it just deletes the selection. This makes sure `LineEdit` behaves the same way

Deleting all the way to the left before:

https://github.com/godotengine/godot/assets/60579014/3e224f78-0785-4f4d-a8df-88df41314466

After:

https://github.com/godotengine/godot/assets/60579014/cca55b43-0f9e-4d3a-82c0-643dbe5ee8e4

Interestingly `LineEdit` already had code to check for that, but it was in the wrong place

This small issue is unreported because before #88057 it was hard to discover