### PR TITLE
Fix broken layout of asset library page

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -55,7 +55,9 @@ static inline void setup_http_request(HTTPRequest *request) {
 }
 
 void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost) {
-	title->set_text(p_title);
+	title_text = p_title;
+	title->set_text(title_text);
+	title->set_tooltip_text(title_text);
 	asset_id = p_asset_id;
 	category->set_text(p_category);
 	category_id = p_category_id;
@@ -66,16 +68,15 @@ void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, co
 
 // TODO: Refactor this method to use the TextServer.
 void EditorAssetLibraryItem::clamp_width(int p_max_width) {
-	int text_pixel_width = title->get_button_font().ptr()->get_string_size(title->get_text()).x * EDSCALE;
-
-	String full_text = title->get_text();
-	title->set_tooltip_text(full_text);
+	int text_pixel_width = title->get_button_font()->get_string_size(title_text).x * EDSCALE;
 
 	if (text_pixel_width > p_max_width) {
 		// Truncate title text to within the current column width.
-		int max_length = p_max_width / (text_pixel_width / full_text.length());
-		String truncated_text = full_text.left(max_length - 3) + "...";
+		int max_length = p_max_width / (text_pixel_width / title_text.length());
+		String truncated_text = title_text.left(max_length - 3) + "...";
 		title->set_text(truncated_text);
+	} else {
+		title->set_text(title_text);
 	}
 }
 
@@ -1525,7 +1526,15 @@ void EditorAssetLibrary::_update_asset_items_columns() {
 		asset_items->set_columns(new_columns);
 	}
 
-	asset_items_column_width = (get_size().x / new_columns) - (100 * EDSCALE);
+	asset_items_column_width = (get_size().x / new_columns) - (120 * EDSCALE);
+
+	for (int i = 0; i < asset_items->get_child_count(); i++) {
+		EditorAssetLibraryItem *item = Object::cast_to<EditorAssetLibraryItem>(asset_items->get_child(i));
+		if (!item || !item->is_visible()) {
+			continue;
+		}
+		item->clamp_width(asset_items_column_width);
+	}
 }
 
 void EditorAssetLibrary::_set_library_message(const String &p_message) {

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -62,6 +62,7 @@ class EditorAssetLibraryItem : public PanelContainer {
 	LinkButton *author = nullptr;
 	Label *price = nullptr;
 
+	String title_text;
 	int asset_id = 0;
 	int category_id = 0;
 	int author_id = 0;


### PR DESCRIPTION
While reviewing #87407, I came across two additional problems. I've recorded a demo to help explain.

https://github.com/godotengine/godot/assets/24380544/573fef12-5efe-4e47-8ff9-9a0bb439a3dc

The first issue, as described in #87407, occurs when horizontally scaling the project manager window while on the asset library page, resulting in a broken layout.
![image](https://github.com/godotengine/godot/assets/24380544/92d1f56f-dbd8-4697-a1d2-f9e44d56625e)

The second issue occurs when scaling to the point where the third column appears. It becomes evident that the widths of the three columns are not evenly distributed.
![image](https://github.com/godotengine/godot/assets/24380544/d18dbbfc-4d5b-4fc5-b36e-bf07ad539c5c)

The third issue occurs when navigating to the asset library page after opening a project and then scaling. As the number of columns in the asset library increases, it becomes impossible to reduce the number of columns. Even attempting to narrow the width of the asset library doesn't work.

My current solution involves fine-tuning the size of `asset_items_columns_width` and performing a clamp operation each time `_update_asset_items_columns` is executed.

Below is the demo video of my solution.

https://github.com/godotengine/godot/assets/24380544/37976075-3304-4c93-b8a3-e01d22609329

Also, I noticed a refactor todo item in the `clamp_width` function. However, I found that refactoring the `LinkButton` to support ellipsing functionality similar to `Button` might not be straightforward for me. I'm also unsure if it would cause some spec changes for `LinkButton`, so I haven't tackled it from that angle.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/87407