### PR TITLE
Fix wrong indexing when generating dummy tangents in GLTF import

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2796,7 +2796,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 
 				Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
 				for (int k = 0; k < vertex_num; k++) {
-					Vector3 tan = Vector3(normals[i].z, -normals[i].x, normals[i].y).cross(normals[k].normalized()).normalized();
+					Vector3 tan = Vector3(normals[k].z, -normals[k].x, normals[k].y).cross(normals[k].normalized()).normalized();
 					tangentsw[k * 4 + 0] = tan.x;
 					tangentsw[k * 4 + 1] = tan.y;
 					tangentsw[k * 4 + 2] = tan.z;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/88903
Follow-up to #88738.

I couldn't reproduce the crash, but I am quite confident this is the problem. `i` is used for the index of the mesh in the GLTF file, so this line will crash whenever a mesh has a smaller number of vertices than its index in the GLTF file. 