### PR TITLE
Copied `get_vector` implementation from `Input` to `InputEvent`

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -75,6 +75,32 @@ float InputEvent::get_action_raw_strength(const StringName &p_action, bool p_exa
 	return valid ? raw_strength : 0.0f;
 }
 
+Vector2 InputEvent::get_vector(const StringName &p_negative_x, const StringName &p_positive_x, const StringName &p_negative_y, const StringName &p_positive_y, float p_deadzone) const {
+	Vector2 vector = Vector2(
+			get_action_raw_strength(p_positive_x) - get_action_raw_strength(p_negative_x),
+			get_action_raw_strength(p_positive_y) - get_action_raw_strength(p_negative_y));
+
+	if (p_deadzone < 0.0f) {
+		// If the deadzone isn't specified, get it from the average of the actions.
+		p_deadzone = 0.25 *
+				(InputMap::get_singleton()->action_get_deadzone(p_positive_x) +
+						InputMap::get_singleton()->action_get_deadzone(p_negative_x) +
+						InputMap::get_singleton()->action_get_deadzone(p_positive_y) +
+						InputMap::get_singleton()->action_get_deadzone(p_negative_y));
+	}
+
+	// Circular length limiting and deadzone.
+	float length = vector.length();
+	if (length <= p_deadzone) {
+		return Vector2();
+	} else if (length > 1.0f) {
+		return vector / length;
+	} else {
+		// Inverse lerp length to map (p_deadzone, 1) to (0, 1).
+		return vector * (Math::inverse_lerp(p_deadzone, 1.0f, length) / length);
+	}
+}
+
 bool InputEvent::is_canceled() const {
 	return canceled;
 }
@@ -115,6 +141,8 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action", "allow_echo", "exact_match"), &InputEvent::is_action_pressed, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_action_released", "action", "exact_match"), &InputEvent::is_action_released, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_strength", "action", "exact_match"), &InputEvent::get_action_strength, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_vector", "negative_x", "positive_x", "negative_y", "positive_y", "deadzone"),
+			&InputEvent::get_vector, DEFVAL(-1.0f));
 
 	ClassDB::bind_method(D_METHOD("is_canceled"), &InputEvent::is_canceled);
 	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEvent::is_pressed);

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -73,6 +73,7 @@ public:
 	bool is_action_released(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact_match = false) const;
+	Vector2 get_vector(const StringName &p_negative_x, const StringName &p_positive_x, const StringName &p_negative_y, const StringName &p_positive_y, float p_deadzone = -1.0f) const;
 
 	bool is_canceled() const;
 	bool is_pressed() const;

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -71,6 +71,19 @@
 				Returns [code]true[/code] if this input event's type is one that can be assigned to an input action.
 			</description>
 		</method>
+		<method name="get_vector" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="negative_x" type="StringName" />
+			<param index="1" name="positive_x" type="StringName" />
+			<param index="2" name="negative_y" type="StringName" />
+			<param index="3" name="positive_y" type="StringName" />
+			<param index="4" name="deadzone" type="float" default="-1.0" />
+			<description>
+				Gets an input vector by specifying four actions for the positive and negative X and Y axes.
+				This method is useful when getting vector input, such as from a joystick, directional pad, arrows, or WASD. The vector has its length limited to 1 and has a circular deadzone, which is useful for using vector input as movement.
+				By default, the deadzone is automatically calculated from the average of the action deadzones. However, you can override the deadzone to be whatever you want (on the range of 0 to 1).
+			</description>
+		</method>
 		<method name="is_canceled" qualifiers="const">
 			<return type="bool" />
 			<description>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
I need this functionality so that I can handle user input both  from InputEvents and the Input singleton in a uniform way. 

I could have implemented something in gdscript, but I think this is an improvement to the engine. 

I have read the contributing guidelines, but I didn't take the effort to write a proposal issue, sorry! 

If anyone else finds this useful, but is missing the related issue, let me know; I will add it then. 

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9195*