### PR TITLE
Allow Roughness/Metallic values above 1.0 in BaseMaterial3D

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -259,8 +259,9 @@
 			For best results, the texture should be normalized (with [member heightmap_scale] reduced to compensate). In [url=https://gimp.org]GIMP[/url], this can be done using [b]Colors &gt; Auto &gt; Equalize[/b]. If the texture only uses a small part of its available range, the parallax effect may look strange, especially when the camera moves.
 			[b]Note:[/b] To reduce memory usage and improve loading times, you may be able to use a lower-resolution heightmap texture as most heightmaps are only comprised of low-frequency data.
 		</member>
-		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0">
-			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].
+		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0" keywords="metalness">
+			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection, use [member roughness].
+			Values above [code]1.0[/code] can be used to further increase metalness when using a [member metallic_texture] by treating its dark spots as more metallic than they would otherwise be, but the final metalness is clamped to [code]1.0[/code].
 		</member>
 		<member name="metallic_specular" type="float" setter="set_specular" getter="get_specular" default="0.5">
 			Adjusts the strength of specular reflections. Specular reflections are composed of scene reflections and the specular lobe which is the bright spot that is reflected from light sources. When set to [code]0.0[/code], no specular reflections will be visible. This differs from the [constant SPECULAR_DISABLED] [enum SpecularMode] as [constant SPECULAR_DISABLED] only applies to the specular lobe from the light source.
@@ -339,8 +340,8 @@
 		<member name="rim_tint" type="float" setter="set_rim_tint" getter="get_rim_tint" default="0.5">
 			The amount of to blend light and albedo color when rendering rim effect. If [code]0[/code] the light color is used, while [code]1[/code] means albedo color is used. An intermediate value generally works best.
 		</member>
-		<member name="roughness" type="float" setter="set_roughness" getter="get_roughness" default="1.0">
-			Surface reflection. A value of [code]0[/code] represents a perfect mirror while a value of [code]1[/code] completely blurs the reflection. See also [member metallic].
+		<member name="roughness" type="float" setter="set_roughness" getter="get_roughness" default="1.0" keywords="smoothness">
+			Surface reflection. A value of [code]0[/code] represents a perfect mirror while a value of [code]1[/code] completely blurs the reflection. Values above [code]1.0[/code] can be used to further increase roughness when using a [member roughness_texture] by treating its dark spots as rougher than they would otherwise be, but the final roughness is clamped to [code]1.0[/code]. See also [member metallic].
 		</member>
 		<member name="roughness_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture used to control the roughness per-pixel. Multiplied by [member roughness].

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3909,8 +3909,10 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 			}
 		}
 
-		mr["metallicFactor"] = base_material->get_metallic();
-		mr["roughnessFactor"] = base_material->get_roughness();
+		// Godot allows setting BaseMaterial3D roughness/metallic above 1.0 (which has an effect on how
+		// the roughness/metallic texture is interpreted), but the glTF specification doesn't allow this.
+		mr["metallicFactor"] = MIN(base_material->get_metallic(), 1.0);
+		mr["roughnessFactor"] = MIN(base_material->get_roughness(), 1.0);
 		if (_image_format != "None") {
 			bool has_roughness = base_material->get_texture(BaseMaterial3D::TEXTURE_ROUGHNESS).is_valid() && base_material->get_texture(BaseMaterial3D::TEXTURE_ROUGHNESS)->get_image().is_valid();
 			bool has_ao = base_material->get_feature(BaseMaterial3D::FEATURE_AMBIENT_OCCLUSION) && base_material->get_texture(BaseMaterial3D::TEXTURE_AMBIENT_OCCLUSION).is_valid();

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1512,7 +1512,7 @@ void fragment() {)";
 		} else {
 			code += "	float roughness_tex = dot(texture(texture_roughness, base_uv), roughness_texture_channel);\n";
 		}
-		code += R"(	ROUGHNESS = roughness_tex * roughness;
+		code += R"(	ROUGHNESS = min(roughness_tex * roughness, 1.0);
 )";
 	} else {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
@@ -3066,13 +3066,13 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "orm_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_ORM);
 
 	ADD_GROUP("Metallic", "metallic_");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "metallic", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_metallic", "get_metallic");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "metallic", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_metallic", "get_metallic");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "metallic_specular", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_specular", "get_specular");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "metallic_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_METALLIC);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "metallic_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_metallic_texture_channel", "get_metallic_texture_channel");
 
 	ADD_GROUP("Roughness", "roughness_");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "roughness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_roughness", "get_roughness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "roughness", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_roughness", "get_roughness");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "roughness_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_ROUGHNESS);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "roughness_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_roughness_texture_channel", "get_roughness_texture_channel");
 


### PR DESCRIPTION
This can be used in conjunction with a roughness/metallic texture to make materials look more rough/metallic without having to edit the texture in question. The final roughness/metallic value on each pixel is clamped to 1.0 regardless.

- This closes https://github.com/godotengine/godot-proposals/issues/9176.

**Testing project:** [test_roughness_above_1.zip](https://github.com/godotengine/godot/files/14439189/test_roughness_above_1.zip)
<sub>Texture from <a href="https://polyhaven.com/a/slab_tiles">Poly Haven</a></sub>

## Preview

https://github.com/godotengine/godot/assets/180032/92ff4d30-2868-49e8-9484-980991282c11

