### PR TITLE
Fix Synchronize Scene Changes value after restarting

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2122,7 +2122,6 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 	msgdialog = memnew(AcceptDialog);
 	add_child(msgdialog);
 
-	live_debug = true;
 	camera_override = CameraOverride::OVERRIDE_NONE;
 	last_path_id = false;
 	error_count = 0;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #88769. 

Might require some testing as the solution I found was to remove a line. I couldn't find the purpose of this line originally so maybe removing it causes another problem, or the line was unnecessary.
