### PR TITLE
Add Texture Smooth Pixel Filter property to BaseMaterial3D

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -393,6 +393,10 @@
 		<member name="texture_repeat" type="bool" setter="set_flag" getter="get_flag" default="true">
 			Repeat flags for the texture. See [enum TextureFilter] for options.
 		</member>
+		<member name="texture_smooth_pixel_filter" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], displays the texture with an appearance that mimics nearest-neighbor filtering with a shader to smooth out aliasing between pixels. This can be used for a pixel art look that is still antialiased regardless of the current antialiasing method in use.
+			[b]Note:[/b] This internally forces the texture filter mode to the corresponding Linear filter mode, as the smooth pixel filtering shader relies on linear filtering to work.
+		</member>
 		<member name="transparency" type="int" setter="set_transparency" getter="get_transparency" enum="BaseMaterial3D.Transparency" default="0">
 			The material's transparency mode. Some transparency modes will disable shadow casting. Any transparency mode other than [constant TRANSPARENCY_DISABLED] has a greater performance impact compared to opaque rendering. See also [member blend_mode].
 		</member>
@@ -707,7 +711,10 @@
 		<constant name="FLAG_DISABLE_FOG" value="21" enum="Flags">
 			Disables receiving depth-based or volumetric fog.
 		</constant>
-		<constant name="FLAG_MAX" value="22" enum="Flags">
+		<constant name="FLAG_USE_TEXTURE_SMOOTH_PIXEL_FILTER" value="22" enum="Flags">
+			Enables shader-based smooth pixel filtering (see [member texture_smooth_pixel_filter]).
+		</constant>
+		<constant name="FLAG_MAX" value="23" enum="Flags">
 			Represents the size of the [enum Flags] enum.
 		</constant>
 		<constant name="DIFFUSE_BURLEY" value="0" enum="DiffuseMode">

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -127,6 +127,10 @@
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
 			Filter flags for the texture. See [enum BaseMaterial3D.TextureFilter] for options.
 		</member>
+		<member name="texture_smooth_pixel_filter" type="bool" setter="set_texture_smooth_pixel_filter" getter="get_texture_smooth_pixel_filter" default="false">
+			If [code]true[/code], displays the texture with an appearance that mimics nearest-neighbor filtering with a shader to smooth out aliasing between pixels. This can be used for a pixel art look that is still antialiased regardless of the current antialiasing method in use.
+			[b]Note:[/b] This internally forces the texture filter mode to the corresponding Linear filter mode, as the smooth pixel filtering shader relies on linear filtering to work.
+		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.
 		</member>

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -101,6 +101,10 @@
 			Filter flags for the texture. See [enum BaseMaterial3D.TextureFilter] for options.
 			[b]Note:[/b] Linear filtering may cause artifacts around the edges, which are especially noticeable on opaque textures. To prevent this, use textures with transparent or identical colors around the edges.
 		</member>
+		<member name="texture_smooth_pixel_filter" type="bool" setter="set_texture_smooth_pixel_filter" getter="get_texture_smooth_pixel_filter" default="false">
+			If [code]true[/code], displays the texture with an appearance that mimics nearest-neighbor filtering with a shader to smooth out aliasing between pixels. This can be used for a pixel art look that is still antialiased regardless of the current antialiasing method in use.
+			[b]Note:[/b] This internally forces the texture filter mode to the corresponding Linear filter mode, as the smooth pixel filtering shader relies on linear filtering to work.
+		</member>
 		<member name="transparent" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="true">
 			If [code]true[/code], the texture's transparency and the opacity are used to make those parts of the sprite invisible.
 		</member>

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -122,6 +122,9 @@ void Label3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &Label3D::set_texture_filter);
 	ClassDB::bind_method(D_METHOD("get_texture_filter"), &Label3D::get_texture_filter);
 
+	ClassDB::bind_method(D_METHOD("set_texture_smooth_pixel_filter", "smooth_pixel_filter"), &Label3D::set_texture_smooth_pixel_filter);
+	ClassDB::bind_method(D_METHOD("get_texture_smooth_pixel_filter"), &Label3D::get_texture_smooth_pixel_filter);
+
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &Label3D::generate_triangle_mesh);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0001,suffix:m"), "set_pixel_size", "get_pixel_size");
@@ -139,6 +142,7 @@ void Label3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alpha_antialiasing_mode", PROPERTY_HINT_ENUM, "Disabled,Alpha Edge Blend,Alpha Edge Clip"), "set_alpha_antialiasing", "get_alpha_antialiasing");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_antialiasing_edge", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_antialiasing_edge", "get_alpha_antialiasing_edge");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "texture_smooth_pixel_filter"), "set_texture_smooth_pixel_filter", "get_texture_smooth_pixel_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "outline_render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_outline_render_priority", "get_outline_render_priority");
 
@@ -388,7 +392,7 @@ void Label3D::_generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, 
 			}
 
 			RID shader_rid;
-			StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, msdf, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), texture_filter, alpha_antialiasing_mode, &shader_rid);
+			StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, msdf, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), texture_filter, texture_smooth_pixel_filter, alpha_antialiasing_mode, &shader_rid);
 
 			RS::get_singleton()->material_set_shader(surf.material, shader_rid);
 			RS::get_singleton()->material_set_param(surf.material, "texture_albedo", tex);
@@ -990,6 +994,17 @@ void Label3D::set_texture_filter(StandardMaterial3D::TextureFilter p_filter) {
 
 StandardMaterial3D::TextureFilter Label3D::get_texture_filter() const {
 	return texture_filter;
+}
+
+void Label3D::set_texture_smooth_pixel_filter(bool p_smooth_pixel_filter) {
+	if (texture_smooth_pixel_filter != p_smooth_pixel_filter) {
+		texture_smooth_pixel_filter = p_smooth_pixel_filter;
+		_queue_update();
+	}
+}
+
+bool Label3D::get_texture_smooth_pixel_filter() const {
+	return texture_smooth_pixel_filter;
 }
 
 Label3D::AlphaCutMode Label3D::get_alpha_cut_mode() const {

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -139,6 +139,7 @@ private:
 	RID base_material;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
 	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	bool texture_smooth_pixel_filter = false;
 
 	bool pending_update = false;
 
@@ -251,6 +252,9 @@ public:
 
 	void set_texture_filter(StandardMaterial3D::TextureFilter p_filter);
 	StandardMaterial3D::TextureFilter get_texture_filter() const;
+
+	void set_texture_smooth_pixel_filter(bool p_smooth_pixel_filter);
+	bool get_texture_smooth_pixel_filter() const;
 
 	virtual AABB get_aabb() const override;
 	Ref<TriangleMesh> generate_triangle_mesh() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -268,7 +268,7 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 	}
 
 	RID shader_rid;
-	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), alpha_antialiasing_mode, &shader_rid);
+	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), texture_smooth_pixel_filter, alpha_antialiasing_mode, &shader_rid);
 
 	if (last_shader != shader_rid) {
 		RS::get_singleton()->material_set_shader(get_material(), shader_rid);
@@ -587,6 +587,19 @@ StandardMaterial3D::TextureFilter SpriteBase3D::get_texture_filter() const {
 	return texture_filter;
 }
 
+void SpriteBase3D::set_texture_smooth_pixel_filter(bool p_smooth_pixel_filter) {
+	if (texture_smooth_pixel_filter == p_smooth_pixel_filter) {
+		return;
+	}
+
+	texture_smooth_pixel_filter = p_smooth_pixel_filter;
+	_queue_redraw();
+}
+
+bool SpriteBase3D::get_texture_smooth_pixel_filter() const {
+	return texture_smooth_pixel_filter;
+}
+
 void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &SpriteBase3D::set_centered);
 	ClassDB::bind_method(D_METHOD("is_centered"), &SpriteBase3D::is_centered);
@@ -636,6 +649,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &SpriteBase3D::set_texture_filter);
 	ClassDB::bind_method(D_METHOD("get_texture_filter"), &SpriteBase3D::get_texture_filter);
 
+	ClassDB::bind_method(D_METHOD("set_texture_smooth_pixel_filter", "smooth_pixel_filter"), &SpriteBase3D::set_texture_smooth_pixel_filter);
+	ClassDB::bind_method(D_METHOD("get_texture_smooth_pixel_filter"), &SpriteBase3D::get_texture_smooth_pixel_filter);
+
 	ClassDB::bind_method(D_METHOD("get_item_rect"), &SpriteBase3D::get_item_rect);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &SpriteBase3D::generate_triangle_mesh);
 
@@ -659,6 +675,7 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alpha_antialiasing_mode", PROPERTY_HINT_ENUM, "Disabled,Alpha Edge Blend,Alpha Edge Clip"), "set_alpha_antialiasing", "get_alpha_antialiasing");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_antialiasing_edge", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_antialiasing_edge", "get_alpha_antialiasing_edge");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "texture_smooth_pixel_filter"), "set_texture_smooth_pixel_filter", "get_texture_smooth_pixel_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 
 	BIND_ENUM_CONSTANT(FLAG_TRANSPARENT);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -93,6 +93,7 @@ private:
 	float alpha_antialiasing_edge = 0.0f;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
 	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	bool texture_smooth_pixel_filter = false;
 	bool pending_update = false;
 	void _im_update();
 
@@ -167,6 +168,9 @@ public:
 
 	void set_texture_filter(StandardMaterial3D::TextureFilter p_filter);
 	StandardMaterial3D::TextureFilter get_texture_filter() const;
+
+	void set_texture_smooth_pixel_filter(bool p_smooth_pixel_filter);
+	bool get_texture_smooth_pixel_filter() const;
 
 	virtual Rect2 get_item_rect() const = 0;
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -261,6 +261,7 @@ public:
 		FLAG_PARTICLE_TRAILS_MODE,
 		FLAG_ALBEDO_TEXTURE_MSDF,
 		FLAG_DISABLE_FOG,
+		FLAG_USE_TEXTURE_SMOOTH_PIXEL_FILTER,
 		FLAG_MAX
 	};
 
@@ -773,7 +774,7 @@ public:
 	static void finish_shaders();
 	static void flush_changes();
 
-	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, RID *r_shader_rid = nullptr);
+	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, bool p_smooth_pixel_filter = false, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, RID *r_shader_rid = nullptr);
 
 	virtual RID get_shader_rid() const override;
 


### PR DESCRIPTION
When enabled, this displays the texture with an appearance that mimics nearest-neighbor filtering with a shader to smooth out aliasing between pixels. This can be used for a pixel art look that is still antialiased regardless of the current antialiasing method in use.

This is also available in SpriteBase3D and Label3D. This could also be implemented in Decal (via a project setting to toggle it for all decals), but this may be left to a future PR as it's more complex.

Thanks to @CptPotato for providing the [shader code](https://github.com/CptPotato/GodotThings/tree/master/SmoothPixelFiltering) :slightly_smiling_face: 

- This closes https://github.com/godotengine/godot-proposals/issues/9106.

**Testing project:** [test_smooth_pixel_filtering.zip](https://github.com/godotengine/godot/files/14366232/test_smooth_pixel_filtering.zip)

## Preview

Disabled | Enabled
-|-
![Disabled](https://github.com/godotengine/godot/assets/180032/ad4206c6-d2a0-4c49-99fa-17f05ce838d9) | ![Enabled](https://github.com/godotengine/godot/assets/180032/1ddf7e4c-71af-4cc1-a8b7-18a19a6bb83c)

On Label3D (alpha transparency) and SpriteBase3D (alpha scissor transparency, so only the internals are smoothed out):

![Label3D and SpriteBase3D](https://github.com/godotengine/godot/assets/180032/3d6f56f7-07ae-4e08-b060-50e2af9d7134)

### Without mipmaps

*Watch videos in fullscreen to avoid aliasing (viewport resolution is 1280×720, but videos are 3840×2160).*

#### Disabled

https://github.com/godotengine/godot/assets/180032/792371f0-ba50-4d5d-a174-5b1ca4f76f43

#### Enabled

https://github.com/godotengine/godot/assets/180032/3247d467-60a6-4d71-b58a-5167c96f41d9

### With mipmaps + 16× anisotropic filtering

#### Disabled

https://github.com/godotengine/godot/assets/180032/ae66bfef-58bc-4eec-96c6-2db8d7622bdc

#### Enabled

https://github.com/godotengine/godot/assets/180032/16dc733a-2ad5-499f-9214-5484b1ef40c0

