### PR TITLE
GDScript: Fix type highlighting after whitespace

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -532,12 +532,14 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				}
 			}
 
-			in_function_declaration = false;
-			in_var_const_declaration = false;
-			in_signal_declaration = false;
-			in_function_name = false;
-			in_lambda = false;
-			in_member_variable = false;
+			if (!is_whitespace(str[j])) {
+				in_function_declaration = false;
+				in_var_const_declaration = false;
+				in_signal_declaration = false;
+				in_function_name = false;
+				in_lambda = false;
+				in_member_variable = false;
+			}
 		}
 
 		if (!in_raw_string && in_region == -1 && str[j] == 'r' && j < line_length - 1 && (str[j + 1] == '"' || str[j + 1] == '\'')) {


### PR DESCRIPTION
* Fix regression from #86176.
* Reported by @nlupugla [here](https://chat.godotengine.org/channel/gdscript?msg=bXngZarH2TuawibSR).

Before:
![](https://github.com/godotengine/godot/assets/47700418/11f84921-a2f7-41d2-b4a0-59e070d54bf6)

After:
![](https://github.com/godotengine/godot/assets/47700418/ab4657c3-0de0-4de5-bf5d-70093654031a)
