### PR TITLE
Fix NavigationObstacle2D debug being affected by Node2D transform

### DIFF
--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -56,6 +56,7 @@ class NavigationObstacle2D : public Node2D {
 
 #ifdef DEBUG_ENABLED
 private:
+	RID debug_canvas_item;
 	void _update_fake_agent_radius_debug();
 	void _update_static_obstacle_debug();
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Fixes NavigationObstacle2D debug being affected by Node2D transform.

Fixes https://github.com/godotengine/godot/issues/88860.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
