### PR TITLE
Add NavigationObstacle options to affect navigation mesh baking

### DIFF
--- a/doc/classes/NavigationMeshSourceGeometryData2D.xml
+++ b/doc/classes/NavigationMeshSourceGeometryData2D.xml
@@ -16,6 +16,14 @@
 				Adds the outline points of a shape as obstructed area.
 			</description>
 		</method>
+		<method name="add_projected_obstruction">
+			<return type="void" />
+			<param index="0" name="vertices" type="PackedVector2Array" />
+			<param index="1" name="carve" type="bool" />
+			<description>
+				Adds a projected obstruction shape to the source geometry. If [param carve] is [code]true[/code] the carved shape will not be affected by additional offsets (e.g. agent radius) of the navigation mesh baking process.
+			</description>
+		</method>
 		<method name="add_traversable_outline">
 			<return type="void" />
 			<param index="0" name="shape_outline" type="PackedVector2Array" />
@@ -29,10 +37,24 @@
 				Clears the internal data.
 			</description>
 		</method>
+		<method name="clear_projected_obstructions">
+			<return type="void" />
+			<description>
+				Clears all projected obstructions.
+			</description>
+		</method>
 		<method name="get_obstruction_outlines" qualifiers="const">
 			<return type="PackedVector2Array[]" />
 			<description>
 				Returns all the obstructed area outlines arrays.
+			</description>
+		</method>
+		<method name="get_projected_obstructions" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns the projected obstructions as an [Array] of dictionaries. Each [Dictionary] contains the following entries:
+				- [code]vertices[/code] - A [PackedFloat32Array] that defines the outline points of the projected shape.
+				- [code]carve[/code] - A [bool] that defines how the projected shape affects the navigation mesh baking. If [code]true[/code] the projected shape will not be affected by addition offsets, e.g. agent radius.
 			</description>
 		</method>
 		<method name="get_traversable_outlines" qualifiers="const">
@@ -59,6 +81,19 @@
 			<param index="0" name="obstruction_outlines" type="PackedVector2Array[]" />
 			<description>
 				Sets all the obstructed area outlines arrays.
+			</description>
+		</method>
+		<method name="set_projected_obstructions">
+			<return type="void" />
+			<param index="0" name="projected_obstructions" type="Array" />
+			<description>
+				Sets the projected obstructions with an Array of Dictionaries with the following key value pairs:
+				[codeblocks]
+				[gdscript]
+				"vertices" : PackedFloat32Array
+				"carve" : bool
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="set_traversable_outlines">

--- a/doc/classes/NavigationMeshSourceGeometryData3D.xml
+++ b/doc/classes/NavigationMeshSourceGeometryData3D.xml
@@ -33,16 +33,42 @@
 				Adds an [Array] the size of [constant Mesh.ARRAY_MAX] and with vertices at index [constant Mesh.ARRAY_VERTEX] and indices at index [constant Mesh.ARRAY_INDEX] to the navigation mesh baking data. The array must have valid triangulated mesh data to be considered. Since [NavigationMesh] resources have no transform, all vertex positions need to be offset by the node's transform using [param xform].
 			</description>
 		</method>
+		<method name="add_projected_obstruction">
+			<return type="void" />
+			<param index="0" name="vertices" type="PackedVector3Array" />
+			<param index="1" name="elevation" type="float" />
+			<param index="2" name="height" type="float" />
+			<param index="3" name="carve" type="bool" />
+			<description>
+				Adds a projected obstruction shape to the source geometry. The [param vertices] are considered projected on a xz-axes plane, placed at the global y-axis [param elevation] and extruded by [param height]. If [param carve] is [code]true[/code] the carved shape will not be affected by additional offsets (e.g. agent radius) of the navigation mesh baking process.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
 				Clears the internal data.
 			</description>
 		</method>
+		<method name="clear_projected_obstructions">
+			<return type="void" />
+			<description>
+				Clears all projected obstructions.
+			</description>
+		</method>
 		<method name="get_indices" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<description>
 				Returns the parsed source geometry data indices array.
+			</description>
+		</method>
+		<method name="get_projected_obstructions" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns the projected obstructions as an [Array] of dictionaries. Each [Dictionary] contains the following entries:
+				- [code]vertices[/code] - A [PackedFloat32Array] that defines the outline points of the projected shape.
+				- [code]elevation[/code] - A [float] that defines the projected shape placement on the y-axis.
+				- [code]height[/code] - A [float] that defines how much the projected shape is extruded along the y-axis.
+				- [code]carve[/code] - A [bool] that defines how the obstacle affects the navigation mesh baking. If [code]true[/code] the projected shape will not be affected by addition offsets, e.g. agent radius.
 			</description>
 		</method>
 		<method name="get_vertices" qualifiers="const">
@@ -70,6 +96,21 @@
 			<description>
 				Sets the parsed source geometry data indices. The indices need to be matched with appropriated vertices.
 				[b]Warning:[/b] Inappropriate data can crash the baking process of the involved third-party libraries.
+			</description>
+		</method>
+		<method name="set_projected_obstructions">
+			<return type="void" />
+			<param index="0" name="projected_obstructions" type="Array" />
+			<description>
+				Sets the projected obstructions with an Array of Dictionaries with the following key value pairs:
+				[codeblocks]
+				[gdscript]
+				"vertices" : PackedFloat32Array
+				"elevation" : float
+				"height" : float
+				"carve" : bool
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="set_vertices">

--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NavigationObstacle2D" inherits="Node2D" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		2D Obstacle used in navigation to constrain avoidance controlled agents outside or inside an area.
+		2D obstacle used to affect navigation mesh baking or constrain velocities of avoidance controlled agents.
 	</brief_description>
 	<description>
-		2D Obstacle used in navigation to constrain avoidance controlled agents outside or inside an area. The obstacle needs a navigation map and outline vertices defined to work correctly.
-		If the obstacle's vertices are winded in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Outlines must not cross or overlap.
-		Obstacles are [b]not[/b] a replacement for a (re)baked navigation mesh. Obstacles [b]don't[/b] change the resulting path from the pathfinding, obstacles only affect the navigation avoidance agent movement by altering the suggested velocity of the avoidance agent.
-		Obstacles using vertices can warp to a new position but should not moved every frame as each move requires a rebuild of the avoidance map.
+		An obstacle needs a navigation map and outline [member vertices] defined to work correctly. The outlines can not cross or overlap.
+		Obstacles can be included in the navigation mesh baking process when [member affect_navigation_mesh] is enabled. They do not add walkable geometry, instead their role is to discard other source geometry inside the shape. This can be used to prevent navigation mesh from appearing in unwanted places. If [member carve_navigation_mesh] is enabled the baked shape will not be affected by offsets of the navigation mesh baking, e.g. the agent radius.
+		With [member avoidance_enabled] the obstacle can constrain the avoidance velocities of avoidance using agents. If the obstacle's vertices are wound in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Obstacles using vertices and avoidance can warp to a new position but should not be moved every single frame as each change requires a rebuild of the avoidance map.
 	</description>
 	<tutorials>
 		<link title="Using NavigationObstacles">$DOCS_URL/tutorials/navigation/navigation_using_navigationobstacles.html</link>
@@ -49,11 +48,19 @@
 		</method>
 	</methods>
 	<members>
+		<member name="affect_navigation_mesh" type="bool" setter="set_affect_navigation_mesh" getter="get_affect_navigation_mesh" default="false">
+			If enabled and parsed in a navigation mesh baking process the obstacle will discard source geometry inside its [member vertices] defined shape.
+		</member>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="true">
 			If [code]true[/code] the obstacle affects avoidance using agents.
 		</member>
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining the avoidance layers for this obstacle. Agents with a matching bit on the their avoidance mask will avoid this obstacle.
+		</member>
+		<member name="carve_navigation_mesh" type="bool" setter="set_carve_navigation_mesh" getter="get_carve_navigation_mesh" default="false">
+			If enabled the obstacle vertices will carve into the baked navigation mesh with the shape unaffected by additional offsets (e.g. agent radius).
+			It will still be affected by further postprocessing of the baking process, like edge and polygon simplification.
+			Requires [member affect_navigation_mesh] to be enabled.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.0">
 			Sets the avoidance radius for the obstacle.

--- a/doc/classes/NavigationObstacle3D.xml
+++ b/doc/classes/NavigationObstacle3D.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NavigationObstacle3D" inherits="Node3D" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		3D Obstacle used in navigation to constrain avoidance controlled agents outside or inside an area.
+		3D obstacle used to affect navigation mesh baking or constrain velocities of avoidance controlled agents.
 	</brief_description>
 	<description>
-		3D Obstacle used in navigation to constrain avoidance controlled agents outside or inside an area. The obstacle needs a navigation map and outline vertices defined to work correctly.
-		If the obstacle's vertices are winded in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Outlines must not cross or overlap.
-		Obstacles are [b]not[/b] a replacement for a (re)baked navigation mesh. Obstacles [b]don't[/b] change the resulting path from the pathfinding, obstacles only affect the navigation avoidance agent movement by altering the suggested velocity of the avoidance agent.
-		Obstacles using vertices can warp to a new position but should not moved every frame as each move requires a rebuild of the avoidance map.
+		An obstacle needs a navigation map and outline [member vertices] defined to work correctly. The outlines can not cross or overlap and are restricted to a plane projection. This means the y-axis of the vertices is ignored, instead the obstacle's global y-axis position is used for placement. The projected shape is extruded by the obstacles height along the y-axis.
+		Obstacles can be included in the navigation mesh baking process when [member affect_navigation_mesh] is enabled. They do not add walkable geometry, instead their role is to discard other source geometry inside the shape. This can be used to prevent navigation mesh from appearing in unwanted places, e.g. inside "solid" geometry or on top of it. If [member carve_navigation_mesh] is enabled the baked shape will not be affected by offsets of the navigation mesh baking, e.g. the agent radius.
+		With [member avoidance_enabled] the obstacle can constrain the avoidance velocities of avoidance using agents. If the obstacle's vertices are wound in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Obstacles using vertices and avoidance can warp to a new position but should not be moved every single frame as each change requires a rebuild of the avoidance map.
 	</description>
 	<tutorials>
 		<link title="Using NavigationObstacles">$DOCS_URL/tutorials/navigation/navigation_using_navigationobstacles.html</link>
@@ -49,11 +48,19 @@
 		</method>
 	</methods>
 	<members>
+		<member name="affect_navigation_mesh" type="bool" setter="set_affect_navigation_mesh" getter="get_affect_navigation_mesh" default="false">
+			If enabled and parsed in a navigation mesh baking process the obstacle will discard source geometry inside its [member vertices] and [member height] defined shape.
+		</member>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="true">
 			If [code]true[/code] the obstacle affects avoidance using agents.
 		</member>
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining the avoidance layers for this obstacle. Agents with a matching bit on the their avoidance mask will avoid this obstacle.
+		</member>
+		<member name="carve_navigation_mesh" type="bool" setter="set_carve_navigation_mesh" getter="get_carve_navigation_mesh" default="false">
+			If enabled the obstacle vertices will carve into the baked navigation mesh with the shape unaffected by additional offsets (e.g. agent radius).
+			It will still be affected by further postprocessing of the baking process, like edge and polygon simplification.
+			Requires [member affect_navigation_mesh] to be enabled.
 		</member>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
 			Sets the obstacle height used in 2D avoidance. 2D avoidance using agent's ignore obstacles that are below or above them.

--- a/modules/navigation/2d/nav_mesh_generator_2d.h
+++ b/modules/navigation/2d/nav_mesh_generator_2d.h
@@ -81,6 +81,7 @@ class NavMeshGenerator2D : public Object {
 	static void generator_parse_polygon2d_node(const Ref<NavigationPolygon> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_node);
 	static void generator_parse_staticbody2d_node(const Ref<NavigationPolygon> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_node);
 	static void generator_parse_tilemap_node(const Ref<NavigationPolygon> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_node);
+	static void generator_parse_navigationobstacle_node(const Ref<NavigationPolygon> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_node);
 
 	static bool generator_emit_callback(const Callable &p_callback);
 

--- a/modules/navigation/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation/3d/nav_mesh_generator_3d.h
@@ -86,6 +86,7 @@ class NavMeshGenerator3D : public Object {
 #ifdef MODULE_GRIDMAP_ENABLED
 	static void generator_parse_gridmap_node(const Ref<NavigationMesh> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_node);
 #endif // MODULE_GRIDMAP_ENABLED
+	static void generator_parse_navigationobstacle_node(const Ref<NavigationMesh> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_node);
 
 	static bool generator_emit_callback(const Callable &p_callback);
 

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -55,14 +55,24 @@ void NavigationObstacle2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_avoidance_layers", "layers"), &NavigationObstacle2D::set_avoidance_layers);
 	ClassDB::bind_method(D_METHOD("get_avoidance_layers"), &NavigationObstacle2D::get_avoidance_layers);
+
 	ClassDB::bind_method(D_METHOD("set_avoidance_layer_value", "layer_number", "value"), &NavigationObstacle2D::set_avoidance_layer_value);
 	ClassDB::bind_method(D_METHOD("get_avoidance_layer_value", "layer_number"), &NavigationObstacle2D::get_avoidance_layer_value);
 
+	ClassDB::bind_method(D_METHOD("set_affect_navigation_mesh", "enabled"), &NavigationObstacle2D::set_affect_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("get_affect_navigation_mesh"), &NavigationObstacle2D::get_affect_navigation_mesh);
+
+	ClassDB::bind_method(D_METHOD("set_carve_navigation_mesh", "enabled"), &NavigationObstacle2D::set_carve_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("get_carve_navigation_mesh"), &NavigationObstacle2D::get_carve_navigation_mesh);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.0,500,0.01,suffix:px"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "vertices"), "set_vertices", "get_vertices");
+	ADD_GROUP("NavigationMesh", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "affect_navigation_mesh"), "set_affect_navigation_mesh", "get_affect_navigation_mesh");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "carve_navigation_mesh"), "set_carve_navigation_mesh", "get_carve_navigation_mesh");
 	ADD_GROUP("Avoidance", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "avoidance_enabled"), "set_avoidance_enabled", "get_avoidance_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_velocity", "get_velocity");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.0,500,0.01,suffix:px"), "set_radius", "get_radius");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "vertices"), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "avoidance_layers", PROPERTY_HINT_LAYERS_AVOIDANCE), "set_avoidance_layers", "get_avoidance_layers");
 }
 
@@ -275,6 +285,22 @@ bool NavigationObstacle2D::get_avoidance_enabled() const {
 void NavigationObstacle2D::set_velocity(const Vector2 p_velocity) {
 	velocity = p_velocity;
 	velocity_submitted = true;
+}
+
+void NavigationObstacle2D::set_affect_navigation_mesh(bool p_enabled) {
+	affect_navigation_mesh = p_enabled;
+}
+
+bool NavigationObstacle2D::get_affect_navigation_mesh() const {
+	return affect_navigation_mesh;
+}
+
+void NavigationObstacle2D::set_carve_navigation_mesh(bool p_enabled) {
+	carve_navigation_mesh = p_enabled;
+}
+
+bool NavigationObstacle2D::get_carve_navigation_mesh() const {
+	return carve_navigation_mesh;
 }
 
 void NavigationObstacle2D::_update_map(RID p_map) {

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -54,6 +54,9 @@ class NavigationObstacle2D : public Node2D {
 	Vector2 previous_velocity;
 	bool velocity_submitted = false;
 
+	bool affect_navigation_mesh = false;
+	bool carve_navigation_mesh = false;
+
 #ifdef DEBUG_ENABLED
 private:
 	RID debug_canvas_item;
@@ -96,6 +99,12 @@ public:
 	Vector2 get_velocity() const { return velocity; };
 
 	void _avoidance_done(Vector3 p_new_velocity); // Dummy
+
+	void set_affect_navigation_mesh(bool p_enabled);
+	bool get_affect_navigation_mesh() const;
+
+	void set_carve_navigation_mesh(bool p_enabled);
+	bool get_carve_navigation_mesh() const;
 
 private:
 	void _update_map(RID p_map);

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -63,12 +63,21 @@ void NavigationObstacle3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_3d_avoidance", "enabled"), &NavigationObstacle3D::set_use_3d_avoidance);
 	ClassDB::bind_method(D_METHOD("get_use_3d_avoidance"), &NavigationObstacle3D::get_use_3d_avoidance);
 
-	ADD_GROUP("Avoidance", "");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "avoidance_enabled"), "set_avoidance_enabled", "get_avoidance_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "velocity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_velocity", "get_velocity");
+	ClassDB::bind_method(D_METHOD("set_affect_navigation_mesh", "enabled"), &NavigationObstacle3D::set_affect_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("get_affect_navigation_mesh"), &NavigationObstacle3D::get_affect_navigation_mesh);
+
+	ClassDB::bind_method(D_METHOD("set_carve_navigation_mesh", "enabled"), &NavigationObstacle3D::set_carve_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("get_carve_navigation_mesh"), &NavigationObstacle3D::get_carve_navigation_mesh);
+
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.0,100,0.01,suffix:m"), "set_radius", "get_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.0,100,0.01,suffix:m"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices"), "set_vertices", "get_vertices");
+	ADD_GROUP("NavigationMesh", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "affect_navigation_mesh"), "set_affect_navigation_mesh", "get_affect_navigation_mesh");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "carve_navigation_mesh"), "set_carve_navigation_mesh", "get_carve_navigation_mesh");
+	ADD_GROUP("Avoidance", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "avoidance_enabled"), "set_avoidance_enabled", "get_avoidance_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "velocity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_velocity", "get_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "avoidance_layers", PROPERTY_HINT_LAYERS_AVOIDANCE), "set_avoidance_layers", "get_avoidance_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_3d_avoidance"), "set_use_3d_avoidance", "get_use_3d_avoidance");
 }
@@ -319,6 +328,22 @@ void NavigationObstacle3D::set_use_3d_avoidance(bool p_use_3d_avoidance) {
 void NavigationObstacle3D::set_velocity(const Vector3 p_velocity) {
 	velocity = p_velocity;
 	velocity_submitted = true;
+}
+
+void NavigationObstacle3D::set_affect_navigation_mesh(bool p_enabled) {
+	affect_navigation_mesh = p_enabled;
+}
+
+bool NavigationObstacle3D::get_affect_navigation_mesh() const {
+	return affect_navigation_mesh;
+}
+
+void NavigationObstacle3D::set_carve_navigation_mesh(bool p_enabled) {
+	carve_navigation_mesh = p_enabled;
+}
+
+bool NavigationObstacle3D::get_carve_navigation_mesh() const {
+	return carve_navigation_mesh;
 }
 
 void NavigationObstacle3D::_update_map(RID p_map) {

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -57,6 +57,9 @@ class NavigationObstacle3D : public Node3D {
 	Vector3 previous_velocity;
 	bool velocity_submitted = false;
 
+	bool affect_navigation_mesh = false;
+	bool carve_navigation_mesh = false;
+
 #ifdef DEBUG_ENABLED
 	RID fake_agent_radius_debug_instance;
 	Ref<ArrayMesh> fake_agent_radius_debug_mesh;
@@ -107,6 +110,12 @@ public:
 	Vector3 get_velocity() const { return velocity; };
 
 	void _avoidance_done(Vector3 p_new_velocity); // Dummy
+
+	void set_affect_navigation_mesh(bool p_enabled);
+	bool get_affect_navigation_mesh() const;
+
+	void set_carve_navigation_mesh(bool p_enabled);
+	bool get_carve_navigation_mesh() const;
 
 private:
 	void _update_map(RID p_map);

--- a/scene/resources/navigation_mesh_source_geometry_data_2d.h
+++ b/scene/resources/navigation_mesh_source_geometry_data_2d.h
@@ -31,19 +31,36 @@
 #ifndef NAVIGATION_MESH_SOURCE_GEOMETRY_DATA_2D_H
 #define NAVIGATION_MESH_SOURCE_GEOMETRY_DATA_2D_H
 
+#include "core/os/rw_lock.h"
 #include "scene/2d/node_2d.h"
 #include "scene/resources/navigation_polygon.h"
 
 class NavigationMeshSourceGeometryData2D : public Resource {
 	GDCLASS(NavigationMeshSourceGeometryData2D, Resource);
+	RWLock geometry_rwlock;
 
 	Vector<Vector<Vector2>> traversable_outlines;
 	Vector<Vector<Vector2>> obstruction_outlines;
 
+public:
+	struct ProjectedObstruction;
+
+private:
+	Vector<ProjectedObstruction> _projected_obstructions;
+
 protected:
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
 	static void _bind_methods();
 
 public:
+	struct ProjectedObstruction {
+		static inline uint32_t VERSION = 1; // Increase when format changes so we can detect outdated formats and provide compatibility.
+
+		Vector<float> vertices;
+		bool carve = false;
+	};
+
 	void _set_traversable_outlines(const Vector<Vector<Vector2>> &p_traversable_outlines);
 	const Vector<Vector<Vector2>> &_get_traversable_outlines() const { return traversable_outlines; }
 
@@ -70,6 +87,13 @@ public:
 
 	bool has_data() { return traversable_outlines.size(); };
 	void clear();
+	void clear_projected_obstructions();
+
+	void add_projected_obstruction(const Vector<Vector2> &p_vertices, bool p_carve);
+	Vector<ProjectedObstruction> _get_projected_obstructions() const;
+
+	void set_projected_obstructions(const Array &p_array);
+	Array get_projected_obstructions() const;
 
 	void merge(const Ref<NavigationMeshSourceGeometryData2D> &p_other_geometry);
 

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
@@ -41,6 +41,12 @@ void NavigationMeshSourceGeometryData3D::set_indices(const Vector<int> &p_indice
 void NavigationMeshSourceGeometryData3D::clear() {
 	vertices.clear();
 	indices.clear();
+	clear_projected_obstructions();
+}
+
+void NavigationMeshSourceGeometryData3D::clear_projected_obstructions() {
+	RWLockWrite write_lock(geometry_rwlock);
+	_projected_obstructions.clear();
 }
 
 void NavigationMeshSourceGeometryData3D::_add_vertex(const Vector3 &p_vec3) {
@@ -174,6 +180,121 @@ void NavigationMeshSourceGeometryData3D::merge(const Ref<NavigationMeshSourceGeo
 	for (int64_t i = number_of_indices_before_merge; i < indices.size(); i++) {
 		indices.set(i, indices[i] + number_of_vertices_before_merge / 3);
 	}
+
+	if (p_other_geometry->_projected_obstructions.size() > 0) {
+		RWLockWrite write_lock(geometry_rwlock);
+
+		for (const ProjectedObstruction &other_projected_obstruction : p_other_geometry->_projected_obstructions) {
+			ProjectedObstruction projected_obstruction;
+			projected_obstruction.vertices.resize(other_projected_obstruction.vertices.size());
+
+			const float *other_obstruction_vertices_ptr = other_projected_obstruction.vertices.ptr();
+			float *obstruction_vertices_ptrw = projected_obstruction.vertices.ptrw();
+
+			for (int j = 0; j < other_projected_obstruction.vertices.size(); j++) {
+				obstruction_vertices_ptrw[j] = other_obstruction_vertices_ptr[j];
+			}
+
+			projected_obstruction.elevation = other_projected_obstruction.elevation;
+			projected_obstruction.height = other_projected_obstruction.height;
+			projected_obstruction.carve = other_projected_obstruction.carve;
+
+			_projected_obstructions.push_back(projected_obstruction);
+		}
+	}
+}
+
+void NavigationMeshSourceGeometryData3D::add_projected_obstruction(const Vector<Vector3> &p_vertices, float p_elevation, float p_height, bool p_carve) {
+	ERR_FAIL_COND(p_vertices.size() < 3);
+	ERR_FAIL_COND(p_height < 0.0);
+
+	ProjectedObstruction projected_obstruction;
+	projected_obstruction.vertices.resize(p_vertices.size() * 3);
+	projected_obstruction.elevation = p_elevation;
+	projected_obstruction.height = p_height;
+	projected_obstruction.carve = p_carve;
+
+	float *obstruction_vertices_ptrw = projected_obstruction.vertices.ptrw();
+
+	int vertex_index = 0;
+	for (const Vector3 &vertex : p_vertices) {
+		obstruction_vertices_ptrw[vertex_index++] = vertex.x;
+		obstruction_vertices_ptrw[vertex_index++] = vertex.y;
+		obstruction_vertices_ptrw[vertex_index++] = vertex.z;
+	}
+
+	RWLockWrite write_lock(geometry_rwlock);
+	_projected_obstructions.push_back(projected_obstruction);
+}
+
+void NavigationMeshSourceGeometryData3D::set_projected_obstructions(const Array &p_array) {
+	clear_projected_obstructions();
+
+	for (int i = 0; i < p_array.size(); i++) {
+		Dictionary data = p_array[i];
+		ERR_FAIL_COND(!data.has("version"));
+
+		uint32_t po_version = data["version"];
+
+		if (po_version == 1) {
+			ERR_FAIL_COND(!data.has("vertices"));
+			ERR_FAIL_COND(!data.has("elevation"));
+			ERR_FAIL_COND(!data.has("height"));
+			ERR_FAIL_COND(!data.has("carve"));
+		}
+
+		ProjectedObstruction projected_obstruction;
+		projected_obstruction.vertices = Vector<float>(data["vertices"]);
+		projected_obstruction.elevation = data["elevation"];
+		projected_obstruction.height = data["height"];
+		projected_obstruction.carve = data["carve"];
+
+		RWLockWrite write_lock(geometry_rwlock);
+		_projected_obstructions.push_back(projected_obstruction);
+	}
+}
+
+Vector<NavigationMeshSourceGeometryData3D::ProjectedObstruction> NavigationMeshSourceGeometryData3D::_get_projected_obstructions() const {
+	RWLockRead read_lock(geometry_rwlock);
+	return _projected_obstructions;
+}
+
+Array NavigationMeshSourceGeometryData3D::get_projected_obstructions() const {
+	RWLockRead read_lock(geometry_rwlock);
+
+	Array ret;
+	ret.resize(_projected_obstructions.size());
+
+	for (int i = 0; i < _projected_obstructions.size(); i++) {
+		const ProjectedObstruction &projected_obstruction = _projected_obstructions[i];
+
+		Dictionary data;
+		data["version"] = (int)ProjectedObstruction::VERSION;
+		data["vertices"] = projected_obstruction.vertices;
+		data["elevation"] = projected_obstruction.elevation;
+		data["height"] = projected_obstruction.height;
+		data["carve"] = projected_obstruction.carve;
+
+		ret[i] = data;
+	}
+
+	return ret;
+}
+
+bool NavigationMeshSourceGeometryData3D::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "projected_obstructions") {
+		set_projected_obstructions(p_value);
+		return true;
+	}
+	return false;
+}
+
+bool NavigationMeshSourceGeometryData3D::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "projected_obstructions") {
+		r_ret = get_projected_obstructions();
+		return true;
+	}
+	return false;
 }
 
 void NavigationMeshSourceGeometryData3D::_bind_methods() {
@@ -191,6 +312,12 @@ void NavigationMeshSourceGeometryData3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_faces", "faces", "xform"), &NavigationMeshSourceGeometryData3D::add_faces);
 	ClassDB::bind_method(D_METHOD("merge", "other_geometry"), &NavigationMeshSourceGeometryData3D::merge);
 
+	ClassDB::bind_method(D_METHOD("add_projected_obstruction", "vertices", "elevation", "height", "carve"), &NavigationMeshSourceGeometryData3D::add_projected_obstruction);
+	ClassDB::bind_method(D_METHOD("clear_projected_obstructions"), &NavigationMeshSourceGeometryData3D::clear_projected_obstructions);
+	ClassDB::bind_method(D_METHOD("set_projected_obstructions", "projected_obstructions"), &NavigationMeshSourceGeometryData3D::set_projected_obstructions);
+	ClassDB::bind_method(D_METHOD("get_projected_obstructions"), &NavigationMeshSourceGeometryData3D::get_projected_obstructions);
+
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "indices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_indices", "get_indices");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "projected_obstructions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_projected_obstructions", "get_projected_obstructions");
 }


### PR DESCRIPTION
Adds obstacle options to contribute to the navigation mesh baking.
Also helps with bake performance and removing unwanted navigation mesh parts.

Both `NavigationObstacle2D` and `NavigationObstacle3D` have new properties that allow the obstacle to take part in the navigation mesh baking process.

### NavigationObstacle2D

![obstacel2dcarve](https://github.com/godotengine/godot/assets/52464204/2ff3a646-8295-4431-a2df-3d503bedd98e)

For 2D the obstacle acts similar to normal source geometry.
The difference is that it "cuts" from the navigation mesh in a late pass after all other geometry.
It also can be made unaffected by the agent radius offset so that it "cuts" without additional margin added.

### NavigationObstacle3D

![obstacle _bake](https://github.com/godotengine/godot/assets/52464204/48dc5b4a-ae6e-4a86-beeb-e29baf53e617)

For 3D the obstacle acts similar to 2D with one major difference compared to normal source geometry.

An obstacle does not add walkable geometry like collision shapes or visual meshes do, instead it acts as a discard for parts of all other source geometry inside its shape.

This can be used to remove navigation mesh from being baked in unwanted places that should not have it, e.g. inside "solid" geometry or on top of geometry.

**In turn the obstacle alone can not be used to create navigation mesh when there is no other geometry around!**

An obstacle does not add, it only removes. It does so by nullifying all the geometry (voxel) cells in the baking process that are inside its parsed shape.

The reason why this "remove navmesh inside geometry" is made available only on the obstacle, and not for all "solid" collision shapes or visual meshes, is that it requires a very restricted shape to be reasonibly accurate and performant to process.
Those restrictions are not possible to put in place for the many allowed uses of physics collision shapes or visual meshes.

This PR was also totally not made after seeing user navigation mesh like this:

![stacked](https://github.com/godotengine/godot/assets/52464204/b7ff4137-f8b8-46a7-ab5a-680903d4f541)

Tbh this feature was cooking on the backburner for a while. Seeing that stuff was just what pushed it over the finishing line. 

Shout out to team scott-veggie for sharing definitely-not-jotson's live struggle.

### Affect the navigation mesh baking



![obstacle_properties](https://github.com/godotengine/godot/assets/52464204/9c13a2c5-ceae-47c1-8c16-738fd6323656)

The shape is defined with the already existing properties for `height` and outline `vertices` that were previously used only for the avoidance.

The property `affect_navigation_mesh` makes the obstacle contribute to the navigation mesh baking. It will be parsed or not-parsed like all other node objects in a navigation mesh baking process.

The property `carve_navigation_mesh` makes the shape unaffected by offsets of the baking, e.g. agent radius. It will basically act as a stencil and cut into the already offset navigation mesh surface. It will still be affected by further postprocessing of the baking process like edge simplification.

### Performance

If you do not plan to use the by default enabled avoidance of the obstacle turn off `enabled_avoidance` to save performance.

The contributed geometry is a simple, projected shape of the obstacle vertices (top-down for 3D) or a low-detail version of the radius. This means this can be used to create comparably performance cheap projected "holes" for the navigation mesh baking.

It is one of the most efficient (but limited) ways available now to affect source geometry when baking navigation mesh. You will still need to combine it with other source geometry as the obstacle only discards.

Since the obstacle has ready-made geometry 100% stored on the CPU similar to physics shapes no parse and server-stalling related performance issues will happen. E.g. they are a regular issue when using MeshInstance3D for the source geometry when baking.

Projects with bake performance issues at runtime often should not look further than if they are using a rendering mesh as source geometry somewhere. Parsing even a single one of them at runtime can completely annihilate the frame rate because all that geometry data of a rendering mesh needs to be received from the GPU blocking the rendering.

It is recommended to use physics collision and obstacles exklusive as source geometry and replace all uses of rendering meshes when baking navigation mesh with them, at least for runtime.

### Limitations and Caveats

Both the bake and carve features are still limited to the (voxel) cell resolution. It is not intended as an equivalent to more detailed boolean operations like e.g. CSG Meshes that are all super-costly in comparison.

The obstacle shape is very similar in function to an AABB except that instead of a square / box shape it uses an outline. Still, it needs to stay aligned to the horizontal xz axes and no transform like rotation or scale will be used, only the positions. This was already the case for the avoidance that has similar axis restrictions so it came naturally to use the same properties.

Do not expect the contours of the obstacle to perfectly carve into the navigation mesh. There are too many steps involved in the baking process that affect the final navigation mesh result and none of them aims for perfect accuracy. They all aim for bake performance and a low-detail polygon surface with a small edge count so the pathfinding can be fast.

For more accuracy the bake cell size and the simplification threshold can be lowered but a noticeable performance hit needs to be accepted when doing so as it creates a high (voxel) cell count that needs to be processed.

For accurate outside edges when baking, e.g. chunk navigation meshes, obstacles are not a good choice. The newer `baking Rect / AABB` and `border_size` can be used. Especially in 3D the baking AABB will also help to fix the voxel span count so navigation mesh polygon edges will not change so much when things are rebaked.

### Prevent navigation mesh from appearing "inside" or "on top" of source geometry

There is also a more subtle feature added with this that many users have asked for over the years.

Since obstacle have a very restricted, plane projected shape that discards geometry they can be used to discard the entire internal geometry of the shape from the navigation mesh baking at comparably low cost. This prevents navigation mesh from appearing both inside as well as on top the source geometry.

So if you have certain areas around a level that should not have unwanted navigation mesh place an obstacle shape there.

![obstacle _carve](https://github.com/godotengine/godot/assets/52464204/6198ace3-dd9c-4c20-b65b-036a3bce0c5b)

I dont want to go into too much technical detail but this would be near impossible to do in a performant manner with visual meshes or collision shapes as source geometry. Both can end up unpredictable complex, or worse, transformed and skewed. That is also why this is such a common issue in nearly all game engines based on ReCast navmesh baking. ReCast has no concept of "inner" geometry.

With an obstacle shape the enclosed voxel cells are now discarded in the baking process so this "block navmesh from appearing in internal geometry" is now done automatically when an obstacle is baked. It still has an added cost but from tests it is nowhere as brutal as with all the other geometry options.

### Adding obstacles to NavigationMeshSourceGeometryData

For those that bake navigation mesh mostly procedural in scripts the source geometry objects have new functions added. 

The `add_projected_obstruction()` can be used to add an obstacle shape to the source geometry.

The `vertices` are in global coordinates by default, just watch out what you set as the root node for the parsing should it not be at origin.

The `carve` parameter defines if the obstacle is affected by offsets, e.g. the agent radius, when baked.

For 3D the y-axis of the vertices is ignored. Instead, the position and shape on the y-axis is controlled with the `elevation` and the extrusion `height`.

``` gdscript
var outline = PackedVector3Array([
	Vector3(-5, 0, -5),
	Vector3(5, 0, -5),
	Vector3(5, 0, 5),
	Vector3(-5, 0, 5)
])

var navmesh = NavigationMesh.new()
var source_geometry = NavigationMeshSourceGeometryData3D.new()

NavigationServer3D.parse_source_geometry_data(navmesh, source_geometry, $MyTestRootNode)

var elevation: float = $MyTestObstacleNode.global_position.y
var height: float = 50.0
var carve: bool = true

source_geometry.add_projected_obstruction(outline, elevation, height, carve)

NavigationServer3D.bake_from_source_geometry_data(navmesh, source_geometry)
```

### Additional background why this is added to the obstacle

One of the main reasons why this is added to the obstacle is shape restrictions but there are also other reasons why this is not just made e.g. a new node type.

The community regularly recommends to use NavigationObstacles to make agents not move somewhere unwanted.

This was and is for the most part well-meaning but wrong advice.

You can not fix any pathfinding issues with the current obstacle, the navigation mesh path will still go right through the obstacle because the navigation mesh is still there unaffected. This creates conflict with the pathfinding wanting to move inside the obstacle while the avoidance pushes back getting the agent stuck.

The attempts to fix this "wrong advice" issue with more and more documentation was more or less in vain. Nearly every new user and even more experienced long-term godot users trip over this regularly.

That the problem even exists I blame on the poor choice of the node name.

The NavigationObstacle never had any functionality outside of avoidance. In hindsight it really should have been named AvoidanceObstacle from the start because that is all it ever did and could do (before 4.1 it could not even do that really).

Now that the NavigationObstacle name can no longer easily be changed and the documentation does not help the solution is another. The obstacle gets the functionality that is the most expected from users and quickly associated due to the node name.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
