### PR TITLE
Multiple fixes for compressed meshes

### DIFF
--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -938,11 +938,11 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 					if (binormal_src && tangent_src) {
 						surftool->set_tangent(vertex_array[k].tangent);
 					} else if (generate_dummy_tangents) {
-						Vector3 tan = Vector3(0.0, 1.0, 0.0).cross(vertex_array[k].normal);
+						Vector3 tan = Vector3(vertex_array[k].normal.z, -vertex_array[k].normal.x, vertex_array[k].normal.y).cross(vertex_array[k].normal.normalized()).normalized();
 						surftool->set_tangent(Plane(tan.x, tan.y, tan.z, 1.0));
 					}
 				} else {
-					// No normals, use a dummy normal since normals will be generated.
+					// No normals, use a dummy tangent since normals will be generated.
 					if (generate_dummy_tangents) {
 						surftool->set_tangent(Plane(1.0, 0.0, 0.0, 1.0));
 					}
@@ -1007,6 +1007,19 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 
 			Array d = surftool->commit_to_arrays();
 			d.resize(RS::ARRAY_MAX);
+
+			if (mesh_flags & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES && (generate_dummy_tangents || generate_tangents)) {
+				// Compression is enabled, so let's validate that the normals and tangents are correct.
+				Vector<Vector3> normals = d[Mesh::ARRAY_NORMAL];
+				Vector<float> tangents = d[Mesh::ARRAY_TANGENT];
+				for (int vert = 0; vert < normals.size(); vert++) {
+					Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
+					if (abs(tan.dot(normals[vert])) > 0.0001) {
+						// Tangent is not perpendicular to the normal, so we can't use compression.
+						mesh_flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+					}
+				}
+			}
 
 			Array mr;
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2813,7 +2813,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 
 				Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
 				for (int k = 0; k < vertex_num; k++) {
-					Vector3 tan = Vector3(0.0, 1.0, 0.0).cross(normals[k]);
+					Vector3 tan = Vector3(normals[i].z, -normals[i].x, normals[i].y).cross(normals[k].normalized()).normalized();
 					tangentsw[k * 4 + 0] = tan.x;
 					tangentsw[k * 4 + 1] = tan.y;
 					tangentsw[k * 4 + 2] = tan.z;
@@ -2838,6 +2838,19 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				mesh_surface_tool->generate_tangents();
 			}
 			array = mesh_surface_tool->commit_to_arrays();
+
+			if ((flags & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) && a.has("NORMAL") && (a.has("TANGENT") || generate_tangents)) {
+				// Compression is enabled, so let's validate that the normals and tangents are correct.
+				Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
+				Vector<float> tangents = array[Mesh::ARRAY_TANGENT];
+				for (int vert = 0; vert < normals.size(); vert++) {
+					Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
+					if (abs(tan.dot(normals[vert])) > 0.0001) {
+						// Tangent is not perpendicular to the normal, so we can't use compression.
+						flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+					}
+				}
+			}
 
 			Array morphs;
 			//blend shapes

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -208,7 +208,7 @@ void ImmediateMesh::surface_end() {
 				if (uses_tangents) {
 					t = tangents[i].normal.octahedron_tangent_encode(tangents[i].d);
 				} else {
-					Vector3 tan = Vector3(0.0, 1.0, 0.0).cross(normals[i].normalized());
+					Vector3 tan = Vector3(normals[i].z, -normals[i].x, normals[i].y).cross(normals[i].normalized()).normalized();
 					t = tan.octahedron_tangent_encode(1.0);
 				}
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -566,7 +566,8 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 								float angle;
 								Vector3 axis;
 								// Generate an arbitrary vector that is tangential to normal.
-								Vector3 tan = Vector3(0.0, 1.0, 0.0).cross(normal_src[i].normalized());
+								// This assumes that the normal is never (0,0,0).
+								Vector3 tan = Vector3(normal_src[i].z, -normal_src[i].x, normal_src[i].y).cross(normal_src[i].normalized()).normalized();
 								Vector4 tangent = Vector4(tan.x, tan.y, tan.z, 1.0);
 								_get_axis_angle(normal_src[i], tangent, angle, axis);
 
@@ -689,7 +690,8 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint
 						// Set data for tangent.
 						for (int i = 0; i < p_vertex_array_len; i++) {
 							// Generate an arbitrary vector that is tangential to normal.
-							Vector3 tan = Vector3(0.0, 1.0, 0.0).cross(normal_src[i].normalized());
+							// This assumes that the normal is never (0,0,0).
+							Vector3 tan = Vector3(normal_src[i].z, -normal_src[i].x, normal_src[i].y).cross(normal_src[i].normalized()).normalized();
 							Vector2 res = tan.octahedron_tangent_encode(1.0);
 							uint16_t vector[2] = {
 								(uint16_t)CLAMP(res.x * 65535, 0, 65535),


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/85406 (fixed by disabling compression when mesh has bogus tangents)
Fixes: https://github.com/godotengine/godot/issues/84270 (fixed by disabling compression when we generate bogus tangents because the mesh has bogus UVs)
Fixes: https://github.com/godotengine/godot/issues/83345
Fixes: https://github.com/godotengine/godot/issues/88619 (fixed by avoiding singularity when generating tangents and normal is exactly (0,1,0)

There are two different fixes here:

1. When generating dummy tangents from normals, there is a singularity when the normal is exactly (0, 1, 0). In that case we generate bad tangents. So we avoid that by using the normal vector and scrambling the channels to generate the tangent vector. This works in all cases except for when normal is (0,0,0). 

2. When users import bogus meshes the normal/tangent compression fails. It requires that both normals and tangents are valid and are actually perpendicular to each other. Since it is difficult to discover the "force disable compression option", we just detect these cases and silently force disable compression for the user. 
