### PR TITLE
[3.x] Tilemap editor - prevent changing tool when mouse buttons pressed

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -150,6 +150,13 @@ void TileMapEditor::_update_button_tool() {
 }
 
 void TileMapEditor::_button_tool_select(int p_tool) {
+	if (_mouse_buttons_pressed) {
+		// Disallow changing tool when drawing,
+		// to prevent undo actions getting messed up
+		// and out of sync.
+		return;
+	}
+
 	tool = (Tool)p_tool;
 	_update_button_tool();
 	switch (tool) {
@@ -1160,6 +1167,14 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid()) {
+		// Keep track internally of which mouse buttons are pressed
+		// so we can disallow changing tool.
+		if (mb->is_pressed()) {
+			_mouse_buttons_pressed |= mb->get_button_index();
+		} else {
+			_mouse_buttons_pressed &= ~mb->get_button_index();
+		}
+
 		if (mb->get_button_index() == BUTTON_LEFT) {
 			if (mb->is_pressed()) {
 				if (Input::get_singleton()->is_key_pressed(KEY_SPACE)) {

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -105,6 +105,7 @@ class TileMapEditor : public VBoxContainer {
 
 	Tool tool;
 	Tool last_tool;
+	uint32_t _mouse_buttons_pressed = 0;
 
 	bool selection_active;
 	bool mouse_over;


### PR DESCRIPTION
Changing tool when painting prevented the corresponding commit of undo action when the mouse button was released. This led to undo actions getting out of sync and the undo system breaking the editor.

This PR simply prevents changing tool while mouse buttons are pressed, and prevents the above scenario.

Fixes #85776

## Discussion
This bug is quite nasty and exposes (imo) a problem with the undo system paradigm, when used in combination with mouse drawing as it is in the tile map editor plugin.

The problem afaik is that the undo system is a state machine, and undo actions are created, and then committed at a later time. If there is a client side bug (as here) the undo action is created but never committed, and the undo stack gets full, and the whole system breaks.

Ideally each create action would be matched and verified with the commit (via e.g. an ID), however there is a lot of existing code that relies on the current undo system as is.

Here I've taken one of the simplest possible courses to fix the bug locally, by preventing the mechanism which gets the undo action out of sync - preventing changing tool while drawing.

## Notes
* There are several other possible ways of addressing this, including committing the current draw when the tool is selected, which I tried first, but is considerably more complex to implement for a "fringe case".
* Ideally the undo system would feature detection code to prevent this kind of thing happening, or flag it up, as it likely occurs in other editor areas other than just the tilemap plugin.
* There is the possibility here of the local mouse button state getting out of sync (e.g. releasing mouse outside a window) so this would need thorough testing in case of regressions.
* This bug has likely existed for years without being reported afaik (likely users would just reboot the editor), so it is not a _must have_ for 3.6 imo.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
