### PR TITLE
GDScript: Fix static initialization order for inner classes

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -667,6 +667,12 @@ String GDScript::_get_debug_path() const {
 }
 
 Error GDScript::_static_init() {
+	for (KeyValue<StringName, Ref<GDScript>> &inner : subclasses) {
+		const Error err = inner.value->_static_init();
+		if (err) {
+			return err;
+		}
+	}
 	if (likely(valid) && static_initializer) {
 		Callable::CallError call_err;
 		static_initializer->call(nullptr, nullptr, 0, call_err);
@@ -674,14 +680,7 @@ Error GDScript::_static_init() {
 			return ERR_CANT_CREATE;
 		}
 	}
-	Error err = OK;
-	for (KeyValue<StringName, Ref<GDScript>> &inner : subclasses) {
-		err = inner.value->_static_init();
-		if (err) {
-			break;
-		}
-	}
-	return err;
+	return OK;
 }
 
 void GDScript::_static_default_init() {

--- a/modules/gdscript/tests/scripts/analyzer/errors/access_outer_static_var_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/access_outer_static_var_func.gd
@@ -1,0 +1,15 @@
+# This works for outer constants, enums, and classes. We _could_ implement this for static variables and functions,
+# but it **SHOULD NOT** be done since inner classes are initialized first. See GH-82141.
+
+static var outer_static_var: int
+
+class InnerClass:
+	static func _static_init() -> void:
+		print(outer_static_var)
+		outer_static_func()
+
+static func outer_static_func():
+	print("This should not be called.")
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/access_outer_static_var_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/access_outer_static_var_func.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 8: Identifier "outer_static_var" not declared in the current scope.
+>> ERROR at line 9: Function "outer_static_func()" not found in base self.

--- a/modules/gdscript/tests/scripts/runtime/features/static_init_order.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/static_init_order.gd
@@ -1,0 +1,46 @@
+# GH-82141
+
+class InnerClass:
+	static var inner_var: int = _get_value()
+	static var inner_inner_instance := InnerInnerClass.new()
+
+	static func _static_init() -> void:
+		prints("InnerClass._static_init()", inner_var)
+
+	static func _get_value() -> int:
+		prints("InnerClass._get_value()", inner_var)
+		return 1
+
+	func _init() -> void:
+		prints("InnerClass._init()", inner_var)
+
+	# Out of order: Make sure that the most nested inner class is initialized first,
+	# not the first one in the source code.
+	class InnerInnerClass:
+		static var inner_inner_var: int = _get_value()
+
+		static func _static_init() -> void:
+			prints("InnerInnerClass._static_init()", inner_inner_var)
+
+		static func _get_value() -> int:
+			prints("InnerInnerClass._get_value()", inner_inner_var)
+			return 1
+
+		func _init() -> void:
+			prints("InnerInnerClass._init()", inner_inner_var)
+
+static var outer_var: int = _get_value()
+static var inner_instance := InnerClass.new()
+
+static func _static_init() -> void:
+	prints("_static_init()", outer_var)
+
+static func _get_value() -> int:
+	prints("_get_value()", outer_var)
+	return 1
+
+func _init() -> void:
+	prints("_init()", outer_var)
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/runtime/features/static_init_order.out
+++ b/modules/gdscript/tests/scripts/runtime/features/static_init_order.out
@@ -1,0 +1,10 @@
+GDTEST_OK
+InnerInnerClass._get_value() 0
+InnerInnerClass._static_init() 1
+InnerClass._get_value() 0
+InnerInnerClass._init() 1
+InnerClass._static_init() 1
+_get_value() 0
+InnerClass._init() 1
+_static_init() 1
+_init() 1

--- a/modules/gdscript/tests/scripts/runtime/features/static_variables.out
+++ b/modules/gdscript/tests/scripts/runtime/features/static_variables.out
@@ -1,6 +1,6 @@
 GDTEST_OK
-Inner._static_init inner
 InnerInner._static_init inner inner
+Inner._static_init inner
 data: data
 perm: 0
 prop: Hello! suffix


### PR DESCRIPTION
* Fixes #82141.

Formally, this breaks compatibility, but I think this is not as critical as the linked bug. Inner classes allow access to constant members of outer classes (constants, enums, classes), but fortunately access to static variables of outer classes is not implemented. I've been thinking about this for a while, and I think that changing the static initialization order is the only good way to solve the problem.

Before:

```
_get_value() 0
InnerClass._init() <null>
_static_init() 1
InnerClass._get_value() 0
InnerInnerClass._init() <null>
InnerClass._static_init() 1
InnerInnerClass._get_value() 0
InnerInnerClass._static_init() 1
_init() 1
```

After:

```
InnerInnerClass._get_value() 0
InnerInnerClass._static_init() 1
InnerClass._get_value() 0
InnerInnerClass._init() 1
InnerClass._static_init() 1
_get_value() 0
InnerClass._init() 1
_static_init() 1
_init() 1
```