### PR TITLE
Add a `h_separation` between icons in `CheckButton`/`CheckBox`

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -50,10 +50,6 @@ void Button::_set_internal_margin(Side p_side, float p_value) {
 void Button::_queue_update_size_cache() {
 }
 
-void Button::_set_h_separation_is_valid_when_no_text(bool p_h_separation_is_valid_when_no_text) {
-	h_separation_is_valid_when_no_text = p_h_separation_is_valid_when_no_text;
-}
-
 Ref<StyleBox> Button::_get_current_stylebox() const {
 	Ref<StyleBox> stylebox = theme_cache.normal;
 	const bool rtl = is_layout_rtl();
@@ -171,14 +167,12 @@ void Button::_notification(int p_what) {
 			float right_internal_margin_with_h_separation = _internal_margin[SIDE_RIGHT];
 			{ // The width reserved for internal element in derived classes (and h_separation if need).
 
-				if (!xl_text.is_empty() || h_separation_is_valid_when_no_text) {
-					if (_internal_margin[SIDE_LEFT] > 0.0f) {
-						left_internal_margin_with_h_separation += h_separation;
-					}
+				if (_internal_margin[SIDE_LEFT] > 0.0f) {
+					left_internal_margin_with_h_separation += h_separation;
+				}
 
-					if (_internal_margin[SIDE_RIGHT] > 0.0f) {
-						right_internal_margin_with_h_separation += h_separation;
-					}
+				if (_internal_margin[SIDE_RIGHT] > 0.0f) {
+					right_internal_margin_with_h_separation += h_separation;
 				}
 
 				drawable_size_remained.width -= left_internal_margin_with_h_separation + right_internal_margin_with_h_separation; // The size after the internal element is stripped.

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -55,8 +55,6 @@ private:
 	VerticalAlignment vertical_icon_alignment = VERTICAL_ALIGNMENT_CENTER;
 	float _internal_margin[4] = {};
 
-	bool h_separation_is_valid_when_no_text = false;
-
 	struct ThemeCache {
 		Ref<StyleBox> normal;
 		Ref<StyleBox> normal_mirrored;
@@ -104,7 +102,6 @@ protected:
 	void _set_internal_margin(Side p_side, float p_value);
 	virtual void _queue_update_size_cache();
 
-	void _set_h_separation_is_valid_when_no_text(bool p_h_separation_is_valid_when_no_text);
 	Ref<StyleBox> _get_current_stylebox() const;
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -64,12 +64,18 @@ Size2 CheckBox::get_icon_size() const {
 
 Size2 CheckBox::get_minimum_size() const {
 	Size2 minsize = Button::get_minimum_size();
-	Size2 tex_size = get_icon_size();
-	minsize.width += tex_size.width;
-	if (get_text().length() > 0) {
-		minsize.width += MAX(0, theme_cache.h_separation);
+	const Size2 tex_size = get_icon_size();
+	if (tex_size.width > 0 || tex_size.height > 0) {
+		const Size2 padding = _get_current_stylebox()->get_minimum_size();
+		Size2 content_size = minsize - padding;
+		if (content_size.width > 0 && tex_size.width > 0) {
+			content_size.width += MAX(0, theme_cache.h_separation);
+		}
+		content_size.width += tex_size.width;
+		content_size.height = MAX(content_size.height, tex_size.height);
+
+		minsize = content_size + padding;
 	}
-	minsize.height = MAX(minsize.height, tex_size.height + theme_cache.normal_style->get_margin(SIDE_TOP) + theme_cache.normal_style->get_margin(SIDE_BOTTOM));
 
 	return minsize;
 }

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -68,12 +68,18 @@ Size2 CheckButton::get_icon_size() const {
 
 Size2 CheckButton::get_minimum_size() const {
 	Size2 minsize = Button::get_minimum_size();
-	Size2 tex_size = get_icon_size();
-	minsize.width += tex_size.width;
-	if (get_text().length() > 0) {
-		minsize.width += MAX(0, theme_cache.h_separation);
+	const Size2 tex_size = get_icon_size();
+	if (tex_size.width > 0 || tex_size.height > 0) {
+		const Size2 padding = _get_current_stylebox()->get_minimum_size();
+		Size2 content_size = minsize - padding;
+		if (content_size.width > 0 && tex_size.width > 0) {
+			content_size.width += MAX(0, theme_cache.h_separation);
+		}
+		content_size.width += tex_size.width;
+		content_size.height = MAX(content_size.height, tex_size.height);
+
+		minsize = content_size + padding;
 	}
-	minsize.height = MAX(minsize.height, tex_size.height + theme_cache.normal_style->get_margin(SIDE_TOP) + theme_cache.normal_style->get_margin(SIDE_BOTTOM));
 
 	return minsize;
 }

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -614,8 +614,6 @@ void OptionButton::set_disable_shortcuts(bool p_disabled) {
 
 OptionButton::OptionButton(const String &p_text) :
 		Button(p_text) {
-	_set_h_separation_is_valid_when_no_text(true);
-
 	set_toggle_mode(true);
 	set_process_shortcut_input(true);
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);


### PR DESCRIPTION
Previously, the `h_separation` between internal elements and custom elements was added when `text` was not empty. That is, this `h_separation` does not exist when there is a valid custom `icon` but `text` is empty.

Now, the `h_separation` between the internal element and the custom element is added when the internal element and any custom element exist (both width are greater than `0`).

Fix #88505.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
