### PR TITLE
Fix Gradient Documentation's PackedColorArray default

### DIFF
--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -77,7 +77,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1)">
+		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray([Color(0, 0, 0, 1), Color(1, 1, 1, 1])">
 			Gradient's colors returned as a [PackedColorArray].
 			[b]Note:[/b] This property returns a copy, modifying the return value does not update the gradient. To update the gradient use [method set_color] method (for updating colors individually) or assign to this property directly (for bulk-updating all colors at once).
 		</member>


### PR DESCRIPTION
Fixes the default PackedColorArray default to reflect the correct way to construct a PackedColorArray.

