### PR TITLE
Fix shared exported variables of inherited scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -189,6 +189,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 		Node *node = nullptr;
 		MissingNode *missing_node = nullptr;
+		bool is_inherited_scene = false;
 
 		if (i == 0 && base_scene_idx >= 0) {
 			// Scene inheritance on root node.
@@ -199,7 +200,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
 				node->set_scene_inherited_state(sdata->get_state());
 			}
-
+			is_inherited_scene = true;
 		} else if (n.instance >= 0) {
 			// Instance a scene into this node.
 			if (n.instance & FLAG_INSTANCE_IS_PLACEHOLDER) {
@@ -343,6 +344,12 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						}
 					} else {
 						Variant value = props[nprops[j].value];
+
+						// Making sure that instances of inherited scenes don't share the same
+						// reference between them.
+						if (is_inherited_scene) {
+							value = value.duplicate(true);
+						}
 
 						if (value.get_type() == Variant::OBJECT) {
 							//handle resources that are local to scene by duplicating them if needed


### PR DESCRIPTION
This PR fixes the "shared" exported variables of inherited scenes.

## Supersedes
Supersedes #88739.

## MRP
Many thanks to @exodrifter for her MRP.
[dictionary-aliasing.zip](https://github.com/godotengine/godot/files/14390531/dictionary-aliasing.zip)

## Notes to merging team
I added the label `cherrypick:4.2`, but this may break projects if they are "exploiting" the bug, ie. fake static variables.

## Fixes
Fixes #81526.
