### PR TITLE
Remove TOOLS_ENABLED check on method_bind.h as they are breaking gdextensions

### DIFF
--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -225,9 +225,6 @@ class MethodBindVarArgT : public MethodBindVarArgBase<MethodBindVarArgT<T>, T, v
 
 public:
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 		(static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>::method)(p_args, p_arg_count, r_error);
 		return {};
 	}
@@ -264,9 +261,6 @@ public:
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 		return (static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>::method)(p_args, p_arg_count, r_error);
 	}
 
@@ -335,9 +329,6 @@ public:
 
 #endif
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_args_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, r_error, get_default_arguments());
 #else
@@ -347,9 +338,6 @@ public:
 	}
 
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_validated_object_instance_args(static_cast<T *>(p_object), method, p_args);
 #else
@@ -358,9 +346,6 @@ public:
 	}
 
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, P...>(static_cast<T *>(p_object), method, p_args);
 #else
@@ -419,9 +404,6 @@ public:
 
 #endif
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder(), Variant(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_argsc_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, r_error, get_default_arguments());
 #else
@@ -431,9 +413,6 @@ public:
 	}
 
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_validated_object_instance_argsc(static_cast<T *>(p_object), method, p_args);
 #else
@@ -442,9 +421,6 @@ public:
 	}
 
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_argsc<T, P...>(static_cast<T *>(p_object), method, p_args);
 #else
@@ -514,9 +490,6 @@ public:
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder(), ret, vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_args_ret_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, ret, r_error, get_default_arguments());
 #else
@@ -526,9 +499,6 @@ public:
 	}
 
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_validated_object_instance_args_ret(static_cast<T *>(p_object), method, p_args, r_ret);
 #else
@@ -537,9 +507,6 @@ public:
 	}
 
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args_ret<T, R, P...>(static_cast<T *>(p_object), method, p_args, r_ret);
 #else
@@ -610,9 +577,6 @@ public:
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_V_MSG(p_object && p_object->is_extension_placeholder(), ret, vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_args_retc_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, ret, r_error, get_default_arguments());
 #else
@@ -622,9 +586,6 @@ public:
 	}
 
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_validated_object_instance_args_retc(static_cast<T *>(p_object), method, p_args, r_ret);
 #else
@@ -633,9 +594,6 @@ public:
 	}
 
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
-#ifdef TOOLS_ENABLED
-		ERR_FAIL_COND_MSG(p_object && p_object->is_extension_placeholder(), vformat("Cannot call method bind '%s' on placeholder instance.", MethodBind::get_name()));
-#endif
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args_retc<T, R, P...>(static_cast<T *>(p_object), method, p_args, r_ret);
 #else


### PR DESCRIPTION
This solves the issue described here: https://github.com/godotengine/godot/issues/88842

Issue description copied in for ease of reading:

### Tested versions

v4.3.dev.mono.custom_build.5ca24ea72

### System information

Pop OS 22.04

### Issue description

Using gdext: https://github.com/godot-rust/gdext

Nodes created using gdext cause the godot editor to not be able to edit the scene that contains these nodes.  It throws errors such as:

```
ERROR: Cannot call method bind 'get_script' on placeholder instance.
   at: ptrcall (./core/object/method_bind.h:637)
ERROR: Cannot call method bind 'add_child' on placeholder instance.
   at: call (./core/object/method_bind.h:339)
ERROR: Invalid owner. Owner must be an ancestor in the tree.
   at: set_owner (scene/main/node.cpp:2044)
ERROR: Condition "!p_node->is_inside_tree()" is true.
   at: add_node (editor/editor_data.cpp:1207)
ERROR: Condition "!p_node->is_inside_tree()" is true.
   at: add_node (editor/editor_data.cpp:1207)
```

This seems to have been introduced by new changes to method_bind.h here: https://github.com/godotengine/godot/commit/4d0b989bb85b0cae95c4535611f755afbbd0bb42#diff-e62d80a6cc1e013bcdf224a542f6afdc28288ef48f096ea7f5f5ba8c5b1dc9a7

Removing these changes allows me to edit my scenes properly again and the errors go away.

### Steps to reproduce

1. Create a custom node with gdext.
2. Add that node to your scene.
3. Click on the node and see errors appear.
4. Try to add a child node to that node and see other errors appear.

Note: You might not be even able to add new nodes to the scene at all if they were made in gdext.
