### PR TITLE
Fix use after free in `GDScriptLanguage::finish`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2154,6 +2154,7 @@ void GDScriptLanguage::finish() {
 	// Clear dependencies between scripts, to ensure cyclic references are broken
 	// (to avoid leaks at exit).
 	SelfList<GDScript> *s = script_list.first();
+	Ref<WeakRef> wnext = memnew(WeakRef);
 	while (s) {
 		// This ensures the current script is not released before we can check
 		// what's the next one in the list (we can't get the next upfront because we
@@ -2178,6 +2179,16 @@ void GDScriptLanguage::finish() {
 			scr->clear();
 		}
 		s = s->next();
+		if (!s) {
+			break;
+		}
+
+		// Destructing scr might lead to s being released. So we store a weakref here to check later
+		wnext->set_obj(s->self());
+		scr.unref();
+		if (wnext->get_ref().is_null()) {
+			s = script_list.first();
+		}
 	}
 	script_list.clear();
 	function_list.clear();


### PR DESCRIPTION
This fixes #80313. It seems that freeing `scr` can cause the next script to also be freed. Why this does not happen when `member_functions` and `member_indices` are cleared I do not know. This might indicate a deeper issue somewhere.

I managed to quite consistently trigger the crash here so I am reasonably sure that this PR fixes it.