### PR TITLE
GDExtension: Fix `-Wtype-limits` warning in `compatibility_maximum` patch check

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -929,9 +929,13 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 			compatible = VERSION_MAJOR < compatibility_maximum[0];
 		} else if (VERSION_MINOR != compatibility_maximum[1]) {
 			compatible = VERSION_MINOR < compatibility_maximum[1];
-		} else {
+		}
+#if VERSION_PATCH
+		// #if check to avoid -Wtype-limits warning when 0.
+		else {
 			compatible = VERSION_PATCH <= compatibility_maximum[2];
 		}
+#endif
 
 		if (!compatible) {
 			ERR_PRINT(vformat("GDExtension only compatible with Godot version %s or earlier: %s", compat_string, p_path));

--- a/core/version.h
+++ b/core/version.h
@@ -47,13 +47,8 @@
 // forward-compatible.
 // Example: "3.1"
 #define VERSION_BRANCH _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR)
-#if VERSION_PATCH
 // Example: "3.1.4"
 #define VERSION_NUMBER VERSION_BRANCH "." _MKSTR(VERSION_PATCH)
-#else // patch is 0, we don't include it in the "pretty" version number.
-// Example: "3.1" instead of "3.1.0"
-#define VERSION_NUMBER VERSION_BRANCH
-#endif // VERSION_PATCH
 
 // Version number encoded as hexadecimal int with one byte for each number,
 // for easy comparison from code.


### PR DESCRIPTION
Fixes this GCC 13.2.1 warning:
```
In file included from core/extension/scu/scu_core_extension.gen.cpp:2:
./core/extension/gdextension.cpp: In static member function 'static Error GDExtensionResourceLoader::load_gdextension_resource(const String&, Ref<GDExtension>&)':
./core/extension/gdextension.cpp:933:52: error: comparison of unsigned expression in '>= 0' is always true [-Werror=type-limits]
  933 |                         compatible = VERSION_PATCH <= compatibility_maximum[2];
```

And cleanup some dead code in `version.h`, we now always define `VERSION_PATCH`.

@godotengine/gdextension After confirming this is correct, feel free to merge the PR yourselves, to fix the warning in the `master` branch for other users.