### PR TITLE
Make `Label3D` obey auto translation

### DIFF
--- a/doc/classes/TextMesh.xml
+++ b/doc/classes/TextMesh.xml
@@ -53,6 +53,7 @@
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			The text to generate mesh from.
+			[b]Note:[/b] Due to being a [Resource], it doesn't follow the rules of [member Node.auto_translate_mode]. If disabling translation is desired, it should be done manually with [method Object.set_message_translation].
 		</member>
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="TextServer.Direction" default="0">
 			Base text writing direction.

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -208,7 +208,7 @@ void Label3D::_notification(int p_what) {
 			viewport->disconnect("size_changed", callable_mp(this, &Label3D::_font_changed));
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			String new_text = tr(text);
+			String new_text = atr(text);
 			if (new_text == xl_text) {
 				return; // Nothing new.
 			}
@@ -636,7 +636,7 @@ void Label3D::_shape() {
 
 void Label3D::set_text(const String &p_string) {
 	text = p_string;
-	xl_text = tr(p_string);
+	xl_text = atr(p_string);
 	dirty_text = true;
 	_queue_update();
 }


### PR DESCRIPTION
A note was also added to `TextMesh`'s doc to explain why the same can't be done to it.