### PR TITLE
[GDScript] Prevent some vararg methods binding arguments to member variables

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/vararg_member_not_shared.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/vararg_member_not_shared.gd
@@ -1,0 +1,23 @@
+# https://github.com/godotengine/godot/issues/88885
+
+extends Node
+
+var member: int
+
+signal s(int)
+
+func _first(arg: int) -> void:
+	print("In first: ", arg)
+	member = 1
+
+func _second(arg: int) -> void:
+	print("In second: ", arg)
+
+@warning_ignore_start("return_value_discarded")
+func test():
+	member = 0
+	s.connect(_first)
+	s.connect(_second)
+	s.emit(member)
+	member = 0
+	emit_signal(&"s", member)

--- a/modules/gdscript/tests/scripts/runtime/features/vararg_member_not_shared.out
+++ b/modules/gdscript/tests/scripts/runtime/features/vararg_member_not_shared.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+In first: 0
+In second: 0
+In first: 0
+In second: 0

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1500,7 +1500,26 @@ void SceneTree::_call_group_flags(const Variant **p_args, int p_argcount, Callab
 	StringName group = *p_args[1];
 	StringName method = *p_args[2];
 
-	call_group_flagsp(flags, group, method, p_args + 3, p_argcount - 3);
+	// Prevent GDScript member variables being passed by pointer, see:
+	// https://github.com/godotengine/godot/issues/88885
+	Variant *args = nullptr;
+	const Variant **argptrs = nullptr;
+
+	int argc = p_argcount - 3;
+	if (argc) {
+		args = (Variant *)alloca(sizeof(Variant) * argc);
+		argptrs = (const Variant **)alloca(sizeof(Variant *) * argc);
+		for (int i = 0; i < argc; i++) {
+			memnew_placement(&args[i], Variant(*p_args[i + 3]));
+			argptrs[i] = &args[i];
+		}
+	}
+
+	call_group_flagsp(flags, group, method, argptrs, argc);
+
+	for (int i = 0; i < argc; i++) {
+		args[i].~Variant();
+	}
 }
 
 void SceneTree::_call_group(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -1513,7 +1532,26 @@ void SceneTree::_call_group(const Variant **p_args, int p_argcount, Callable::Ca
 	StringName group = *p_args[0];
 	StringName method = *p_args[1];
 
-	call_group_flagsp(GROUP_CALL_DEFAULT, group, method, p_args + 2, p_argcount - 2);
+	// Prevent GDScript member variables being passed by pointer, see:
+	// https://github.com/godotengine/godot/issues/88885
+	Variant *args = nullptr;
+	const Variant **argptrs = nullptr;
+
+	int argc = p_argcount - 2;
+	if (argc) {
+		args = (Variant *)alloca(sizeof(Variant) * argc);
+		argptrs = (const Variant **)alloca(sizeof(Variant *) * argc);
+		for (int i = 0; i < argc; i++) {
+			memnew_placement(&args[i], Variant(*p_args[i + 2]));
+			argptrs[i] = &args[i];
+		}
+	}
+
+	call_group_flagsp(GROUP_CALL_DEFAULT, group, method, argptrs, argc);
+
+	for (int i = 0; i < argc; i++) {
+		args[i].~Variant();
+	}
 }
 
 int64_t SceneTree::get_frame() const {


### PR DESCRIPTION
Calling some methods from GDScript with member variable arguments causes the pointer to that argument being passed instead of the value, affects:
* `Signal.emit`
* `Object.emit_signal`
* `SceneTree.call_group/_flags`

Tried a separate method that's possibly more secure, by copying arguments into temporaries if they are member variables, this is a bit hit and miss and had some problems applying them *just* for vararg methods, this problem doesn't really affect other cases significantly either as most of the time it doesn't cause this kind of chain effect, so I feel this is more of a targeted situation where we can just fix it in the places where it's needed, instead of hitting every method called with a member variable with a temporary

I only added these fixes to the bound methods, so it won't affect calls from c++ normally, like `Signal.emit`, but instead the bound method under `variant_call`

Note also that the `ptrcall` methods in `Variant` use temporary storage for variants, and these are called from extensions AFAIK, so there's precedent for this solution

The immediate, indiscriminate solution (as I couldn't reliably test for vararg, and therefore would miss some cases) would have been:
```diff
diff --git a/modules/gdscript/gdscript_compiler.cpp b/modules/gdscript/gdscript_compiler.cpp
index 13ed66710c..5a9a5b2264 100644
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -614,6 +614,11 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
                                if (r_error) {
                                        return GDScriptCodeGenerator::Address();
                                }
+                               if (arg.mode == GDScriptCodeGenerator::Address::MEMBER) {
+                                       GDScriptCodeGenerator::Address temp = codegen.add_temporary(arg.type);
+                                       gen->write_assign(temp, arg);
+                                       arg = temp;
+                               }
                                arguments.push_back(arg);
                        }

```
This is a bit brute force, but it works as well

* Fixes: https://github.com/godotengine/godot/issues/88885

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
