### PR TITLE
Don't access Node3D/Node2D/Control global transform in `reparent` unless needed

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -143,10 +143,12 @@ void Node2D::_update_transform() {
 
 void Node2D::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD;
-	Transform2D temp = get_global_transform();
-	Node::reparent(p_parent);
 	if (p_keep_global_transform) {
+		Transform2D temp = get_global_transform();
+		Node::reparent(p_parent);
 		set_global_transform(temp);
+	} else {
+		Node::reparent(p_parent);
 	}
 }
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -719,10 +719,12 @@ void Node3D::set_disable_gizmos(bool p_enabled) {
 
 void Node3D::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD;
-	Transform3D temp = get_global_transform();
-	Node::reparent(p_parent);
 	if (p_keep_global_transform) {
+		Transform3D temp = get_global_transform();
+		Node::reparent(p_parent);
 		set_global_transform(temp);
+	} else {
+		Node::reparent(p_parent);
 	}
 }
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -188,10 +188,12 @@ Size2 Control::_edit_get_minimum_size() const {
 
 void Control::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_MAIN_THREAD_GUARD;
-	Transform2D temp = get_global_transform();
-	Node::reparent(p_parent);
 	if (p_keep_global_transform) {
+		Transform2D temp = get_global_transform();
+		Node::reparent(p_parent);
 		set_global_position(temp.get_origin());
+	} else {
+		Node::reparent(p_parent);
 	}
 }
 


### PR DESCRIPTION
Fixes #89002.

Marked as co-authored by @elementbound who found what the problem was. The solution needs to be slightly different to the one suggested in #89002, as the global transform needs to be fetched _before_ reparenting, otherwise it won't work.