### PR TITLE
GDScript: Fix paths in `ResourceFormatLoaderGDScript::load()`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2818,11 +2818,11 @@ Ref<GDScript> GDScriptLanguage::get_script_by_fully_qualified_name(const String 
 Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Error err;
 	bool ignoring = p_cache_mode == CACHE_MODE_IGNORE || p_cache_mode == CACHE_MODE_IGNORE_DEEP;
-	Ref<GDScript> scr = GDScriptCache::get_full_script(p_path, err, "", ignoring);
+	Ref<GDScript> scr = GDScriptCache::get_full_script(p_original_path, err, "", ignoring);
 
 	if (err && scr.is_valid()) {
 		// If !scr.is_valid(), the error was likely from scr->load_source_code(), which already generates an error.
-		ERR_PRINT_ED(vformat(R"(Failed to load script "%s" with error "%s".)", p_path, error_names[err]));
+		ERR_PRINT_ED(vformat(R"(Failed to load script "%s" with error "%s".)", p_original_path, error_names[err]));
 	}
 
 	if (r_error) {


### PR DESCRIPTION
* Continuation of #88365.
* Continuation of #88853.
* Fixes #88796.

Resource, FQCN and `GDScriptCache` use canonical paths. I'm not sure if we fixed all the regressions, but I tried to check as much as possible. At least the bug described in the linked comment is not reproduced.