### PR TITLE
Remove almost all remaining dependencies of TileMapLayer on TileMap

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -46,9 +46,10 @@ enum TileMapDataFormat {
 };
 
 class TileMap : public TileMapLayerGroup {
-	GDCLASS(TileMap, TileMapLayerGroup);
+	GDCLASS(TileMap, TileMapLayerGroup)
 
 public:
+	// Kept for compatibility, but should use TileMapLayer::VisibilityMode instead.
 	enum VisibilityMode {
 		VISIBILITY_MODE_DEFAULT,
 		VISIBILITY_MODE_FORCE_SHOW,
@@ -187,8 +188,7 @@ public:
 
 	// Override some methods of the CanvasItem class to pass the changes to the quadrants CanvasItems.
 	virtual void set_light_mask(int p_light_mask) override;
-	virtual void set_material(const Ref<Material> &p_material) override;
-	virtual void set_use_parent_material(bool p_use_parent_material) override;
+	virtual void set_self_modulate(const Color &p_self_modulate) override;
 	virtual void set_texture_filter(CanvasItem::TextureFilter p_texture_filter) override;
 	virtual void set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) override;
 

--- a/scene/2d/tile_map_layer_group.cpp
+++ b/scene/2d/tile_map_layer_group.cpp
@@ -53,7 +53,7 @@ void TileMapLayerGroup::_tile_set_changed() {
 	for (int i = 0; i < get_child_count(); i++) {
 		TileMapLayer *layer = Object::cast_to<TileMapLayer>(get_child(i));
 		if (layer) {
-			layer->notify_tile_map_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_TILE_SET);
+			layer->notify_tile_map_layer_group_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_TILE_SET);
 		}
 	}
 
@@ -70,7 +70,7 @@ void TileMapLayerGroup::set_selected_layers(Vector<StringName> p_layer_names) {
 	for (int i = 0; i < get_child_count(); i++) {
 		TileMapLayer *layer = Object::cast_to<TileMapLayer>(get_child(i));
 		if (layer) {
-			layer->notify_tile_map_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_SELECTED_LAYERS);
+			layer->notify_tile_map_layer_group_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_SELECTED_LAYERS);
 		}
 	}
 }
@@ -89,7 +89,7 @@ void TileMapLayerGroup::set_highlight_selected_layer(bool p_highlight_selected_l
 	for (int i = 0; i < get_child_count(); i++) {
 		TileMapLayer *layer = Object::cast_to<TileMapLayer>(get_child(i));
 		if (layer) {
-			layer->notify_tile_map_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_HIGHLIGHT_SELECTED);
+			layer->notify_tile_map_layer_group_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_HIGHLIGHT_SELECTED);
 		}
 	}
 }
@@ -132,7 +132,7 @@ void TileMapLayerGroup::set_tileset(const Ref<TileSet> &p_tileset) {
 	for (int i = 0; i < get_child_count(); i++) {
 		TileMapLayer *layer = Object::cast_to<TileMapLayer>(get_child(i));
 		if (layer) {
-			layer->notify_tile_map_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_TILE_SET);
+			layer->notify_tile_map_layer_group_change(TileMapLayer::DIRTY_FLAGS_LAYER_GROUP_TILE_SET);
 		}
 	}
 }


### PR DESCRIPTION
This is probably the last step before we can expose TileMap layers as individual nodes, as this makes TileMapLayer self-sufficient. Instead of TileMap fetching data from its parent TileMap node, the TileMap nodes sets properties on its children layers. 

The TileMap has however to call `set_as_tile_map_internal_node` to adjust the behavior of the layer. It makes some callbacks (navigation and physics mainly) point towards the TileMap node as a source of the interaction (collision) instead of the layer node itself. It also automatically instantiate a navigation map for layers with index >= 1, and sets a few needed properties. Basically it allows keeping compatibility.

This PR should keep full compatibility (and fix self_modulate on TileMap not working, while we are at it).
*Bugsquad edit:* Fixes #31413
Edit: supersedes https://github.com/godotengine/godot/pull/75320