### PR TITLE
[macOS] Set `double_click` for mouse up events and non left mouse button events.

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -388,7 +388,7 @@
 	mb->set_position(wd.mouse_pos);
 	mb->set_global_position(wd.mouse_pos);
 	mb->set_button_mask(last_button_state);
-	if (!outofstream && index == MouseButton::LEFT && pressed) {
+	if (!outofstream) {
 		mb->set_double_click([event clickCount] == 2);
 	}
 


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/89018 for macOS, also allow double click from other buttons than left.