### PR TITLE
[RTL] Add optional `push_meta` argument to disable underline for specific meta item.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -428,6 +428,7 @@
 		<method name="push_meta">
 			<return type="void" />
 			<param index="0" name="data" type="Variant" />
+			<param index="1" name="no_underline" type="bool" default="false" />
 			<description>
 				Adds a meta tag to the tag stack. Similar to the BBCode [code skip-lint][url=something]{text}[/url][/code], but supports non-[String] metadata types.
 			</description>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -224,3 +224,10 @@ Validate extension JSON: JSON file: Field was added in a way that breaks compati
 Added a return value for add_bone.
 Should not affect existing regular use - the return value would just be unused.
 Compatibility method registered.
+
+
+GH-89000
+--------
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_meta/arguments': size changed value in new API, from 1 to 2.
+
+Added optional argument. Compatibility method registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -30,11 +30,16 @@
 
 #ifndef DISABLE_DEPRECATED
 
+void RichTextLabel::_push_meta_bind_compat_89000(const Variant &p_meta) {
+	push_meta(p_meta, false);
+}
+
 void RichTextLabel::_add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region) {
 	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, Variant(), false, String(), false);
 }
 
 void RichTextLabel::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data"), &RichTextLabel::_push_meta_bind_compat_89000);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::_add_image_bind_compat_80410, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()));
 }
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -117,6 +117,7 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
+	void _push_meta_bind_compat_89000(const Variant &p_meta);
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
 	static void _bind_compatibility_methods();
 #endif
@@ -271,6 +272,7 @@ private:
 
 	struct ItemMeta : public Item {
 		Variant meta;
+		bool no_underline = false;
 		ItemMeta() { type = ITEM_META; }
 	};
 
@@ -668,7 +670,7 @@ public:
 	void push_paragraph(HorizontalAlignment p_alignment, Control::TextDirection p_direction = Control::TEXT_DIRECTION_INHERITED, const String &p_language = "", TextServer::StructuredTextParser p_st_parser = TextServer::STRUCTURED_TEXT_DEFAULT, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE, const PackedFloat32Array &p_tab_stops = PackedFloat32Array());
 	void push_indent(int p_level);
 	void push_list(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = String::utf8("•"));
-	void push_meta(const Variant &p_meta);
+	void push_meta(const Variant &p_meta, bool p_no_underline = false);
 	void push_hint(const String &p_string);
 	void push_table(int p_columns, InlineAlignment p_alignment = INLINE_ALIGNMENT_TOP, int p_align_to_row = -1);
 	void push_fade(int p_start_index, int p_length);


### PR DESCRIPTION
Adds extra argument to disable underline for specific meta, previously it was possible to do it only for the whole RTL (`set_meta_underline`).

Useful for something like https://github.com/godotengine/godot/pull/87363