### PR TITLE
Make `Skeleton3D::add_bone` return the new bone index

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -14,10 +14,11 @@
 	</tutorials>
 	<methods>
 		<method name="add_bone">
-			<return type="void" />
+			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Adds a bone, with name [param name]. [method get_bone_count] will become the bone index.
+				Adds a new bone with the given name. Returns the new bone's index, or [code]-1[/code] if this method fails.
+				[b]Note:[/b] Bone names should be unique, non empty, and cannot include the [code]:[/code] and [code]/[/code] characters.
 			</description>
 		</method>
 		<method name="clear_bones">

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -215,3 +215,12 @@ Renamed to EditorSceneFormatImporterFBX2GLTF.
 The compat breakage was deemed necessary as this is a class most users wouldn't
 use directly, and the name needs to be disambiguated with the new
 EditorSceneFormatImporterUFBX.
+
+
+GH-88791
+--------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Skeleton3D/methods/add_bone': return_value
+
+Added a return value for add_bone.
+Should not affect existing regular use - the return value would just be unused.
+Compatibility method registered.

--- a/scene/3d/skeleton_3d.compat.inc
+++ b/scene/3d/skeleton_3d.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  skeleton_3d.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void Skeleton3D::_add_bone_bind_compat_88791(const String &p_name) {
+	add_bone(p_name);
+}
+
+void Skeleton3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("add_bone", "p_name"), &Skeleton3D::_add_bone_bind_compat_88791);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "skeleton_3d.h"
+#include "skeleton_3d.compat.inc"
 
 #include "core/variant/type_info.h"
 #include "scene/3d/physics_body_3d.h"
@@ -409,18 +410,21 @@ uint64_t Skeleton3D::get_version() const {
 	return version;
 }
 
-void Skeleton3D::add_bone(const String &p_name) {
-	ERR_FAIL_COND(p_name.is_empty() || p_name.contains(":") || p_name.contains("/") || name_to_bone_index.has(p_name));
+int Skeleton3D::add_bone(const String &p_name) {
+	ERR_FAIL_COND_V_MSG(p_name.is_empty() || p_name.contains(":") || p_name.contains("/"), -1, vformat("Bone name cannot be empty or contain ':' or '/'.", p_name));
+	ERR_FAIL_COND_V_MSG(name_to_bone_index.has(p_name), -1, vformat("Skeleton3D \"%s\" already has a bone with name \"%s\".", to_string(), p_name));
 
 	Bone b;
 	b.name = p_name;
 	bones.push_back(b);
-	name_to_bone_index.insert(p_name, bones.size() - 1);
+	int new_idx = bones.size() - 1;
+	name_to_bone_index.insert(p_name, new_idx);
 	process_order_dirty = true;
 	version++;
 	rest_dirty = true;
 	_make_dirty();
 	update_gizmos();
+	return new_idx;
 }
 
 int Skeleton3D::find_bone(const String &p_name) const {

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -138,6 +138,12 @@ private:
 
 	void _update_process_order();
 
+#ifndef DISABLE_DEPRECATED
+	void _add_bone_bind_compat_88791(const String &p_name);
+
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
@@ -153,7 +159,7 @@ public:
 
 	// skeleton creation api
 	uint64_t get_version() const;
-	void add_bone(const String &p_name);
+	int add_bone(const String &p_name);
 	int find_bone(const String &p_name) const;
 	String get_bone_name(int p_bone) const;
 	void set_bone_name(int p_bone, const String &p_name);


### PR DESCRIPTION
This is a small quality-of-life change which makes `Skeleton3D::add_bone` return the newly assigned bone index as part of the same call, instead of requiring an additional function call.

This PR should be backwards-compatible and not break any existing use of the function.

Additionally, the original documentation was also confusing and misleading because it said that `get_bone_count` would become the new index. However, it fails to mention that this value must be retrieved _before_ adding the bone. It's pretty unintuitive to get the index of a bone before you add it. If you fetch the index afterwards, you'd actually have to use `get_bone_count() - 1`. As part of this PR, the documentation was updated to avoid this confusion.

New usage:
```
idx = skel.add_bone("Thumb")
```
Old usage (correct):
```
idx = skel.get_bone_count()
skel.add_bone("Thumb")

OR

skel.add_bone("Thumb")
idx = skel.get_bone_count() - 1
```
Old usage (incorrect):
```
skel.add_bone("Thumb")
idx = skel.get_bone_count()
```