### PR TITLE
Use `META_UNDERLINE_ON_HOVER` in built-in class reference

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -360,7 +360,7 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum, bool p_is
 			link_t = link_t.trim_suffix("[]");
 			display_t = display_t.trim_suffix("[]");
 
-			class_desc->push_meta("#Array"); // class
+			class_desc->push_meta("#Array", RichTextLabel::META_UNDERLINE_ON_HOVER); // class
 			class_desc->add_text("Array");
 			class_desc->pop(); // meta
 			class_desc->add_text("[");
@@ -374,9 +374,9 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum, bool p_is
 		}
 
 		if (is_enum_type) {
-			class_desc->push_meta("$" + link_t); // enum
+			class_desc->push_meta("$" + link_t, RichTextLabel::META_UNDERLINE_ON_HOVER); // enum
 		} else {
-			class_desc->push_meta("#" + link_t); // class
+			class_desc->push_meta("#" + link_t, RichTextLabel::META_UNDERLINE_ON_HOVER); // class
 		}
 	}
 	class_desc->add_text(display_t);
@@ -503,7 +503,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	const bool is_documented = p_method.is_deprecated || p_method.is_experimental || !p_method.description.strip_edges().is_empty();
 
 	if (p_overview && is_documented) {
-		class_desc->push_meta("@method " + p_method.name);
+		class_desc->push_meta("@method " + p_method.name, RichTextLabel::META_UNDERLINE_ON_HOVER);
 	}
 
 	class_desc->push_color(theme_cache.headline_color);
@@ -1210,7 +1210,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_color(theme_cache.headline_color);
 
 			if (describe) {
-				class_desc->push_meta("@member " + prop.name);
+				class_desc->push_meta("@member " + prop.name, RichTextLabel::META_UNDERLINE_ON_HOVER);
 			}
 
 			class_desc->add_text(prop.name);
@@ -2452,12 +2452,16 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
 			Color target_color = link_color;
+			RichTextLabel::MetaUnderline underline_mode = RichTextLabel::META_UNDERLINE_ON_HOVER;
 			if (link_tag == "method" || link_tag == "constructor" || link_tag == "operator") {
 				target_color = link_method_color;
 			} else if (link_tag == "member" || link_tag == "signal" || link_tag == "theme_item") {
 				target_color = link_property_color;
 			} else if (link_tag == "annotation") {
 				target_color = link_annotation_color;
+			} else {
+				// Better visibility for constants, enums, etc.
+				underline_mode = RichTextLabel::META_UNDERLINE_ALWAYS;
 			}
 
 			// Use monospace font to make clickable references
@@ -2465,7 +2469,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 			p_rt->push_font(doc_code_font);
 			p_rt->push_font_size(doc_code_font_size);
 			p_rt->push_color(target_color);
-			p_rt->push_meta("@" + link_tag + " " + link_target);
+			p_rt->push_meta("@" + link_tag + " " + link_target, underline_mode);
 
 			if (link_tag == "member" &&
 					((!link_target.contains(".") && (p_class == "ProjectSettings" || p_class == "EditorSettings")) ||
@@ -2526,7 +2530,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 			p_rt->push_font(doc_code_font);
 			p_rt->push_font_size(doc_code_font_size);
 			p_rt->push_color(type_color);
-			p_rt->push_meta("#" + tag);
+			p_rt->push_meta("#" + tag, RichTextLabel::META_UNDERLINE_ON_HOVER);
 
 			p_rt->add_text(tag);
 


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/64861

I am moved. Thank you https://github.com/godotengine/godot/pull/89024.

![32880471e4e74d421b24e3cccdbe0616](https://github.com/godotengine/godot/assets/66727710/4c22e989-6e15-41ab-b3ff-ba5d6e3fa81d)
![c93327603394fd190aac30efb6f9cdb1](https://github.com/godotengine/godot/assets/66727710/448e4ecc-f3ec-4702-b4d4-00aa06377100)
![5589e90aa1bcce583717597349a9ca7f](https://github.com/godotengine/godot/assets/66727710/cc8eb5bf-2e5b-4eb2-ba03-9edad46a69f2)

~~You can see that those constants are harder to notice but it's nothing that can't be adjusted...~~

Please feel free to share opinions but this _is_ the way to go now. It's consistent with the online docs, and it's just... almost objectively good, compared to https://github.com/godotengine/godot/pull/64861 ?

Note that this PR does not affect `[url]` tags at all for clarity.