### PR TITLE
Add missing barrier to SSIL and SSAO in Very Low quality.

### DIFF
--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -899,7 +899,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 				int y_groups = p_ssil_buffers.buffer_height;
 
 				RD::get_singleton()->compute_list_dispatch_threads(compute_list, x_groups, y_groups, 1);
-				if (ssil_quality > RS::ENV_SSIL_QUALITY_VERY_LOW) {
+				if (ssil_quality > RS::ENV_SSIL_QUALITY_VERY_LOW || i == 3) {
 					RD::get_singleton()->compute_list_add_barrier(compute_list);
 				}
 			}
@@ -1285,9 +1285,7 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 				RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_ssao_buffers.buffer_width, p_ssao_buffers.buffer_height, 1);
 			}
 
-			if (ssao_quality > RS::ENV_SSAO_QUALITY_VERY_LOW) {
-				RD::get_singleton()->compute_list_add_barrier(compute_list);
-			}
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
 		}
 		RD::get_singleton()->draw_command_end_label(); // Blur
 	}


### PR DESCRIPTION
@clayjohn may want to review if this change is correct, but basically the next step in the compute list was being parallelized incorrectly with this step and causing a validation error when using very low quality.

Fixes #88468.

EDIT: Also added a fix for SSAO.