### PR TITLE
Fix animation player error dialog focus

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -2038,10 +2038,10 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	vb->add_child(name_hb);
 	name_dialog->register_text_enter(name);
 
-	error_dialog = memnew(ConfirmationDialog);
+	error_dialog = memnew(AcceptDialog);
 	error_dialog->set_ok_button_text(TTR("Close"));
 	error_dialog->set_title(TTR("Error!"));
-	add_child(error_dialog);
+	name_dialog->add_child(error_dialog);
 
 	name_dialog->connect(SNAME("confirmed"), callable_mp(this, &AnimationPlayerEditor::_animation_name_edited));
 

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -128,7 +128,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	} blend_editor;
 
 	ConfirmationDialog *name_dialog = nullptr;
-	ConfirmationDialog *error_dialog = nullptr;
+	AcceptDialog *error_dialog = nullptr;
 	int name_dialog_op = TOOL_NEW_ANIM;
 
 	bool updating = false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88930

The error dialog of the animation player would appear behind the name dialog. So, to the user it appeared like clicking OK when creating/duplication an animation was just broken (if there was already an animation of the same name). This PR makes sure the error dialog always appears in front of the name dialog.

The name dialog could also be closed independently of the error dialog which was weird. This PR makes the error dialog a child of the name dialog so it always must be closed before returning to the name dialog.

The error dialog had two buttons which made little sense "Cancel" and "Ok". This PR just now gives the dialog one "Close".

Before:
![image](https://github.com/godotengine/godot/assets/4586101/9ace171a-06b0-49ce-91f7-c4fda4a3e720)


After:
![image](https://github.com/godotengine/godot/assets/4586101/1a3456dd-ae7e-414a-9fe0-85f9122ab2ce)
