### PR TITLE
Add Codium support to C# external editors

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -177,7 +177,7 @@ namespace GodotTools
 
         private static readonly string[] VsCodeNames =
         {
-            "code", "code-oss", "vscode", "vscode-oss", "visual-studio-code", "visual-studio-code-oss"
+            "code", "code-oss", "vscode", "vscode-oss", "visual-studio-code", "visual-studio-code-oss", "codium"
         };
 
         [UsedImplicitly]
@@ -330,7 +330,7 @@ namespace GodotTools
                             args.Add("-b");
                             args.Add(vscodeBundleId);
 
-                            // The reusing of existing windows made by the 'open' command might not choose a wubdiw that is
+                            // The reusing of existing windows made by the 'open' command might not choose a window that is
                             // editing our folder. It's better to ask for a new window and let VSCode do the window management.
                             args.Add("-n");
 
@@ -338,6 +338,28 @@ namespace GodotTools
                             args.Add("--wait-apps");
 
                             args.Add("--args");
+                        }
+
+                        // Try VSCodium as a fallback if Visual Studio Code can't be found.
+                        if (!macOSAppBundleInstalled)
+                        {
+                            const string VscodiumBundleId = "com.vscodium.codium";
+                            macOSAppBundleInstalled = Internal.IsMacOSAppBundleInstalled(VscodiumBundleId);
+
+                            if (macOSAppBundleInstalled)
+                            {
+                                args.Add("-b");
+                                args.Add(VscodiumBundleId);
+
+                                // The reusing of existing windows made by the 'open' command might not choose a window that is
+                                // editing our folder. It's better to ask for a new window and let VSCode do the window management.
+                                args.Add("-n");
+
+                                // The open process must wait until the application finishes (which is instant in VSCode's case)
+                                args.Add("--wait-apps");
+
+                                args.Add("--args");
+                            }
                         }
                     }
 
@@ -361,7 +383,7 @@ namespace GodotTools
                     {
                         if (!macOSAppBundleInstalled && string.IsNullOrEmpty(_vsCodePath))
                         {
-                            GD.PushError("Cannot find code editor: VSCode");
+                            GD.PushError("Cannot find code editor: Visual Studio Code or VSCodium");
                             return Error.FileNotFound;
                         }
 
@@ -371,7 +393,7 @@ namespace GodotTools
                     {
                         if (string.IsNullOrEmpty(_vsCodePath))
                         {
-                            GD.PushError("Cannot find code editor: VSCode");
+                            GD.PushError("Cannot find code editor: Visual Studio Code or VSCodium");
                             return Error.FileNotFound;
                         }
 
@@ -384,7 +406,7 @@ namespace GodotTools
                     }
                     catch (Exception e)
                     {
-                        GD.PushError($"Error when trying to run code editor: VSCode. Exception message: '{e.Message}'");
+                        GD.PushError($"Error when trying to run code editor: Visual Studio Code or VSCodium. Exception message: '{e.Message}'");
                     }
 
                     break;
@@ -550,7 +572,7 @@ namespace GodotTools
             {
                 settingsHintStr += $",Visual Studio:{(int)ExternalEditorId.VisualStudio}" +
                                    $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +
-                                   $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
+                                   $",Visual Studio Code and VSCodium:{(int)ExternalEditorId.VsCode}" +
                                    $",JetBrains Rider and Fleet:{(int)ExternalEditorId.Rider}" +
                                    $",Custom:{(int)ExternalEditorId.CustomEditor}";
             }
@@ -558,14 +580,14 @@ namespace GodotTools
             {
                 settingsHintStr += $",Visual Studio:{(int)ExternalEditorId.VisualStudioForMac}" +
                                    $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +
-                                   $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
+                                   $",Visual Studio Code and VSCodium:{(int)ExternalEditorId.VsCode}" +
                                    $",JetBrains Rider and Fleet:{(int)ExternalEditorId.Rider}" +
                                    $",Custom:{(int)ExternalEditorId.CustomEditor}";
             }
             else if (OS.IsUnixLike)
             {
                 settingsHintStr += $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +
-                                   $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
+                                   $",Visual Studio Code and VSCodium:{(int)ExternalEditorId.VsCode}" +
                                    $",JetBrains Rider and Fleet:{(int)ExternalEditorId.Rider}" +
                                    $",Custom:{(int)ExternalEditorId.CustomEditor}";
             }


### PR DESCRIPTION
Selecting the VS Code option will now work if Codium is installed, picking it as the last option after attempting to run VS Code.

**Not tested on any OS**, so please test on macOS and Windows or Linux before merging.

- This closes https://github.com/godotengine/godot-proposals/issues/6518.
