### PR TITLE
[3.x] Fix SceneTree dock filter crash

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -594,9 +594,16 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 	}
 
 	bool keep_for_children = false;
+
+	// Get the list of children ahead of time, as the list may be invalidated by deleting one of them.
+	LocalVector<TreeItem *> children;
 	for (TreeItem *child = p_parent->get_children(); child; child = child->get_next()) {
+		children.push_back(child);
+	}
+
+	for (uint32_t n = 0; n < children.size(); n++) {
 		// Always keep if at least one of the children are kept.
-		keep_for_children = _update_filter(child, p_scroll_to_selected) || keep_for_children;
+		keep_for_children = _update_filter(children[n], p_scroll_to_selected) || keep_for_children;
 	}
 
 	// Now find other reasons to keep this Node, too.
@@ -617,8 +624,6 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 				}
 			}
 		}
-	} else {
-		memdelete(p_parent);
 	}
 
 	if (editor_selection) {
@@ -633,6 +638,10 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 				p_parent->deselect(0);
 			}
 		}
+	}
+
+	if (!(keep || keep_for_children)) {
+		memdelete(p_parent);
 	}
 
 	return keep || keep_for_children;


### PR DESCRIPTION
The filter was crashing for two reasons:
1) Deleting a child invalidated the iteration of children
2) Child was accessed after deletion

Fixes #88194

## Notes
* Crash regression introduced in #67347

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
