### PR TITLE
[Curve3D] Fix middle point forward vector when control1=end and control2=begin

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -899,6 +899,10 @@ Vector2 Curve2D::_calculate_tangent(const Vector2 &p_begin, const Vector2 &p_con
 		}
 	}
 
+	if (p_control_1.is_equal_approx(p_end) && p_control_2.is_equal_approx(p_begin)) {
+		return (p_end - p_begin).normalized();
+	}
+
 	return p_begin.bezier_derivative(p_control_1, p_control_2, p_end, p_t).normalized();
 }
 
@@ -1646,6 +1650,10 @@ Vector3 Curve3D::_calculate_tangent(const Vector3 &p_begin, const Vector3 &p_con
 				return (p_end - p_control_1).normalized();
 			}
 		}
+	}
+
+	if (p_control_1.is_equal_approx(p_end) && p_control_2.is_equal_approx(p_begin)) {
+		return (p_end - p_begin).normalized();
 	}
 
 	return p_begin.bezier_derivative(p_control_1, p_control_2, p_end, p_t).normalized();

--- a/tests/scene/test_curve_2d.h
+++ b/tests/scene/test_curve_2d.h
@@ -236,6 +236,19 @@ TEST_CASE("[Curve2D] Sampling") {
 		CHECK(curve->get_closest_point(Vector2(50, 50)) == Vector2(0, 50));
 		CHECK(curve->get_closest_point(Vector2(0, 100)) == Vector2(0, 50));
 	}
+
+	SUBCASE("sample_baked_with_rotation, linear curve with control1 = end and control2 = begin") {
+		// Regression test for issue #88923
+		// The Vector2s that aren't relevant to the issue have x = 2 or x = -2.
+		// They're just set to make collisions with corner cases less likely
+		// that involve zero-vector control points.
+		Ref<Curve2D> cross_linear_curve = memnew(Curve2D);
+		cross_linear_curve->set_bake_interval(0.5);
+		cross_linear_curve->add_point(Vector2(), Vector2(-2, 0), Vector2(1, 0));
+		cross_linear_curve->add_point(Vector2(1, 0), Vector2(-1, 0), Vector2(2, 0));
+		CHECK(cross_linear_curve->get_baked_points().size() >= 3);
+		CHECK(cross_linear_curve->sample_baked_with_rotation(cross_linear_curve->get_closest_offset(Vector2(0.5, 0))).is_equal_approx(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(0.5, 0))));
+	}
 }
 
 TEST_CASE("[Curve2D] Tessellation") {

--- a/tests/scene/test_curve_3d.h
+++ b/tests/scene/test_curve_3d.h
@@ -234,6 +234,18 @@ TEST_CASE("[Curve3D] Sampling") {
 		c->add_point(Vector3(0, .1, 1));
 		CHECK_LT((c->sample_baked_up_vector(c->get_closest_offset(Vector3(0, 0, .9))) - Vector3(0, 0.995037, -0.099504)).length(), 0.01);
 	}
+
+	SUBCASE("sample_baked_with_rotation, linear curve with control1 = end and control2 = begin") {
+		// Regression test for issue #88923
+		// The Vector3s that aren't relevant to the issue have z = 2.
+		// They're just set to make collisions with corner cases less likely
+		// that involve zero-vector control points.
+		Ref<Curve3D> cross_linear_curve = memnew(Curve3D);
+		cross_linear_curve->add_point(Vector3(), Vector3(-1, 0, 2), Vector3(1, 0, 0));
+		cross_linear_curve->add_point(Vector3(1, 0, 0), Vector3(-1, 0, 0), Vector3(1, 0, 2));
+		CHECK(cross_linear_curve->get_baked_points().size() >= 3);
+		CHECK(cross_linear_curve->sample_baked_with_rotation(cross_linear_curve->get_closest_offset(Vector3(0.5, 0, 0))).is_equal_approx(Transform3D(Basis(Vector3(0, 0, 1), Vector3(0, 1, 0), Vector3(-1, 0, 0)), Vector3(0.5, 0, 0))));
+	}
 }
 
 TEST_CASE("[Curve3D] Tessellation") {


### PR DESCRIPTION
This, in turn, fixes the wrong middle point transform returned by `sample_baked_with_rotation` with the control point constellation mentioned in the title.

Fixes #88923, which contains further details.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
