### PR TITLE
Fix linking NavigationServer2D/3D with all classes disabled in build profile

### DIFF
--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -625,5 +625,3 @@ bool NavigationMesh::_get(const StringName &p_name, Variant &r_ret) const {
 	return false;
 }
 #endif // DISABLE_DEPRECATED
-
-NavigationMesh::NavigationMesh() {}

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -199,7 +199,8 @@ public:
 	Ref<ArrayMesh> get_debug_mesh();
 #endif // DEBUG_ENABLED
 
-	NavigationMesh();
+	NavigationMesh() {}
+	~NavigationMesh() {}
 };
 
 VARIANT_ENUM_CAST(NavigationMesh::SamplePartitionType);

--- a/scene/resources/navigation_mesh_source_geometry_data_2d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_2d.cpp
@@ -129,10 +129,3 @@ void NavigationMeshSourceGeometryData2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "traversable_outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_traversable_outlines", "get_traversable_outlines");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "obstruction_outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_obstruction_outlines", "get_obstruction_outlines");
 }
-
-NavigationMeshSourceGeometryData2D::NavigationMeshSourceGeometryData2D() {
-}
-
-NavigationMeshSourceGeometryData2D::~NavigationMeshSourceGeometryData2D() {
-	clear();
-}

--- a/scene/resources/navigation_mesh_source_geometry_data_2d.h
+++ b/scene/resources/navigation_mesh_source_geometry_data_2d.h
@@ -71,8 +71,8 @@ public:
 	bool has_data() { return traversable_outlines.size(); };
 	void clear();
 
-	NavigationMeshSourceGeometryData2D();
-	~NavigationMeshSourceGeometryData2D();
+	NavigationMeshSourceGeometryData2D() {}
+	~NavigationMeshSourceGeometryData2D() { clear(); }
 };
 
 #endif // NAVIGATION_MESH_SOURCE_GEOMETRY_DATA_2D_H

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
@@ -182,10 +182,3 @@ void NavigationMeshSourceGeometryData3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "indices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_indices", "get_indices");
 }
-
-NavigationMeshSourceGeometryData3D::NavigationMeshSourceGeometryData3D() {
-}
-
-NavigationMeshSourceGeometryData3D::~NavigationMeshSourceGeometryData3D() {
-	clear();
-}

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.h
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.h
@@ -68,8 +68,8 @@ public:
 	void add_mesh_array(const Array &p_mesh_array, const Transform3D &p_xform);
 	void add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform);
 
-	NavigationMeshSourceGeometryData3D();
-	~NavigationMeshSourceGeometryData3D();
+	NavigationMeshSourceGeometryData3D() {}
+	~NavigationMeshSourceGeometryData3D() { clear(); }
 };
 
 #endif // NAVIGATION_MESH_SOURCE_GEOMETRY_DATA_3D_H

--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -541,5 +541,3 @@ void NavigationPolygon::_validate_property(PropertyInfo &p_property) const {
 		}
 	}
 }
-
-NavigationPolygon::NavigationPolygon() {}

--- a/scene/resources/navigation_polygon.h
+++ b/scene/resources/navigation_polygon.h
@@ -153,7 +153,7 @@ public:
 
 	void clear();
 
-	NavigationPolygon();
+	NavigationPolygon() {}
 	~NavigationPolygon() {}
 };
 


### PR DESCRIPTION
For some reason the destructor for NavigationMeshSourceGeometryData2D/3D being implemented in the .cpp was causing linking issues.

---

I was testing making minimal sized export templates with the following command:
```
scons target=template_release production=yes disable_3d=yes disable_advanced_gui=yes optimize=size deprecated=no minizip=no modules_enabled_by_default=no module_gdscript_enabled=yes vulkan=no wayland=no build_profile=blank.build lto=none
```
And this build profile which disables nearly all classes in the engine, generated from a blank project with just icon.svg, so that's the only type of resource it needs to support: [blank.build.txt](https://github.com/godotengine/godot/files/14440179/blank.build.txt)

I would get this linking issue:
```
/usr/bin/ld: servers/libservers.linuxbsd.template_release.x86_64.a(navigation_server_2d.linuxbsd.template_release.x86_64.o): in function `Ref<NavigationMeshSourceGeometryData2D>::Ref(Variant const&)':
navigation_server_2d.cpp:(.text._ZN3RefI34NavigationMeshSourceGeometryData2DEC2ERK7Variant[_ZN3RefI34NavigationMeshSourceGeometryData2DEC5ERK7Variant]+0x1f): undefined reference to `typeinfo for NavigationMeshSourceGeometryData2D'
/usr/bin/ld: servers/libservers.linuxbsd.template_release.x86_64.a(navigation_server_3d.linuxbsd.template_release.x86_64.o): in function `Ref<NavigationMeshSourceGeometryData3D>::Ref(Variant const&)':
navigation_server_3d.cpp:(.text._ZN3RefI34NavigationMeshSourceGeometryData3DEC2ERK7Variant[_ZN3RefI34NavigationMeshSourceGeometryData3DEC5ERK7Variant]+0x1f): undefined reference to `typeinfo for NavigationMeshSourceGeometryData3D'
```

I was puzzled to have this issue with NavigationMeshSourceGeometryData2D but not NavigationPolygon, when both are used as `Ref<T>` in NavigationServer2D. Comparing both classes, the main difference seemed to be the destructor implemented in the .cpp, and moving it solved the issue. The rest of the changes are just for consistency.

I don't really know why this fixes the linking issue, or why it happened before this fix. Maybe someone more versed in C++ can clarify :)