### PR TITLE
Remove some redundant method calls from ScriptEditor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -866,8 +866,6 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 	if (script_close_queue.is_empty()) {
 		_update_history_arrows();
 		_update_script_names();
-		_update_members_overview_visibility();
-		_update_help_overview_visibility();
 		_save_layout();
 		_update_find_replace_bar();
 	}
@@ -1670,7 +1668,6 @@ void ScriptEditor::_notification(int p_what) {
 			recent_scripts->reset_size();
 
 			if (is_inside_tree()) {
-				_update_script_colors();
 				_update_script_names();
 			}
 		} break;
@@ -2820,7 +2817,6 @@ void ScriptEditor::_apply_editor_settings() {
 		EditorSettings::get_singleton()->load_text_editor_theme();
 	}
 
-	_update_script_colors();
 	_update_script_names();
 
 	ScriptServer::set_reload_scripts_on_save(EDITOR_GET("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save"));


### PR DESCRIPTION
`ScriptEditor::_update_script_names` calls `ScriptEditor::_update_script_colors`, but there were a couple places where both are called back-to-back. This PR removes those instances of `_update_script_colors`. Tagging @KoBeWi to verify if this is actually a good idea.