### PR TITLE
[4.2] Fix shader cache with transform feedback on some Android devices

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -584,6 +584,19 @@ bool ShaderGLES3::_load_from_cache(Version *p_version) {
 			Version::Specialization specialization;
 
 			specialization.id = glCreateProgram();
+			if (feedback_count) {
+				Vector<const char *> feedback;
+				for (int i = 0; i < feedback_count; i++) {
+					if (feedbacks[i].specialization == 0 || (feedbacks[i].specialization & specialization_key)) {
+						// Specialization for this feedback is enabled
+						feedback.push_back(feedbacks[i].name);
+					}
+				}
+
+				if (feedback.size()) {
+					glTransformFeedbackVaryings(specialization.id, feedback.size(), feedback.ptr(), GL_INTERLEAVED_ATTRIBS);
+				}
+			}
 			glProgramBinary(specialization.id, variant_format, variant_bytes.ptr(), variant_bytes.size());
 
 			GLint link_status = 0;


### PR DESCRIPTION
Fix issue #82419 tested on vivo 1907, vsmart active 3, samsung a12