### PR TITLE
Linux: Handle export preset compat with 'Linux/X11' platform name

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -219,6 +219,12 @@ void EditorExport::load_config() {
 		}
 
 		String platform = config->get_value(section, "platform");
+#ifndef DISABLE_DEPRECATED
+		// Compatibility with Linux platform before 4.3.
+		if (platform == "Linux/X11") {
+			platform = "Linux";
+		}
+#endif
 
 		Ref<EditorExportPreset> preset;
 


### PR DESCRIPTION
Fixes #89012.

I'm not changing the preset name itself as it doesn't matter, so I think it's better not to mess with the user's files.
This also doesn't save the changes out of the box, so as long as users don't modify the export preset's configuration further, it will stay compatible with 4.2.x and earlier. If they modify the preset in 4.3, then saving the project will save the platform name change.

I could also add a similar check in 4.2.2 and 4.1.4 for forward compatibility, WDYT?