### PR TITLE
Don't translate filenames in FileSystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -154,6 +154,8 @@ void FileSystemList::_bind_methods() {
 }
 
 FileSystemList::FileSystemList() {
+	set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+
 	popup_editor = memnew(Popup);
 	add_child(popup_editor);
 


### PR DESCRIPTION
Likely regression from #87530.

The FileSystem dock translates filenames when in split mode:

![image](https://github.com/godotengine/godot/assets/372476/75ecf97d-a469-453e-88a6-d3d05f9c716c)

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/88717*