### PR TITLE
Allow splitting GodotDisabledSourceGenerators by comma (Updates ExtensionMethods.cs)

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -30,7 +30,7 @@ namespace Godot.SourceGenerators
             AreGodotSourceGeneratorsDisabled(context) ||
             (context.TryGetGlobalAnalyzerProperty("GodotDisabledSourceGenerators", out string? disabledGenerators) &&
             disabledGenerators != null &&
-            disabledGenerators.Split(';').Contains(generatorName));
+            disabledGenerators.Split(';', ',').Contains(generatorName));
 
         public static bool InheritsFrom(this ITypeSymbol? symbol, string assemblyName, string typeFullName)
         {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -26,6 +26,7 @@ namespace Godot.SourceGenerators
                toggle != null &&
                toggle.Equals("true", StringComparison.OrdinalIgnoreCase);
 
+        // NOTE: Settings in the editorconfig file (including csproj files) should not use ; as a seperator as it will be treated as a comment
         public static bool IsGodotSourceGeneratorDisabled(this GeneratorExecutionContext context, string generatorName) =>
             AreGodotSourceGeneratorsDisabled(context) ||
             (context.TryGetGlobalAnalyzerProperty("GodotDisabledSourceGenerators", out string? disabledGenerators) &&

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -26,7 +26,7 @@ namespace Godot.SourceGenerators
                toggle != null &&
                toggle.Equals("true", StringComparison.OrdinalIgnoreCase);
 
-        // NOTE: Settings in the editorconfig file (including csproj files) should not use ; as a seperator as it will be treated as a comment
+        // NOTE: Settings in the editorconfig file (including csproj files) should not use ; as a separator as it will be treated as a comment
         public static bool IsGodotSourceGeneratorDisabled(this GeneratorExecutionContext context, string generatorName) =>
             AreGodotSourceGeneratorsDisabled(context) ||
             (context.TryGetGlobalAnalyzerProperty("GodotDisabledSourceGenerators", out string? disabledGenerators) &&


### PR DESCRIPTION
Allows separating GodotDisabledSourceGenerators by comma

There's a bug in the Roslyn analyzers that describes the ; character being treated as a comment in the resulting editorconfig file and thus stripping all values after it: https://github.com/dotnet/roslyn/issues/43970

I noticed this when trying to disable multiple source generators in my csproj file like so:

    <GodotDisabledSourceGenerators>ScriptSignals;ScriptProperties</GodotDisabledSourceGenerators>

This results in the following line in *.GeneratedMSBuildEditorConfig.editorconfig:

```lisp
    build_property.GodotDisabledSourceGenerators = ScriptSignals;ScriptProperties
```

Which results in only ScriptSignals to be disabled. ScriptProperties is ignored and doesn;t reach the checking-code.

----

This change allows to also split the setting with a comma.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
