### PR TITLE
icu4c: Fix `-Wstringop-overflow` warning

### DIFF
--- a/thirdparty/icu4c/common/umutablecptrie.cpp
+++ b/thirdparty/icu4c/common/umutablecptrie.cpp
@@ -1304,7 +1304,7 @@ int32_t MutableCodePointTrie::compactIndex(int32_t fastILimit, MixedBlocks &mixe
         errorCode = U_MEMORY_ALLOCATION_ERROR;
         return 0;
     }
-    uprv_memcpy(index16, fastIndex, fastIndexLength * 2);
+    uprv_memcpy(index16, fastIndex, index16Capacity * 2);
 
     if (!mixedBlocks.init(index16Capacity, UCPTRIE_INDEX_3_BLOCK_LENGTH)) {
         errorCode = U_MEMORY_ALLOCATION_ERROR;

--- a/thirdparty/icu4c/patches/fix-Wstringop-overflow.patch
+++ b/thirdparty/icu4c/patches/fix-Wstringop-overflow.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/icu4c/common/umutablecptrie.cpp b/thirdparty/icu4c/common/umutablecptrie.cpp
+index cdbe27080b..0d5e8560c5 100644
+--- a/thirdparty/icu4c/common/umutablecptrie.cpp
++++ b/thirdparty/icu4c/common/umutablecptrie.cpp
+@@ -1304,7 +1304,7 @@ int32_t MutableCodePointTrie::compactIndex(int32_t fastILimit, MixedBlocks &mixe
+         errorCode = U_MEMORY_ALLOCATION_ERROR;
+         return 0;
+     }
+-    uprv_memcpy(index16, fastIndex, fastIndexLength * 2);
++    uprv_memcpy(index16, fastIndex, index16Capacity * 2);
+ 
+     if (!mixedBlocks.init(index16Capacity, UCPTRIE_INDEX_3_BLOCK_LENGTH)) {
+         errorCode = U_MEMORY_ALLOCATION_ERROR;


### PR DESCRIPTION
The warning was:
```
In member function 'compactIndex',
    inlined from 'compactTrie' at thirdparty/icu4c/common/umutablecptrie.cpp:1571:39:
thirdparty/icu4c/common/umutablecptrie.cpp:1307:5: warning: 'memcpy' writing between 128 and 2048 bytes into a region of size 24 overflows the destination [-Wstringop-overflow=]
 1307 |     uprv_memcpy(index16, fastIndex, fastIndexLength * 2);
      |     ^
thirdparty/icu4c/common/cmemory.cpp: In member function 'compactTrie':
thirdparty/icu4c/common/cmemory.cpp:30: note: destination object 'zeroMem' of size 24
   30 | static const int32_t zeroMem[] = {0, 0, 0, 0, 0, 0};
      | 
```

I'll check if this can be submitted upstream or if they fixed it already.
*Edit:* The apparent bug still seems present in their current branch: https://github.com/unicode-org/icu/blob/f3e50a7624384e325b9fb2c133a887c505308301/icu4c/source/common/umutablecptrie.cpp#L1299-L1307

Might need double checking that I understood the intended code's logic here, CC @bruvzg.

- Part of #88504.