### PR TITLE
Networking scene multiplayer: Fix removing connected peer during disconnection

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -428,7 +428,7 @@ void SceneMultiplayer::disconnect_peer(int p_id) {
 	if (pending_peers.has(p_id)) {
 		pending_peers.erase(p_id);
 	} else if (connected_peers.has(p_id)) {
-		connected_peers.has(p_id);
+		connected_peers.erase(p_id);
 	}
 	multiplayer_peer->disconnect_peer(p_id);
 }


### PR DESCRIPTION
Obvious typo. Spent a few minutes investigating all uses of `.has()` in the codebase and found no other similar mistakes. Still, I wonder if automated detection of code without any effect is possible for us.

Spotted by user **danielsnd** on RC.