### PR TITLE
Display a warning if device CPU architecture is not active in the export preset.

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -79,6 +79,11 @@ void EditorRunNative::_notification(int p_what) {
 	}
 }
 
+void EditorRunNative::_confirm_run_native() {
+	run_confirmed = true;
+	resume_run_native();
+}
+
 Error EditorRunNative::start_run_native(int p_id) {
 	if (p_id < 0) {
 		return OK;
@@ -86,9 +91,9 @@ Error EditorRunNative::start_run_native(int p_id) {
 
 	int platform = p_id / 10000;
 	int idx = p_id % 10000;
+	resume_id = p_id;
 
 	if (!EditorNode::get_singleton()->ensure_main_scene(true)) {
-		resume_id = p_id;
 		return OK;
 	}
 
@@ -109,6 +114,22 @@ Error EditorRunNative::start_run_native(int p_id) {
 		EditorNode::get_singleton()->show_warning(TTR("No runnable export preset found for this platform.\nPlease add a runnable preset in the Export menu or define an existing preset as runnable."));
 		return ERR_UNAVAILABLE;
 	}
+
+	String architecture = eep->get_device_architecture(idx);
+	if (!run_confirmed && !architecture.is_empty()) {
+		String preset_arch = "architectures/" + architecture;
+		bool is_arch_enabled = preset->get(preset_arch);
+
+		if (!is_arch_enabled) {
+			String warning_message = vformat(TTR("Warning: The CPU architecture '%s' is not active in your export preset.\n\n"), Variant(architecture));
+			warning_message += TTR("Run 'Remote Debug' anyway?");
+
+			run_native_confirm->set_text(warning_message);
+			run_native_confirm->popup_centered();
+			return OK;
+		}
+	}
+	run_confirmed = false;
 
 	emit_signal(SNAME("native_run"), preset);
 
@@ -173,6 +194,10 @@ EditorRunNative::EditorRunNative() {
 
 	add_child(result_dialog);
 	result_dialog->hide();
+
+	run_native_confirm = memnew(ConfirmationDialog);
+	add_child(run_native_confirm);
+	run_native_confirm->connect("confirmed", callable_mp(this, &EditorRunNative::_confirm_run_native));
 
 	set_process(true);
 }

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -41,11 +41,15 @@ class EditorRunNative : public HBoxContainer {
 
 	RichTextLabel *result_dialog_log = nullptr;
 	AcceptDialog *result_dialog = nullptr;
+	ConfirmationDialog *run_native_confirm = nullptr;
+	bool run_confirmed = false;
 
 	MenuButton *remote_debug = nullptr;
 	bool first = true;
 
 	int resume_id = -1;
+
+	void _confirm_run_native();
 
 protected:
 	static void _bind_methods();

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -227,6 +227,7 @@ public:
 	virtual Ref<ImageTexture> get_option_icon(int p_index) const;
 	virtual String get_option_label(int p_device) const { return ""; }
 	virtual String get_option_tooltip(int p_device) const { return ""; }
+	virtual String get_device_architecture(int p_device) const { return ""; }
 
 	enum DebugFlags {
 		DEBUG_FLAG_DUMB_CLIENT = 1,

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -379,7 +379,8 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 							} else if (p.begins_with("ro.build.version.sdk=")) {
 								d.api_level = p.get_slice("=", 1).to_int();
 							} else if (p.begins_with("ro.product.cpu.abi=")) {
-								d.description += "CPU: " + p.get_slice("=", 1).strip_edges() + "\n";
+								d.architecture = p.get_slice("=", 1).strip_edges();
+								d.description += "CPU: " + d.architecture + "\n";
 							} else if (p.begins_with("ro.product.manufacturer=")) {
 								d.description += "Manufacturer: " + p.get_slice("=", 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.board.platform=")) {
@@ -1990,6 +1991,12 @@ String EditorExportPlatformAndroid::get_option_tooltip(int p_index) const {
 		s = devices[p_index].name + "\n\n" + s;
 	}
 	return s;
+}
+
+String EditorExportPlatformAndroid::get_device_architecture(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, devices.size(), "");
+	MutexLock lock(device_lock);
+	return devices[p_index].architecture;
 }
 
 Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -76,6 +76,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		String name;
 		String description;
 		int api_level = 0;
+		String architecture;
 	};
 
 	struct APKExportData {
@@ -220,6 +221,8 @@ public:
 	virtual String get_option_label(int p_index) const override;
 
 	virtual String get_option_tooltip(int p_index) const override;
+
+	virtual String get_device_architecture(int p_index) const override;
 
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) override;
 


### PR DESCRIPTION
Fixes #86284

Editor crash / freeze _(with arm32 devices)_ are prevented by selecting the correct device CPU architecture. It should also be more user-friendly. https://github.com/godotengine/godot/issues/86284#issuecomment-1941920808