### PR TITLE
[macOS] Enable input from controllers in the background.

### DIFF
--- a/platform/macos/joypad_macos.mm
+++ b/platform/macos/joypad_macos.mm
@@ -136,6 +136,10 @@
 JoypadMacOS::JoypadMacOS() {
 	observer = [[JoypadMacOSObserver alloc] init];
 	[observer startObserving];
+
+	if (@available(macOS 11.3, *)) {
+		GCController.shouldMonitorBackgroundEvents = YES;
+	}
 }
 
 JoypadMacOS::~JoypadMacOS() {


### PR DESCRIPTION
Enables input from controllers when app is in the background (on macOS 11.3+, it's always enabled on older macOS versions and not supported on iOS), for consistency with other platforms.

See https://github.com/godotengine/godot/issues/88693#issuecomment-1969545554