### PR TITLE
Add CollisionObject and CollisionShape non-uniform scale warnings

### DIFF
--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -83,6 +83,10 @@ private:
 	void _apply_disabled();
 	void _apply_enabled();
 
+#ifdef DEBUG_ENABLED
+	void _validate_transform_scale();
+#endif // DEBUG_ENABLED
+
 protected:
 	_FORCE_INLINE_ void lock_callback() { callback_lock++; }
 	_FORCE_INLINE_ void unlock_callback() {

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -51,6 +51,10 @@ class CollisionShape2D : public Node2D {
 	void _update_in_shape_owner(bool p_xform_only = false);
 	Color _get_default_debug_color() const;
 
+#ifdef DEBUG_ENABLED
+	void _validate_transform_scale();
+#endif // DEBUG_ENABLED
+
 protected:
 	void _notification(int p_what);
 	bool _property_can_revert(const StringName &p_name) const;

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -95,6 +95,10 @@ private:
 	void _apply_disabled();
 	void _apply_enabled();
 
+#ifdef DEBUG_ENABLED
+	void _validate_transform_scale();
+#endif // DEBUG_ENABLED
+
 protected:
 	CollisionObject3D(RID p_rid, bool p_area);
 

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -43,6 +43,10 @@ class CollisionShape3D : public Node3D {
 	uint32_t owner_id = 0;
 	CollisionObject3D *collision_object = nullptr;
 
+#ifdef DEBUG_ENABLED
+	void _validate_transform_scale();
+#endif // DEBUG_ENABLED
+
 #ifndef DISABLE_DEPRECATED
 	void resource_changed(Ref<Resource> res);
 #endif
@@ -53,6 +57,7 @@ protected:
 
 protected:
 	void _notification(int p_what);
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Adds CollisionObject and CollisionShape non-uniform scale warnings (i.e. not the same scale on all axes).

This extends the already existing configuration warning of the `CollisionShape3D` to the other physics node classes that inherit Node2D/Node3D and are susceptible to physics bugs caused by non-uniform node transform scaling.

Fixes https://github.com/godotengine/godot/issues/88415 documentation.

May fix a large number of projects with reported physics bugs by making users aware of the consequences of their used node scaling.

For the CollisionShape nodes this also hides the `scale` property in general from the inspector. A physics shape should not be scaled, only resized, but seeing the scale property tempts inexperienced users to use it. The exception is if the scale is already non-uniform in an existing project. In this case it is not hidden so users can change it back.

I did not add any extra warnings for PhysicsServer API as I think users capable of working with the API should be experienced enough to not apply a non-uniform transform scale to an area / body / shape.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
