### PR TITLE
[macOS] Add null checks for `NSString stringWithUTF8String`.

### DIFF
--- a/platform/macos/dir_access_macos.mm
+++ b/platform/macos/dir_access_macos.mm
@@ -41,9 +41,10 @@
 
 String DirAccessMacOS::fix_unicode_name(const char *p_name) const {
 	String fname;
-	NSString *nsstr = [[NSString stringWithUTF8String:p_name] precomposedStringWithCanonicalMapping];
-
-	fname.parse_utf8([nsstr UTF8String]);
+	if (p_name != nullptr) {
+		NSString *nsstr = [[NSString stringWithUTF8String:p_name] precomposedStringWithCanonicalMapping];
+		fname.parse_utf8([nsstr UTF8String]);
+	}
 
 	return fname;
 }

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -125,7 +125,8 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notice {
 	NSString *nsappname = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
-	NSString *nsbundleid_env = [NSString stringWithUTF8String:getenv("__CFBundleIdentifier")];
+	const char *bundled_id = getenv("__CFBundleIdentifier");
+	NSString *nsbundleid_env = [NSString stringWithUTF8String:(bundled_id != nullptr) ? bundled_id : ""];
 	NSString *nsbundleid = [[NSBundle mainBundle] bundleIdentifier];
 	if (nsappname == nil || isatty(STDOUT_FILENO) || isatty(STDIN_FILENO) || isatty(STDERR_FILENO) || ![nsbundleid isEqualToString:nsbundleid_env]) {
 		// If the executable is started from terminal or is not bundled, macOS WindowServer won't register and activate app window correctly (menu and title bar are grayed out and input ignored).


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/88686 (but I can't reproduce it to test).
