### PR TITLE
Add thread support to `CreateDialog`

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -31,6 +31,8 @@
 #ifndef CREATE_DIALOG_H
 #define CREATE_DIALOG_H
 
+#include "core/os/mutex.h"
+#include "core/os/thread.h"
 #include "editor/editor_help.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
@@ -46,6 +48,21 @@ class CreateDialog : public ConfirmationDialog {
 		PATH_TYPE,
 		OTHER_TYPE
 	};
+
+	struct SearchOptionItem {
+		String search_text;
+		String inherits;
+		String type;
+		TypeCategory type_category;
+		SearchOptionItem(const String &p_inherits, const String &p_type, const TypeCategory p_type_category) :
+				inherits(p_inherits), type(p_type), type_category(p_type_category) {}
+	};
+	Mutex search_mutex;
+	Thread search_thread;
+	SafeFlag search_abort;
+	SafeFlag search_invalidate;
+	List<SearchOptionItem *> search_option_item_list;
+	bool use_threads = false;
 
 	LineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
@@ -66,6 +83,10 @@ class CreateDialog : public ConfirmationDialog {
 	HashMap<String, int> custom_type_indices;
 	List<StringName> type_list;
 	HashSet<StringName> type_blacklist;
+
+	static void _search_thread_func(void *p_userdata);
+	void _create_search_option_items(const Vector<String> &p_candidates, const String &p_search_text);
+	void _clear_search_option_items();
 
 	void _update_search();
 	bool _should_hide_type(const String &p_type) const;


### PR DESCRIPTION
Adds thread support to `CreateDialog`. This removes will remove any engine-wide lag when searching in the `CreateDialog`.

[Capture vidéo du 2024-02-28 15-47-45.webm](https://github.com/godotengine/godot/assets/270928/faf30c59-1f45-4e78-b9db-03b8d60d6d78)

(it has some glitches, see the note below about "Draft")

# Notes
- This takes into account `THREADS_ENABLED`, so it should work as well on builds without threads support.

# Draft
- This is in an early stage, so a lot will change before it being ready for production.
- Will need to refactor a lot the code, as it is pretty ugly as of 2024-02-28.

# Fixes
- Fixes https://github.com/godotengine/godot/issues/27333
- Fixes https://github.com/godotengine/godot/issues/34205