### PR TITLE
Change glow calculation back to `max(r,g,b)`

### DIFF
--- a/drivers/gles3/shaders/effects/glow.glsl
+++ b/drivers/gles3/shaders/effects/glow.glsl
@@ -78,8 +78,8 @@ void main() {
 #endif // USE_MULTIVIEW
 	color /= luminance_multiplier * 8.0;
 
-	float luminance = dot(color, vec3(0.2126, 0.7152, 0.0722));
-	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, luminance), glow_bloom);
+	float feedback_factor = max(color.r, max(color.g, color.b));
+	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, feedback_factor), glow_bloom);
 
 	color = min(color * feedback, vec3(glow_luminance_cap));
 


### PR DESCRIPTION
Follow up on #87360 based on a remark by @clayjohn :

> 1. Improve the luminance calculation. Using the current method means that blue objects don't glow

In this PR I change the calculation back to max(r, g, b) which gives a more pronounced glow on all colors. I've also renamed the variable because it isn't really a luminance calculation, it's really the max strength that is important here for the glow, as we end up using the color as is. I think with the normal luminance calculation we're actually doubling up and making the glow fairly unusable.. 