### PR TITLE
Use black border color in borderless fullscreen mode on Windows

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1988,7 +1988,7 @@
 		<constant name="WINDOW_MODE_FULLSCREEN" value="3" enum="WindowMode">
 			Full screen mode with full multi-window support.
 			Full screen window covers the entire display area of a screen and has no decorations. The display's video mode is not changed.
-			[b]On Windows:[/b] Multi-window full-screen mode has a 1px border of the [member ProjectSettings.rendering/environment/defaults/default_clear_color] color.
+			[b]On Windows:[/b] Multi-window full-screen mode has a 1px black border on each side to prevent the graphics driver from automatically converting it to exclusive fullscreen, which would break the ability to overlay other windows on top.
 			[b]On macOS:[/b] A new desktop is used to display the running project.
 			[b]Note:[/b] Regardless of the platform, enabling full screen will change the window size to match the monitor's size. Therefore, make sure your project supports [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] when enabling full screen mode.
 		</constant>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -793,7 +793,7 @@
 		<constant name="MODE_FULLSCREEN" value="3" enum="Mode">
 			Full screen mode with full multi-window support.
 			Full screen window covers the entire display area of a screen and has no decorations. The display's video mode is not changed.
-			[b]On Windows:[/b] Multi-window full-screen mode has a 1px border of the [member ProjectSettings.rendering/environment/defaults/default_clear_color] color.
+			[b]On Windows:[/b] Multi-window full-screen mode has a 1px black border on each side to prevent the graphics driver from automatically converting it to exclusive fullscreen, which would break the ability to overlay other windows on top.
 			[b]On macOS:[/b] A new desktop is used to display the running project.
 			[b]Note:[/b] Regardless of the platform, enabling full screen will change the window size to match the monitor's size. Therefore, make sure your project supports [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] when enabling full screen mode.
 		</constant>

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3406,10 +3406,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 		case WM_NCPAINT: {
 			if (RenderingServer::get_singleton() && (windows[window_id].borderless || (windows[window_id].fullscreen && windows[window_id].multiwindow_fs))) {
-				Color color = RenderingServer::get_singleton()->get_default_clear_color();
 				HDC hdc = GetWindowDC(hWnd);
 				if (hdc) {
-					HPEN pen = CreatePen(PS_SOLID, 1, RGB(color.r * 255.f, color.g * 255.f, color.b * 255.f));
+					// Use solid black border color to make the border as unobtrusive as possible.
+					HPEN pen = CreatePen(PS_SOLID, 1, RGB(0, 0, 0));
 					if (pen) {
 						HGDIOBJ prev_pen = SelectObject(hdc, pen);
 						HGDIOBJ prev_brush = SelectObject(hdc, GetStockObject(NULL_BRUSH));


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/82031.

This makes the border much less noticeable, or even completely invisible on OLED displays.

The gray border is still visible for a split second after starting a project configured to run in fullscreen (while the splash screen is still displayed). Any ideas on how to make it black as soon as possible? cc @bruvzg 

- See https://github.com/godotengine/godot/issues/63500.

## Preview

*Example on the edges of an OLED display (LG C2 42"):*

### Before

![20240223_194005](https://github.com/godotengine/godot/assets/180032/5f6959bf-c652-4d09-80a2-6b91832bc09e)

### After

![20240223_194011](https://github.com/godotengine/godot/assets/180032/11a244c3-002e-4900-92db-2349e17f45e0)
