### PR TITLE
Remove useless if condition in `EditorPropertyArrayObject` as they always evaluate to false

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -49,14 +49,7 @@ bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_
 		return false;
 	}
 
-	int index;
-	if (name.begins_with("metadata/")) {
-		index = name.get_slice("/", 2).to_int();
-	} else {
-		index = name.get_slice("/", 1).to_int();
-	}
-
-	array.set(index, p_value);
+	array.set(name.get_slice("/", 1).to_int(), p_value);
 	return true;
 }
 
@@ -67,15 +60,8 @@ bool EditorPropertyArrayObject::_get(const StringName &p_name, Variant &r_ret) c
 		return false;
 	}
 
-	int index;
-	if (name.begins_with("metadata/")) {
-		index = name.get_slice("/", 2).to_int();
-	} else {
-		index = name.get_slice("/", 1).to_int();
-	}
-
 	bool valid;
-	r_ret = array.get(index, &valid);
+	r_ret = array.get(name.get_slice("/", 1).to_int(), &valid);
 
 	if (r_ret.get_type() == Variant::OBJECT && Object::cast_to<EncodedObjectAsID>(r_ret)) {
 		r_ret = Object::cast_to<EncodedObjectAsID>(r_ret)->get_object_id();


### PR DESCRIPTION
I discovered two `if` condition that would always be evaluated to false  so I made this PR that just remove them I think it is a bad merge (most likely mine) that they are still here as I thought I had already removed them.
