### PR TITLE
Fix release event's double click is not correctly set on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4118,6 +4118,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				case WM_LBUTTONUP: {
 					mb->set_pressed(false);
 					mb->set_button_index(MouseButton::LEFT);
+					MouseButtonMask mask = mouse_button_to_mask(MouseButton::LEFT);
+					if (last_is_double_click.has_flag(mask)) {
+						mb->set_double_click(true);
+						last_is_double_click.clear_flag(mask);
+					}
 				} break;
 				case WM_MBUTTONDOWN: {
 					mb->set_pressed(true);
@@ -4126,6 +4131,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				case WM_MBUTTONUP: {
 					mb->set_pressed(false);
 					mb->set_button_index(MouseButton::MIDDLE);
+					MouseButtonMask mask = mouse_button_to_mask(MouseButton::MIDDLE);
+					if (last_is_double_click.has_flag(mask)) {
+						mb->set_double_click(true);
+						last_is_double_click.clear_flag(mask);
+					}
 				} break;
 				case WM_RBUTTONDOWN: {
 					mb->set_pressed(true);
@@ -4134,21 +4144,29 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				case WM_RBUTTONUP: {
 					mb->set_pressed(false);
 					mb->set_button_index(MouseButton::RIGHT);
+					MouseButtonMask mask = mouse_button_to_mask(MouseButton::RIGHT);
+					if (last_is_double_click.has_flag(mask)) {
+						mb->set_double_click(true);
+						last_is_double_click.clear_flag(mask);
+					}
 				} break;
 				case WM_LBUTTONDBLCLK: {
 					mb->set_pressed(true);
 					mb->set_button_index(MouseButton::LEFT);
 					mb->set_double_click(true);
+					last_is_double_click.set_flag(mouse_button_to_mask(MouseButton::LEFT));
 				} break;
 				case WM_RBUTTONDBLCLK: {
 					mb->set_pressed(true);
 					mb->set_button_index(MouseButton::RIGHT);
 					mb->set_double_click(true);
+					last_is_double_click.set_flag(mouse_button_to_mask(MouseButton::RIGHT));
 				} break;
 				case WM_MBUTTONDBLCLK: {
 					mb->set_pressed(true);
 					mb->set_button_index(MouseButton::MIDDLE);
 					mb->set_double_click(true);
+					last_is_double_click.set_flag(mouse_button_to_mask(MouseButton::MIDDLE));
 				} break;
 				case WM_MOUSEWHEEL: {
 					mb->set_pressed(true);
@@ -4188,18 +4206,27 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				} break;
 				case WM_XBUTTONUP: {
 					mb->set_pressed(false);
+					MouseButtonMask mask;
 					if (HIWORD(wParam) == XBUTTON1) {
 						mb->set_button_index(MouseButton::MB_XBUTTON1);
+						mask = mouse_button_to_mask(MouseButton::MB_XBUTTON1);
 					} else {
 						mb->set_button_index(MouseButton::MB_XBUTTON2);
+						mask = mouse_button_to_mask(MouseButton::MB_XBUTTON2);
+					}
+					if (last_is_double_click.has_flag(mask)) {
+						mb->set_double_click(true);
+						last_is_double_click.clear_flag(mask);
 					}
 				} break;
 				case WM_XBUTTONDBLCLK: {
 					mb->set_pressed(true);
 					if (HIWORD(wParam) == XBUTTON1) {
 						mb->set_button_index(MouseButton::MB_XBUTTON1);
+						last_is_double_click.set_flag(mouse_button_to_mask(MouseButton::MB_XBUTTON1));
 					} else {
 						mb->set_button_index(MouseButton::MB_XBUTTON2);
+						last_is_double_click.set_flag(mouse_button_to_mask(MouseButton::MB_XBUTTON2));
 					}
 					mb->set_double_click(true);
 				} break;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -465,6 +465,7 @@ class DisplayServerWindows : public DisplayServer {
 	bool control_mem = false;
 	bool meta_mem = false;
 	BitField<MouseButtonMask> last_button_state;
+	BitField<MouseButtonMask> last_is_double_click;
 	bool use_raw_input = false;
 	bool drop_events = false;
 	bool in_dispatch_input_event = false;


### PR DESCRIPTION
Fix the windows part of https://github.com/godotengine/godot/issues/88872 , not sure whether it's the best way to fix this, but did some test and it looks ok.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
