### PR TITLE
Image: Add `is_hdr()` and `is_format_hdr()` functions

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2619,6 +2619,16 @@ bool Image::is_compressed() const {
 	return format > FORMAT_RGBE9995;
 }
 
+bool Image::is_hdr() const {
+	return is_format_hdr(format);
+}
+
+bool Image::is_format_hdr(Format p_format) {
+	return (p_format >= FORMAT_RF && p_format <= FORMAT_RGBE9995) ||
+			p_format == FORMAT_BPTC_RGBF || p_format == FORMAT_BPTC_RGBFU ||
+			p_format == FORMAT_ASTC_4x4_HDR || p_format == FORMAT_ASTC_8x8_HDR;
+}
+
 Error Image::decompress() {
 	if (((format >= FORMAT_DXT1 && format <= FORMAT_RGTC_RG) || (format == FORMAT_DXT5_RA_AS_RG)) && _image_decompress_bc) {
 		_image_decompress_bc(this);
@@ -3464,6 +3474,9 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("compress_from_channels", "mode", "channels", "astc_format"), &Image::compress_from_channels, DEFVAL(ASTC_FORMAT_4x4));
 	ClassDB::bind_method(D_METHOD("decompress"), &Image::decompress);
 	ClassDB::bind_method(D_METHOD("is_compressed"), &Image::is_compressed);
+
+	ClassDB::bind_method(D_METHOD("is_hdr"), &Image::is_hdr);
+	ClassDB::bind_static_method("Image", D_METHOD("is_format_hdr", "format"), &Image::is_format_hdr);
 
 	ClassDB::bind_method(D_METHOD("rotate_90", "direction"), &Image::rotate_90);
 	ClassDB::bind_method(D_METHOD("rotate_180"), &Image::rotate_180);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -377,6 +377,9 @@ public:
 	Error decompress();
 	bool is_compressed() const;
 
+	bool is_hdr() const;
+	static bool is_format_hdr(Format p_format);
+
 	void fix_alpha_edges();
 	void premultiply_alpha();
 	void srgb_to_linear();

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -299,6 +299,19 @@
 				Returns [code]true[/code] if the image has no data.
 			</description>
 		</method>
+		<method name="is_format_hdr" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="format" type="int" enum="Image.Format" />
+			<description>
+				Returns [code]true[/code] if [param format] can store color data in the HDR color space.
+			</description>
+		</method>
+		<method name="is_hdr" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the image stores color data in the HDR color space.
+			</description>
+		</method>
 		<method name="is_invisible" qualifiers="const">
 			<return type="bool" />
 			<description>


### PR DESCRIPTION
This PR adds two new functions to `Image` for checking if a format supports the HDR color space. 

~It also improves consistency in the code by replacing 'manual' hdr checks which often omitted float formats.~