### PR TITLE
AudioEffectPitchShift: Prevent negative size memset (GCC warning)

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -87,8 +87,10 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	double magn, phase, tmp, window, real, imag;
 	double freqPerBin, expct;
 	long i,k, qpd, index, inFifoLatency, stepSize, fftFrameSize2;
+	unsigned long fftFrameBufferSize;
 
 	/* set up some handy variables */
+	fftFrameBufferSize = (unsigned long)fftFrameSize*sizeof(float);
 	fftFrameSize2 = fftFrameSize/2;
 	stepSize = fftFrameSize/osamp;
 	freqPerBin = sampleRate/(double)fftFrameSize;
@@ -160,8 +162,8 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* ***************** PROCESSING ******************* */
 			/* this does the actual pitch shifting */
-			memset(gSynMagn, 0, fftFrameSize*sizeof(float));
-			memset(gSynFreq, 0, fftFrameSize*sizeof(float));
+			memset(gSynMagn, 0, fftFrameBufferSize);
+			memset(gSynFreq, 0, fftFrameBufferSize);
 			for (k = 0; k <= fftFrameSize2; k++) {
 				index = k*pitchShift;
 				if (index <= fftFrameSize2) {
@@ -214,7 +216,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 }
 
 			/* shift accumulator */
-			memmove(gOutputAccum, gOutputAccum+stepSize, fftFrameSize*sizeof(float));
+			memmove(gOutputAccum, gOutputAccum+stepSize, fftFrameBufferSize);
 
 			/* move input FIFO */
 			for (k = 0; k < inFifoLatency; k++) { gInFIFO[k] = gInFIFO[k+stepSize];


### PR DESCRIPTION
Fixes a warning when using it for memset (from #88504):

```
servers/audio/effects/audio_effect_pitch_shift.cpp: In member function 'PitchShift.constprop':
servers/audio/effects/audio_effect_pitch_shift.cpp:163:31: warning: 'memset' specified bound between 18446744065119617024 and 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  163 |                         memset(gSynMagn, 0, fftFrameSize*sizeof(float));
      |                               ^
servers/audio/effects/audio_effect_pitch_shift.cpp:164:31: warning: 'memset' specified bound between 18446744065119617024 and 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  164 |                         memset(gSynFreq, 0, fftFrameSize*sizeof(float));
      |                               ^
```

This is "thirdparty" code part of our own Godot code, so I just worked around the problem where it appears, instead of refactoring the whole function to properly make use of unsigned types throughout when signed results aren't needed.