### PR TITLE
[Core] Upgrade some array helper classes to 64 bits

### DIFF
--- a/core/templates/search_array.h
+++ b/core/templates/search_array.h
@@ -38,12 +38,12 @@ class SearchArray {
 public:
 	Comparator compare;
 
-	inline int bisect(const T *p_array, int p_len, const T &p_value, bool p_before) const {
-		int lo = 0;
-		int hi = p_len;
+	inline int64_t bisect(const T *p_array, int64_t p_len, const T &p_value, bool p_before) const {
+		int64_t lo = 0;
+		int64_t hi = p_len;
 		if (p_before) {
 			while (lo < hi) {
-				const int mid = (lo + hi) / 2;
+				const int64_t mid = (lo + hi) / 2;
 				if (compare(p_array[mid], p_value)) {
 					lo = mid + 1;
 				} else {
@@ -52,7 +52,7 @@ public:
 			}
 		} else {
 			while (lo < hi) {
-				const int mid = (lo + hi) / 2;
+				const int64_t mid = (lo + hi) / 2;
 				if (compare(p_value, p_array[mid])) {
 					hi = mid;
 				} else {

--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -78,8 +78,8 @@ public:
 		}
 	}
 
-	inline int bitlog(int n) const {
-		int k;
+	inline int64_t bitlog(int64_t n) const {
+		int64_t k;
 		for (k = 0; n != 1; n >>= 1) {
 			++k;
 		}
@@ -88,8 +88,8 @@ public:
 
 	/* Heap / Heapsort functions */
 
-	inline void push_heap(int p_first, int p_hole_idx, int p_top_index, T p_value, T *p_array) const {
-		int parent = (p_hole_idx - 1) / 2;
+	inline void push_heap(int64_t p_first, int64_t p_hole_idx, int64_t p_top_index, T p_value, T *p_array) const {
+		int64_t parent = (p_hole_idx - 1) / 2;
 		while (p_hole_idx > p_top_index && compare(p_array[p_first + parent], p_value)) {
 			p_array[p_first + p_hole_idx] = p_array[p_first + parent];
 			p_hole_idx = parent;
@@ -98,17 +98,17 @@ public:
 		p_array[p_first + p_hole_idx] = p_value;
 	}
 
-	inline void pop_heap(int p_first, int p_last, int p_result, T p_value, T *p_array) const {
+	inline void pop_heap(int64_t p_first, int64_t p_last, int64_t p_result, T p_value, T *p_array) const {
 		p_array[p_result] = p_array[p_first];
 		adjust_heap(p_first, 0, p_last - p_first, p_value, p_array);
 	}
-	inline void pop_heap(int p_first, int p_last, T *p_array) const {
+	inline void pop_heap(int64_t p_first, int64_t p_last, T *p_array) const {
 		pop_heap(p_first, p_last - 1, p_last - 1, p_array[p_last - 1], p_array);
 	}
 
-	inline void adjust_heap(int p_first, int p_hole_idx, int p_len, T p_value, T *p_array) const {
-		int top_index = p_hole_idx;
-		int second_child = 2 * p_hole_idx + 2;
+	inline void adjust_heap(int64_t p_first, int64_t p_hole_idx, int64_t p_len, T p_value, T *p_array) const {
+		int64_t top_index = p_hole_idx;
+		int64_t second_child = 2 * p_hole_idx + 2;
 
 		while (second_child < p_len) {
 			if (compare(p_array[p_first + second_child], p_array[p_first + (second_child - 1)])) {
@@ -127,18 +127,18 @@ public:
 		push_heap(p_first, p_hole_idx, top_index, p_value, p_array);
 	}
 
-	inline void sort_heap(int p_first, int p_last, T *p_array) const {
+	inline void sort_heap(int64_t p_first, int64_t p_last, T *p_array) const {
 		while (p_last - p_first > 1) {
 			pop_heap(p_first, p_last--, p_array);
 		}
 	}
 
-	inline void make_heap(int p_first, int p_last, T *p_array) const {
+	inline void make_heap(int64_t p_first, int64_t p_last, T *p_array) const {
 		if (p_last - p_first < 2) {
 			return;
 		}
-		int len = p_last - p_first;
-		int parent = (len - 2) / 2;
+		int64_t len = p_last - p_first;
+		int64_t parent = (len - 2) / 2;
 
 		while (true) {
 			adjust_heap(p_first, parent, len, p_array[p_first + parent], p_array);
@@ -149,9 +149,9 @@ public:
 		}
 	}
 
-	inline void partial_sort(int p_first, int p_last, int p_middle, T *p_array) const {
+	inline void partial_sort(int64_t p_first, int64_t p_last, int64_t p_middle, T *p_array) const {
 		make_heap(p_first, p_middle, p_array);
-		for (int i = p_middle; i < p_last; i++) {
+		for (int64_t i = p_middle; i < p_last; i++) {
 			if (compare(p_array[i], p_array[p_first])) {
 				pop_heap(p_first, p_middle, i, p_array[i], p_array);
 			}
@@ -159,18 +159,18 @@ public:
 		sort_heap(p_first, p_middle, p_array);
 	}
 
-	inline void partial_select(int p_first, int p_last, int p_middle, T *p_array) const {
+	inline void partial_select(int64_t p_first, int64_t p_last, int64_t p_middle, T *p_array) const {
 		make_heap(p_first, p_middle, p_array);
-		for (int i = p_middle; i < p_last; i++) {
+		for (int64_t i = p_middle; i < p_last; i++) {
 			if (compare(p_array[i], p_array[p_first])) {
 				pop_heap(p_first, p_middle, i, p_array[i], p_array);
 			}
 		}
 	}
 
-	inline int partitioner(int p_first, int p_last, T p_pivot, T *p_array) const {
-		const int unmodified_first = p_first;
-		const int unmodified_last = p_last;
+	inline int64_t partitioner(int64_t p_first, int64_t p_last, T p_pivot, T *p_array) const {
+		const int64_t unmodified_first = p_first;
+		const int64_t unmodified_last = p_last;
 
 		while (true) {
 			while (compare(p_array[p_first], p_pivot)) {
@@ -196,7 +196,7 @@ public:
 		}
 	}
 
-	inline void introsort(int p_first, int p_last, T *p_array, int p_max_depth) const {
+	inline void introsort(int64_t p_first, int64_t p_last, T *p_array, int64_t p_max_depth) const {
 		while (p_last - p_first > INTROSORT_THRESHOLD) {
 			if (p_max_depth == 0) {
 				partial_sort(p_first, p_last, p_last, p_array);
@@ -205,7 +205,7 @@ public:
 
 			p_max_depth--;
 
-			int cut = partitioner(
+			int64_t cut = partitioner(
 					p_first,
 					p_last,
 					median_of_3(
@@ -219,7 +219,7 @@ public:
 		}
 	}
 
-	inline void introselect(int p_first, int p_nth, int p_last, T *p_array, int p_max_depth) const {
+	inline void introselect(int64_t p_first, int64_t p_nth, int64_t p_last, T *p_array, int64_t p_max_depth) const {
 		while (p_last - p_first > 3) {
 			if (p_max_depth == 0) {
 				partial_select(p_first, p_nth + 1, p_last, p_array);
@@ -229,7 +229,7 @@ public:
 
 			p_max_depth--;
 
-			int cut = partitioner(
+			int64_t cut = partitioner(
 					p_first,
 					p_last,
 					median_of_3(
@@ -248,8 +248,8 @@ public:
 		insertion_sort(p_first, p_last, p_array);
 	}
 
-	inline void unguarded_linear_insert(int p_last, T p_value, T *p_array) const {
-		int next = p_last - 1;
+	inline void unguarded_linear_insert(int64_t p_last, T p_value, T *p_array) const {
+		int64_t next = p_last - 1;
 		while (compare(p_value, p_array[next])) {
 			if (Validate) {
 				ERR_BAD_COMPARE(next == 0);
@@ -261,10 +261,10 @@ public:
 		p_array[p_last] = p_value;
 	}
 
-	inline void linear_insert(int p_first, int p_last, T *p_array) const {
+	inline void linear_insert(int64_t p_first, int64_t p_last, T *p_array) const {
 		T val = p_array[p_last];
 		if (compare(val, p_array[p_first])) {
-			for (int i = p_last; i > p_first; i--) {
+			for (int64_t i = p_last; i > p_first; i--) {
 				p_array[i] = p_array[i - 1];
 			}
 
@@ -274,22 +274,22 @@ public:
 		}
 	}
 
-	inline void insertion_sort(int p_first, int p_last, T *p_array) const {
+	inline void insertion_sort(int64_t p_first, int64_t p_last, T *p_array) const {
 		if (p_first == p_last) {
 			return;
 		}
-		for (int i = p_first + 1; i != p_last; i++) {
+		for (int64_t i = p_first + 1; i != p_last; i++) {
 			linear_insert(p_first, i, p_array);
 		}
 	}
 
-	inline void unguarded_insertion_sort(int p_first, int p_last, T *p_array) const {
-		for (int i = p_first; i != p_last; i++) {
+	inline void unguarded_insertion_sort(int64_t p_first, int64_t p_last, T *p_array) const {
+		for (int64_t i = p_first; i != p_last; i++) {
 			unguarded_linear_insert(i, p_array[i], p_array);
 		}
 	}
 
-	inline void final_insertion_sort(int p_first, int p_last, T *p_array) const {
+	inline void final_insertion_sort(int64_t p_first, int64_t p_last, T *p_array) const {
 		if (p_last - p_first > INTROSORT_THRESHOLD) {
 			insertion_sort(p_first, p_first + INTROSORT_THRESHOLD, p_array);
 			unguarded_insertion_sort(p_first + INTROSORT_THRESHOLD, p_last, p_array);
@@ -298,18 +298,18 @@ public:
 		}
 	}
 
-	inline void sort_range(int p_first, int p_last, T *p_array) const {
+	inline void sort_range(int64_t p_first, int64_t p_last, T *p_array) const {
 		if (p_first != p_last) {
 			introsort(p_first, p_last, p_array, bitlog(p_last - p_first) * 2);
 			final_insertion_sort(p_first, p_last, p_array);
 		}
 	}
 
-	inline void sort(T *p_array, int p_len) const {
+	inline void sort(T *p_array, int64_t p_len) const {
 		sort_range(0, p_len, p_array);
 	}
 
-	inline void nth_element(int p_first, int p_last, int p_nth, T *p_array) const {
+	inline void nth_element(int64_t p_first, int64_t p_last, int64_t p_nth, T *p_array) const {
 		if (p_first == p_last || p_nth == p_last) {
 			return;
 		}


### PR DESCRIPTION
Following upgrades to `CowData` to 64 bit indices these helpers are no longer able to handle the index ranges, possibly causing bugs on sort and search.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
