### PR TITLE
[RTL] Add optional `push_meta` argument to control how meta underline is drawn.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -428,8 +428,10 @@
 		<method name="push_meta">
 			<return type="void" />
 			<param index="0" name="data" type="Variant" />
+			<param index="1" name="underline_mode" type="int" enum="RichTextLabel.MetaUnderline" default="1" />
 			<description>
 				Adds a meta tag to the tag stack. Similar to the BBCode [code skip-lint][url=something]{text}[/url][/code], but supports non-[String] metadata types.
+				If [member meta_underlined] is [code]true[/code], meta tags display an underline. This behavior can be customized with [param underline_mode].
 				[b]Note:[/b] Meta tags do nothing by default when clicked. To assign behavior when clicked, connect [signal meta_clicked] to a function that is called when the meta tag is clicked.
 			</description>
 		</method>
@@ -722,6 +724,15 @@
 		</constant>
 		<constant name="MENU_MAX" value="2" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
+		</constant>
+		<constant name="META_UNDERLINE_NEVER" value="0" enum="MetaUnderline">
+			Meta tag does not display an underline, even if [member meta_underlined] is [code]true[/code].
+		</constant>
+		<constant name="META_UNDERLINE_ALWAYS" value="1" enum="MetaUnderline">
+			If [member meta_underlined] is [code]true[/code], meta tag always display an underline.
+		</constant>
+		<constant name="META_UNDERLINE_ON_HOVER" value="2" enum="MetaUnderline">
+			If [member meta_underlined] is [code]true[/code], meta tag display an underline when the mouse cursor is over it.
 		</constant>
 		<constant name="UPDATE_TEXTURE" value="1" enum="ImageUpdateMask" is_bitfield="true">
 			If this bit is set, [method update_image] changes image texture.

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -224,3 +224,10 @@ Validate extension JSON: JSON file: Field was added in a way that breaks compati
 Added a return value for add_bone.
 Should not affect existing regular use - the return value would just be unused.
 Compatibility method registered.
+
+
+GH-89024
+--------
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_meta/arguments': size changed value in new API, from 1 to 2.
+
+Added optional argument. Compatibility method registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -30,11 +30,16 @@
 
 #ifndef DISABLE_DEPRECATED
 
+void RichTextLabel::_push_meta_bind_compat_89024(const Variant &p_meta) {
+	push_meta(p_meta, RichTextLabel::MetaUnderline::META_UNDERLINE_ALWAYS);
+}
+
 void RichTextLabel::_add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region) {
 	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, Variant(), false, String(), false);
 }
 
 void RichTextLabel::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data"), &RichTextLabel::_push_meta_bind_compat_89024);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::_add_image_bind_compat_80410, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()));
 }
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -51,6 +51,12 @@ public:
 		LIST_DOTS
 	};
 
+	enum MetaUnderline {
+		META_UNDERLINE_NEVER,
+		META_UNDERLINE_ALWAYS,
+		META_UNDERLINE_ON_HOVER,
+	};
+
 	enum ItemType {
 		ITEM_FRAME,
 		ITEM_TEXT,
@@ -117,6 +123,7 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
+	void _push_meta_bind_compat_89024(const Variant &p_meta);
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
 	static void _bind_compatibility_methods();
 #endif
@@ -271,6 +278,7 @@ private:
 
 	struct ItemMeta : public Item {
 		Variant meta;
+		MetaUnderline underline = META_UNDERLINE_ALWAYS;
 		ItemMeta() { type = ITEM_META; }
 	};
 
@@ -668,7 +676,7 @@ public:
 	void push_paragraph(HorizontalAlignment p_alignment, Control::TextDirection p_direction = Control::TEXT_DIRECTION_INHERITED, const String &p_language = "", TextServer::StructuredTextParser p_st_parser = TextServer::STRUCTURED_TEXT_DEFAULT, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE, const PackedFloat32Array &p_tab_stops = PackedFloat32Array());
 	void push_indent(int p_level);
 	void push_list(int p_level, ListType p_list, bool p_capitalize, const String &p_bullet = String::utf8("•"));
-	void push_meta(const Variant &p_meta);
+	void push_meta(const Variant &p_meta, MetaUnderline p_underline_mode = META_UNDERLINE_ALWAYS);
 	void push_hint(const String &p_string);
 	void push_table(int p_columns, InlineAlignment p_alignment = INLINE_ALIGNMENT_TOP, int p_align_to_row = -1);
 	void push_fade(int p_start_index, int p_length);
@@ -824,6 +832,7 @@ public:
 
 VARIANT_ENUM_CAST(RichTextLabel::ListType);
 VARIANT_ENUM_CAST(RichTextLabel::MenuItems);
+VARIANT_ENUM_CAST(RichTextLabel::MetaUnderline);
 VARIANT_BITFIELD_CAST(RichTextLabel::ImageUpdateMask);
 
 #endif // RICH_TEXT_LABEL_H


### PR DESCRIPTION
- Adds option to hide underline or show it on hover for individual meta tags.

Supersede https://github.com/godotengine/godot/pull/89000
