### PR TITLE
Allow docks to be closed and opened

### DIFF
--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -62,6 +62,7 @@ class EditorDockManager : public Object {
 
 public:
 	enum DockSlot {
+		DOCK_SLOT_NONE = -1,
 		DOCK_SLOT_LEFT_UL,
 		DOCK_SLOT_LEFT_BL,
 		DOCK_SLOT_LEFT_UR,
@@ -84,7 +85,7 @@ private:
 		int previous_tab_index = -1;
 		bool previous_at_bottom = false;
 		WindowWrapper *dock_window = nullptr;
-		int dock_slot_index = DOCK_SLOT_LEFT_UL;
+		int dock_slot_index = DOCK_SLOT_NONE;
 		Ref<Shortcut> shortcut;
 	};
 
@@ -100,6 +101,8 @@ private:
 	bool docks_visible = true;
 
 	DockContextPopup *dock_context_popup = nullptr;
+	PopupMenu *docks_menu = nullptr;
+	Vector<Control *> docks_menu_docks;
 	Control *closed_dock_parent = nullptr;
 
 	void _dock_split_dragged(int p_offset);
@@ -108,9 +111,12 @@ private:
 	void _dock_container_update_visibility(TabContainer *p_dock_container);
 	void _update_layout();
 
+	void _update_docks_menu();
+	void _docks_menu_option(int p_id);
+
 	void _window_close_request(WindowWrapper *p_wrapper);
 	Control *_close_window(WindowWrapper *p_wrapper);
-	void _open_dock_in_window(Control *p_dock, bool p_show_window = true);
+	void _open_dock_in_window(Control *p_dock, bool p_show_window = true, bool p_reset_size = false);
 	void _restore_dock_to_saved_window(Control *p_dock, const Dictionary &p_window_dump);
 
 	void _dock_move_to_bottom(Control *p_dock);
@@ -127,6 +133,7 @@ public:
 	void add_hsplit(DockSplitContainer *p_split);
 	void register_dock_slot(DockSlot p_dock_slot, TabContainer *p_tab_container);
 	int get_vsplit_count() const;
+	PopupMenu *get_docks_menu();
 
 	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
 	void load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section);
@@ -143,8 +150,8 @@ public:
 	void set_docks_visible(bool p_show);
 	bool are_docks_visible() const;
 
-	void add_control_to_dock(DockSlot p_slot, Control *p_dock, const String &p_title = "", const Ref<Shortcut> &p_shortcut = nullptr);
-	void remove_control_from_dock(Control *p_dock);
+	void add_dock(Control *p_dock, const String &p_title = "", DockSlot p_slot = DOCK_SLOT_NONE, const Ref<Shortcut> &p_shortcut = nullptr);
+	void remove_dock(Control *p_dock);
 
 	EditorDockManager();
 };
@@ -157,6 +164,7 @@ class DockContextPopup : public PopupPanel {
 	Button *make_float_button = nullptr;
 	Button *tab_move_left_button = nullptr;
 	Button *tab_move_right_button = nullptr;
+	Button *close_button = nullptr;
 	Button *dock_to_bottom_button = nullptr;
 
 	Control *dock_select = nullptr;
@@ -169,6 +177,7 @@ class DockContextPopup : public PopupPanel {
 
 	void _tab_move_left();
 	void _tab_move_right();
+	void _close_dock();
 	void _float_dock();
 	void _move_dock_to_bottom();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6829,6 +6829,8 @@ EditorNode::EditorNode() {
 	settings_menu->add_shortcut(ED_SHORTCUT("editor/command_palette", TTR("Command Palette..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::P), HELP_COMMAND_PALETTE);
 	settings_menu->add_separator();
 
+	settings_menu->add_submenu_node_item(TTR("Editor Docks"), editor_dock_manager->get_docks_menu());
+
 	editor_layouts = memnew(PopupMenu);
 	editor_layouts->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	settings_menu->add_submenu_node_item(TTR("Editor Layout"), editor_layouts);
@@ -6998,22 +7000,22 @@ EditorNode::EditorNode() {
 	history_dock = memnew(HistoryDock);
 
 	// Scene: Top left.
-	editor_dock_manager->add_control_to_dock(EditorDockManager::DOCK_SLOT_LEFT_UR, SceneTreeDock::get_singleton(), TTR("Scene"));
+	editor_dock_manager->add_dock(SceneTreeDock::get_singleton(), TTR("Scene"), EditorDockManager::DOCK_SLOT_LEFT_UR);
 
 	// Import: Top left, behind Scene.
-	editor_dock_manager->add_control_to_dock(EditorDockManager::DOCK_SLOT_LEFT_UR, ImportDock::get_singleton(), TTR("Import"));
+	editor_dock_manager->add_dock(ImportDock::get_singleton(), TTR("Import"), EditorDockManager::DOCK_SLOT_LEFT_UR);
 
 	// FileSystem: Bottom left.
-	editor_dock_manager->add_control_to_dock(EditorDockManager::DOCK_SLOT_LEFT_BR, FileSystemDock::get_singleton(), TTR("FileSystem"), ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_filesystem_bottom_panel", TTR("Toggle FileSystem Bottom Panel"), KeyModifierMask::ALT | Key::F));
+	editor_dock_manager->add_dock(FileSystemDock::get_singleton(), TTR("FileSystem"), EditorDockManager::DOCK_SLOT_LEFT_BR, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_filesystem_bottom_panel", TTR("Toggle FileSystem Bottom Panel"), KeyModifierMask::ALT | Key::F));
 
 	// Inspector: Full height right.
-	editor_dock_manager->add_control_to_dock(EditorDockManager::DOCK_SLOT_RIGHT_UL, InspectorDock::get_singleton(), TTR("Inspector"));
+	editor_dock_manager->add_dock(InspectorDock::get_singleton(), TTR("Inspector"), EditorDockManager::DOCK_SLOT_RIGHT_UL);
 
 	// Node: Full height right, behind Inspector.
-	editor_dock_manager->add_control_to_dock(EditorDockManager::DOCK_SLOT_RIGHT_UL, NodeDock::get_singleton(), TTR("Node"));
+	editor_dock_manager->add_dock(NodeDock::get_singleton(), TTR("Node"), EditorDockManager::DOCK_SLOT_RIGHT_UL);
 
 	// History: Full height right, behind Node.
-	editor_dock_manager->add_control_to_dock(EditorDockManager::DOCK_SLOT_RIGHT_UL, history_dock, TTR("History"));
+	editor_dock_manager->add_dock(history_dock, TTR("History"), EditorDockManager::DOCK_SLOT_RIGHT_UL);
 
 	// Add some offsets to left_r and main hsplits to make LEFT_R and RIGHT_L docks wider than minsize.
 	left_r_hsplit->set_split_offset(270 * EDSCALE);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -87,12 +87,12 @@ Button *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const Stri
 
 void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_NULL(p_control);
-	EditorDockManager::get_singleton()->add_control_to_dock(EditorDockManager::DockSlot(p_slot), p_control, String(), p_shortcut);
+	EditorDockManager::get_singleton()->add_dock(p_control, String(), EditorDockManager::DockSlot(p_slot), p_shortcut);
 }
 
 void EditorPlugin::remove_control_from_docks(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
-	EditorDockManager::get_singleton()->remove_control_from_dock(p_control);
+	EditorDockManager::get_singleton()->remove_dock(p_control);
 }
 
 void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -911,7 +911,7 @@ void VersionControlEditorPlugin::fetch_available_vcs_plugin_names() {
 }
 
 void VersionControlEditorPlugin::register_editor() {
-	EditorDockManager::get_singleton()->add_control_to_dock(EditorDockManager::DOCK_SLOT_RIGHT_UL, version_commit_dock);
+	EditorDockManager::get_singleton()->add_dock(version_commit_dock, "", EditorDockManager::DOCK_SLOT_RIGHT_UL);
 
 	version_control_dock_button = EditorNode::get_bottom_panel()->add_item(TTR("Version Control"), version_control_dock, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_version_control_bottom_panel", TTR("Toggle Version Control Bottom Panel")));
 
@@ -931,7 +931,7 @@ void VersionControlEditorPlugin::shut_down() {
 	memdelete(EditorVCSInterface::get_singleton());
 	EditorVCSInterface::set_singleton(nullptr);
 
-	EditorDockManager::get_singleton()->remove_control_from_dock(version_commit_dock);
+	EditorDockManager::get_singleton()->remove_dock(version_commit_dock);
 	EditorNode::get_bottom_panel()->remove_item(version_control_dock);
 
 	_set_vcs_ui_state(false);


### PR DESCRIPTION
- requires https://github.com/godotengine/godot/pull/88003
- closes https://github.com/godotengine/godot-proposals/issues/8206
- related https://github.com/godotengine/godot-proposals/issues/1441
- related https://github.com/godotengine/godot-proposals/issues/7233

Docks can be closed through their context menu, and reopened through the new `Window` menu.
If a dock is already open, clicking on it in the `Window` menu will focus on it.
Dock layouts can be saved with closed tabs. This helps with some of the use cases in https://github.com/godotengine/godot-proposals/issues/1441.

Added dock slot `DOCK_SLOT_NONE`. Using this with `add_control_to_dock` allows the dock to not be opened immediately, it will be closed by default. When it is opened from the `Window` menu, it will appear floating.

Internally, renamed `add_control_to_dock` to `add_dock` and `remove_control_from_dock` to `remove_dock`. This is because I want to unify the language used better, the Control that is being added and removed *is* the dock, and it is added to a dock slot/dock container. However, I didn't change it in the editor plugin since it would break compat. I want to add it as the new names in EditorInterface in a future PR.

Closed docks aren't unloaded, they are just removed from any TabContainers and hidden.

After https://github.com/godotengine/godot/pull/88081, shortcuts can be added to open docks.

![image](https://github.com/godotengine/godot/assets/10054226/44b3215e-9bcd-4563-954e-d24b8415a8b7)

![image](https://github.com/godotengine/godot/assets/10054226/cdf640c0-d435-47cc-91db-372ad495ed36)

Updated (import closed, history disabled):

![image](https://github.com/godotengine/godot/assets/10054226/fdb58c67-d8e3-4f8e-b30b-01a9892039c2)

