### PR TITLE
[macOS/iOS] Use hardware sampling rates for audio I/O.

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -117,6 +117,12 @@
 				[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 			</description>
 		</method>
+		<method name="get_input_mix_rate" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the sample rate at the input of the [AudioServer].
+			</description>
+		</method>
 		<method name="get_mix_rate" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -14,7 +14,8 @@ SConscript("windows/SCsub")
 
 # Sounds drivers
 SConscript("alsa/SCsub")
-SConscript("coreaudio/SCsub")
+if env["platform"] == "ios" or env["platform"] == "macos":
+    SConscript("coreaudio/SCsub")
 SConscript("pulseaudio/SCsub")
 if env["platform"] == "windows":
     SConscript("wasapi/SCsub")

--- a/drivers/coreaudio/SCsub
+++ b/drivers/coreaudio/SCsub
@@ -4,4 +4,4 @@ from misc.utility.scons_hints import *
 Import("env")
 
 # Driver source files
-env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_source_files(env.drivers_sources, "*.mm")

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -38,6 +38,8 @@
 #import <AudioUnit/AudioUnit.h>
 #ifdef MACOS_ENABLED
 #import <CoreAudio/AudioHardware.h>
+#else
+#import <AVFoundation/AVFoundation.h>
 #endif
 
 class AudioDriverCoreAudio : public AudioDriver {
@@ -51,9 +53,11 @@ class AudioDriverCoreAudio : public AudioDriver {
 	String input_device_name = "Default";
 
 	int mix_rate = 0;
+	int capture_mix_rate = 0;
 	unsigned int channels = 2;
 	unsigned int capture_channels = 2;
 	unsigned int buffer_frames = 0;
+	unsigned int capture_buffer_frames = 0;
 
 	Vector<int32_t> samples_in;
 	Vector<int16_t> input_buf;
@@ -94,6 +98,7 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
+	virtual int get_input_mix_rate() const override;
 	virtual SpeakerMode get_speaker_mode() const override;
 
 	virtual void lock() override;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -390,7 +390,7 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 
 	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
 	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
-	int mix_rate = AudioDriver::get_singleton()->get_mix_rate();
+	int mix_rate = AudioDriver::get_singleton()->get_input_mix_rate();
 	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
 #ifdef DEBUG_ENABLED
 	unsigned int input_position = AudioDriver::get_singleton()->get_input_position();
@@ -441,7 +441,7 @@ int AudioStreamPlaybackMicrophone::mix(AudioFrame *p_buffer, float p_rate_scale,
 }
 
 float AudioStreamPlaybackMicrophone::get_stream_sampling_rate() {
-	return AudioDriver::get_singleton()->get_mix_rate();
+	return AudioDriver::get_singleton()->get_input_mix_rate();
 }
 
 void AudioStreamPlaybackMicrophone::start(double p_from_pos) {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1614,6 +1614,10 @@ float AudioServer::get_mix_rate() const {
 	return AudioDriver::get_singleton()->get_mix_rate();
 }
 
+float AudioServer::get_input_mix_rate() const {
+	return AudioDriver::get_singleton()->get_input_mix_rate();
+}
+
 float AudioServer::read_output_peak_db() const {
 	return 0;
 }
@@ -1946,6 +1950,7 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_speaker_mode"), &AudioServer::get_speaker_mode);
 	ClassDB::bind_method(D_METHOD("get_mix_rate"), &AudioServer::get_mix_rate);
+	ClassDB::bind_method(D_METHOD("get_input_mix_rate"), &AudioServer::get_input_mix_rate);
 
 	ClassDB::bind_method(D_METHOD("get_output_device_list"), &AudioServer::get_output_device_list);
 	ClassDB::bind_method(D_METHOD("get_output_device"), &AudioServer::get_output_device);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -99,6 +99,7 @@ public:
 	virtual Error init() = 0;
 	virtual void start() = 0;
 	virtual int get_mix_rate() const = 0;
+	virtual int get_input_mix_rate() const { return get_mix_rate(); }
 	virtual SpeakerMode get_speaker_mode() const = 0;
 	virtual float get_latency() { return 0; }
 
@@ -441,6 +442,7 @@ public:
 
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual float get_mix_rate() const;
+	virtual float get_input_mix_rate() const;
 
 	virtual float read_output_peak_db() const;
 


### PR DESCRIPTION
Instead of "mix_rate" from the project settings, use preferred OS values, since API can work only with the limited set of values depending on device.

Fixes https://github.com/godotengine/godot/issues/58180

TODO:
- I'm not sure if changes in the `AudioStreamPlaybackMicrophone` are sufficient to correctly resample it.
- We should track device changes and adjust sampling rates accordingly, but I'm not sure if Godot audio subsystem is capable of handling sampling rate changes.

_Edit: I corrected a typo in "mix_rate". - @adamscott_ 