### PR TITLE
Add `WASM_BIGINT` linker flag to the web build

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -253,6 +253,9 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-fvisibility=hidden"])
         env.extra_suffix = ".dlink" + env.extra_suffix
 
+    # WASM_BIGINT is needed since emscripten ≥ 3.1.41
+    needs_wasm_bigint = cc_semver >= (3, 1, 41)
+
     # Run the main application in a web worker
     if env["proxy_to_pthread"]:
         env.Append(LINKFLAGS=["-s", "PROXY_TO_PTHREAD=1"])
@@ -261,6 +264,9 @@ def configure(env: "SConsEnvironment"):
         # https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-1277561925
         env.Append(LINKFLAGS=["-s", "TEXTDECODER=0"])
         # BigInt support to pass object pointers between contexts
+        needs_wasm_bigint = True
+
+    if needs_wasm_bigint:
         env.Append(LINKFLAGS=["-s", "WASM_BIGINT"])
 
     # Reduce code size by generating less support code (e.g. skip NodeJS support).


### PR DESCRIPTION
Adds the `WASM_BIGINT` linker flag to the web build in order to fix issues with `i64` values. This fix is needed to call Javascript from Godot since emscripten version 3.1.41.

Fixes #88249
