### PR TITLE
Add const lvalue ref to remaining container parameters

### DIFF
--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -248,7 +248,7 @@ bool NetSocketPosix::_can_use_ip(const IPAddress &p_ip, const bool p_for_bind) c
 	return !(_ip_type != IP::TYPE_ANY && !p_ip.is_wildcard() && _ip_type != type);
 }
 
-_FORCE_INLINE_ Error NetSocketPosix::_change_multicast_group(IPAddress p_ip, String p_if_name, bool p_add) {
+_FORCE_INLINE_ Error NetSocketPosix::_change_multicast_group(IPAddress p_ip, const String &p_if_name, bool p_add) {
 	ERR_FAIL_COND_V(!is_open(), ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(!_can_use_ip(p_ip, false), ERR_INVALID_PARAMETER);
 

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -62,7 +62,7 @@ private:
 
 	NetError _get_socket_error() const;
 	void _set_socket(SOCKET_TYPE p_sock, IP::Type p_ip_type, bool p_is_stream);
-	_FORCE_INLINE_ Error _change_multicast_group(IPAddress p_ip, String p_if_name, bool p_add);
+	_FORCE_INLINE_ Error _change_multicast_group(IPAddress p_ip, const String &p_if_name, bool p_add);
 	_FORCE_INLINE_ void _set_close_exec_enabled(bool p_enabled);
 
 protected:

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -330,7 +330,7 @@ Performance::Performance() {
 	singleton = this;
 }
 
-Performance::MonitorCall::MonitorCall(Callable p_callable, Vector<Variant> p_arguments) {
+Performance::MonitorCall::MonitorCall(Callable p_callable, const Vector<Variant> &p_arguments) {
 	_callable = p_callable;
 	_arguments = p_arguments;
 }

--- a/main/performance.h
+++ b/main/performance.h
@@ -57,7 +57,7 @@ class Performance : public Object {
 		Vector<Variant> _arguments;
 
 	public:
-		MonitorCall(Callable p_callable, Vector<Variant> p_arguments);
+		MonitorCall(Callable p_callable, const Vector<Variant> &p_arguments);
 		MonitorCall();
 		Variant call(bool &r_error, String &r_error_message);
 	};


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds const lvalue reference to the core container types specified in the [documentation](https://docs.godotengine.org/en/stable/development/cpp/core_types.html) that are declared in function parameters in the remaining files.

I believe that's all. If there are other folders/files that need this optimization please let me know 👍

initial: https://github.com/godotengine/godot/pull/51156
`core/*`: https://github.com/godotengine/godot/pull/86966
`editor/*`: https://github.com/godotengine/godot/pull/88368
`modules/*`: https://github.com/godotengine/godot/pull/88915
`platform/*`: https://github.com/godotengine/godot/pull/88971
`servers/*`: https://github.com/godotengine/godot/pull/88972
`scene/*`: https://github.com/godotengine/godot/pull/88974