### PR TITLE
Properly calculate binormal when creating SurfaceTool from arrays

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -880,9 +880,9 @@ void SurfaceTool::create_vertex_array_from_triangle_arrays(const Array &p_arrays
 			v.normal = narr[i];
 		}
 		if (lformat & RS::ARRAY_FORMAT_TANGENT) {
-			Plane p(tarr[i * 4 + 0], tarr[i * 4 + 1], tarr[i * 4 + 2], tarr[i * 4 + 3]);
-			v.tangent = p.normal;
-			v.binormal = p.normal.cross(v.tangent).normalized() * p.d;
+			v.tangent = Vector3(tarr[i * 4 + 0], tarr[i * 4 + 1], tarr[i * 4 + 2]);
+			float d = tarr[i * 4 + 3];
+			v.binormal = v.normal.cross(v.tangent).normalized() * d;
 		}
 		if (lformat & RS::ARRAY_FORMAT_COLOR) {
 			v.color = carr[i];

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -340,7 +340,7 @@ void _get_axis_angle(const Vector3 &p_normal, const Vector4 &p_tangent, float &r
 	if (d < 0.0) {
 		r_angle = CLAMP((1.0 - r_angle / Math_PI) * 0.5, 0.0, 0.49999);
 	} else {
-		r_angle = (r_angle / Math_PI) * 0.5 + 0.5;
+		r_angle = CLAMP((r_angle / Math_PI) * 0.5 + 0.5, 0.500008, 1.0);
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/86131

I suspect that this will also fix some other subtle bugs.

This bug has existed in the SurfaceTool code for many many years. But it wasn't caught as there were very few situations where this code made a major impact. However, we started using `create_vertex_array_from_triangle_arrays()` in the default GLTF import path a few years ago. The result was that we ended up forcing the binormal sign of all GLTF meshes to 1.0. This is fine for most meshes, but the binormal sign is necessary when mirroring normal maps, so losing it totally broke those meshes. 

_edit: I have also pushed a related fix that ensures that the binormal sign is properly encoded when sending it to the shader. This fixes a related bug when using the compressed mesh format_

_Before:_
![Screenshot from 2024-02-23 10-17-23](https://github.com/godotengine/godot/assets/16521339/540cccd5-620f-4105-a9e8-c520787d81af)
_After_
![Screenshot from 2024-02-23 10-16-48](https://github.com/godotengine/godot/assets/16521339/5c1263f5-7edc-4391-8d8f-1d49883334af)
