### PR TITLE
Add debounce to `CreateDialog` search

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -616,6 +616,11 @@
 		<member name="interface/editor/code_font_size" type="int" setter="" getter="">
 			The size of the font in the script editor. This setting does not impact the font size of the Output panel (see [member run/output/font_size]).
 		</member>
+		<member name="interface/editor/create_dialog/search_delay_msec" type="int" setter="" getter="">
+			The delay before the create dialog (i.e. "Create New Node" or "Create New Resource") actually searches what was typed.
+			Currently, the editor locks up while trying to show the elements searched, this is to prevent lock ups during typing.
+			[b]Note:[/b] Higher values are useful for substantial projects.
+		</member>
 		<member name="interface/editor/custom_display_scale" type="float" setter="" getter="">
 			The custom editor scale factor to use. This can be used for displays with very high DPI where a scale factor of 200% is not sufficient.
 			[b]Note:[/b] Only effective if [member interface/editor/display_scale] is set to [b]Custom[/b].

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -435,7 +435,12 @@ void CreateDialog::_confirmed() {
 }
 
 void CreateDialog::_text_changed(const String &p_newtext) {
-	_update_search();
+	float search_delay_msec = (float)EDITOR_GET("interface/editor/create_dialog/search_delay_msec") / 1000.0f;
+	if (Math::is_zero_approx(search_delay_msec)) {
+		_update_search();
+		return;
+	}
+	search_debounce->start(search_delay_msec);
 }
 
 void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
@@ -454,6 +459,19 @@ void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
 				if (ti) {
 					ti->set_collapsed(!ti->is_collapsed());
 				}
+				search_box->accept_event();
+			} break;
+			case Key::ENTER: {
+				if (!search_debounce->is_stopped()) {
+					// Stop the debounce and update the search.
+					search_box->accept_event();
+					search_debounce->stop();
+					_update_search();
+					return;
+				}
+
+				// Let's select the current node
+				search_options->gui_input(k);
 				search_box->accept_event();
 			} break;
 			default:
@@ -834,4 +852,10 @@ CreateDialog::CreateDialog() {
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
 	set_clamp_to_embedder(true);
+
+	search_debounce = memnew(Timer);
+	search_debounce->set_autostart(false);
+	search_debounce->set_one_shot(true);
+	search_debounce->connect("timeout", callable_mp(this, &CreateDialog::_update_search));
+	add_child(search_debounce);
 }

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -47,6 +47,7 @@ class CreateDialog : public ConfirmationDialog {
 		OTHER_TYPE
 	};
 
+	Timer *search_debounce = nullptr;
 	LineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -464,6 +464,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")
 
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/create_dialog/search_delay_msec", 250, "0,1000,1,or_greater");
+
 	// Inspector
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/max_array_dictionary_items_per_page", 20, "10,100,1")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/show_low_level_opentype_features", false, "")


### PR DESCRIPTION
This PR adds a 500ms debounce to the editor `CreateDialog` search.

I wasn't able to fix (yet) the CreateDialog display and search lag. There is a lot to optimize, but it will require serious work. For more info, see the profiling I did: https://share.firefox.dev/3SXaYXK

So I used my web dev background to at least make the experience a little bit better.

# Example

I created a project with 10000 custom global classes.

I used this Bash function to create them:
```bash
for i in {1..10000}; do   echo -e "extends Node \nclass_name MyClass$i\n\nfunc _ready():\n\tpass" > "$i.gd"; done
```

## Before

[Capture vidéo du 2024-03-01 11-47-37.webm](https://github.com/godotengine/godot/assets/270928/1d7a6f71-929d-4352-b31a-f7e196ae7fe4)

## After

[Capture vidéo du 2024-03-01 11-37-28.webm](https://github.com/godotengine/godot/assets/270928/33d7a783-9b02-4107-ae5a-02754ba5392c)

See how I am able to write text in the `CreateDialog` without it actually start the search before I end writing. **But when the search is occuring, the engine will freeze as usual.**

# Side-effect
By design, this will make the search lag by 500ms, even in the occasions where it would be faster to search (i.e. there's not a lot of custom global classes).
