### PR TITLE
Fix `BoneAttachment3D` responding to only local transform changes

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -244,7 +244,7 @@ int BoneAttachment3D::get_bone_idx() const {
 
 void BoneAttachment3D::set_override_pose(bool p_override) {
 	override_pose = p_override;
-	set_notify_local_transform(override_pose);
+	set_notify_transform(override_pose);
 	set_process_internal(override_pose);
 
 	if (!override_pose) {
@@ -301,7 +301,7 @@ void BoneAttachment3D::_notification(int p_what) {
 			_check_unbind();
 		} break;
 
-		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+		case NOTIFICATION_TRANSFORM_CHANGED: {
 			_transform_changed();
 		} break;
 


### PR DESCRIPTION
`BoneAttachment3D` was only listening to local transform changes. That means if `override_pose` was turned on, and the `BoneAttachment3D` was moved as part of a parent object (no local transform changes), it does nothing, in editor and at runtime. See broken behaviour below:
![bone_attachment_broken](https://github.com/godotengine/godot/assets/13228932/9bacef20-4dfe-4d6e-8a39-6d8474d7d5a7)

This PR corrects this by listening to global transform changes. See fixed behaviour:
![bone_attachment](https://github.com/godotengine/godot/assets/13228932/27b48b0b-4690-47ac-84ce-ec16af4ddcf9)
