### PR TITLE
Use godot-cpp 4.2 for the "Godot CPP" CI workflow

### DIFF
--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   # Used for the godot-cpp checkout.
-  GODOT_CPP_BRANCH: '4.1'
+  GODOT_CPP_BRANCH: '4.2'
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-cpp-tests


### PR DESCRIPTION
On PR https://github.com/godotengine/godot/pull/81238, we decided to pin CI to use version N-1 of godot-cpp, in order to prevent circular dependencies.

It's still currently on `4.1`. I've been meaning to make the PR to update it to `4.2` forever, which is what this PR is :-)
