### PR TITLE
Change default visual indication for the Tree cursor

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -950,16 +950,11 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_stylebox("selected_focus", "Tree", style_tree_focus);
 			p_theme->set_stylebox("selected", "Tree", style_tree_selected);
 
-			Ref<StyleBoxFlat> style_tree_cursor = p_config.base_style->duplicate();
-			style_tree_cursor->set_draw_center(false);
-			style_tree_cursor->set_border_width_all(MAX(1, p_config.border_width));
-			style_tree_cursor->set_border_color(p_config.contrast_color_1);
-
 			Ref<StyleBoxFlat> style_tree_title = p_config.base_style->duplicate();
 			style_tree_title->set_bg_color(p_config.dark_color_3);
 			style_tree_title->set_border_width_all(0);
-			p_theme->set_stylebox("cursor", "Tree", style_tree_cursor);
-			p_theme->set_stylebox("cursor_unfocused", "Tree", style_tree_cursor);
+			p_theme->set_stylebox("cursor", "Tree", make_empty_stylebox());
+			p_theme->set_stylebox("cursor_unfocused", "Tree", make_empty_stylebox());
 			p_theme->set_stylebox("title_button_normal", "Tree", style_tree_title);
 			p_theme->set_stylebox("title_button_hover", "Tree", style_tree_title);
 			p_theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -762,8 +762,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("focus", "Tree", focus);
 	theme->set_stylebox("selected", "Tree", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("selected_focus", "Tree", make_flat_stylebox(style_selected_color));
-	theme->set_stylebox("cursor", "Tree", focus);
-	theme->set_stylebox("cursor_unfocused", "Tree", focus);
+	theme->set_stylebox("cursor", "Tree", make_empty_stylebox());
+	theme->set_stylebox("cursor_unfocused", "Tree", make_empty_stylebox());
 	theme->set_stylebox("button_pressed", "Tree", button_pressed);
 	theme->set_stylebox("title_button_normal", "Tree", make_flat_stylebox(style_pressed_color, 4, 4, 4, 4));
 	theme->set_stylebox("title_button_pressed", "Tree", make_flat_stylebox(style_hover_color, 4, 4, 4, 4));


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/discussions/9123

![tree](https://github.com/godotengine/godot/assets/60579014/8f872331-06d5-4634-baee-ee86208cc10e)
