### PR TITLE
[Doc] Fix GDScript casing of `String.num_scientific`

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -651,8 +651,8 @@
 				[codeblocks]
 				[gdscript]
 				var n = -5.2e8
-				print(n)                       # Prints -520000000
-				print(String.NumScientific(n)) # Prints -5.2e+08
+				print(n)                        # Prints -520000000
+				print(String.num_scientific(n)) # Prints -5.2e+08
 				[/gdscript]
 				[csharp]
 				// This method is not implemented in C#.


### PR DESCRIPTION
* Closes: https://github.com/godotengine/godot-docs/issues/9012
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
