### PR TITLE
Make `Variant.As<T>` deriving from `GodotObject` return null if unable to cast

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -378,7 +378,16 @@ public partial class VariantUtils
         // `typeof(X).IsAssignableFrom(typeof(T))` is optimized away
 
         if (typeof(GodotObject).IsAssignableFrom(typeof(T)))
-            return (T)(object)ConvertToGodotObject(variant);
+        {
+            var godotObject = ConvertToGodotObject(variant);
+
+            //Disable the "Possible null reference return" warning for this line
+            #pragma warning disable CS8603
+
+            //Only cast if the type matches, otherwise sends null
+            return godotObject is T ? (T)(object)godotObject : default;
+            #pragma warning restore CS8603
+        }
 
         // `typeof(T).IsValueType` is optimized away
         // `typeof(T).IsEnum` is NOT optimized away: https://github.com/dotnet/runtime/issues/67113

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -382,11 +382,11 @@ public partial class VariantUtils
             var godotObject = ConvertToGodotObject(variant);
 
             //Disable the "Possible null reference return" warning for this line
-            #pragma warning disable CS8603
+#pragma warning disable CS8603
 
             //Only cast if the type matches, otherwise sends null
             return godotObject is T ? (T)(object)godotObject : default;
-            #pragma warning restore CS8603
+#pragma warning restore CS8603
         }
 
         // `typeof(T).IsValueType` is optimized away


### PR DESCRIPTION
```Variant.As<T>``` deriving from GodotObject will return null if unable to cast instead of throwing ```InvalidCastException```. This is so that its consistent with the ```as``` operator in C# which to return null if it can't cast.

