### PR TITLE
Fix undo/redo behavior of ColorPicker and add ability to cancel/confirm color selection

### DIFF
--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -621,10 +621,10 @@ class EditorPropertyColor : public EditorProperty {
 	ColorPickerButton *picker = nullptr;
 	void _color_changed(const Color &p_color);
 	void _popup_closed();
-	void _picker_created();
 	void _picker_opening();
 
 	Color last_color;
+	bool live_changes_enabled = true;
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
@@ -633,6 +633,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(bool p_show_alpha);
+	void set_live_changes_enabled(bool p_enabled);
 	EditorPropertyColor();
 };
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6922,6 +6922,8 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 		} else if (Object::cast_to<EditorPropertyEnum>(prop)) {
 			prop->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 			Object::cast_to<EditorPropertyEnum>(prop)->set_option_button_clip(false);
+		} else if (Object::cast_to<EditorPropertyColor>(prop)) {
+			Object::cast_to<EditorPropertyColor>(prop)->set_live_changes_enabled(false);
 		}
 
 		editors.push_back(prop);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -317,12 +317,11 @@ public:
 	void set_edit_alpha(bool p_show);
 	bool is_editing_alpha() const;
 
-	int get_preset_size();
-
 	void _set_pick_color(const Color &p_color, bool p_update_sliders);
 	void set_pick_color(const Color &p_color);
 	Color get_pick_color() const;
 	void set_old_color(const Color &p_color);
+	Color get_old_color() const;
 
 	void set_display_old_color(bool p_enabled);
 	bool is_displaying_old_color() const;
@@ -373,6 +372,10 @@ public:
 
 	ColorPicker();
 	~ColorPicker();
+};
+
+class ColorPickerPopupPanel : public PopupPanel {
+	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
 };
 
 class ColorPickerButton : public Button {


### PR DESCRIPTION
### Relevant Issues
- Fixes #88607 
- Fixes #83642 
- Fixes #45186
- Could replace #83786

### Changes
This PR fixes a couple of bugs while at the same time introducing some UX changes:
- There will no longer be multiple undos committed for the same color.
- Operations performed in the popup are no longer individually committed to the undo stack. Rather, only one operation is committed when the popup is dismissed.
- If the popup is closed while the HEX code is being edited, it will no longer retain its (possibly invalid) contents when you re-open the popup.
- You are now able to cancel out of the popup without following through with the color selection, instead of having to commit a value you don't want, and then undo it. The `ui_cancel` action (`ESCAPE` by default) is used to cancel out. Dismissing the popup through other means (like clicking outside of it) still confirms the color change as before.
- You can now additionally use the `ui_accept` action (`ENTER` by default) to dismiss the popup and confirm the color operation.

### UX Impact
- The color picker dialog (as in other software) is designed to be a workspace/context in which the user has tools at their disposal to tweak a color as they wish, while previewing the changes. It would be inconsistent with this intent if each color tweak commits an additional undo operation. With this PR, the UX now aligns with the intent.
- The user is now able to either _confirm_ or _cancel_ their operation via keyboard. Granted, users who have grown accustomed to using `ui_cancel` to *confirm* a color operation would have to get used to now pressing `ui_accept` instead, but the old scheme was an oddity and the new scheme is universally known and consistent with the behaviour of all other dialogs.