### PR TITLE
Do overflow check in when generating NoiseTexture3D

### DIFF
--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -142,6 +142,8 @@ TypedArray<Image> NoiseTexture3D::_generate_texture() {
 		return TypedArray<Image>();
 	}
 
+	ERR_FAIL_COND_V_MSG((int64_t)width * height * depth > Image::MAX_PIXELS, TypedArray<Image>(), "The NoiseTexture3D is too big, consider lowering its width, height, or depth.");
+
 	Vector<Ref<Image>> images;
 
 	if (seamless) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88800

The origin problem is that the MRP's NoiseTexture3D's width is 4096, height is 4096 and depth is 4096. And In `Noise::_get_image` it will call `values.resize(p_width * p_height * p_depth)`, the values vector's capacity is uint32_t which can not handle 4096^3 and overflows, thus the `resize` failed, or more preciously speaking, it overflowed to 0, and the later vector indexing caused this crash.

My solution here, technically speaking is not overflow check but more like an sanity check that should be placed somewhere in `NoiseTexture3D`. Feel free to correct me.

Also the `NoiseTexture2D` may need the same check too, although it's less likely to have the same problem as `NoiseTexture3D`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
