### PR TITLE
[.NET] Fix interpolated strings in ScriptPropertyDefVal

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedComplexStrings.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedComplexStrings.cs
@@ -1,0 +1,26 @@
+using Godot;
+
+namespace Godot.SourceGenerators.Sample
+{
+    public partial class ExportedComplexStrings : Node
+    {
+        [Export]
+        private string _fieldInterpolated1 = $"The quick brown fox jumps over ({Engine.GetVersionInfo()})";
+
+        [Export]
+        private string _fieldInterpolated2 = $"The quick brown fox jumps over ({Engine.GetVersionInfo()["major"],0:G}) the lazy dog.";
+
+        [Export]
+        private string _fieldInterpolated3 = $"{((int)Engine.GetVersionInfo()["major"]) * -1 * -1:G} the lazy dog.";
+
+        [Export]
+        private string _fieldInterpolated4 = $"{":::fff,,}<,<}},,}]"}";
+
+        [Export]
+        public string PropertyInterpolated1
+        {
+            get;
+            private set;
+        } = $"The quick brown fox jumps over {GD.VarToStr($"the lazy {Engine.GetVersionInfo()} do")}g.";
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertyDefValGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertyDefValGeneratorTests.cs
@@ -21,4 +21,13 @@ public class ScriptPropertyDefValGeneratorTests
             "ExportedProperties_ScriptPropertyDefVal.generated.cs"
         );
     }
+
+    [Fact]
+    public async void ExportedComplexStrings()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
+            "ExportedComplexStrings.cs",
+            "ExportedComplexStrings_ScriptPropertyDefVal.generated.cs"
+        );
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedComplexStrings_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedComplexStrings_ScriptPropertyDefVal.generated.cs
@@ -1,0 +1,29 @@
+partial class ExportedComplexStrings
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+#if TOOLS
+    /// <summary>
+    /// Get the default values for all properties declared in this class.
+    /// This method is used by Godot to determine the value that will be
+    /// used by the inspector when resetting properties.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
+    {
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(5);
+        string __PropertyInterpolated1_default_value = $"The quick brown fox jumps over {(global::Godot.GD.VarToStr($"the lazy {(global::Godot.Engine.GetVersionInfo())} do"))}g.";
+        values.Add(PropertyName.PropertyInterpolated1, global::Godot.Variant.From<string>(__PropertyInterpolated1_default_value));
+        string ___fieldInterpolated1_default_value = $"The quick brown fox jumps over ({(global::Godot.Engine.GetVersionInfo())})";
+        values.Add(PropertyName._fieldInterpolated1, global::Godot.Variant.From<string>(___fieldInterpolated1_default_value));
+        string ___fieldInterpolated2_default_value = $"The quick brown fox jumps over ({(global::Godot.Engine.GetVersionInfo()["major"]),0:G}) the lazy dog.";
+        values.Add(PropertyName._fieldInterpolated2, global::Godot.Variant.From<string>(___fieldInterpolated2_default_value));
+        string ___fieldInterpolated3_default_value = $"{(((int)global::Godot.Engine.GetVersionInfo()["major"])  * -1    * -1):G} the lazy dog.";
+        values.Add(PropertyName._fieldInterpolated3, global::Godot.Variant.From<string>(___fieldInterpolated3_default_value));
+        string ___fieldInterpolated4_default_value = $"{(":::fff,,}<,<}},,}]")}";
+        values.Add(PropertyName._fieldInterpolated4, global::Godot.Variant.From<string>(___fieldInterpolated4_default_value));
+        return values;
+    }
+#endif // TOOLS
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedComplexStrings.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedComplexStrings.cs
@@ -1,0 +1,23 @@
+using Godot;
+
+public partial class ExportedComplexStrings : Node
+{
+    [Export]
+    private string _fieldInterpolated1 = $"The quick brown fox jumps over ({Engine.GetVersionInfo()})";
+
+    [Export]
+    private string _fieldInterpolated2 = $"The quick brown fox jumps over ({Engine.GetVersionInfo()["major"],0:G}) the lazy dog.";
+
+    [Export]
+    private string _fieldInterpolated3 = $"{((int)Engine.GetVersionInfo()["major"]) * -1 * -1:G} the lazy dog.";
+
+    [Export]
+    private string _fieldInterpolated4 = $"{":::fff,,}<,<}},,}]"}";
+
+    [Export]
+    public string PropertyInterpolated1
+    {
+        get;
+        private set;
+    } = $"The quick brown fox jumps over {GD.VarToStr($"the lazy {Engine.GetVersionInfo()} do")}g.";
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -208,7 +208,17 @@ namespace Godot.SourceGenerators
 
                 if (child.IsNode)
                 {
-                    FullQualifiedSyntax(child.AsNode()!, sm, sb, isFirstNode: innerIsFirstNode);
+                    var childNode = child.AsNode()!;
+
+                    if (node is InterpolationSyntax && childNode is ExpressionSyntax)
+                    {
+                        ParenEnclosedFullQualifiedSyntax(childNode, sm, sb, isFirstNode: innerIsFirstNode);
+                    }
+                    else
+                    {
+                        FullQualifiedSyntax(childNode, sm, sb, isFirstNode: innerIsFirstNode);
+                    }
+
                     innerIsFirstNode = false;
                 }
                 else
@@ -220,6 +230,13 @@ namespace Godot.SourceGenerators
                 {
                     sb.Append(child.GetTrailingTrivia());
                 }
+            }
+
+            static void ParenEnclosedFullQualifiedSyntax(SyntaxNode node, SemanticModel sm, StringBuilder sb, bool isFirstNode)
+            {
+                sb.Append(SyntaxFactory.Token(SyntaxKind.OpenParenToken));
+                FullQualifiedSyntax(node, sm, sb, isFirstNode);
+                sb.Append(SyntaxFactory.Token(SyntaxKind.CloseParenToken));
             }
         }
 


### PR DESCRIPTION
- Inject `OpenParenToken` and `CloseParenToken` around all `ExpressionSyntax` that are children of `InterpolationSyntax` in our `FullQualifiedSyntax` function
- Added some unit tests
- Fixes #88982
