### PR TITLE
[TextEdit] Add support for optional wrapped line indentation.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -992,6 +992,9 @@
 		<member name="text_editor/behavior/indent/auto_indent" type="bool" setter="" getter="">
 			If [code]true[/code], automatically indents code when pressing the [kbd]Enter[/kbd] key based on blocks above the new line.
 		</member>
+		<member name="text_editor/behavior/indent/indent_wrapped_lines" type="bool" setter="" getter="">
+			If [code]true[/code], all wrapped lines are indented to the same amount as the unwrapped line.
+		</member>
 		<member name="text_editor/behavior/indent/size" type="int" setter="" getter="">
 			When using tab indentation, determines the length of each tab. When using space indentation, determines how many spaces are inserted when pressing [kbd]Tab[/kbd] and when automatic indentation is performed.
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1154,6 +1154,9 @@
 		<member name="highlight_current_line" type="bool" setter="set_highlight_current_line" getter="is_highlight_current_line_enabled" default="false">
 			If [code]true[/code], the line containing the cursor is highlighted.
 		</member>
+		<member name="indent_wrapped_lines" type="bool" setter="set_indent_wrapped_lines" getter="is_indent_wrapped_lines" default="false">
+			If [code]true[/code], all wrapped lines are indented to the same amount as the unwrapped line.
+		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1837,6 +1837,9 @@
 		<constant name="BREAK_TRIM_EDGE_SPACES" value="16" enum="LineBreakFlag" is_bitfield="true">
 			Remove edge spaces from the broken line segments.
 		</constant>
+		<constant name="BREAK_TRIM_INDENT" value="32" enum="LineBreakFlag" is_bitfield="true">
+			Subtract first line indentation width from all lines after the first one.
+		</constant>
 		<constant name="VC_CHARS_BEFORE_SHAPING" value="0" enum="VisibleCharactersBehavior">
 			Trims text before the shaping. e.g, increasing [member Label.visible_characters] or [member RichTextLabel.visible_characters] value is visually identical to typing the text.
 		</constant>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1039,6 +1039,7 @@ void CodeTextEditor::update_editor_settings() {
 	set_indent_using_spaces(EDITOR_GET("text_editor/behavior/indent/type"));
 	text_editor->set_indent_size(EDITOR_GET("text_editor/behavior/indent/size"));
 	text_editor->set_auto_indent_enabled(EDITOR_GET("text_editor/behavior/indent/auto_indent"));
+	text_editor->set_indent_wrapped_lines(EDITOR_GET("text_editor/behavior/indent/indent_wrapped_lines"));
 
 	// Completion
 	text_editor->set_auto_brace_completion_enabled(EDITOR_GET("text_editor/completion/auto_brace_complete"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -631,6 +631,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/indent/size", 4, "1,64,1") // size of 0 crashes.
 	_initial_set("text_editor/behavior/indent/auto_indent", true);
+	_initial_set("text_editor/behavior/indent/indent_wrapped_lines", true);
 
 	// Behavior: Files
 	_initial_set("text_editor/behavior/files/trim_trailing_whitespace_on_save", false);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -181,6 +181,7 @@ private:
 
 		int tab_size = 4;
 		int gutter_count = 0;
+		bool indent_wrapped_lines = false;
 
 		void _calculate_line_height();
 		void _calculate_max_line_width();
@@ -188,6 +189,9 @@ private:
 	public:
 		void set_tab_size(int p_tab_size);
 		int get_tab_size() const;
+		void set_indent_wrapped_lines(bool p_enabled);
+		bool is_indent_wrapped_lines() const;
+
 		void set_font(const Ref<Font> &p_font);
 		void set_font_size(int p_font_size);
 		void set_direction_and_language(TextServer::Direction p_direction, const String &p_language);
@@ -719,6 +723,9 @@ public:
 
 	void set_tab_size(const int p_size);
 	int get_tab_size() const;
+
+	void set_indent_wrapped_lines(bool p_enabled);
+	bool is_indent_wrapped_lines() const;
 
 	// User controls
 	void set_overtype_mode_enabled(const bool p_enabled);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -108,6 +108,7 @@ public:
 		BREAK_GRAPHEME_BOUND = 1 << 2,
 		BREAK_ADAPTIVE = 1 << 3,
 		BREAK_TRIM_EDGE_SPACES = 1 << 4,
+		BREAK_TRIM_INDENT = 1 << 5,
 	};
 
 	enum OverrunBehavior {


### PR DESCRIPTION
Adds a new `text_editor/behavior/indent/indent_wrapped_lines` editor setting and `TextEdit` property to control how wrapped lines are indented.
| Enabled | Disabled|
| -- | -- |
| <img width="667" alt="Screenshot 2024-02-19 at 13 48 29" src="https://github.com/godotengine/godot/assets/7645683/297bfea1-4cf0-4ff9-a9fa-ee52d84c8b73"> | <img width="667" alt="Screenshot 2024-02-19 at 14 02 03" src="https://github.com/godotengine/godot/assets/7645683/1a53094b-1370-4423-ab2a-a8cd7ee41e5e"> |

Fixes https://github.com/godotengine/godot/issues/88478