### PR TITLE
C#: Document that MainLoop needs to be registered in the global class

### DIFF
--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -30,6 +30,7 @@
 		[csharp]
 		using Godot;
 
+		[GlobalClass]
 		public partial class CustomMainLoop : MainLoop
 		{
 		    private double _timeElapsed = 0;


### PR DESCRIPTION
When I tried to use c# to implement a custom MainLoop, I found that it seemed that it had to be registered in the global class for it to work.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot-docs/issues/8799*