### PR TITLE
Fix rendering issue with depth in WebXR

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -913,8 +913,7 @@ ivec2 multiview_uv(ivec2 uv) {
 uniform highp mat4 world_transform;
 uniform mediump float opaque_prepass_threshold;
 
-#ifndef MODE_RENDER_DEPTH
-#ifdef RENDER_MATERIAL
+#if defined(RENDER_MATERIAL)
 layout(location = 0) out vec4 albedo_output_buffer;
 layout(location = 1) out vec4 normal_output_buffer;
 layout(location = 2) out vec4 orm_output_buffer;
@@ -925,7 +924,6 @@ layout(location = 3) out vec4 emission_output_buffer;
 layout(location = 0) out vec4 frag_color;
 
 #endif // !RENDER_MATERIAL
-#endif // !MODE_RENDER_DEPTH
 
 vec3 F0(float metallic, float specular, vec3 albedo) {
 	float dielectric = 0.16 * specular * specular;


### PR DESCRIPTION
Currently on `master`, in WebXR there is a rendering issue with depth where it draws some triangles in front, that really should be behind.

Here's a screenshot showing the problem (most obvious on the fingers):

![ab052a9ff5c4c335aab55d052fb06fa6](https://github.com/godotengine/godot/assets/191561/0058b374-e28d-4c28-b9ff-a13e3e501bf6)

And here's a screenshot with this PR:

![8ced2edeec825a7e9af9a8a7f099fdba](https://github.com/godotengine/godot/assets/191561/57751473-06d0-49fa-9da3-06fdbef7c41b)

It looks like this issue was introduced in PR https://github.com/godotengine/godot/pull/87386

