### PR TITLE
Revert "Fix `NOTIFICATION_WM_SIZE_CHANGED` firing if the size hasn't changed"

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1193,10 +1193,7 @@ void Window::_update_viewport_size() {
 		}
 	}
 
-	if (old_size != size) {
-		old_size = size;
-		notification(NOTIFICATION_WM_SIZE_CHANGED);
-	}
+	notification(NOTIFICATION_WM_SIZE_CHANGED);
 
 	if (embedder) {
 		embedder->_sub_window_update(this);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -116,7 +116,6 @@ private:
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
 	mutable Size2i min_size;
 	mutable Size2i max_size;
-	mutable Size2i old_size = size;
 	mutable Vector<Vector2> mpath;
 	mutable Mode mode = MODE_WINDOWED;
 	mutable bool flags[FLAG_MAX] = {};


### PR DESCRIPTION
Reverts #84151. Welp, I tried. 

I still think this should be tackled sometime, as the `NOTIFICATION_WM_SIZE_CHANGED` notification fires an unnecessarily amount of times. But alas, there's stuff that currently relies on the faulty behavior.

Fixes #86767.