### PR TITLE
Add new `type_info` properties to detect & identify Variant types

### DIFF
--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -31,9 +31,8 @@
 #ifndef TYPE_INFO_H
 #define TYPE_INFO_H
 
+#include "core/templates/simple_type.h"
 #include "core/typedefs.h"
-
-#include <type_traits>
 
 namespace GodotTypeInfo {
 enum Metadata {
@@ -335,5 +334,86 @@ ZERO_INITIALIZER_NUMBER(char16_t)
 ZERO_INITIALIZER_NUMBER(char32_t)
 ZERO_INITIALIZER_NUMBER(float)
 ZERO_INITIALIZER_NUMBER(double)
+
+template <typename T>
+inline constexpr Variant::Type get_variant_type_v = std::is_base_of_v<Object, GetSimpleTypeT<T>> ? Variant::OBJECT : Variant::VARIANT_MAX;
+
+template <typename T>
+inline constexpr bool is_variant_type_v = get_variant_type_v<T> != Variant::VARIANT_MAX;
+
+template <typename T>
+struct GetObjectClassName {
+	constexpr GetObjectClassName() { static_assert(is_variant_type_v<T>); }
+
+	static const String self() {
+		if constexpr (get_variant_type_v<T> == Variant::OBJECT) {
+			return T::get_class_static();
+		} else {
+			return String();
+		}
+	}
+	static const String parent() {
+		if constexpr (get_variant_type_v<T> == Variant::OBJECT) {
+			return T::get_parent_class_static();
+		} else {
+			return String();
+		}
+	}
+};
+
+#define MAKE_VARIANT_TYPE_CONSTANTS(m_type, m_variant_type) \
+	template <>                                             \
+	inline constexpr Variant::Type get_variant_type_v<m_type> = m_variant_type;
+
+MAKE_VARIANT_TYPE_CONSTANTS(Variant, Variant::NIL)
+MAKE_VARIANT_TYPE_CONSTANTS(bool, Variant::BOOL)
+MAKE_VARIANT_TYPE_CONSTANTS(uint8_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(int8_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(uint16_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(int16_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(uint32_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(int32_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(uint64_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(int64_t, Variant::INT)
+MAKE_VARIANT_TYPE_CONSTANTS(float, Variant::FLOAT)
+MAKE_VARIANT_TYPE_CONSTANTS(double, Variant::FLOAT)
+MAKE_VARIANT_TYPE_CONSTANTS(String, Variant::STRING)
+MAKE_VARIANT_TYPE_CONSTANTS(Vector2, Variant::VECTOR2)
+MAKE_VARIANT_TYPE_CONSTANTS(Vector2i, Variant::VECTOR2I)
+MAKE_VARIANT_TYPE_CONSTANTS(Rect2, Variant::RECT2)
+MAKE_VARIANT_TYPE_CONSTANTS(Rect2i, Variant::RECT2I)
+MAKE_VARIANT_TYPE_CONSTANTS(Vector3, Variant::VECTOR3)
+MAKE_VARIANT_TYPE_CONSTANTS(Vector3i, Variant::VECTOR3I)
+MAKE_VARIANT_TYPE_CONSTANTS(Transform2D, Variant::TRANSFORM2D)
+MAKE_VARIANT_TYPE_CONSTANTS(Vector4, Variant::VECTOR4)
+MAKE_VARIANT_TYPE_CONSTANTS(Vector4i, Variant::VECTOR4I)
+MAKE_VARIANT_TYPE_CONSTANTS(Plane, Variant::PLANE)
+MAKE_VARIANT_TYPE_CONSTANTS(Quaternion, Variant::QUATERNION)
+MAKE_VARIANT_TYPE_CONSTANTS(AABB, Variant::AABB)
+MAKE_VARIANT_TYPE_CONSTANTS(Basis, Variant::BASIS)
+MAKE_VARIANT_TYPE_CONSTANTS(Transform3D, Variant::TRANSFORM3D)
+MAKE_VARIANT_TYPE_CONSTANTS(Projection, Variant::PROJECTION)
+MAKE_VARIANT_TYPE_CONSTANTS(Color, Variant::COLOR)
+MAKE_VARIANT_TYPE_CONSTANTS(StringName, Variant::STRING_NAME)
+MAKE_VARIANT_TYPE_CONSTANTS(NodePath, Variant::NODE_PATH)
+MAKE_VARIANT_TYPE_CONSTANTS(RID, Variant::RID)
+MAKE_VARIANT_TYPE_CONSTANTS(Object, Variant::OBJECT)
+MAKE_VARIANT_TYPE_CONSTANTS(Callable, Variant::CALLABLE)
+MAKE_VARIANT_TYPE_CONSTANTS(Signal, Variant::SIGNAL)
+MAKE_VARIANT_TYPE_CONSTANTS(Dictionary, Variant::DICTIONARY)
+MAKE_VARIANT_TYPE_CONSTANTS(Array, Variant::ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedStringArray, Variant::PACKED_STRING_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
+MAKE_VARIANT_TYPE_CONSTANTS(IPAddress, Variant::STRING)
+
+#undef MAKE_VARIANT_TYPE_CONSTANTS
 
 #endif // TYPE_INFO_H

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -45,19 +45,20 @@ public:
 		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
 		_ref(p_array);
 	}
+	_FORCE_INLINE_ TypedArray() {
+		static_assert(is_variant_type_v<T>, "Only Variant types are allowed for typed arrays.");
+		set_typed(get_variant_type_v<T>, GetObjectClassName<T>::self(), Variant());
+	}
 	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
 			TypedArray(Array(p_variant)) {
 	}
-	_FORCE_INLINE_ TypedArray(const Array &p_array) {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+	_FORCE_INLINE_ TypedArray(const Array &p_array) :
+			TypedArray() {
 		if (is_same_typed(p_array)) {
 			_ref(p_array);
 		} else {
 			assign(p_array);
 		}
-	}
-	_FORCE_INLINE_ TypedArray() {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
 	}
 };
 
@@ -71,81 +72,6 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
 	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
 };
-
-//specialization for the rest of variant types
-
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
-	template <>                                                                                                  \
-	class TypedArray<m_type> : public Array {                                                                    \
-	public:                                                                                                      \
-		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
-			_ref(p_array);                                                                                       \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
-				TypedArray(Array(p_variant)) {                                                                   \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Array &p_array) {                                                        \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-			if (is_same_typed(p_array)) {                                                                        \
-				_ref(p_array);                                                                                   \
-			} else {                                                                                             \
-				assign(p_array);                                                                                 \
-			}                                                                                                    \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-		}                                                                                                        \
-	};
-
-// All Variant::OBJECT types are intentionally omitted from this list because they are handled by
-// the unspecialized TypedArray definition.
-MAKE_TYPED_ARRAY(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY(String, Variant::STRING)
-MAKE_TYPED_ARRAY(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY(RID, Variant::RID)
-MAKE_TYPED_ARRAY(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
-MAKE_TYPED_ARRAY(IPAddress, Variant::STRING)
 
 template <typename T>
 struct PtrToArg<TypedArray<T>> {
@@ -171,7 +97,8 @@ struct GetTypeInfo<TypedArray<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE,
+				get_variant_type_v<T> == Variant::OBJECT ? GetObjectClassName<T>::self() : Variant::get_type_name(get_variant_type_v<T>));
 	}
 };
 
@@ -180,76 +107,9 @@ struct GetTypeInfo<const TypedArray<T> &> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE,
+				get_variant_type_v<T> == Variant::OBJECT ? GetObjectClassName<T>::self() : Variant::get_type_name(get_variant_type_v<T>));
 	}
 };
-
-#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type)                                                                        \
-	template <>                                                                                                              \
-	struct GetTypeInfo<TypedArray<m_type>> {                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};                                                                                                                       \
-	template <>                                                                                                              \
-	struct GetTypeInfo<const TypedArray<m_type> &> {                                                                         \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};
-
-MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY_INFO(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(String, Variant::STRING)
-MAKE_TYPED_ARRAY_INFO(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY_INFO(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY_INFO(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY_INFO(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY_INFO(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY_INFO(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY_INFO(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY_INFO(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY_INFO(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY_INFO(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY_INFO(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY_INFO(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY_INFO(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY_INFO(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY_INFO(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY_INFO(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY_INFO(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY_INFO(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY_INFO(RID, Variant::RID)
-MAKE_TYPED_ARRAY_INFO(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY_INFO(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY_INFO(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY_INFO(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
-MAKE_TYPED_ARRAY_INFO(IPAddress, Variant::STRING)
-
-#undef MAKE_TYPED_ARRAY
-#undef MAKE_TYPED_ARRAY_INFO
 
 #endif // TYPED_ARRAY_H


### PR DESCRIPTION
Migrates most of the Variant construction logic from `typed_array.h` into `type_info.h` with the aim of consolidating logic that's otherwise redundant in practice. Reduced the overall code required for setting up templates in typed arrays, as only a single declaration was needed. Additionally, implemented a static assert to the typed array template, ensuring that an inappropriate type being used is caught as early as possible.