### PR TITLE
Fix AnimationMixer breaking animations with redundant check

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -661,13 +661,6 @@ bool AnimationMixer::_update_caches() {
 				Ref<Resource> resource;
 				Vector<StringName> leftover_path;
 
-				if (!parent->has_node_and_resource(path)) {
-					if (check_path) {
-						WARN_PRINT_ED(mixer_name + ": '" + String(E) + "', couldn't resolve track:  '" + String(path) + "'. This warning can be disabled in Project Settings.");
-					}
-					continue;
-				}
-
 				Node *child = parent->get_node_and_resource(path, resource, leftover_path);
 				if (!child) {
 					if (check_path) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3025,9 +3025,9 @@ Array Node::_get_node_and_resource(const NodePath &p_path) {
 
 Node *Node::get_node_and_resource(const NodePath &p_path, Ref<Resource> &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property) const {
 	ERR_THREAD_GUARD_V(nullptr);
-	Node *node = get_node(p_path);
 	r_res = Ref<Resource>();
 	r_leftover_subpath = Vector<StringName>();
+	Node *node = get_node_or_null(p_path);
 	if (!node) {
 		return nullptr;
 	}


### PR DESCRIPTION
Also change `Node::get_node_and_resource` to prevent it from printing an error from `Node::get_node`, and just returns nullptr. This is what the redundant check was trying to prevent.

- Fixes #88428.
- Supersedes #88554.

(I would have force pushed #88554 with the `get_node_and_resource` changes, but the fork it's made from doesn't allow force pushes on PR branches.)