### PR TITLE
Invert Force Disable Compression import option to be easier to discover

### DIFF
--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -30,15 +30,15 @@
 		<member name="import_script/path" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to an import script, which can run code after the import process has completed for custom processing. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.html#using-import-scripts-for-automation]Using import scripts for automation[/url] for more information.
 		</member>
+		<member name="meshes/compress" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the importer will attempt to use mesh compression to improve rendering performance. Consider disabling if you notice blocky artifacts in your mesh normals or UVs, or if you have meshes that are larger than a few thousand meters in each direction. The importer may decide to disable compression in certain cases even if this setting is enabled.
+		</member>
 		<member name="meshes/create_shadow_meshes" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables the generation of shadow meshes on import. This optimizes shadow rendering without reducing quality by welding vertices together when possible. This in turn reduces the memory bandwidth required to render shadows. Shadow mesh generation currently doesn't support using a lower detail level than the source mesh (but shadow rendering will make use of LODs when relevant).
 		</member>
 		<member name="meshes/ensure_tangents" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], generate vertex tangents using [url=http://www.mikktspace.com/]Mikktspace[/url] if the input meshes don't have tangent data. When possible, it's recommended to let the 3D modeling software generate tangents on export instead on relying on this option. Tangents are required for correct display of normal and height maps, along with any material/shader features that require tangents.
 			If you don't need material features that require tangents, disabling this can reduce output file size and speed up importing if the source 3D file doesn't contain tangents.
-		</member>
-		<member name="meshes/force_disable_compression" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], mesh compression will not be used. Consider enabling if you notice blocky artifacts in your mesh normals or UVs, or if you have meshes that are larger than a few thousand meters in each direction.
 		</member>
 		<member name="meshes/generate_lods" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], generates lower detail variants of the mesh which will be displayed in the distance to improve rendering performance. Not all meshes benefit from LOD, especially if they are never rendered from far away. Disabling this can reduce output file size and speed up importing. See [url=$DOCS_URL/tutorials/3d/mesh_lod.html#doc-mesh-lod]Mesh level of detail (LOD)[/url] for more information.

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1939,7 +1939,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/create_shadow_meshes"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "meshes/light_baking", PROPERTY_HINT_ENUM, "Disabled,Static,Static Lightmaps,Dynamic", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "meshes/lightmap_texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.2));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/force_disable_compression"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/compress"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "skins/use_named_skins"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/fps", PROPERTY_HINT_RANGE, "1,120,1"), 30));
@@ -1959,6 +1959,13 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 }
 
 void ResourceImporterScene::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
+	print_line("Handle compatibility options");
+	if (p_import_params.has("meshes/force_disable_compression") && !p_import_params.has("meshes/compress")) {
+		print_line("Invert Force Disable Compression");
+		// Handle legacy option which had inverted behavior.
+		p_import_params["meshes/compress"] = !p_import_params["meshes/force_disable_compression"];
+	}
+
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->handle_compatibility_options(p_import_params);
 	}
@@ -2456,8 +2463,8 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		import_flags |= EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS;
 	}
 
-	bool force_disable_compression = p_options["meshes/force_disable_compression"];
-	if (force_disable_compression) {
+	bool compress = p_options["meshes/compress"];
+	if (!compress) {
 		import_flags |= EditorSceneFormatImporter::IMPORT_FORCE_DISABLE_MESH_COMPRESSION;
 	}
 


### PR DESCRIPTION
The option is now called Compress and is enabled by default. The constant in EditorSceneFormatImporter keeps its prior name to preserve compatibility.

**Marked as draft**, as I've added a compatibility handler but its inner part (the one that is evaluated if `meshes/force_disable_compression` is present in the `.import` file) is never being run, so I can't invert the value of the previous option and store it in `meshes/compress`.

- See https://github.com/godotengine/godot/issues/85406.

## Preview

Before | After
-|-
![image](https://github.com/godotengine/godot/assets/180032/c3087187-a8a3-4968-8728-3cc3f4b1a95d) | ![image](https://github.com/godotengine/godot/assets/180032/16d77106-18fa-49c0-9a75-2e44907e6b9b)
