### PR TITLE
Fail early if shader mode is invalid in dummy renderer

### DIFF
--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -81,6 +81,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 		new_mode = RS::SHADER_FOG;
 	} else {
 		new_mode = RS::SHADER_MAX;
+		ERR_FAIL_MSG("Shader type " + mode_string + " not supported in Dummy renderer.");
 	}
 	ShaderCompiler::IdentifierActions actions;
 	actions.uniforms = &shader->uniforms;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87812 cc @clayjohn 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
