### PR TITLE
Fix physics platform crash

### DIFF
--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -56,8 +56,15 @@ bool CharacterBody3D::move_and_slide() {
 			excluded = (platform_wall_layers & platform_layer) == 0;
 		}
 		if (!excluded) {
-			//this approach makes sure there is less delay between the actual body velocity and the one we saved
-			PhysicsDirectBodyState3D *bs = PhysicsServer3D::get_singleton()->body_get_direct_state(platform_rid);
+			PhysicsDirectBodyState3D *bs = nullptr;
+
+			// We need to check the platform_rid object still exists before accessing.
+			// A valid RID is no guarantee that the object has not been deleted.
+			if (ObjectDB::get_instance(platform_object_id)) {
+				//this approach makes sure there is less delay between the actual body velocity and the one we saved
+				bs = PhysicsServer3D::get_singleton()->body_get_direct_state(platform_rid);
+			}
+
 			if (bs) {
 				Vector3 local_position = gt.origin - bs->get_transform().origin;
 				current_platform_velocity = bs->get_velocity_at_local_position(local_position);


### PR DESCRIPTION
Physics body previously stored the RID of a collision object and accessed it on the next frame, leading to a crash if the object had been deleted. This PR checks the object still exists via the ObjectID prior to access.

Fixes 4.x version of #74732
4.x port of #88946

## Notes
* See #88946 for details, and pros cons.
* Also note possibility of race condition if another thread deletes object in between checking `ObjectDB` and access.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
