### PR TITLE
Fix mouse entered notifications

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3158,9 +3158,6 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 							gui.subwindow_over->_mouse_leave_viewport();
 						}
 						gui.subwindow_over = sw;
-						if (!sw->is_input_disabled()) {
-							sw->_propagate_window_notification(sw, NOTIFICATION_WM_MOUSE_ENTER);
-						}
 					}
 					if (!sw->is_input_disabled()) {
 						sw->_update_mouse_over(sw->get_final_transform().affine_inverse().xform(p_pos - sw->get_position()));

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -352,7 +352,7 @@ private:
 
 	struct GUI {
 		bool forced_mouse_focus = false; //used for menu buttons
-		bool mouse_in_viewport = true;
+		bool mouse_in_viewport = false;
 		bool key_event_accepted = false;
 		HashMap<int, ObjectID> touch_focus;
 		Control *mouse_focus = nullptr;


### PR DESCRIPTION
Make sure, that a windows initial state is `mouse_in_viewport = false`. This makes sure, that the mouse entered notification is sent when the mouse hovers a window for the first time. (resolve #88942)

For embedded Windows, `NOTIFICATION_WM_MOUSE_ENTER` is currently sent twice in a row. Remove one of the places where it is sent. `Window::_update_mouse_over()` is the correct one, because there it is also called for native windows. (bug detected while investigating #88942)
