### PR TITLE
Use barriers between all blur passes with SSAO and SSIL

### DIFF
--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -899,10 +899,9 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 				int y_groups = p_ssil_buffers.buffer_height;
 
 				RD::get_singleton()->compute_list_dispatch_threads(compute_list, x_groups, y_groups, 1);
-				if (ssil_quality > RS::ENV_SSIL_QUALITY_VERY_LOW) {
-					RD::get_singleton()->compute_list_add_barrier(compute_list);
-				}
 			}
+
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
 		}
 
 		RD::get_singleton()->draw_command_end_label(); // Blur
@@ -1285,9 +1284,7 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 				RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_ssao_buffers.buffer_width, p_ssao_buffers.buffer_height, 1);
 			}
 
-			if (ssao_quality > RS::ENV_SSAO_QUALITY_VERY_LOW) {
-				RD::get_singleton()->compute_list_add_barrier(compute_list);
-			}
+			RD::get_singleton()->compute_list_add_barrier(compute_list);
 		}
 		RD::get_singleton()->draw_command_end_label(); // Blur
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/88468

Supersedes https://github.com/godotengine/godot/pull/88548