### PR TITLE
Make shader editor won't pop up error toasts too often, only do it when manually save

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -443,15 +443,10 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 }
 
 void ShaderTextEditor::_validate_script() {
-	emit_signal(CoreStringName(script_changed)); // Ensure to notify that it changed, so it is applied
-
-	String code;
+	String code = get_text_editor()->get_text();
 
 	if (shader.is_valid()) {
 		_check_shader_mode();
-		code = shader->get_code();
-	} else {
-		code = shader_inc->get_code();
 	}
 
 	ShaderPreprocessor preprocessor;
@@ -566,6 +561,8 @@ void ShaderTextEditor::_validate_script() {
 			get_text_editor()->set_line_background_color(err_line - 1, marked_line_color);
 		} else {
 			set_error("");
+			// After there is no compile error, ensure to notify that it changed, so it is applied.
+			emit_signal(SNAME("script_changed"));
 		}
 
 		if (warnings.size() > 0 || last_compile_result != OK) {


### PR DESCRIPTION
This pr addresses part of https://github.com/godotengine/godot/issues/88616, it make the text shader editor won't apply the ongoing shader when it failed to compile, thus greatly reduce the situation where toasts pop up and block the error message.

However it might has side effects that I did not find out, feel free to correct me.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
