### PR TITLE
Fix shared variables of inherited scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -200,6 +200,23 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				node->set_scene_inherited_state(sdata->get_state());
 			}
 
+			for (int64_t i = 0; i < variants.size(); i++) {
+				Variant variant = variants[i];
+				Variant::Type variant_type = variant.get_type();
+				switch (variant_type) {
+					case Variant::Type::ARRAY: {
+						Array array = variant;
+						node->set(names[i], array.duplicate(true));
+					} break;
+					case Variant::Type::DICTIONARY: {
+						Dictionary dict = variant;
+						node->set(names[i], dict.duplicate(true));
+					} break;
+					default: {
+						// Do nothing.
+					}
+				}
+			}
 		} else if (n.instance >= 0) {
 			// Instance a scene into this node.
 			if (n.instance & FLAG_INSTANCE_IS_PLACEHOLDER) {


### PR DESCRIPTION
This PR fixes the "shared" variables of inherited scenes.

## MRP
Many thanks to @exodrifter for her MRP.
[dictionary-aliasing.zip](https://github.com/godotengine/godot/files/14390531/dictionary-aliasing.zip)

## Notes
- This may not be an optimal fix, hence the draft status. I would need some reviews, because this fix is pretty naive.

## Notes to merging team
I added the label `cherrypick:4.2`, but this may break projects if they are "exploiting" the bug, ie. fake static variables.

## Fixes
Fixes #81526
