### PR TITLE
[Navigation] Restore 2D only navigation

### DIFF
--- a/modules/navigation/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation/3d/godot_navigation_server_3d.cpp
@@ -1147,8 +1147,8 @@ uint32_t GodotNavigationServer3D::obstacle_get_avoidance_layers(RID p_obstacle) 
 	return obstacle->get_avoidance_layers();
 }
 
-void GodotNavigationServer3D::parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {
 #ifndef _3D_DISABLED
+void GodotNavigationServer3D::parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "The SceneTree can only be parsed on the main thread. Call this function from the main thread or use call_deferred().");
 	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
 	ERR_FAIL_NULL_MSG(p_root_node, "No parsing root node specified.");
@@ -1156,36 +1156,28 @@ void GodotNavigationServer3D::parse_source_geometry_data(const Ref<NavigationMes
 
 	ERR_FAIL_NULL(NavMeshGenerator3D::get_singleton());
 	NavMeshGenerator3D::get_singleton()->parse_source_geometry_data(p_navigation_mesh, p_source_geometry_data, p_root_node, p_callback);
-#endif // _3D_DISABLED
 }
 
 void GodotNavigationServer3D::bake_from_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback) {
-#ifndef _3D_DISABLED
 	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
 	ERR_FAIL_COND_MSG(!p_source_geometry_data.is_valid(), "Invalid NavigationMeshSourceGeometryData3D.");
 
 	ERR_FAIL_NULL(NavMeshGenerator3D::get_singleton());
 	NavMeshGenerator3D::get_singleton()->bake_from_source_geometry_data(p_navigation_mesh, p_source_geometry_data, p_callback);
-#endif // _3D_DISABLED
 }
 
 void GodotNavigationServer3D::bake_from_source_geometry_data_async(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback) {
-#ifndef _3D_DISABLED
 	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
 	ERR_FAIL_COND_MSG(!p_source_geometry_data.is_valid(), "Invalid NavigationMeshSourceGeometryData3D.");
 
 	ERR_FAIL_NULL(NavMeshGenerator3D::get_singleton());
 	NavMeshGenerator3D::get_singleton()->bake_from_source_geometry_data_async(p_navigation_mesh, p_source_geometry_data, p_callback);
-#endif // _3D_DISABLED
 }
 
 bool GodotNavigationServer3D::is_baking_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) const {
-#ifdef _3D_DISABLED
-	return false;
-#else
 	return NavMeshGenerator3D::get_singleton()->is_baking(p_navigation_mesh);
-#endif // _3D_DISABLED
 }
+#endif // _3D_DISABLED
 
 COMMAND_1(free, RID, p_object) {
 	if (map_owner.owns(p_object)) {

--- a/modules/navigation/3d/godot_navigation_server_3d.h
+++ b/modules/navigation/3d/godot_navigation_server_3d.h
@@ -265,10 +265,12 @@ public:
 	COMMAND_2(obstacle_set_avoidance_layers, RID, p_obstacle, uint32_t, p_layers);
 	virtual uint32_t obstacle_get_avoidance_layers(RID p_obstacle) const override;
 
+#ifndef _3D_DISABLED
 	virtual void parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) override;
 	virtual void bake_from_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override;
 	virtual void bake_from_source_geometry_data_async(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback = Callable()) override;
 	virtual bool is_baking_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) const override;
+#endif // _3D_DISABLED
 
 	virtual RID source_geometry_parser_create() override;
 	virtual void source_geometry_parser_set_callback(RID p_parser, const Callable &p_callback) override;

--- a/modules/navigation/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_queries_3d.cpp
@@ -28,8 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef _3D_DISABLED
-
 #include "nav_mesh_queries_3d.h"
 
 #include "../nav_base.h"
@@ -976,5 +974,3 @@ void NavMeshQueries3D::simplify_path_segment(int p_start_inx, int p_end_inx, con
 		simplify_path_segment(point_max_index, p_end_inx, p_points, p_epsilon, r_valid_points);
 	}
 }
-
-#endif // _3D_DISABLED

--- a/modules/navigation/3d/nav_mesh_queries_3d.h
+++ b/modules/navigation/3d/nav_mesh_queries_3d.h
@@ -31,8 +31,6 @@
 #ifndef NAV_MESH_QUERIES_3D_H
 #define NAV_MESH_QUERIES_3D_H
 
-#ifndef _3D_DISABLED
-
 #include "../nav_utils.h"
 
 #include "servers/navigation/navigation_path_query_parameters_3d.h"
@@ -119,7 +117,5 @@ public:
 	static void simplify_path_segment(int p_start_inx, int p_end_inx, const LocalVector<Vector3> &p_points, real_t p_epsilon, LocalVector<bool> &r_valid_points);
 	static LocalVector<uint32_t> get_simplified_path_indices(const LocalVector<Vector3> &p_path, real_t p_epsilon);
 };
-
-#endif // _3D_DISABLED
 
 #endif // NAV_MESH_QUERIES_3D_H

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -11,7 +11,7 @@ env_navigation = env_modules.Clone()
 thirdparty_obj = []
 
 # Recast Thirdparty source files
-if env["builtin_recastnavigation"]:
+if not env["disable_3d"] and env["builtin_recastnavigation"]:
     thirdparty_dir = "#thirdparty/recastnavigation/Recast/"
     thirdparty_sources = [
         "Source/Recast.cpp",
@@ -52,7 +52,7 @@ if env["builtin_rvo2_2d"]:
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 
 # RVO 3D Thirdparty source files
-if env["builtin_rvo2_3d"]:
+if not env["disable_3d"] and env["builtin_rvo2_3d"]:
     thirdparty_dir = "#thirdparty/rvo2/rvo2_3d/"
     thirdparty_sources = [
         "Agent3d.cpp",
@@ -76,8 +76,7 @@ module_obj = []
 
 env_navigation.add_source_files(module_obj, "*.cpp")
 env_navigation.add_source_files(module_obj, "2d/*.cpp")
-if not env["disable_3d"]:
-    env_navigation.add_source_files(module_obj, "3d/*.cpp")
+env_navigation.add_source_files(module_obj, "3d/*.cpp")
 if env.editor_build:
     env_navigation.add_source_files(module_obj, "editor/*.cpp")
 env.modules_sources += module_obj

--- a/modules/navigation/config.py
+++ b/modules/navigation/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return not env["disable_3d"]
+    return True
 
 
 def configure(env):

--- a/modules/navigation/nav_agent.cpp
+++ b/modules/navigation/nav_agent.cpp
@@ -37,12 +37,15 @@ void NavAgent::set_avoidance_enabled(bool p_enabled) {
 	_update_rvo_agent_properties();
 }
 
+#ifndef _3D_DISABLED
 void NavAgent::set_use_3d_avoidance(bool p_enabled) {
 	use_3d_avoidance = p_enabled;
 	_update_rvo_agent_properties();
 }
+#endif
 
 void NavAgent::_update_rvo_agent_properties() {
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.neighborDist_ = neighbor_distance;
 		rvo_agent_3d.maxNeighbors_ = max_neighbors;
@@ -58,7 +61,9 @@ void NavAgent::_update_rvo_agent_properties() {
 		rvo_agent_3d.avoidance_layers_ = avoidance_layers;
 		rvo_agent_3d.avoidance_mask_ = avoidance_mask;
 		rvo_agent_3d.avoidance_priority_ = avoidance_priority;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.neighborDist_ = neighbor_distance;
 		rvo_agent_2d.maxNeighbors_ = max_neighbors;
 		rvo_agent_2d.timeHorizon_ = time_horizon_agents;
@@ -137,9 +142,12 @@ void NavAgent::dispatch_avoidance_callback() {
 
 	Vector3 new_velocity;
 
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		new_velocity = Vector3(rvo_agent_3d.velocity_.x(), rvo_agent_3d.velocity_.y(), rvo_agent_3d.velocity_.z());
-	} else {
+	} else
+#endif
+	{
 		new_velocity = Vector3(rvo_agent_2d.velocity_.x(), 0.0, rvo_agent_2d.velocity_.y());
 	}
 
@@ -153,9 +161,12 @@ void NavAgent::dispatch_avoidance_callback() {
 
 void NavAgent::set_neighbor_distance(real_t p_neighbor_distance) {
 	neighbor_distance = p_neighbor_distance;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.neighborDist_ = neighbor_distance;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.neighborDist_ = neighbor_distance;
 	}
 	agent_dirty = true;
@@ -165,9 +176,12 @@ void NavAgent::set_neighbor_distance(real_t p_neighbor_distance) {
 
 void NavAgent::set_max_neighbors(int p_max_neighbors) {
 	max_neighbors = p_max_neighbors;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.maxNeighbors_ = max_neighbors;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.maxNeighbors_ = max_neighbors;
 	}
 	agent_dirty = true;
@@ -177,9 +191,12 @@ void NavAgent::set_max_neighbors(int p_max_neighbors) {
 
 void NavAgent::set_time_horizon_agents(real_t p_time_horizon) {
 	time_horizon_agents = p_time_horizon;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.timeHorizon_ = time_horizon_agents;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.timeHorizon_ = time_horizon_agents;
 	}
 	agent_dirty = true;
@@ -189,9 +206,12 @@ void NavAgent::set_time_horizon_agents(real_t p_time_horizon) {
 
 void NavAgent::set_time_horizon_obstacles(real_t p_time_horizon) {
 	time_horizon_obstacles = p_time_horizon;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.timeHorizonObst_ = time_horizon_obstacles;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.timeHorizonObst_ = time_horizon_obstacles;
 	}
 	agent_dirty = true;
@@ -201,9 +221,12 @@ void NavAgent::set_time_horizon_obstacles(real_t p_time_horizon) {
 
 void NavAgent::set_radius(real_t p_radius) {
 	radius = p_radius;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.radius_ = radius;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.radius_ = radius;
 	}
 	agent_dirty = true;
@@ -213,9 +236,12 @@ void NavAgent::set_radius(real_t p_radius) {
 
 void NavAgent::set_height(real_t p_height) {
 	height = p_height;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.height_ = height;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.height_ = height;
 	}
 	agent_dirty = true;
@@ -226,9 +252,12 @@ void NavAgent::set_height(real_t p_height) {
 void NavAgent::set_max_speed(real_t p_max_speed) {
 	max_speed = p_max_speed;
 	if (avoidance_enabled) {
+#ifndef _3D_DISABLED
 		if (use_3d_avoidance) {
 			rvo_agent_3d.maxSpeed_ = max_speed;
-		} else {
+		} else
+#endif
+		{
 			rvo_agent_2d.maxSpeed_ = max_speed;
 		}
 	}
@@ -240,9 +269,12 @@ void NavAgent::set_max_speed(real_t p_max_speed) {
 void NavAgent::set_position(const Vector3 p_position) {
 	position = p_position;
 	if (avoidance_enabled) {
+#ifndef _3D_DISABLED
 		if (use_3d_avoidance) {
 			rvo_agent_3d.position_ = RVO3D::Vector3(p_position.x, p_position.y, p_position.z);
-		} else {
+		} else
+#endif
+		{
 			rvo_agent_2d.elevation_ = p_position.y;
 			rvo_agent_2d.position_ = RVO2D::Vector2(p_position.x, p_position.z);
 		}
@@ -261,9 +293,12 @@ void NavAgent::set_velocity(const Vector3 p_velocity) {
 	// This velocity is not guaranteed, RVO simulation will only try to fulfill it
 	velocity = p_velocity;
 	if (avoidance_enabled) {
+#ifndef _3D_DISABLED
 		if (use_3d_avoidance) {
 			rvo_agent_3d.prefVelocity_ = RVO3D::Vector3(velocity.x, velocity.y, velocity.z);
-		} else {
+		} else
+#endif
+		{
 			rvo_agent_2d.prefVelocity_ = RVO2D::Vector2(velocity.x, velocity.z);
 		}
 	}
@@ -279,9 +314,12 @@ void NavAgent::set_velocity_forced(const Vector3 p_velocity) {
 	// use velocity instead to update with a safer "suggestion"
 	velocity_forced = p_velocity;
 	if (avoidance_enabled) {
+#ifndef _3D_DISABLED
 		if (use_3d_avoidance) {
 			rvo_agent_3d.velocity_ = RVO3D::Vector3(p_velocity.x, p_velocity.y, p_velocity.z);
-		} else {
+		} else
+#endif
+		{
 			rvo_agent_2d.velocity_ = RVO2D::Vector2(p_velocity.x, p_velocity.z);
 		}
 	}
@@ -293,9 +331,12 @@ void NavAgent::set_velocity_forced(const Vector3 p_velocity) {
 void NavAgent::update() {
 	// Updates this agent with the calculated results from the rvo simulation
 	if (avoidance_enabled) {
+#ifndef _3D_DISABLED
 		if (use_3d_avoidance) {
 			velocity = Vector3(rvo_agent_3d.velocity_.x(), rvo_agent_3d.velocity_.y(), rvo_agent_3d.velocity_.z());
-		} else {
+		} else
+#endif
+		{
 			velocity = Vector3(rvo_agent_2d.velocity_.x(), 0.0, rvo_agent_2d.velocity_.y());
 		}
 	}
@@ -303,9 +344,12 @@ void NavAgent::update() {
 
 void NavAgent::set_avoidance_mask(uint32_t p_mask) {
 	avoidance_mask = p_mask;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.avoidance_mask_ = avoidance_mask;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.avoidance_mask_ = avoidance_mask;
 	}
 	agent_dirty = true;
@@ -315,9 +359,12 @@ void NavAgent::set_avoidance_mask(uint32_t p_mask) {
 
 void NavAgent::set_avoidance_layers(uint32_t p_layers) {
 	avoidance_layers = p_layers;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.avoidance_layers_ = avoidance_layers;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.avoidance_layers_ = avoidance_layers;
 	}
 	agent_dirty = true;
@@ -329,9 +376,12 @@ void NavAgent::set_avoidance_priority(real_t p_priority) {
 	ERR_FAIL_COND_MSG(p_priority < 0.0, "Avoidance priority must be between 0.0 and 1.0 inclusive.");
 	ERR_FAIL_COND_MSG(p_priority > 1.0, "Avoidance priority must be between 0.0 and 1.0 inclusive.");
 	avoidance_priority = p_priority;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		rvo_agent_3d.avoidance_priority_ = avoidance_priority;
-	} else {
+	} else
+#endif
+	{
 		rvo_agent_2d.avoidance_priority_ = avoidance_priority;
 	}
 	agent_dirty = true;
@@ -350,6 +400,7 @@ void NavAgent::sync() {
 const Dictionary NavAgent::get_avoidance_data() const {
 	// Returns debug data from RVO simulation internals of this agent.
 	Dictionary _avoidance_data;
+#ifndef _3D_DISABLED
 	if (use_3d_avoidance) {
 		_avoidance_data["max_neighbors"] = int(rvo_agent_3d.maxNeighbors_);
 		_avoidance_data["max_speed"] = float(rvo_agent_3d.maxSpeed_);
@@ -365,7 +416,9 @@ const Dictionary NavAgent::get_avoidance_data() const {
 		_avoidance_data["avoidance_layers"] = int(rvo_agent_3d.avoidance_layers_);
 		_avoidance_data["avoidance_mask"] = int(rvo_agent_3d.avoidance_mask_);
 		_avoidance_data["avoidance_priority"] = float(rvo_agent_3d.avoidance_priority_);
-	} else {
+	} else
+#endif
+	{
 		_avoidance_data["max_neighbors"] = int(rvo_agent_2d.maxNeighbors_);
 		_avoidance_data["max_speed"] = float(rvo_agent_2d.maxSpeed_);
 		_avoidance_data["neighbor_distance"] = float(rvo_agent_2d.neighborDist_);

--- a/modules/navigation/nav_agent.h
+++ b/modules/navigation/nav_agent.h
@@ -38,7 +38,9 @@
 #include "core/templates/self_list.h"
 
 #include <Agent2d.h>
+#ifndef _3D_DISABLED
 #include <Agent3d.h>
+#endif
 
 class NavMap;
 
@@ -60,8 +62,10 @@ class NavAgent : public NavRid {
 	NavMap *map = nullptr;
 
 	RVO2D::Agent2D rvo_agent_2d;
+#ifndef _3D_DISABLED
 	RVO3D::Agent3D rvo_agent_3d;
 	bool use_3d_avoidance = false;
+#endif
 	bool avoidance_enabled = false;
 
 	uint32_t avoidance_layers = 1;
@@ -84,8 +88,13 @@ public:
 	void set_avoidance_enabled(bool p_enabled);
 	bool is_avoidance_enabled() { return avoidance_enabled; }
 
+#ifdef _3D_DISABLED
+	void set_use_3d_avoidance(bool p_enabled) {}
+	bool get_use_3d_avoidance() { return false; }
+#else
 	void set_use_3d_avoidance(bool p_enabled);
 	bool get_use_3d_avoidance() { return use_3d_avoidance; }
+#endif
 
 	void set_map(NavMap *p_map);
 	NavMap *get_map() { return map; }
@@ -93,7 +102,9 @@ public:
 	bool is_map_changed();
 
 	RVO2D::Agent2D *get_rvo_agent_2d() { return &rvo_agent_2d; }
+#ifndef _3D_DISABLED
 	RVO3D::Agent3D *get_rvo_agent_3d() { return &rvo_agent_3d; }
+#endif
 
 	void set_avoidance_callback(Callable p_callback);
 	bool has_avoidance_callback() const;

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -40,9 +40,11 @@
 #include "servers/navigation/navigation_globals.h"
 
 #include <KdTree2d.h>
-#include <KdTree3d.h>
 #include <RVOSimulator2d.h>
+#ifndef _3D_DISABLED
+#include <KdTree3d.h>
 #include <RVOSimulator3d.h>
+#endif
 
 class NavLink;
 class NavRegion;
@@ -88,11 +90,15 @@ class NavMap : public NavRid {
 
 	/// RVO avoidance worlds
 	RVO2D::RVOSimulator2D rvo_simulation_2d;
+#ifndef _3D_DISABLED
 	RVO3D::RVOSimulator3D rvo_simulation_3d;
+#endif
 
 	/// avoidance controlled agents
 	LocalVector<NavAgent *> active_2d_avoidance_agents;
+#ifndef _3D_DISABLED
 	LocalVector<NavAgent *> active_3d_avoidance_agents;
+#endif
 
 	/// dirty flag when one of the agent's arrays are modified
 	bool agents_dirty = true;
@@ -257,13 +263,21 @@ private:
 	void compute_single_step(uint32_t index, NavAgent **agent);
 
 	void compute_single_avoidance_step_2d(uint32_t index, NavAgent **agent);
+#ifdef _3D_DISABLED
+	void compute_single_avoidance_step_3d(uint32_t index, NavAgent **agent) {}
+#else
 	void compute_single_avoidance_step_3d(uint32_t index, NavAgent **agent);
+#endif
 
 	void _sync_avoidance();
 	void _update_rvo_simulation();
 	void _update_rvo_obstacles_tree_2d();
 	void _update_rvo_agents_tree_2d();
+#ifdef _3D_DISABLED
+	void _update_rvo_agents_tree_3d() {}
+#else
 	void _update_rvo_agents_tree_3d();
+#endif
 
 	void _update_merge_rasterizer_cell_dimensions();
 };

--- a/modules/navigation/nav_obstacle.cpp
+++ b/modules/navigation/nav_obstacle.cpp
@@ -58,6 +58,7 @@ void NavObstacle::set_avoidance_enabled(bool p_enabled) {
 	request_sync();
 }
 
+#ifndef _3D_DISABLED
 void NavObstacle::set_use_3d_avoidance(bool p_enabled) {
 	if (use_3d_avoidance == p_enabled) {
 		return;
@@ -72,6 +73,7 @@ void NavObstacle::set_use_3d_avoidance(bool p_enabled) {
 
 	request_sync();
 }
+#endif
 
 void NavObstacle::set_map(NavMap *p_map) {
 	if (map == p_map) {
@@ -208,7 +210,9 @@ void NavObstacle::internal_update_agent() {
 		agent->set_position(position);
 		agent->set_avoidance_layers(avoidance_layers);
 		agent->set_avoidance_enabled(avoidance_enabled);
+#ifndef _3D_DISABLED
 		agent->set_use_3d_avoidance(use_3d_avoidance);
+#endif
 	}
 }
 

--- a/modules/navigation/nav_obstacle.h
+++ b/modules/navigation/nav_obstacle.h
@@ -51,7 +51,9 @@ class NavObstacle : public NavRid {
 	real_t height = 0.0;
 
 	bool avoidance_enabled = false;
+#ifndef _3D_DISABLED
 	bool use_3d_avoidance = false;
+#endif
 	uint32_t avoidance_layers = 1;
 
 	bool obstacle_dirty = true;
@@ -68,8 +70,13 @@ public:
 	void set_avoidance_enabled(bool p_enabled);
 	bool is_avoidance_enabled() { return avoidance_enabled; }
 
+#ifdef _3D_DISABLED
+	void set_use_3d_avoidance(bool p_enabled) {}
+	bool get_use_3d_avoidance() { return false; }
+#else
 	void set_use_3d_avoidance(bool p_enabled);
 	bool get_use_3d_avoidance() { return use_3d_avoidance; }
+#endif
 
 	void set_map(NavMap *p_map);
 	NavMap *get_map() { return map; }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -155,18 +155,21 @@
 #include "tests/scene/test_tree.h"
 #endif // ADVANCED_GUI_DISABLED
 
-#ifndef _3D_DISABLED
 #ifdef MODULE_NAVIGATION_ENABLED
 #include "tests/scene/test_navigation_agent_2d.h"
-#include "tests/scene/test_navigation_agent_3d.h"
 #include "tests/scene/test_navigation_obstacle_2d.h"
-#include "tests/scene/test_navigation_obstacle_3d.h"
 #include "tests/scene/test_navigation_region_2d.h"
-#include "tests/scene/test_navigation_region_3d.h"
 #include "tests/servers/test_navigation_server_2d.h"
+
+#ifndef _3D_DISABLED
+#include "tests/scene/test_navigation_agent_3d.h"
+#include "tests/scene/test_navigation_obstacle_3d.h"
+#include "tests/scene/test_navigation_region_3d.h"
 #include "tests/servers/test_navigation_server_3d.h"
+#endif // _3D_DISABLED
 #endif // MODULE_NAVIGATION_ENABLED
 
+#ifndef _3D_DISABLED
 #include "tests/scene/test_arraymesh.h"
 #include "tests/scene/test_camera_3d.h"
 #include "tests/scene/test_height_map_shape_3d.h"
@@ -183,10 +186,8 @@
 #include "tests/test_macros.h"
 
 #include "scene/theme/theme_db.h"
-#ifndef _3D_DISABLED
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_3d.h"
-#endif // _3D_DISABLED
 #include "servers/physics_server_2d.h"
 #include "servers/physics_server_2d_dummy.h"
 #ifndef _3D_DISABLED
@@ -270,9 +271,9 @@ struct GodotTestCaseListener : public doctest::IReporter {
 	PhysicsServer2D *physics_server_2d = nullptr;
 #ifndef _3D_DISABLED
 	PhysicsServer3D *physics_server_3d = nullptr;
+#endif // _3D_DISABLED
 	NavigationServer3D *navigation_server_3d = nullptr;
 	NavigationServer2D *navigation_server_2d = nullptr;
-#endif // _3D_DISABLED
 
 	void test_case_start(const doctest::TestCaseData &p_in) override {
 		reinitialize();
@@ -318,12 +319,10 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			}
 			physics_server_2d->init();
 
-#ifndef _3D_DISABLED
 			ERR_PRINT_OFF;
 			navigation_server_3d = NavigationServer3DManager::new_default_server();
 			navigation_server_2d = NavigationServer2DManager::new_default_server();
 			ERR_PRINT_ON;
-#endif // _3D_DISABLED
 
 			memnew(InputMap);
 			InputMap::get_singleton()->load_default();
@@ -354,7 +353,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			return;
 		}
 
-#ifndef _3D_DISABLED
 		if (suite_name.contains("[Navigation]") && navigation_server_2d == nullptr && navigation_server_3d == nullptr) {
 			ERR_PRINT_OFF;
 			navigation_server_3d = NavigationServer3DManager::new_default_server();
@@ -362,7 +360,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			ERR_PRINT_ON;
 			return;
 		}
-#endif // _3D_DISABLED
 	}
 
 	void test_case_end(const doctest::CurrentTestCaseStats &) override {
@@ -389,7 +386,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			memdelete(SceneTree::get_singleton());
 		}
 
-#ifndef _3D_DISABLED
 		if (navigation_server_3d) {
 			memdelete(navigation_server_3d);
 			navigation_server_3d = nullptr;
@@ -399,7 +395,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			memdelete(navigation_server_2d);
 			navigation_server_2d = nullptr;
 		}
-#endif // _3D_DISABLED
 
 #ifndef _3D_DISABLED
 		if (physics_server_3d) {


### PR DESCRIPTION
Starting in 4.2 navigation was restricted to 3D enabled builds only, in my testing this isn't an actual limitation, and my testing shows navigation works ~(haven't tested baking in 2D, but pathfinding works fine, and unit tests work correctly)~

Edit: Tested and runtime baking works fine too

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
