### PR TITLE
RTL: Clarify that line, paragraph, and character numbers are zero-indexed

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -69,7 +69,7 @@
 			<return type="int" />
 			<param index="0" name="character" type="int" />
 			<description>
-				Returns the line number of the character position provided.
+				Returns the line number of the character position provided. Line and character numbers are both zero-indexed.
 				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_ready] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>
@@ -77,7 +77,7 @@
 			<return type="int" />
 			<param index="0" name="character" type="int" />
 			<description>
-				Returns the paragraph number of the character position provided.
+				Returns the paragraph number of the character position provided. Paragraph and character numbers are both zero-indexed.
 				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_ready] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>


### PR DESCRIPTION
Closes #82885 once cherry-picked to `4.1` with this additional change:
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 895d4da342..52395a3037 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,6 +598,7 @@ See the [release announcement](https://godotengine.org/article/maintenance-relea
 #### GUI
 
 - Fix RichTextLabel character line and paragraph index getters ([GH-76759](https://github.com/godotengine/godot/pull/76759)).
+  * This corrects an off-by-one error for the indices, making lines/paragraphs zero-indexed instead of one-indexed.
 - Fix text overlapping icon in `Tree` ([GH-78756](https://github.com/godotengine/godot/pull/78756)).
 - Fix delay on tab resizing when (un)hovering tabs ([GH-78777](https://github.com/godotengine/godot/pull/78777)).
 - Fix `Tree` performance regression by using cache ([GH-79325](https://github.com/godotengine/godot/pull/79325)).
```