### PR TITLE
Fix implementation of `property_can_revert()` in PropertyListHelper

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -220,7 +220,7 @@
 			<return type="bool" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Override this method to customize the given [param property]'s revert behavior. Should return [code]true[/code] if the [param property] can be reverted in the Inspector dock. Use [method _property_get_revert] to specify the [param property]'s default value.
+				Override this method to customize the given [param property]'s revert behavior. Should return [code]true[/code] if the [param property] has a custom default value and is revertible in the Inspector dock. Use [method _property_get_revert] to specify the [param property]'s default value.
 				[b]Note:[/b] This method must return consistently, regardless of the current value of the [param property].
 			</description>
 		</method>

--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -111,12 +111,7 @@ bool PropertyListHelper::property_set_value(const String &p_property, const Vari
 
 bool PropertyListHelper::property_can_revert(const String &p_property) const {
 	int index;
-	const Property *property = _get_property(p_property, &index);
-
-	if (property) {
-		return _call_getter(property->getter, index) != property->default_value;
-	}
-	return false;
+	return _get_property(p_property, &index) != nullptr;
 }
 
 bool PropertyListHelper::property_get_revert(const String &p_property, Variant &r_value) const {


### PR DESCRIPTION
Apparently `_property_can_revert()` is supposed to always return true for a recognized custom property. This PR fixes the PropertyListHelper implementation and clarifies the doc.