### PR TITLE
[XR] Fix building on MinGW

### DIFF
--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
@@ -238,3 +238,6 @@ OpenXRExtensionWrapperExtension::OpenXRExtensionWrapperExtension() :
 		Object(), OpenXRExtensionWrapper() {
 	openxr_api.instantiate();
 }
+
+OpenXRExtensionWrapperExtension::~OpenXRExtensionWrapperExtension() {
+}

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.h
@@ -118,6 +118,7 @@ public:
 	void register_extension_wrapper();
 
 	OpenXRExtensionWrapperExtension();
+	virtual ~OpenXRExtensionWrapperExtension() override;
 };
 
 #endif // OPENXR_EXTENSION_WRAPPER_EXTENSION_H


### PR DESCRIPTION
Destructor was defined in multiple places due to multiple inheritance

Using MinGW 13.2.0

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
