### PR TITLE
Bump `Rider.PathLocator` nuget version, which provides a fix for detecting Rider installations

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="JetBrains.Rider.PathLocator" Version="1.0.8" />
+    <PackageReference Include="JetBrains.Rider.PathLocator" Version="1.0.9" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <Reference Include="GodotSharp">


### PR DESCRIPTION
Corresponding change in the RiderPathLocator sources https://github.com/JetBrains/resharper-unity/commit/cc2a0e8b4b9cecdf583bcd9ca8daa7a2d7fe63e5
