### PR TITLE
Include tangent in SurfaceTool vertex compare operator

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -97,6 +97,10 @@ bool SurfaceTool::Vertex::operator==(const Vertex &p_vertex) const {
 		return false;
 	}
 
+	if (tangent != p_vertex.tangent) {
+		return false;
+	}
+
 	if (color != p_vertex.color) {
 		return false;
 	}


### PR DESCRIPTION
This doesn't fix any reported bugs, but it is possible to run into an edge case where two vertices have different tangents and nothing else. In practice, such a situation is extremely unlikely, but the comparison operator should cover all properties. 