### PR TITLE
Fix inefficient list iteration in Node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2963,12 +2963,12 @@ void Node::replace_by(Node *p_node, bool p_keep_groups) {
 	}
 
 	p_node->set_owner(owner);
-	for (int i = 0; i < owned.size(); i++) {
-		owned[i]->set_owner(p_node);
+	for (Node *E : owned) {
+		E->set_owner(p_node);
 	}
 
-	for (int i = 0; i < owned_by_owner.size(); i++) {
-		owned_by_owner[i]->set_owner(owner);
+	for (Node *E : owned_by_owner) {
+		E->set_owner(owner);
 	}
 
 	p_node->set_scene_file_path(get_scene_file_path());


### PR DESCRIPTION
Noticed some random code that iterates a List using indices.