### PR TITLE
Add `android` to auto-generated `.gitignore`

### DIFF
--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -367,6 +367,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		} else {
 			f->store_line("# Godot 4+ specific ignores");
 			f->store_line(".godot/");
+			f->store_line("android/");
 		}
 		f = FileAccess::open(p_dir.path_join(".gitattributes"), FileAccess::WRITE);
 		if (f.is_null()) {


### PR DESCRIPTION
Added `android/` to the `.gitignore` file automatically generated by the VCS plugin.