### PR TITLE
Add `compositor_free` branch in Compatibility scene renderer free function

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3969,6 +3969,10 @@ bool RasterizerSceneGLES3::free(RID p_rid) {
 	} else if (RSG::camera_attributes->owns_camera_attributes(p_rid)) {
 		//not much to delete, just free it
 		RSG::camera_attributes->camera_attributes_free(p_rid);
+	} else if (is_compositor(p_rid)) {
+		compositor_free(p_rid);
+	} else if (is_compositor_effect(p_rid)) {
+		compositor_effect_free(p_rid);
 	} else {
 		return false;
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/88861

See the equivalent code in the other renderers:
https://github.com/godotengine/godot/blob/bb6b06c81343073f10cbbd2af515cf0dac1e6549/servers/rendering/dummy/rasterizer_scene_dummy.h#L171-L173

https://github.com/godotengine/godot/blob/bb6b06c81343073f10cbbd2af515cf0dac1e6549/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp#L1199-L1200

CC @BastiaanOlij 