### PR TITLE
Provide generic interface for XR hand tracking

### DIFF
--- a/doc/classes/XRHandModifier3D.xml
+++ b/doc/classes/XRHandModifier3D.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="XRHandModifier3D" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A node for driving hand meshes from [XRHandTracker] data.
+	</brief_description>
+	<description>
+		This node uses hand tracking data from a [XRHandTracker] to animate the skeleton of a hand mesh.
+	</description>
+	<tutorials>
+		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
+	</tutorials>
+	<members>
+		<member name="bone_update" type="int" setter="set_bone_update" getter="get_bone_update" enum="XRHandModifier3D.BoneUpdate" default="0">
+			Specifies the type of updates to perform on the bones.
+		</member>
+		<member name="hand_tracker" type="StringName" setter="set_hand_tracker" getter="get_hand_tracker" default="&amp;&quot;/user/left&quot;">
+			The name of the [XRHandTracker] registered with [XRServer] to obtain the hand tracking data from.
+		</member>
+		<member name="target" type="NodePath" setter="set_target" getter="get_target" default="NodePath(&quot;&quot;)">
+			A [NodePath] to a [Skeleton3D] to animate.
+		</member>
+	</members>
+	<constants>
+		<constant name="BONE_UPDATE_FULL" value="0" enum="BoneUpdate">
+			The skeleton's bones are fully updated (both position and rotation) to match the tracked bones.
+		</constant>
+		<constant name="BONE_UPDATE_ROTATION_ONLY" value="1" enum="BoneUpdate">
+			The skeleton's bones are only rotated to align with the tracked bones, preserving bone length.
+		</constant>
+		<constant name="BONE_UPDATE_MAX" value="2" enum="BoneUpdate">
+			Represents the size of the [enum BoneUpdate] enum.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/XRHandTracker.xml
+++ b/doc/classes/XRHandTracker.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="XRHandTracker" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A tracked hand in XR.
+	</brief_description>
+	<description>
+		A hand tracking system will create an instance of this object and add it to the [XRServer]. This tracking system will then obtain skeleton data, convert it to the Godot Humanoid hand skeleton and store this data on the [XRHandTracker] object.
+		Use [XRHandModifier3D] to animate a hand mesh using hand tracking data.
+	</description>
+	<tutorials>
+		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
+	</tutorials>
+	<methods>
+		<method name="get_hand_joint_angular_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<description>
+				Returns the angular velocity for the given hand joint.
+			</description>
+		</method>
+		<method name="get_hand_joint_flags" qualifiers="const">
+			<return type="int" enum="XRHandTracker.HandJointFlags" is_bitfield="true" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<description>
+				Returns flags about the validity of the tracking data for the given hand joint (see [enum XRHandTracker.HandJointFlags]).
+			</description>
+		</method>
+		<method name="get_hand_joint_linear_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<description>
+				Returns the linear velocity for the given hand joint.
+			</description>
+		</method>
+		<method name="get_hand_joint_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<description>
+				Returns the radius of the given hand joint.
+			</description>
+		</method>
+		<method name="get_hand_joint_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<description>
+				Returns the transform for the given hand joint.
+			</description>
+		</method>
+		<method name="set_hand_joint_angular_velocity">
+			<return type="void" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<param index="1" name="angular_velocity" type="Vector3" />
+			<description>
+				Sets the angular velocity for the given hand joint.
+			</description>
+		</method>
+		<method name="set_hand_joint_flags">
+			<return type="void" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<param index="1" name="flags" type="int" enum="XRHandTracker.HandJointFlags" is_bitfield="true" />
+			<description>
+				Sets flags about the validity of the tracking data for the given hand joint.
+			</description>
+		</method>
+		<method name="set_hand_joint_linear_velocity">
+			<return type="void" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<param index="1" name="linear_velocity" type="Vector3" />
+			<description>
+				Sets the linear velocity for the given hand joint.
+			</description>
+		</method>
+		<method name="set_hand_joint_radius">
+			<return type="void" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<param index="1" name="radius" type="float" />
+			<description>
+				Sets the radius of the given hand joint.
+			</description>
+		</method>
+		<method name="set_hand_joint_transform">
+			<return type="void" />
+			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<param index="1" name="transform" type="Transform3D" />
+			<description>
+				Sets the transform for the given hand joint.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="hand" type="int" setter="set_hand" getter="get_hand" enum="XRHandTracker.Hand" default="0">
+			The type of hand.
+		</member>
+		<member name="hand_tracking_source" type="int" setter="set_hand_tracking_source" getter="get_hand_tracking_source" enum="XRHandTracker.HandTrackingSource" default="0">
+			The source of the hand tracking data.
+		</member>
+		<member name="has_tracking_data" type="bool" setter="set_has_tracking_data" getter="get_has_tracking_data" default="false">
+			If [code]true[/code], the hand tracking data is valid.
+		</member>
+	</members>
+	<constants>
+		<constant name="HAND_LEFT" value="0" enum="Hand">
+			A left hand.
+		</constant>
+		<constant name="HAND_RIGHT" value="1" enum="Hand">
+			A right hand.
+		</constant>
+		<constant name="HAND_MAX" value="2" enum="Hand">
+			Represents the size of the [enum Hand] enum.
+		</constant>
+		<constant name="HAND_TRACKING_SOURCE_UNKNOWN" value="0" enum="HandTrackingSource">
+			The source of hand tracking data is unknown.
+		</constant>
+		<constant name="HAND_TRACKING_SOURCE_UNOBSTRUCTED" value="1" enum="HandTrackingSource">
+			The source of hand tracking data is unobstructed, meaning that an accurate method of hand tracking is used. These include optical hand tracking, data gloves, etc.
+		</constant>
+		<constant name="HAND_TRACKING_SOURCE_CONTROLLER" value="2" enum="HandTrackingSource">
+			The source of hand tracking data is a controller, meaning that joint positions are inferred from controller inputs.
+		</constant>
+		<constant name="HAND_TRACKING_SOURCE_MAX" value="3" enum="HandTrackingSource">
+			Represents the size of the [enum HandTrackingSource] enum.
+		</constant>
+		<constant name="HAND_JOINT_PALM" value="0" enum="HandJoint">
+			Palm joint.
+		</constant>
+		<constant name="HAND_JOINT_WRIST" value="1" enum="HandJoint">
+			Wrist joint.
+		</constant>
+		<constant name="HAND_JOINT_THUMB_METACARPAL" value="2" enum="HandJoint">
+			Thumb metacarpal joint.
+		</constant>
+		<constant name="HAND_JOINT_THUMB_PHALANX_PROXIMAL" value="3" enum="HandJoint">
+			Thumb phalanx proximal joint.
+		</constant>
+		<constant name="HAND_JOINT_THUMB_PHALANX_DISTAL" value="4" enum="HandJoint">
+			Thumb phalanx distal joint.
+		</constant>
+		<constant name="HAND_JOINT_THUMB_TIP" value="5" enum="HandJoint">
+			Thumb tip joint.
+		</constant>
+		<constant name="HAND_JOINT_INDEX_FINGER_METACARPAL" value="6" enum="HandJoint">
+			Index finger metacarpal joint.
+		</constant>
+		<constant name="HAND_JOINT_INDEX_FINGER_PHALANX_PROXIMAL" value="7" enum="HandJoint">
+			Index finger phalanx proximal joint.
+		</constant>
+		<constant name="HAND_JOINT_INDEX_FINGER_PHALANX_INTERMEDIATE" value="8" enum="HandJoint">
+			Index finger phalanx intermediate joint.
+		</constant>
+		<constant name="HAND_JOINT_INDEX_FINGER_PHALANX_DISTAL" value="9" enum="HandJoint">
+			Index finger phalanx distal joint.
+		</constant>
+		<constant name="HAND_JOINT_INDEX_FINGER_TIP" value="10" enum="HandJoint">
+			Index finger tip joint.
+		</constant>
+		<constant name="HAND_JOINT_MIDDLE_FINGER_METACARPAL" value="11" enum="HandJoint">
+			Middle finger metacarpal joint.
+		</constant>
+		<constant name="HAND_JOINT_MIDDLE_FINGER_PHALANX_PROXIMAL" value="12" enum="HandJoint">
+			Middle finger phalanx proximal joint.
+		</constant>
+		<constant name="HAND_JOINT_MIDDLE_FINGER_PHALANX_INTERMEDIATE" value="13" enum="HandJoint">
+			Middle finger phalanx intermediate joint.
+		</constant>
+		<constant name="HAND_JOINT_MIDDLE_FINGER_PHALANX_DISTAL" value="14" enum="HandJoint">
+			Middle finger phalanx distal joint.
+		</constant>
+		<constant name="HAND_JOINT_MIDDLE_FINGER_TIP" value="15" enum="HandJoint">
+			Middle finger tip joint.
+		</constant>
+		<constant name="HAND_JOINT_RING_FINGER_METACARPAL" value="16" enum="HandJoint">
+			Ring finger metacarpal joint.
+		</constant>
+		<constant name="HAND_JOINT_RING_FINGER_PHALANX_PROXIMAL" value="17" enum="HandJoint">
+			Ring finger phalanx proximal joint.
+		</constant>
+		<constant name="HAND_JOINT_RING_FINGER_PHALANX_INTERMEDIATE" value="18" enum="HandJoint">
+			Ring finger phalanx intermediate joint.
+		</constant>
+		<constant name="HAND_JOINT_RING_FINGER_PHALANX_DISTAL" value="19" enum="HandJoint">
+			Ring finger phalanx distal joint.
+		</constant>
+		<constant name="HAND_JOINT_RING_FINGER_TIP" value="20" enum="HandJoint">
+			Ring finger tip joint.
+		</constant>
+		<constant name="HAND_JOINT_PINKY_FINGER_METACARPAL" value="21" enum="HandJoint">
+			Pinky finger metacarpal joint.
+		</constant>
+		<constant name="HAND_JOINT_PINKY_FINGER_PHALANX_PROXIMAL" value="22" enum="HandJoint">
+			Pinky finger phalanx proximal joint.
+		</constant>
+		<constant name="HAND_JOINT_PINKY_FINGER_PHALANX_INTERMEDIATE" value="23" enum="HandJoint">
+			Pinky finger phalanx intermediate joint.
+		</constant>
+		<constant name="HAND_JOINT_PINKY_FINGER_PHALANX_DISTAL" value="24" enum="HandJoint">
+			Pinky finger phalanx distal joint.
+		</constant>
+		<constant name="HAND_JOINT_PINKY_FINGER_TIP" value="25" enum="HandJoint">
+			Pinky finger tip joint.
+		</constant>
+		<constant name="HAND_JOINT_MAX" value="26" enum="HandJoint">
+			Represents the size of the [enum HandJoint] enum.
+		</constant>
+		<constant name="HAND_JOINT_FLAG_ORIENTATION_VALID" value="1" enum="HandJointFlags" is_bitfield="true">
+			The hand joint's orientation data is valid.
+		</constant>
+		<constant name="HAND_JOINT_FLAG_ORIENTATION_TRACKED" value="2" enum="HandJointFlags" is_bitfield="true">
+			The hand joint's orientation is actively tracked. May not be set if tracking has been temporarily lost.
+		</constant>
+		<constant name="HAND_JOINT_FLAG_POSITION_VALID" value="4" enum="HandJointFlags" is_bitfield="true">
+			The hand joint's position data is valid.
+		</constant>
+		<constant name="HAND_JOINT_FLAG_POSITION_TRACKED" value="8" enum="HandJointFlags" is_bitfield="true">
+			The hand joint's position is actively tracked. May not be set if tracking has been temporarily lost.
+		</constant>
+		<constant name="HAND_JOINT_FLAG_LINEAR_VELOCITY_VALID" value="16" enum="HandJointFlags" is_bitfield="true">
+			The hand joint's linear velocity data is valid.
+		</constant>
+		<constant name="HAND_JOINT_FLAG_ANGULAR_VELOCITY_VALID" value="32" enum="HandJointFlags" is_bitfield="true">
+			The hand joint's angular velocity data is valid.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/XRServer.xml
+++ b/doc/classes/XRServer.xml
@@ -18,6 +18,14 @@
 				Registers a new [XRFaceTracker] that tracks the blend shapes of a face.
 			</description>
 		</method>
+		<method name="add_hand_tracker">
+			<return type="void" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="hand_tracker" type="XRHandTracker" />
+			<description>
+				Registers a new [XRHandTracker] that tracks the joints of a hand.
+			</description>
+		</method>
 		<method name="add_interface">
 			<return type="void" />
 			<param index="0" name="interface" type="XRInterface" />
@@ -69,6 +77,19 @@
 			<return type="Dictionary" />
 			<description>
 				Returns a dictionary of the registered face trackers. Each element of the dictionary is a tracker name mapping to the [XRFaceTracker] instance.
+			</description>
+		</method>
+		<method name="get_hand_tracker" qualifiers="const">
+			<return type="XRHandTracker" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Returns the [XRHandTracker] with the given tracker name.
+			</description>
+		</method>
+		<method name="get_hand_trackers" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns a dictionary of the registered hand trackers. Each element of the dictionary is a tracker name mapping to the [XRHandTracker] instance.
 			</description>
 		</method>
 		<method name="get_hmd_transform">
@@ -123,6 +144,13 @@
 				Removes a registered [XRFaceTracker].
 			</description>
 		</method>
+		<method name="remove_hand_tracker">
+			<return type="void" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Removes a registered [XRHandTracker].
+			</description>
+		</method>
 		<method name="remove_interface">
 			<return type="void" />
 			<param index="0" name="interface" type="XRInterface" />
@@ -169,6 +197,26 @@
 			<param index="1" name="face_tracker" type="XRFaceTracker" />
 			<description>
 				Emitted when an existing face tracker is updated.
+			</description>
+		</signal>
+		<signal name="hand_tracker_added">
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="hand_tracker" type="XRHandTracker" />
+			<description>
+				Emitted when a new hand tracker is added.
+			</description>
+		</signal>
+		<signal name="hand_tracker_removed">
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Emitted when a hand tracker is removed.
+			</description>
+		</signal>
+		<signal name="hand_tracker_updated">
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="hand_tracker" type="XRHandTracker" />
+			<description>
+				Emitted when an existing hand tracker is updated.
 			</description>
 		</signal>
 		<signal name="interface_added">

--- a/modules/openxr/doc_classes/OpenXRHand.xml
+++ b/modules/openxr/doc_classes/OpenXRHand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OpenXRHand" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="OpenXRHand" inherits="Node3D" deprecated="Use [XRHandModifier3D] instead." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Node supporting hand and finger tracking in OpenXR.
 	</brief_description>

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -23,7 +23,7 @@
 				Returns display refresh rates supported by the current HMD. Only returned if this feature is supported by the OpenXR runtime and after the interface has been initialized.
 			</description>
 		</method>
-		<method name="get_hand_joint_angular_velocity" qualifiers="const">
+		<method name="get_hand_joint_angular_velocity" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_angular_velocity] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="Vector3" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
@@ -31,7 +31,7 @@
 				If handtracking is enabled, returns the angular velocity of a joint ([param joint]) of a hand ([param hand]) as provided by OpenXR. This is relative to [XROrigin3D]!
 			</description>
 		</method>
-		<method name="get_hand_joint_flags" qualifiers="const">
+		<method name="get_hand_joint_flags" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_flags] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="int" enum="OpenXRInterface.HandJointFlags" is_bitfield="true" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
@@ -39,7 +39,7 @@
 				If handtracking is enabled, returns flags that inform us of the validity of the tracking data.
 			</description>
 		</method>
-		<method name="get_hand_joint_linear_velocity" qualifiers="const">
+		<method name="get_hand_joint_linear_velocity" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_linear_velocity] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="Vector3" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
@@ -47,7 +47,7 @@
 				If handtracking is enabled, returns the linear velocity of a joint ([param joint]) of a hand ([param hand]) as provided by OpenXR. This is relative to [XROrigin3D] without worldscale applied!
 			</description>
 		</method>
-		<method name="get_hand_joint_position" qualifiers="const">
+		<method name="get_hand_joint_position" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_transform] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="Vector3" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
@@ -55,7 +55,7 @@
 				If handtracking is enabled, returns the position of a joint ([param joint]) of a hand ([param hand]) as provided by OpenXR. This is relative to [XROrigin3D] without worldscale applied!
 			</description>
 		</method>
-		<method name="get_hand_joint_radius" qualifiers="const">
+		<method name="get_hand_joint_radius" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_radius] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="float" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
@@ -63,7 +63,7 @@
 				If handtracking is enabled, returns the radius of a joint ([param joint]) of a hand ([param hand]) as provided by OpenXR. This is without worldscale applied!
 			</description>
 		</method>
-		<method name="get_hand_joint_rotation" qualifiers="const">
+		<method name="get_hand_joint_rotation" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_transform] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="Quaternion" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
@@ -71,7 +71,7 @@
 				If handtracking is enabled, returns the rotation of a joint ([param joint]) of a hand ([param hand]) as provided by OpenXR.
 			</description>
 		</method>
-		<method name="get_hand_tracking_source" qualifiers="const">
+		<method name="get_hand_tracking_source" qualifiers="const" deprecated="Use [member XRHandTracker.hand_tracking_source] obtained from [method XRServer.get_hand_tracker] instead.">
 			<return type="int" enum="OpenXRInterface.HandTrackedSource" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
 			<description>

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.h
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.h
@@ -34,6 +34,7 @@
 #include "../util.h"
 #include "core/math/quaternion.h"
 #include "openxr_extension_wrapper.h"
+#include "servers/xr/xr_hand_tracker.h"
 
 class OpenXRHandTrackingExtension : public OpenXRExtensionWrapper {
 public:
@@ -52,6 +53,7 @@ public:
 
 	struct HandTracker {
 		bool is_initialized = false;
+		Ref<XRHandTracker> godot_tracker;
 		XrHandJointsMotionRangeEXT motion_range = XR_HAND_JOINTS_MOTION_RANGE_UNOBSTRUCTED_EXT;
 		HandTrackedSource source = OPENXR_SOURCE_UNKNOWN;
 

--- a/scene/3d/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr_hand_modifier_3d.cpp
@@ -1,0 +1,309 @@
+/**************************************************************************/
+/*  xr_hand_modifier_3d.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "xr_hand_modifier_3d.h"
+
+#include "scene/3d/skeleton_3d.h"
+#include "servers/xr/xr_pose.h"
+#include "servers/xr_server.h"
+
+void XRHandModifier3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_hand_tracker", "tracker_name"), &XRHandModifier3D::set_hand_tracker);
+	ClassDB::bind_method(D_METHOD("get_hand_tracker"), &XRHandModifier3D::get_hand_tracker);
+
+	ClassDB::bind_method(D_METHOD("set_target", "target"), &XRHandModifier3D::set_target);
+	ClassDB::bind_method(D_METHOD("get_target"), &XRHandModifier3D::get_target);
+
+	ClassDB::bind_method(D_METHOD("set_bone_update", "bone_update"), &XRHandModifier3D::set_bone_update);
+	ClassDB::bind_method(D_METHOD("get_bone_update"), &XRHandModifier3D::get_bone_update);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "hand_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/left,/user/right"), "set_hand_tracker", "get_hand_tracker");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "target", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton3D"), "set_target", "get_target");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_update", PROPERTY_HINT_ENUM, "Full,Rotation Only"), "set_bone_update", "get_bone_update");
+
+	BIND_ENUM_CONSTANT(BONE_UPDATE_FULL);
+	BIND_ENUM_CONSTANT(BONE_UPDATE_ROTATION_ONLY);
+	BIND_ENUM_CONSTANT(BONE_UPDATE_MAX);
+}
+
+void XRHandModifier3D::set_hand_tracker(const StringName &p_tracker_name) {
+	tracker_name = p_tracker_name;
+}
+
+StringName XRHandModifier3D::get_hand_tracker() const {
+	return tracker_name;
+}
+
+void XRHandModifier3D::set_target(const NodePath &p_target) {
+	target = p_target;
+
+	if (is_inside_tree()) {
+		_get_joint_data();
+	}
+}
+
+NodePath XRHandModifier3D::get_target() const {
+	return target;
+}
+
+void XRHandModifier3D::set_bone_update(BoneUpdate p_bone_update) {
+	ERR_FAIL_INDEX(p_bone_update, BONE_UPDATE_MAX);
+	bone_update = p_bone_update;
+}
+
+XRHandModifier3D::BoneUpdate XRHandModifier3D::get_bone_update() const {
+	return bone_update;
+}
+
+Skeleton3D *XRHandModifier3D::get_skeleton() {
+	if (!has_node(target)) {
+		return nullptr;
+	}
+
+	Node *node = get_node(target);
+	if (!node) {
+		return nullptr;
+	}
+
+	Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
+	return skeleton;
+}
+
+void XRHandModifier3D::_get_joint_data() {
+	// Table of bone names for different rig types.
+	static const String bone_names[XRHandTracker::HAND_JOINT_MAX] = {
+		"Palm",
+		"Hand",
+		"ThumbMetacarpal",
+		"ThumbProximal",
+		"ThumbDistal",
+		"ThumbTip",
+		"IndexMetacarpal",
+		"IndexProximal",
+		"IndexIntermediate",
+		"IndexDistal",
+		"IndexTip",
+		"MiddleMetacarpal",
+		"MiddleProximal",
+		"MiddleIntermediate",
+		"MiddleDistal",
+		"MiddleTip",
+		"RingMetacarpal",
+		"RingProximal",
+		"RingIntermediate",
+		"RingDistal",
+		"RingTip",
+		"LittleMetacarpal",
+		"LittleProximal",
+		"LittleIntermediate",
+		"LittleDistal",
+		"LittleTip",
+	};
+
+	static const String bone_name_format[2] = {
+		"Left<bone>",
+		"Right<bone>",
+	};
+
+	// reset JIC
+	for (int i = 0; i < XRHandTracker::HAND_JOINT_MAX; i++) {
+		joints[i].bone = -1;
+		joints[i].parent_joint = -1;
+	}
+
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	if (!xr_server) {
+		return;
+	}
+
+	Ref<XRHandTracker> tracker = xr_server->get_hand_tracker(tracker_name);
+	if (tracker.is_null()) {
+		return;
+	}
+
+	XRHandTracker::Hand hand = tracker->get_hand();
+
+	// Find the skeleton-bones associated with each joint.
+	int bones[XRHandTracker::HAND_JOINT_MAX];
+	for (int i = 0; i < XRHandTracker::HAND_JOINT_MAX; i++) {
+		// Construct the expected bone name.
+		String bone_name = bone_name_format[hand].replace("<bone>", bone_names[i]);
+
+		// Find the skeleton bone.
+		bones[i] = skeleton->find_bone(bone_name);
+		if (bones[i] == -1) {
+			WARN_PRINT(vformat("Couldn't obtain bone for %s", bone_name));
+		}
+	}
+
+	// Assemble the joint relationship to the available skeleton bones.
+	for (int i = 0; i < XRHandTracker::HAND_JOINT_MAX; i++) {
+		// Get the skeleton bone (skip if not found).
+		const int bone = bones[i];
+		if (bone == -1) {
+			continue;
+		}
+
+		// Find the parent skeleton-bone.
+		const int parent_bone = skeleton->get_bone_parent(bone);
+		if (parent_bone == -1) {
+			// If no parent skeleton-bone exists then drive this relative to palm joint.
+			joints[i].bone = bone;
+			joints[i].parent_joint = XRHandTracker::HAND_JOINT_PALM;
+			continue;
+		}
+
+		// Find the joint associated with the parent skeleton-bone.
+		for (int j = 0; j < XRHandTracker::HAND_JOINT_MAX; ++j) {
+			if (bones[j] == parent_bone) {
+				// If a parent joint is found then drive this bone relative to it.
+				joints[i].bone = bone;
+				joints[i].parent_joint = j;
+				break;
+			}
+		}
+	}
+}
+
+void XRHandModifier3D::_update_skeleton() {
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	if (!xr_server) {
+		return;
+	}
+
+	Ref<XRHandTracker> tracker = xr_server->get_hand_tracker(tracker_name);
+	if (tracker.is_null()) {
+		return;
+	}
+
+	// We cache our transforms so we can quickly calculate local transforms.
+	bool has_valid_data[XRHandTracker::HAND_JOINT_MAX];
+	Transform3D transforms[XRHandTracker::HAND_JOINT_MAX];
+	Transform3D inv_transforms[XRHandTracker::HAND_JOINT_MAX];
+
+	const float ws = xr_server->get_world_scale();
+
+	if (tracker->get_has_tracking_data()) {
+		for (int joint = 0; joint < XRHandTracker::HAND_JOINT_MAX; joint++) {
+			BitField<XRHandTracker::HandJointFlags> flags = tracker->get_hand_joint_flags((XRHandTracker::HandJoint)joint);
+			has_valid_data[joint] = flags.has_flag(XRHandTracker::HAND_JOINT_FLAG_ORIENTATION_VALID);
+
+			if (has_valid_data[joint]) {
+				transforms[joint] = tracker->get_hand_joint_transform((XRHandTracker::HandJoint)joint);
+				transforms[joint].origin *= ws;
+				inv_transforms[joint] = transforms[joint].inverse();
+			}
+		}
+
+		if (has_valid_data[XRHandTracker::HAND_JOINT_PALM]) {
+			for (int joint = 0; joint < XRHandTracker::HAND_JOINT_MAX; joint++) {
+				// Get the skeleton bone (skip if none).
+				const int bone = joints[joint].bone;
+				if (bone == -1) {
+					continue;
+				}
+
+				// Calculate the relative relationship to the parent bone joint.
+				const int parent_joint = joints[joint].parent_joint;
+				const Transform3D relative_transform = inv_transforms[parent_joint] * transforms[joint];
+
+				// Update the bone position if enabled by update mode.
+				if (bone_update == BONE_UPDATE_FULL) {
+					skeleton->set_bone_pose_position(joints[joint].bone, relative_transform.origin);
+				}
+
+				// Always update the bone rotation.
+				skeleton->set_bone_pose_rotation(joints[joint].bone, Quaternion(relative_transform.basis));
+			}
+
+			// Transform to the skeleton pose.
+			set_transform(transforms[XRHandTracker::HAND_JOINT_PALM]);
+
+			set_visible(true);
+		} else {
+			set_visible(false);
+		}
+	} else {
+		set_visible(false);
+	}
+}
+
+void XRHandModifier3D::_tracker_changed(StringName p_tracker_name, const Ref<XRHandTracker> &p_tracker) {
+	if (tracker_name == p_tracker_name) {
+		_get_joint_data();
+	}
+}
+
+void XRHandModifier3D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			XRServer *xr_server = XRServer::get_singleton();
+			if (xr_server) {
+				xr_server->connect("hand_tracker_added", callable_mp(this, &XRHandModifier3D::_tracker_changed));
+				xr_server->connect("hand_tracker_updated", callable_mp(this, &XRHandModifier3D::_tracker_changed));
+				xr_server->connect("hand_tracker_removed", callable_mp(this, &XRHandModifier3D::_tracker_changed).bind(Ref<XRHandTracker>()));
+			}
+
+			_get_joint_data();
+
+			set_process_internal(true);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			XRServer *xr_server = XRServer::get_singleton();
+			if (xr_server) {
+				xr_server->disconnect("hand_tracker_added", callable_mp(this, &XRHandModifier3D::_tracker_changed));
+				xr_server->disconnect("hand_tracker_updated", callable_mp(this, &XRHandModifier3D::_tracker_changed));
+				xr_server->disconnect("hand_tracker_removed", callable_mp(this, &XRHandModifier3D::_tracker_changed).bind(Ref<XRHandTracker>()));
+			}
+
+			set_process_internal(false);
+
+			for (int i = 0; i < XRHandTracker::HAND_JOINT_MAX; i++) {
+				joints[i].bone = -1;
+				joints[i].parent_joint = -1;
+			}
+		} break;
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			_update_skeleton();
+		} break;
+		default: {
+		} break;
+	}
+}

--- a/scene/3d/xr_hand_modifier_3d.h
+++ b/scene/3d/xr_hand_modifier_3d.h
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  xr_hand_modifier_3d.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef XR_HAND_MODIFIER_3D_H
+#define XR_HAND_MODIFIER_3D_H
+
+#include "scene/3d/node_3d.h"
+#include "servers/xr/xr_hand_tracker.h"
+
+class Skeleton3D;
+
+/**
+	The XRHandModifier3D node drives a hand skeleton using hand tracking
+	data from an XRHandTracking instance.
+ */
+
+class XRHandModifier3D : public Node3D {
+	GDCLASS(XRHandModifier3D, Node3D);
+
+public:
+	enum BoneUpdate {
+		BONE_UPDATE_FULL,
+		BONE_UPDATE_ROTATION_ONLY,
+		BONE_UPDATE_MAX
+	};
+
+	void set_hand_tracker(const StringName &p_tracker_name);
+	StringName get_hand_tracker() const;
+
+	void set_target(const NodePath &p_target);
+	NodePath get_target() const;
+
+	void set_bone_update(BoneUpdate p_bone_update);
+	BoneUpdate get_bone_update() const;
+
+	void _notification(int p_what);
+
+protected:
+	static void _bind_methods();
+
+private:
+	struct JointData {
+		int bone = -1;
+		int parent_joint = -1;
+	};
+
+	StringName tracker_name = "/user/left";
+	NodePath target;
+	BoneUpdate bone_update = BONE_UPDATE_FULL;
+	JointData joints[XRHandTracker::HAND_JOINT_MAX];
+
+	Skeleton3D *get_skeleton();
+	void _get_joint_data();
+	void _update_skeleton();
+	void _tracker_changed(StringName p_tracker_name, const Ref<XRHandTracker> &p_tracker);
+};
+
+VARIANT_ENUM_CAST(XRHandModifier3D::BoneUpdate)
+
+#endif // XR_HAND_MODIFIER_3D_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -274,6 +274,7 @@
 #include "scene/3d/voxel_gi.h"
 #include "scene/3d/world_environment.h"
 #include "scene/3d/xr_face_modifier_3d.h"
+#include "scene/3d/xr_hand_modifier_3d.h"
 #include "scene/3d/xr_nodes.h"
 #include "scene/animation/root_motion_view.h"
 #include "scene/resources/environment.h"
@@ -523,6 +524,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(XRController3D);
 	GDREGISTER_CLASS(XRAnchor3D);
 	GDREGISTER_CLASS(XROrigin3D);
+	GDREGISTER_CLASS(XRHandModifier3D);
 	GDREGISTER_CLASS(XRFaceModifier3D);
 	GDREGISTER_CLASS(MeshInstance3D);
 	GDREGISTER_CLASS(OccluderInstance3D);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -87,6 +87,7 @@
 #include "text/text_server_extension.h"
 #include "text_server.h"
 #include "xr/xr_face_tracker.h"
+#include "xr/xr_hand_tracker.h"
 #include "xr/xr_interface.h"
 #include "xr/xr_interface_extension.h"
 #include "xr/xr_positional_tracker.h"
@@ -193,6 +194,7 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(RenderingDevice);
 
 	GDREGISTER_ABSTRACT_CLASS(XRInterface);
+	GDREGISTER_CLASS(XRHandTracker);
 	GDREGISTER_CLASS(XRInterfaceExtension); // can't register this as virtual because we need a creation function for our extensions.
 	GDREGISTER_CLASS(XRPose);
 	GDREGISTER_CLASS(XRPositionalTracker);

--- a/servers/xr/xr_hand_tracker.cpp
+++ b/servers/xr/xr_hand_tracker.cpp
@@ -1,0 +1,179 @@
+/**************************************************************************/
+/*  xr_hand_tracker.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "xr_hand_tracker.h"
+
+void XRHandTracker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_hand", "hand"), &XRHandTracker::set_hand);
+	ClassDB::bind_method(D_METHOD("get_hand"), &XRHandTracker::get_hand);
+
+	ClassDB::bind_method(D_METHOD("set_has_tracking_data", "has_data"), &XRHandTracker::set_has_tracking_data);
+	ClassDB::bind_method(D_METHOD("get_has_tracking_data"), &XRHandTracker::get_has_tracking_data);
+
+	ClassDB::bind_method(D_METHOD("set_hand_tracking_source", "source"), &XRHandTracker::set_hand_tracking_source);
+	ClassDB::bind_method(D_METHOD("get_hand_tracking_source"), &XRHandTracker::get_hand_tracking_source);
+
+	ClassDB::bind_method(D_METHOD("set_hand_joint_flags", "joint", "flags"), &XRHandTracker::set_hand_joint_flags);
+	ClassDB::bind_method(D_METHOD("get_hand_joint_flags", "joint"), &XRHandTracker::get_hand_joint_flags);
+
+	ClassDB::bind_method(D_METHOD("set_hand_joint_transform", "joint", "transform"), &XRHandTracker::set_hand_joint_transform);
+	ClassDB::bind_method(D_METHOD("get_hand_joint_transform", "joint"), &XRHandTracker::get_hand_joint_transform);
+
+	ClassDB::bind_method(D_METHOD("set_hand_joint_radius", "joint", "radius"), &XRHandTracker::set_hand_joint_radius);
+	ClassDB::bind_method(D_METHOD("get_hand_joint_radius", "joint"), &XRHandTracker::get_hand_joint_radius);
+
+	ClassDB::bind_method(D_METHOD("set_hand_joint_linear_velocity", "joint", "linear_velocity"), &XRHandTracker::set_hand_joint_linear_velocity);
+	ClassDB::bind_method(D_METHOD("get_hand_joint_linear_velocity", "joint"), &XRHandTracker::get_hand_joint_linear_velocity);
+
+	ClassDB::bind_method(D_METHOD("set_hand_joint_angular_velocity", "joint", "angular_velocity"), &XRHandTracker::set_hand_joint_angular_velocity);
+	ClassDB::bind_method(D_METHOD("get_hand_joint_angular_velocity", "joint"), &XRHandTracker::get_hand_joint_angular_velocity);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand", PROPERTY_HINT_ENUM, "Left,Right"), "set_hand", "get_hand");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_tracking_data", PROPERTY_HINT_NONE), "set_has_tracking_data", "get_has_tracking_data");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand_tracking_source", PROPERTY_HINT_ENUM, "Unknown,Unobstructed,Controller"), "set_hand_tracking_source", "get_hand_tracking_source");
+
+	BIND_ENUM_CONSTANT(HAND_LEFT);
+	BIND_ENUM_CONSTANT(HAND_RIGHT);
+	BIND_ENUM_CONSTANT(HAND_MAX);
+
+	BIND_ENUM_CONSTANT(HAND_TRACKING_SOURCE_UNKNOWN);
+	BIND_ENUM_CONSTANT(HAND_TRACKING_SOURCE_UNOBSTRUCTED);
+	BIND_ENUM_CONSTANT(HAND_TRACKING_SOURCE_CONTROLLER);
+	BIND_ENUM_CONSTANT(HAND_TRACKING_SOURCE_MAX);
+
+	BIND_ENUM_CONSTANT(HAND_JOINT_PALM);
+	BIND_ENUM_CONSTANT(HAND_JOINT_WRIST);
+	BIND_ENUM_CONSTANT(HAND_JOINT_THUMB_METACARPAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_THUMB_PHALANX_PROXIMAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_THUMB_PHALANX_DISTAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_THUMB_TIP);
+	BIND_ENUM_CONSTANT(HAND_JOINT_INDEX_FINGER_METACARPAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_INDEX_FINGER_PHALANX_PROXIMAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_INDEX_FINGER_PHALANX_INTERMEDIATE);
+	BIND_ENUM_CONSTANT(HAND_JOINT_INDEX_FINGER_PHALANX_DISTAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_INDEX_FINGER_TIP);
+	BIND_ENUM_CONSTANT(HAND_JOINT_MIDDLE_FINGER_METACARPAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_MIDDLE_FINGER_PHALANX_PROXIMAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_MIDDLE_FINGER_PHALANX_INTERMEDIATE);
+	BIND_ENUM_CONSTANT(HAND_JOINT_MIDDLE_FINGER_PHALANX_DISTAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_MIDDLE_FINGER_TIP);
+	BIND_ENUM_CONSTANT(HAND_JOINT_RING_FINGER_METACARPAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_RING_FINGER_PHALANX_PROXIMAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_RING_FINGER_PHALANX_INTERMEDIATE);
+	BIND_ENUM_CONSTANT(HAND_JOINT_RING_FINGER_PHALANX_DISTAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_RING_FINGER_TIP);
+	BIND_ENUM_CONSTANT(HAND_JOINT_PINKY_FINGER_METACARPAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_PINKY_FINGER_PHALANX_PROXIMAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_PINKY_FINGER_PHALANX_INTERMEDIATE);
+	BIND_ENUM_CONSTANT(HAND_JOINT_PINKY_FINGER_PHALANX_DISTAL);
+	BIND_ENUM_CONSTANT(HAND_JOINT_PINKY_FINGER_TIP);
+	BIND_ENUM_CONSTANT(HAND_JOINT_MAX);
+
+	BIND_BITFIELD_FLAG(HAND_JOINT_FLAG_ORIENTATION_VALID);
+	BIND_BITFIELD_FLAG(HAND_JOINT_FLAG_ORIENTATION_TRACKED);
+	BIND_BITFIELD_FLAG(HAND_JOINT_FLAG_POSITION_VALID);
+	BIND_BITFIELD_FLAG(HAND_JOINT_FLAG_POSITION_TRACKED);
+	BIND_BITFIELD_FLAG(HAND_JOINT_FLAG_LINEAR_VELOCITY_VALID);
+	BIND_BITFIELD_FLAG(HAND_JOINT_FLAG_ANGULAR_VELOCITY_VALID);
+}
+
+void XRHandTracker::set_hand(XRHandTracker::Hand p_hand) {
+	hand = p_hand;
+}
+
+XRHandTracker::Hand XRHandTracker::get_hand() const {
+	return hand;
+}
+
+void XRHandTracker::set_has_tracking_data(bool p_has_tracking_data) {
+	has_tracking_data = p_has_tracking_data;
+}
+
+bool XRHandTracker::get_has_tracking_data() const {
+	return has_tracking_data;
+}
+
+void XRHandTracker::set_hand_tracking_source(XRHandTracker::HandTrackingSource p_source) {
+	hand_tracking_source = p_source;
+}
+
+XRHandTracker::HandTrackingSource XRHandTracker::get_hand_tracking_source() const {
+	return hand_tracking_source;
+}
+
+void XRHandTracker::set_hand_joint_flags(XRHandTracker::HandJoint p_joint, BitField<XRHandTracker::HandJointFlags> p_flags) {
+	ERR_FAIL_INDEX(p_joint, HAND_JOINT_MAX);
+	hand_joint_flags[p_joint] = p_flags;
+}
+
+BitField<XRHandTracker::HandJointFlags> XRHandTracker::get_hand_joint_flags(XRHandTracker::HandJoint p_joint) const {
+	ERR_FAIL_INDEX_V(p_joint, HAND_JOINT_MAX, BitField<HandJointFlags>());
+	return hand_joint_flags[p_joint];
+}
+
+void XRHandTracker::set_hand_joint_transform(XRHandTracker::HandJoint p_joint, const Transform3D &p_transform) {
+	ERR_FAIL_INDEX(p_joint, HAND_JOINT_MAX);
+	hand_joint_transforms[p_joint] = p_transform;
+}
+
+Transform3D XRHandTracker::get_hand_joint_transform(XRHandTracker::HandJoint p_joint) const {
+	ERR_FAIL_INDEX_V(p_joint, HAND_JOINT_MAX, Transform3D());
+	return hand_joint_transforms[p_joint];
+}
+
+void XRHandTracker::set_hand_joint_radius(XRHandTracker::HandJoint p_joint, float p_radius) {
+	ERR_FAIL_INDEX(p_joint, HAND_JOINT_MAX);
+	hand_joint_radii[p_joint] = p_radius;
+}
+
+float XRHandTracker::get_hand_joint_radius(XRHandTracker::HandJoint p_joint) const {
+	ERR_FAIL_INDEX_V(p_joint, HAND_JOINT_MAX, 0.0);
+	return hand_joint_radii[p_joint];
+}
+
+void XRHandTracker::set_hand_joint_linear_velocity(XRHandTracker::HandJoint p_joint, const Vector3 &p_velocity) {
+	ERR_FAIL_INDEX(p_joint, HAND_JOINT_MAX);
+	hand_joint_linear_velocities[p_joint] = p_velocity;
+}
+
+Vector3 XRHandTracker::get_hand_joint_linear_velocity(XRHandTracker::HandJoint p_joint) const {
+	ERR_FAIL_INDEX_V(p_joint, HAND_JOINT_MAX, Vector3());
+	return hand_joint_linear_velocities[p_joint];
+}
+
+void XRHandTracker::set_hand_joint_angular_velocity(XRHandTracker::HandJoint p_joint, const Vector3 &p_velocity) {
+	ERR_FAIL_INDEX(p_joint, HAND_JOINT_MAX);
+	hand_joint_angular_velocities[p_joint] = p_velocity;
+}
+
+Vector3 XRHandTracker::get_hand_joint_angular_velocity(XRHandTracker::HandJoint p_joint) const {
+	ERR_FAIL_INDEX_V(p_joint, HAND_JOINT_MAX, Vector3());
+	return hand_joint_angular_velocities[p_joint];
+}

--- a/servers/xr/xr_hand_tracker.h
+++ b/servers/xr/xr_hand_tracker.h
@@ -1,0 +1,137 @@
+/**************************************************************************/
+/*  xr_hand_tracker.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef XR_HAND_TRACKER_H
+#define XR_HAND_TRACKER_H
+
+#include "core/object/ref_counted.h"
+
+class XRHandTracker : public RefCounted {
+	GDCLASS(XRHandTracker, RefCounted);
+	_THREAD_SAFE_CLASS_
+
+public:
+	enum Hand {
+		HAND_LEFT,
+		HAND_RIGHT,
+		HAND_MAX,
+	};
+
+	enum HandTrackingSource {
+		HAND_TRACKING_SOURCE_UNKNOWN,
+		HAND_TRACKING_SOURCE_UNOBSTRUCTED,
+		HAND_TRACKING_SOURCE_CONTROLLER,
+		HAND_TRACKING_SOURCE_MAX
+	};
+
+	enum HandJoint {
+		HAND_JOINT_PALM,
+		HAND_JOINT_WRIST,
+		HAND_JOINT_THUMB_METACARPAL,
+		HAND_JOINT_THUMB_PHALANX_PROXIMAL,
+		HAND_JOINT_THUMB_PHALANX_DISTAL,
+		HAND_JOINT_THUMB_TIP,
+		HAND_JOINT_INDEX_FINGER_METACARPAL,
+		HAND_JOINT_INDEX_FINGER_PHALANX_PROXIMAL,
+		HAND_JOINT_INDEX_FINGER_PHALANX_INTERMEDIATE,
+		HAND_JOINT_INDEX_FINGER_PHALANX_DISTAL,
+		HAND_JOINT_INDEX_FINGER_TIP,
+		HAND_JOINT_MIDDLE_FINGER_METACARPAL,
+		HAND_JOINT_MIDDLE_FINGER_PHALANX_PROXIMAL,
+		HAND_JOINT_MIDDLE_FINGER_PHALANX_INTERMEDIATE,
+		HAND_JOINT_MIDDLE_FINGER_PHALANX_DISTAL,
+		HAND_JOINT_MIDDLE_FINGER_TIP,
+		HAND_JOINT_RING_FINGER_METACARPAL,
+		HAND_JOINT_RING_FINGER_PHALANX_PROXIMAL,
+		HAND_JOINT_RING_FINGER_PHALANX_INTERMEDIATE,
+		HAND_JOINT_RING_FINGER_PHALANX_DISTAL,
+		HAND_JOINT_RING_FINGER_TIP,
+		HAND_JOINT_PINKY_FINGER_METACARPAL,
+		HAND_JOINT_PINKY_FINGER_PHALANX_PROXIMAL,
+		HAND_JOINT_PINKY_FINGER_PHALANX_INTERMEDIATE,
+		HAND_JOINT_PINKY_FINGER_PHALANX_DISTAL,
+		HAND_JOINT_PINKY_FINGER_TIP,
+		HAND_JOINT_MAX,
+	};
+
+	enum HandJointFlags {
+		HAND_JOINT_FLAG_ORIENTATION_VALID = 1,
+		HAND_JOINT_FLAG_ORIENTATION_TRACKED = 2,
+		HAND_JOINT_FLAG_POSITION_VALID = 4,
+		HAND_JOINT_FLAG_POSITION_TRACKED = 8,
+		HAND_JOINT_FLAG_LINEAR_VELOCITY_VALID = 16,
+		HAND_JOINT_FLAG_ANGULAR_VELOCITY_VALID = 32,
+	};
+
+	void set_hand(Hand p_hand);
+	Hand get_hand() const;
+
+	void set_has_tracking_data(bool p_has_tracking_data);
+	bool get_has_tracking_data() const;
+
+	void set_hand_tracking_source(HandTrackingSource p_source);
+	HandTrackingSource get_hand_tracking_source() const;
+
+	void set_hand_joint_flags(HandJoint p_joint, BitField<HandJointFlags> p_flags);
+	BitField<HandJointFlags> get_hand_joint_flags(HandJoint p_joint) const;
+
+	void set_hand_joint_transform(HandJoint p_joint, const Transform3D &p_transform);
+	Transform3D get_hand_joint_transform(HandJoint p_joint) const;
+
+	void set_hand_joint_radius(HandJoint p_joint, float p_radius);
+	float get_hand_joint_radius(HandJoint p_joint) const;
+
+	void set_hand_joint_linear_velocity(HandJoint p_joint, const Vector3 &p_velocity);
+	Vector3 get_hand_joint_linear_velocity(HandJoint p_joint) const;
+
+	void set_hand_joint_angular_velocity(HandJoint p_joint, const Vector3 &p_velocity);
+	Vector3 get_hand_joint_angular_velocity(HandJoint p_joint) const;
+
+protected:
+	static void _bind_methods();
+
+private:
+	Hand hand = HAND_LEFT;
+	bool has_tracking_data = false;
+	HandTrackingSource hand_tracking_source = HAND_TRACKING_SOURCE_UNKNOWN;
+
+	BitField<HandJointFlags> hand_joint_flags[HAND_JOINT_MAX];
+	Transform3D hand_joint_transforms[HAND_JOINT_MAX];
+	float hand_joint_radii[HAND_JOINT_MAX] = {};
+	Vector3 hand_joint_linear_velocities[HAND_JOINT_MAX];
+	Vector3 hand_joint_angular_velocities[HAND_JOINT_MAX];
+};
+
+VARIANT_ENUM_CAST(XRHandTracker::Hand)
+VARIANT_ENUM_CAST(XRHandTracker::HandTrackingSource)
+VARIANT_ENUM_CAST(XRHandTracker::HandJoint)
+VARIANT_BITFIELD_CAST(XRHandTracker::HandJointFlags)
+
+#endif // XR_HAND_TRACKER_H

--- a/servers/xr_server.h
+++ b/servers/xr_server.h
@@ -39,6 +39,7 @@
 
 class XRInterface;
 class XRPositionalTracker;
+class XRHandTracker;
 class XRFaceTracker;
 
 /**
@@ -86,7 +87,7 @@ private:
 
 	Vector<Ref<XRInterface>> interfaces;
 	Dictionary trackers;
-
+	Dictionary hand_trackers;
 	Dictionary face_trackers;
 
 	Ref<XRInterface> primary_interface; /* we'll identify one interface as primary, this will be used by our viewports */
@@ -185,6 +186,14 @@ public:
 	PackedStringArray get_suggested_tracker_names() const;
 	PackedStringArray get_suggested_pose_names(const StringName &p_tracker_name) const;
 	// Q: Should we add get_suggested_input_names and get_suggested_haptic_names even though we don't use them for the IDE?
+
+	/*
+		Hand trackers are objects that expose the tracked joints of a hand.
+	*/
+	void add_hand_tracker(const StringName &p_tracker_name, Ref<XRHandTracker> p_hand_tracker);
+	void remove_hand_tracker(const StringName &p_tracker_name);
+	Dictionary get_hand_trackers() const;
+	Ref<XRHandTracker> get_hand_tracker(const StringName &p_tracker_name) const;
 
 	/*
 		Face trackers are objects that expose the tracked blend shapes of a face.


### PR DESCRIPTION
This adds a generic interface for hand tracking similar to what PR https://github.com/godotengine/godot/pull/88312 added for face tracking, based on notes from @BastiaanOlij and @Malcolmnixon on RocketChat and Discord.

It deprecates `OpenXRHand` and the methods for accessing raw hand tracking data on `OpenXRInterface`.

While this does seem to work, it could use some testing - I plan to experiment with it some more myself, but testing from others would also be much appreciated as well!