### PR TITLE
[TextServer] Improve text server interlocking (ver. 3).

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -141,6 +141,7 @@ public:
 		initialize_rid(rid);
 		return rid;
 	}
+
 	RID make_rid(const T &p_value) {
 		RID rid = _allocate_rid();
 		initialize_rid(rid, p_value);
@@ -209,11 +210,13 @@ public:
 
 		return ptr;
 	}
+
 	void initialize_rid(RID p_rid) {
 		T *mem = get_or_null(p_rid, true);
 		ERR_FAIL_NULL(mem);
 		memnew_placement(mem, T);
 	}
+
 	void initialize_rid(RID p_rid, const T &p_value) {
 		T *mem = get_or_null(p_rid, true);
 		ERR_FAIL_NULL(mem);
@@ -292,6 +295,7 @@ public:
 	_FORCE_INLINE_ uint32_t get_rid_count() const {
 		return alloc_count;
 	}
+
 	void get_owned_list(List<RID> *p_owned) const {
 		if (THREAD_SAFE) {
 			spin_lock.lock();
@@ -345,6 +349,371 @@ public:
 				}
 				if (validator != 0xFFFFFFFF) {
 					chunks[i / elements_in_chunk][i % elements_in_chunk].~T();
+				}
+			}
+		}
+
+		uint32_t chunk_count = max_alloc / elements_in_chunk;
+		for (uint32_t i = 0; i < chunk_count; i++) {
+			memfree(chunks[i]);
+			memfree(validator_chunks[i]);
+			memfree(free_list_chunks[i]);
+		}
+
+		if (chunks) {
+			memfree(chunks);
+			memfree(free_list_chunks);
+			memfree(validator_chunks);
+		}
+	}
+};
+
+template <class T, bool THREAD_SAFE = false>
+class RID_AllocRefCounted : public RID_AllocBase {
+	T ***chunks = nullptr;
+	uint32_t **free_list_chunks = nullptr;
+	uint32_t **validator_chunks = nullptr;
+
+	uint32_t elements_in_chunk;
+	uint32_t max_alloc = 0;
+	uint32_t alloc_count = 0;
+
+	const char *description = nullptr;
+
+	mutable SpinLock spin_lock;
+
+	_FORCE_INLINE_ RID _allocate_rid() {
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+
+		if (alloc_count == max_alloc) {
+			//allocate a new chunk
+			uint32_t chunk_count = alloc_count == 0 ? 0 : (max_alloc / elements_in_chunk);
+
+			//grow chunks
+			chunks = (T ***)memrealloc(chunks, sizeof(T **) * (chunk_count + 1));
+			chunks[chunk_count] = (T **)memalloc(sizeof(T) * elements_in_chunk); //but don't initialize
+
+			//grow validators
+			validator_chunks = (uint32_t **)memrealloc(validator_chunks, sizeof(uint32_t *) * (chunk_count + 1));
+			validator_chunks[chunk_count] = (uint32_t *)memalloc(sizeof(uint32_t) * elements_in_chunk);
+			//grow free lists
+			free_list_chunks = (uint32_t **)memrealloc(free_list_chunks, sizeof(uint32_t *) * (chunk_count + 1));
+			free_list_chunks[chunk_count] = (uint32_t *)memalloc(sizeof(uint32_t) * elements_in_chunk);
+
+			//initialize
+			for (uint32_t i = 0; i < elements_in_chunk; i++) {
+				// Don't initialize chunk.
+				validator_chunks[chunk_count][i] = 0xFFFFFFFF;
+				free_list_chunks[chunk_count][i] = alloc_count + i;
+			}
+
+			max_alloc += elements_in_chunk;
+		}
+
+		uint32_t free_index = free_list_chunks[alloc_count / elements_in_chunk][alloc_count % elements_in_chunk];
+
+		uint32_t free_chunk = free_index / elements_in_chunk;
+		uint32_t free_element = free_index % elements_in_chunk;
+
+		uint32_t validator = (uint32_t)(_gen_id() & 0x7FFFFFFF);
+		CRASH_COND_MSG(validator == 0x7FFFFFFF, "Overflow in RID validator");
+		uint64_t id = validator;
+		id <<= 32;
+		id |= free_index;
+
+		validator_chunks[free_chunk][free_element] = validator;
+
+		validator_chunks[free_chunk][free_element] |= 0x80000000; //mark uninitialized bit
+
+		alloc_count++;
+
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+
+		return _make_from_id(id);
+	}
+
+public:
+	RID make_rid() {
+		RID rid = _allocate_rid();
+		initialize_rid(rid);
+		return rid;
+	}
+
+	RID make_rid(T *p_value) {
+		RID rid = _allocate_rid();
+		initialize_rid(rid, p_value);
+		return rid;
+	}
+
+	//allocate but don't initialize, use initialize_rid afterwards
+	RID allocate_rid() {
+		return _allocate_rid();
+	}
+
+	_FORCE_INLINE_ T **get_or_null(const RID &p_rid, bool p_initialize = false) {
+		if (p_rid == RID()) {
+			return nullptr;
+		}
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+
+		uint64_t id = p_rid.get_id();
+		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
+		if (unlikely(idx >= max_alloc)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			return nullptr;
+		}
+
+		uint32_t idx_chunk = idx / elements_in_chunk;
+		uint32_t idx_element = idx % elements_in_chunk;
+
+		uint32_t validator = uint32_t(id >> 32);
+
+		if (unlikely(p_initialize)) {
+			if (unlikely(!(validator_chunks[idx_chunk][idx_element] & 0x80000000))) {
+				if (THREAD_SAFE) {
+					spin_lock.unlock();
+				}
+				ERR_FAIL_V_MSG(nullptr, "Initializing already initialized RID");
+			}
+
+			if (unlikely((validator_chunks[idx_chunk][idx_element] & 0x7FFFFFFF) != validator)) {
+				if (THREAD_SAFE) {
+					spin_lock.unlock();
+				}
+				ERR_FAIL_V_MSG(nullptr, "Attempting to initialize the wrong RID");
+			}
+
+			validator_chunks[idx_chunk][idx_element] &= 0x7FFFFFFF; //initialized
+
+		} else if (unlikely(validator_chunks[idx_chunk][idx_element] != validator)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			if ((validator_chunks[idx_chunk][idx_element] & 0x80000000) && validator_chunks[idx_chunk][idx_element] != 0xFFFFFFFF) {
+				ERR_FAIL_V_MSG(nullptr, "Attempting to use an uninitialized RID");
+			}
+			return nullptr;
+		}
+
+		T **ptr = &chunks[idx_chunk][idx_element];
+
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+
+		return ptr;
+	}
+
+	_FORCE_INLINE_ Ref<T> get_ref(const RID &p_rid, bool p_initialize = false) {
+		if (p_rid == RID()) {
+			return Ref<T>();
+		}
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+
+		uint64_t id = p_rid.get_id();
+		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
+		if (unlikely(idx >= max_alloc)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			return Ref<T>();
+		}
+
+		uint32_t idx_chunk = idx / elements_in_chunk;
+		uint32_t idx_element = idx % elements_in_chunk;
+
+		uint32_t validator = uint32_t(id >> 32);
+
+		if (unlikely(p_initialize)) {
+			if (unlikely(!(validator_chunks[idx_chunk][idx_element] & 0x80000000))) {
+				if (THREAD_SAFE) {
+					spin_lock.unlock();
+				}
+				ERR_FAIL_V_MSG(Ref<T>(), "Initializing already initialized RID");
+			}
+
+			if (unlikely((validator_chunks[idx_chunk][idx_element] & 0x7FFFFFFF) != validator)) {
+				if (THREAD_SAFE) {
+					spin_lock.unlock();
+				}
+				ERR_FAIL_V_MSG(Ref<T>(), "Attempting to initialize the wrong RID");
+			}
+
+			validator_chunks[idx_chunk][idx_element] &= 0x7FFFFFFF; //initialized
+
+		} else if (unlikely(validator_chunks[idx_chunk][idx_element] != validator)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			if ((validator_chunks[idx_chunk][idx_element] & 0x80000000) && validator_chunks[idx_chunk][idx_element] != 0xFFFFFFFF) {
+				ERR_FAIL_V_MSG(Ref<T>(), "Attempting to use an uninitialized RID");
+			}
+			return Ref<T>();
+		}
+
+		Ref<T> ptr = Ref<T>(chunks[idx_chunk][idx_element]);
+
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+
+		return ptr;
+	}
+
+	void initialize_rid(RID p_rid) {
+		T **mem = get_or_null(p_rid, true);
+		ERR_FAIL_NULL(mem);
+		*mem = nullptr;
+	}
+
+	void initialize_rid(RID p_rid, T *p_value) {
+		T **mem = get_or_null(p_rid, true);
+		ERR_FAIL_NULL(mem);
+		*mem = p_value;
+	}
+
+	_FORCE_INLINE_ bool owns(const RID &p_rid) const {
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+
+		uint64_t id = p_rid.get_id();
+		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
+		if (unlikely(idx >= max_alloc)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			return false;
+		}
+
+		uint32_t idx_chunk = idx / elements_in_chunk;
+		uint32_t idx_element = idx % elements_in_chunk;
+
+		uint32_t validator = uint32_t(id >> 32);
+
+		bool owned = (validator != 0x7FFFFFFF) && (validator_chunks[idx_chunk][idx_element] & 0x7FFFFFFF) == validator;
+
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+
+		return owned;
+	}
+
+	_FORCE_INLINE_ void free(const RID &p_rid) {
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+
+		uint64_t id = p_rid.get_id();
+		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
+		if (unlikely(idx >= max_alloc)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			ERR_FAIL();
+		}
+
+		uint32_t idx_chunk = idx / elements_in_chunk;
+		uint32_t idx_element = idx % elements_in_chunk;
+
+		uint32_t validator = uint32_t(id >> 32);
+		if (unlikely(validator_chunks[idx_chunk][idx_element] & 0x80000000)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			ERR_FAIL_MSG("Attempted to free an uninitialized or invalid RID");
+		} else if (unlikely(validator_chunks[idx_chunk][idx_element] != validator)) {
+			if (THREAD_SAFE) {
+				spin_lock.unlock();
+			}
+			ERR_FAIL();
+		}
+
+		if (chunks[idx_chunk][idx_element] && chunks[idx_chunk][idx_element]->unreference()) {
+			memdelete(chunks[idx_chunk][idx_element]);
+		}
+		chunks[idx_chunk][idx_element] = nullptr;
+		validator_chunks[idx_chunk][idx_element] = 0xFFFFFFFF; // go invalid
+
+		alloc_count--;
+		free_list_chunks[alloc_count / elements_in_chunk][alloc_count % elements_in_chunk] = idx;
+
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+	}
+
+	_FORCE_INLINE_ uint32_t get_rid_count() const {
+		return alloc_count;
+	}
+
+	void get_owned_list(List<RID> *p_owned) const {
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+		for (size_t i = 0; i < max_alloc; i++) {
+			uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];
+			if (validator != 0xFFFFFFFF) {
+				p_owned->push_back(_make_from_id((validator << 32) | i));
+			}
+		}
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+	}
+
+	//used for fast iteration in the elements or RIDs
+	void fill_owned_buffer(RID *p_rid_buffer) const {
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+		uint32_t idx = 0;
+		for (size_t i = 0; i < max_alloc; i++) {
+			uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];
+			if (validator != 0xFFFFFFFF) {
+				p_rid_buffer[idx] = _make_from_id((validator << 32) | i);
+				idx++;
+			}
+		}
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+	}
+
+	void set_description(const char *p_descrption) {
+		description = p_descrption;
+	}
+
+	RID_AllocRefCounted(uint32_t p_target_chunk_byte_size = 65536) {
+		elements_in_chunk = sizeof(T *) > p_target_chunk_byte_size ? 1 : (p_target_chunk_byte_size / sizeof(T *));
+	}
+
+	~RID_AllocRefCounted() {
+		if (alloc_count) {
+			print_error(vformat("ERROR: %d RID allocations of type '%s' were leaked at exit.",
+					alloc_count, description ? description : typeid(T).name()));
+
+			for (size_t i = 0; i < max_alloc; i++) {
+				uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];
+				if (validator & 0x80000000) {
+					continue; //uninitialized
+				}
+				if (validator != 0xFFFFFFFF) {
+					if (chunks[i / elements_in_chunk][i % elements_in_chunk] && chunks[i / elements_in_chunk][i % elements_in_chunk]->unreference()) {
+						memdelete(chunks[i / elements_in_chunk][i % elements_in_chunk]);
+					}
+					chunks[i / elements_in_chunk][i % elements_in_chunk] = nullptr;
 				}
 			}
 		}
@@ -474,6 +843,55 @@ public:
 		alloc.set_description(p_descrption);
 	}
 	RID_Owner(uint32_t p_target_chunk_byte_size = 65536) :
+			alloc(p_target_chunk_byte_size) {}
+};
+
+template <class T, bool THREAD_SAFE = false>
+class RID_RefCountedOwner {
+	RID_AllocRefCounted<T, THREAD_SAFE> alloc;
+
+public:
+	_FORCE_INLINE_ RID make_rid(T *p_ptr) {
+		return alloc.make_rid(p_ptr);
+	}
+
+	_FORCE_INLINE_ RID allocate_rid() {
+		return alloc.allocate_rid();
+	}
+
+	_FORCE_INLINE_ void initialize_rid(RID p_rid, T *p_ptr) {
+		alloc.initialize_rid(p_rid, p_ptr);
+	}
+
+	_FORCE_INLINE_ Ref<T> get_ref(const RID &p_rid) {
+		return alloc.get_ref(p_rid);
+	}
+
+	_FORCE_INLINE_ bool owns(const RID &p_rid) const {
+		return alloc.owns(p_rid);
+	}
+
+	_FORCE_INLINE_ void free(const RID &p_rid) {
+		alloc.free(p_rid);
+	}
+
+	_FORCE_INLINE_ uint32_t get_rid_count() const {
+		return alloc.get_rid_count();
+	}
+
+	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) const {
+		return alloc.get_owned_list(p_owned);
+	}
+
+	void fill_owned_buffer(RID *p_rid_buffer) const {
+		alloc.fill_owned_buffer(p_rid_buffer);
+	}
+
+	void set_description(const char *p_descrption) {
+		alloc.set_description(p_descrption);
+	}
+
+	RID_RefCountedOwner(uint32_t p_target_chunk_byte_size = 65536) :
 			alloc(p_target_chunk_byte_size) {}
 };
 

--- a/misc/error_suppressions/tsan.txt
+++ b/misc/error_suppressions/tsan.txt
@@ -2,7 +2,5 @@
 # https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
 deadlock:tests/core/templates/test_command_queue.h
-deadlock:modules/text_server_adv/text_server_adv.cpp
-deadlock:modules/text_server_fb/text_server_fb.cpp
 race:modules/navigation/nav_map.cpp
 

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -131,7 +131,6 @@ using namespace godot;
 
 class TextServerAdvanced : public TextServerExtension {
 	GDCLASS(TextServerAdvanced, TextServerExtension);
-	_THREAD_SAFE_CLASS_
 
 	struct NumSystemData {
 		HashSet<StringName> lang;
@@ -260,6 +259,8 @@ class TextServerAdvanced : public TextServerExtension {
 		Vector2 advance;
 	};
 
+	static Mutex ft_mutex;
+
 	struct FontForSizeAdvanced {
 		double ascent = 0.0;
 		double descent = 0.0;
@@ -287,19 +288,23 @@ class TextServerAdvanced : public TextServerExtension {
 			}
 #ifdef MODULE_FREETYPE_ENABLED
 			if (face != nullptr) {
+				TextServerAdvanced::ft_mutex.lock();
 				FT_Done_Face(face);
+				TextServerAdvanced::ft_mutex.unlock();
 			}
 #endif
 		}
 	};
 
-	struct FontAdvancedLinkedVariation {
+	struct FontAdvancedLinkedVariation : public RefCounted {
+		Mutex mutex;
+
 		RID base_font;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
 		float baseline_offset = 0.0;
 	};
 
-	struct FontAdvanced {
+	struct FontAdvanced : public RefCounted {
 		Mutex mutex;
 
 		TextServer::FontAntialiasing antialiasing = TextServer::FONT_ANTIALIASING_GRAY;
@@ -353,17 +358,17 @@ class TextServerAdvanced : public TextServerExtension {
 
 	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeAdvanced *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
 #ifdef MODULE_MSDFGEN_ENABLED
-	_FORCE_INLINE_ FontGlyph rasterize_msdf(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const;
+	_FORCE_INLINE_ FontGlyph rasterize_msdf(Ref<FontAdvanced> &p_font_data, FontForSizeAdvanced *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const;
 #endif
 #ifdef MODULE_FREETYPE_ENABLED
 	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap bitmap, int yofs, int xofs, const Vector2 &advance, bool p_bgra) const;
 #endif
-	_FORCE_INLINE_ bool _ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
-	_FORCE_INLINE_ bool _ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size) const;
-	_FORCE_INLINE_ void _font_clear_cache(FontAdvanced *p_font_data);
+	_FORCE_INLINE_ bool _ensure_glyph(Ref<FontAdvanced> &p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
+	_FORCE_INLINE_ bool _ensure_cache_for_size(Ref<FontAdvanced> &p_font_data, const Vector2i &p_size) const;
+	_FORCE_INLINE_ void _font_clear_cache(Ref<FontAdvanced> &p_font_data);
 	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
-	_FORCE_INLINE_ Vector2i _get_size(const FontAdvanced *p_font_data, int p_size) const {
+	_FORCE_INLINE_ Vector2i _get_size(const Ref<FontAdvanced> &p_font_data, int p_size) const {
 		if (p_font_data->msdf) {
 			return Vector2i(p_font_data->msdf_source_size, 0);
 		} else if (p_font_data->fixed_size > 0) {
@@ -373,7 +378,7 @@ class TextServerAdvanced : public TextServerExtension {
 		}
 	}
 
-	_FORCE_INLINE_ Vector2i _get_size_outline(const FontAdvanced *p_font_data, const Vector2i &p_size) const {
+	_FORCE_INLINE_ Vector2i _get_size_outline(const Ref<FontAdvanced> &p_font_data, const Vector2i &p_size) const {
 		if (p_font_data->msdf) {
 			return Vector2i(p_font_data->msdf_source_size, 0);
 		} else if (p_font_data->fixed_size > 0) {
@@ -445,7 +450,7 @@ class TextServerAdvanced : public TextServerExtension {
 		Vector<Glyph> ellipsis_glyph_buf;
 	};
 
-	struct ShapedTextDataAdvanced {
+	struct ShapedTextDataAdvanced : public RefCounted {
 		Mutex mutex;
 
 		/* Source data */
@@ -543,17 +548,17 @@ class TextServerAdvanced : public TextServerExtension {
 	// Common data.
 
 	double oversampling = 1.0;
-	mutable RID_PtrOwner<FontAdvancedLinkedVariation> font_var_owner;
-	mutable RID_PtrOwner<FontAdvanced> font_owner;
-	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
+	mutable RID_RefCountedOwner<FontAdvancedLinkedVariation, true> font_var_owner;
+	mutable RID_RefCountedOwner<FontAdvanced, true> font_owner;
+	mutable RID_RefCountedOwner<ShapedTextDataAdvanced, true> shaped_owner;
 
-	_FORCE_INLINE_ FontAdvanced *_get_font_data(const RID &p_font_rid) const {
+	_FORCE_INLINE_ Ref<FontAdvanced> _get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
-		FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(rid);
-		if (unlikely(fdv)) {
+		Ref<FontAdvancedLinkedVariation> fdv = font_var_owner.get_ref(p_font_rid);
+		if (unlikely(fdv.is_valid())) {
 			rid = fdv->base_font;
 		}
-		return font_owner.get_or_null(rid);
+		return font_owner.get_ref(rid);
 	}
 
 	struct SystemFontKey {
@@ -643,19 +648,17 @@ class TextServerAdvanced : public TextServerExtension {
 	mutable HashMap<SystemFontKey, SystemFontCache, SystemFontKeyHasher> system_fonts;
 	mutable HashMap<String, PackedByteArray> system_font_data;
 
-	void _update_chars(ShapedTextDataAdvanced *p_sd) const;
-	void _realign(ShapedTextDataAdvanced *p_sd) const;
+	void _update_chars(Ref<ShapedTextDataAdvanced> &p_sd) const;
+	void _realign(Ref<ShapedTextDataAdvanced> &p_sd) const;
 	int64_t _convert_pos(const String &p_utf32, const Char16String &p_utf16, int64_t p_pos) const;
-	int64_t _convert_pos(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const;
-	int64_t _convert_pos_inv(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const;
-	bool _shape_substr(ShapedTextDataAdvanced *p_new_sd, const ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_length) const;
-	void _shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, RID p_prev_font);
-	Glyph _shape_single_glyph(ShapedTextDataAdvanced *p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size);
+	int64_t _convert_pos(const Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_pos) const;
+	int64_t _convert_pos_inv(const Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_pos) const;
+	bool _shape_substr(Ref<ShapedTextDataAdvanced> &p_new_sd, const Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_start, int64_t p_length) const;
+	void _shape_run(Ref<ShapedTextDataAdvanced> &p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, RID p_prev_font);
+	Glyph _shape_single_glyph(Ref<ShapedTextDataAdvanced> &p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size);
 	_FORCE_INLINE_ RID _find_sys_font_for_text(const RID &p_fdef, const String &p_script_code, const String &p_language, const String &p_text);
 
 	_FORCE_INLINE_ void _add_featuers(const Dictionary &p_source, Vector<hb_feature_t> &r_ftrs);
-
-	Mutex ft_mutex;
 
 	// HarfBuzz bitmap font interface.
 
@@ -698,8 +701,8 @@ class TextServerAdvanced : public TextServerExtension {
 protected:
 	static void _bind_methods(){};
 
-	void full_copy(ShapedTextDataAdvanced *p_shaped);
-	void invalidate(ShapedTextDataAdvanced *p_shaped, bool p_text = false);
+	void full_copy(Ref<ShapedTextDataAdvanced> &p_shaped);
+	void invalidate(Ref<ShapedTextDataAdvanced> &p_shaped, bool p_text = false);
 
 public:
 	MODBIND1RC(bool, has_feature, Feature);

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -111,7 +111,6 @@ using namespace godot;
 
 class TextServerFallback : public TextServerExtension {
 	GDCLASS(TextServerFallback, TextServerExtension);
-	_THREAD_SAFE_CLASS_
 
 	HashMap<StringName, int32_t> feature_sets;
 	HashMap<int32_t, StringName> feature_sets_inv;
@@ -216,6 +215,8 @@ class TextServerFallback : public TextServerExtension {
 		Vector2 advance;
 	};
 
+	static Mutex ft_mutex;
+
 	struct FontForSizeFallback {
 		double ascent = 0.0;
 		double descent = 0.0;
@@ -238,19 +239,23 @@ class TextServerFallback : public TextServerExtension {
 		~FontForSizeFallback() {
 #ifdef MODULE_FREETYPE_ENABLED
 			if (face != nullptr) {
+				TextServerFallback::ft_mutex.lock();
 				FT_Done_Face(face);
+				TextServerFallback::ft_mutex.unlock();
 			}
 #endif
 		}
 	};
 
-	struct FontFallbackLinkedVariation {
+	struct FontFallbackLinkedVariation : public RefCounted {
+		Mutex mutex;
+
 		RID base_font;
 		int extra_spacing[4] = { 0, 0, 0, 0 };
 		float baseline_offset = 0.0;
 	};
 
-	struct FontFallback {
+	struct FontFallback : public RefCounted {
 		Mutex mutex;
 
 		TextServer::FontAntialiasing antialiasing = TextServer::FONT_ANTIALIASING_GRAY;
@@ -302,17 +307,17 @@ class TextServerFallback : public TextServerExtension {
 
 	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeFallback *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
 #ifdef MODULE_MSDFGEN_ENABLED
-	_FORCE_INLINE_ FontGlyph rasterize_msdf(FontFallback *p_font_data, FontForSizeFallback *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const;
+	_FORCE_INLINE_ FontGlyph rasterize_msdf(Ref<FontFallback> &p_font_data, FontForSizeFallback *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const;
 #endif
 #ifdef MODULE_FREETYPE_ENABLED
 	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap bitmap, int yofs, int xofs, const Vector2 &advance, bool p_bgra) const;
 #endif
-	_FORCE_INLINE_ bool _ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
-	_FORCE_INLINE_ bool _ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size) const;
-	_FORCE_INLINE_ void _font_clear_cache(FontFallback *p_font_data);
+	_FORCE_INLINE_ bool _ensure_glyph(Ref<FontFallback> &p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
+	_FORCE_INLINE_ bool _ensure_cache_for_size(Ref<FontFallback> &p_font_data, const Vector2i &p_size) const;
+	_FORCE_INLINE_ void _font_clear_cache(Ref<FontFallback> &p_font_data);
 	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
-	_FORCE_INLINE_ Vector2i _get_size(const FontFallback *p_font_data, int p_size) const {
+	_FORCE_INLINE_ Vector2i _get_size(const Ref<FontFallback> &p_font_data, int p_size) const {
 		if (p_font_data->msdf) {
 			return Vector2i(p_font_data->msdf_source_size, 0);
 		} else if (p_font_data->fixed_size > 0) {
@@ -322,7 +327,7 @@ class TextServerFallback : public TextServerExtension {
 		}
 	}
 
-	_FORCE_INLINE_ Vector2i _get_size_outline(const FontFallback *p_font_data, const Vector2i &p_size) const {
+	_FORCE_INLINE_ Vector2i _get_size_outline(const Ref<FontFallback> &p_font_data, const Vector2i &p_size) const {
 		if (p_font_data->msdf) {
 			return Vector2i(p_font_data->msdf_source_size, 0);
 		} else if (p_font_data->fixed_size > 0) {
@@ -391,7 +396,7 @@ class TextServerFallback : public TextServerExtension {
 		Vector<Glyph> ellipsis_glyph_buf;
 	};
 
-	struct ShapedTextDataFallback {
+	struct ShapedTextDataFallback : public RefCounted {
 		Mutex mutex;
 
 		/* Source data */
@@ -459,17 +464,17 @@ class TextServerFallback : public TextServerExtension {
 	// Common data.
 
 	double oversampling = 1.0;
-	mutable RID_PtrOwner<FontFallbackLinkedVariation> font_var_owner;
-	mutable RID_PtrOwner<FontFallback> font_owner;
-	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner;
+	mutable RID_RefCountedOwner<FontFallbackLinkedVariation, true> font_var_owner;
+	mutable RID_RefCountedOwner<FontFallback, true> font_owner;
+	mutable RID_RefCountedOwner<ShapedTextDataFallback, true> shaped_owner;
 
-	_FORCE_INLINE_ FontFallback *_get_font_data(const RID &p_font_rid) const {
+	_FORCE_INLINE_ Ref<FontFallback> _get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
-		FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(rid);
-		if (unlikely(fdv)) {
+		Ref<FontFallbackLinkedVariation> fdv = font_var_owner.get_ref(p_font_rid);
+		if (unlikely(fdv.is_valid())) {
 			rid = fdv->base_font;
 		}
-		return font_owner.get_or_null(rid);
+		return font_owner.get_ref(rid);
 	}
 
 	struct SystemFontKey {
@@ -559,16 +564,14 @@ class TextServerFallback : public TextServerExtension {
 	mutable HashMap<SystemFontKey, SystemFontCache, SystemFontKeyHasher> system_fonts;
 	mutable HashMap<String, PackedByteArray> system_font_data;
 
-	void _realign(ShapedTextDataFallback *p_sd) const;
+	void _realign(Ref<ShapedTextDataFallback> &p_sd) const;
 	_FORCE_INLINE_ RID _find_sys_font_for_text(const RID &p_fdef, const String &p_script_code, const String &p_language, const String &p_text);
-
-	Mutex ft_mutex;
 
 protected:
 	static void _bind_methods(){};
 
-	void full_copy(ShapedTextDataFallback *p_shaped);
-	void invalidate(ShapedTextDataFallback *p_shaped);
+	void full_copy(Ref<ShapedTextDataFallback> &p_shaped);
+	void invalidate(Ref<ShapedTextDataFallback> &p_shaped);
 
 public:
 	MODBIND1RC(bool, has_feature, Feature);


### PR DESCRIPTION
A version of https://github.com/godotengine/godot/pull/88241 with some changes moved to `RID_Owner`, should be the same but remove some duplicate interlocking. I'll test which one is better a bit later.