### PR TITLE
Disable the crash handler if `execinfo=no` scons option is set

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -36,8 +36,8 @@
 #include "core/version.h"
 #include "main/main.h"
 
-#ifdef DEBUG_ENABLED
-#define CRASH_HANDLER_ENABLED 1
+#ifndef DEBUG_ENABLED
+#undef CRASH_HANDLER_ENABLED
 #endif
 
 #ifdef CRASH_HANDLER_ENABLED

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -50,7 +50,7 @@ def get_opts():
         BoolVariable("wayland", "Enable Wayland display", True),
         BoolVariable("libdecor", "Enable libdecor support", True),
         BoolVariable("touch", "Enable touch events", True),
-        BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", None),
     ]
 
 
@@ -487,14 +487,20 @@ def configure(env: "SConsEnvironment"):
     if platform.system() == "Linux":
         env.Append(LIBS=["dl"])
 
-    if not env["execinfo"] and platform.libc_ver()[0] != "glibc":
+    if platform.libc_ver()[0] != "glibc":
         # The default crash handler depends on glibc, so if the host uses
         # a different libc (BSD libc, musl), fall back to libexecinfo.
-        print("Note: Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.")
-        env["execinfo"] = True
+        if not "execinfo" in env:
+            print("Note: Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.")
+            env["execinfo"] = True
 
-    if env["execinfo"]:
-        env.Append(LIBS=["execinfo"])
+        if env["execinfo"]:
+            env.Append(LIBS=["execinfo"])
+            env.Append(CPPDEFINES=["CRASH_HANDLER_ENABLED"])
+        else:
+            print("Note: Using `execinfo=no` disables the crash handler on platforms where glibc is missing.")
+    else:
+        env.Append(CPPDEFINES=["CRASH_HANDLER_ENABLED"])
 
     if platform.system() == "FreeBSD":
         env.Append(LINKFLAGS=["-lkvm"])


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Because the crash handler is not enabled in `template_release` build mode, `libexecinfo` is not always required on non-glibc systems.

On Gentoo Linux, libexecinfo is not packaged and therefore scons is patched to disable `execinfo=yes` by default:
https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-games/godot/files/godot-4.0_rc2-musl.patch

The PR changes the default value of the Scons option `execinfo` to `None` so libexecinfo will not be implicitely linked if the Scons option `execinfo=no` is specified.

See https://github.com/godotengine/godot/issues/57193