### PR TITLE
[Doc] Clarify some details about deferred calls

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -110,6 +110,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] Deferred calls are processed at idle time. Idle time happens mainly at the end of process and physics frames. In it, deferred calls will be run until there are none left, which means you can defer calls from other deferred calls and they'll still be run in the current idle time cycle. This means you should not call a method deferred from itself (or from a method called by it), as this causes infinite recursion the same way as if you had called the method directly.
 				See also [method Object.call_deferred].
 			</description>
 		</method>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -406,7 +406,7 @@
 			<param index="0" name="method" type="StringName" />
 			<description>
 				Calls the [param method] on the object during idle time. Always returns null, [b]not[/b] the method's result.
-				Idle time happens mainly at the end of process and physics frames. In it, deferred calls will be run until there are none left, which means you can defer calls from other deferred calls and they'll still be run in the current idle time cycle. If not done carefully, this can result in infinite recursion without causing a stack overflow, which will hang the game similarly to an infinite loop.
+				Idle time happens mainly at the end of process and physics frames. In it, deferred calls will be run until there are none left, which means you can defer calls from other deferred calls and they'll still be run in the current idle time cycle. This means you should not call a method deferred from itself (or from a method called by it), as this causes infinite recursion the same way as if you had called the method directly.
 				This method supports a variable number of arguments, so parameters can be passed as a comma separated list.
 				[codeblocks]
 				[gdscript]


### PR DESCRIPTION
Added information directly to `Callable.call_deferred` as while this information is given in `Object.call_deferred` it is a bit too important information to have behind a "see also". Made the details about infinite recursion to the two descriptions, and removed an incorrect statement. Calling deferred like this can't cause the game to freeze, it simply crashes as the message queue runs out of space, otherwise nothing will happen unless you just have a lot of processing going on which will freeze the game regardless of using deferred calls or not.

* Fixes: https://github.com/godotengine/godot/issues/88953

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
