### PR TITLE
OpenXR Input Changed Events report prev value

### DIFF
--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -64,6 +64,7 @@
 		<signal name="input_float_changed">
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="float" />
+			<param index="2" name="prev_value" type="float" />
 			<description>
 				Emitted when a trigger or similar input on this controller changes value.
 			</description>
@@ -71,6 +72,7 @@
 		<signal name="input_vector2_changed">
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="Vector2" />
+			<param index="2" name="prev_value" type="Vector2" />
 			<description>
 				Emitted when a thumbstick or thumbpad on this controller is moved.
 			</description>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -95,6 +95,7 @@
 		<signal name="input_float_changed">
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="float" />
+			<param index="2" name="prev_value" type="float" />
 			<description>
 				Emitted when a trigger or similar input on this tracker changes value.
 			</description>
@@ -102,6 +103,7 @@
 		<signal name="input_vector2_changed">
 			<param index="0" name="name" type="String" />
 			<param index="1" name="vector" type="Vector2" />
+			<param index="2" name="prev_vector" type="float" />
 			<description>
 				Emitted when a thumbstick or thumbpad on this tracker moves.
 			</description>

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -459,8 +459,8 @@ void XRController3D::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
-	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "value")));
+	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value"), PropertyInfo(Variant::FLOAT, "prev_value")));
+	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "value"), PropertyInfo(Variant::VECTOR2, "prev_value")));
 };
 
 void XRController3D::_bind_tracker() {
@@ -496,14 +496,14 @@ void XRController3D::_button_released(const String &p_name) {
 	emit_signal(SNAME("button_released"), p_name);
 }
 
-void XRController3D::_input_float_changed(const String &p_name, float p_value) {
+void XRController3D::_input_float_changed(const String &p_name, float p_value, float p_value_prev) {
 	// just pass it on...
-	emit_signal(SNAME("input_float_changed"), p_name, p_value);
+	emit_signal(SNAME("input_float_changed"), p_name, p_value, p_value_prev);
 }
 
-void XRController3D::_input_vector2_changed(const String &p_name, Vector2 p_value) {
+void XRController3D::_input_vector2_changed(const String &p_name, Vector2 p_value, Vector2 p_value_prev) {
 	// just pass it on...
-	emit_signal(SNAME("input_vector2_changed"), p_name, p_value);
+	emit_signal(SNAME("input_vector2_changed"), p_name, p_value, p_value_prev);
 }
 
 bool XRController3D::is_button_pressed(const StringName &p_name) const {

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -133,8 +133,8 @@ protected:
 
 	void _button_pressed(const String &p_name);
 	void _button_released(const String &p_name);
-	void _input_float_changed(const String &p_name, float p_value);
-	void _input_vector2_changed(const String &p_name, Vector2 p_value);
+	void _input_float_changed(const String &p_name, float p_value, float p_value_prev);
+	void _input_vector2_changed(const String &p_name, Vector2 p_value, Vector2 p_value_prev);
 
 public:
 	bool is_button_pressed(const StringName &p_name) const;

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -199,7 +199,7 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 		// emit signals to let the rest of the world know
 		switch (p_value.get_type()) {
 			case Variant::BOOL: {
-				bool pressed = inputs[p_action_name];
+				bool pressed = p_value;
 				if (pressed) {
 					emit_signal(SNAME("button_pressed"), p_action_name);
 				} else {
@@ -209,12 +209,12 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 				// TODO discuss whether we also want to create and emit an InputEventXRButton event
 			} break;
 			case Variant::FLOAT: {
-				emit_signal(SNAME("input_float_changed"), p_action_name, inputs[p_action_name], p_value);
+				emit_signal(SNAME("input_float_changed"), p_action_name, p_value, inputs[p_action_name]);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRValue event
 			} break;
 			case Variant::VECTOR2: {
-				emit_signal(SNAME("input_vector2_changed"), p_action_name, inputs[p_action_name], p_value);
+				emit_signal(SNAME("input_vector2_changed"), p_action_name, p_value, inputs[p_action_name]);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRAxis event
 			} break;

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -186,6 +186,7 @@ Variant XRPositionalTracker::get_input(const StringName &p_action_name) const {
 
 void XRPositionalTracker::set_input(const StringName &p_action_name, const Variant &p_value) {
 	bool changed = false;
+	bool first_value = false;
 
 	// XR inputs
 
@@ -193,6 +194,7 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 		changed = inputs[p_action_name] != p_value;
 	} else {
 		changed = true;
+		first_value = true; // to avoid nil conversion
 	}
 
 	if (changed) {
@@ -209,11 +211,17 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 				// TODO discuss whether we also want to create and emit an InputEventXRButton event
 			} break;
 			case Variant::FLOAT: {
+				if (first_value) {
+					inputs[p_action_name] = 0.0f;
+				}
 				emit_signal(SNAME("input_float_changed"), p_action_name, p_value, inputs[p_action_name]);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRValue event
 			} break;
 			case Variant::VECTOR2: {
+				if (first_value) {
+					inputs[p_action_name] = Vector2(0.0f, 0.0f);
+				}
 				emit_signal(SNAME("input_vector2_changed"), p_action_name, p_value, inputs[p_action_name]);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRAxis event

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -68,8 +68,8 @@ void XRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_input", "name", "value"), &XRPositionalTracker::set_input);
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
-	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector")));
+	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value"), PropertyInfo(Variant::FLOAT, "prev_value")));
+	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector"), PropertyInfo(Variant::VECTOR2, "prev_vector")));
 	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
 };
 
@@ -196,13 +196,10 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 	}
 
 	if (changed) {
-		// store the new value
-		inputs[p_action_name] = p_value;
-
 		// emit signals to let the rest of the world know
 		switch (p_value.get_type()) {
 			case Variant::BOOL: {
-				bool pressed = p_value;
+				bool pressed = inputs[p_action_name];
 				if (pressed) {
 					emit_signal(SNAME("button_pressed"), p_action_name);
 				} else {
@@ -212,12 +209,12 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 				// TODO discuss whether we also want to create and emit an InputEventXRButton event
 			} break;
 			case Variant::FLOAT: {
-				emit_signal(SNAME("input_float_changed"), p_action_name, p_value);
+				emit_signal(SNAME("input_float_changed"), p_action_name, inputs[p_action_name], p_value);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRValue event
 			} break;
 			case Variant::VECTOR2: {
-				emit_signal(SNAME("input_vector2_changed"), p_action_name, p_value);
+				emit_signal(SNAME("input_vector2_changed"), p_action_name, inputs[p_action_name], p_value);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRAxis event
 			} break;
@@ -225,6 +222,9 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 				// ???
 			} break;
 		}
+
+		// store the new value
+		inputs[p_action_name] = p_value;
 	}
 }
 


### PR DESCRIPTION
The code knows the previous value and its very common that code which cares about input values changing needs to know the previous value.

This avoids higher level code caching the value

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9206*