### PR TITLE
Pre-commit: Move codespell script to `pre-commit`

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -95,11 +95,3 @@ jobs:
           else
             echo "Skipping dotnet format as no C# files were changed."
           fi
-
-      - name: Spell checks via codespell
-        if: github.event_name == 'pull_request' && env.CHANGED_FILES != ''
-        uses: codespell-project/actions-codespell@v2
-        with:
-          skip: "./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json"
-          ignore_words_list: "breaked,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,vai"
-          path: ${{ env.CHANGED_FILES }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,32 @@ repos:
         args:
           - --line-length=120
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: 9061d95aa
+    hooks:
+      - id: codespell
+        types_or: [text]
+        exclude: |
+          (?x)^(
+            \..*|
+            .*thirdparty.*|
+            .*\.desktop|
+            .*\.po|
+            AUTHORS\.md|
+            DONORS\.md|
+            core/input/gamecontrollerdb\.txt|
+            core/string/locales\.h|
+            misc/scripts/codespell_ignore_list.txt|
+            platform/android/java/lib/src/com/.*|
+            platform/web/node_modules/.*|
+            platform/web/package-lock\.json
+          )
+        args:
+          - -w
+          - -q 8
+          - -Imisc/scripts/codespell_ignore_list.txt
+          - --builtin "clear,rare,en-GB_to_en-US"
+
   - repo: local
     hooks:
       - id: make-rst

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6867,7 +6867,7 @@ bool AnimationTrackEditor::is_grouping_tracks() {
 
 void AnimationTrackEditor::_selection_changed() {
 	if (selected_filter->is_pressed()) {
-		_update_tracks(); // Needs updatin.
+		_update_tracks(); // Needs updating.
 	} else {
 		_redraw_tracks();
 		_redraw_groups();

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -393,24 +393,24 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 		bool smooth = false;
 
 		if (i < len - 1) {
-			Vector2 pointout = xform.xform(curve->get_point_position(i) + curve->get_point_out(i));
-			if (point != pointout) {
+			Vector2 point_out = xform.xform(curve->get_point_position(i) + curve->get_point_out(i));
+			if (point != point_out) {
 				smooth = true;
 				// Draw the line with a dark and light color to be visible on all backgrounds
-				vpc->draw_line(point, pointout, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
-				vpc->draw_line(point, pointout, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
-				vpc->draw_texture_rect(curve_handle, Rect2(pointout - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
+				vpc->draw_line(point, point_out, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
+				vpc->draw_line(point, point_out, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
+				vpc->draw_texture_rect(curve_handle, Rect2(point_out - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
 			}
 		}
 
 		if (i > 0) {
-			Vector2 pointin = xform.xform(curve->get_point_position(i) + curve->get_point_in(i));
-			if (point != pointin) {
+			Vector2 point_in = xform.xform(curve->get_point_position(i) + curve->get_point_in(i));
+			if (point != point_in) {
 				smooth = true;
 				// Draw the line with a dark and light color to be visible on all backgrounds
-				vpc->draw_line(point, pointin, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
-				vpc->draw_line(point, pointin, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
-				vpc->draw_texture_rect(curve_handle, Rect2(pointin - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
+				vpc->draw_line(point, point_in, Color(0, 0, 0, 0.5), Math::round(EDSCALE));
+				vpc->draw_line(point, point_in, Color(1, 1, 1, 0.5), Math::round(EDSCALE));
+				vpc->draw_texture_rect(curve_handle, Rect2(point_in - curve_handle_size * 0.5, curve_handle_size), false, Color(1, 1, 1, 0.75));
 			}
 		}
 

--- a/misc/scripts/codespell.sh
+++ b/misc/scripts/codespell.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-SKIP_LIST="./.*,./**/.*,./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,"
-SKIP_LIST+="./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/renames_map_3_to_4.cpp,./misc/scripts/codespell.sh,"
-SKIP_LIST+="./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json,"
-
-IGNORE_LIST="breaked,cancelled,curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,mis,nd,numer,ot,requestor,te,vai"
-
-codespell -w -q 3 -S "${SKIP_LIST}" -L "${IGNORE_LIST}" --builtin "clear,rare,en-GB_to_en-US"

--- a/misc/scripts/codespell_ignore_list.txt
+++ b/misc/scripts/codespell_ignore_list.txt
@@ -1,0 +1,6 @@
+breaked
+curvelinear
+doubleclick
+findn
+numer
+requestor

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -85,7 +85,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	*/
 
 	double magn, phase, tmp, window, real, imag;
-	double freqPerBin, expct;
+	double freqPerBin, expect;
 	long i,k, qpd, index, inFifoLatency, stepSize, fftFrameSize2;
 	unsigned long fftFrameBufferSize;
 
@@ -94,7 +94,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	fftFrameSize2 = fftFrameSize/2;
 	stepSize = fftFrameSize/osamp;
 	freqPerBin = sampleRate/(double)fftFrameSize;
-	expct = 2.*Math_PI*(double)stepSize/(double)fftFrameSize;
+	expect = 2.*Math_PI*(double)stepSize/(double)fftFrameSize;
 	inFifoLatency = fftFrameSize-stepSize;
 	if (gRover == 0) { gRover = inFifoLatency;
 }
@@ -139,7 +139,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				gLastPhase[k] = phase;
 
 				/* subtract expected phase difference */
-				tmp -= (double)k*expct;
+				tmp -= (double)k*expect;
 
 				/* map delta phase into +/- Pi interval */
 				qpd = tmp/Math_PI;
@@ -189,7 +189,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				tmp = 2.*Math_PI*tmp/osamp;
 
 				/* add the overlap phase advance back in */
-				tmp += (double)k*expct;
+				tmp += (double)k*expect;
 
 				/* accumulate delta phase to get bin phase */
 				gSumPhase[k] += tmp;


### PR DESCRIPTION
Makes it enabled by default in pre-commit hooks, which should help users catch typos.

Opening as a draft as I think this risks being a bother to users, as codespell can sometimes have false positives, and it won't let them commit before solving the false positive or adding it to the ignore list.

On the other hand I raised its quietness option, which means it no longer nags about potential issues that it spotted but refused to fix as those fixes are disabled by default (due to often being false positives). So the remaining "sure" fixes might not be too bad.

One option could be to add this but leave it opt-in, by using `stage: [manual]`, so it doesn't actually run automatically on pre-commit hooks. It then needs to be run manually with `pre-commit run codespell --hook-stage manual`... seems a bit tedious too.

Another drawback to the approach in this PR is that we lose the PR diff annotations on GitHub, but I'm not sure how useful they were as they were not blocking, and we still introduced typos regardless.

*Edit:* This may be a nicer approach to set the file exclude and words ignore lists: https://github.com/codespell-project/codespell/blob/master/pyproject-codespell.precommit-toml