### PR TITLE
C#: Add deprecated message to generated bindings

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -150,8 +150,268 @@ static String fix_doc_description(const String &p_bbcode) {
 			.strip_edges();
 }
 
+String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype) {
+	// Based on the version in EditorHelp.
+
+	if (p_bbcode.is_empty()) {
+		return String();
+	}
+
+	DocTools *doc = EditorHelp::get_doc_data();
+
+	String bbcode = p_bbcode;
+
+	StringBuilder output;
+
+	List<String> tag_stack;
+	bool code_tag = false;
+
+	int pos = 0;
+	while (pos < bbcode.length()) {
+		int brk_pos = bbcode.find("[", pos);
+
+		if (brk_pos < 0) {
+			brk_pos = bbcode.length();
+		}
+
+		if (brk_pos > pos) {
+			String text = bbcode.substr(pos, brk_pos - pos);
+			if (code_tag || tag_stack.size() > 0) {
+				output.append("'" + text + "'");
+			} else {
+				output.append(text);
+			}
+		}
+
+		if (brk_pos == bbcode.length()) {
+			// Nothing else to add.
+			break;
+		}
+
+		int brk_end = bbcode.find("]", brk_pos + 1);
+
+		if (brk_end == -1) {
+			String text = bbcode.substr(brk_pos, bbcode.length() - brk_pos);
+			if (code_tag || tag_stack.size() > 0) {
+				output.append("'" + text + "'");
+			}
+
+			break;
+		}
+
+		String tag = bbcode.substr(brk_pos + 1, brk_end - brk_pos - 1);
+
+		if (tag.begins_with("/")) {
+			bool tag_ok = tag_stack.size() && tag_stack.front()->get() == tag.substr(1, tag.length());
+
+			if (!tag_ok) {
+				output.append("]");
+				pos = brk_pos + 1;
+				continue;
+			}
+
+			tag_stack.pop_front();
+			pos = brk_end + 1;
+			code_tag = false;
+		} else if (code_tag) {
+			output.append("[");
+			pos = brk_pos + 1;
+		} else if (tag.begins_with("method ") || tag.begins_with("constructor ") || tag.begins_with("operator ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("theme_item ") || tag.begins_with("param ")) {
+			const int tag_end = tag.find(" ");
+			const String link_tag = tag.substr(0, tag_end);
+			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
+
+			const Vector<String> link_target_parts = link_target.split(".");
+
+			if (link_target_parts.size() <= 0 || link_target_parts.size() > 2) {
+				ERR_PRINT("Invalid reference format: '" + tag + "'.");
+
+				output.append(tag);
+
+				pos = brk_end + 1;
+				continue;
+			}
+
+			const TypeInterface *target_itype;
+			StringName target_cname;
+
+			if (link_target_parts.size() == 2) {
+				target_itype = _get_type_or_null(TypeReference(link_target_parts[0]));
+				if (!target_itype) {
+					target_itype = _get_type_or_null(TypeReference("_" + link_target_parts[0]));
+				}
+				target_cname = link_target_parts[1];
+			} else {
+				target_itype = p_itype;
+				target_cname = link_target_parts[0];
+			}
+
+			if (link_tag == "method") {
+				_append_text_method(output, target_itype, target_cname, link_target, link_target_parts);
+			} else if (link_tag == "constructor") {
+				// TODO: Support constructors?
+				_append_text_undeclared(output, link_target);
+			} else if (link_tag == "operator") {
+				// TODO: Support operators?
+				_append_text_undeclared(output, link_target);
+			} else if (link_tag == "member") {
+				_append_text_member(output, target_itype, target_cname, link_target, link_target_parts);
+			} else if (link_tag == "signal") {
+				_append_text_signal(output, target_itype, target_cname, link_target, link_target_parts);
+			} else if (link_tag == "enum") {
+				_append_text_enum(output, target_itype, target_cname, link_target, link_target_parts);
+			} else if (link_tag == "constant") {
+				_append_text_constant(output, target_itype, target_cname, link_target, link_target_parts);
+			} else if (link_tag == "param") {
+				_append_text_param(output, link_target);
+			} else if (link_tag == "theme_item") {
+				// We do not declare theme_items in any way in C#, so there is nothing to reference.
+				_append_text_undeclared(output, link_target);
+			}
+
+			pos = brk_end + 1;
+		} else if (doc->class_list.has(tag)) {
+			if (tag == "Array" || tag == "Dictionary") {
+				output.append("'" BINDINGS_NAMESPACE_COLLECTIONS ".");
+				output.append(tag);
+				output.append("'");
+			} else if (tag == "bool" || tag == "int") {
+				output.append(tag);
+			} else if (tag == "float") {
+				output.append(
+#ifdef REAL_T_IS_DOUBLE
+						"double"
+#else
+						"float"
+#endif
+				);
+			} else if (tag == "Variant") {
+				output.append("'Godot.Variant'");
+			} else if (tag == "String") {
+				output.append("string");
+			} else if (tag == "Nil") {
+				output.append("null");
+			} else if (tag.begins_with("@")) {
+				// @GlobalScope, @GDScript, etc.
+				output.append("'" + tag + "'");
+			} else if (tag == "PackedByteArray") {
+				output.append("byte[]");
+			} else if (tag == "PackedInt32Array") {
+				output.append("int[]");
+			} else if (tag == "PackedInt64Array") {
+				output.append("long[]");
+			} else if (tag == "PackedFloat32Array") {
+				output.append("float[]");
+			} else if (tag == "PackedFloat64Array") {
+				output.append("double[]");
+			} else if (tag == "PackedStringArray") {
+				output.append("string[]");
+			} else if (tag == "PackedVector2Array") {
+				output.append("'" BINDINGS_NAMESPACE ".Vector2[]'");
+			} else if (tag == "PackedVector3Array") {
+				output.append("'" BINDINGS_NAMESPACE ".Vector3[]'");
+			} else if (tag == "PackedColorArray") {
+				output.append("'" BINDINGS_NAMESPACE ".Color[]'");
+			} else {
+				const TypeInterface *target_itype = _get_type_or_null(TypeReference(tag));
+
+				if (!target_itype) {
+					target_itype = _get_type_or_null(TypeReference("_" + tag));
+				}
+
+				if (target_itype) {
+					output.append("'" + target_itype->proxy_name + "'");
+				} else {
+					ERR_PRINT("Cannot resolve type reference in documentation: '" + tag + "'.");
+					output.append("'" + tag + "'");
+				}
+			}
+
+			pos = brk_end + 1;
+		} else if (tag == "b") {
+			// Bold is not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "i") {
+			// Italic is not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "code" || tag.begins_with("code ")) {
+			code_tag = true;
+			pos = brk_end + 1;
+			tag_stack.push_front("code");
+		} else if (tag == "kbd") {
+			// Keyboard combinations are not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "center") {
+			// Center alignment is not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "br") {
+			// Break is not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "u") {
+			// Underline is not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "s") {
+			// Strikethrough is not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "url") {
+			int end = bbcode.find("[", brk_end);
+			if (end == -1) {
+				end = bbcode.length();
+			}
+			String url = bbcode.substr(brk_end + 1, end - brk_end - 1);
+			// Not supported. Just append the url.
+			output.append(url);
+
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag.begins_with("url=")) {
+			String url = tag.substr(4, tag.length());
+			// Not supported. Just append the url.
+			output.append(url);
+
+			pos = brk_end + 1;
+			tag_stack.push_front("url");
+		} else if (tag == "img") {
+			int end = bbcode.find("[", brk_end);
+			if (end == -1) {
+				end = bbcode.length();
+			}
+			String image = bbcode.substr(brk_end + 1, end - brk_end - 1);
+
+			// Not supported. Just append the bbcode.
+			output.append("[img]");
+			output.append(image);
+			output.append("[/img]");
+
+			pos = end;
+			tag_stack.push_front(tag);
+		} else if (tag.begins_with("color=")) {
+			// Not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front("color");
+		} else if (tag.begins_with("font=")) {
+			// Not supported.
+			pos = brk_end + 1;
+			tag_stack.push_front("font");
+		} else {
+			// Ignore unrecognized tag.
+			output.append("[");
+			pos = brk_pos + 1;
+		}
+	}
+
+	return output.as_string();
+}
+
 String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype, bool p_is_signal) {
-	// Based on the version in EditorHelp
+	// Based on the version in EditorHelp.
 
 	if (p_bbcode.is_empty()) {
 		return String();
@@ -200,7 +460,8 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 		}
 
 		if (brk_pos == bbcode.length()) {
-			break; // nothing else to add
+			// Nothing else to add.
+			break;
 		}
 
 		int brk_end = bbcode.find("]", brk_pos + 1);
@@ -316,7 +577,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			} else if (link_tag == "param") {
 				_append_xml_param(xml_output, link_target, p_is_signal);
 			} else if (link_tag == "theme_item") {
-				// We do not declare theme_items in any way in C#, so there is nothing to reference
+				// We do not declare theme_items in any way in C#, so there is nothing to reference.
 				_append_xml_undeclared(xml_output, link_target);
 			}
 
@@ -345,7 +606,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			} else if (tag == "Nil") {
 				xml_output.append("<see langword=\"null\"/>");
 			} else if (tag.begins_with("@")) {
-				// @GlobalScope, @GDScript, etc
+				// @GlobalScope, @GDScript, etc.
 				xml_output.append("<c>");
 				xml_output.append(tag);
 				xml_output.append("</c>");
@@ -432,22 +693,22 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			pos = brk_end + 1;
 			tag_stack.push_front("csharp");
 		} else if (tag == "kbd") {
-			// keyboard combinations are not supported in xml comments
+			// Keyboard combinations are not supported in xml comments.
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "center") {
-			// center alignment is not supported in xml comments
+			// Center alignment is not supported in xml comments.
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "br") {
 			xml_output.append("\n"); // FIXME: Should use <para> instead. Luckily this tag isn't used for now.
 			pos = brk_end + 1;
 		} else if (tag == "u") {
-			// underline is not supported in Rider xml comments
+			// Underline is not supported in Rider xml comments.
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "s") {
-			// strikethrough is not supported in xml comments
+			// Strikethrough is not supported in xml comments.
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "url") {
@@ -495,7 +756,8 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			tag_stack.push_front("font");
 		} else {
 			if (!line_del) {
-				xml_output.append("["); // ignore
+				// Ignore unrecognized tag.
+				xml_output.append("[");
 			}
 			pos = brk_pos + 1;
 		}
@@ -504,6 +766,285 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 	xml_output.append("</para>");
 
 	return xml_output.as_string();
+}
+
+void BindingsGenerator::_append_text_method(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+	if (p_link_target_parts[0] == name_cache.type_at_GlobalScope) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			OS::get_singleton()->print("Cannot resolve @GlobalScope method reference in documentation: %s\n", p_link_target.utf8().get_data());
+		}
+
+		// TODO Map what we can
+		_append_text_undeclared(p_output, p_link_target);
+	} else if (!p_target_itype || !p_target_itype->is_object_type) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			if (p_target_itype) {
+				OS::get_singleton()->print("Cannot resolve method reference for non-GodotObject type in documentation: %s\n", p_link_target.utf8().get_data());
+			} else {
+				OS::get_singleton()->print("Cannot resolve type from method reference in documentation: %s\n", p_link_target.utf8().get_data());
+			}
+		}
+
+		// TODO Map what we can
+		_append_text_undeclared(p_output, p_link_target);
+	} else {
+		if (p_target_cname == "_init") {
+			// The _init method is not declared in C#, reference the constructor instead
+			p_output.append("'new " BINDINGS_NAMESPACE ".");
+			p_output.append(p_target_itype->proxy_name);
+			p_output.append("()'");
+		} else {
+			const MethodInterface *target_imethod = p_target_itype->find_method_by_name(p_target_cname);
+
+			if (target_imethod) {
+				p_output.append("'" BINDINGS_NAMESPACE ".");
+				p_output.append(p_target_itype->proxy_name);
+				p_output.append(".");
+				p_output.append(target_imethod->proxy_name);
+				p_output.append("(");
+				bool first_key = true;
+				for (const ArgumentInterface &iarg : target_imethod->arguments) {
+					const TypeInterface *arg_type = _get_type_or_null(iarg.type);
+
+					if (first_key) {
+						first_key = false;
+					} else {
+						p_output.append(", ");
+					}
+					if (!arg_type) {
+						ERR_PRINT("Cannot resolve argument type in documentation: '" + p_link_target + "'.");
+						p_output.append(iarg.type.cname);
+						continue;
+					}
+					if (iarg.def_param_mode == ArgumentInterface::NULLABLE_VAL) {
+						p_output.append("Nullable<");
+					}
+					String arg_cs_type = arg_type->cs_type + _get_generic_type_parameters(*arg_type, iarg.type.generic_type_parameters);
+					p_output.append(arg_cs_type.replacen("params ", ""));
+					if (iarg.def_param_mode == ArgumentInterface::NULLABLE_VAL) {
+						p_output.append(">");
+					}
+				}
+				p_output.append(")'");
+			} else {
+				if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+					ERR_PRINT("Cannot resolve method reference in documentation: '" + p_link_target + "'.");
+				}
+
+				_append_text_undeclared(p_output, p_link_target);
+			}
+		}
+	}
+}
+
+void BindingsGenerator::_append_text_member(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+	if (p_link_target.find("/") >= 0) {
+		// Properties with '/' (slash) in the name are not declared in C#, so there is nothing to reference.
+		_append_text_undeclared(p_output, p_link_target);
+	} else if (!p_target_itype || !p_target_itype->is_object_type) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			if (p_target_itype) {
+				OS::get_singleton()->print("Cannot resolve member reference for non-GodotObject type in documentation: %s\n", p_link_target.utf8().get_data());
+			} else {
+				OS::get_singleton()->print("Cannot resolve type from member reference in documentation: %s\n", p_link_target.utf8().get_data());
+			}
+		}
+
+		// TODO Map what we can
+		_append_text_undeclared(p_output, p_link_target);
+	} else {
+		const TypeInterface *current_itype = p_target_itype;
+		const PropertyInterface *target_iprop = nullptr;
+
+		while (target_iprop == nullptr && current_itype != nullptr) {
+			target_iprop = current_itype->find_property_by_name(p_target_cname);
+			if (target_iprop == nullptr) {
+				current_itype = _get_type_or_null(TypeReference(current_itype->base_name));
+			}
+		}
+
+		if (target_iprop) {
+			p_output.append("'" BINDINGS_NAMESPACE ".");
+			p_output.append(current_itype->proxy_name);
+			p_output.append(".");
+			p_output.append(target_iprop->proxy_name);
+			p_output.append("'");
+		} else {
+			if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+				ERR_PRINT("Cannot resolve member reference in documentation: '" + p_link_target + "'.");
+			}
+
+			_append_text_undeclared(p_output, p_link_target);
+		}
+	}
+}
+
+void BindingsGenerator::_append_text_signal(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+	if (!p_target_itype || !p_target_itype->is_object_type) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			if (p_target_itype) {
+				OS::get_singleton()->print("Cannot resolve signal reference for non-GodotObject type in documentation: %s\n", p_link_target.utf8().get_data());
+			} else {
+				OS::get_singleton()->print("Cannot resolve type from signal reference in documentation: %s\n", p_link_target.utf8().get_data());
+			}
+		}
+
+		// TODO Map what we can
+		_append_text_undeclared(p_output, p_link_target);
+	} else {
+		const SignalInterface *target_isignal = p_target_itype->find_signal_by_name(p_target_cname);
+
+		if (target_isignal) {
+			p_output.append("'" BINDINGS_NAMESPACE ".");
+			p_output.append(p_target_itype->proxy_name);
+			p_output.append(".");
+			p_output.append(target_isignal->proxy_name);
+			p_output.append("'");
+		} else {
+			if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+				ERR_PRINT("Cannot resolve signal reference in documentation: '" + p_link_target + "'.");
+			}
+
+			_append_text_undeclared(p_output, p_link_target);
+		}
+	}
+}
+
+void BindingsGenerator::_append_text_enum(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+	const StringName search_cname = !p_target_itype ? p_target_cname : StringName(p_target_itype->name + "." + (String)p_target_cname);
+
+	HashMap<StringName, TypeInterface>::ConstIterator enum_match = enum_types.find(search_cname);
+
+	if (!enum_match && search_cname != p_target_cname) {
+		enum_match = enum_types.find(p_target_cname);
+	}
+
+	if (enum_match) {
+		const TypeInterface &target_enum_itype = enum_match->value;
+
+		p_output.append("'" BINDINGS_NAMESPACE ".");
+		p_output.append(target_enum_itype.proxy_name); // Includes nesting class if any
+		p_output.append("'");
+	} else {
+		if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+			ERR_PRINT("Cannot resolve enum reference in documentation: '" + p_link_target + "'.");
+		}
+
+		_append_text_undeclared(p_output, p_link_target);
+	}
+}
+
+void BindingsGenerator::_append_text_constant(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+	if (p_link_target_parts[0] == name_cache.type_at_GlobalScope) {
+		_append_text_constant_in_global_scope(p_output, p_target_cname, p_link_target);
+	} else if (!p_target_itype || !p_target_itype->is_object_type) {
+		// Search in @GlobalScope as a last resort if no class was specified
+		if (p_link_target_parts.size() == 1) {
+			_append_text_constant_in_global_scope(p_output, p_target_cname, p_link_target);
+			return;
+		}
+
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			if (p_target_itype) {
+				OS::get_singleton()->print("Cannot resolve constant reference for non-GodotObject type in documentation: %s\n", p_link_target.utf8().get_data());
+			} else {
+				OS::get_singleton()->print("Cannot resolve type from constant reference in documentation: %s\n", p_link_target.utf8().get_data());
+			}
+		}
+
+		// TODO Map what we can
+		_append_text_undeclared(p_output, p_link_target);
+	} else {
+		// Try to find the constant in the current class
+		if (p_target_itype->is_singleton_instance) {
+			// Constants and enums are declared in the static singleton class.
+			p_target_itype = &obj_types[p_target_itype->cname];
+		}
+
+		const ConstantInterface *target_iconst = find_constant_by_name(p_target_cname, p_target_itype->constants);
+
+		if (target_iconst) {
+			// Found constant in current class
+			p_output.append("'" BINDINGS_NAMESPACE ".");
+			p_output.append(p_target_itype->proxy_name);
+			p_output.append(".");
+			p_output.append(target_iconst->proxy_name);
+			p_output.append("'");
+		} else {
+			// Try to find as enum constant in the current class
+			const EnumInterface *target_ienum = nullptr;
+
+			for (const EnumInterface &ienum : p_target_itype->enums) {
+				target_ienum = &ienum;
+				target_iconst = find_constant_by_name(p_target_cname, target_ienum->constants);
+				if (target_iconst) {
+					break;
+				}
+			}
+
+			if (target_iconst) {
+				p_output.append("'" BINDINGS_NAMESPACE ".");
+				p_output.append(p_target_itype->proxy_name);
+				p_output.append(".");
+				p_output.append(target_ienum->proxy_name);
+				p_output.append(".");
+				p_output.append(target_iconst->proxy_name);
+				p_output.append("'");
+			} else if (p_link_target_parts.size() == 1) {
+				// Also search in @GlobalScope as a last resort if no class was specified
+				_append_text_constant_in_global_scope(p_output, p_target_cname, p_link_target);
+			} else {
+				if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+					ERR_PRINT("Cannot resolve constant reference in documentation: '" + p_link_target + "'.");
+				}
+
+				_append_xml_undeclared(p_output, p_link_target);
+			}
+		}
+	}
+}
+
+void BindingsGenerator::_append_text_constant_in_global_scope(StringBuilder &p_output, const String &p_target_cname, const String &p_link_target) {
+	// Try to find as a global constant
+	const ConstantInterface *target_iconst = find_constant_by_name(p_target_cname, global_constants);
+
+	if (target_iconst) {
+		// Found global constant
+		p_output.append("'" BINDINGS_NAMESPACE "." BINDINGS_GLOBAL_SCOPE_CLASS ".");
+		p_output.append(target_iconst->proxy_name);
+		p_output.append("'");
+	} else {
+		// Try to find as global enum constant
+		const EnumInterface *target_ienum = nullptr;
+
+		for (const EnumInterface &ienum : global_enums) {
+			target_ienum = &ienum;
+			target_iconst = find_constant_by_name(p_target_cname, target_ienum->constants);
+			if (target_iconst) {
+				break;
+			}
+		}
+
+		if (target_iconst) {
+			p_output.append("'" BINDINGS_NAMESPACE ".");
+			p_output.append(target_ienum->proxy_name);
+			p_output.append(".");
+			p_output.append(target_iconst->proxy_name);
+			p_output.append("'");
+		} else {
+			ERR_PRINT("Cannot resolve global constant reference in documentation: '" + p_link_target + "'.");
+			_append_text_undeclared(p_output, p_link_target);
+		}
+	}
+}
+
+void BindingsGenerator::_append_text_param(StringBuilder &p_output, const String &p_link_target) {
+	const String link_target = snake_to_camel_case(p_link_target);
+	p_output.append("'" + link_target + "'");
+}
+
+void BindingsGenerator::_append_text_undeclared(StringBuilder &p_output, const String &p_link_target) {
+	p_output.append("'" + p_link_target + "'");
 }
 
 void BindingsGenerator::_append_xml_method(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
@@ -1429,10 +1970,12 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 			output.append("/// </summary>\n");
 		}
+	}
 
-		if (class_doc->is_deprecated) {
-			output.append("[Obsolete(\"This class is deprecated.\")]\n");
-		}
+	if (itype.is_deprecated) {
+		output.append("[Obsolete(\"");
+		output.append(bbcode_to_text(itype.deprecation_message, &itype));
+		output.append("\")]\n");
 	}
 
 	// We generate a `GodotClassName` attribute if the engine class name is not the same as the
@@ -1489,10 +2032,12 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 				output.append(INDENT1 "/// </summary>");
 			}
+		}
 
-			if (iconstant.const_doc->is_deprecated) {
-				output.append(MEMBER_BEGIN "[Obsolete(\"This constant is deprecated.\")]");
-			}
+		if (iconstant.is_deprecated) {
+			output.append(MEMBER_BEGIN "[Obsolete(\"");
+			output.append(bbcode_to_text(iconstant.deprecation_message, &itype));
+			output.append("\")]");
 		}
 
 		output.append(MEMBER_BEGIN "public const long ");
@@ -1537,10 +2082,12 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 					output.append(INDENT2 "/// </summary>\n");
 				}
+			}
 
-				if (iconstant.const_doc->is_deprecated) {
-					output.append(INDENT2 "[Obsolete(\"This enum member is deprecated.\")]\n");
-				}
+			if (iconstant.is_deprecated) {
+				output.append(INDENT2 "[Obsolete(\"");
+				output.append(bbcode_to_text(iconstant.deprecation_message, &itype));
+				output.append("\")]\n");
 			}
 
 			output.append(INDENT2);
@@ -1992,10 +2539,12 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 
 			p_output.append(INDENT1 "/// </summary>");
 		}
+	}
 
-		if (p_iprop.prop_doc->is_deprecated) {
-			p_output.append(MEMBER_BEGIN "[Obsolete(\"This property is deprecated.\")]");
-		}
+	if (p_iprop.is_deprecated) {
+		p_output.append(MEMBER_BEGIN "[Obsolete(\"");
+		p_output.append(bbcode_to_text(p_iprop.deprecation_message, &p_itype));
+		p_output.append("\")]");
 	}
 
 	p_output.append(MEMBER_BEGIN "public ");
@@ -2248,15 +2797,9 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		}
 
 		if (p_imethod.is_deprecated) {
-			if (p_imethod.deprecation_message.is_empty()) {
-				WARN_PRINT("An empty deprecation message is discouraged. Method: '" + p_imethod.proxy_name + "'.");
-			}
-
 			p_output.append(MEMBER_BEGIN "[Obsolete(\"");
-			p_output.append(p_imethod.deprecation_message);
+			p_output.append(bbcode_to_text(p_imethod.deprecation_message, &p_itype));
 			p_output.append("\")]");
-		} else if (p_imethod.method_doc && p_imethod.method_doc->is_deprecated) {
-			p_output.append(MEMBER_BEGIN "[Obsolete(\"This method is deprecated.\")]");
 		}
 
 		if (p_imethod.is_compat) {
@@ -2401,12 +2944,8 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 			p_output.append(INDENT1 "/// </summary>");
 
 			if (p_isignal.is_deprecated) {
-				if (p_isignal.deprecation_message.is_empty()) {
-					WARN_PRINT("An empty deprecation message is discouraged. Signal: '" + p_isignal.proxy_name + "'.");
-				}
-
 				p_output.append(MEMBER_BEGIN "[Obsolete(\"");
-				p_output.append(p_isignal.deprecation_message);
+				p_output.append(bbcode_to_text(p_isignal.deprecation_message, &p_itype));
 				p_output.append("\")]");
 			}
 
@@ -2459,15 +2998,11 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 
 				p_output.append(INDENT1 "/// </summary>");
 			}
-
-			if (p_isignal.method_doc->is_deprecated) {
-				p_output.append(MEMBER_BEGIN "[Obsolete(\"This signal is deprecated.\")]");
-			}
 		}
 
 		if (p_isignal.is_deprecated) {
 			p_output.append(MEMBER_BEGIN "[Obsolete(\"");
-			p_output.append(p_isignal.deprecation_message);
+			p_output.append(bbcode_to_text(p_isignal.deprecation_message, &p_itype));
 			p_output.append("\")]");
 		}
 
@@ -3029,6 +3564,16 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		itype.is_ref_counted = ClassDB::is_parent_class(type_cname, name_cache.type_RefCounted);
 		itype.memory_own = itype.is_ref_counted;
 
+		if (itype.class_doc) {
+			itype.is_deprecated = itype.class_doc->is_deprecated;
+			itype.deprecation_message = itype.class_doc->deprecated_message;
+
+			if (itype.deprecation_message.is_empty()) {
+				WARN_PRINT("An empty deprecation message is discouraged. Type: '" + itype.proxy_name + "'.");
+				itype.deprecation_message = "This class is deprecated.";
+			}
+		}
+
 		if (itype.is_singleton && compat_singletons.has(itype.cname)) {
 			itype.is_singleton = false;
 			itype.is_compat_singleton = true;
@@ -3100,6 +3645,16 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				if (prop_doc.name == iprop.cname) {
 					iprop.prop_doc = &prop_doc;
 					break;
+				}
+			}
+
+			if (iprop.prop_doc) {
+				iprop.is_deprecated = iprop.prop_doc->is_deprecated;
+				iprop.deprecation_message = iprop.prop_doc->deprecated_message;
+
+				if (iprop.deprecation_message.is_empty()) {
+					WARN_PRINT("An empty deprecation message is discouraged. Property: '" + itype.proxy_name + "." + iprop.proxy_name + "'.");
+					iprop.deprecation_message = "This property is deprecated.";
 				}
 			}
 
@@ -3282,6 +3837,16 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				}
 			}
 
+			if (imethod.method_doc) {
+				imethod.is_deprecated = imethod.method_doc->is_deprecated;
+				imethod.deprecation_message = imethod.method_doc->deprecated_message;
+
+				if (imethod.deprecation_message.is_empty()) {
+					WARN_PRINT("An empty deprecation message is discouraged. Method: '" + itype.proxy_name + "." + imethod.proxy_name + "'.");
+					imethod.deprecation_message = "This method is deprecated.";
+				}
+			}
+
 			ERR_FAIL_COND_V_MSG(itype.find_property_by_name(imethod.cname), false,
 					"Method name conflicts with property: '" + itype.name + "." + imethod.name + "'.");
 
@@ -3388,6 +3953,16 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				}
 			}
 
+			if (isignal.method_doc) {
+				isignal.is_deprecated = isignal.method_doc->is_deprecated;
+				isignal.deprecation_message = isignal.method_doc->deprecated_message;
+
+				if (isignal.deprecation_message.is_empty()) {
+					WARN_PRINT("An empty deprecation message is discouraged. Signal: '" + itype.proxy_name + "." + isignal.proxy_name + "'.");
+					isignal.deprecation_message = "This signal is deprecated.";
+				}
+			}
+
 			itype.signals_.push_back(isignal);
 		}
 
@@ -3425,6 +4000,16 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 					if (const_doc.name == iconstant.name) {
 						iconstant.const_doc = &const_doc;
 						break;
+					}
+				}
+
+				if (iconstant.const_doc) {
+					iconstant.is_deprecated = iconstant.const_doc->is_deprecated;
+					iconstant.deprecation_message = iconstant.const_doc->deprecated_message;
+
+					if (iconstant.deprecation_message.is_empty()) {
+						WARN_PRINT("An empty deprecation message is discouraged. Enum member: '" + itype.proxy_name + "." + ienum.proxy_name + "." + iconstant.proxy_name + "'.");
+						iconstant.deprecation_message = "This enum member is deprecated.";
 					}
 				}
 
@@ -3467,6 +4052,16 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				if (const_doc.name == iconstant.name) {
 					iconstant.const_doc = &const_doc;
 					break;
+				}
+			}
+
+			if (iconstant.const_doc) {
+				iconstant.is_deprecated = iconstant.const_doc->is_deprecated;
+				iconstant.deprecation_message = iconstant.const_doc->deprecated_message;
+
+				if (iconstant.deprecation_message.is_empty()) {
+					WARN_PRINT("An empty deprecation message is discouraged. Constant: '" + itype.proxy_name + "." + iconstant.proxy_name + "'.");
+					iconstant.deprecation_message = "This constant is deprecated.";
 				}
 			}
 

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -47,7 +47,10 @@ class BindingsGenerator {
 		String name;
 		String proxy_name;
 		int64_t value = 0;
-		const DocData::ConstantDoc *const_doc;
+		const DocData::ConstantDoc *const_doc = nullptr;
+
+		bool is_deprecated = false;
+		String deprecation_message;
 
 		ConstantInterface() {}
 
@@ -86,6 +89,9 @@ class BindingsGenerator {
 		StringName getter;
 
 		const DocData::PropertyDoc *prop_doc;
+
+		bool is_deprecated = false;
+		String deprecation_message;
 	};
 
 	struct TypeReference {
@@ -427,6 +433,9 @@ class BindingsGenerator {
 
 		const DocData::ClassDoc *class_doc = nullptr;
 
+		bool is_deprecated = false;
+		String deprecation_message;
+
 		List<ConstantInterface> constants;
 		List<EnumInterface> enums;
 		List<PropertyInterface> properties;
@@ -765,7 +774,17 @@ class BindingsGenerator {
 		return p_type->name;
 	}
 
+	String bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype);
 	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype, bool p_is_signal = false);
+
+	void _append_text_method(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_member(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_signal(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_enum(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_constant(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_constant_in_global_scope(StringBuilder &p_output, const String &p_target_cname, const String &p_link_target);
+	void _append_text_param(StringBuilder &p_output, const String &p_link_target);
+	void _append_text_undeclared(StringBuilder &p_output, const String &p_link_target);
 
 	void _append_xml_method(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
 	void _append_xml_member(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/81458.

Uses the `DocData` deprecated message in the C# `[Obsolete]` attribute added to deprecated members.

<details>
<summary>Diff of the generated GodotSharp bindings</summary>

```diff
diff --git a/Generated/GodotObjects/AStarGrid2D.cs b/Generated/GodotObjects/AStarGrid2D.cs
index 0679ea5..c59e5f4 100644
--- a/Generated/GodotObjects/AStarGrid2D.cs
+++ b/Generated/GodotObjects/AStarGrid2D.cs
@@ -130,7 +130,7 @@ public partial class AStarGrid2D : RefCounted
     /// <summary>
     /// <para>The size of the grid (number of cells of size <see cref="Godot.AStarGrid2D.CellSize"/> on each axis). If changed, <see cref="Godot.AStarGrid2D.Update()"/> needs to be called before finding the next path.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Use 'Godot.AStarGrid2D.Region' instead.")]
     public Vector2I Size
     {
         get
diff --git a/Generated/GodotObjects/AnimatedTexture.cs b/Generated/GodotObjects/AnimatedTexture.cs
index b7d4719..9109e8a 100644
--- a/Generated/GodotObjects/AnimatedTexture.cs
+++ b/Generated/GodotObjects/AnimatedTexture.cs
@@ -13,7 +13,7 @@ using Godot.NativeInterop;
 /// <para><b>Note:</b> AnimatedTexture doesn't support using <see cref="Godot.AtlasTexture"/>s. Each frame needs to be a separate <see cref="Godot.Texture2D"/>.</para>
 /// <para><b>Warning:</b> The current implementation is not efficient for the modern renderers.</para>
 /// </summary>
-[Obsolete("This class is deprecated.")]
+[Obsolete("This class does not work properly in current versions and may be removed in the future. There is currently no equivalent workaround.")]
 public partial class AnimatedTexture : Texture2D
 {
     /// <summary>
diff --git a/Generated/GodotObjects/AnimationPlayer.cs b/Generated/GodotObjects/AnimationPlayer.cs
index db9510b..bc98c02 100644
--- a/Generated/GodotObjects/AnimationPlayer.cs
+++ b/Generated/GodotObjects/AnimationPlayer.cs
@@ -16,19 +16,19 @@ public partial class AnimationPlayer : AnimationMixer
 {
     public enum AnimationProcessCallback : long
     {
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeProcess.Physics'.")]
         Physics = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeProcess.Idle'.")]
         Idle = 1,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeProcess.Manual'.")]
         Manual = 2
     }
 
     public enum AnimationMethodCallMode : long
     {
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeMethod.Deferred'.")]
         Deferred = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeMethod.Immediate'.")]
         Immediate = 1
     }
 
@@ -465,7 +465,7 @@ public partial class AnimationPlayer : AnimationMixer
     /// <summary>
     /// <para>Sets the process notification in which to update animations.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.CallbackModeProcess' instead.")]
     public void SetProcessCallback(AnimationPlayer.AnimationProcessCallback mode)
     {
         NativeCalls.godot_icall_1_33(MethodBind29, GodotObject.GetPtr(this), (int)mode);
@@ -477,7 +477,7 @@ public partial class AnimationPlayer : AnimationMixer
     /// <summary>
     /// <para>Returns the process notification in which to update animations.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.CallbackModeProcess' instead.")]
     public AnimationPlayer.AnimationProcessCallback GetProcessCallback()
     {
         return (AnimationPlayer.AnimationProcessCallback)NativeCalls.godot_icall_0_34(MethodBind30, GodotObject.GetPtr(this));
@@ -489,7 +489,7 @@ public partial class AnimationPlayer : AnimationMixer
     /// <summary>
     /// <para>Sets the call mode used for "Call Method" tracks.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.CallbackModeMethod' instead.")]
     public void SetMethodCallMode(AnimationPlayer.AnimationMethodCallMode mode)
     {
         NativeCalls.godot_icall_1_33(MethodBind31, GodotObject.GetPtr(this), (int)mode);
@@ -501,7 +501,7 @@ public partial class AnimationPlayer : AnimationMixer
     /// <summary>
     /// <para>Returns the call mode used for "Call Method" tracks.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.CallbackModeMethod' instead.")]
     public AnimationPlayer.AnimationMethodCallMode GetMethodCallMode()
     {
         return (AnimationPlayer.AnimationMethodCallMode)NativeCalls.godot_icall_0_34(MethodBind32, GodotObject.GetPtr(this));
@@ -513,7 +513,7 @@ public partial class AnimationPlayer : AnimationMixer
     /// <summary>
     /// <para>Sets the node which node path references will travel from.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.RootNode' instead.")]
     public void SetRoot(NodePath path)
     {
         NativeCalls.godot_icall_1_111(MethodBind33, GodotObject.GetPtr(this), (godot_node_path)(path?.NativeValue ?? default));
@@ -525,7 +525,7 @@ public partial class AnimationPlayer : AnimationMixer
     /// <summary>
     /// <para>Returns the node which node path references will travel from.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.RootNode' instead.")]
     public NodePath GetRoot()
     {
         return NativeCalls.godot_icall_0_112(MethodBind34, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/AnimationTree.cs b/Generated/GodotObjects/AnimationTree.cs
index 9b8d963..abca8ef 100644
--- a/Generated/GodotObjects/AnimationTree.cs
+++ b/Generated/GodotObjects/AnimationTree.cs
@@ -14,11 +14,11 @@ public partial class AnimationTree : AnimationMixer
 {
     public enum AnimationProcessCallback : long
     {
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeProcess.Physics'.")]
         Physics = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeProcess.Idle'.")]
         Idle = 1,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("See 'Godot.AnimationMixer.AnimationCallbackModeProcess.Manual'.")]
         Manual = 2
     }
 
@@ -138,7 +138,7 @@ public partial class AnimationTree : AnimationMixer
     /// <summary>
     /// <para>Sets the process notification in which to update animations.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.CallbackModeProcess' instead.")]
     public void SetProcessCallback(AnimationTree.AnimationProcessCallback mode)
     {
         NativeCalls.godot_icall_1_33(MethodBind6, GodotObject.GetPtr(this), (int)mode);
@@ -150,7 +150,7 @@ public partial class AnimationTree : AnimationMixer
     /// <summary>
     /// <para>Returns the process notification in which to update animations.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.AnimationMixer.CallbackModeProcess' instead.")]
     public AnimationTree.AnimationProcessCallback GetProcessCallback()
     {
         return (AnimationTree.AnimationProcessCallback)NativeCalls.godot_icall_0_34(MethodBind7, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/CollisionShape3D.cs b/Generated/GodotObjects/CollisionShape3D.cs
index 9c076ab..215135a 100644
--- a/Generated/GodotObjects/CollisionShape3D.cs
+++ b/Generated/GodotObjects/CollisionShape3D.cs
@@ -65,7 +65,7 @@ public partial class CollisionShape3D : Node3D
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.Resource.Changed' instead.")]
     public void ResourceChanged(Resource resource)
     {
         NativeCalls.godot_icall_1_50(MethodBind0, GodotObject.GetPtr(this), GodotObject.GetPtr(resource));
diff --git a/Generated/GodotObjects/Control.cs b/Generated/GodotObjects/Control.cs
index cbddd45..6d12884 100644
--- a/Generated/GodotObjects/Control.cs
+++ b/Generated/GodotObjects/Control.cs
@@ -767,7 +767,7 @@ public partial class Control : CanvasItem
     /// <summary>
     /// <para>Toggles if any text should automatically change to its translated version depending on the current locale.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Use 'Godot.Node.AutoTranslateMode' instead.")]
     public bool AutoTranslate
     {
         get
diff --git a/Generated/GodotObjects/GridMap.cs b/Generated/GodotObjects/GridMap.cs
index 1c40f5f..a18bdaa 100644
--- a/Generated/GodotObjects/GridMap.cs
+++ b/Generated/GodotObjects/GridMap.cs
@@ -527,7 +527,7 @@ public partial class GridMap : Node3D
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.Resource.Changed' instead.")]
     public void ResourceChanged(Resource resource)
     {
         NativeCalls.godot_icall_1_50(MethodBind32, GodotObject.GetPtr(this), GodotObject.GetPtr(resource));
diff --git a/Generated/GodotObjects/HttpClient.cs b/Generated/GodotObjects/HttpClient.cs
index 6a6b47f..52bc92e 100644
--- a/Generated/GodotObjects/HttpClient.cs
+++ b/Generated/GodotObjects/HttpClient.cs
@@ -186,12 +186,12 @@ public partial class HttpClient : RefCounted
         /// <summary>
         /// <para>HTTP status code <c>305 Use Proxy</c>.</para>
         /// </summary>
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Many clients ignore this response code for security reasons. It is also deprecated by the HTTP standard.")]
         UseProxy = 305,
         /// <summary>
         /// <para>HTTP status code <c>306 Switch Proxy</c>.</para>
         /// </summary>
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Many clients ignore this response code for security reasons. It is also deprecated by the HTTP standard.")]
         SwitchProxy = 306,
         /// <summary>
         /// <para>HTTP status code <c>307 Temporary Redirect</c>. The target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.</para>
diff --git a/Generated/GodotObjects/InputEventJoypadButton.cs b/Generated/GodotObjects/InputEventJoypadButton.cs
index 3312217..5d536a0 100644
--- a/Generated/GodotObjects/InputEventJoypadButton.cs
+++ b/Generated/GodotObjects/InputEventJoypadButton.cs
@@ -26,7 +26,7 @@ public partial class InputEventJoypadButton : InputEvent
         }
     }
 
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("This property is never set by the engine and is always '0'.")]
     public float Pressure
     {
         get
diff --git a/Generated/GodotObjects/LightmapGIData.cs b/Generated/GodotObjects/LightmapGIData.cs
index 8f5a1c9..a4f3a95 100644
--- a/Generated/GodotObjects/LightmapGIData.cs
+++ b/Generated/GodotObjects/LightmapGIData.cs
@@ -65,7 +65,7 @@ public partial class LightmapGIData : Resource
     /// <summary>
     /// <para>The lightmap atlas texture generated by the lightmapper.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("The lightmap atlas can now contain multiple textures. See 'Godot.LightmapGIData.LightmapTextures'.")]
     public TextureLayered LightTexture
     {
         get
diff --git a/Generated/GodotObjects/MultiMesh.cs b/Generated/GodotObjects/MultiMesh.cs
index 62e83f2..21ae4e9 100644
--- a/Generated/GodotObjects/MultiMesh.cs
+++ b/Generated/GodotObjects/MultiMesh.cs
@@ -150,7 +150,7 @@ public partial class MultiMesh : Resource
     /// <summary>
     /// <para>Array containing each <see cref="Godot.Transform3D"/> value used by all instances of this mesh, as a <see cref="Godot.Vector3"/>[]. Each transform is divided into 4 <see cref="Godot.Vector3"/> values corresponding to the transforms' <c>x</c>, <c>y</c>, <c>z</c>, and <c>origin</c>.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Accessing this property is very slow. Use 'Godot.MultiMesh.SetInstanceTransform(int, Transform3D)' and 'Godot.MultiMesh.GetInstanceTransform(int)' instead.")]
     public Vector3[] TransformArray
     {
         get
@@ -166,7 +166,7 @@ public partial class MultiMesh : Resource
     /// <summary>
     /// <para>Array containing each <see cref="Godot.Transform2D"/> value used by all instances of this mesh, as a <see cref="Godot.Vector2"/>[]. Each transform is divided into 3 <see cref="Godot.Vector2"/> values corresponding to the transforms' <c>x</c>, <c>y</c>, and <c>origin</c>.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Accessing this property is very slow. Use 'Godot.MultiMesh.SetInstanceTransform2D(int, Transform2D)' and 'Godot.MultiMesh.GetInstanceTransform2D(int)' instead.")]
     public Vector2[] Transform2DArray
     {
         get
@@ -182,7 +182,7 @@ public partial class MultiMesh : Resource
     /// <summary>
     /// <para>Array containing each <see cref="Godot.Color"/> used by all instances of this mesh.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Accessing this property is very slow. Use 'Godot.MultiMesh.SetInstanceColor(int, Color)' and 'Godot.MultiMesh.GetInstanceColor(int)' instead.")]
     public Color[] ColorArray
     {
         get
@@ -198,7 +198,7 @@ public partial class MultiMesh : Resource
     /// <summary>
     /// <para>Array containing each custom data value used by all instances of this mesh, as a <see cref="Godot.Color"/>[].</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Accessing this property is very slow. Use 'Godot.MultiMesh.SetInstanceCustomData(int, Color)' and 'Godot.MultiMesh.GetInstanceCustomData(int)' instead.")]
     public Color[] CustomDataArray
     {
         get
diff --git a/Generated/GodotObjects/NavigationMeshGenerator.cs b/Generated/GodotObjects/NavigationMeshGenerator.cs
index 105257d..b2105a2 100644
--- a/Generated/GodotObjects/NavigationMeshGenerator.cs
+++ b/Generated/GodotObjects/NavigationMeshGenerator.cs
@@ -29,7 +29,7 @@ public static partial class NavigationMeshGenerator
     /// <summary>
     /// <para>Bakes the <paramref name="navigationMesh"/> with source geometry collected starting from the <paramref name="rootNode"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method is deprecated due to core threading changes. To upgrade existing code, first create a 'NavigationMeshSourceGeometryData3D' resource. Use this resource with 'Godot.NavigationMeshGenerator.ParseSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Node, Callable)' to parse the 'SceneTree' for nodes that should contribute to the navigation mesh baking. The 'SceneTree' parsing needs to happen on the main thread. After the parsing is finished use the resource with 'Godot.NavigationMeshGenerator.BakeFromSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Callable)' to bake a navigation mesh.")]
     public static void Bake(NavigationMesh navigationMesh, Node rootNode)
     {
         NativeCalls.godot_icall_2_235(MethodBind0, GodotObject.GetPtr(Singleton), GodotObject.GetPtr(navigationMesh), GodotObject.GetPtr(rootNode));
diff --git a/Generated/GodotObjects/NavigationMeshGeneratorInstance.cs b/Generated/GodotObjects/NavigationMeshGeneratorInstance.cs
index 5b588aa..a211703 100644
--- a/Generated/GodotObjects/NavigationMeshGeneratorInstance.cs
+++ b/Generated/GodotObjects/NavigationMeshGeneratorInstance.cs
@@ -37,7 +37,7 @@ public partial class NavigationMeshGeneratorInstance : GodotObject
     /// <summary>
     /// <para>Bakes the <paramref name="navigationMesh"/> with source geometry collected starting from the <paramref name="rootNode"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method is deprecated due to core threading changes. To upgrade existing code, first create a 'NavigationMeshSourceGeometryData3D' resource. Use this resource with 'Godot.NavigationMeshGeneratorInstance.ParseSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Node, Callable)' to parse the 'SceneTree' for nodes that should contribute to the navigation mesh baking. The 'SceneTree' parsing needs to happen on the main thread. After the parsing is finished use the resource with 'Godot.NavigationMeshGeneratorInstance.BakeFromSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Callable)' to bake a navigation mesh.")]
     public void Bake(NavigationMesh navigationMesh, Node rootNode)
     {
         NativeCalls.godot_icall_2_235(MethodBind0, GodotObject.GetPtr(this), GodotObject.GetPtr(navigationMesh), GodotObject.GetPtr(rootNode));
diff --git a/Generated/GodotObjects/NavigationPolygon.cs b/Generated/GodotObjects/NavigationPolygon.cs
index ba5410b..a490a95 100644
--- a/Generated/GodotObjects/NavigationPolygon.cs
+++ b/Generated/GodotObjects/NavigationPolygon.cs
@@ -420,7 +420,7 @@ public partial class NavigationPolygon : Resource
     /// <summary>
     /// <para>Creates polygons from the outlines added in the editor or by script.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.NavigationServer2D.ParseSourceGeometryData(NavigationPolygon, NavigationMeshSourceGeometryData2D, Node, Callable)' and 'Godot.NavigationServer2D.BakeFromSourceGeometryData(NavigationPolygon, NavigationMeshSourceGeometryData2D, Callable)' instead.")]
     public void MakePolygonsFromOutlines()
     {
         NativeCalls.godot_icall_0_3(MethodBind14, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/NavigationRegion2D.cs b/Generated/GodotObjects/NavigationRegion2D.cs
index 9b662a6..7f2d283 100644
--- a/Generated/GodotObjects/NavigationRegion2D.cs
+++ b/Generated/GodotObjects/NavigationRegion2D.cs
@@ -334,7 +334,7 @@ public partial class NavigationRegion2D : Node2D
     /// <summary>
     /// <para>Returns the <see cref="Godot.Rid"/> of this region on the <see cref="Godot.NavigationServer2D"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.NavigationRegion2D.GetRid()' instead.")]
     public Rid GetRegionRid()
     {
         return NativeCalls.godot_icall_0_210(MethodBind19, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/NavigationRegion3D.cs b/Generated/GodotObjects/NavigationRegion3D.cs
index 862ddeb..84dfca5 100644
--- a/Generated/GodotObjects/NavigationRegion3D.cs
+++ b/Generated/GodotObjects/NavigationRegion3D.cs
@@ -249,7 +249,7 @@ public partial class NavigationRegion3D : Node3D
     /// <summary>
     /// <para>Returns the <see cref="Godot.Rid"/> of this region on the <see cref="Godot.NavigationServer3D"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.NavigationRegion3D.GetRid()' instead.")]
     public Rid GetRegionRid()
     {
         return NativeCalls.godot_icall_0_210(MethodBind13, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/NavigationServer3D.cs b/Generated/GodotObjects/NavigationServer3D.cs
index cfc78f6..05ea0a2 100644
--- a/Generated/GodotObjects/NavigationServer3D.cs
+++ b/Generated/GodotObjects/NavigationServer3D.cs
@@ -629,7 +629,7 @@ public static partial class NavigationServer3D
     /// <summary>
     /// <para>Bakes the <paramref name="navigationMesh"/> with bake source geometry collected starting from the <paramref name="rootNode"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method is deprecated due to core threading changes. To upgrade existing code, first create a 'NavigationMeshSourceGeometryData3D' resource. Use this resource with 'Godot.NavigationServer3D.ParseSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Node, Callable)' to parse the 'SceneTree' for nodes that should contribute to the navigation mesh baking. The 'SceneTree' parsing needs to happen on the main thread. After the parsing is finished use the resource with 'Godot.NavigationServer3D.BakeFromSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Callable)' to bake a navigation mesh.")]
     public static void RegionBakeNavigationMesh(NavigationMesh navigationMesh, Node rootNode)
     {
         NativeCalls.godot_icall_2_235(MethodBind50, GodotObject.GetPtr(Singleton), GodotObject.GetPtr(navigationMesh), GodotObject.GetPtr(rootNode));
diff --git a/Generated/GodotObjects/NavigationServer3DInstance.cs b/Generated/GodotObjects/NavigationServer3DInstance.cs
index 84536e0..b8eefb1 100644
--- a/Generated/GodotObjects/NavigationServer3DInstance.cs
+++ b/Generated/GodotObjects/NavigationServer3DInstance.cs
@@ -597,7 +597,7 @@ public partial class NavigationServer3DInstance : GodotObject
     /// <summary>
     /// <para>Bakes the <paramref name="navigationMesh"/> with bake source geometry collected starting from the <paramref name="rootNode"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method is deprecated due to core threading changes. To upgrade existing code, first create a 'NavigationMeshSourceGeometryData3D' resource. Use this resource with 'Godot.NavigationServer3DInstance.ParseSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Node, Callable)' to parse the 'SceneTree' for nodes that should contribute to the navigation mesh baking. The 'SceneTree' parsing needs to happen on the main thread. After the parsing is finished use the resource with 'Godot.NavigationServer3DInstance.BakeFromSourceGeometryData(NavigationMesh, NavigationMeshSourceGeometryData3D, Callable)' to bake a navigation mesh.")]
     public void RegionBakeNavigationMesh(NavigationMesh navigationMesh, Node rootNode)
     {
         NativeCalls.godot_icall_2_235(MethodBind50, GodotObject.GetPtr(this), GodotObject.GetPtr(navigationMesh), GodotObject.GetPtr(rootNode));
diff --git a/Generated/GodotObjects/Node.cs b/Generated/GodotObjects/Node.cs
index 6cf7d95..5e5c1ed 100644
--- a/Generated/GodotObjects/Node.cs
+++ b/Generated/GodotObjects/Node.cs
@@ -32,7 +32,7 @@ public partial class Node : GodotObject
     /// <para>This notification is received <i>after</i> the related <see cref="Godot.Node.TreeExiting"/> signal.</para>
     /// </summary>
     public const long NotificationExitTree = 11;
-    [Obsolete("This constant is deprecated.")]
+    [Obsolete("This notification is no longer sent by the engine. Use 'Godot.Node.NotificationChildOrderChanged' instead.")]
     public const long NotificationMovedInParent = 12;
     /// <summary>
     /// <para>Notification received when the node is ready. See <see cref="Godot.Node._Ready()"/>.</para>
diff --git a/Generated/GodotObjects/RenderingDevice.cs b/Generated/GodotObjects/RenderingDevice.cs
index 800fa27..a52b109 100644
--- a/Generated/GodotObjects/RenderingDevice.cs
+++ b/Generated/GodotObjects/RenderingDevice.cs
@@ -114,31 +114,31 @@ public partial class RenderingDevice : GodotObject
         /// <para>- Vulkan: <c>VkPipeline</c>.</para>
         /// </summary>
         RenderPipeline = 12,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.LogicalDevice' instead.")]
         VulkanDevice = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.PhysicalDevice' instead.")]
         VulkanPhysicalDevice = 1,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.TopmostObject' instead.")]
         VulkanInstance = 2,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.CommandQueue' instead.")]
         VulkanQueue = 3,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.QueueFamily' instead.")]
         VulkanQueueFamilyIndex = 4,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.Texture' instead.")]
         VulkanImage = 5,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.TextureView' instead.")]
         VulkanImageView = 6,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.TextureDataFormat' instead.")]
         VulkanImageNativeTextureFormat = 7,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.Sampler' instead.")]
         VulkanSampler = 8,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.UniformSet' instead.")]
         VulkanDescriptorSet = 9,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.Buffer' instead.")]
         VulkanBuffer = 10,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.ComputePipeline' instead.")]
         VulkanComputePipeline = 11,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.DriverResource.RenderPipeline' instead.")]
         VulkanRenderPipeline = 12
     }
 
@@ -1754,15 +1754,15 @@ public partial class RenderingDevice : GodotObject
         /// <para>Represents the size of the <see cref="Godot.RenderingDevice.InitialAction"/> enum.</para>
         /// </summary>
         Max = 3,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.InitialAction.Clear' instead.")]
         ClearRegion = 1,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.InitialAction.Load' instead.")]
         ClearRegionContinue = 1,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.InitialAction.Load' instead.")]
         Keep = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.InitialAction.Discard' instead.")]
         Drop = 2,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.InitialAction.Load' instead.")]
         Continue = 0
     }
 
@@ -1780,9 +1780,9 @@ public partial class RenderingDevice : GodotObject
         /// <para>Represents the size of the <see cref="Godot.RenderingDevice.FinalAction"/> enum.</para>
         /// </summary>
         Max = 2,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.FinalAction.Store' instead.")]
         Read = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("Use 'Godot.RenderingDevice.FinalAction.Store' instead.")]
         Continue = 0
     }
 
@@ -2216,7 +2216,7 @@ public partial class RenderingDevice : GodotObject
     /// <para>Returns the internal graphics handle for this texture object. For use when communicating with third-party APIs mostly with GDExtension.</para>
     /// <para><b>Note:</b> This function returns a <c>uint64_t</c> which internally maps to a <c>GLuint</c> (OpenGL) or <c>VkImage</c> (Vulkan).</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.RenderingDevice.GetDriverResource(RenderingDevice.DriverResource, Rid, ulong)' with 'Godot.RenderingDevice.DriverResource.Texture' instead.")]
     public ulong TextureGetNativeHandle(Rid texture)
     {
         return NativeCalls.godot_icall_1_688(MethodBind13, GodotObject.GetPtr(this), texture);
@@ -2743,7 +2743,7 @@ public partial class RenderingDevice : GodotObject
     /// </summary>
     /// <param name="clearColorValues">If the parameter is null, then the default value is <c>Array.Empty&lt;Color&gt;()</c>.</param>
     /// <param name="region">If the parameter is null, then the default value is <c>new Rect2(new Vector2(0, 0), new Vector2(0, 0))</c>.</param>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Split draw lists are used automatically by RenderingDevice.")]
     public unsafe long[] DrawListBeginSplit(Rid framebuffer, uint splits, RenderingDevice.InitialAction initialColorAction, RenderingDevice.FinalAction finalColorAction, RenderingDevice.InitialAction initialDepthAction, RenderingDevice.FinalAction finalDepthAction, Color[] clearColorValues = null, float clearDepth = 1f, uint clearStencil = (uint)(0), Nullable<Rect2> region = null, Godot.Collections.Array<Rid> storageTextures = null)
     {
         Color[] clearColorValuesOrDefVal = clearColorValues != null ? clearColorValues : Array.Empty<Color>();
@@ -2870,7 +2870,7 @@ public partial class RenderingDevice : GodotObject
     /// <summary>
     /// <para>This method does nothing and always returns an empty <see cref="long"/>[].</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Split draw lists are used automatically by RenderingDevice.")]
     public long[] DrawListSwitchToNextPassSplit(uint splits)
     {
         return NativeCalls.godot_icall_1_904(MethodBind65, GodotObject.GetPtr(this), splits);
@@ -3112,7 +3112,7 @@ public partial class RenderingDevice : GodotObject
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Barriers are automatically inserted by RenderingDevice.")]
     public void Barrier(RenderingDevice.BarrierMask from = (RenderingDevice.BarrierMask)(32767), RenderingDevice.BarrierMask to = (RenderingDevice.BarrierMask)(32767))
     {
         NativeCalls.godot_icall_2_68(MethodBind85, GodotObject.GetPtr(this), (int)from, (int)to);
@@ -3124,7 +3124,7 @@ public partial class RenderingDevice : GodotObject
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Barriers are automatically inserted by RenderingDevice.")]
     public void FullBarrier()
     {
         NativeCalls.godot_icall_0_3(MethodBind86, GodotObject.GetPtr(this));
@@ -3172,7 +3172,7 @@ public partial class RenderingDevice : GodotObject
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Inserting labels no longer applies due to command reordering.")]
     public unsafe void DrawCommandInsertLabel(string name, Color color)
     {
         NativeCalls.godot_icall_2_264(MethodBind90, GodotObject.GetPtr(this), name, &color);
diff --git a/Generated/GodotObjects/RenderingServer.cs b/Generated/GodotObjects/RenderingServer.cs
index c977dba..56d5c05 100644
--- a/Generated/GodotObjects/RenderingServer.cs
+++ b/Generated/GodotObjects/RenderingServer.cs
@@ -39,7 +39,7 @@ public static partial class RenderingServer
     /// <para>The maximum number of glow levels that can be used with the glow post-processing effect.</para>
     /// </summary>
     public const long MaxGlowLevels = 7;
-    [Obsolete("This constant is deprecated.")]
+    [Obsolete("This constant is not used by the engine.")]
     public const long MaxCursors = 8;
     /// <summary>
     /// <para>The maximum number of directional lights that can be rendered at a given time in 2D.</para>
@@ -2062,9 +2062,9 @@ public static partial class RenderingServer
 
     public enum Features : long
     {
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("This constant has not been used since Godot 3.0.")]
         Shaders = 0,
-        [Obsolete("This enum member is deprecated.")]
+        [Obsolete("This constant has not been used since Godot 3.0.")]
         Multithreaded = 1
     }
 
@@ -2134,7 +2134,7 @@ public static partial class RenderingServer
     /// <summary>
     /// <para>This method does nothing and always returns an invalid <see cref="Godot.Rid"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("ProxyTexture was removed in Godot 4.")]
     public static Rid TextureProxyCreate(Rid @base)
     {
         return NativeCalls.godot_icall_1_691(MethodBind3, GodotObject.GetPtr(Singleton), @base);
@@ -2170,7 +2170,7 @@ public static partial class RenderingServer
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("ProxyTexture was removed in Godot 4.")]
     public static void TextureProxyUpdate(Rid texture, Rid proxyTo)
     {
         NativeCalls.godot_icall_2_690(MethodBind6, GodotObject.GetPtr(Singleton), texture, proxyTo);
@@ -7465,7 +7465,7 @@ public static partial class RenderingServer
     /// <summary>
     /// <para>This method does nothing and always returns <c>false</c>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method has not been used since Godot 3.0.")]
     public static bool HasFeature(RenderingServer.Features feature)
     {
         return NativeCalls.godot_icall_1_70(MethodBind480, GodotObject.GetPtr(Singleton), (int)feature).ToBool();
diff --git a/Generated/GodotObjects/RenderingServerInstance.cs b/Generated/GodotObjects/RenderingServerInstance.cs
index a266cd5..06ae6bc 100644
--- a/Generated/GodotObjects/RenderingServerInstance.cs
+++ b/Generated/GodotObjects/RenderingServerInstance.cs
@@ -93,7 +93,7 @@ public partial class RenderingServerInstance : GodotObject
     /// <summary>
     /// <para>This method does nothing and always returns an invalid <see cref="Godot.Rid"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("ProxyTexture was removed in Godot 4.")]
     public Rid TextureProxyCreate(Rid @base)
     {
         return NativeCalls.godot_icall_1_691(MethodBind3, GodotObject.GetPtr(this), @base);
@@ -129,7 +129,7 @@ public partial class RenderingServerInstance : GodotObject
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("ProxyTexture was removed in Godot 4.")]
     public void TextureProxyUpdate(Rid texture, Rid proxyTo)
     {
         NativeCalls.godot_icall_2_690(MethodBind6, GodotObject.GetPtr(this), texture, proxyTo);
@@ -5424,7 +5424,7 @@ public partial class RenderingServerInstance : GodotObject
     /// <summary>
     /// <para>This method does nothing and always returns <c>false</c>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method has not been used since Godot 3.0.")]
     public bool HasFeature(RenderingServer.Features feature)
     {
         return NativeCalls.godot_icall_1_70(MethodBind480, GodotObject.GetPtr(this), (int)feature).ToBool();
diff --git a/Generated/GodotObjects/Resource.cs b/Generated/GodotObjects/Resource.cs
index 62476ca..7de416c 100644
--- a/Generated/GodotObjects/Resource.cs
+++ b/Generated/GodotObjects/Resource.cs
@@ -190,7 +190,7 @@ public partial class Resource : RefCounted
     /// <summary>
     /// <para>Calls <see cref="Godot.Resource._SetupLocalToScene()"/>. If <see cref="Godot.Resource.ResourceLocalToScene"/> is set to <c>true</c>, this method is automatically called from <see cref="Godot.PackedScene.Instantiate(PackedScene.GenEditState)"/> by the newly duplicated resource within the scene instance.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method should only be called internally.")]
     public void SetupLocalToScene()
     {
         NativeCalls.godot_icall_0_3(MethodBind9, GodotObject.GetPtr(this));
@@ -242,7 +242,7 @@ public partial class Resource : RefCounted
     /// <summary>
     /// <para>Emitted by a newly duplicated resource with <see cref="Godot.Resource.ResourceLocalToScene"/> set to <c>true</c>.</para>
     /// </summary>
-    [Obsolete("This signal is deprecated.")]
+    [Obsolete("This signal is only emitted when the resource is created. Override 'Godot.Resource._SetupLocalToScene()' instead.")]
     public event Action SetupLocalToSceneRequested
     {
         add => Connect(SignalName.SetupLocalToSceneRequested, Callable.From(value));
diff --git a/Generated/GodotObjects/SceneReplicationConfig.cs b/Generated/GodotObjects/SceneReplicationConfig.cs
index b0804e8..c3be999 100644
--- a/Generated/GodotObjects/SceneReplicationConfig.cs
+++ b/Generated/GodotObjects/SceneReplicationConfig.cs
@@ -147,7 +147,7 @@ public partial class SceneReplicationConfig : Resource
     /// <summary>
     /// <para>Returns <c>true</c> if the property identified by the given <paramref name="path"/> is configured to be synchronized on process.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.SceneReplicationConfig.PropertyGetReplicationMode(NodePath)' instead.")]
     public bool PropertyGetSync(NodePath path)
     {
         return NativeCalls.godot_icall_1_124(MethodBind9, GodotObject.GetPtr(this), (godot_node_path)(path?.NativeValue ?? default)).ToBool();
@@ -159,7 +159,7 @@ public partial class SceneReplicationConfig : Resource
     /// <summary>
     /// <para>Sets whether the property identified by the given <paramref name="path"/> is configured to be synchronized on process.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.SceneReplicationConfig.PropertySetReplicationMode(NodePath, SceneReplicationConfig.ReplicationMode)' with 'Godot.SceneReplicationConfig.ReplicationMode.Always' instead.")]
     public void PropertySetSync(NodePath path, bool enabled)
     {
         NativeCalls.godot_icall_2_123(MethodBind10, GodotObject.GetPtr(this), (godot_node_path)(path?.NativeValue ?? default), enabled.ToGodotBool());
@@ -171,7 +171,7 @@ public partial class SceneReplicationConfig : Resource
     /// <summary>
     /// <para>Returns <c>true</c> if the property identified by the given <paramref name="path"/> is configured to be reliably synchronized when changes are detected on process.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.SceneReplicationConfig.PropertyGetReplicationMode(NodePath)' instead.")]
     public bool PropertyGetWatch(NodePath path)
     {
         return NativeCalls.godot_icall_1_124(MethodBind11, GodotObject.GetPtr(this), (godot_node_path)(path?.NativeValue ?? default)).ToBool();
@@ -183,7 +183,7 @@ public partial class SceneReplicationConfig : Resource
     /// <summary>
     /// <para>Sets whether the property identified by the given <paramref name="path"/> is configured to be reliably synchronized when changes are detected on process.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.SceneReplicationConfig.PropertySetReplicationMode(NodePath, SceneReplicationConfig.ReplicationMode)' with 'Godot.SceneReplicationConfig.ReplicationMode.OnChange' instead.")]
     public void PropertySetWatch(NodePath path, bool enabled)
     {
         NativeCalls.godot_icall_2_123(MethodBind12, GodotObject.GetPtr(this), (godot_node_path)(path?.NativeValue ?? default), enabled.ToGodotBool());
diff --git a/Generated/GodotObjects/ScriptLanguageExtension.cs b/Generated/GodotObjects/ScriptLanguageExtension.cs
index e64283b..2b16603 100644
--- a/Generated/GodotObjects/ScriptLanguageExtension.cs
+++ b/Generated/GodotObjects/ScriptLanguageExtension.cs
@@ -238,7 +238,7 @@ public partial class ScriptLanguageExtension : ScriptLanguage
         return default;
     }
 
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method is not called by the engine.")]
     public virtual bool _HasNamedClasses()
     {
         return default;
diff --git a/Generated/GodotObjects/ShapeCast3D.cs b/Generated/GodotObjects/ShapeCast3D.cs
index 4c82a60..c559ed4 100644
--- a/Generated/GodotObjects/ShapeCast3D.cs
+++ b/Generated/GodotObjects/ShapeCast3D.cs
@@ -198,7 +198,7 @@ public partial class ShapeCast3D : Node3D
     /// <summary>
     /// <para>This method does nothing.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.Resource.Changed' instead.")]
     public void ResourceChanged(Resource resource)
     {
         NativeCalls.godot_icall_1_50(MethodBind0, GodotObject.GetPtr(this), GodotObject.GetPtr(resource));
diff --git a/Generated/GodotObjects/Skeleton3D.cs b/Generated/GodotObjects/Skeleton3D.cs
index 88aaca2..7b6cb35 100644
--- a/Generated/GodotObjects/Skeleton3D.cs
+++ b/Generated/GodotObjects/Skeleton3D.cs
@@ -459,7 +459,7 @@ public partial class Skeleton3D : Node3D
     /// <summary>
     /// <para>Force updates the bone transforms/poses for all bones in the skeleton.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method should only be called internally.")]
     public void ForceUpdateAllBoneTransforms()
     {
         NativeCalls.godot_icall_0_3(MethodBind34, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/SurfaceTool.cs b/Generated/GodotObjects/SurfaceTool.cs
index ed28068..fd48cc1 100644
--- a/Generated/GodotObjects/SurfaceTool.cs
+++ b/Generated/GodotObjects/SurfaceTool.cs
@@ -370,7 +370,7 @@ public partial class SurfaceTool : RefCounted
     /// <summary>
     /// <para>Generates a LOD for a given <paramref name="ndThreshold"/> in linear units (square root of quadric error metric), using at most <paramref name="targetIndexCount"/> indices.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("This method is unused internally, as it does not preserve normals or UVs. Consider using 'Godot.ImporterMesh.GenerateLods(float, float, Godot.Collections.Array)' instead.")]
     public int[] GenerateLod(float ndThreshold, int targetIndexCount = 3)
     {
         return NativeCalls.godot_icall_2_1080(MethodBind23, GodotObject.GetPtr(this), ndThreshold, targetIndexCount);
diff --git a/Generated/GodotObjects/TileMap.cs b/Generated/GodotObjects/TileMap.cs
index 21442c3..86bf93a 100644
--- a/Generated/GodotObjects/TileMap.cs
+++ b/Generated/GodotObjects/TileMap.cs
@@ -135,7 +135,7 @@ public partial class TileMap : TileMapLayerGroup
     /// <summary>
     /// <para>Assigns <paramref name="map"/> as a <see cref="Godot.NavigationServer2D"/> navigation map for the specified TileMap layer <paramref name="layer"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.TileMap.SetLayerNavigationMap(int, Rid)' instead.")]
     public void SetNavigationMap(int layer, Rid map)
     {
         NativeCalls.godot_icall_2_1190(MethodBind0, GodotObject.GetPtr(this), layer, map);
@@ -147,7 +147,7 @@ public partial class TileMap : TileMapLayerGroup
     /// <summary>
     /// <para>Returns the <see cref="Godot.Rid"/> of the <see cref="Godot.NavigationServer2D"/> navigation map assigned to the specified TileMap layer <paramref name="layer"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.TileMap.GetLayerNavigationMap(int)' instead.")]
     public Rid GetNavigationMap(int layer)
     {
         return NativeCalls.godot_icall_1_569(MethodBind1, GodotObject.GetPtr(this), layer);
@@ -159,7 +159,7 @@ public partial class TileMap : TileMapLayerGroup
     /// <summary>
     /// <para>Forces the TileMap and the layer <paramref name="layer"/> to update.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.TileMap.NotifyRuntimeTileDataUpdate(int)' and/or 'Godot.TileMap.UpdateInternals()' instead.")]
     public void ForceUpdate(int layer = -1)
     {
         NativeCalls.godot_icall_1_33(MethodBind2, GodotObject.GetPtr(this), layer);
diff --git a/Generated/GodotObjects/TreeItem.cs b/Generated/GodotObjects/TreeItem.cs
index aaf886c..fe74ab1 100644
--- a/Generated/GodotObjects/TreeItem.cs
+++ b/Generated/GodotObjects/TreeItem.cs
@@ -536,7 +536,7 @@ public partial class TreeItem : GodotObject
     /// <para>Sets the given column's custom draw callback to the <paramref name="callback"/> method on <paramref name="object"/>.</para>
     /// <para>The method named <paramref name="callback"/> should accept two arguments: the <see cref="Godot.TreeItem"/> that is drawn and its position and size as a <see cref="Godot.Rect2"/>.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.TreeItem.SetCustomDrawCallback(int, Callable)' instead.")]
     public void SetCustomDraw(int column, GodotObject @object, StringName callback)
     {
         NativeCalls.godot_icall_3_1237(MethodBind39, GodotObject.GetPtr(this), column, GodotObject.GetPtr(@object), (godot_string_name)(callback?.NativeValue ?? default));
diff --git a/Generated/GodotObjects/Viewport.cs b/Generated/GodotObjects/Viewport.cs
index f9e8f1b..3b46aa7 100644
--- a/Generated/GodotObjects/Viewport.cs
+++ b/Generated/GodotObjects/Viewport.cs
@@ -1375,7 +1375,7 @@ public partial class Viewport : Node
     /// <para>If none of the methods handle the event and <see cref="Godot.Viewport.PhysicsObjectPicking"/> is <c>true</c>, the event is used for physics object picking.</para>
     /// <para><b>Note:</b> This method doesn't propagate input events to embedded <see cref="Godot.Window"/>s or <see cref="Godot.SubViewport"/>s.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.Viewport.PushInput(InputEvent, bool)' instead.")]
     public void PushUnhandledInput(InputEvent @event, bool inLocalCoords = false)
     {
         NativeCalls.godot_icall_2_422(MethodBind39, GodotObject.GetPtr(this), GodotObject.GetPtr(@event), inLocalCoords.ToGodotBool());
diff --git a/Generated/GodotObjects/Window.cs b/Generated/GodotObjects/Window.cs
index 9d2b525..3228c6a 100644
--- a/Generated/GodotObjects/Window.cs
+++ b/Generated/GodotObjects/Window.cs
@@ -655,7 +655,7 @@ public partial class Window : Viewport
     /// <summary>
     /// <para>Toggles if any text should automatically change to its translated version depending on the current locale.</para>
     /// </summary>
-    [Obsolete("This property is deprecated.")]
+    [Obsolete("Use 'Godot.Node.AutoTranslateMode' instead.")]
     public bool AutoTranslate
     {
         get
@@ -957,7 +957,7 @@ public partial class Window : Viewport
     /// <summary>
     /// <para>Causes the window to grab focus, allowing it to receive user input.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Use 'Godot.Window.GrabFocus()' instead.")]
     public void MoveToForeground()
     {
         NativeCalls.godot_icall_0_3(MethodBind25, GodotObject.GetPtr(this));
diff --git a/Generated/GodotObjects/XRInterface.cs b/Generated/GodotObjects/XRInterface.cs
index c3f827a..919e9c3 100644
--- a/Generated/GodotObjects/XRInterface.cs
+++ b/Generated/GodotObjects/XRInterface.cs
@@ -390,7 +390,7 @@ public partial class XRInterface : RefCounted
     /// <summary>
     /// <para>Returns <c>true</c> if this interface supports passthrough.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Check that 'Godot.XRInterface.EnvironmentBlendModeEnum.AlphaBlend' is supported using 'Godot.XRInterface.GetSupportedEnvironmentBlendModes()', instead.")]
     public bool IsPassthroughSupported()
     {
         return NativeCalls.godot_icall_0_37(MethodBind19, GodotObject.GetPtr(this)).ToBool();
@@ -402,7 +402,7 @@ public partial class XRInterface : RefCounted
     /// <summary>
     /// <para>Returns <c>true</c> if passthrough is enabled.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Check if 'Godot.XRInterface.EnvironmentBlendMode' is 'Godot.XRInterface.EnvironmentBlendModeEnum.AlphaBlend', instead.")]
     public bool IsPassthroughEnabled()
     {
         return NativeCalls.godot_icall_0_37(MethodBind20, GodotObject.GetPtr(this)).ToBool();
@@ -415,7 +415,7 @@ public partial class XRInterface : RefCounted
     /// <para>Starts passthrough, will return <c>false</c> if passthrough couldn't be started.</para>
     /// <para><b>Note:</b> The viewport used for XR must have a transparent background, otherwise passthrough may not properly render.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Set the 'Godot.XRInterface.EnvironmentBlendMode' to 'Godot.XRInterface.EnvironmentBlendModeEnum.AlphaBlend', instead.")]
     public bool StartPassthrough()
     {
         return NativeCalls.godot_icall_0_37(MethodBind21, GodotObject.GetPtr(this)).ToBool();
@@ -427,7 +427,7 @@ public partial class XRInterface : RefCounted
     /// <summary>
     /// <para>Stops passthrough.</para>
     /// </summary>
-    [Obsolete("This method is deprecated.")]
+    [Obsolete("Set the 'Godot.XRInterface.EnvironmentBlendMode' to 'Godot.XRInterface.EnvironmentBlendModeEnum.Opaque', instead.")]
     public void StopPassthrough()
     {
         NativeCalls.godot_icall_0_3(MethodBind22, GodotObject.GetPtr(this));

```

</details>