### PR TITLE
Add const lvalue ref to `scene/*` container parameters

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -581,7 +581,7 @@ Error SceneMultiplayer::rpcp(Object *p_obj, int p_peer_id, const StringName &p_m
 	return rpc->rpcp(p_obj, p_peer_id, p_method, p_arg, p_argcount);
 }
 
-Error SceneMultiplayer::object_configuration_add(Object *p_obj, Variant p_config) {
+Error SceneMultiplayer::object_configuration_add(Object *p_obj, const Variant &p_config) {
 	if (p_obj == nullptr && p_config.get_type() == Variant::NODE_PATH) {
 		set_root_path(p_config);
 		return OK;
@@ -596,7 +596,7 @@ Error SceneMultiplayer::object_configuration_add(Object *p_obj, Variant p_config
 	return ERR_INVALID_PARAMETER;
 }
 
-Error SceneMultiplayer::object_configuration_remove(Object *p_obj, Variant p_config) {
+Error SceneMultiplayer::object_configuration_remove(Object *p_obj, const Variant &p_config) {
 	if (p_obj == nullptr && p_config.get_type() == Variant::NODE_PATH) {
 		ERR_FAIL_COND_V(root_path != p_config.operator NodePath(), ERR_INVALID_PARAMETER);
 		set_root_path(NodePath());

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -160,8 +160,8 @@ public:
 
 	virtual Error rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) override;
 
-	virtual Error object_configuration_add(Object *p_obj, Variant p_config) override;
-	virtual Error object_configuration_remove(Object *p_obj, Variant p_config) override;
+	virtual Error object_configuration_add(Object *p_obj, const Variant &p_config) override;
+	virtual Error object_configuration_remove(Object *p_obj, const Variant &p_config) override;
 
 	void clear();
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -321,7 +321,7 @@ void TileMap::remove_layer(int p_layer) {
 	update_configuration_warnings();
 }
 
-void TileMap::set_layer_name(int p_layer, String p_name) {
+void TileMap::set_layer_name(int p_layer, const String &p_name) {
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_name, p_name);
 }
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -131,7 +131,7 @@ public:
 	void move_layer(int p_layer, int p_to_pos);
 	void remove_layer(int p_layer);
 
-	void set_layer_name(int p_layer, String p_name);
+	void set_layer_name(int p_layer, const String &p_name);
 	String get_layer_name(int p_layer) const;
 	void set_layer_enabled(int p_layer, bool p_visible);
 	bool is_layer_enabled(int p_layer) const;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -141,7 +141,7 @@ void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, real_t tig
 	}
 }
 
-void AudioStreamPlayer3D::_calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, Vector<AudioFrame> direct_path_vol, Vector<AudioFrame> &reverb_vol) {
+void AudioStreamPlayer3D::_calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, const Vector<AudioFrame> &direct_path_vol, Vector<AudioFrame> &reverb_vol) {
 	reverb_vol.resize(4);
 	reverb_vol.write[0] = AudioFrame(0, 0);
 	reverb_vol.write[1] = AudioFrame(0, 0);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -82,7 +82,7 @@ private:
 
 	static void _calc_output_vol(const Vector3 &source_dir, real_t tightness, Vector<AudioFrame> &output);
 
-	void _calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, Vector<AudioFrame> direct_path_vol, Vector<AudioFrame> &reverb_vol);
+	void _calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, const Vector<AudioFrame> &direct_path_vol, Vector<AudioFrame> &reverb_vol);
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->force_update_panning = true; }
 

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -337,7 +337,7 @@ void BoneAttachment3D::on_skeleton_update() {
 	updating = false;
 }
 #ifdef TOOLS_ENABLED
-void BoneAttachment3D::notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map) {
+void BoneAttachment3D::notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, const Dictionary &p_rename_map) {
 	const Skeleton3D *parent = nullptr;
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_valid()) {

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -74,7 +74,7 @@ protected:
 
 public:
 #ifdef TOOLS_ENABLED
-	virtual void notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map);
+	virtual void notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, const Dictionary &p_rename_map);
 #endif // TOOLS_ENABLED
 
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -713,7 +713,7 @@ TextServer::StructuredTextParser Label3D::get_structured_text_bidi_override() co
 	return st_parser;
 }
 
-void Label3D::set_structured_text_bidi_override_options(Array p_args) {
+void Label3D::set_structured_text_bidi_override_options(const Array &p_args) {
 	if (st_args != p_args) {
 		st_args = p_args;
 		dirty_text = true;

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -188,7 +188,7 @@ public:
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
 	void set_uppercase(bool p_uppercase);

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -142,18 +142,18 @@ Occluder3D::~Occluder3D() {
 
 /////////////////////////////////////////////////
 
-void ArrayOccluder3D::set_arrays(PackedVector3Array p_vertices, PackedInt32Array p_indices) {
+void ArrayOccluder3D::set_arrays(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices) {
 	vertices = p_vertices;
 	indices = p_indices;
 	_update();
 }
 
-void ArrayOccluder3D::set_vertices(PackedVector3Array p_vertices) {
+void ArrayOccluder3D::set_vertices(const PackedVector3Array &p_vertices) {
 	vertices = p_vertices;
 	_update();
 }
 
-void ArrayOccluder3D::set_indices(PackedInt32Array p_indices) {
+void ArrayOccluder3D::set_indices(const PackedInt32Array &p_indices) {
 	indices = p_indices;
 	_update();
 }
@@ -512,7 +512,7 @@ bool OccluderInstance3D::_bake_material_check(Ref<Material> p_material) {
 	return true;
 }
 
-void OccluderInstance3D::_bake_surface(const Transform3D &p_transform, Array p_surface_arrays, Ref<Material> p_material, float p_simplification_dist, PackedVector3Array &r_vertices, PackedInt32Array &r_indices) {
+void OccluderInstance3D::_bake_surface(const Transform3D &p_transform, const Array &p_surface_arrays, Ref<Material> p_material, float p_simplification_dist, PackedVector3Array &r_vertices, PackedInt32Array &r_indices) {
 	if (!_bake_material_check(p_material)) {
 		return;
 	}

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -75,9 +75,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_arrays(PackedVector3Array p_vertices, PackedInt32Array p_indices);
-	void set_vertices(PackedVector3Array p_vertices);
-	void set_indices(PackedInt32Array p_indices);
+	void set_arrays(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices);
+	void set_vertices(const PackedVector3Array &p_vertices);
+	void set_indices(const PackedInt32Array &p_indices);
 
 	ArrayOccluder3D();
 	~ArrayOccluder3D();
@@ -170,7 +170,7 @@ private:
 	void _occluder_changed();
 
 	static bool _bake_material_check(Ref<Material> p_material);
-	static void _bake_surface(const Transform3D &p_transform, Array p_surface_arrays, Ref<Material> p_material, float p_simplification_dist, PackedVector3Array &r_vertices, PackedInt32Array &r_indices);
+	static void _bake_surface(const Transform3D &p_transform, const Array &p_surface_arrays, Ref<Material> p_material, float p_simplification_dist, PackedVector3Array &r_vertices, PackedInt32Array &r_indices);
 	void _bake_node(Node *p_node, PackedVector3Array &r_vertices, PackedInt32Array &r_indices);
 
 	bool _is_editable_3d_polygon() const;

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -574,7 +574,7 @@ const NodePath &SoftBody3D::get_parent_collision_ignore() const {
 	return parent_collision_ignore;
 }
 
-void SoftBody3D::set_pinned_points_indices(Vector<SoftBody3D::PinnedPoint> p_pinned_points_indices) {
+void SoftBody3D::set_pinned_points_indices(const Vector<SoftBody3D::PinnedPoint> &p_pinned_points_indices) {
 	pinned_points = p_pinned_points_indices;
 	for (int i = pinned_points.size() - 1; 0 <= i; --i) {
 		pin_point(p_pinned_points_indices[i].point_index, true);

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -149,7 +149,7 @@ public:
 	void set_parent_collision_ignore(const NodePath &p_parent_collision_ignore);
 	const NodePath &get_parent_collision_ignore() const;
 
-	void set_pinned_points_indices(Vector<PinnedPoint> p_pinned_points_indices);
+	void set_pinned_points_indices(const Vector<PinnedPoint> &p_pinned_points_indices);
 	Vector<PinnedPoint> get_pinned_points_indices();
 
 	void set_simulation_precision(int p_simulation_precision);

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -947,7 +947,7 @@ void AnimationMixer::_process_animation(double p_delta, bool p_update_only) {
 	clear_animation_instances();
 }
 
-Variant AnimationMixer::post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, ObjectID p_object_id, int p_object_sub_idx) {
+Variant AnimationMixer::post_process_key_value(const Ref<Animation> &p_anim, int p_track, const Variant &p_value, ObjectID p_object_id, int p_object_sub_idx) {
 	Variant res;
 	if (GDVIRTUAL_CALL(_post_process_key_value, p_anim, p_track, p_value, p_object_id, p_object_sub_idx, res)) {
 		return res;
@@ -955,7 +955,7 @@ Variant AnimationMixer::post_process_key_value(const Ref<Animation> &p_anim, int
 	return _post_process_key_value(p_anim, p_track, p_value, p_object_id, p_object_sub_idx);
 }
 
-Variant AnimationMixer::_post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, ObjectID p_object_id, int p_object_sub_idx) {
+Variant AnimationMixer::_post_process_key_value(const Ref<Animation> &p_anim, int p_track, const Variant &p_value, ObjectID p_object_id, int p_object_sub_idx) {
 #ifndef _3D_DISABLED
 	switch (p_anim->track_get_type(p_track)) {
 		case Animation::TYPE_POSITION_3D: {
@@ -2348,7 +2348,7 @@ AnimationMixer::AnimationMixer() {
 AnimationMixer::~AnimationMixer() {
 }
 
-void AnimatedValuesBackup::set_data(const HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> p_data) {
+void AnimatedValuesBackup::set_data(const HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> &p_data) {
 	clear_data();
 
 	for (const KeyValue<Animation::TypeHash, AnimationMixer::TrackCache *> &E : p_data) {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -356,8 +356,8 @@ protected:
 	virtual void _process_animation(double p_delta, bool p_update_only = false);
 
 	// For post process with retrieved key value during blending.
-	virtual Variant _post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
-	Variant post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
+	virtual Variant _post_process_key_value(const Ref<Animation> &p_anim, int p_track, const Variant &p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
+	Variant post_process_key_value(const Ref<Animation> &p_anim, int p_track, const Variant &p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
 	GDVIRTUAL5RC(Variant, _post_process_key_value, Ref<Animation>, int, Variant, ObjectID, int);
 
 	void _blend_init();
@@ -485,7 +485,7 @@ class AnimatedValuesBackup : public RefCounted {
 	HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> data;
 
 public:
-	void set_data(const HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> p_data);
+	void set_data(const HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> &p_data);
 	HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> get_data() const;
 	void clear_data();
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -142,7 +142,7 @@ Ref<CallbackTweener> Tween::tween_callback(const Callable &p_callback) {
 	return tweener;
 }
 
-Ref<MethodTweener> Tween::tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration) {
+Ref<MethodTweener> Tween::tween_method(const Callable &p_callback, const Variant &p_from, Variant p_to, double p_duration) {
 	CHECK_VALID();
 
 	if (!_validate_type_match(p_from, p_to)) {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -143,7 +143,7 @@ public:
 	Ref<PropertyTweener> tween_property(const Object *p_target, const NodePath &p_property, Variant p_to, double p_duration);
 	Ref<IntervalTweener> tween_interval(double p_time);
 	Ref<CallbackTweener> tween_callback(const Callable &p_callback);
-	Ref<MethodTweener> tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration);
+	Ref<MethodTweener> tween_method(const Callable &p_callback, const Variant &p_from, Variant p_to, double p_duration);
 	void append(Ref<Tweener> p_tweener);
 
 	bool custom_step(double p_delta);

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -101,7 +101,7 @@ public:
 			VIEW_VISIBLE_IN_TREE = 1 << 3,
 		};
 
-		RemoteNode(int p_child, const String &p_name, const String &p_type, ObjectID p_id, const String p_scene_file_path, int p_view_flags) {
+		RemoteNode(int p_child, const String &p_name, const String &p_type, ObjectID p_id, const String &p_scene_file_path, int p_view_flags) {
 			child_count = p_child;
 			name = p_name;
 			type_name = p_type;

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -162,7 +162,7 @@ String AcceptDialog::get_text() const {
 	return message_label->get_text();
 }
 
-void AcceptDialog::set_text(String p_text) {
+void AcceptDialog::set_text(const String &p_text) {
 	if (message_label->get_text() == p_text) {
 		return;
 	}
@@ -199,7 +199,7 @@ bool AcceptDialog::has_autowrap() {
 	return message_label->get_autowrap_mode() != TextServer::AUTOWRAP_OFF;
 }
 
-void AcceptDialog::set_ok_button_text(String p_ok_button_text) {
+void AcceptDialog::set_ok_button_text(const String &p_ok_button_text) {
 	ok_button->set_text(p_ok_button_text);
 
 	child_controls_changed();
@@ -459,7 +459,7 @@ AcceptDialog::~AcceptDialog() {
 
 // ConfirmationDialog
 
-void ConfirmationDialog::set_cancel_button_text(String p_cancel_button_text) {
+void ConfirmationDialog::set_cancel_button_text(const String &p_cancel_button_text) {
 	cancel->set_text(p_cancel_button_text);
 }
 

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -111,13 +111,13 @@ public:
 	void set_close_on_escape(bool p_enable);
 	bool get_close_on_escape() const;
 
-	void set_text(String p_text);
+	void set_text(const String &p_text);
 	String get_text() const;
 
 	void set_autowrap(bool p_autowrap);
 	bool has_autowrap();
 
-	void set_ok_button_text(String p_ok_button_text);
+	void set_ok_button_text(const String &p_ok_button_text);
 	String get_ok_button_text() const;
 
 	AcceptDialog();
@@ -134,7 +134,7 @@ protected:
 public:
 	Button *get_cancel_button();
 
-	void set_cancel_button_text(String p_cancel_button_text);
+	void set_cancel_button_text(const String &p_cancel_button_text);
 	String get_cancel_button_text() const;
 
 	ConfirmationDialog();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -353,7 +353,7 @@ void FileDialog::update_dir() {
 	deselect_all();
 }
 
-void FileDialog::_dir_submitted(String p_dir) {
+void FileDialog::_dir_submitted(const String &p_dir) {
 	_change_dir(root_prefix.path_join(p_dir));
 	file->set_text("");
 	_push_history();

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -158,7 +158,7 @@ private:
 
 	void _select_drive(int p_idx);
 	void _tree_item_activated();
-	void _dir_submitted(String p_dir);
+	void _dir_submitted(const String &p_dir);
 	void _file_submitted(const String &p_file);
 	void _action_pressed();
 	void _save_confirm_pressed();

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -920,7 +920,7 @@ TextServer::StructuredTextParser Label::get_structured_text_bidi_override() cons
 	return st_parser;
 }
 
-void Label::set_structured_text_bidi_override_options(Array p_args) {
+void Label::set_structured_text_bidi_override_options(const Array &p_args) {
 	if (st_args == p_args) {
 		return;
 	}

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -127,7 +127,7 @@ public:
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
 	void set_autowrap_mode(TextServer::AutowrapMode p_mode);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1538,7 +1538,7 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 	}
 }
 
-void LineEdit::set_text(String p_text) {
+void LineEdit::set_text(const String &p_text) {
 	clear_internal();
 	insert_text_at_caret(p_text);
 	_create_undo_state();
@@ -1626,7 +1626,7 @@ TextServer::StructuredTextParser LineEdit::get_structured_text_bidi_override() c
 	return st_parser;
 }
 
-void LineEdit::set_structured_text_bidi_override_options(Array p_args) {
+void LineEdit::set_structured_text_bidi_override_options(const Array &p_args) {
 	st_args = p_args;
 	_shape();
 	queue_redraw();
@@ -1660,7 +1660,7 @@ String LineEdit::get_text() const {
 	return text;
 }
 
-void LineEdit::set_placeholder(String p_text) {
+void LineEdit::set_placeholder(const String &p_text) {
 	if (placeholder == p_text) {
 		return;
 	}

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -284,7 +284,7 @@ public:
 	void delete_char();
 	void delete_text(int p_from_column, int p_to_column);
 
-	void set_text(String p_text);
+	void set_text(const String &p_text);
 	String get_text() const;
 	void set_text_with_selection(const String &p_text); // Set text, while preserving selection.
 
@@ -300,10 +300,10 @@ public:
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
-	void set_placeholder(String p_text);
+	void set_placeholder(const String &p_text);
 	String get_placeholder() const;
 
 	void set_caret_column(int p_column);

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -74,7 +74,7 @@ TextServer::StructuredTextParser LinkButton::get_structured_text_bidi_override()
 	return st_parser;
 }
 
-void LinkButton::set_structured_text_bidi_override_options(Array p_args) {
+void LinkButton::set_structured_text_bidi_override_options(const Array &p_args) {
 	st_args = p_args;
 	_shape();
 	queue_redraw();

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -92,7 +92,7 @@ public:
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
 	void set_text_direction(TextDirection p_text_direction);

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -95,7 +95,7 @@ public:
 	void set_font(RID p_font) { font = p_font; };
 
 	Dictionary get_environment() { return environment; }
-	void set_environment(Dictionary p_environment) { environment = p_environment; }
+	void set_environment(const Dictionary &p_environment) { environment = p_environment; }
 };
 
 class RichTextEffect : public Resource {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3831,7 +3831,7 @@ void RichTextLabel::push_fgcolor(const Color &p_color) {
 	_add_item(item, true);
 }
 
-void RichTextLabel::push_customfx(Ref<RichTextEffect> p_custom_effect, Dictionary p_environment) {
+void RichTextLabel::push_customfx(Ref<RichTextEffect> p_custom_effect, const Dictionary &p_environment) {
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
@@ -5755,7 +5755,7 @@ TextServer::StructuredTextParser RichTextLabel::get_structured_text_bidi_overrid
 	return st_parser;
 }
 
-void RichTextLabel::set_structured_text_bidi_override_options(Array p_args) {
+void RichTextLabel::set_structured_text_bidi_override_options(const Array &p_args) {
 	if (st_args != p_args) {
 		_stop_thread();
 
@@ -5831,7 +5831,7 @@ float RichTextLabel::get_visible_ratio() const {
 	return visible_ratio;
 }
 
-void RichTextLabel::set_effects(Array p_effects) {
+void RichTextLabel::set_effects(const Array &p_effects) {
 	custom_effects = p_effects;
 	if ((!text.is_empty()) && use_bbcode) {
 		parse_bbcode(atr(text));
@@ -5842,7 +5842,7 @@ Array RichTextLabel::get_effects() {
 	return custom_effects;
 }
 
-void RichTextLabel::install_effect(const Variant effect) {
+void RichTextLabel::install_effect(const Variant &effect) {
 	Ref<RichTextEffect> rteffect;
 	rteffect = effect;
 
@@ -6359,7 +6359,7 @@ void RichTextLabel::menu_option(int p_option) {
 	}
 }
 
-Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_identifier) {
+Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(const String &p_bbcode_identifier) {
 	for (int i = 0; i < custom_effects.size(); i++) {
 		Ref<RichTextEffect> effect = custom_effects[i];
 		if (!effect.is_valid()) {
@@ -6374,7 +6374,7 @@ Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_id
 	return Ref<RichTextEffect>();
 }
 
-Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressions) {
+Dictionary RichTextLabel::parse_expressions_for_values(const Vector<String> &p_expressions) {
 	Dictionary d;
 	for (int i = 0; i < p_expressions.size(); i++) {
 		Array a;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -606,8 +606,8 @@ private:
 	Item *_get_prev_item(Item *p_item, bool p_free = false) const;
 
 	Rect2 _get_text_rect();
-	Ref<RichTextEffect> _get_custom_effect_by_code(String p_bbcode_identifier);
-	virtual Dictionary parse_expressions_for_values(Vector<String> p_expressions);
+	Ref<RichTextEffect> _get_custom_effect_by_code(const String &p_bbcode_identifier);
+	virtual Dictionary parse_expressions_for_values(const Vector<String> &p_expressions);
 
 	Size2 _get_image_size(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Rect2 &p_region = Rect2());
 
@@ -704,7 +704,7 @@ public:
 	void push_pulse(const Color &p_color, float p_frequency, float p_ease);
 	void push_bgcolor(const Color &p_color);
 	void push_fgcolor(const Color &p_color);
-	void push_customfx(Ref<RichTextEffect> p_custom_effect, Dictionary p_environment);
+	void push_customfx(Ref<RichTextEffect> p_custom_effect, const Dictionary &p_environment);
 	void push_context();
 	void set_table_column_expand(int p_column, bool p_expand, int p_ratio = 1);
 	void set_cell_row_background_color(const Color &p_odd_row_bg, const Color &p_even_row_bg);
@@ -820,7 +820,7 @@ public:
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
 	void set_visible_characters(int p_visible);
@@ -836,10 +836,10 @@ public:
 	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);
 
-	void set_effects(Array p_effects);
+	void set_effects(const Array &p_effects);
 	Array get_effects();
 
-	void install_effect(const Variant effect);
+	void install_effect(const Variant &effect);
 
 	virtual Size2 get_minimum_size() const override;
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3177,7 +3177,7 @@ TextServer::StructuredTextParser TextEdit::get_structured_text_bidi_override() c
 	return st_parser;
 }
 
-void TextEdit::set_structured_text_bidi_override_options(Array p_args) {
+void TextEdit::set_structured_text_bidi_override_options(const Array &p_args) {
 	if (st_args == p_args) {
 		return;
 	}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -745,7 +745,7 @@ public:
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
 	void set_tab_size(const int p_size);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -290,7 +290,7 @@ void TreeItem::_propagate_check_through_parents(int p_column, bool p_emit_signal
 	current->_propagate_check_through_parents(p_column, p_emit_signal);
 }
 
-void TreeItem::set_text(int p_column, String p_text) {
+void TreeItem::set_text(int p_column, const String &p_text) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
 	if (cells[p_column].text == p_text) {
@@ -405,7 +405,7 @@ TextServer::StructuredTextParser TreeItem::get_structured_text_bidi_override(int
 	return cells[p_column].st_parser;
 }
 
-void TreeItem::set_structured_text_bidi_override_options(int p_column, Array p_args) {
+void TreeItem::set_structured_text_bidi_override_options(int p_column, const Array &p_args) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
 	if (cells[p_column].st_args == p_args) {
@@ -441,7 +441,7 @@ String TreeItem::get_language(int p_column) const {
 	return cells[p_column].language;
 }
 
-void TreeItem::set_suffix(int p_column, String p_suffix) {
+void TreeItem::set_suffix(int p_column, const String &p_suffix) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
 	if (cells[p_column].suffix == p_suffix) {
@@ -3217,7 +3217,7 @@ void Tree::_apply_multiline_edit() {
 	queue_redraw();
 }
 
-void Tree::_line_editor_submit(String p_text) {
+void Tree::_line_editor_submit(const String &p_text) {
 	if (popup_edit_commited) {
 		return; // Already processed by _text_editor_popup_modal_close
 	}

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -226,7 +226,7 @@ private:
 	TreeItem *_get_next_in_tree(bool p_wrap = false, bool p_include_invisible = false);
 
 public:
-	void set_text(int p_column, String p_text);
+	void set_text(int p_column, const String &p_text);
 	String get_text(int p_column) const;
 
 	void set_text_direction(int p_column, Control::TextDirection p_text_direction);
@@ -241,13 +241,13 @@ public:
 	void set_structured_text_bidi_override(int p_column, TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override(int p_column) const;
 
-	void set_structured_text_bidi_override_options(int p_column, Array p_args);
+	void set_structured_text_bidi_override_options(int p_column, const Array &p_args);
 	Array get_structured_text_bidi_override_options(int p_column) const;
 
 	void set_language(int p_column, const String &p_language);
 	String get_language(int p_column) const;
 
-	void set_suffix(int p_column, String p_suffix);
+	void set_suffix(int p_column, const String &p_suffix);
 	String get_suffix(int p_column) const;
 
 	void set_icon(int p_column, const Ref<Texture2D> &p_icon);
@@ -501,12 +501,12 @@ private:
 	void update_column(int p_col);
 	void update_item_cell(TreeItem *p_item, int p_col);
 	void update_item_cache(TreeItem *p_item);
-	//void draw_item_text(String p_text,const Ref<Texture2D>& p_icon,int p_icon_max_w,bool p_tool,Rect2i p_rect,const Color& p_color);
+	//void draw_item_text(const String &p_text,const Ref<Texture2D>& p_icon,int p_icon_max_w,bool p_tool,Rect2i p_rect,const Color& p_color);
 	void draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color);
 	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height);
 	void select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev = nullptr, bool *r_in_range = nullptr, bool p_force_deselect = false);
 	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int x_limit, bool p_double_click, TreeItem *p_item, MouseButton p_button, const Ref<InputEventWithModifiers> &p_mod);
-	void _line_editor_submit(String p_text);
+	void _line_editor_submit(const String &p_text);
 	void _apply_multiline_edit();
 	void _text_editor_popup_modal_close();
 	void _text_editor_gui_input(const Ref<InputEvent> &p_event);

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -277,7 +277,7 @@ Error MultiplayerAPI::decode_and_decompress_variants(Vector<Variant> &r_variants
 	return OK;
 }
 
-Error MultiplayerAPI::_rpc_bind(int p_peer, Object *p_object, const StringName &p_method, Array p_args) {
+Error MultiplayerAPI::_rpc_bind(int p_peer, Object *p_object, const StringName &p_method, const Array &p_args) {
 	Vector<Variant> args;
 	Vector<const Variant *> argsp;
 	args.resize(p_args.size());
@@ -371,13 +371,13 @@ int MultiplayerAPIExtension::get_remote_sender_id() {
 	return id;
 }
 
-Error MultiplayerAPIExtension::object_configuration_add(Object *p_object, Variant p_config) {
+Error MultiplayerAPIExtension::object_configuration_add(Object *p_object, const Variant &p_config) {
 	Error err = ERR_UNAVAILABLE;
 	GDVIRTUAL_CALL(_object_configuration_add, p_object, p_config, err);
 	return err;
 }
 
-Error MultiplayerAPIExtension::object_configuration_remove(Object *p_object, Variant p_config) {
+Error MultiplayerAPIExtension::object_configuration_remove(Object *p_object, const Variant &p_config) {
 	Error err = ERR_UNAVAILABLE;
 	GDVIRTUAL_CALL(_object_configuration_remove, p_object, p_config, err);
 	return err;

--- a/scene/main/multiplayer_api.h
+++ b/scene/main/multiplayer_api.h
@@ -42,7 +42,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	Error _rpc_bind(int p_peer, Object *p_obj, const StringName &p_method, Array args = Array());
+	Error _rpc_bind(int p_peer, Object *p_obj, const StringName &p_method, const Array &args = Array());
 
 public:
 	enum RPCMode {
@@ -69,8 +69,8 @@ public:
 	virtual Error rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) = 0;
 	virtual int get_remote_sender_id() = 0;
 
-	virtual Error object_configuration_add(Object *p_object, Variant p_config) = 0;
-	virtual Error object_configuration_remove(Object *p_object, Variant p_config) = 0;
+	virtual Error object_configuration_add(Object *p_object, const Variant &p_config) = 0;
+	virtual Error object_configuration_remove(Object *p_object, const Variant &p_config) = 0;
 
 	bool has_multiplayer_peer() { return get_multiplayer_peer().is_valid(); }
 	bool is_server() { return get_unique_id() == MultiplayerPeer::TARGET_PEER_SERVER; }
@@ -97,8 +97,8 @@ public:
 	virtual Error rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) override;
 	virtual int get_remote_sender_id() override;
 
-	virtual Error object_configuration_add(Object *p_object, Variant p_config) override;
-	virtual Error object_configuration_remove(Object *p_object, Variant p_config) override;
+	virtual Error object_configuration_add(Object *p_object, const Variant &p_config) override;
+	virtual Error object_configuration_remove(Object *p_object, const Variant &p_config) override;
 
 	// Extensions
 	GDVIRTUAL0R(Error, _poll);

--- a/scene/resources/2d/skeleton/skeleton_modification_2d.h
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d.h
@@ -55,7 +55,7 @@ protected:
 	bool enabled = true;
 	bool is_setup = false;
 
-	bool _print_execution_error(bool p_condition, String p_message);
+	bool _print_execution_error(bool p_condition, const String &p_message);
 
 	virtual void reset_state() override;
 

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -292,7 +292,7 @@ int TileSet::TerrainsPattern::get_terrain_peering_bit(TileSet::CellNeighbor p_pe
 	return bits[p_peering_bit];
 }
 
-void TileSet::TerrainsPattern::from_array(Array p_terrains) {
+void TileSet::TerrainsPattern::from_array(const Array &p_terrains) {
 	set_terrain(p_terrains[0]);
 	int in_array_index = 1;
 	for (int i = 0; i < TileSet::CELL_NEIGHBOR_MAX; i++) {
@@ -831,7 +831,7 @@ void TileSet::remove_terrain(int p_terrain_set, int p_index) {
 	emit_changed();
 }
 
-void TileSet::set_terrain_name(int p_terrain_set, int p_terrain_index, String p_name) {
+void TileSet::set_terrain_name(int p_terrain_set, int p_terrain_index, const String &p_name) {
 	ERR_FAIL_INDEX(p_terrain_set, terrain_sets.size());
 	ERR_FAIL_INDEX(p_terrain_index, terrain_sets[p_terrain_set].terrains.size());
 	terrain_sets.write[p_terrain_set].terrains.write[p_terrain_index].name = p_name;
@@ -1081,7 +1081,7 @@ void TileSet::remove_custom_data_layer(int p_index) {
 	emit_changed();
 }
 
-int TileSet::get_custom_data_layer_by_name(String p_value) const {
+int TileSet::get_custom_data_layer_by_name(const String &p_value) const {
 	if (custom_data_layers_by_name.has(p_value)) {
 		return custom_data_layers_by_name[p_value];
 	} else {
@@ -1089,7 +1089,7 @@ int TileSet::get_custom_data_layer_by_name(String p_value) const {
 	}
 }
 
-void TileSet::set_custom_data_layer_name(int p_layer_id, String p_value) {
+void TileSet::set_custom_data_layer_name(int p_layer_id, const String &p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
 
 	// Exit if another property has the same name.
@@ -6305,7 +6305,7 @@ void TileData::remove_collision_polygon(int p_layer_id, int p_polygon_index) {
 	emit_signal(CoreStringName(changed));
 }
 
-void TileData::set_collision_polygon_points(int p_layer_id, int p_polygon_index, Vector<Vector2> p_polygon) {
+void TileData::set_collision_polygon_points(int p_layer_id, int p_polygon_index, const Vector<Vector2> &p_polygon) {
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
 	ERR_FAIL_COND_MSG(p_polygon.size() != 0 && p_polygon.size() < 3, "Invalid polygon. Needs either 0 or more than 3 points.");
@@ -6532,21 +6532,21 @@ float TileData::get_probability() const {
 }
 
 // Custom data
-void TileData::set_custom_data(String p_layer_name, Variant p_value) {
+void TileData::set_custom_data(const String &p_layer_name, const Variant &p_value) {
 	ERR_FAIL_NULL(tile_set);
 	int p_layer_id = tile_set->get_custom_data_layer_by_name(p_layer_name);
 	ERR_FAIL_COND_MSG(p_layer_id < 0, vformat("TileSet has no layer with name: %s", p_layer_name));
 	set_custom_data_by_layer_id(p_layer_id, p_value);
 }
 
-Variant TileData::get_custom_data(String p_layer_name) const {
+Variant TileData::get_custom_data(const String &p_layer_name) const {
 	ERR_FAIL_NULL_V(tile_set, Variant());
 	int p_layer_id = tile_set->get_custom_data_layer_by_name(p_layer_name);
 	ERR_FAIL_COND_V_MSG(p_layer_id < 0, Variant(), vformat("TileSet has no layer with name: %s", p_layer_name));
 	return get_custom_data_by_layer_id(p_layer_id);
 }
 
-void TileData::set_custom_data_by_layer_id(int p_layer_id, Variant p_value) {
+void TileData::set_custom_data_by_layer_id(int p_layer_id, const Variant &p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data.size());
 	custom_data.write[p_layer_id] = p_value;
 	emit_signal(CoreStringName(changed));

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -286,7 +286,7 @@ public:
 		void set_terrain_peering_bit(TileSet::CellNeighbor p_peering_bit, int p_terrain);
 		int get_terrain_peering_bit(TileSet::CellNeighbor p_peering_bit) const;
 
-		void from_array(Array p_terrains);
+		void from_array(const Array &p_terrains);
 		Array as_array() const;
 
 		TerrainsPattern(const TileSet *p_tile_set, int p_terrain_set);
@@ -464,7 +464,7 @@ public:
 	void add_terrain(int p_terrain_set, int p_index = -1);
 	void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos);
 	void remove_terrain(int p_terrain_set, int p_index);
-	void set_terrain_name(int p_terrain_set, int p_terrain_index, String p_name);
+	void set_terrain_name(int p_terrain_set, int p_terrain_index, const String &p_name);
 	String get_terrain_name(int p_terrain_set, int p_terrain_index) const;
 	void set_terrain_color(int p_terrain_set, int p_terrain_index, Color p_color);
 	Color get_terrain_color(int p_terrain_set, int p_terrain_index) const;
@@ -486,8 +486,8 @@ public:
 	void add_custom_data_layer(int p_index = -1);
 	void move_custom_data_layer(int p_from_index, int p_to_pos);
 	void remove_custom_data_layer(int p_index);
-	int get_custom_data_layer_by_name(String p_value) const;
-	void set_custom_data_layer_name(int p_layer_id, String p_value);
+	int get_custom_data_layer_by_name(const String &p_value) const;
+	void set_custom_data_layer_name(int p_layer_id, const String &p_value);
 	String get_custom_data_layer_name(int p_layer_id) const;
 	void set_custom_data_layer_type(int p_layer_id, Variant::Type p_value);
 	Variant::Type get_custom_data_layer_type(int p_layer_id) const;
@@ -953,7 +953,7 @@ public:
 	int get_collision_polygons_count(int p_layer_id) const;
 	void add_collision_polygon(int p_layer_id);
 	void remove_collision_polygon(int p_layer_id, int p_polygon_index);
-	void set_collision_polygon_points(int p_layer_id, int p_polygon_index, Vector<Vector2> p_polygon);
+	void set_collision_polygon_points(int p_layer_id, int p_polygon_index, const Vector<Vector2> &p_polygon);
 	Vector<Vector2> get_collision_polygon_points(int p_layer_id, int p_polygon_index) const;
 	void set_collision_polygon_one_way(int p_layer_id, int p_polygon_index, bool p_one_way);
 	bool is_collision_polygon_one_way(int p_layer_id, int p_polygon_index) const;
@@ -982,9 +982,9 @@ public:
 	float get_probability() const;
 
 	// Custom data.
-	void set_custom_data(String p_layer_name, Variant p_value);
-	Variant get_custom_data(String p_layer_name) const;
-	void set_custom_data_by_layer_id(int p_layer_id, Variant p_value);
+	void set_custom_data(const String &p_layer_name, const Variant &p_value);
+	Variant get_custom_data(const String &p_layer_name) const;
+	void set_custom_data_by_layer_id(int p_layer_id, const Variant &p_value);
 	Variant get_custom_data_by_layer_id(int p_layer_id) const;
 
 	// Polygons.

--- a/scene/resources/3d/height_map_shape_3d.cpp
+++ b/scene/resources/3d/height_map_shape_3d.cpp
@@ -145,7 +145,7 @@ int HeightMapShape3D::get_map_depth() const {
 	return map_depth;
 }
 
-void HeightMapShape3D::set_map_data(Vector<real_t> p_new) {
+void HeightMapShape3D::set_map_data(const Vector<real_t> &p_new) {
 	int size = (map_width * map_depth);
 	if (p_new.size() != size) {
 		// fail

--- a/scene/resources/3d/height_map_shape_3d.h
+++ b/scene/resources/3d/height_map_shape_3d.h
@@ -53,7 +53,7 @@ public:
 	int get_map_width() const;
 	void set_map_depth(int p_new);
 	int get_map_depth() const;
-	void set_map_data(Vector<real_t> p_new);
+	void set_map_data(const Vector<real_t> &p_new);
 	Vector<real_t> get_map_data() const;
 
 	real_t get_min_height() const;

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -269,7 +269,7 @@ void ImporterMesh::set_surface_material(int p_surface, const Ref<Material> &p_ma
 	}                                                                                                              \
 	write_array[vert_idx] = transformed_vert;
 
-void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_split_angle, Array p_bone_transform_array, bool p_raycast_normals) {
+void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_split_angle, const Array &p_bone_transform_array, bool p_raycast_normals) {
 	if (!SurfaceTool::simplify_scale_func) {
 		return;
 	}

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -114,7 +114,7 @@ public:
 
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 
-	void generate_lods(float p_normal_merge_angle, float p_normal_split_angle, Array p_skin_pose_transform_array, bool p_raycast_normals = false);
+	void generate_lods(float p_normal_merge_angle, float p_normal_split_angle, const Array &p_skin_pose_transform_array, bool p_raycast_normals = false);
 
 	void create_shadow_mesh();
 	Ref<ImporterMesh> get_shadow_mesh() const;

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3643,7 +3643,7 @@ TextServer::StructuredTextParser TextMesh::get_structured_text_bidi_override() c
 	return st_parser;
 }
 
-void TextMesh::set_structured_text_bidi_override_options(Array p_args) {
+void TextMesh::set_structured_text_bidi_override_options(const Array &p_args) {
 	if (st_args != p_args) {
 		st_args = p_args;
 		dirty_text = true;

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -668,7 +668,7 @@ public:
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
 
-	void set_structured_text_bidi_override_options(Array p_args);
+	void set_structured_text_bidi_override_options(const Array &p_args);
 	Array get_structured_text_bidi_override_options() const;
 
 	void set_uppercase(bool p_uppercase);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5472,12 +5472,12 @@ bool Animation::_fetch_compressed_by_index(uint32_t p_compressed_track, int p_in
 }
 
 // Helper math functions for Variant.
-bool Animation::is_variant_interpolatable(const Variant p_value) {
+bool Animation::is_variant_interpolatable(const Variant &p_value) {
 	Variant::Type type = p_value.get_type();
 	return (type >= Variant::BOOL && type <= Variant::STRING_NAME) || type == Variant::ARRAY || type >= Variant::PACKED_INT32_ARRAY; // PackedByteArray is unsigned, so it would be better to ignore since blending uses float.
 }
 
-Variant Animation::cast_to_blendwise(const Variant p_value) {
+Variant Animation::cast_to_blendwise(const Variant &p_value) {
 	switch (p_value.get_type()) {
 		case Variant::BOOL:
 		case Variant::INT: {
@@ -5511,7 +5511,7 @@ Variant Animation::cast_to_blendwise(const Variant p_value) {
 	return p_value;
 }
 
-Variant Animation::cast_from_blendwise(const Variant p_value, const Variant::Type p_type) {
+Variant Animation::cast_from_blendwise(const Variant &p_value, const Variant::Type p_type) {
 	switch (p_type) {
 		case Variant::BOOL: {
 			return p_value.operator real_t() >= 0.5;
@@ -5561,7 +5561,7 @@ Variant Animation::cast_from_blendwise(const Variant p_value, const Variant::Typ
 	return p_value;
 }
 
-Variant Animation::string_to_array(const Variant p_value) {
+Variant Animation::string_to_array(const Variant &p_value) {
 	if (!p_value.is_string()) {
 		return p_value;
 	};
@@ -5573,7 +5573,7 @@ Variant Animation::string_to_array(const Variant p_value) {
 	return arr;
 }
 
-Variant Animation::array_to_string(const Variant p_value) {
+Variant Animation::array_to_string(const Variant &p_value) {
 	if (!p_value.is_array()) {
 		return p_value;
 	};

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -512,13 +512,13 @@ public:
 	void compress(uint32_t p_page_size = 8192, uint32_t p_fps = 120, float p_split_tolerance = 4.0); // 4.0 seems to be the split tolerance sweet spot from many tests.
 
 	// Helper functions for Variant.
-	static bool is_variant_interpolatable(const Variant p_value);
+	static bool is_variant_interpolatable(const Variant &p_value);
 
-	static Variant cast_to_blendwise(const Variant p_value);
-	static Variant cast_from_blendwise(const Variant p_value, const Variant::Type p_type);
+	static Variant cast_to_blendwise(const Variant &p_value);
+	static Variant cast_from_blendwise(const Variant &p_value, const Variant::Type p_type);
 
-	static Variant string_to_array(const Variant p_value);
-	static Variant array_to_string(const Variant p_value);
+	static Variant string_to_array(const Variant &p_value);
+	static Variant array_to_string(const Variant &p_value);
 
 	static Variant add_variant(const Variant &a, const Variant &b);
 	static Variant subtract_variant(const Variant &a, const Variant &b);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -409,7 +409,7 @@ Array Curve::get_data() const {
 	return output;
 }
 
-void Curve::set_data(const Array p_input) {
+void Curve::set_data(const Array &p_input) {
 	const unsigned int ELEMS = 5;
 	ERR_FAIL_COND(p_input.size() % ELEMS != 0);
 

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -125,7 +125,7 @@ public:
 	void update_auto_tangents(int i);
 
 	Array get_data() const;
-	void set_data(Array input);
+	void set_data(const Array &input);
 
 	void bake();
 	int get_bake_resolution() const { return _bake_resolution; }

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -290,7 +290,7 @@ void ImageTextureLayered::_set_images(const TypedArray<Image> &p_images) {
 	ERR_FAIL_COND(_create_from_images(p_images) != OK);
 }
 
-Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
+Error ImageTextureLayered::create_from_images(const Vector<Ref<Image>> &p_images) {
 	int new_layers = p_images.size();
 	ERR_FAIL_COND_V(new_layers == 0, ERR_INVALID_PARAMETER);
 	if (layered_type == LAYERED_TYPE_CUBEMAP) {

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -115,7 +115,7 @@ public:
 	virtual bool has_mipmaps() const override;
 	virtual LayeredType get_layered_type() const override;
 
-	Error create_from_images(Vector<Ref<Image>> p_images);
+	Error create_from_images(const Vector<Ref<Image>> &p_images);
 	void update_layer(const Ref<Image> &p_image, int p_layer);
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1267,7 +1267,7 @@ Ref<SceneState> SceneState::get_base_scene_state() const {
 	return Ref<SceneState>();
 }
 
-void SceneState::update_instance_resource(String p_path, Ref<PackedScene> p_packed_scene) {
+void SceneState::update_instance_resource(const String &p_path, Ref<PackedScene> p_packed_scene) {
 	ERR_FAIL_COND(p_packed_scene.is_null());
 
 	for (const NodeData &nd : nodes) {

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -163,7 +163,7 @@ public:
 
 	Ref<SceneState> get_base_scene_state() const;
 
-	void update_instance_resource(String p_path, Ref<PackedScene> p_packed_scene);
+	void update_instance_resource(const String &p_path, Ref<PackedScene> p_packed_scene);
 
 	//unbuild API
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -933,7 +933,7 @@ void SurfaceTool::create_vertex_array_from_arrays(const Array &p_arrays, LocalVe
 	}
 }
 
-void SurfaceTool::_create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat) {
+void SurfaceTool::_create_list_from_arrays(const Array &arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat) {
 	create_vertex_array_from_arrays(arr, *r_vertex, &lformat);
 	ERR_FAIL_COND(r_vertex->size() == 0);
 

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -158,7 +158,7 @@ private:
 
 	CustomFormat last_custom_format[RS::ARRAY_CUSTOM_COUNT];
 
-	void _create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat);
+	void _create_list_from_arrays(const Array &arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat);
 	void _create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat);
 
 	//mikktspace callbacks

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -441,7 +441,7 @@ Color CodeHighlighter::get_keyword_color(const String &p_keyword) const {
 	return keywords[p_keyword];
 }
 
-void CodeHighlighter::set_keyword_colors(const Dictionary p_keywords) {
+void CodeHighlighter::set_keyword_colors(const Dictionary &p_keywords) {
 	keywords.clear();
 	keywords = p_keywords;
 	clear_highlighting_cache();

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -109,7 +109,7 @@ public:
 	bool has_keyword_color(const String &p_keyword) const;
 	Color get_keyword_color(const String &p_keyword) const;
 
-	void set_keyword_colors(const Dictionary p_keywords);
+	void set_keyword_colors(const Dictionary &p_keywords);
 	void clear_keyword_colors();
 	Dictionary get_keyword_colors() const;
 

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -210,13 +210,13 @@ bool TextLine::add_string(const String &p_text, const Ref<Font> &p_font, int p_f
 	return res;
 }
 
-bool TextLine::add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align, int p_length, float p_baseline) {
+bool TextLine::add_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int p_length, float p_baseline) {
 	bool res = TS->shaped_text_add_object(rid, p_key, p_size, p_inline_align, p_length, p_baseline);
 	dirty = true;
 	return res;
 }
 
-bool TextLine::resize_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align, float p_baseline) {
+bool TextLine::resize_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, float p_baseline) {
 	const_cast<TextLine *>(this)->_shape();
 	return TS->shaped_text_resize_object(rid, p_key, p_size, p_inline_align, p_baseline);
 }
@@ -225,7 +225,7 @@ Array TextLine::get_objects() const {
 	return TS->shaped_text_get_objects(rid);
 }
 
-Rect2 TextLine::get_object_rect(Variant p_key) const {
+Rect2 TextLine::get_object_rect(const Variant &p_key) const {
 	Vector2 ofs;
 
 	float length = TS->shaped_text_get_width(rid);

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -77,8 +77,8 @@ public:
 	bool get_preserve_control() const;
 
 	bool add_string(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", const Variant &p_meta = Variant());
-	bool add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int p_length = 1, float p_baseline = 0.0);
-	bool resize_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, float p_baseline = 0.0);
+	bool add_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int p_length = 1, float p_baseline = 0.0);
+	bool resize_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, float p_baseline = 0.0);
 
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;
@@ -98,7 +98,7 @@ public:
 	float get_width() const;
 
 	Array get_objects() const;
-	Rect2 get_object_rect(Variant p_key) const;
+	Rect2 get_object_rect(const Variant &p_key) const;
 
 	Size2 get_size() const;
 

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -430,7 +430,7 @@ void TextParagraph::set_bidi_override(const Array &p_override) {
 	lines_dirty = true;
 }
 
-bool TextParagraph::add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align, int p_length, float p_baseline) {
+bool TextParagraph::add_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int p_length, float p_baseline) {
 	_THREAD_SAFE_METHOD_
 
 	bool res = TS->shaped_text_add_object(rid, p_key, p_size, p_inline_align, p_length, p_baseline);
@@ -438,7 +438,7 @@ bool TextParagraph::add_object(Variant p_key, const Size2 &p_size, InlineAlignme
 	return res;
 }
 
-bool TextParagraph::resize_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align, float p_baseline) {
+bool TextParagraph::resize_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, float p_baseline) {
 	_THREAD_SAFE_METHOD_
 
 	bool res = TS->shaped_text_resize_object(rid, p_key, p_size, p_inline_align, p_baseline);
@@ -593,7 +593,7 @@ Array TextParagraph::get_line_objects(int p_line) const {
 	return TS->shaped_text_get_objects(lines_rid[p_line]);
 }
 
-Rect2 TextParagraph::get_line_object_rect(int p_line, Variant p_key) const {
+Rect2 TextParagraph::get_line_object_rect(int p_line, const Variant &p_key) const {
 	_THREAD_SAFE_METHOD_
 
 	const_cast<TextParagraph *>(this)->_shape_lines();

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -96,8 +96,8 @@ public:
 	void clear_dropcap();
 
 	bool add_string(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", const Variant &p_meta = Variant());
-	bool add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int p_length = 1, float p_baseline = 0.0);
-	bool resize_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, float p_baseline = 0.0);
+	bool add_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int p_length = 1, float p_baseline = 0.0);
+	bool resize_object(const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, float p_baseline = 0.0);
 
 	void set_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_alignment() const;
@@ -129,7 +129,7 @@ public:
 	int get_line_count() const;
 
 	Array get_line_objects(int p_line) const;
-	Rect2 get_line_object_rect(int p_line, Variant p_key) const;
+	Rect2 get_line_object_rect(int p_line, const Variant &p_key) const;
 	Size2 get_line_size(int p_line) const;
 	float get_line_ascent(int p_line) const;
 	float get_line_descent(int p_line) const;

--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -144,7 +144,7 @@ int VideoStreamPlayback::get_mix_rate() const {
 	return 0;
 }
 
-int VideoStreamPlayback::mix_audio(int num_frames, PackedFloat32Array buffer, int offset) {
+int VideoStreamPlayback::mix_audio(int num_frames, const PackedFloat32Array &buffer, int offset) {
 	if (num_frames <= 0) {
 		return 0;
 	}

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -60,7 +60,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_channels);
 	GDVIRTUAL0RC(int, _get_mix_rate);
 
-	int mix_audio(int num_frames, PackedFloat32Array buffer = {}, int offset = 0);
+	int mix_audio(int num_frames, const PackedFloat32Array &buffer = {}, int offset = 0);
 
 public:
 	VideoStreamPlayback();

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3467,7 +3467,7 @@ String VisualShaderNodeInput::generate_code(Shader::Mode p_mode, VisualShader::T
 	}
 }
 
-void VisualShaderNodeInput::set_input_name(String p_name) {
+void VisualShaderNodeInput::set_input_name(const String &p_name) {
 	PortType prev_type = get_input_type_by_name(input_name);
 	input_name = p_name;
 	emit_changed();
@@ -3493,7 +3493,7 @@ String VisualShaderNodeInput::get_input_real_name() const {
 	return "";
 }
 
-VisualShaderNodeInput::PortType VisualShaderNodeInput::get_input_type_by_name(String p_name) const {
+VisualShaderNodeInput::PortType VisualShaderNodeInput::get_input_type_by_name(const String &p_name) const {
 	int idx = 0;
 
 	while (ports[idx].mode != Shader::MODE_MAX) {
@@ -5182,7 +5182,7 @@ VisualShaderNodeVarying::PortType VisualShaderNodeVarying::get_port_type(VisualS
 	return PORT_TYPE_SCALAR;
 }
 
-void VisualShaderNodeVarying::set_varying_name(String p_varying_name) {
+void VisualShaderNodeVarying::set_varying_name(const String &p_varying_name) {
 	if (varying_name == p_varying_name) {
 		return;
 	}

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -96,7 +96,7 @@ public:
 
 		Varying() {}
 
-		Varying(String p_name, VaryingMode p_mode, VaryingType p_type) :
+		Varying(const String &p_name, VaryingMode p_mode, VaryingType p_type) :
 				name(p_name), mode(p_mode), type(p_type) {}
 
 		bool from_string(const String &p_str) {
@@ -526,7 +526,7 @@ public:
 
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
-	void set_input_name(String p_name);
+	void set_input_name(const String &p_name);
 	String get_input_name() const;
 	String get_input_real_name() const;
 
@@ -534,7 +534,7 @@ public:
 	PortType get_input_index_type(int p_index) const;
 	String get_input_index_name(int p_index) const;
 
-	PortType get_input_type_by_name(String p_name) const;
+	PortType get_input_type_by_name(const String &p_name) const;
 
 	virtual Vector<StringName> get_editable_properties() const override;
 
@@ -949,7 +949,7 @@ public:
 
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override = 0;
 
-	void set_varying_name(String p_varying_name);
+	void set_varying_name(const String &p_varying_name);
 	String get_varying_name() const;
 
 	void set_varying_type(VisualShader::VaryingType p_varying_type);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds const lvalue reference to the core container types specified in the [documentation](https://docs.godotengine.org/en/stable/development/cpp/core_types.html) that are declared in function parameters in `scene/*` files

initial: https://github.com/godotengine/godot/pull/51156
`core/*`: https://github.com/godotengine/godot/pull/86966
`editor/*`: https://github.com/godotengine/godot/pull/88368
`modules/*`: https://github.com/godotengine/godot/pull/88915
`platform/*`: https://github.com/godotengine/godot/pull/88971
`servers/*`: https://github.com/godotengine/godot/pull/88972
others: https://github.com/godotengine/godot/pull/88975