### PR TITLE
Add const lvalue ref to `servers/*` container parameters

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -289,8 +289,8 @@ public:
 	virtual Color get_base_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
-	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
-	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;
+	virtual Error dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback) override;
+	virtual Error dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback) override;
 
 	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) override;
 	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback) override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -900,7 +900,7 @@ void DisplayServerMacOS::emit_system_theme_changed() {
 	}
 }
 
-Error DisplayServerMacOS::dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) {
+Error DisplayServerMacOS::dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback) {
 	_THREAD_SAFE_METHOD_
 
 	NSAlert *window = [[NSAlert alloc] init];
@@ -1190,7 +1190,7 @@ Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, 
 	return OK;
 }
 
-Error DisplayServerMacOS::dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) {
+Error DisplayServerMacOS::dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback) {
 	_THREAD_SAFE_METHOD_
 
 	NSAlert *window = [[NSAlert alloc] init];

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1168,7 +1168,7 @@ float AudioServer::get_playback_speed_scale() const {
 	return playback_speed_scale;
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, const Vector<AudioFrame> &p_volume_db_vector, float p_start_time, float p_pitch_scale) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	HashMap<StringName, Vector<AudioFrame>> map;
@@ -1242,7 +1242,7 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
 }
 
-void AudioServer::set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes) {
+void AudioServer::set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, const Vector<AudioFrame> &p_volumes) {
 	ERR_FAIL_COND(p_volumes.size() != MAX_CHANNELS_PER_BUS);
 
 	HashMap<StringName, Vector<AudioFrame>> map;
@@ -1290,7 +1290,7 @@ void AudioServer::set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_pla
 	bus_details_graveyard.insert(old_bus_details);
 }
 
-void AudioServer::set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes) {
+void AudioServer::set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const Vector<AudioFrame> &p_volumes) {
 	ERR_FAIL_COND(p_playback.is_null());
 	ERR_FAIL_COND(p_volumes.size() != MAX_CHANNELS_PER_BUS);
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -406,14 +406,14 @@ public:
 	float get_playback_speed_scale() const;
 
 	// Convenience method.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, const Vector<AudioFrame> &p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
 	// Expose all parameters.
 	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
 	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
 
-	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes);
+	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, const Vector<AudioFrame> &p_volumes);
 	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes);
-	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes);
+	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const Vector<AudioFrame> &p_volumes);
 	void set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale);
 	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused);
 	void set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz);

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -99,7 +99,7 @@ String CameraFeed::get_name() const {
 	return name;
 }
 
-void CameraFeed::set_name(String p_name) {
+void CameraFeed::set_name(const String &p_name) {
 	name = p_name;
 }
 
@@ -149,7 +149,7 @@ CameraFeed::CameraFeed() {
 	texture[CameraServer::FEED_CBCR_IMAGE] = RenderingServer::get_singleton()->texture_2d_placeholder_create();
 }
 
-CameraFeed::CameraFeed(String p_name, FeedPosition p_position) {
+CameraFeed::CameraFeed(const String &p_name, FeedPosition p_position) {
 	// initialize our feed
 	id = CameraServer::get_singleton()->get_free_id();
 	base_width = 0;

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -80,7 +80,7 @@ public:
 	void set_active(bool p_is_active);
 
 	String get_name() const;
-	void set_name(String p_name);
+	void set_name(const String &p_name);
 
 	int get_base_width() const;
 	int get_base_height() const;
@@ -94,7 +94,7 @@ public:
 	RID get_texture(CameraServer::FeedImage p_which);
 
 	CameraFeed();
-	CameraFeed(String p_name, FeedPosition p_position = CameraFeed::FEED_UNSPECIFIED);
+	CameraFeed(const String &p_name, FeedPosition p_position = CameraFeed::FEED_UNSPECIFIED);
 	virtual ~CameraFeed();
 
 	FeedDataType get_datatype() const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -642,12 +642,12 @@ bool DisplayServer::get_swap_cancel_ok() {
 void DisplayServer::enable_for_stealing_focus(OS::ProcessID pid) {
 }
 
-Error DisplayServer::dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) {
+Error DisplayServer::dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback) {
 	WARN_PRINT("Native dialogs not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
 
-Error DisplayServer::dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) {
+Error DisplayServer::dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback) {
 	WARN_PRINT("Native dialogs not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -535,8 +535,8 @@ public:
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid);
 
-	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback);
-	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback);
+	virtual Error dialog_show(const String &p_title, const String &p_description, const Vector<String> &p_buttons, const Callable &p_callback);
+	virtual Error dialog_input_text(const String &p_title, const String &p_description, const String &p_partial, const Callable &p_callback);
 
 	enum FileDialogMode {
 		FILE_DIALOG_MODE_OPEN_FILE,

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -789,7 +789,7 @@ class PhysicsServer2DManager : public Object {
 
 		ClassInfo() {}
 
-		ClassInfo(String p_name, Callable p_create_callback) :
+		ClassInfo(const String &p_name, Callable p_create_callback) :
 				name(p_name),
 				create_callback(p_create_callback) {}
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -997,7 +997,7 @@ class PhysicsServer3DManager : public Object {
 
 		ClassInfo() {}
 
-		ClassInfo(String p_name, Callable p_create_callback) :
+		ClassInfo(const String &p_name, Callable p_create_callback) :
 				name(p_name),
 				create_callback(p_create_callback) {}
 

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -1096,7 +1096,7 @@ void CopyEffects::cubemap_downsample_raster(RID p_source_cubemap, RID p_dest_fra
 	RD::get_singleton()->draw_list_end();
 }
 
-void CopyEffects::cubemap_filter(RID p_source_cubemap, Vector<RID> p_dest_cubemap, bool p_use_array) {
+void CopyEffects::cubemap_filter(RID p_source_cubemap, const Vector<RID> &p_dest_cubemap, bool p_use_array) {
 	ERR_FAIL_COND_MSG(prefer_raster_effects, "Can't use compute based cubemap filter with the mobile renderer.");
 
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -349,7 +349,7 @@ public:
 	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip);
 	void cubemap_downsample(RID p_source_cubemap, RID p_dest_cubemap, const Size2i &p_size);
 	void cubemap_downsample_raster(RID p_source_cubemap, RID p_dest_framebuffer, uint32_t p_face_id, const Size2i &p_size);
-	void cubemap_filter(RID p_source_cubemap, Vector<RID> p_dest_cubemap, bool p_use_array);
+	void cubemap_filter(RID p_source_cubemap, const Vector<RID> &p_dest_cubemap, bool p_use_array);
 	void cubemap_filter_raster(RID p_source_cubemap, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_mip_level);
 
 	void cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -493,7 +493,7 @@ SceneShaderForwardClustered::~SceneShaderForwardClustered() {
 	material_storage->material_free(debug_shadow_splits_material);
 }
 
-void SceneShaderForwardClustered::init(const String p_defines) {
+void SceneShaderForwardClustered::init(const String &p_defines) {
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
 	{

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -255,7 +255,7 @@ public:
 	SceneShaderForwardClustered();
 	~SceneShaderForwardClustered();
 
-	void init(const String p_defines);
+	void init(const String &p_defines);
 	void set_default_specialization_constants(const Vector<RD::PipelineSpecializationConstant> &p_constants);
 	void enable_advanced_shader_group(bool p_needs_multiview = false);
 };

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -432,7 +432,7 @@ SceneShaderForwardMobile::SceneShaderForwardMobile() {
 	singleton = this;
 }
 
-void SceneShaderForwardMobile::init(const String p_defines) {
+void SceneShaderForwardMobile::init(const String &p_defines) {
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
 	/* SCENE SHADER */

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -206,7 +206,7 @@ public:
 
 	Vector<RD::PipelineSpecializationConstant> default_specialization_constants;
 
-	void init(const String p_defines);
+	void init(const String &p_defines);
 	void set_default_specialization_constants(const Vector<RD::PipelineSpecializationConstant> &p_constants);
 };
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1314,7 +1314,7 @@ public:
 	PASS1RC(float, environment_get_volumetric_fog_ambient_inject, RID)
 
 	// Glow
-	PASS13(environment_set_glow, RID, bool, Vector<float>, float, float, float, float, RS::EnvironmentGlowBlendMode, float, float, float, float, RID)
+	PASS13(environment_set_glow, RID, bool, const Vector<float> &, float, float, float, float, RS::EnvironmentGlowBlendMode, float, float, float, float, RID)
 
 	PASS1RC(bool, environment_get_glow_enabled, RID)
 	PASS1RC(Vector<float>, environment_get_glow_levels, RID)

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -490,7 +490,7 @@ float RendererSceneRender::environment_get_volumetric_fog_ambient_inject(RID p_e
 
 // GLOW
 
-void RendererSceneRender::environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) {
+void RendererSceneRender::environment_set_glow(RID p_env, bool p_enable, const Vector<float> &p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) {
 	environment_storage.environment_set_glow(p_env, p_enable, p_levels, p_intensity, p_strength, p_mix, p_bloom_threshold, p_blend_mode, p_hdr_bleed_threshold, p_hdr_bleed_scale, p_hdr_luminance_cap, p_glow_map_strength, p_glow_map);
 }
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -177,7 +177,7 @@ public:
 	virtual void environment_set_volumetric_fog_filter_active(bool p_enable) = 0;
 
 	// GLOW
-	void environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map);
+	void environment_set_glow(RID p_env, bool p_enable, const Vector<float> &p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map);
 	bool environment_get_glow_enabled(RID p_env) const;
 	Vector<float> environment_get_glow_levels(RID p_env) const;
 	float environment_get_glow_intensity(RID p_env) const;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1506,7 +1506,7 @@ bool RendererViewport::free(RID p_rid) {
 	return false;
 }
 
-void RendererViewport::handle_timestamp(String p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time) {
+void RendererViewport::handle_timestamp(const String &p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time) {
 	RID *vp = timestamp_vp_map.getptr(p_timestamp);
 	if (!vp) {
 		return;

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -301,7 +301,7 @@ public:
 	void viewport_set_vrs_update_mode(RID p_viewport, RS::ViewportVRSUpdateMode p_mode);
 	void viewport_set_vrs_texture(RID p_viewport, RID p_texture);
 
-	void handle_timestamp(String p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time);
+	void handle_timestamp(const String &p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time);
 
 	void draw_viewports(bool p_swap_buffers);
 

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -30,7 +30,7 @@
 
 #include "rendering_device_binds.h"
 
-Error RDShaderFile::parse_versions_from_text(const String &p_text, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
+Error RDShaderFile::parse_versions_from_text(const String &p_text, const String &p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
 	ERR_FAIL_NULL_V(RenderingDevice::get_singleton(), ERR_UNAVAILABLE);
 
 	Vector<String> lines = p_text.split("\n");

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -400,7 +400,7 @@ public:
 	}
 
 	typedef String (*OpenIncludeFunction)(const String &, void *userdata);
-	Error parse_versions_from_text(const String &p_text, const String p_defines = String(), OpenIncludeFunction p_include_func = nullptr, void *p_include_func_userdata = nullptr);
+	Error parse_versions_from_text(const String &p_text, const String &p_defines = String(), OpenIncludeFunction p_include_func = nullptr, void *p_include_func_userdata = nullptr);
 
 protected:
 	Dictionary _get_versions() const {

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -228,7 +228,7 @@ public:
 
 	// Glow
 
-	virtual void environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) = 0;
+	virtual void environment_set_glow(RID p_env, bool p_enable, const Vector<float> &p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) = 0;
 
 	virtual bool environment_get_glow_enabled(RID p_env) const = 0;
 	virtual Vector<float> environment_get_glow_levels(RID p_env) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -731,7 +731,7 @@ public:
 	FUNC6(environment_set_ssil, RID, bool, float, float, float, float)
 	FUNC6(environment_set_ssil_quality, EnvironmentSSILQuality, bool, float, int, float, float)
 
-	FUNC13(environment_set_glow, RID, bool, Vector<float>, float, float, float, float, EnvironmentGlowBlendMode, float, float, float, float, RID)
+	FUNC13(environment_set_glow, RID, bool, const Vector<float> &, float, float, float, float, EnvironmentGlowBlendMode, float, float, float, float, RID)
 	FUNC1(environment_glow_set_use_bicubic_upscale, bool)
 
 	FUNC4(environment_set_tonemap, RID, EnvironmentToneMapper, float, float)

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3558,7 +3558,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 	return false;
 }
 
-bool ShaderLanguage::_compare_datatypes(DataType p_datatype_a, String p_datatype_name_a, int p_array_size_a, DataType p_datatype_b, String p_datatype_name_b, int p_array_size_b) {
+bool ShaderLanguage::_compare_datatypes(DataType p_datatype_a, const String &p_datatype_name_a, int p_array_size_a, DataType p_datatype_b, const String &p_datatype_name_b, int p_array_size_b) {
 	bool result = true;
 
 	if (p_datatype_a == TYPE_STRUCT || p_datatype_b == TYPE_STRUCT) {
@@ -4402,7 +4402,7 @@ void ShaderLanguage::get_keyword_list(List<String> *r_keywords) {
 	}
 }
 
-bool ShaderLanguage::is_control_flow_keyword(String p_keyword) {
+bool ShaderLanguage::is_control_flow_keyword(const String &p_keyword) {
 	return p_keyword == "break" ||
 			p_keyword == "case" ||
 			p_keyword == "continue" ||

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -798,7 +798,7 @@ public:
 	static uint32_t get_datatype_size(DataType p_type);
 
 	static void get_keyword_list(List<String> *r_keywords);
-	static bool is_control_flow_keyword(String p_keyword);
+	static bool is_control_flow_keyword(const String &p_keyword);
 	static void get_builtin_funcs(List<String> *r_keywords);
 
 	static int instance_counter;
@@ -1016,7 +1016,7 @@ private:
 		_set_error(vformat(RTR("Expected a '%s'."), p_what));
 	}
 
-	void _set_expected_error(const String &p_first, const String p_second) {
+	void _set_expected_error(const String &p_first, const String &p_second) {
 		_set_error(vformat(RTR("Expected a '%s' or '%s'."), p_first, p_second));
 	}
 
@@ -1119,7 +1119,7 @@ private:
 	static bool is_const_suffix_lut_initialized;
 
 	Error _validate_precision(DataType p_type, DataPrecision p_precision);
-	bool _compare_datatypes(DataType p_datatype_a, String p_datatype_name_a, int p_array_size_a, DataType p_datatype_b, String p_datatype_name_b, int p_array_size_b);
+	bool _compare_datatypes(DataType p_datatype_a, const String &p_datatype_name_a, int p_array_size_a, DataType p_datatype_b, const String &p_datatype_name_b, int p_array_size_b);
 	bool _compare_datatypes_in_nodes(Node *a, Node *b);
 
 	bool _validate_function_call(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, DataType *r_ret_type, StringName *r_ret_type_str, bool *r_is_custom_function = nullptr);

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -427,7 +427,7 @@ float RendererEnvironmentStorage::environment_get_volumetric_fog_ambient_inject(
 
 // GLOW
 
-void RendererEnvironmentStorage::environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) {
+void RendererEnvironmentStorage::environment_set_glow(RID p_env, bool p_enable, const Vector<float> &p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL(env);
 	ERR_FAIL_COND_MSG(p_levels.size() != 7, "Size of array of glow levels must be 7");

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -242,7 +242,7 @@ public:
 	float environment_get_volumetric_fog_ambient_inject(RID p_env) const;
 
 	// GLOW
-	void environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map);
+	void environment_set_glow(RID p_env, bool p_enable, const Vector<float> &p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map);
 	bool environment_get_glow_enabled(RID p_env) const;
 	Vector<float> environment_get_glow_levels(RID p_env) const;
 	float environment_get_glow_intensity(RID p_env) const;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -363,7 +363,7 @@ AABB _compute_aabb_from_points(const Vector3 *p_data, int p_length) {
 	return AABB(min, max - min);
 }
 
-Error RenderingServer::_surface_set_data(Array p_arrays, uint64_t p_format, uint32_t *p_offsets, uint32_t p_vertex_stride, uint32_t p_normal_stride, uint32_t p_attrib_stride, uint32_t p_skin_stride, Vector<uint8_t> &r_vertex_array, Vector<uint8_t> &r_attrib_array, Vector<uint8_t> &r_skin_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb, Vector4 &r_uv_scale) {
+Error RenderingServer::_surface_set_data(const Array &p_arrays, uint64_t p_format, uint32_t *p_offsets, uint32_t p_vertex_stride, uint32_t p_normal_stride, uint32_t p_attrib_stride, uint32_t p_skin_stride, Vector<uint8_t> &r_vertex_array, Vector<uint8_t> &r_attrib_array, Vector<uint8_t> &r_skin_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb, Vector4 &r_uv_scale) {
 	uint8_t *vw = r_vertex_array.ptrw();
 	uint8_t *aw = r_attrib_array.ptrw();
 	uint8_t *sw = r_skin_array.ptrw();
@@ -1385,7 +1385,7 @@ void RenderingServer::mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_p
 	mesh_add_surface(p_mesh, sd);
 }
 
-Array RenderingServer::_get_array_from_surface(uint64_t p_format, Vector<uint8_t> p_vertex_data, Vector<uint8_t> p_attrib_data, Vector<uint8_t> p_skin_data, int p_vertex_len, Vector<uint8_t> p_index_data, int p_index_len, const AABB &p_aabb, const Vector4 &p_uv_scale) const {
+Array RenderingServer::_get_array_from_surface(uint64_t p_format, const Vector<uint8_t> &p_vertex_data, const Vector<uint8_t> &p_attrib_data, const Vector<uint8_t> &p_skin_data, int p_vertex_len, const Vector<uint8_t> &p_index_data, int p_index_len, const AABB &p_aabb, const Vector4 &p_uv_scale) const {
 	uint32_t offsets[RS::ARRAY_MAX];
 
 	uint32_t vertex_elem_size;
@@ -2067,7 +2067,7 @@ void RenderingServer::_particles_set_trail_bind_poses(RID p_particles, const Typ
 	particles_set_trail_bind_poses(p_particles, tbposes);
 }
 
-Vector<uint8_t> _convert_surface_version_1_to_surface_version_2(uint64_t p_format, Vector<uint8_t> p_vertex_data, uint32_t p_vertex_count, uint32_t p_old_stride, uint32_t p_vertex_size, uint32_t p_normal_size, uint32_t p_position_stride, uint32_t p_normal_tangent_stride) {
+Vector<uint8_t> _convert_surface_version_1_to_surface_version_2(uint64_t p_format, const Vector<uint8_t> &p_vertex_data, uint32_t p_vertex_count, uint32_t p_old_stride, uint32_t p_vertex_size, uint32_t p_normal_size, uint32_t p_position_stride, uint32_t p_normal_tangent_stride) {
 	Vector<uint8_t> new_vertex_data;
 	new_vertex_data.resize(p_vertex_data.size());
 	uint8_t *dst_vertex_ptr = new_vertex_data.ptrw();

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -68,7 +68,7 @@ class RenderingServer : public Object {
 	int mm_policy = 0;
 	bool render_loop_enabled = true;
 
-	Array _get_array_from_surface(uint64_t p_format, Vector<uint8_t> p_vertex_data, Vector<uint8_t> p_attrib_data, Vector<uint8_t> p_skin_data, int p_vertex_len, Vector<uint8_t> p_index_data, int p_index_len, const AABB &p_aabb, const Vector4 &p_uv_scale) const;
+	Array _get_array_from_surface(uint64_t p_format, const Vector<uint8_t> &p_vertex_data, const Vector<uint8_t> &p_attrib_data, const Vector<uint8_t> &p_skin_data, int p_vertex_len, const Vector<uint8_t> &p_index_data, int p_index_len, const AABB &p_aabb, const Vector4 &p_uv_scale) const;
 
 	const Vector2 SMALL_VEC2 = Vector2(CMP_EPSILON, CMP_EPSILON);
 	const Vector3 SMALL_VEC3 = Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON);
@@ -82,7 +82,7 @@ protected:
 	RID white_texture;
 	RID test_material;
 
-	Error _surface_set_data(Array p_arrays, uint64_t p_format, uint32_t *p_offsets, uint32_t p_vertex_stride, uint32_t p_normal_stride, uint32_t p_attrib_stride, uint32_t p_skin_stride, Vector<uint8_t> &r_vertex_array, Vector<uint8_t> &r_attrib_array, Vector<uint8_t> &r_skin_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb, Vector4 &r_uv_scale);
+	Error _surface_set_data(const Array &p_arrays, uint64_t p_format, uint32_t *p_offsets, uint32_t p_vertex_stride, uint32_t p_normal_stride, uint32_t p_attrib_stride, uint32_t p_skin_stride, Vector<uint8_t> &r_vertex_array, Vector<uint8_t> &r_attrib_array, Vector<uint8_t> &r_skin_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb, Vector4 &r_uv_scale);
 
 	static RenderingServer *(*create_func)();
 	static void _bind_methods();
@@ -1151,7 +1151,7 @@ public:
 		ENV_GLOW_BLEND_MODE_MIX,
 	};
 
-	virtual void environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) = 0;
+	virtual void environment_set_glow(RID p_env, bool p_enable, const Vector<float> &p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) = 0;
 
 	virtual void environment_glow_set_use_bicubic_upscale(bool p_enable) = 0;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds const lvalue reference to the core container types specified in the [documentation](https://docs.godotengine.org/en/stable/development/cpp/core_types.html) that are declared in function parameters in `servers/*` files

initial: https://github.com/godotengine/godot/pull/51156
`core/*`: https://github.com/godotengine/godot/pull/86966
`editor/*`: https://github.com/godotengine/godot/pull/88368
`modules/*`: https://github.com/godotengine/godot/pull/88915
`platform/*`: https://github.com/godotengine/godot/pull/88971
`scene/*`: https://github.com/godotengine/godot/pull/88974
others: https://github.com/godotengine/godot/pull/88975