### PR TITLE
Add mouse_passthrough_rects

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1657,9 +1657,9 @@
 				[b]Note:[/b] Setting the window to full screen forcibly sets the borderless flag to [code]true[/code], so make sure to set it back to [code]false[/code] when not wanted.
 			</description>
 		</method>
-		<method name="window_set_mouse_passthrough">
+		<method name="window_set_mouse_passthrough_polygons">
 			<return type="void" />
-			<param index="0" name="region" type="PackedVector2Array" />
+			<param index="0" name="regions" type="PackedVector2Array[]" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
 				Sets a polygonal region of the window which accepts mouse events. Mouse events outside the region will be passed through.
@@ -1688,6 +1688,13 @@
 				[/codeblocks]
 				[b]Note:[/b] On Windows, the portion of a window that lies outside the region is not drawn, while on Linux (X11) and macOS it is.
 				[b]Note:[/b] This method is implemented on Linux (X11), macOS and Windows.
+			</description>
+		</method>
+		<method name="window_set_mouse_passthrough_rects">
+			<return type="void" />
+			<param index="0" name="rectangles" type="Rect2i[]" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
 			</description>
 		</method>
 		<method name="window_set_popup_safe_rect">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -619,9 +619,9 @@
 			[b]Note:[/b] This property is implemented on Linux (X11), macOS and Windows.
 			[b]Note:[/b] This property only works with native windows.
 		</member>
-		<member name="mouse_passthrough_polygon" type="PackedVector2Array" setter="set_mouse_passthrough_polygon" getter="get_mouse_passthrough_polygon" default="PackedVector2Array()">
+		<member name="mouse_passthrough_polygons" type="PackedVector2Array[]" setter="set_mouse_passthrough_polygons" getter="get_mouse_passthrough_polygons" default="[]">
 			Sets a polygonal region of the window which accepts mouse events. Mouse events outside the region will be passed through.
-			Passing an empty array will disable passthrough support (all mouse events will be intercepted by the window, which is the default behavior).
+			Passing empty arrays to this and [member mouse_passthrough_rects] will disable passthrough support (all mouse events will be intercepted by the window, which is the default behavior).
 			[codeblocks]
 			[gdscript]
 			# Set region, using Path2D node.
@@ -646,7 +646,20 @@
 			[/codeblocks]
 			[b]Note:[/b] This property is ignored if [member mouse_passthrough] is set to [code]true[/code].
 			[b]Note:[/b] On Windows, the portion of a window that lies outside the region is not drawn, while on Linux (X11) and macOS it is.
-			[b]Note:[/b] This property is implemented on Linux (X11), macOS and Windows.
+			[b]Note:[/b] This property is implemented on Linux (X11), macOS and Windows. For wider support use [member mouse_passthrough_rects].
+		</member>
+		<member name="mouse_passthrough_rects" type="Rect2i[]" setter="set_mouse_passthrough_rects" getter="get_mouse_passthrough_rects" default="[]">
+			Sets an input region out of rectangles for the window which accept mouse events. Mouse events outside the input region will be passed through.
+			Passing empty arrays to this and [member mouse_passthrough_polygon] will disable passthrough support (all mouse events will be intercepted by the window, which is the default behavior).
+			[codeblocks]
+			[gdscript]
+			# Set region, using control node bounds.
+			$Window.mouse_passthrough_rects = [Rect2i($Control.get_rect())]
+			[/gdscript]
+			[/codeblocks]
+			[b]Note:[/b] This property is ignored if [member mouse_passthrough] is set to [code]true[/code].
+			[b]Note:[/b] On Windows, the portion of a window that lies outside the region is not drawn, while on Linux (X11) and macOS it is.
+			[b]Note:[/b] This property is implemented on Linux (X11, Wayland), macOS and Windows.
 		</member>
 		<member name="popup_window" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] will be considered a popup. Popups are sub-windows that don't show as separate windows in system's window manager's window list and will send close request when anything is clicked outside of them (unless [member exclusive] is enabled).

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -364,3 +364,13 @@ GH-92322
 Validate extension JSON: Error: Field 'classes/EditorInspectorPlugin/methods/add_property_editor/arguments': size changed value in new API, from 3 to 4.
 
 Optional arguments added. Compatibility methods registered.
+
+
+GH-88558
+--------
+Validate extension JSON: API was removed: classes/DisplayServer/methods/window_set_mouse_passthrough
+Validate extension JSON: API was removed: classes/Window/methods/get_mouse_passthrough_polygon
+Validate extension JSON: API was removed: classes/Window/methods/set_mouse_passthrough_polygon
+Validate extension JSON: API was removed: classes/Window/properties/mouse_passthrough_polygon
+
+Replaced by mouse_passthrough_polygons.

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -98,6 +98,8 @@ class DisplayServerWayland : public DisplayServer {
 
 		String title;
 		ObjectID instance_id;
+
+		TypedArray<Rect2i> passthrough_rectangles;
 	};
 
 	struct CustomCursor {
@@ -150,6 +152,8 @@ class DisplayServerWayland : public DisplayServer {
 	void _resize_window(const Size2i &p_size);
 
 	virtual void _show_window();
+
+	void _update_window_mouse_passthrough(WindowID p_window_id);
 
 public:
 	virtual bool has_feature(Feature p_feature) const override;
@@ -211,7 +215,8 @@ public:
 	virtual ObjectID window_get_attached_instance_id(WindowID p_window_id = MAIN_WINDOW_ID) const override;
 
 	virtual void window_set_title(const String &p_title, WindowID p_window_id = MAIN_WINDOW_ID) override;
-	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window_id = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window_id = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window_id = MAIN_WINDOW_ID) override;
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window_id = MAIN_WINDOW_ID) override;

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -184,7 +184,8 @@ class DisplayServerX11 : public DisplayServer {
 		Callable input_text_callback;
 		Callable drop_files_callback;
 
-		Vector<Vector2> mpath;
+		TypedArray<Vector<Vector2>> mregions;
+		TypedArray<Rect2i> mrects;
 
 		WindowID transient_parent = INVALID_WINDOW_ID;
 		HashSet<WindowID> transient_children;
@@ -303,6 +304,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	Atom _process_selection_request_target(Atom p_target, Window p_requestor, Atom p_property, Atom p_selection) const;
 	void _handle_selection_request_event(XSelectionRequestEvent *p_event) const;
+	void _update_window_input_region(WindowID p_window);
 	void _update_window_mouse_passthrough(WindowID p_window);
 
 	String _clipboard_get_impl(Atom p_source, Window x11_window, Atom target) const;
@@ -455,7 +457,8 @@ public:
 	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const override;
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
-	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -86,7 +86,8 @@ public:
 		id window_view;
 		id window_button_view;
 
-		Vector<Vector2> mpath;
+		TypedArray<Vector<Vector2>> mregions;
+		TypedArray<Rect2i> mrects;
 
 		Point2i mouse_pos;
 
@@ -225,6 +226,7 @@ private:
 	void _process_key_events();
 	void _update_keyboard_layouts();
 	static void _keyboard_layout_changed(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef user_info);
+	bool _mouse_intersects_input_region(const WindowData &p_wd) const;
 
 	static NSCursor *_cursor_from_selector(SEL p_selector, SEL p_fallback = nil);
 
@@ -344,7 +346,8 @@ public:
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, WindowID p_window) const override;
-	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1576,35 +1576,68 @@ Size2i DisplayServerWindows::window_get_title_size(const String &p_title, Window
 	return size;
 }
 
-void DisplayServerWindows::window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window) {
+void DisplayServerWindows::window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND(!windows.has(p_window));
-	windows[p_window].mpath = p_region;
+	windows[p_window].mregions = p_regions;
+	_update_window_mouse_passthrough(p_window);
+}
+
+void DisplayServerWindows::window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	windows[p_window].mrects = p_rects;
 	_update_window_mouse_passthrough(p_window);
 }
 
 void DisplayServerWindows::_update_window_mouse_passthrough(WindowID p_window) {
 	ERR_FAIL_COND(!windows.has(p_window));
 
-	if (windows[p_window].mpass || windows[p_window].mpath.size() == 0) {
+	const bool has_region_passthrough = windows[p_window].mregions.size() != 0 || windows[p_window].mrects.size() != 0;
+	if (windows[p_window].mpass || !has_region_passthrough) {
 		SetWindowRgn(windows[p_window].hWnd, nullptr, FALSE);
 	} else {
-		POINT *points = (POINT *)memalloc(sizeof(POINT) * windows[p_window].mpath.size());
-		for (int i = 0; i < windows[p_window].mpath.size(); i++) {
-			if (windows[p_window].borderless) {
-				points[i].x = windows[p_window].mpath[i].x;
-				points[i].y = windows[p_window].mpath[i].y;
-			} else {
-				points[i].x = windows[p_window].mpath[i].x + GetSystemMetrics(SM_CXSIZEFRAME);
-				points[i].y = windows[p_window].mpath[i].y + GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CYCAPTION);
-			}
+		_update_window_input_region(p_window);
+	}
+}
+
+void DisplayServerWindows::_update_window_input_region(WindowID p_window) {
+	const TypedArray<Vector<Vector2>> &region_paths = windows[p_window].mregions;
+	const TypedArray<Rect2i> &region_rectangles = windows[p_window].mrects;
+
+	Vector2i frame_offset(0, 0);
+	if (!windows[p_window].borderless) {
+		frame_offset = Vector2i(GetSystemMetrics(SM_CXSIZEFRAME), GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CYCAPTION));
+	}
+
+	HRGN input_region = CreateRectRgn(0, 0, 0, 0);
+	for (int region_idx = 0; region_idx < region_paths.size(); region_idx++) {
+		const Vector<Vector2> &region_path = region_paths[region_idx];
+		POINT *points = (POINT *)memalloc(sizeof(POINT) * region_path.size());
+
+		for (int i = 0; i < region_path.size(); i++) {
+			points[i].x = region_path[i].x + frame_offset.x;
+			points[i].y = region_path[i].y + frame_offset.y;
 		}
 
-		HRGN region = CreatePolygonRgn(points, windows[p_window].mpath.size(), ALTERNATE);
-		SetWindowRgn(windows[p_window].hWnd, region, FALSE);
+		HRGN path_input_region = CreatePolygonRgn(points, region_path.size(), ALTERNATE);
 		memfree(points);
+
+		CombineRgn(input_region, input_region, path_input_region, RGN_OR);
+		DeleteObject(path_input_region);
 	}
+
+	for (int i = 0; i < region_rectangles.size(); i++) {
+		const Rect2i &rect = region_rectangles[i];
+		const Vector2i true_position = rect.position + frame_offset;
+		HRGN rect_input_region = CreateRectRgn(true_position.x, true_position.y, true_position.x + rect.size.x, true_position.y + rect.size.y);
+		CombineRgn(input_region, input_region, rect_input_region, RGN_OR);
+		DeleteObject(rect_input_region);
+	}
+
+	SetWindowRgn(windows[p_window].hWnd, input_region, FALSE);
 }
 
 int DisplayServerWindows::window_get_current_screen(WindowID p_window) const {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -377,7 +377,8 @@ class DisplayServerWindows : public DisplayServer {
 	struct WindowData {
 		HWND hWnd;
 
-		Vector<Vector2> mpath;
+		TypedArray<Vector<Vector2>> mregions;
+		TypedArray<Rect2i> mrects;
 
 		bool pre_fs_valid = false;
 		RECT pre_fs_rect;
@@ -498,6 +499,7 @@ class DisplayServerWindows : public DisplayServer {
 
 	void _update_window_style(WindowID p_window, bool p_repaint = true);
 	void _update_window_mouse_passthrough(WindowID p_window);
+	void _update_window_input_region(WindowID p_window);
 
 	void _update_real_mouse_position(WindowID p_window);
 
@@ -608,7 +610,8 @@ public:
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) const override;
-	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -635,7 +635,7 @@ void Window::_make_window() {
 	ERR_FAIL_COND(window_id == DisplayServer::INVALID_WINDOW_ID);
 	DisplayServer::get_singleton()->window_set_max_size(Size2i(), window_id);
 	DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
-	DisplayServer::get_singleton()->window_set_mouse_passthrough(mpath, window_id);
+	DisplayServer::get_singleton()->window_set_mouse_passthrough_polygons(mregions, window_id);
 	DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 
@@ -1556,17 +1556,30 @@ DisplayServer::WindowID Window::get_window_id() const {
 	return window_id;
 }
 
-void Window::set_mouse_passthrough_polygon(const Vector<Vector2> &p_region) {
+void Window::set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions) {
 	ERR_MAIN_THREAD_GUARD;
-	mpath = p_region;
+	mregions = p_regions;
 	if (window_id == DisplayServer::INVALID_WINDOW_ID) {
 		return;
 	}
-	DisplayServer::get_singleton()->window_set_mouse_passthrough(mpath, window_id);
+	DisplayServer::get_singleton()->window_set_mouse_passthrough_polygons(mregions, window_id);
 }
 
-Vector<Vector2> Window::get_mouse_passthrough_polygon() const {
-	return mpath;
+TypedArray<Vector<Vector2>> Window::get_mouse_passthrough_polygons() const {
+	return mregions;
+}
+
+void Window::set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects) {
+	ERR_MAIN_THREAD_GUARD;
+	mrects = p_rects;
+	if (window_id == DisplayServer::INVALID_WINDOW_ID) {
+		return;
+	}
+	DisplayServer::get_singleton()->window_set_mouse_passthrough_rects(mrects, window_id);
+}
+
+TypedArray<Rect2i> Window::get_mouse_passthrough_rects() const {
+	return mrects;
 }
 
 void Window::set_wrap_controls(bool p_enable) {
@@ -2894,8 +2907,11 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_font_oversampling", "enable"), &Window::set_use_font_oversampling);
 	ClassDB::bind_method(D_METHOD("is_using_font_oversampling"), &Window::is_using_font_oversampling);
 
-	ClassDB::bind_method(D_METHOD("set_mouse_passthrough_polygon", "polygon"), &Window::set_mouse_passthrough_polygon);
-	ClassDB::bind_method(D_METHOD("get_mouse_passthrough_polygon"), &Window::get_mouse_passthrough_polygon);
+	ClassDB::bind_method(D_METHOD("set_mouse_passthrough_polygons", "polygons"), &Window::set_mouse_passthrough_polygons);
+	ClassDB::bind_method(D_METHOD("get_mouse_passthrough_polygons"), &Window::get_mouse_passthrough_polygons);
+
+	ClassDB::bind_method(D_METHOD("set_mouse_passthrough_rects", "rectangles"), &Window::set_mouse_passthrough_rects);
+	ClassDB::bind_method(D_METHOD("get_mouse_passthrough_rects"), &Window::get_mouse_passthrough_rects);
 
 	ClassDB::bind_method(D_METHOD("set_wrap_controls", "enable"), &Window::set_wrap_controls);
 	ClassDB::bind_method(D_METHOD("is_wrapping_controls"), &Window::is_wrapping_controls);
@@ -2981,7 +2997,8 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_screen", PROPERTY_HINT_RANGE, "0,64,1,or_greater"), "set_current_screen", "get_current_screen");
 
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "mouse_passthrough_polygon"), "set_mouse_passthrough_polygon", "get_mouse_passthrough_polygon");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "mouse_passthrough_polygons"), "set_mouse_passthrough_polygons", "get_mouse_passthrough_polygons");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "mouse_passthrough_rects", PROPERTY_HINT_ARRAY_TYPE, "Rect2i"), "set_mouse_passthrough_rects", "get_mouse_passthrough_rects");
 
 	ADD_GROUP("Flags", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -116,7 +116,8 @@ private:
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
 	mutable Size2i min_size;
 	mutable Size2i max_size;
-	mutable Vector<Vector2> mpath;
+	mutable TypedArray<Vector<Vector2>> mregions;
+	mutable TypedArray<Rect2i> mrects;
 	mutable Mode mode = MODE_WINDOWED;
 	mutable bool flags[FLAG_MAX] = {};
 	bool visible = true;
@@ -365,8 +366,11 @@ public:
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;
 
-	void set_mouse_passthrough_polygon(const Vector<Vector2> &p_region);
-	Vector<Vector2> get_mouse_passthrough_polygon() const;
+	void set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_region);
+	TypedArray<Vector<Vector2>> get_mouse_passthrough_polygons() const;
+
+	void set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects);
+	TypedArray<Rect2i> get_mouse_passthrough_rects() const;
 
 	void set_wrap_controls(bool p_enable);
 	bool is_wrapping_controls() const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -587,8 +587,12 @@ void DisplayServer::window_set_exclusive(WindowID p_window, bool p_exclusive) {
 	// Do nothing, if not supported.
 }
 
-void DisplayServer::window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window) {
-	ERR_FAIL_MSG("Mouse passthrough not supported by this display server.");
+void DisplayServer::window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window) {
+	ERR_FAIL_MSG("Mouse polygon passthrough not supported by this display server.");
+}
+
+void DisplayServer::window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window) {
+	ERR_FAIL_MSG("Mouse rectangle passthrough not supported by this display server.");
 }
 
 void DisplayServer::gl_window_make_current(DisplayServer::WindowID p_window_id) {
@@ -892,7 +896,8 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("window_set_title", "title", "window_id"), &DisplayServer::window_set_title, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_title_size", "title", "window_id"), &DisplayServer::window_get_title_size, DEFVAL(MAIN_WINDOW_ID));
-	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough", "region", "window_id"), &DisplayServer::window_set_mouse_passthrough, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough_polygons", "regions", "window_id"), &DisplayServer::window_set_mouse_passthrough_polygons, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough_rects", "rectangles", "window_id"), &DisplayServer::window_set_mouse_passthrough_rects, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_current_screen", "window_id"), &DisplayServer::window_get_current_screen, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_current_screen", "screen", "window_id"), &DisplayServer::window_set_current_screen, DEFVAL(MAIN_WINDOW_ID));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -430,7 +430,8 @@ public:
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual Size2i window_get_title_size(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) const { return Size2i(); }
 
-	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window = MAIN_WINDOW_ID);
 
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) = 0;

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -92,7 +92,8 @@ public:
 
 	void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override {}
 
-	void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override {}
+	void window_set_mouse_passthrough_polygons(const TypedArray<Vector<Vector2>> &p_regions, WindowID p_window = MAIN_WINDOW_ID) override {}
+	void window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rects, WindowID p_window = MAIN_WINDOW_ID) override  {}
 
 	int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override { return -1; }
 	void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override {}


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/8568

Implements the following:
- `DisplayServer`: Adds `window_set_mouse_passthrough_rects(const TypedArray<Rect2i> &p_rectangles, WindowID p_window)`
- `Window`: Adds property `mouse_passthrough_rects` which define input regions

For display servers supporting `mouse_passthrough_polygon` (X11, Windows, macOS) a combined input region is created out of both properties. As before everything outside of the region will be passed through.
For Wayland only `mouse_passthrough_rects` is implemented.

I tested on X11, Wayland and Windows. I can't test macOS myself. A simple test project showcasing both passthrough types used together is here [input_region_test.zip](https://github.com/user-attachments/files/15527173/input_region_test.zip): (the root node has export variables to cover all test cases, default is just polygon and rect passthrough on, if you see black areas on windows try removing the top part of the script (changing mode) and set the project to fullscreen)


I'm making this a draft for now since I want to check how much we can change the existing API. Also unsure if the display server specific implementations are fine since I never wrote something like that before.