### PR TITLE
Add support for italic tab titles & italicise unsaved scene tabs

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -382,8 +382,14 @@
 		<theme_item name="font" data_type="font" type="Font">
 			The font used to draw tab names.
 		</theme_item>
+		<theme_item name="italics_font" data_type="font" type="Font">
+			The font used to draw tab names in italic style.
+		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the tab names.
+		</theme_item>
+		<theme_item name="italics_font_size" data_type="font_size" type="int">
+			Font size of the italic tab names.
 		</theme_item>
 		<theme_item name="close" data_type="icon" type="Texture2D">
 			The icon for the close button (see [member tab_close_display_policy]).

--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -244,6 +244,7 @@ void EditorSceneTabs::_update_tab_titles() {
 
 		bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(EditorNode::get_editor_data().get_scene_history_id(i));
 		scene_tabs->set_tab_title(i, disambiguated_scene_names[i] + (unsaved ? "(*)" : ""));
+		scene_tabs->set_tab_title_style(i, unsaved ? TabBar::TabTitleStyle::ITALIC_FONT : TabBar::TabTitleStyle::NORMAL_FONT); // Italic Tabs For Unsaved Progress
 
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
 			int global_menu_index = scene_tabs->get_tab_metadata(i);

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -421,6 +421,8 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	p_theme->set_font("italics_font", "RichTextLabel", italic_fc);
 	p_theme->set_font("bold_italics_font", "RichTextLabel", bold_italic_fc);
 
+	p_theme->set_font("italics_font", "TabBar", italic_fc);
+
 	// Documentation fonts
 	p_theme->set_font_size("doc_size", EditorStringName(EditorFonts), int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
 	p_theme->set_font("doc", EditorStringName(EditorFonts), default_fc);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -30,11 +30,13 @@
 
 #include "tab_bar.h"
 
-#include "core/string/translation.h"
+#include "core/math/vector2.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/main/viewport.h"
+#include "scene/resources/font.h"
+#include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 
 Size2 TabBar::get_minimum_size() const {
@@ -324,15 +326,19 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void TabBar::_shape(int p_tab) {
-	tabs.write[p_tab].text_buf->clear();
-	tabs.write[p_tab].text_buf->set_width(-1);
-	if (tabs[p_tab].text_direction == Control::TEXT_DIRECTION_INHERITED) {
-		tabs.write[p_tab].text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
+	TabBar::Tab *tab = &tabs.write[p_tab];
+	tab->text_buf->clear();
+	tab->text_buf->set_width(-1);
+	if (tab->text_direction == Control::TEXT_DIRECTION_INHERITED) {
+		tab->text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 	} else {
-		tabs.write[p_tab].text_buf->set_direction((TextServer::Direction)tabs[p_tab].text_direction);
+		tab->text_buf->set_direction((TextServer::Direction)tabs[p_tab].text_direction);
 	}
-
-	tabs.write[p_tab].text_buf->add_string(atr(tabs[p_tab].text), theme_cache.font, theme_cache.font_size, tabs[p_tab].language);
+	if (tab->title_style == ITALIC_FONT) {
+		tab->text_buf->add_string(atr(tabs[p_tab].text), theme_cache.italics_font, theme_cache.italics_font_size, tabs[p_tab].language);
+	} else {
+		tab->text_buf->add_string(atr(tabs[p_tab].text), theme_cache.font, theme_cache.font_size, tabs[p_tab].language);
+	}
 }
 
 void TabBar::_notification(int p_what) {
@@ -518,8 +524,9 @@ void TabBar::_notification(int p_what) {
 void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_index, float p_x, bool p_focus) {
 	RID ci = get_canvas_item();
 	bool rtl = is_layout_rtl();
+	const TabBar::Tab *tab = &tabs[p_index];
 
-	Rect2 sb_rect = Rect2(p_x, 0, tabs[p_index].size_cache, get_size().height);
+	Rect2 sb_rect = Rect2(p_x, 0, tab->size_cache, get_size().height);
 	if (tab_style_v_flip) {
 		draw_set_transform(Point2(0.0, p_tab_style->get_draw_rect(sb_rect).size.y), 0.0, Size2(1.0, -1.0));
 	}
@@ -532,12 +539,12 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 		focus_style->draw(ci, sb_rect);
 	}
 
-	p_x += rtl ? tabs[p_index].size_cache - p_tab_style->get_margin(SIDE_LEFT) : p_tab_style->get_margin(SIDE_LEFT);
+	p_x += rtl ? tab->size_cache - p_tab_style->get_margin(SIDE_LEFT) : p_tab_style->get_margin(SIDE_LEFT);
 
 	Size2i sb_ms = p_tab_style->get_minimum_size();
 
 	// Draw the icon.
-	Ref<Texture2D> icon = tabs[p_index].icon;
+	Ref<Texture2D> icon = tab->icon;
 	if (icon.is_valid()) {
 		const Size2 icon_size = _get_tab_icon_size(p_index);
 		const Point2 icon_pos = Point2i(rtl ? p_x - icon_size.width : p_x, p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon_size.height) / 2);
@@ -547,22 +554,21 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 	}
 
 	// Draw the text.
-	if (!tabs[p_index].text.is_empty()) {
-		Point2i text_pos = Point2i(rtl ? p_x - tabs[p_index].size_text : p_x,
-				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
+	if (!tab->text.is_empty()) {
+		Point2i text_pos = Point2i(rtl ? p_x - tab->size_text : p_x,
+				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tab->text_buf->get_size().y) / 2);
 
 		if (theme_cache.outline_size > 0 && theme_cache.font_outline_color.a > 0) {
-			tabs[p_index].text_buf->draw_outline(ci, text_pos, theme_cache.outline_size, theme_cache.font_outline_color);
+			tab->text_buf->draw_outline(ci, text_pos, theme_cache.outline_size, theme_cache.font_outline_color);
 		}
-		tabs[p_index].text_buf->draw(ci, text_pos, p_font_color);
-
-		p_x = rtl ? p_x - tabs[p_index].size_text - theme_cache.h_separation : p_x + tabs[p_index].size_text + theme_cache.h_separation;
+		tab->text_buf->draw(ci, text_pos, p_font_color);
+		p_x = rtl ? p_x - tab->size_text - theme_cache.h_separation : p_x + tab->size_text + theme_cache.h_separation;
 	}
 
 	// Draw and calculate rect of the right button.
-	if (tabs[p_index].right_button.is_valid()) {
+	if (tab->right_button.is_valid()) {
 		Ref<StyleBox> style = theme_cache.button_hl_style;
-		Ref<Texture2D> rb = tabs[p_index].right_button;
+		Ref<Texture2D> rb = tab->right_button;
 
 		Rect2 rb_rect;
 		rb_rect.size = style->get_minimum_size() + rb->get_size();
@@ -598,7 +604,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 
 		tabs.write[p_index].cb_rect = cb_rect;
 
-		if (!tabs[p_index].disabled && cb_hover == p_index) {
+		if (!tab->disabled && cb_hover == p_index) {
 			if (cb_pressing) {
 				theme_cache.button_pressed_style->draw(ci, cb_rect);
 			} else {
@@ -751,6 +757,30 @@ void TabBar::set_tab_title(int p_tab, const String &p_title) {
 String TabBar::get_tab_title(int p_tab) const {
 	ERR_FAIL_INDEX_V(p_tab, tabs.size(), "");
 	return tabs[p_tab].text;
+}
+
+void TabBar::set_tab_title_style(int p_tab, const TabTitleStyle style) {
+	ERR_FAIL_INDEX(p_tab, tabs.size());
+
+	if (tabs[p_tab].title_style == style) {
+		return;
+	}
+
+	tabs.write[p_tab].title_style = style;
+
+	_shape(p_tab);
+	_update_cache();
+	_ensure_no_over_offset();
+	if (scroll_to_selected) {
+		ensure_tab_visible(current);
+	}
+	queue_redraw();
+	update_minimum_size();
+}
+
+TabBar::TabTitleStyle TabBar::get_tab_title_style(int p_tab) const {
+	ERR_FAIL_INDEX_V(p_tab, tabs.size(), TabTitleStyle::NORMAL_FONT);
+	return tabs[p_tab].title_style;
 }
 
 void TabBar::set_tab_text_direction(int p_tab, Control::TextDirection p_text_direction) {
@@ -1885,6 +1915,9 @@ void TabBar::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT, TabBar, font);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT_SIZE, TabBar, font_size);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, TabBar, outline_size);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT, TabBar, italics_font);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT_SIZE, TabBar, italics_font_size);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, TabBar, close_icon, "close");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabBar, button_pressed_style, "button_pressed");

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -38,6 +38,10 @@ class TabBar : public Control {
 	GDCLASS(TabBar, Control);
 
 public:
+	enum TabTitleStyle {
+		NORMAL_FONT,
+		ITALIC_FONT //TODO: add bold support
+	};
 	enum AlignmentMode {
 		ALIGNMENT_LEFT,
 		ALIGNMENT_CENTER,
@@ -64,6 +68,7 @@ private:
 		int icon_max_width = 0;
 
 		bool disabled = false;
+		TabTitleStyle title_style = NORMAL_FONT;
 		bool hidden = false;
 		Variant metadata;
 		int ofs_cache = 0;
@@ -134,6 +139,8 @@ private:
 
 		Ref<Font> font;
 		int font_size;
+		Ref<Font> italics_font;
+		int italics_font_size;
 		int outline_size = 0;
 
 		Color font_selected_color;
@@ -183,6 +190,9 @@ public:
 
 	void set_tab_title(int p_tab, const String &p_title);
 	String get_tab_title(int p_tab) const;
+
+	void set_tab_title_style(int p_tab, TabTitleStyle p_style);
+	TabTitleStyle get_tab_title_style(int p_tab) const;
 
 	void set_tab_text_direction(int p_tab, TextDirection p_text_direction);
 	TextDirection get_tab_text_direction(int p_tab) const;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -918,6 +918,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font("font", "TabBar", Ref<Font>());
 	theme->set_font_size("font_size", "TabBar", -1);
 
+	theme->set_font("italics_font", "TabBar", italics_font);
+	theme->set_font_size("italics_font_size", "TabBar", -1);
+
 	theme->set_color("font_selected_color", "TabBar", control_font_hover_color);
 	theme->set_color("font_hovered_color", "TabBar", control_font_hover_color);
 	theme->set_color("font_unselected_color", "TabBar", control_font_low_color);


### PR DESCRIPTION
Bugsquad: Closes https://github.com/godotengine/godot-proposals/issues/9161 .

This PR [derived from [proposition](https://github.com/godotengine/godot-proposals/issues/9161)]:
- Adds support to vary the style of the tab titles on the group `TabBar::Tab` using the new enum `TabBar::TabTitleStyle`.
- Makes any unsaved scene tab have its title italicised for clearer communication with the user

_PS: There's room for improvement when it comes to performance. See `Line 343` of `scene/gui/tab_bar.cpp`_