### PR TITLE
Make `Image::Format` compressed checks consistent

### DIFF
--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -41,7 +41,7 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 	// TODO: See how to handle lossy quality.
 
 	Image::Format img_format = r_img->get_format();
-	if (img_format >= Image::FORMAT_DXT1) {
+	if (img_format > Image::FORMAT_RGBE9995) {
 		return; // Do not compress, already compressed.
 	}
 

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -243,7 +243,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 		basist::basisu_image_level_info basisu_level;
 		transcoder.get_image_level_info(src_ptr, src_size, basisu_level, 0, i);
 
-		uint32_t mip_block_or_pixel_count = image_format >= Image::FORMAT_DXT1 ? basisu_level.m_total_blocks : basisu_level.m_orig_width * basisu_level.m_orig_height;
+		uint32_t mip_block_or_pixel_count = image_format > Image::FORMAT_RGBE9995 ? basisu_level.m_total_blocks : basisu_level.m_orig_width * basisu_level.m_orig_height;
 		int ofs = Image::get_image_mipmap_offset(basisu_info.m_width, basisu_info.m_height, image_format, i);
 
 		bool result = transcoder.transcode_image_level(src_ptr, src_size, 0, i, dst + ofs, mip_block_or_pixel_count, basisu_format);

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -142,7 +142,7 @@ static void _digest_job_queue(void *p_job_queue, uint32_t p_index) {
 }
 
 void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
-	if (p_image->get_format() >= Image::FORMAT_BPTC_RGBA) {
+	if (p_image->get_format() > Image::FORMAT_RGBE9995) {
 		return; //do not compress, already compressed
 	}
 	int w = p_image->get_width();

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -92,7 +92,7 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img) {
 	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
 
 	Image::Format img_format = r_img->get_format();
-	if (img_format >= Image::FORMAT_DXT1) {
+	if (img_format > Image::FORMAT_RGBE9995) {
 		return; // Do not compress, already compressed.
 	}
 	if (img_format > Image::FORMAT_RGBA8) {


### PR DESCRIPTION
Alternative to #88763

Unifies the checks for whether an image's format is compressed across the codebase. See https://github.com/godotengine/godot/pull/88763#issuecomment-1962618260.