### PR TITLE
Fix Script Editor saves C# files as embedded scripts.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2851,7 +2851,22 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 	ERR_FAIL_COND_V_MSG(!scr->get_path().is_empty() && scr->get_path() != p_original_path, Ref<Resource>(),
 			"The C# script path is different from the path it was registered in the C# dictionary.");
 
-	scr->set_path(p_original_path, true);
+	Ref<Resource> existing = ResourceCache::get_ref(p_path);
+	switch (p_cache_mode) {
+		case ResourceFormatLoader::CACHE_MODE_IGNORE:
+			break;
+		case ResourceFormatLoader::CACHE_MODE_REUSE:
+			if (existing.is_null()) {
+				scr->set_path(p_original_path);
+			} else {
+				scr = existing;
+			}
+			break;
+		case ResourceFormatLoader::CACHE_MODE_REPLACE:
+			scr->set_path(p_original_path, true);
+			break;
+	}
+
 	scr->reload();
 
 	if (r_error) {


### PR DESCRIPTION
fixes: https://github.com/godotengine/godot/issues/88543
fixes: https://github.com/godotengine/godot/issues/88160

Because of the limitations of compiled programming languages like C#, when a newly created *.cs file hasn't been compiled, we don't have any information about its `Path` or `Type` in the `assembly`. This means we end up creating an invalid instance of this file whenever there's a request. Consequently, multiple instances of the script can exist. When a new instance takes over the path, it clears the `path_cache` of the previous instance, leading to undefined behavior.