### PR TITLE
Fix item positioning, text alignment & unwanted clipping of ItemList items

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -483,7 +483,7 @@
 			The size of the item text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 		</theme_item>
-		<theme_item name="v_separation" data_type="constant" type="int" default="2">
+		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical spacing between items.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1036,7 +1036,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 			p_theme->set_color("font_selected_color", "ItemList", p_config.mono_color);
 			p_theme->set_color("font_outline_color", "ItemList", p_config.font_outline_color);
 			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
-			p_theme->set_constant("v_separation", "ItemList", p_config.forced_even_separation * 0.5 * EDSCALE);
+			p_theme->set_constant("v_separation", "ItemList", p_config.forced_even_separation * EDSCALE);
 			p_theme->set_constant("h_separation", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
 			p_theme->set_constant("icon_margin", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
 			p_theme->set_constant("line_separation", "ItemList", p_config.separation_margin);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -832,7 +832,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("panel", "ItemList", make_flat_stylebox(style_normal_color));
 	theme->set_stylebox("focus", "ItemList", focus);
 	theme->set_constant("h_separation", "ItemList", Math::round(4 * scale));
-	theme->set_constant("v_separation", "ItemList", Math::round(2 * scale));
+	theme->set_constant("v_separation", "ItemList", Math::round(4 * scale));
 	theme->set_constant("icon_margin", "ItemList", Math::round(4 * scale));
 	theme->set_constant("line_separation", "ItemList", Math::round(2 * scale));
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Implements part of the fixes mentioned in #88217 

The following points are fixed:

- Clipping of selection indicator at the top or bottom of the list
- Gap at the bottom of the list in rows mode when the end of the scrollbar is reached
- In grid display, labels were not properly centered, a little offset to the side was happening
- Separators overlapping some items by a pixel or two beyond the border
- Inconsistent scale of vertical separation, which is double in comparison to horizontal separation (if you put 10px vertically, it displays like 20px, while if you put 10px horizontally, it remains 10px). Default & editor themes adjusted to compensate.

For the sake of consistency, the horizontal separation which did nothing on list rows (non-grid) mode is now acting like an internal padding, the same way it does for grid items.

This is a rewrite of the positioning algorithm so that internal calculation of item positions now corresponds to the actual screen rendering.

In the base situation before this fix, items positions are calculated with a gap in mind then grown on the four sides to cover that gap. This is responsible of the clipped selection indicators.

With this fix applied, the position calculation takes into account an appropriate padding to give the same effect as in the initial situation, and positions them correctly to align with the container borders without unwanted clippings and paddings.

No more clipping at the top and left

![Capture d’écran du 2024-02-20 03-49-31](https://github.com/godotengine/godot/assets/26961646/5b14fe0c-0670-4ae8-a47f-7e92bf51e001) 
![Capture d’écran du 2024-02-20 03-49-12](https://github.com/godotengine/godot/assets/26961646/cb9beb2c-9340-45e9-be1b-acba2ebb26f3)

No more extra gap at the bottom

![Capture d’écran du 2024-02-20 03-49-51](https://github.com/godotengine/godot/assets/26961646/efb57d38-bb5a-4a84-a4d1-5bfd03f4f217)

Text is correctly centered within grid items

![Capture d’écran du 2024-02-20 03-48-53](https://github.com/godotengine/godot/assets/26961646/87a9330a-716e-4353-b4bb-3a3c22bb6937)
![Capture d’écran du 2024-02-20 03-42-02](https://github.com/godotengine/godot/assets/26961646/a3fe8834-bed2-4e49-b96c-eb77e9dda688)

Row items can have horizontal padding, leveraging the h_separation parameter that was not taken into account in this mode

![Capture d’écran du 2024-02-20 04-12-07](https://github.com/godotengine/godot/assets/26961646/6eff18eb-99ec-493d-a8c8-e400b2999084)



