### PR TITLE
Update docs: Clarify how to use advance expression with a previously defined advance condition

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -24,6 +24,12 @@
 		</member>
 		<member name="advance_expression" type="String" setter="set_advance_expression" getter="get_advance_expression" default="&quot;&quot;">
 			Use an expression as a condition for state machine transitions. It is possible to create complex animation advance conditions for switching between states and gives much greater flexibility for creating complex state machines by directly interfacing with the script code.
+			[codeblocks]
+			[gdscript]
+			# get from the tree's advance_expression_base_node: evaluate an advance condition parameter defined by an existing transition
+			get("parameters/conditions/run") == false
+			[/gdscript]
+			[/codeblocks]
 		</member>
 		<member name="advance_mode" type="int" setter="set_advance_mode" getter="get_advance_mode" enum="AnimationNodeStateMachineTransition.AdvanceMode" default="1">
 			Determines whether the transition should disabled, enabled when using [method AnimationNodeStateMachinePlayback.travel], or traversed automatically if the [member advance_condition] and [member advance_expression] checks are true (if assigned).


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

While setting up an animation state machine for an animated character I had, it was unclear how to define/reference an existing advance condition I had set. Once I realized the way to set it up it became a lot clearer, so I think this could be  useful addition for people to get a basic idea of how it works.
