### PR TITLE
AudioEffectPitchShift: Actually fix `-Wstringop-overflow` warning

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -87,10 +87,8 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	double magn, phase, tmp, window, real, imag;
 	double freqPerBin, expct;
 	long i,k, qpd, index, inFifoLatency, stepSize, fftFrameSize2;
-	unsigned long fftFrameBufferSize;
 
 	/* set up some handy variables */
-	fftFrameBufferSize = (unsigned long)fftFrameSize*sizeof(float);
 	fftFrameSize2 = fftFrameSize/2;
 	stepSize = fftFrameSize/osamp;
 	freqPerBin = sampleRate/(double)fftFrameSize;
@@ -162,8 +160,8 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* ***************** PROCESSING ******************* */
 			/* this does the actual pitch shifting */
-			memset(gSynMagn, 0, fftFrameBufferSize);
-			memset(gSynFreq, 0, fftFrameBufferSize);
+			memset(gSynMagn, 0, fftFrameSize*sizeof(float));
+			memset(gSynFreq, 0, fftFrameSize*sizeof(float));
 			for (k = 0; k <= fftFrameSize2; k++) {
 				index = k*pitchShift;
 				if (index <= fftFrameSize2) {
@@ -216,7 +214,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 }
 
 			/* shift accumulator */
-			memmove(gOutputAccum, gOutputAccum+stepSize, fftFrameBufferSize);
+			memmove(gOutputAccum, gOutputAccum+stepSize, fftFrameSize*sizeof(float));
 
 			/* move input FIFO */
 			for (k = 0; k < inFifoLatency; k++) { gInFIFO[k] = gInFIFO[k+stepSize];
@@ -357,13 +355,4 @@ void AudioEffectPitchShift::_bind_methods() {
 	BIND_ENUM_CONSTANT(FFT_SIZE_2048);
 	BIND_ENUM_CONSTANT(FFT_SIZE_4096);
 	BIND_ENUM_CONSTANT(FFT_SIZE_MAX);
-}
-
-AudioEffectPitchShift::AudioEffectPitchShift() {
-	pitch_scale = 1.0;
-	oversampling = 4;
-	fft_size = FFT_SIZE_2048;
-	wet = 0.0;
-	dry = 0.0;
-	filter = false;
 }

--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -38,34 +38,22 @@ class SMBPitchShift {
 		MAX_FRAME_LENGTH = 8192
 	};
 
-	float gInFIFO[MAX_FRAME_LENGTH];
-	float gOutFIFO[MAX_FRAME_LENGTH];
-	float gFFTworksp[2 * MAX_FRAME_LENGTH];
-	float gLastPhase[MAX_FRAME_LENGTH / 2 + 1];
-	float gSumPhase[MAX_FRAME_LENGTH / 2 + 1];
-	float gOutputAccum[2 * MAX_FRAME_LENGTH];
-	float gAnaFreq[MAX_FRAME_LENGTH];
-	float gAnaMagn[MAX_FRAME_LENGTH];
-	float gSynFreq[MAX_FRAME_LENGTH];
-	float gSynMagn[MAX_FRAME_LENGTH];
-	long gRover;
+	float gInFIFO[MAX_FRAME_LENGTH] = {};
+	float gOutFIFO[MAX_FRAME_LENGTH] = {};
+	float gFFTworksp[2 * MAX_FRAME_LENGTH] = {};
+	float gLastPhase[MAX_FRAME_LENGTH / 2 + 1] = {};
+	float gSumPhase[MAX_FRAME_LENGTH / 2 + 1] = {};
+	float gOutputAccum[2 * MAX_FRAME_LENGTH] = {};
+	float gAnaFreq[MAX_FRAME_LENGTH] = {};
+	float gAnaMagn[MAX_FRAME_LENGTH] = {};
+	float gSynFreq[MAX_FRAME_LENGTH] = {};
+	float gSynMagn[MAX_FRAME_LENGTH] = {};
+	long gRover = 0;
 
 	void smbFft(float *fftBuffer, long fftFrameSize, long sign);
 
 public:
 	void PitchShift(float pitchShift, long numSampsToProcess, long fftFrameSize, long osamp, float sampleRate, float *indata, float *outdata, int stride);
-
-	SMBPitchShift() {
-		gRover = 0;
-		memset(gInFIFO, 0, MAX_FRAME_LENGTH * sizeof(float));
-		memset(gOutFIFO, 0, MAX_FRAME_LENGTH * sizeof(float));
-		memset(gFFTworksp, 0, 2 * MAX_FRAME_LENGTH * sizeof(float));
-		memset(gLastPhase, 0, (MAX_FRAME_LENGTH / 2 + 1) * sizeof(float));
-		memset(gSumPhase, 0, (MAX_FRAME_LENGTH / 2 + 1) * sizeof(float));
-		memset(gOutputAccum, 0, 2 * MAX_FRAME_LENGTH * sizeof(float));
-		memset(gAnaFreq, 0, MAX_FRAME_LENGTH * sizeof(float));
-		memset(gAnaMagn, 0, MAX_FRAME_LENGTH * sizeof(float));
-	}
 };
 
 class AudioEffectPitchShift;
@@ -75,7 +63,7 @@ class AudioEffectPitchShiftInstance : public AudioEffectInstance {
 	friend class AudioEffectPitchShift;
 	Ref<AudioEffectPitchShift> base;
 
-	int fft_size;
+	int fft_size = 0;
 	SMBPitchShift shift_l;
 	SMBPitchShift shift_r;
 
@@ -98,12 +86,12 @@ public:
 		FFT_SIZE_MAX
 	};
 
-	float pitch_scale;
-	int oversampling;
-	FFTSize fft_size;
-	float wet;
-	float dry;
-	bool filter;
+	float pitch_scale = 1.0;
+	int oversampling = 4;
+	FFTSize fft_size = FFT_SIZE_2048;
+	float wet = 0.0;
+	float dry = 0.0;
+	bool filter = false;
 
 protected:
 	static void _bind_methods();
@@ -119,8 +107,6 @@ public:
 
 	void set_fft_size(FFTSize);
 	FFTSize get_fft_size() const;
-
-	AudioEffectPitchShift();
 };
 
 VARIANT_ENUM_CAST(AudioEffectPitchShift::FFTSize);


### PR DESCRIPTION
Previous commit #88509 didn't help, so its changes are reverted

- Part of #88504.