### PR TITLE
Fix `RichTextLabel`'s tag stack being overridden on translation change

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5650,10 +5650,15 @@ void RichTextLabel::set_text(const String &p_bbcode) {
 }
 
 void RichTextLabel::_apply_translation() {
+	// If `text` is empty, it could mean that the tag stack is being used instead. Leave it be.
+	if (text.is_empty()) {
+		return;
+	}
+
 	String xl_text = atr(text);
 	if (use_bbcode) {
 		parse_bbcode(xl_text);
-	} else { // raw text
+	} else { // Raw text.
 		clear();
 		add_text(xl_text);
 	}


### PR DESCRIPTION
Turns out my "regression" was just me stumbling into a bug. When `RichTextLabel` reacted to a translation change, it would try to translate its `text` variable, but if the content was added with the `add/push_*()` methods, said variable would be empty, and the tag stack would be overridden with an empty string.

Fixes #88532.