### PR TITLE
Fix animation mixer breaking animations with redundant check

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -661,13 +661,6 @@ bool AnimationMixer::_update_caches() {
 				Ref<Resource> resource;
 				Vector<StringName> leftover_path;
 
-				if (!parent->has_node_and_resource(path)) {
-					if (check_path) {
-						WARN_PRINT_ED(mixer_name + ": '" + String(E) + "', couldn't resolve track:  '" + String(path) + "'. This warning can be disabled in Project Settings.");
-					}
-					continue;
-				}
-
 				Node *child = parent->get_node_and_resource(path, resource, leftover_path);
 				if (!child) {
 					if (check_path) {


### PR DESCRIPTION
The animation mixer is breaking animations as described here: https://github.com/godotengine/godot/issues/88428

Shoutout to @monxa and @personalmountains for helping with the fix!  Simply removing the incorrect and redundant check fixes it.

Incorrect reasoning here: https://github.com/godotengine/godot/issues/88428#issuecomment-1950286835

Redundant reasoning here: https://github.com/godotengine/godot/issues/88428#issuecomment-1952559684