### PR TITLE
Remove self includes in some files

### DIFF
--- a/modules/navigation/nav_agent.h
+++ b/modules/navigation/nav_agent.h
@@ -31,7 +31,6 @@
 #ifndef NAV_AGENT_H
 #define NAV_AGENT_H
 
-#include "nav_agent.h"
 #include "nav_rid.h"
 
 #include "core/object/class_db.h"

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -32,7 +32,6 @@
 #define WORLD_2D_H
 
 #include "core/io/resource.h"
-#include "scene/resources/world_2d.h"
 #include "servers/physics_server_2d.h"
 
 class VisibleOnScreenNotifier2D;

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -39,7 +39,6 @@
 #include "core/templates/rid_owner.h"
 #include "core/variant/typed_array.h"
 #include "servers/display_server.h"
-#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_device_commons.h"
 #include "servers/rendering/rendering_device_driver.h"
 #include "servers/rendering/rendering_device_graph.h"


### PR DESCRIPTION
It seems that rendering_device.h is including himself, so I just removed that.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
