### PR TITLE
Fix `memdelete()` of `Object` using pointer to secondary parent class

### DIFF
--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -44,6 +44,9 @@ class OpenXRActionMap;
 
 // `OpenXRExtensionWrapper` allows us to implement OpenXR extensions.
 class OpenXRExtensionWrapper {
+	// Allows memdelete() to work correctly with multiple inheritance as used by this class.
+	IS_POSSIBLE_GDCLASS();
+
 public:
 	// `get_requested_extensions` should return a list of OpenXR extensions related to this extension.
 	// If the bool * is a nullptr this extension is mandatory


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88613

There is a pattern used in a very small number of places in Godot, in order to simulate "interfaces" (which C++ doesn't directly support).

Here's how it works:

- Declare an abstract class (aka a class with all pure virtual methods) to act as the interface
- In classes that want to implement that interface, use multiple inheritance to extend `Object` (or some other ancestor of `Object`) as the first parent class, and then extend the abstract class as a secondary parent class
- Then methods that want to accept instances that implement this "interface" can specify the secondary parent class as the type

This is used by a couple of classes in the OpenXR module:

- `OpenXRExtensionWrapper`
- `OpenXRGraphicsExtensionWrapper` (which extends the previous one)
- `OpenXRCompositionLayerProvider`

This all works fine, except when you keep a reference to one of these types and then later try to `memdelete()` it, which is done in the case of `OpenXRExtensionWrapper` and is the source of the bug from issue https://github.com/godotengine/godot/issues/88613

This PR allows developers to mark one of these interface classes using a new `IS_POSSIBLE_GDCLASS()` macro, that will tell `memdelete()` to do some additional work that will clean everything up correctly.

Given how uncommon this pattern is in Godot, I could understand not wanting to accept this general change to `memdelete()` and instead have the OpenXR implement its own bespoke solution. However, I thought I would propose it and see what folks thought :-)
