### PR TITLE
Add create folder icon

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -210,6 +210,9 @@
 		<theme_item name="back_folder" data_type="icon" type="Texture2D">
 			Custom icon for the back arrow.
 		</theme_item>
+		<theme_item name="create_folder" data_type="icon" type="Texture2D">
+			Custom icon for the create folder button.
+		</theme_item>
 		<theme_item name="file" data_type="icon" type="Texture2D">
 			Custom icon for files.
 		</theme_item>

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -86,6 +86,7 @@ void EditorFileDialog::_update_theme_item_cache() {
 	theme_cache.mode_list = get_editor_theme_icon(SNAME("FileList"));
 	theme_cache.favorites_up = get_editor_theme_icon(SNAME("MoveUp"));
 	theme_cache.favorites_down = get_editor_theme_icon(SNAME("MoveDown"));
+	theme_cache.create_folder = get_editor_theme_icon(SNAME("FolderCreate"));
 
 	theme_cache.folder = get_editor_theme_icon(SNAME("Folder"));
 	theme_cache.folder_icon_color = get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog"));
@@ -1328,6 +1329,7 @@ void EditorFileDialog::_update_icons() {
 	refresh->set_icon(theme_cache.reload);
 	favorite->set_icon(theme_cache.favorite);
 	show_hidden->set_icon(theme_cache.toggle_hidden);
+	makedir->set_icon(theme_cache.create_folder);
 
 	fav_up->set_icon(theme_cache.favorites_up);
 	fav_down->set_icon(theme_cache.favorites_down);
@@ -1875,8 +1877,11 @@ EditorFileDialog::EditorFileDialog() {
 	drives->connect("item_selected", callable_mp(this, &EditorFileDialog::_select_drive));
 	pathhb->add_child(drives);
 
+	pathhb->add_child(memnew(VSeparator));
+
 	makedir = memnew(Button);
-	makedir->set_text(TTR("Create Folder"));
+	makedir->set_theme_type_variation("FlatButton");
+	makedir->set_tooltip_text(TTR("Create a new folder."));
 	makedir->connect("pressed", callable_mp(this, &EditorFileDialog::_make_dir));
 	pathhb->add_child(makedir);
 

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -155,6 +155,7 @@ private:
 		Ref<Texture2D> favorite;
 		Ref<Texture2D> mode_thumbnails;
 		Ref<Texture2D> mode_list;
+		Ref<Texture2D> create_folder;
 		Ref<Texture2D> favorites_up;
 		Ref<Texture2D> favorites_down;
 

--- a/editor/icons/FolderCreate.svg
+++ b/editor/icons/FolderCreate.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M2 3a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h8v-1H8v-4h2V8h4v2h1V7a1 1 0 0 0-1-1h-4a1 1 0 0 1-1-1V4a1 1 0 0 0-1-1Z" fill="#e0e0e0"/><path d="M13 13h2v-2h-2V9h-2v2H9v2h2v2h2z" fill="#5fff97"/></svg>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1279,6 +1279,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_icon("forward_folder", "FileDialog", p_theme->get_icon(SNAME("Forward"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("reload", "FileDialog", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("toggle_hidden", "FileDialog", p_theme->get_icon(SNAME("GuiVisibilityVisible"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("create_folder", "FileDialog", p_theme->get_icon(SNAME("FolderCreate"), EditorStringName(EditorIcons)));
 		// Use a different color for folder icons to make them easier to distinguish from files.
 		// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
 		p_theme->set_color("folder_icon_color", "FileDialog", (p_config.dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(p_config.accent_color, 0.7));

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -187,6 +187,7 @@ void FileDialog::_notification(int p_what) {
 			}
 			refresh->set_icon(theme_cache.reload);
 			show_hidden->set_icon(theme_cache.toggle_hidden);
+			makedir->set_icon(theme_cache.create_folder);
 
 			dir_up->begin_bulk_theme_override();
 			dir_up->add_theme_color_override("icon_normal_color", theme_cache.icon_normal_color);
@@ -222,6 +223,13 @@ void FileDialog::_notification(int p_what) {
 			show_hidden->add_theme_color_override("icon_focus_color", theme_cache.icon_focus_color);
 			show_hidden->add_theme_color_override("icon_pressed_color", theme_cache.icon_pressed_color);
 			show_hidden->end_bulk_theme_override();
+
+			makedir->begin_bulk_theme_override();
+			makedir->add_theme_color_override("icon_normal_color", theme_cache.icon_normal_color);
+			makedir->add_theme_color_override("icon_hover_color", theme_cache.icon_hover_color);
+			makedir->add_theme_color_override("icon_focus_color", theme_cache.icon_focus_color);
+			makedir->add_theme_color_override("icon_pressed_color", theme_cache.icon_pressed_color);
+			makedir->end_bulk_theme_override();
 
 			invalidate();
 		} break;
@@ -1331,6 +1339,7 @@ void FileDialog::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FileDialog, toggle_hidden);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FileDialog, folder);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FileDialog, file);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FileDialog, create_folder);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, folder_icon_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, file_icon_color);
@@ -1426,7 +1435,8 @@ FileDialog::FileDialog() {
 	hbc->add_child(shortcuts_container);
 
 	makedir = memnew(Button);
-	makedir->set_text(RTR("Create Folder"));
+	makedir->set_theme_type_variation("FlatButton");
+	makedir->set_tooltip_text(RTR("Create a new folder."));
 	makedir->connect("pressed", callable_mp(this, &FileDialog::_make_dir));
 	hbc->add_child(makedir);
 	vbox->add_child(hbc);

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -120,6 +120,7 @@ private:
 		Ref<Texture2D> toggle_hidden;
 		Ref<Texture2D> folder;
 		Ref<Texture2D> file;
+		Ref<Texture2D> create_folder;
 
 		Color folder_icon_color;
 		Color file_icon_color;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -651,6 +651,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("toggle_hidden", "FileDialog", icons["visibility_visible"]);
 	theme->set_icon("folder", "FileDialog", icons["folder"]);
 	theme->set_icon("file", "FileDialog", icons["file"]);
+	theme->set_icon("create_folder", "FileDialog", icons["folder_create"]);
 	theme->set_color("folder_icon_color", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_icon_color", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_disabled_color", "FileDialog", Color(1, 1, 1, 0.25));

--- a/scene/theme/icons/folder_create.svg
+++ b/scene/theme/icons/folder_create.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M2 3a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h8v-1H8v-4h2V8h4v2h1V7a1 1 0 0 0-1-1h-4a1 1 0 0 1-1-1V4a1 1 0 0 0-1-1Z" fill="#b2b2b2"/><path d="M13 13h2v-2h-2V9h-2v2H9v2h2v2h2z" fill="#fefffe"/></svg>


### PR DESCRIPTION
Adds the missing "create folder" icon and replaces the "Create folder" text buttons of the `FileDialog`, the `EditorFileDialog`, and the `ProjectDialog` to an icon button.

New icon (click for better preview): ![FolderCreate](https://github.com/godotengine/godot/assets/270928/089e1801-bf05-418b-bbc1-1bbf5e9468fd)

I opened the folder icon in Inkscape (![Folder](https://github.com/godotengine/godot/assets/270928/3755bad2-9fe9-4375-b153-f44613007d56) [`editor/icons/Folder.svg`](https://github.com/godotengine/godot/blob/81f3d43cc1ba01136795fb2059bbaa55bc514a16/editor/icons/Folder.svg)), traced the margin around the plus sign from the new file icon (![New](https://github.com/godotengine/godot/assets/270928/89cc8df6-1a59-4a87-833f-b8815b49a488) [`editor/icons/New.svg`](https://github.com/godotengine/godot/blob/81f3d43cc1ba01136795fb2059bbaa55bc514a16/editor/icons/New.svg)), did a difference operation on the folder with the trace, exported it to SVG, then I optimized it [with SVGOMG](https://jakearchibald.github.io/svgomg/).



| Before | After |
| --- | --- |
|![Capture d’écran du 2024-02-25 11-56-08](https://github.com/godotengine/godot/assets/270928/dc6d3c28-77a0-4622-805f-746dd459a6a7) | ![Capture d’écran du 2024-02-25 11-53-59](https://github.com/godotengine/godot/assets/270928/f3bc4dbd-210f-48cc-bd05-5903abfb5703) |
|![Capture d’écran du 2024-02-25 11-56-30](https://github.com/godotengine/godot/assets/270928/c1fa0cb4-2fa4-405d-81fd-f92504dac74e) | ![Capture d’écran du 2024-02-26 09-09-02](https://github.com/godotengine/godot/assets/270928/337e895b-c7e8-4ee4-9583-5be5ea8894b7)|

As you can see, the top bar occupies now less real estate and it makes the file dialogs more intuitive to use.

Relates to #88827

# Edits
- 2024-02-26
  - Reverted the "Create Project" dialog edits.