### PR TITLE
[Navigation] Add some missing compile checks

### DIFF
--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -1131,7 +1131,11 @@ void GodotNavigationServer::bake_from_source_geometry_data_async(const Ref<Navig
 }
 
 bool GodotNavigationServer::is_baking_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) const {
+#ifdef _3D_DISABLED
+	return false;
+#else
 	return NavMeshGenerator3D::get_singleton()->is_baking(p_navigation_mesh);
+#endif // _3D_DISABLED
 }
 
 COMMAND_1(free, RID, p_object) {

--- a/modules/navigation/godot_navigation_server_2d.cpp
+++ b/modules/navigation/godot_navigation_server_2d.cpp
@@ -222,7 +222,11 @@ void GodotNavigationServer2D::bake_from_source_geometry_data_async(const Ref<Nav
 }
 
 bool GodotNavigationServer2D::is_baking_navigation_polygon(Ref<NavigationPolygon> p_navigation_polygon) const {
+#ifdef CLIPPER2_ENABLED
 	return NavMeshGenerator2D::get_singleton()->is_baking(p_navigation_polygon);
+#else
+	return false;
+#endif
 }
 
 GodotNavigationServer2D::GodotNavigationServer2D() {}

--- a/modules/navigation/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/nav_mesh_generator_2d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef CLIPPER2_ENABLED
+
 #include "nav_mesh_generator_2d.h"
 
 #include "core/config/project_settings.h"
@@ -902,3 +904,5 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 		p_navigation_mesh->add_polygon(new_polygons[i]);
 	}
 }
+
+#endif // CLIPPER2_ENABLED

--- a/modules/navigation/nav_mesh_generator_2d.h
+++ b/modules/navigation/nav_mesh_generator_2d.h
@@ -31,6 +31,8 @@
 #ifndef NAV_MESH_GENERATOR_2D_H
 #define NAV_MESH_GENERATOR_2D_H
 
+#ifdef CLIPPER2_ENABLED
+
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
 
@@ -97,5 +99,7 @@ public:
 	NavMeshGenerator2D();
 	~NavMeshGenerator2D();
 };
+
+#endif // CLIPPER2_ENABLED
 
 #endif // NAV_MESH_GENERATOR_2D_H


### PR DESCRIPTION
Adds checks to ensure unavailable classes are not invoked

Unsure if the checks around `NavMeshGenerator2D` but it matches the 3D case
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
