### PR TITLE
Fix crash when using OpenXR extension wrappers from GDExtension

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1532,7 +1532,13 @@ void OpenXRAPI::register_extension_metadata() {
 
 void OpenXRAPI::cleanup_extension_wrappers() {
 	for (OpenXRExtensionWrapper *extension_wrapper : registered_extension_wrappers) {
-		memdelete(extension_wrapper);
+		// Fix crash when the extension wrapper comes from GDExtension.
+		OpenXRExtensionWrapperExtension *gdextension_extension_wrapper = dynamic_cast<OpenXRExtensionWrapperExtension *>(extension_wrapper);
+		if (gdextension_extension_wrapper) {
+			memdelete(gdextension_extension_wrapper);
+		} else {
+			memdelete(extension_wrapper);
+		}
 	}
 	registered_extension_wrappers.clear();
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88613

This is an alternative to PR https://github.com/godotengine/godot/pull/88688 which tries to fix the pattern generally, whereas this PR is just a targeted fix for issue https://github.com/godotengine/godot/issues/88613