### PR TITLE
Add const lvalue ref to `platform/*` container parameters

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -328,7 +328,7 @@ DirAccessJAndroid::~DirAccessJAndroid() {
 	list_dir_end();
 }
 
-int DirAccessJAndroid::dir_open(String p_path) {
+int DirAccessJAndroid::dir_open(const String &p_path) {
 	if (_dir_open) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, 0);

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -99,7 +99,7 @@ protected:
 private:
 	int id = 0;
 
-	int dir_open(String p_path);
+	int dir_open(const String &p_path);
 	void dir_close(int p_id);
 	String get_absolute_path(String p_path);
 };

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2229,7 +2229,7 @@ String EditorExportPlatformAndroid::get_apksigner_path(int p_target_sdk, bool p_
 	bool found_target_sdk = false;
 	// We only allow for versions <= 27 if specifically set
 	int min_version = p_target_sdk <= 27 ? p_target_sdk : 28;
-	for (String sub_dir : dir_list) {
+	for (const String &sub_dir : dir_list) {
 		if (!sub_dir.begins_with(".")) {
 			Vector<String> ver_numbers = sub_dir.split(".");
 			// Dir not a version number, will use as last resort

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -47,7 +47,7 @@
 //     /*.custom_maven_repos =*/{}
 // };
 
-String PluginConfigAndroid::resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
+String PluginConfigAndroid::resolve_local_dependency_path(const String &plugin_config_dir, const String &dependency_path) {
 	String absolute_path;
 	if (!dependency_path.is_empty()) {
 		if (dependency_path.is_absolute_path()) {
@@ -60,7 +60,7 @@ String PluginConfigAndroid::resolve_local_dependency_path(String plugin_config_d
 	return absolute_path;
 }
 
-PluginConfigAndroid PluginConfigAndroid::resolve_prebuilt_plugin(PluginConfigAndroid prebuilt_plugin, String plugin_config_dir) {
+PluginConfigAndroid PluginConfigAndroid::resolve_prebuilt_plugin(PluginConfigAndroid prebuilt_plugin, const String &plugin_config_dir) {
 	PluginConfigAndroid resolved = prebuilt_plugin;
 	resolved.binary = resolved.binary_type == PluginConfigAndroid::BINARY_TYPE_LOCAL ? resolve_local_dependency_path(plugin_config_dir, prebuilt_plugin.binary) : prebuilt_plugin.binary;
 	if (!prebuilt_plugin.local_dependencies.is_empty()) {
@@ -72,7 +72,7 @@ PluginConfigAndroid PluginConfigAndroid::resolve_prebuilt_plugin(PluginConfigAnd
 	return resolved;
 }
 
-Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(String plugins_base_dir) {
+Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(const String &plugins_base_dir) {
 	Vector<PluginConfigAndroid> prebuilt_plugins;
 	return prebuilt_plugins;
 }
@@ -147,7 +147,7 @@ PluginConfigAndroid PluginConfigAndroid::load_plugin_config(Ref<ConfigFile> conf
 	return plugin_config;
 }
 
-void PluginConfigAndroid::get_plugins_binaries(String binary_type, Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result) {
+void PluginConfigAndroid::get_plugins_binaries(const String &binary_type, const Vector<PluginConfigAndroid> &plugins_configs, Vector<String> &r_result) {
 	if (!plugins_configs.is_empty()) {
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfigAndroid config = plugins_configs[i];
@@ -170,7 +170,7 @@ void PluginConfigAndroid::get_plugins_binaries(String binary_type, Vector<Plugin
 	}
 }
 
-void PluginConfigAndroid::get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result) {
+void PluginConfigAndroid::get_plugins_custom_maven_repos(const Vector<PluginConfigAndroid> &plugins_configs, Vector<String> &r_result) {
 	if (!plugins_configs.is_empty()) {
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfigAndroid config = plugins_configs[i];
@@ -183,7 +183,7 @@ void PluginConfigAndroid::get_plugins_custom_maven_repos(Vector<PluginConfigAndr
 	}
 }
 
-void PluginConfigAndroid::get_plugins_names(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result) {
+void PluginConfigAndroid::get_plugins_names(const Vector<PluginConfigAndroid> &plugins_configs, Vector<String> &r_result) {
 	if (!plugins_configs.is_empty()) {
 		for (int i = 0; i < plugins_configs.size(); i++) {
 			PluginConfigAndroid config = plugins_configs[i];

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -84,11 +84,11 @@ struct PluginConfigAndroid {
 	Vector<String> remote_dependencies;
 	Vector<String> custom_maven_repos;
 
-	static String resolve_local_dependency_path(String plugin_config_dir, String dependency_path);
+	static String resolve_local_dependency_path(const String &plugin_config_dir, const String &dependency_path);
 
-	static PluginConfigAndroid resolve_prebuilt_plugin(PluginConfigAndroid prebuilt_plugin, String plugin_config_dir);
+	static PluginConfigAndroid resolve_prebuilt_plugin(PluginConfigAndroid prebuilt_plugin, const String &plugin_config_dir);
 
-	static Vector<PluginConfigAndroid> get_prebuilt_plugins(String plugins_base_dir);
+	static Vector<PluginConfigAndroid> get_prebuilt_plugins(const String &plugins_base_dir);
 
 	static bool is_plugin_config_valid(PluginConfigAndroid plugin_config);
 
@@ -96,11 +96,11 @@ struct PluginConfigAndroid {
 
 	static PluginConfigAndroid load_plugin_config(Ref<ConfigFile> config_file, const String &path);
 
-	static void get_plugins_binaries(String binary_type, Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result);
+	static void get_plugins_binaries(const String &binary_type, const Vector<PluginConfigAndroid> &plugins_configs, Vector<String> &r_result);
 
-	static void get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result);
+	static void get_plugins_custom_maven_repos(const Vector<PluginConfigAndroid> &plugins_configs, Vector<String> &r_result);
 
-	static void get_plugins_names(Vector<PluginConfigAndroid> plugins_configs, Vector<String> &r_result);
+	static void get_plugins_names(const Vector<PluginConfigAndroid> &plugins_configs, Vector<String> &r_result);
 };
 
 #endif // DISABLE_DEPRECATED

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -838,7 +838,7 @@ Error OS_Android::setup_remote_filesystem(const String &p_server_host, int p_por
 
 void OS_Android::load_platform_gdextensions() const {
 	Vector<String> extension_list_config_file = godot_java->get_gdextension_list_config_file();
-	for (String config_file_path : extension_list_config_file) {
+	for (const String &config_file_path : extension_list_config_file) {
 		GDExtensionManager::LoadStatus err = GDExtensionManager::get_singleton()->load_extension(config_file_path);
 		ERR_CONTINUE_MSG(err == GDExtensionManager::LOAD_STATUS_FAILED, "Error loading platform extension: " + config_file_path);
 	}

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -806,7 +806,7 @@ struct CodesignData {
 	}
 };
 
-Error EditorExportPlatformIOS::_codesign(String p_file, void *p_userdata) {
+Error EditorExportPlatformIOS::_codesign(const String &p_file, void *p_userdata) {
 	if (p_file.ends_with(".dylib")) {
 		CodesignData *data = static_cast<CodesignData *>(p_userdata);
 		print_line(String("Signing ") + p_file);

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -88,9 +88,9 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	void _update_preset_status();
 #endif
 
-	typedef Error (*FileHandler)(String p_file, void *p_userdata);
+	typedef Error (*FileHandler)(const String &p_file, void *p_userdata);
 	static Error _walk_dir_recursive(Ref<DirAccess> &p_da, FileHandler p_handler, void *p_userdata);
-	static Error _codesign(String p_file, void *p_userdata);
+	static Error _codesign(const String &p_file, void *p_userdata);
 	void _blend_and_rotate(Ref<Image> &p_dst, Ref<Image> &p_src, bool p_rot);
 
 	struct IOSConfigData {
@@ -113,7 +113,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 
 		ExportArchitecture() {}
 
-		ExportArchitecture(String p_name, bool p_is_default) {
+		ExportArchitecture(const String &p_name, bool p_is_default) {
 			name = p_name;
 			is_default = p_is_default;
 		}

--- a/platform/ios/export/godot_plugin_config.cpp
+++ b/platform/ios/export/godot_plugin_config.cpp
@@ -34,7 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 
-String PluginConfigIOS::resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
+String PluginConfigIOS::resolve_local_dependency_path(const String &plugin_config_dir, const String &dependency_path) {
 	String absolute_path;
 
 	if (dependency_path.is_empty()) {
@@ -51,7 +51,7 @@ String PluginConfigIOS::resolve_local_dependency_path(String plugin_config_dir, 
 	return absolute_path.replace(res_path, "res://");
 }
 
-String PluginConfigIOS::resolve_system_dependency_path(String dependency_path) {
+String PluginConfigIOS::resolve_system_dependency_path(const String &dependency_path) {
 	String absolute_path;
 
 	if (dependency_path.is_empty()) {
@@ -67,7 +67,7 @@ String PluginConfigIOS::resolve_system_dependency_path(String dependency_path) {
 	return system_path.path_join(dependency_path);
 }
 
-Vector<String> PluginConfigIOS::resolve_local_dependencies(String plugin_config_dir, Vector<String> p_paths) {
+Vector<String> PluginConfigIOS::resolve_local_dependencies(const String &plugin_config_dir, const Vector<String> &p_paths) {
 	Vector<String> paths;
 
 	for (int i = 0; i < p_paths.size(); i++) {
@@ -83,7 +83,7 @@ Vector<String> PluginConfigIOS::resolve_local_dependencies(String plugin_config_
 	return paths;
 }
 
-Vector<String> PluginConfigIOS::resolve_system_dependencies(Vector<String> p_paths) {
+Vector<String> PluginConfigIOS::resolve_system_dependencies(const Vector<String> &p_paths) {
 	Vector<String> paths;
 
 	for (int i = 0; i < p_paths.size(); i++) {

--- a/platform/ios/export/godot_plugin_config.h
+++ b/platform/ios/export/godot_plugin_config.h
@@ -115,13 +115,13 @@ struct PluginConfigIOS {
 	// <name>:<type> = <value>
 	HashMap<String, PlistItem> plist;
 
-	static String resolve_local_dependency_path(String plugin_config_dir, String dependency_path);
+	static String resolve_local_dependency_path(const String &plugin_config_dir, const String &dependency_path);
 
-	static String resolve_system_dependency_path(String dependency_path);
+	static String resolve_system_dependency_path(const String &dependency_path);
 
-	static Vector<String> resolve_local_dependencies(String plugin_config_dir, Vector<String> p_paths);
+	static Vector<String> resolve_local_dependencies(const String &plugin_config_dir, const Vector<String> &p_paths);
 
-	static Vector<String> resolve_system_dependencies(Vector<String> p_paths);
+	static Vector<String> resolve_system_dependencies(const Vector<String> &p_paths);
 
 	static bool validate_plugin(PluginConfigIOS &plugin_config);
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -400,7 +400,7 @@ Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
 	return info;
 }
 
-Vector<String> OS_LinuxBSD::lspci_device_filter(Vector<String> vendor_device_id_mapping, String class_suffix, String check_column, String whitelist) const {
+Vector<String> OS_LinuxBSD::lspci_device_filter(const Vector<String> &vendor_device_id_mapping, const String &class_suffix, const String &check_column, const String &whitelist) const {
 	// NOTE: whitelist can be changed to `Vector<String>`, if the need arises.
 	const String sep = ":";
 	Vector<String> devices;
@@ -439,7 +439,7 @@ Vector<String> OS_LinuxBSD::lspci_device_filter(Vector<String> vendor_device_id_
 	return devices;
 }
 
-Vector<String> OS_LinuxBSD::lspci_get_device_value(Vector<String> vendor_device_id_mapping, String check_column, String blacklist) const {
+Vector<String> OS_LinuxBSD::lspci_get_device_value(const Vector<String> &vendor_device_id_mapping, const String &check_column, const String &blacklist) const {
 	// NOTE: blacklist can be changed to `Vector<String>`, if the need arises.
 	const String sep = ":";
 	Vector<String> values;

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -83,8 +83,8 @@ class OS_LinuxBSD : public OS_Unix {
 
 	String get_systemd_os_release_info_value(const String &key) const;
 
-	Vector<String> lspci_device_filter(Vector<String> vendor_device_id_mapping, String class_suffix, String check_column, String whitelist) const;
-	Vector<String> lspci_get_device_value(Vector<String> vendor_device_id_mapping, String check_column, String blacklist) const;
+	Vector<String> lspci_device_filter(const Vector<String> &vendor_device_id_mapping, const String &class_suffix, const String &check_column, const String &whitelist) const;
+	Vector<String> lspci_get_device_value(const Vector<String> &vendor_device_id_mapping, const String &check_column, const String &blacklist) const;
 
 	String system_dir_desktop_cache;
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -365,8 +365,8 @@ public:
 	virtual Color get_base_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
-	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
-	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;
+	virtual Error dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback) override;
+	virtual Error dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback) override;
 
 	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) override;
 	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback) override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2129,7 +2129,7 @@ void DisplayServerMacOS::emit_system_theme_changed() {
 	}
 }
 
-Error DisplayServerMacOS::dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) {
+Error DisplayServerMacOS::dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback) {
 	_THREAD_SAFE_METHOD_
 
 	NSAlert *window = [[NSAlert alloc] init];
@@ -2419,7 +2419,7 @@ Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, 
 	return OK;
 }
 
-Error DisplayServerMacOS::dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) {
+Error DisplayServerMacOS::dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback) {
 	_THREAD_SAFE_METHOD_
 
 	NSAlert *window = [[NSAlert alloc] init];

--- a/platform/web/api/api.cpp
+++ b/platform/web/api/api.cpp
@@ -123,7 +123,7 @@ Error JavaScriptBridge::pwa_update() {
 void JavaScriptBridge::force_fs_sync() {
 }
 
-void JavaScriptBridge::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
+void JavaScriptBridge::download_buffer(const Vector<uint8_t> &p_arr, const String &p_name, const String &p_mime) {
 }
 
 #endif

--- a/platform/web/api/javascript_bridge_singleton.h
+++ b/platform/web/api/javascript_bridge_singleton.h
@@ -58,7 +58,7 @@ public:
 	Ref<JavaScriptObject> get_interface(const String &p_interface);
 	Ref<JavaScriptObject> create_callback(const Callable &p_callable);
 	Variant _create_object_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	void download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime = "application/octet-stream");
+	void download_buffer(const Vector<uint8_t> &p_arr, const String &p_name, const String &p_mime = "application/octet-stream");
 	bool pwa_needs_update() const;
 	Error pwa_update();
 	void force_fs_sync();

--- a/platform/web/api/web_tools_editor_plugin.cpp
+++ b/platform/web/api/web_tools_editor_plugin.cpp
@@ -96,7 +96,7 @@ void WebToolsEditorPlugin::_download_zip() {
 	DirAccess::remove_file_or_error(output_path);
 }
 
-void WebToolsEditorPlugin::_zip_file(String p_path, String p_base_path, zipFile p_zip) {
+void WebToolsEditorPlugin::_zip_file(const String &p_path, const String &p_base_path, zipFile p_zip) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
 		WARN_PRINT("Unable to open file for zipping: " + p_path);
@@ -122,7 +122,7 @@ void WebToolsEditorPlugin::_zip_file(String p_path, String p_base_path, zipFile 
 	zipCloseFileInZip(p_zip);
 }
 
-void WebToolsEditorPlugin::_zip_recursive(String p_path, String p_base_path, zipFile p_zip) {
+void WebToolsEditorPlugin::_zip_recursive(const String &p_path, const String &p_base_path, zipFile p_zip) {
 	Ref<DirAccess> dir = DirAccess::open(p_path);
 	if (dir.is_null()) {
 		WARN_PRINT("Unable to open directory for zipping: " + p_path);

--- a/platform/web/api/web_tools_editor_plugin.h
+++ b/platform/web/api/web_tools_editor_plugin.h
@@ -40,8 +40,8 @@ class WebToolsEditorPlugin : public EditorPlugin {
 	GDCLASS(WebToolsEditorPlugin, EditorPlugin);
 
 private:
-	void _zip_file(String p_path, String p_base_path, zipFile p_zip);
-	void _zip_recursive(String p_path, String p_base_path, zipFile p_zip);
+	void _zip_file(const String &p_path, const String &p_base_path, zipFile p_zip);
+	void _zip_recursive(const String &p_path, const String &p_base_path, zipFile p_zip);
 	void _download_zip();
 
 public:

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -102,7 +102,7 @@ Error EditorExportPlatformWeb::_extract_template(const String &p_template, const
 	return OK;
 }
 
-Error EditorExportPlatformWeb::_write_or_error(const uint8_t *p_content, int p_size, String p_path) {
+Error EditorExportPlatformWeb::_write_or_error(const uint8_t *p_content, int p_size, const String &p_path) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
 	if (f.is_null()) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not write file: \"%s\"."), p_path));
@@ -130,7 +130,7 @@ void EditorExportPlatformWeb::_replace_strings(const HashMap<String, String> &p_
 	}
 }
 
-void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes) {
+void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags, const Vector<SharedObject> &p_shared_objects, const Dictionary &p_file_sizes) {
 	// Engine.js config
 	Dictionary config;
 	Array libs;
@@ -213,7 +213,7 @@ Error EditorExportPlatformWeb::_add_manifest_icon(const String &p_path, const St
 	return err;
 }
 
-Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects) {
+Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_preset, const String &p_path, const Vector<SharedObject> &p_shared_objects) {
 	String proj_name = GLOBAL_GET("application/config/name");
 	if (proj_name.is_empty()) {
 		proj_name = "Godot Game";

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -91,10 +91,10 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 
 	Error _extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa);
 	void _replace_strings(const HashMap<String, String> &p_replaces, Vector<uint8_t> &r_template);
-	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes);
+	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags, const Vector<SharedObject> &p_shared_objects, const Dictionary &p_file_sizes);
 	Error _add_manifest_icon(const String &p_path, const String &p_icon, int p_size, Array &r_arr);
-	Error _build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects);
-	Error _write_or_error(const uint8_t *p_content, int p_len, String p_path);
+	Error _build_pwa(const Ref<EditorExportPreset> &p_preset, const String &p_path, const Vector<SharedObject> &p_shared_objects);
+	Error _write_or_error(const uint8_t *p_content, int p_len, const String &p_path);
 
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;

--- a/platform/web/javascript_bridge_singleton.cpp
+++ b/platform/web/javascript_bridge_singleton.cpp
@@ -73,7 +73,7 @@ private:
 	WASM_EXPORT static Variant _js2variant(int p_type, godot_js_wrapper_ex *p_val);
 	WASM_EXPORT static void *_alloc_variants(int p_size);
 	WASM_EXPORT static void callback(void *p_ref, int p_arg_id, int p_argc);
-	static void _callback(const JavaScriptObjectImpl *obj, Variant arg);
+	static void _callback(const JavaScriptObjectImpl *obj, const Variant &arg);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value) override;
@@ -270,7 +270,7 @@ void JavaScriptObjectImpl::callback(void *p_ref, int p_args_id, int p_argc) {
 	_callback(obj, arg);
 }
 
-void JavaScriptObjectImpl::_callback(const JavaScriptObjectImpl *obj, Variant arg) {
+void JavaScriptObjectImpl::_callback(const JavaScriptObjectImpl *obj, const Variant &arg) {
 	obj->_callable.call(arg);
 
 	// Set return value
@@ -368,7 +368,7 @@ Variant JavaScriptBridge::eval(const String &p_code, bool p_use_global_exec_cont
 
 #endif // JAVASCRIPT_EVAL_ENABLED
 
-void JavaScriptBridge::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
+void JavaScriptBridge::download_buffer(const Vector<uint8_t> &p_arr, const String &p_name, const String &p_mime) {
 	godot_js_os_download_buffer(p_arr.ptr(), p_arr.size(), p_name.utf8().get_data(), p_mime.utf8().get_data());
 }
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -521,12 +521,12 @@ bool DisplayServer::get_swap_cancel_ok() {
 void DisplayServer::enable_for_stealing_focus(OS::ProcessID pid) {
 }
 
-Error DisplayServer::dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) {
+Error DisplayServer::dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback) {
 	WARN_PRINT("Native dialogs not supported by this display server.");
 	return OK;
 }
 
-Error DisplayServer::dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) {
+Error DisplayServer::dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback) {
 	WARN_PRINT("Native dialogs not supported by this display server.");
 	return OK;
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -510,8 +510,8 @@ public:
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid);
 
-	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback);
-	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback);
+	virtual Error dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback);
+	virtual Error dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback);
 
 	enum FileDialogMode {
 		FILE_DIALOG_MODE_OPEN_FILE,


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds const lvalue reference to the core container types specified in the [documentation](https://docs.godotengine.org/en/stable/development/cpp/core_types.html) that are declared in function parameters in `platform/*` files

initial: https://github.com/godotengine/godot/pull/51156
`core/*`: https://github.com/godotengine/godot/pull/86966
`editor/*`: https://github.com/godotengine/godot/pull/88368
`modules/*`: https://github.com/godotengine/godot/pull/88915
`servers/*`: https://github.com/godotengine/godot/pull/88972
`scene/*`: https://github.com/godotengine/godot/pull/88974
others: https://github.com/godotengine/godot/pull/88975