### PR TITLE
Remove error when property is outside inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -429,7 +429,7 @@ EditorInspector *EditorProperty::get_parent_inspector() const {
 		}
 		parent = parent->get_parent();
 	}
-	ERR_FAIL_V_MSG(nullptr, "EditorProperty is outside inspector.");
+	return nullptr;
 }
 
 void EditorProperty::set_doc_path(const String &p_doc_path) {


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/issues/88425#issuecomment-1949965770
I was going to make the error optional, but then realized it serves no purpose. All uses of this method come with null checks anyway.