### PR TITLE
Fix NavigationObstacle3D debug not reacting to visibility changes

### DIFF
--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -132,6 +132,19 @@ void NavigationObstacle3D::_notification(int p_what) {
 			NavigationServer3D::get_singleton()->obstacle_set_paused(obstacle, !can_process());
 		} break;
 
+#ifdef DEBUG_ENABLED
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_inside_tree()) {
+				if (fake_agent_radius_debug_instance.is_valid()) {
+					RS::get_singleton()->instance_set_visible(fake_agent_radius_debug_instance, is_visible_in_tree());
+				}
+				if (static_obstacle_debug_instance.is_valid()) {
+					RS::get_singleton()->instance_set_visible(static_obstacle_debug_instance, is_visible_in_tree());
+				}
+			}
+		} break;
+#endif // DEBUG_ENABLED
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (is_inside_tree()) {
 				_update_position(get_global_transform().origin);


### PR DESCRIPTION
Fixes NavigationObstacle3D debug not reacting to visiblity changes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
