### PR TITLE
[4.2] Linux: Handle export preset forward compat with 4.3+ platform name

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -210,6 +210,10 @@ void EditorExport::load_config() {
 		}
 
 		String platform = config->get_value(section, "platform");
+		// Forward compatibility with Linux platform after 4.3.
+		if (platform == "Linux") {
+			platform = "Linux/X11";
+		}
 
 		Ref<EditorExportPreset> preset;
 


### PR DESCRIPTION
`4.2` (and `4.1` once cherry-picked) counterpart to #89044 to ensure forward compatibility.