### PR TITLE
Fix reversed custom `AABB` check when recalculating multimesh `AABB`s

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1962,7 +1962,7 @@ void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_b
 		//if we have a mesh set, we need to re-generate the AABB from the new data
 		const float *data = p_buffer.ptr();
 
-		if (multimesh->custom_aabb != AABB()) {
+		if (multimesh->custom_aabb == AABB()) {
 			_multimesh_re_create_aabb(multimesh, data, multimesh->instances);
 			multimesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 		}
@@ -2113,7 +2113,7 @@ void MeshStorage::_update_dirty_multimeshes() {
 
 			if (multimesh->aabb_dirty && multimesh->mesh.is_valid()) {
 				multimesh->aabb_dirty = false;
-				if (multimesh->custom_aabb != AABB()) {
+				if (multimesh->custom_aabb == AABB()) {
 					_multimesh_re_create_aabb(multimesh, data, visible_instances);
 					multimesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 				}

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1963,7 +1963,7 @@ void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_b
 		//if we have a mesh set, we need to re-generate the AABB from the new data
 		const float *data = p_buffer.ptr();
 
-		if (multimesh->custom_aabb != AABB()) {
+		if (multimesh->custom_aabb == AABB()) {
 			_multimesh_re_create_aabb(multimesh, data, multimesh->instances);
 			multimesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 		}
@@ -2087,7 +2087,7 @@ void MeshStorage::_update_dirty_multimeshes() {
 			if (multimesh->aabb_dirty) {
 				//aabb is dirty..
 				multimesh->aabb_dirty = false;
-				if (multimesh->custom_aabb != AABB()) {
+				if (multimesh->custom_aabb == AABB()) {
 					_multimesh_re_create_aabb(multimesh, data, visible_instances);
 					multimesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 				}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

When deciding whether to recalculate AABBs, the check for whether a custom AABB exists is reversed. This PR corrects the check and fixes AABB recalculation problems.

Fixes #88458 