### PR TITLE
Remove redundant space after enum/flags word in editor docs

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1622,9 +1622,9 @@ void EditorHelp::_update_doc() {
 				enum_line[E.key] = class_desc->get_paragraph_count() - 2;
 				class_desc->push_color(theme_cache.title_color);
 				if (E.value.size() && E.value[0].is_bitfield) {
-					class_desc->add_text("flags  ");
+					class_desc->add_text("flags ");
 				} else {
-					class_desc->add_text("enum  ");
+					class_desc->add_text("enum ");
 				}
 				class_desc->pop(); // color
 


### PR DESCRIPTION
Just cosmetic change, I think it's a typo?

<details>
<summary>Before</summary>

![изображение](https://github.com/godotengine/godot/assets/3036176/5aad63db-1908-4f35-a738-52fd870be727)

</details>

<details>
<summary>After</summary>

![изображение](https://github.com/godotengine/godot/assets/3036176/9be65553-302f-468b-b8e8-e93751fd0085)

</details>
