### PR TITLE
Fix some additional errors with 3D disabled

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4778,10 +4778,10 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scaling_3d_scale", PROPERTY_HINT_RANGE, "0.25,2.0,0.01"), "set_scaling_3d_scale", "get_scaling_3d_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "texture_mipmap_bias", PROPERTY_HINT_RANGE, "-2,2,0.001"), "set_texture_mipmap_bias", "get_texture_mipmap_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fsr_sharpness", PROPERTY_HINT_RANGE, "0,2,0.1"), "set_fsr_sharpness", "get_fsr_sharpness");
-#endif
 	ADD_GROUP("Variable Rate Shading", "vrs_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vrs_mode", PROPERTY_HINT_ENUM, "Disabled,Texture,Depth buffer,XR"), "set_vrs_mode", "get_vrs_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "vrs_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_vrs_texture", "get_vrs_texture");
+#endif
 	ADD_GROUP("Canvas Items", "canvas_item_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap"), "set_default_canvas_item_texture_filter", "get_default_canvas_item_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_item_default_texture_repeat", PROPERTY_HINT_ENUM, "Disabled,Enabled,Mirror"), "set_default_canvas_item_texture_repeat", "get_default_canvas_item_texture_repeat");

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -147,25 +147,19 @@
 #include "scene/resources/audio_stream_wav.h"
 #include "scene/resources/bit_map.h"
 #include "scene/resources/bone_map.h"
-#include "scene/resources/box_shape_3d.h"
 #include "scene/resources/camera_attributes.h"
 #include "scene/resources/camera_texture.h"
 #include "scene/resources/capsule_shape_2d.h"
-#include "scene/resources/capsule_shape_3d.h"
 #include "scene/resources/circle_shape_2d.h"
 #include "scene/resources/compositor.h"
 #include "scene/resources/compressed_texture.h"
 #include "scene/resources/concave_polygon_shape_2d.h"
-#include "scene/resources/concave_polygon_shape_3d.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
-#include "scene/resources/convex_polygon_shape_3d.h"
 #include "scene/resources/curve_texture.h"
-#include "scene/resources/cylinder_shape_3d.h"
 #include "scene/resources/environment.h"
 #include "scene/resources/font.h"
 #include "scene/resources/gradient.h"
 #include "scene/resources/gradient_texture.h"
-#include "scene/resources/height_map_shape_3d.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/immediate_mesh.h"
 #include "scene/resources/label_settings.h"
@@ -183,12 +177,10 @@
 #include "scene/resources/placeholder_textures.h"
 #include "scene/resources/polygon_path_finder.h"
 #include "scene/resources/portable_compressed_texture.h"
-#include "scene/resources/primitive_meshes.h"
 #include "scene/resources/rectangle_shape_2d.h"
 #include "scene/resources/resource_format_text.h"
 #include "scene/resources/segment_shape_2d.h"
 #include "scene/resources/separation_ray_shape_2d.h"
-#include "scene/resources/separation_ray_shape_3d.h"
 #include "scene/resources/shader_include.h"
 #include "scene/resources/skeleton_modification_2d.h"
 #include "scene/resources/skeleton_modification_2d_ccdik.h"
@@ -202,7 +194,6 @@
 #include "scene/resources/skeleton_profile.h"
 #include "scene/resources/sky.h"
 #include "scene/resources/sky_material.h"
-#include "scene/resources/sphere_shape_3d.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
@@ -222,9 +213,7 @@
 #include "scene/resources/visual_shader_particle_nodes.h"
 #include "scene/resources/visual_shader_sdf_nodes.h"
 #include "scene/resources/world_2d.h"
-#include "scene/resources/world_3d.h"
 #include "scene/resources/world_boundary_shape_2d.h"
-#include "scene/resources/world_boundary_shape_3d.h"
 #include "scene/scene_string_names.h"
 #include "scene/theme/theme_db.h"
 
@@ -276,10 +265,20 @@
 #include "scene/3d/xr_face_modifier_3d.h"
 #include "scene/3d/xr_nodes.h"
 #include "scene/animation/root_motion_view.h"
-#include "scene/resources/environment.h"
+#include "scene/resources/box_shape_3d.h"
+#include "scene/resources/capsule_shape_3d.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/convex_polygon_shape_3d.h"
+#include "scene/resources/cylinder_shape_3d.h"
 #include "scene/resources/fog_material.h"
+#include "scene/resources/height_map_shape_3d.h"
 #include "scene/resources/importer_mesh.h"
 #include "scene/resources/mesh_library.h"
+#include "scene/resources/primitive_meshes.h"
+#include "scene/resources/separation_ray_shape_3d.h"
+#include "scene/resources/sphere_shape_3d.h"
+#include "scene/resources/world_3d.h"
+#include "scene/resources/world_boundary_shape_3d.h"
 #endif // _3D_DISABLED
 
 static Ref<ResourceFormatSaverText> resource_saver_text;
@@ -864,12 +863,12 @@ void register_scene_types() {
 	GDREGISTER_CLASS(WorldBoundaryShape3D);
 	GDREGISTER_CLASS(ConvexPolygonShape3D);
 	GDREGISTER_CLASS(ConcavePolygonShape3D);
+	GDREGISTER_CLASS(World3D);
 
 	OS::get_singleton()->yield(); // may take time to init
 #endif // _3D_DISABLED
 
 	GDREGISTER_CLASS(PhysicsMaterial);
-	GDREGISTER_CLASS(World3D);
 	GDREGISTER_CLASS(Compositor);
 	GDREGISTER_CLASS(Environment);
 	GDREGISTER_VIRTUAL_CLASS(CameraAttributes);

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2278,8 +2278,10 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("surface_find_by_name", "name"), &ArrayMesh::surface_find_by_name);
 	ClassDB::bind_method(D_METHOD("surface_set_name", "surf_idx", "name"), &ArrayMesh::surface_set_name);
 	ClassDB::bind_method(D_METHOD("surface_get_name", "surf_idx"), &ArrayMesh::surface_get_name);
+#ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("create_trimesh_shape"), &ArrayMesh::create_trimesh_shape);
 	ClassDB::bind_method(D_METHOD("create_convex_shape", "clean", "simplify"), &ArrayMesh::create_convex_shape, DEFVAL(true), DEFVAL(false));
+#endif // _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("create_outline", "margin"), &ArrayMesh::create_outline);
 	ClassDB::bind_method(D_METHOD("regen_normal_maps"), &ArrayMesh::regen_normal_maps);
 	ClassDB::set_method_flags(get_class_static(), _scs_create("regen_normal_maps"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -354,7 +354,9 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
+#ifndef _3D_DISABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));
+#endif // _3D_DISABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton(), "NavigationServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton(), "NavigationServer3D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -420,12 +420,15 @@ TEST_CASE("[Image] Convert image") {
 
 	Ref<Image> image = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
 	PackedByteArray image_data = image->get_data();
+	ERR_PRINT_OFF;
 	image->convert((Image::Format)-1);
+	ERR_PRINT_ON;
 	CHECK_MESSAGE(image->get_data() == image_data, "Image conversion to invalid type (-1) should not alter image.");
-
 	Ref<Image> image2 = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
 	image_data = image2->get_data();
+	ERR_PRINT_OFF;
 	image2->convert((Image::Format)(Image::FORMAT_MAX + 1));
+	ERR_PRINT_ON;
 	CHECK_MESSAGE(image2->get_data() == image_data, "Image conversion to invalid type (Image::FORMAT_MAX + 1) should not alter image.");
 }
 

--- a/tests/scene/test_primitives.h
+++ b/tests/scene/test_primitives.h
@@ -68,8 +68,10 @@ TEST_CASE("[SceneTree][Primitive][Capsule] Capsule Primitive") {
 	}
 
 	SUBCASE("[SceneTree][Primitive][Capsule] If set segments negative, default to at least 0") {
+		ERR_PRINT_OFF;
 		capsule->set_radial_segments(-5);
 		capsule->set_rings(-17);
+		ERR_PRINT_ON;
 
 		CHECK_MESSAGE(capsule->get_radial_segments() >= 0,
 				"Ensure number of radial segments is >= 0.");
@@ -165,9 +167,11 @@ TEST_CASE("[SceneTree][Primitive][Box] Box Primitive") {
 	}
 
 	SUBCASE("[SceneTree][Primitive][Box] Set subdivides to negative and ensure they are >= 0") {
+		ERR_PRINT_OFF;
 		box->set_subdivide_width(-2);
 		box->set_subdivide_height(-2);
 		box->set_subdivide_depth(-2);
+		ERR_PRINT_ON;
 
 		CHECK(box->get_subdivide_width() >= 0);
 		CHECK(box->get_subdivide_height() >= 0);
@@ -254,8 +258,10 @@ TEST_CASE("[SceneTree][Primitive][Cylinder] Cylinder Primitive") {
 	}
 
 	SUBCASE("[SceneTree][Primitive][Cylinder] Ensure num segments is >= 0") {
+		ERR_PRINT_OFF;
 		cylinder->set_radial_segments(-12);
 		cylinder->set_rings(-16);
+		ERR_PRINT_ON;
 
 		CHECK(cylinder->get_radial_segments() >= 0);
 		CHECK(cylinder->get_rings() >= 0);
@@ -441,8 +447,10 @@ TEST_CASE("[SceneTree][Primitive][Plane] Plane Primitive") {
 	}
 
 	SUBCASE("[SceneTree][Primitive][Plane] Ensure number of segments is >= 0.") {
+		ERR_PRINT_OFF;
 		plane->set_subdivide_width(-15);
 		plane->set_subdivide_depth(-29);
+		ERR_PRINT_ON;
 
 		CHECK(plane->get_subdivide_width() >= 0);
 		CHECK(plane->get_subdivide_depth() >= 0);
@@ -486,9 +494,11 @@ TEST_CASE("[SceneTree][Primitive][Prism] Prism Primitive") {
 	}
 
 	SUBCASE("[Primitive][Prism] Ensure number of segments always >= 0") {
+		ERR_PRINT_OFF;
 		prism->set_subdivide_width(-36);
 		prism->set_subdivide_height(-5);
 		prism->set_subdivide_depth(-64);
+		ERR_PRINT_ON;
 
 		CHECK(prism->get_subdivide_width() >= 0);
 		CHECK(prism->get_subdivide_height() >= 0);
@@ -521,8 +531,10 @@ TEST_CASE("[SceneTree][Primitive][Sphere] Sphere Primitive") {
 	}
 
 	SUBCASE("[Primitive][Sphere] Ensure number of segments always >= 0") {
+		ERR_PRINT_OFF;
 		sphere->set_radial_segments(-36);
 		sphere->set_rings(-5);
+		ERR_PRINT_ON;
 
 		CHECK(sphere->get_radial_segments() >= 0);
 		CHECK(sphere->get_rings() >= 0);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -107,14 +107,10 @@
 #include "tests/scene/test_curve_3d.h"
 #include "tests/scene/test_gradient.h"
 #include "tests/scene/test_image_texture.h"
-#include "tests/scene/test_navigation_agent_2d.h"
-#include "tests/scene/test_navigation_obstacle_2d.h"
-#include "tests/scene/test_navigation_region_2d.h"
 #include "tests/scene/test_node.h"
 #include "tests/scene/test_node_2d.h"
 #include "tests/scene/test_packed_scene.h"
 #include "tests/scene/test_path_2d.h"
-#include "tests/scene/test_primitives.h"
 #include "tests/scene/test_sprite_frames.h"
 #include "tests/scene/test_text_edit.h"
 #include "tests/scene/test_theme.h"
@@ -122,16 +118,20 @@
 #include "tests/scene/test_visual_shader.h"
 #include "tests/scene/test_window.h"
 #include "tests/servers/rendering/test_shader_preprocessor.h"
-#include "tests/servers/test_navigation_server_2d.h"
 #include "tests/servers/test_text_server.h"
 #include "tests/test_validate_testing.h"
 
 #ifndef _3D_DISABLED
 #include "tests/scene/test_camera_3d.h"
+#include "tests/scene/test_navigation_agent_2d.h"
 #include "tests/scene/test_navigation_agent_3d.h"
+#include "tests/scene/test_navigation_obstacle_2d.h"
 #include "tests/scene/test_navigation_obstacle_3d.h"
+#include "tests/scene/test_navigation_region_2d.h"
 #include "tests/scene/test_navigation_region_3d.h"
 #include "tests/scene/test_path_3d.h"
+#include "tests/scene/test_primitives.h"
+#include "tests/servers/test_navigation_server_2d.h"
 #include "tests/servers/test_navigation_server_3d.h"
 #endif // _3D_DISABLED
 
@@ -141,8 +141,10 @@
 #include "tests/test_macros.h"
 
 #include "scene/theme/theme_db.h"
+#ifndef _3D_DISABLED
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_3d.h"
+#endif // _3D_DISABLED
 #include "servers/physics_server_2d.h"
 #ifndef _3D_DISABLED
 #include "servers/physics_server_3d.h"
@@ -221,12 +223,12 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 	SignalWatcher *signal_watcher = nullptr;
 
+	PhysicsServer2D *physics_server_2d = nullptr;
 #ifndef _3D_DISABLED
 	PhysicsServer3D *physics_server_3d = nullptr;
-#endif // _3D_DISABLED
-	PhysicsServer2D *physics_server_2d = nullptr;
 	NavigationServer3D *navigation_server_3d = nullptr;
 	NavigationServer2D *navigation_server_2d = nullptr;
+#endif // _3D_DISABLED
 
 	void test_case_start(const doctest::TestCaseData &p_in) override {
 		reinitialize();
@@ -266,10 +268,12 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			physics_server_2d = PhysicsServer2DManager::get_singleton()->new_default_server();
 			physics_server_2d->init();
 
+#ifndef _3D_DISABLED
 			ERR_PRINT_OFF;
 			navigation_server_3d = NavigationServer3DManager::new_default_server();
 			navigation_server_2d = NavigationServer2DManager::new_default_server();
 			ERR_PRINT_ON;
+#endif // _3D_DISABLED
 
 			memnew(InputMap);
 			InputMap::get_singleton()->load_default();
@@ -300,6 +304,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			return;
 		}
 
+#ifndef _3D_DISABLED
 		if (suite_name.find("[Navigation]") != -1 && navigation_server_2d == nullptr && navigation_server_3d == nullptr) {
 			ERR_PRINT_OFF;
 			navigation_server_3d = NavigationServer3DManager::new_default_server();
@@ -307,6 +312,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			ERR_PRINT_ON;
 			return;
 		}
+#endif // _3D_DISABLED
 	}
 
 	void test_case_end(const doctest::CurrentTestCaseStats &) override {
@@ -330,6 +336,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			memdelete(SceneTree::get_singleton());
 		}
 
+#ifndef _3D_DISABLED
 		if (navigation_server_3d) {
 			memdelete(navigation_server_3d);
 			navigation_server_3d = nullptr;
@@ -339,6 +346,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			memdelete(navigation_server_2d);
 			navigation_server_2d = nullptr;
 		}
+#endif // _3D_DISABLED
 
 #ifndef _3D_DISABLED
 		if (physics_server_3d) {


### PR DESCRIPTION
* Disabled 2D navigation tests as they do not work
* Unbound some `Mesh` methods that rely on 3D resources
* Unexposed `World3D` as it depends on physics (and isn't useful)
* Unexposed some `Viewport` vrs related properties that had unexposed methods

With these changes tests run equivalently in `template_debug` to the normal build, and with the tests for `ClassDB` this should indicate that all the methods exposed in this build works correctly at least in that their arguments and return values are exposed types

Edit: Fixed some includes

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
