### PR TITLE
OpenXR: Register eye gaze even when disabled

### DIFF
--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
@@ -30,6 +30,7 @@
 
 #include "openxr_eye_gaze_interaction.h"
 
+#include "core/config/project_settings.h"
 #include "core/os/os.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
@@ -52,7 +53,11 @@ OpenXREyeGazeInteractionExtension::~OpenXREyeGazeInteractionExtension() {
 HashMap<String, bool *> OpenXREyeGazeInteractionExtension::get_requested_extensions() {
 	HashMap<String, bool *> request_extensions;
 
-	request_extensions[XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME] = &available;
+	// Only enable this extension when requested.
+	// We still register our meta data or the action map editor will fail.
+	if (GLOBAL_GET("xr/openxr/extensions/eye_gaze_interaction") && (!OS::get_singleton()->has_feature("mobile") || OS::get_singleton()->has_feature(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME))) {
+		request_extensions[XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME] = &available;
+	}
 
 	return request_extensions;
 }

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -117,11 +117,9 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRWMRControllerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRML2ControllerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRMetaControllerExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXREyeGazeInteractionExtension));
 
 			// register gated extensions
-			if (GLOBAL_GET("xr/openxr/extensions/eye_gaze_interaction") && (!OS::get_singleton()->has_feature("mobile") || OS::get_singleton()->has_feature(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME))) {
-				OpenXRAPI::register_extension_wrapper(memnew(OpenXREyeGazeInteractionExtension));
-			}
 			if (GLOBAL_GET("xr/openxr/extensions/hand_tracking")) {
 				OpenXRAPI::register_extension_wrapper(memnew(OpenXRHandTrackingExtension));
 			}


### PR DESCRIPTION
When we added the option to gate certain extensions, we implemented this such that the extension is not registered at all.
For the eye gaze interaction extension we need to make an exception because this extension also registers meta data for our action map. If it doesn't do this our action map UI will fail when interactions have been added to the action map, but the action map UI is unable to make sense of this.
Instead the extension simply remains disabled.

Fixes #86358

