### PR TITLE
Add more keywords to base Variant types

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AABB" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AABB" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd" keywords="bounding_box">
 	<brief_description>
 		A 3D axis-aligned bounding box.
 	</brief_description>
@@ -59,7 +59,7 @@
 				[b]Note:[/b] It's recommended to use this method when [member size] is negative, as most other methods in Godot assume that the [member size]'s components are greater than [code]0[/code].
 			</description>
 		</method>
-		<method name="encloses" qualifiers="const">
+		<method name="encloses" qualifiers="const" keywords="includes, contains">
 			<return type="bool" />
 			<param index="0" name="with" type="AABB" />
 			<description>
@@ -123,7 +123,7 @@
 				Returns the center point of the bounding box. This is the same as [code]position + (size / 2.0)[/code].
 			</description>
 		</method>
-		<method name="get_endpoint" qualifiers="const">
+		<method name="get_endpoint" qualifiers="const" keywords="get_vertex, get_corner">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
@@ -217,7 +217,7 @@
 				Returns the bounding box's volume. This is equivalent to [code]size.x * size.y * size.z[/code]. See also [method has_volume].
 			</description>
 		</method>
-		<method name="grow" qualifiers="const">
+		<method name="grow" qualifiers="const" keywords="extend">
 			<return type="AABB" />
 			<param index="0" name="by" type="float" />
 			<description>
@@ -244,7 +244,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="has_point" qualifiers="const">
+		<method name="has_point" qualifiers="const" keywords="contains">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector3" />
 			<description>
@@ -290,21 +290,21 @@
 				[b]Note:[/b] If you only need to know whether two bounding boxes are intersecting, use [method intersects], instead.
 			</description>
 		</method>
-		<method name="intersects" qualifiers="const">
+		<method name="intersects" qualifiers="const" keywords="overlaps">
 			<return type="bool" />
 			<param index="0" name="with" type="AABB" />
 			<description>
 				Returns [code]true[/code] if this bounding box overlaps with the box [param with]. The edges of both boxes are [i]always[/i] excluded.
 			</description>
 		</method>
-		<method name="intersects_plane" qualifiers="const">
+		<method name="intersects_plane" qualifiers="const" keywords="overlaps_plane">
 			<return type="bool" />
 			<param index="0" name="plane" type="Plane" />
 			<description>
 				Returns [code]true[/code] if this bounding box is on both sides of the given [param plane].
 			</description>
 		</method>
-		<method name="intersects_ray" qualifiers="const">
+		<method name="intersects_ray" qualifiers="const" keywords="overlaps_ray">
 			<return type="Variant" />
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="dir" type="Vector3" />
@@ -313,7 +313,7 @@
 				The ray begin at [param from], faces [param dir] and extends towards infinity.
 			</description>
 		</method>
-		<method name="intersects_segment" qualifiers="const">
+		<method name="intersects_segment" qualifiers="const" keywords="overlaps_segment">
 			<return type="Variant" />
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="to" type="Vector3" />
@@ -350,7 +350,7 @@
 		<member name="position" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			The origin point. This is usually the corner on the bottom-left and back of the bounding box.
 		</member>
-		<member name="size" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+		<member name="size" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)" keywords="width, height, depth">
 			The bounding box's width, height, and depth starting from [member position]. Setting this value also affects the [member end] point.
 			[b]Note:[/b] It's recommended setting the width, height, and depth to non-negative values. This is because most methods in Godot assume that the [member position] is the bottom-left-back corner, and the [member end] is the top-right-forward corner. To get an equivalent bounding box with non-negative size, use [method abs].
 		</member>

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Color" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="Color" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd" keywords="colour">
 	<brief_description>
 		A color represented in RGBA format.
 	</brief_description>
@@ -97,7 +97,7 @@
 		</constructor>
 	</constructors>
 	<methods>
-		<method name="blend" qualifiers="const">
+		<method name="blend" qualifiers="const" keywords="mix">
 			<return type="Color" />
 			<param index="0" name="over" type="Color" />
 			<description>
@@ -141,7 +141,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="from_hsv" qualifiers="static">
+		<method name="from_hsv" qualifiers="static" keywords="hue, saturation, value">
 			<return type="Color" />
 			<param index="0" name="h" type="float" />
 			<param index="1" name="s" type="float" />
@@ -159,7 +159,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="from_ok_hsl" qualifiers="static">
+		<method name="from_ok_hsl" qualifiers="static" keywords="hue, saturation, lightness">
 			<return type="Color" />
 			<param index="0" name="h" type="float" />
 			<param index="1" name="s" type="float" />
@@ -472,37 +472,37 @@
 		</method>
 	</methods>
 	<members>
-		<member name="a" type="float" setter="" getter="" default="1.0">
+		<member name="a" type="float" setter="" getter="" default="1.0" keywords="alpha, transparency, opacity">
 			The color's alpha component, typically on the range of 0 to 1. A value of 0 means that the color is fully transparent. A value of 1 means that the color is fully opaque.
 		</member>
-		<member name="a8" type="int" setter="" getter="" default="255">
+		<member name="a8" type="int" setter="" getter="" default="255" keywords="alpha, transparency, opacity">
 			Wrapper for [member a] that uses the range 0 to 255, instead of 0 to 1.
 		</member>
-		<member name="b" type="float" setter="" getter="" default="0.0">
+		<member name="b" type="float" setter="" getter="" default="0.0" keywords="blue">
 			The color's blue component, typically on the range of 0 to 1.
 		</member>
-		<member name="b8" type="int" setter="" getter="" default="0">
+		<member name="b8" type="int" setter="" getter="" default="0" keywords="blue">
 			Wrapper for [member b] that uses the range 0 to 255, instead of 0 to 1.
 		</member>
-		<member name="g" type="float" setter="" getter="" default="0.0">
+		<member name="g" type="float" setter="" getter="" default="0.0" keywords="green">
 			The color's green component, typically on the range of 0 to 1.
 		</member>
-		<member name="g8" type="int" setter="" getter="" default="0">
+		<member name="g8" type="int" setter="" getter="" default="0" keywords="green">
 			Wrapper for [member g] that uses the range 0 to 255, instead of 0 to 1.
 		</member>
-		<member name="h" type="float" setter="" getter="" default="0.0">
+		<member name="h" type="float" setter="" getter="" default="0.0" keywords="hue, tint, tone">
 			The HSV hue of this color, on the range 0 to 1.
 		</member>
-		<member name="r" type="float" setter="" getter="" default="0.0">
+		<member name="r" type="float" setter="" getter="" default="0.0" keywords="red">
 			The color's red component, typically on the range of 0 to 1.
 		</member>
-		<member name="r8" type="int" setter="" getter="" default="0">
+		<member name="r8" type="int" setter="" getter="" default="0" keywords="red">
 			Wrapper for [member r] that uses the range 0 to 255, instead of 0 to 1.
 		</member>
-		<member name="s" type="float" setter="" getter="" default="0.0">
+		<member name="s" type="float" setter="" getter="" default="0.0" keywords="saturation">
 			The HSV saturation of this color, on the range 0 to 1.
 		</member>
-		<member name="v" type="float" setter="" getter="" default="0.0">
+		<member name="v" type="float" setter="" getter="" default="0.0" keywords="value, brightness">
 			The HSV value (brightness) of this color, on the range 0 to 1.
 		</member>
 	</members>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Rect2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="Rect2" keywords="rectangle, bounding_box" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A 2D axis-aligned bounding box using floating-point coordinates.
 	</brief_description>
@@ -72,7 +72,7 @@
 				[b]Note:[/b] It's recommended to use this method when [member size] is negative, as most other methods in Godot assume that the [member position] is the top-left corner, and the [member end] is the bottom-right corner.
 			</description>
 		</method>
-		<method name="encloses" qualifiers="const">
+		<method name="encloses" qualifiers="const" keywords="includes, contains">
 			<return type="bool" />
 			<param index="0" name="b" type="Rect2" />
 			<description>
@@ -112,7 +112,7 @@
 				Returns the center point of the rectangle. This is the same as [code]position + (size / 2.0)[/code].
 			</description>
 		</method>
-		<method name="grow" qualifiers="const">
+		<method name="grow" qualifiers="const" keywords="extend">
 			<return type="Rect2" />
 			<param index="0" name="amount" type="float" />
 			<description>
@@ -129,7 +129,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="grow_individual" qualifiers="const">
+		<method name="grow_individual" qualifiers="const" keywords="extend_sides, grow_sides">
 			<return type="Rect2" />
 			<param index="0" name="left" type="float" />
 			<param index="1" name="top" type="float" />
@@ -139,7 +139,7 @@
 				Returns a copy of this rectangle with its [param left], [param top], [param right], and [param bottom] sides extended by the given amounts. Negative values shrink the sides, instead. See also [method grow] and [method grow_side].
 			</description>
 		</method>
-		<method name="grow_side" qualifiers="const">
+		<method name="grow_side" qualifiers="const" keywords="extend_side">
 			<return type="Rect2" />
 			<param index="0" name="side" type="int" />
 			<param index="1" name="amount" type="float" />
@@ -153,7 +153,7 @@
 				Returns [code]true[/code] if this rectangle has positive width and height. See also [method get_area].
 			</description>
 		</method>
-		<method name="has_point" qualifiers="const">
+		<method name="has_point" qualifiers="const" keywords="contains">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
@@ -183,7 +183,7 @@
 				[b]Note:[/b] If you only need to know whether two rectangles are overlapping, use [method intersects], instead.
 			</description>
 		</method>
-		<method name="intersects" qualifiers="const">
+		<method name="intersects" qualifiers="const" keywords="overlaps">
 			<return type="bool" />
 			<param index="0" name="b" type="Rect2" />
 			<param index="1" name="include_borders" type="bool" default="false" />
@@ -219,7 +219,7 @@
 		<member name="position" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			The origin point. This is usually the top-left corner of the rectangle.
 		</member>
-		<member name="size" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
+		<member name="size" type="Vector2" setter="" getter="" default="Vector2(0, 0)" keywords="width, height">
 			The rectangle's width and height, starting from [member position]. Setting this value also affects the [member end] point.
 			[b]Note:[/b] It's recommended setting the width and height to non-negative values, as most methods in Godot assume that the [member position] is the top-left corner, and the [member end] is the bottom-right corner. To get an equivalent rectangle with non-negative size, use [method abs].
 		</member>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Rect2i" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="Rect2i" keywords="rectangle, bounding_box" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A 2D axis-aligned bounding box using integer coordinates.
 	</brief_description>
@@ -71,7 +71,7 @@
 				[b]Note:[/b] It's recommended to use this method when [member size] is negative, as most other methods in Godot assume that the [member position] is the top-left corner, and the [member end] is the bottom-right corner.
 			</description>
 		</method>
-		<method name="encloses" qualifiers="const">
+		<method name="encloses" qualifiers="const" keywords="includes, contains">
 			<return type="bool" />
 			<param index="0" name="b" type="Rect2i" />
 			<description>
@@ -112,7 +112,7 @@
 				[b]Note:[/b] If the [member size] is odd, the result will be rounded towards [member position].
 			</description>
 		</method>
-		<method name="grow" qualifiers="const">
+		<method name="grow" qualifiers="const" keywords="extend">
 			<return type="Rect2i" />
 			<param index="0" name="amount" type="int" />
 			<description>
@@ -129,7 +129,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="grow_individual" qualifiers="const">
+		<method name="grow_individual" qualifiers="const" keywords="extend_sides, grow_sides">
 			<return type="Rect2i" />
 			<param index="0" name="left" type="int" />
 			<param index="1" name="top" type="int" />
@@ -139,7 +139,7 @@
 				Returns a copy of this rectangle with its [param left], [param top], [param right], and [param bottom] sides extended by the given amounts. Negative values shrink the sides, instead. See also [method grow] and [method grow_side].
 			</description>
 		</method>
-		<method name="grow_side" qualifiers="const">
+		<method name="grow_side" qualifiers="const" keywords="extend_side">
 			<return type="Rect2i" />
 			<param index="0" name="side" type="int" />
 			<param index="1" name="amount" type="int" />
@@ -153,7 +153,7 @@
 				Returns [code]true[/code] if this rectangle has positive width and height. See also [method get_area].
 			</description>
 		</method>
-		<method name="has_point" qualifiers="const">
+		<method name="has_point" qualifiers="const" keywords="contains">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2i" />
 			<description>
@@ -183,7 +183,7 @@
 				[b]Note:[/b] If you only need to know whether two rectangles are overlapping, use [method intersects], instead.
 			</description>
 		</method>
-		<method name="intersects" qualifiers="const">
+		<method name="intersects" qualifiers="const" keywords="overlaps">
 			<return type="bool" />
 			<param index="0" name="b" type="Rect2i" />
 			<description>
@@ -205,7 +205,7 @@
 		<member name="position" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
 			The origin point. This is usually the top-left corner of the rectangle.
 		</member>
-		<member name="size" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
+		<member name="size" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)" keywords="width, height">
 			The rectangle's width and height, starting from [member position]. Setting this value also affects the [member end] point.
 			[b]Note:[/b] It's recommended setting the width and height to non-negative values, as most methods in Godot assume that the [member position] is the top-left corner, and the [member end] is the bottom-right corner. To get an equivalent rectangle with non-negative size, use [method abs].
 		</member>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -115,7 +115,7 @@
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method nocasecmp_to], [method naturalcasecmp_to], and [method naturalnocasecmp_to].
 			</description>
 		</method>
-		<method name="chr" qualifiers="static">
+		<method name="chr" qualifiers="static" keywords="unicode">
 			<return type="String" />
 			<param index="0" name="char" type="int" />
 			<description>
@@ -184,7 +184,7 @@
 				Returns a string with [param chars] characters erased starting from [param position]. If [param chars] goes beyond the string's length given the specified [param position], fewer characters will be erased from the returned string. Returns an empty string if either [param position] or [param chars] is negative. Returns the original string unmodified if [param chars] is [code]0[/code].
 			</description>
 		</method>
-		<method name="find" qualifiers="const">
+		<method name="find" qualifiers="const" keywords="index_of, indexOf">
 			<return type="int" />
 			<param index="0" name="what" type="String" />
 			<param index="1" name="from" type="int" default="0" />
@@ -209,7 +209,7 @@
 				[b]Note:[/b] If you just want to know whether the string contains [param what], use [method contains]. In GDScript, you may also use the [code]in[/code] operator.
 			</description>
 		</method>
-		<method name="findn" qualifiers="const">
+		<method name="findn" qualifiers="const" keywords="index_of, indexOf">
 			<return type="int" />
 			<param index="0" name="what" type="String" />
 			<param index="1" name="from" type="int" default="0" />
@@ -537,7 +537,7 @@
 				Returns the number of characters in the string. Empty strings ([code]""[/code]) always return [code]0[/code]. See also [method is_empty].
 			</description>
 		</method>
-		<method name="lpad" qualifiers="const">
+		<method name="lpad" qualifiers="const" keywords="pad_start, padStart">
 			<return type="String" />
 			<param index="0" name="min_length" type="int" />
 			<param index="1" name="character" type="String" default="&quot; &quot;" />
@@ -553,14 +553,14 @@
 				[b]Note:[/b] [param chars] is not a prefix. Use [method trim_prefix] to remove a single prefix, rather than a set of characters.
 			</description>
 		</method>
-		<method name="match" qualifiers="const">
+		<method name="match" qualifiers="const" keywords="glob">
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
 				Does a simple expression match (also called "glob" or "globbing"), where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). An empty string or empty expression always evaluates to [code]false[/code].
 			</description>
 		</method>
-		<method name="matchn" qualifiers="const">
+		<method name="matchn" qualifiers="const" keywords="glob">
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
@@ -727,7 +727,7 @@
 				Returns the copy of this string in reverse order.
 			</description>
 		</method>
-		<method name="rfind" qualifiers="const">
+		<method name="rfind" qualifiers="const" keywords="last_index_of, lastIndexOf">
 			<return type="int" />
 			<param index="0" name="what" type="String" />
 			<param index="1" name="from" type="int" default="-1" />
@@ -735,7 +735,7 @@
 				Returns the index of the [b]last[/b] occurrence of [param what] in this string, or [code]-1[/code] if there are none. The search's start can be specified with [param from], continuing to the beginning of the string. This method is the reverse of [method find].
 			</description>
 		</method>
-		<method name="rfindn" qualifiers="const">
+		<method name="rfindn" qualifiers="const" keywords="last_index_of, lastIndexOf">
 			<return type="int" />
 			<param index="0" name="what" type="String" />
 			<param index="1" name="from" type="int" default="-1" />
@@ -754,7 +754,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="rpad" qualifiers="const">
+		<method name="rpad" qualifiers="const" keywords="pad_end, padEnd">
 			<return type="String" />
 			<param index="0" name="min_length" type="int" />
 			<param index="1" name="character" type="String" default="&quot; &quot;" />
@@ -762,7 +762,7 @@
 				Formats the string to be at least [param min_length] long, by adding [param character]s to the right of the string, if necessary. See also [method lpad].
 			</description>
 		</method>
-		<method name="rsplit" qualifiers="const">
+		<method name="rsplit" qualifiers="const" keywords="reverse_split">
 			<return type="PackedStringArray" />
 			<param index="0" name="delimiter" type="String" default="&quot;&quot;" />
 			<param index="1" name="allow_empty" type="bool" default="true" />
@@ -887,7 +887,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="strip_edges" qualifiers="const">
+		<method name="strip_edges" qualifiers="const" keywords="trim">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />
 			<param index="1" name="right" type="bool" default="true" />
@@ -1008,21 +1008,21 @@
 				Converts the string to a [url=https://en.wikipedia.org/wiki/Wide_character]wide character[/url] ([code]wchar_t[/code], UTF-16 on Windows, UTF-32 on other platforms) encoded [PackedByteArray]. This is the inverse of [method PackedByteArray.get_string_from_wchar].
 			</description>
 		</method>
-		<method name="trim_prefix" qualifiers="const">
+		<method name="trim_prefix" qualifiers="const" keywords="trim_start">
 			<return type="String" />
 			<param index="0" name="prefix" type="String" />
 			<description>
 				Removes the given [param prefix] from the start of the string, or returns the string unchanged.
 			</description>
 		</method>
-		<method name="trim_suffix" qualifiers="const">
+		<method name="trim_suffix" qualifiers="const" keywords="trim_end">
 			<return type="String" />
 			<param index="0" name="suffix" type="String" />
 			<description>
 				Removes the given [param suffix] from the end of the string, or returns the string unchanged.
 			</description>
 		</method>
-		<method name="unicode_at" qualifiers="const">
+		<method name="unicode_at" qualifiers="const" keywords="char_at, character_at">
 			<return type="int" />
 			<param index="0" name="at" type="int" />
 			<description>


### PR DESCRIPTION
This PR adds more keywords for **AABB**, **Color**, **Rect2**, **Rect2i**, and **String**'s methods and properties. A good chunk of these keywords are taken from the equivalent methods' names in e.g. Unity or JavaScript.

Do note that the current Editor Help Search does not seem to search through keywords twice, which feels like an oversight.
For example, this means that searching for "starts with" (notice the space) would not typically match String's `begins_with`, even though it has the "starts_with" keyword.

In fact, as a result of that, I could not even include `axis_aligned_bounding_box` as a singular  keyword for **AABB**.

Also I did not forget about **StringName**, I just am not sure if duplicating the keyword results with **StringName** is a good idea here.