### PR TITLE
Add extension support for argument count to `ScriptInstance`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1302,6 +1302,7 @@ static GDExtensionScriptInstancePtr gdextension_script_instance_create(const GDE
 	info_3->get_property_type_func = p_info->get_property_type_func;
 	info_3->validate_property_func = nullptr;
 	info_3->has_method_func = p_info->has_method_func;
+	info_3->get_method_argument_count_func = nullptr;
 	info_3->call_func = p_info->call_func;
 	info_3->notification_func = nullptr;
 	info_3->to_string_func = p_info->to_string_func;
@@ -1341,6 +1342,7 @@ static GDExtensionScriptInstancePtr gdextension_script_instance_create2(const GD
 	info_3->get_property_type_func = p_info->get_property_type_func;
 	info_3->validate_property_func = nullptr;
 	info_3->has_method_func = p_info->has_method_func;
+	info_3->get_method_argument_count_func = nullptr;
 	info_3->call_func = p_info->call_func;
 	info_3->notification_func = p_info->notification_func;
 	info_3->to_string_func = p_info->to_string_func;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -535,6 +535,8 @@ typedef void (*GDExtensionScriptInstanceFreeMethodList2)(GDExtensionScriptInstan
 
 typedef GDExtensionBool (*GDExtensionScriptInstanceHasMethod)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name);
 
+typedef GDExtensionInt (*GDExtensionScriptInstanceGetMethodArgumentCount)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid);
+
 typedef void (*GDExtensionScriptInstanceCall)(GDExtensionScriptInstanceDataPtr p_self, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error);
 typedef void (*GDExtensionScriptInstanceNotification)(GDExtensionScriptInstanceDataPtr p_instance, int32_t p_what); // Deprecated. Use GDExtensionScriptInstanceNotification2 instead.
 typedef void (*GDExtensionScriptInstanceNotification2)(GDExtensionScriptInstanceDataPtr p_instance, int32_t p_what, GDExtensionBool p_reversed);
@@ -653,6 +655,8 @@ typedef struct {
 	GDExtensionScriptInstanceValidateProperty validate_property_func;
 
 	GDExtensionScriptInstanceHasMethod has_method_func;
+
+	GDExtensionScriptInstanceGetMethodArgumentCount get_method_argument_count_func;
 
 	GDExtensionScriptInstanceCall call_func;
 	GDExtensionScriptInstanceNotification2 notification_func;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -821,6 +821,14 @@ public:
 	}
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override {
+		if (native_info->get_method_argument_count_func) {
+			GDExtensionBool is_valid = 0;
+			GDExtensionInt ret = native_info->get_method_argument_count_func(instance, (GDExtensionStringNamePtr)&p_method, &is_valid);
+			if (r_is_valid) {
+				*r_is_valid = is_valid != 0;
+			}
+			return ret;
+		}
 		// Fallback to default.
 		return ScriptInstance::get_method_argument_count(p_method, r_is_valid);
 	}
@@ -912,7 +920,6 @@ public:
 			return reinterpret_cast<ScriptLanguage *>(lang);
 		}
 		return nullptr;
-		;
 	}
 	virtual ~ScriptInstanceExtension() {
 		if (native_info->free_func) {

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -84,6 +84,7 @@
 			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />
 			<description>
+				Return the expected argument count for the given [param method], or [code]null[/code] if it can't be determined (which will then fall back to the default behavior).
 			</description>
 		</method>
 		<method name="_get_script_method_list" qualifiers="virtual const">


### PR DESCRIPTION
Split off from:
* https://github.com/godotengine/godot/pull/87680

To aid with synchronizing extensions to the `GDExtensionScriptInstanceInfo` struct, see there for details, only the latest commit is relevant for this
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
