### PR TITLE
Improve thread safety of resource loading

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -41,7 +41,12 @@
 #include <stdio.h>
 
 void Resource::emit_changed() {
-	emit_signal(CoreStringNames::get_singleton()->changed);
+	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
+		// Let the connection happen on the main thread, later, since signals are not thread-safe.
+		call_deferred("emit_signal", CoreStringNames::get_singleton()->changed);
+	} else {
+		emit_signal(CoreStringNames::get_singleton()->changed);
+	}
 }
 
 void Resource::_resource_path_changed() {
@@ -152,12 +157,22 @@ bool Resource::editor_can_reload_from_file() {
 }
 
 void Resource::connect_changed(const Callable &p_callable, uint32_t p_flags) {
+	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
+		// Let the check and connection happen on the main thread, later, since signals are not thread-safe.
+		callable_mp(this, &Resource::connect_changed).call_deferred(p_callable, p_flags);
+		return;
+	}
 	if (!is_connected(CoreStringNames::get_singleton()->changed, p_callable) || p_flags & CONNECT_REFERENCE_COUNTED) {
 		connect(CoreStringNames::get_singleton()->changed, p_callable, p_flags);
 	}
 }
 
 void Resource::disconnect_changed(const Callable &p_callable) {
+	if (ResourceLoader::is_within_load() && !Thread::is_main_thread()) {
+		// Let the check and disconnection happen on the main thread, later, since signals are not thread-safe.
+		callable_mp(this, &Resource::disconnect_changed).call_deferred(p_callable);
+		return;
+	}
 	if (is_connected(CoreStringNames::get_singleton()->changed, p_callable)) {
 		disconnect(CoreStringNames::get_singleton()->changed, p_callable);
 	}


### PR DESCRIPTION
During resource loading, including threaded loading, certain resources want to emit a `changed` signal. Since most of the `Object` API, including signals, is not thread-safe, there's the risk of this causing issues. I've actually seen it happening, but I can't be sure if not getting them anymore is due to this fix.

This PR will defer any emissions of that kind involved in loading that happen on a non-main thread. **UPDATE:** Bear in mind that during threaded loading, deferred calls are even more deferred, queued in a thread-specific call queue, until the resource is done loading, then flushed on the main thread.

**UPDATE 2:** An alternative would be letting `Object` itself defer signal-related calls during loads. However, I'm a bit afraid of adding a check there is too heavy for what so far seem to be few cases (more to discover, likely). Additionally, maybe at some point `Object` has to be made entirely thread-safe due to popular demand or something, and patches like this are not needed anymore.