### PR TITLE
Fix OpenGL on Android after adding optional depth fog

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1268,7 +1268,7 @@ vec4 fog_process(vec3 vertex) {
 	float fog_z = smoothstep(scene_data.fog_depth_begin, scene_data.fog_depth_end, length(vertex));
 	fog_amount = pow(fog_z, scene_data.fog_depth_curve) * scene_data.fog_density;
 #else
-	fog_amount = 1 - exp(min(0.0, -length(vertex) * scene_data.fog_density));
+	fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data.fog_density));
 #endif // USE_DEPTH_FOG
 
 	if (abs(scene_data.fog_height_density) >= 0.0001) {


### PR DESCRIPTION
After PR https://github.com/godotengine/godot/pull/84792 was merged, I'm getting this error on Android (I'm testing on the Meta Quest 3) with the OpenGL renderer:

```
02-21 09:51:43.351 24292 24339 E godot   : USER ERROR: SceneShaderGLES3: Fragment shader compilation failed:
02-21 09:51:43.351 24292 24339 E godot   : ERROR: 0:989: '-' :  wrong operand types  no operation '-' exists that takes a left-hand operand of type 'const int' and a right operand of type 'float' (or there is no acceptable conversion)
02-21 09:51:43.351 24292 24339 E godot   : ERROR: 0:989: 'assign' :  cannot convert from 'const int' to 'float'
02-21 09:51:43.351 24292 24339 E godot   : ERROR: 2 compilation errors.  No code generated.
```

This PR fixes that!