### PR TITLE
[Docs] Fix some experimental/deprecated hints

### DIFF
--- a/doc/classes/Compositor.xml
+++ b/doc/classes/Compositor.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Compositor" inherits="Resource" experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="Compositor" inherits="Resource" experimental="More customisation of the rendering pipeline will be added in the future." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		The compositor resource holds the configuration with which rendering of a viewport can be customised.
 	</brief_description>
 	<description>
 		The compositor resource holds the configuration with which rendering of a viewport can be customised.
-		[b]Note:[/b] This functionality is still experimental as more customisation of the rendering pipeline will be added in the near future.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CompositorEffect.xml
+++ b/doc/classes/CompositorEffect.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="CompositorEffect" inherits="Resource" experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="CompositorEffect" inherits="Resource" experimental="The implementation may change as more of the rendering internals are exposed over time." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		This resource allows for creating a custom rendering effect.
 	</brief_description>
 	<description>
 		This resource defines a custom rendering effect that can be applied to [Viewport]s through the viewports' [Environment]. You can implement a callback that is called during rendering at a given stage of the rendering pipeline and allows you to insert additional passes. Note that this callback happens on the rendering thread.
-		[b]Note:[/b] This functionality is still experimental, there will be changes to the implementation as we expose more of the rendering internals.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -89,9 +89,8 @@
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining all avoidance layers for the avoidance constrain.
 		</member>
-		<member name="constrain_avoidance" type="bool" setter="set_constrain_avoidance" getter="get_constrain_avoidance" default="false">
+		<member name="constrain_avoidance" type="bool" setter="set_constrain_avoidance" getter="get_constrain_avoidance" default="false" experimental="When enabled, agents are known to get stuck on the navigation polygon corners and edges, especially at a high frame rate. Not recommended for use in production at this stage.">
 			If [code]true[/code] constraints avoidance agent's with an avoidance mask bit that matches with a bit of the [member avoidance_layers] to the navigation polygon. Due to each navigation polygon outline creating an obstacle and each polygon edge creating an avoidance line constrain keep the navigation polygon shape as simple as possible for performance.
-			[b]Experimental:[/b] This is an experimental feature and should not be used in production as agent's can get stuck on the navigation polygon corners and edges especially at high frame rate.
 		</member>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			Determines if the [NavigationRegion2D] is enabled or disabled.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2345,9 +2345,8 @@
 			If [code]true[/code], performs a previous depth pass before rendering 3D materials. This increases performance significantly in scenes with high overdraw, when complex materials and lighting are used. However, in scenes with few occluded surfaces, the depth prepass may reduce performance. If your game is viewed from a fixed angle that makes it easy to avoid overdraw (such as top-down or side-scrolling perspective), consider disabling the depth prepass to improve performance. This setting can be changed at run-time to optimize performance depending on the scene currently being viewed.
 			[b]Note:[/b] Depth prepass is only supported when using the Forward+ or Compatibility rendering method. When using the Mobile rendering method, there is no depth prepass performed.
 		</member>
-		<member name="rendering/driver/threads/thread_model" type="int" setter="" getter="" default="1">
+		<member name="rendering/driver/threads/thread_model" type="int" setter="" getter="" default="1" experimental="This setting has several known bugs which can lead to crashing, especially when using particles or resizing the window. Not recommended for use in production at this stage.">
 			The thread model to use for rendering. Rendering on a thread may improve performance, but synchronizing to the main thread can cause a bit more jitter.
-			[b]Note:[/b] The [b]Multi-Threaded[/b] option is experimental, and has several known bugs which can lead to crashing, especially when using particles or resizing the window. Not recommended for use in production at this stage.
 		</member>
 		<member name="rendering/environment/defaults/default_clear_color" type="Color" setter="" getter="" default="Color(0.3, 0.3, 0.3, 1)">
 			Default background clear color. Overridable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method RenderingServer.set_default_clear_color].

--- a/doc/classes/SkeletonModification2DPhysicalBones.xml
+++ b/doc/classes/SkeletonModification2DPhysicalBones.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DPhysicalBones" inherits="SkeletonModification2D" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DPhysicalBones" inherits="SkeletonModification2D" experimental="Physical bones may be changed in the future to perform the position update of [Bone2D] on their own, without needing this resource." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that applies the transforms of [PhysicalBone2D] nodes to [Bone2D] nodes.
 	</brief_description>
 	<description>
 		This modification takes the transforms of [PhysicalBone2D] nodes and applies them to [Bone2D] nodes. This allows the [Bone2D] nodes to react to physics thanks to the linked [PhysicalBone2D] nodes.
-		Experimental. Physical bones may be changed in the future to perform the position update of [Bone2D] on their own.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -274,8 +274,7 @@
 		<member name="permissions/custom_permissions" type="PackedStringArray" setter="" getter="">
 			Array of custom permission strings.
 		</member>
-		<member name="permissions/delete_cache_files" type="bool" setter="" getter="">
-			Deprecated.
+		<member name="permissions/delete_cache_files" type="bool" setter="" getter="" deprecated="">
 		</member>
 		<member name="permissions/delete_packages" type="bool" setter="" getter="">
 			Allows an application to delete packages. See [url=https://developer.android.com/reference/android/Manifest.permission#DELETE_PACKAGES]DELETE_PACKAGES[/url].
@@ -310,8 +309,7 @@
 		<member name="permissions/get_package_size" type="bool" setter="" getter="">
 			Allows an application to find out the space used by any package. See [url=https://developer.android.com/reference/android/Manifest.permission#GET_PACKAGE_SIZE]GET_PACKAGE_SIZE[/url].
 		</member>
-		<member name="permissions/get_tasks" type="bool" setter="" getter="">
-			Deprecated in API level 21.
+		<member name="permissions/get_tasks" type="bool" setter="" getter="" deprecated="Deprecated in API level 21.">
 		</member>
 		<member name="permissions/get_top_activity_info" type="bool" setter="" getter="">
 			Allows an application to retrieve private information about the current top activity.
@@ -379,13 +377,11 @@
 		<member name="permissions/nfc" type="bool" setter="" getter="">
 			Allows applications to perform I/O operations over NFC. See [url=https://developer.android.com/reference/android/Manifest.permission#NFC]NFC[/url].
 		</member>
-		<member name="permissions/persistent_activity" type="bool" setter="" getter="">
+		<member name="permissions/persistent_activity" type="bool" setter="" getter="" deprecated="Deprecated in API level 15.">
 			Allow an application to make its activities persistent.
-			Deprecated in API level 15.
 		</member>
-		<member name="permissions/process_outgoing_calls" type="bool" setter="" getter="">
+		<member name="permissions/process_outgoing_calls" type="bool" setter="" getter="" deprecated="Deprecated in API level 29.">
 			Allows an application to see the number being dialed during an outgoing call with the option to redirect the call to a different number or abort the call altogether. See [url=https://developer.android.com/reference/android/Manifest.permission#PROCESS_OUTGOING_CALLS]PROCESS_OUTGOING_CALLS[/url].
-			Deprecated in API level 29.
 		</member>
 		<member name="permissions/read_calendar" type="bool" setter="" getter="">
 			Allows an application to read the user's calendar data. See [url=https://developer.android.com/reference/android/Manifest.permission#READ_CALENDAR]READ_CALENDAR[/url].
@@ -396,9 +392,8 @@
 		<member name="permissions/read_contacts" type="bool" setter="" getter="">
 			Allows an application to read the user's contacts data. See [url=https://developer.android.com/reference/android/Manifest.permission#READ_CONTACTS]READ_CONTACTS[/url].
 		</member>
-		<member name="permissions/read_external_storage" type="bool" setter="" getter="">
+		<member name="permissions/read_external_storage" type="bool" setter="" getter="" deprecated="Deprecated in API level 33.">
 			Allows an application to read from external storage. See [url=https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE]READ_EXTERNAL_STORAGE[/url].
-			Deprecated in API level 33.
 		</member>
 		<member name="permissions/read_frame_buffer" type="bool" setter="" getter="">
 			Allows an application to take screen shots and more generally get access to the frame buffer data.
@@ -406,8 +401,7 @@
 		<member name="permissions/read_history_bookmarks" type="bool" setter="" getter="">
 			Allows an application to read (but not write) the user's browsing history and bookmarks.
 		</member>
-		<member name="permissions/read_input_state" type="bool" setter="" getter="">
-			Deprecated in API level 16.
+		<member name="permissions/read_input_state" type="bool" setter="" getter="" deprecated="Deprecated in API level 16.">
 		</member>
 		<member name="permissions/read_logs" type="bool" setter="" getter="">
 			Allows an application to read the low-level system log files. See [url=https://developer.android.com/reference/android/Manifest.permission#READ_LOGS]READ_LOGS[/url].
@@ -454,8 +448,7 @@
 		<member name="permissions/reorder_tasks" type="bool" setter="" getter="">
 			Allows an application to change the Z-order of tasks. See [url=https://developer.android.com/reference/android/Manifest.permission#REORDER_TASKS]REORDER_TASKS[/url].
 		</member>
-		<member name="permissions/restart_packages" type="bool" setter="" getter="">
-			Deprecated in API level 15.
+		<member name="permissions/restart_packages" type="bool" setter="" getter="" deprecated="Deprecated in API level 15.">
 		</member>
 		<member name="permissions/send_respond_via_message" type="bool" setter="" getter="">
 			Allows an application (Phone) to send a request to other applications to handle the respond-via-message action during incoming calls. See [url=https://developer.android.com/reference/android/Manifest.permission#SEND_RESPOND_VIA_MESSAGE]SEND_RESPOND_VIA_MESSAGE[/url].
@@ -484,8 +477,7 @@
 		<member name="permissions/set_pointer_speed" type="bool" setter="" getter="">
 			Allows low-level access to setting the pointer speed.
 		</member>
-		<member name="permissions/set_preferred_applications" type="bool" setter="" getter="">
-			Deprecated in API level 15.
+		<member name="permissions/set_preferred_applications" type="bool" setter="" getter="" deprecated="Deprecated in API level 15.">
 		</member>
 		<member name="permissions/set_process_limit" type="bool" setter="" getter="">
 			Allows an application to set the maximum number of (not needed) application processes that can be running. See [url=https://developer.android.com/reference/android/Manifest.permission#SET_PROCESS_LIMIT]SET_PROCESS_LIMIT[/url].
@@ -511,8 +503,7 @@
 		<member name="permissions/subscribed_feeds_read" type="bool" setter="" getter="">
 			Allows an application to allow access the subscribed feeds ContentProvider.
 		</member>
-		<member name="permissions/subscribed_feeds_write" type="bool" setter="" getter="">
-			Deprecated.
+		<member name="permissions/subscribed_feeds_write" type="bool" setter="" getter="" deprecated="">
 		</member>
 		<member name="permissions/system_alert_window" type="bool" setter="" getter="">
 			Allows an app to create windows using the type WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY, shown on top of all other apps. See [url=https://developer.android.com/reference/android/Manifest.permission#SYSTEM_ALERT_WINDOW]SYSTEM_ALERT_WINDOW[/url].
@@ -520,8 +511,7 @@
 		<member name="permissions/transmit_ir" type="bool" setter="" getter="">
 			Allows using the device's IR transmitter, if available. See [url=https://developer.android.com/reference/android/Manifest.permission#TRANSMIT_IR]TRANSMIT_IR[/url].
 		</member>
-		<member name="permissions/uninstall_shortcut" type="bool" setter="" getter="">
-			Deprecated.
+		<member name="permissions/uninstall_shortcut" type="bool" setter="" getter="" deprecated="">
 		</member>
 		<member name="permissions/update_device_stats" type="bool" setter="" getter="">
 			Allows an application to update device statistics. See [url=https://developer.android.com/reference/android/Manifest.permission#UPDATE_DEVICE_STATS]UPDATE_DEVICE_STATS[/url].

--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -28,9 +28,8 @@
 			The custom HTML page that wraps the exported web build. If left empty, the default HTML shell is used.
 			For more information, see the [url=$DOCS_URL/tutorials/platform/web/customizing_html5_shell.html]Customizing HTML5 Shell[/url] tutorial.
 		</member>
-		<member name="html/experimental_virtual_keyboard" type="bool" setter="" getter="">
+		<member name="html/experimental_virtual_keyboard" type="bool" setter="" getter="" experimental="">
 			If [code]true[/code], embeds support for a virtual keyboard into the web page, which is shown when necessary on touchscreen devices.
-			[b]Warning:[/b] This feature is experimental and may be changed in a future release.
 		</member>
 		<member name="html/export_icon" type="bool" setter="" getter="">
 			If [code]true[/code], the project icon will be used as the favicon for this application's web page.


### PR DESCRIPTION
Two cases from the recent rendering PR that went unnoticed, and some cases that have a deprecated or experimental message but doesn't use the property

Can remove some of those if they are incorrect, but I think they match, if they have the message in the description I don't think there's an issue making it an "official" tag

~Left some of the cases in the Android export in a separate commit for simplicity, as they are specific to an API level, will restore them if they're unwanted~

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
