### PR TITLE
Fix error spam when adding tabs to `TabBar` without deselect

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -627,6 +627,10 @@ void TabBar::set_tab_count(int p_count) {
 		offset = MIN(offset, p_count - 1);
 		max_drawn_tab = MIN(max_drawn_tab, p_count - 1);
 		current = MIN(current, p_count - 1);
+		// Fix range if unable to deselect.
+		if (current == -1 && !_can_deselect()) {
+			current = 0;
+		}
 
 		_update_cache();
 		_ensure_no_over_offset();
@@ -1557,10 +1561,7 @@ bool TabBar::_can_deselect() const {
 }
 
 void TabBar::ensure_tab_visible(int p_idx) {
-	if (!is_inside_tree() || !buttons_visible) {
-		return;
-	}
-	if (p_idx == -1 && _can_deselect()) {
+	if (p_idx == -1 || !is_inside_tree() || !buttons_visible) {
 		return;
 	}
 	ERR_FAIL_INDEX(p_idx, tabs.size());


### PR DESCRIPTION
Ensures `current` has a valid value after resizing if deselection is not allowed.

The revert marker being visible for the deselect disabled case is a bit annoying and confusing but is a bit more complex to solve, and unsure how it would affect other things with the default values etc., but worth looking into in the future as well.

MRP:
[TabMRP.zip](https://github.com/godotengine/godot/files/14322670/TabMRP.zip)

Note how it will print:
```
ERROR: Index p_idx = -1 is out of bounds (tabs.size() = 2).
   at: TabBar::ensure_tab_visible (scene/gui/tab_bar.cpp:1555)
```
When opening the file, and also when resizing the tab bar

This ensures the `current` value is updated to the correct range in this case

Edit: Confirmed that this works on top of:
* https://github.com/godotengine/godot/pull/88477

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
