### PR TITLE
Fix selecting first character with mouse in script editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4340,7 +4340,7 @@ Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_allow_out_
 		colx = TS->shaped_text_get_size(text_rid).x - colx;
 	}
 	col = TS->shaped_text_hit_test_position(text_rid, colx);
-	if (!caret_mid_grapheme_enabled) {
+	if (!caret_mid_grapheme_enabled && get_line_wrapping_mode() == LineWrappingMode::LINE_WRAPPING_NONE) {
 		col = TS->shaped_text_closest_character_pos(text_rid, col);
 	}
 


### PR DESCRIPTION
When a line is wrapped in a text editor, column position for the left most click should point to the end of the last character in the previous line to fix this issue #88632.

* *Bugsquad edit, fixes: #88632*