### PR TITLE
Refactor type_info.h

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -80,6 +80,7 @@ class Ref {
 
 	//virtual RefCounted * get_reference() const { return reference; }
 public:
+	typedef T Type;
 	_FORCE_INLINE_ bool operator==(const T *p_ptr) const {
 		return reference == p_ptr;
 	}
@@ -272,22 +273,12 @@ struct PtrToArg<const Ref<T> &> {
 };
 
 template <class T>
-struct GetTypeInfo<Ref<T>> {
+struct GetTypeInfo<T, EnableIf_t<types_are_same_v<Ref<typename RemoveRefPointerConst_t<T>::Type>, RemoveRefPointerConst_t<T>>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
-	}
-};
-
-template <class T>
-struct GetTypeInfo<const Ref<T> &> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
+		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, RemoveRefPointerConst_t<T>::Type::get_class_static());
 	}
 };
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -303,6 +303,56 @@ struct BuildIndexSequence : BuildIndexSequence<N - 1, N - 1, Is...> {};
 template <size_t... Is>
 struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 
+template <bool C, typename T = void>
+struct EnableIf {
+	typedef T type;
+};
+
+template <typename T>
+struct EnableIf<false, T> {
+};
+
+template <bool C, typename T = void>
+using EnableIf_t = typename EnableIf<C, T>::type;
+
+template <typename, typename>
+inline constexpr bool types_are_same_v = false;
+
+template <typename T>
+inline constexpr bool types_are_same_v<T, T> = true;
+
+template <typename B, typename D>
+struct TypeInherits {
+	static D *get_d();
+
+	static char (&test(B *))[1];
+	static char (&test(...))[2];
+
+	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
+			!types_are_same_v<B volatile const, void volatile const>;
+};
+
+template <typename B, typename D>
+constexpr bool TypeInherits_v = TypeInherits<B, D>::value;
+
+// Recursively remove pointer-to-const, reference, and pointer from type.
+template <typename T>
+struct RemoveRefPointerConst { using Type = T; };
+template <typename T>
+struct RemoveRefPointerConst<T *> { using Type = typename RemoveRefPointerConst<T>::Type; };
+template <typename T>
+struct RemoveRefPointerConst<T &> { using Type = typename RemoveRefPointerConst<T>::Type; };
+template <typename T>
+struct RemoveRefPointerConst<T *&> { using Type = typename RemoveRefPointerConst<T>::Type; };
+template <typename T>
+struct RemoveRefPointerConst<const T *> { using Type = typename RemoveRefPointerConst<T>::Type; };
+template <typename T>
+struct RemoveRefPointerConst<const T &> { using Type = typename RemoveRefPointerConst<T>::Type; };
+template <typename T>
+struct RemoveRefPointerConst<const T *&> { using Type = typename RemoveRefPointerConst<T>::Type; };
+
+template <typename T>
+using RemoveRefPointerConst_t = typename RemoveRefPointerConst<T>::Type;
 // Limit the depth of recursive algorithms when dealing with Array/Dictionary
 #define MAX_RECURSION 100
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -833,7 +833,7 @@ void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)(b
 	}
 
 #ifdef TOOLS_ENABLED
-	if constexpr (std::is_same_v<T, ClassNode>) {
+	if constexpr (types_are_same_v<T, ClassNode>) {
 		if (has_comment(member->start_line, true)) {
 			// Inline doc comment.
 			member->doc_data = parse_class_doc_comment(member->start_line, true);


### PR DESCRIPTION
First refactor PR, from https://github.com/godotengine/godot/pull/88404
Below is a summary of what was changed, please see comments in https://github.com/godotengine/godot/pull/88404 for additional justification (some is duplicated below).

* Refactor type_info.h by collapsing multiple, duplicate, specializations into single specializations with enable-if.
For example, this
   ``` C++
   template<typename T> struct MyStruct;
   template<> struct MyStruct<MyType> { /* some specialization */ };
   template<> struct MyStruct<const MyType&> { /* identical specialization as just "MyType"*/ };
   ```
   Becomes
   ``` C++
   template<typename T, typename = void> struct MyStruct;
   template<typename T> struct MyStruct<T, EnableIf_t<types_are_same_v<MyType, RemoveRefPointerConst_t<T>>> {
     /* some specialization */
   };
   ```
* Add `RemoveRefPointerConst_t`, which removes const, ref, and pointer(s) from a type, leaving you with the base type.
    I tried `std::decay` too, but it returned `false` for every case.
    Test:
    ``` C++
    print_line("std",
               std::is_same_v<int, std::remove_cv_t<std::remove_reference_t<int>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int&>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int*>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int*&>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int**>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<int**&>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int&>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int*>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int*&>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int**>>>>,
               std::is_same_v<int, std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<const int**&>>>>);

    print_line("custom",
               std::is_same_v<int, RemoveRefPointerConst_t<int>>,
               std::is_same_v<int, RemoveRefPointerConst_t<int&>>,
               std::is_same_v<int, RemoveRefPointerConst_t<int*>>,
               std::is_same_v<int, RemoveRefPointerConst_t<int*&>>,
               std::is_same_v<int, RemoveRefPointerConst_t<int**>>,
               std::is_same_v<int, RemoveRefPointerConst_t<int**&>>,
               std::is_same_v<int, RemoveRefPointerConst_t<const int&>>,
               std::is_same_v<int, RemoveRefPointerConst_t<const int*>>,
               std::is_same_v<int, RemoveRefPointerConst_t<const int*&>>,
               std::is_same_v<int, RemoveRefPointerConst_t<const int**>>,
               std::is_same_v<int, RemoveRefPointerConst_t<const int**&>>);
    ```
    Output:
    ```
    std true true true true false false true true true false false
    custom true true true true true true true true true true true
    ```
* Move existing templates to typedefs.h since a later PR depends on this. Figure it doesn't hurt to move them since it increases visibility.
* One kind of unrelated change to ref_counted.h to collapse one `GetTypeInfo` since (almost) all other `GetTypeInfos` were collapsed.  The remaining `GetTypeInfo` is in typed_array.h, but it cannot be collapsed in this PR.
* One unrelated (though trivial) change to `modules/gdscript/gdscript_parser.cpp` since I couldn't find a different PR to make the change in.