### PR TITLE
Disable add new item from Dictionary Editor when there is an invalid key.

### DIFF
--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -60,6 +60,7 @@ class EditorPropertyDictionaryObject : public RefCounted {
 	Variant new_item_key;
 	Variant new_item_value;
 	Dictionary dict;
+	bool new_item_key_invalidity = true;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -71,6 +72,10 @@ public:
 
 	void set_new_item_key(const Variant &p_new_item);
 	Variant get_new_item_key();
+
+	void update_new_item_key_invalidity();
+	bool get_new_item_key_invalidity();
+	Callable validity_change_callback;
 
 	void set_new_item_value(const Variant &p_new_item);
 	Variant get_new_item_value();
@@ -183,6 +188,7 @@ class EditorPropertyDictionary : public EditorProperty {
 
 	void _add_key_value();
 	void _object_id_selected(const StringName &p_property, ObjectID p_id);
+	void _on_new_key_validity_changed(bool p_invalidity);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Small step towards #76078
Commentary stating the need of this fix : https://github.com/godotengine/godot/pull/88636#pullrequestreview-1894210868

I'm not confident at all but the message in the tooltip so feel to give ideas for a better tootltip. The one thing I feel is missing is that I don't know at all why tis behaviour is even needed :(. I tracked the addition to #20400 but there is no reason given.