### PR TITLE
Fix crash when selecting re-added `TreeItem::Cell`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -120,6 +120,10 @@ void TreeItem::_change_tree(Tree *p_tree) {
 		}
 
 		if (tree->selected_item == this) {
+			for (int i = 0; i < tree->selected_item->cells.size(); i++) {
+				tree->selected_item->cells.write[i].selected = false;
+			}
+
 			tree->selected_item = nullptr;
 		}
 


### PR DESCRIPTION
Fixes #88889.

When removing a `TreeItem` from a `Tree` it doesn't clear the `selected` property of the cells in the `TreeItem`, which means that if you remove this `TreeItem` from the `Tree` and then add it back again, and then select the same item/cell, you wouldn't pass this condition:

https://github.com/godotengine/godot/blob/a586e860e5fc382dec4ad9a0bec72f7c6684f020/scene/gui/tree.cpp#L2664-L2668

Which then left `selected_item` at `nullptr` and would subsequently crash here:

https://github.com/godotengine/godot/blob/a586e860e5fc382dec4ad9a0bec72f7c6684f020/scene/gui/tree.cpp#L3736

This PR fixes this by simply clearing the `selected` property of all the item's cells when it's removed from the tree.