### PR TITLE
Feature/add mirror animation option

### DIFF
--- a/editor/import/3d/post_import_plugin_skeleton_renamer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_renamer.h
@@ -35,14 +35,21 @@
 
 class PostImportPluginSkeletonRenamer : public EditorScenePostImportPlugin {
 	GDCLASS(PostImportPluginSkeletonRenamer, EditorScenePostImportPlugin);
+private:
+
+	struct BoneRenameMapEntry {
+		String bone_name;
+		String bone_counterpart_name;
+	};
 
 public:
 	virtual void get_internal_import_options(InternalImportCategory p_category, List<ResourceImporter::ImportOption> *r_options) override;
 	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) override;
 
-	void _internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options, const HashMap<String, String> &p_rename_map);
+	void _internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options, const HashMap<String, BoneRenameMapEntry> &p_rename_map);
 
 	PostImportPluginSkeletonRenamer();
+
 };
 
 #endif // POST_IMPORT_PLUGIN_SKELETON_RENAMER_H

--- a/modules/mirror_animations/README.md
+++ b/modules/mirror_animations/README.md
@@ -1,0 +1,39 @@
+# Godot - Mirror Animations
+
+This module adds a "Mirror" option to animations imported via FBX / GLTF etc.  
+It only works for humanoid rigs and only if the armatures rest pose is in a proper T-Pose.
+
+It's not tested with other poses, however, not having a proper rest pose will break the animation.  
+This module was written for Godot v4.2+ and might not compile for version lower than that.  
+
+## Setup
+
+1. Clone the godot engine somewhere to your local machine
+2. Follow the `Building from source` guidelines [here](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html)
+3. Add this repo as a submodule to your project:  
+   `cd /path/to/godot/`
+   `git submodule add -b main https://github.com/Lunatix89/godot-mirror-animations modules/mirror_animations`
+4. Rebuild the engine
+
+## Guidelines for typical unity animations 
+
+Unity animations are typically split up in a character in T-Pose and several, small animation files which won't contain a skin, just the armature with the specific animation.  
+There are also animations out there which don't have a proper T-Pose set for the individual animation, the rest pose is just the first animation frame.  
+
+To work around this:
+1. Buy and install [Better FBX Importer & Exporter](https://blendermarket.com/products/better-fbx-importer--exporter) from blender market.  
+   This plugin will solve wrong bone orientations which can occur with the default FBX import plugin as well as having a special import option which we later need.
+2. Import the actual character which should has it's rest pose set to T-Pose.
+   Make sure that it has a proper armature and rest pose set up.
+3. Select the armature
+4. Import the desired animation with `Animations Options / Attach to Selected Armature` checked.
+   If the animation files also import an armature and model, select and delete them
+5. Export as `glTF 2.0` - this is important, do not export to FBX again
+6. Import into Godot
+7. Open the advanced import options dialog
+8. Select the desired animation
+9. Check `Mirror` on the animation
+10. Click `Reimport`
+
+Please note that I can't guarantee that this will work for every animation file as I only have a limited amount of files to test with.  
+

--- a/modules/mirror_animations/SCsub
+++ b/modules/mirror_animations/SCsub
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_mirror_animations = env_modules.Clone()
+
+# Godot source files
+
+env_mirror_animations.add_source_files(env.modules_sources, "*.cpp")
+
+if env.editor_build:
+    env_mirror_animations.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/mirror_animations/config.py
+++ b/modules/mirror_animations/config.py
@@ -1,0 +1,5 @@
+def can_build(env, platform):
+    return not env["disable_3d"]
+
+def configure(env):
+    pass

--- a/modules/mirror_animations/editor/post_import_plugin_animation_mirror.cpp
+++ b/modules/mirror_animations/editor/post_import_plugin_animation_mirror.cpp
@@ -1,0 +1,120 @@
+﻿#ifdef TOOLS_ENABLED
+
+#include "post_import_plugin_animation_mirror.h"
+
+#include "scene/3d/skeleton_3d.h"
+#include "scene/animation/animation_player.h"
+
+void PostImportPluginAnimationMirror::get_internal_import_options(InternalImportCategory p_category, List<ResourceImporter::ImportOption> *r_options) {
+	EditorScenePostImportPlugin::get_internal_import_options(p_category, r_options);
+}
+
+void PostImportPluginAnimationMirror::internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) {
+	EditorScenePostImportPlugin::internal_process(p_category, p_base_scene, p_node, p_resource, p_options);
+
+	if (p_category == INTERNAL_IMPORT_CATEGORY_ANIMATION) {
+		if (!static_cast<bool>(p_options["settings/mirror"])) {
+			return;
+		}
+
+		Animation *animation = Object::cast_to<Animation>(p_resource.ptr());
+		if (animation == nullptr) {
+			return;
+		}
+
+		AnimationPlayer *animation_player = nullptr;
+
+		TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
+		while (nodes.size()) {
+			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
+			if (!ap->has_animation(animation->get_name())) {
+				continue;
+			}
+
+			// sanity check for same animation name in different players
+			if (ap->get_animation(animation->get_name()) != animation) {
+				continue;
+			}
+
+			animation_player = ap;
+			break;
+		}
+
+		const int track_count = animation->get_track_count();
+		for (int i = 0; i < track_count; i++) {
+			mirror_node_path(animation, animation_player, i);
+
+			switch (animation->track_get_type(i)) {
+				case Animation::TYPE_POSITION_3D:
+					mirror_position_track(animation, i);
+					break;
+				case Animation::TYPE_ROTATION_3D:
+					mirror_rotation_track(animation, i);
+					break;
+			}
+		}
+	}
+}
+
+PostImportPluginAnimationMirror::PostImportPluginAnimationMirror() {
+}
+
+void PostImportPluginAnimationMirror::mirror_node_path(Animation *p_animation, const AnimationPlayer *p_animation_player, const int &p_track_index) const {
+	const auto node_path = p_animation->track_get_path(p_track_index);
+	if (node_path.get_subname_count() <= 0) {
+		return;
+	}
+
+	Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(p_animation_player->get_node(p_animation_player->get_root_node())->get_node(node_path));
+	ERR_FAIL_COND_MSG(skeleton == nullptr, vformat("Can't mirror animation \"%s\" - no skeleton found for track path \"%s\"", p_animation->get_name(), node_path));
+
+	const auto &bone_name = node_path.get_subname(node_path.get_subname_count() - 1);
+	const auto &bone_index = skeleton->find_bone(bone_name);
+
+	if (bone_index < 0) {
+		return;
+	}
+
+	const auto &bone_counterpart_name = skeleton->get_bone_counterpart_name(bone_index);
+	if (bone_counterpart_name == StringName()) {
+		return;
+	}
+
+	auto sub_names = node_path.get_subnames();
+	sub_names.set(sub_names.size() - 1, bone_counterpart_name);
+
+	const auto mirror_path = NodePath(node_path.get_names(), sub_names, node_path.is_absolute());
+	p_animation->track_set_path(p_track_index, mirror_path);
+}
+
+void PostImportPluginAnimationMirror::mirror_position_track(Animation *p_animation, const int &p_track_index) {
+	const auto scale = Vector3(-1, 1, 1);
+
+	for (int i = 0; i < p_animation->track_get_key_count(p_track_index); i++) {
+		const auto value = p_animation->track_get_key_value(p_track_index, i);
+
+		if (value.get_type() != Variant::VECTOR3) {
+			continue;
+		}
+
+		const auto newValue = static_cast<Vector3>(value) * scale;
+		p_animation->track_set_key_value(p_track_index, i, newValue);
+	}
+}
+
+void PostImportPluginAnimationMirror::mirror_rotation_track(Animation *p_animation, const int &p_track_index) {
+	for (int i = 0; i < p_animation->track_get_key_count(p_track_index); i++) {
+		const auto value = p_animation->track_get_key_value(p_track_index, i);
+
+		if (value.get_type() != Variant::QUATERNION) {
+			continue;
+		}
+
+		const auto current_rotation = static_cast<Quaternion>(value);
+		const auto new_rotation = Quaternion(-current_rotation.x, current_rotation.y, current_rotation.z, -current_rotation.w);
+
+		p_animation->track_set_key_value(p_track_index, i, new_rotation);
+	}
+}
+
+#endif // TOOLS_ENABLED

--- a/modules/mirror_animations/editor/post_import_plugin_animation_mirror.h
+++ b/modules/mirror_animations/editor/post_import_plugin_animation_mirror.h
@@ -1,0 +1,57 @@
+﻿/**************************************************************************/
+/*  post_import_plugin_skeleton_track_organizer.h                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef POST_IMPORT_PLUGIN_ANIMATION_MIRROR_H
+#define POST_IMPORT_PLUGIN_ANIMATION_MIRROR_H
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/import/3d/resource_importer_scene.h"
+
+class AnimationPlayer;
+
+class PostImportPluginAnimationMirror : public EditorScenePostImportPlugin {
+	GDCLASS(PostImportPluginAnimationMirror, EditorScenePostImportPlugin);
+
+public:
+	virtual void get_internal_import_options(InternalImportCategory p_category, List<ResourceImporter::ImportOption> *r_options) override;
+	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) override;
+
+	PostImportPluginAnimationMirror();
+
+private:
+	void mirror_node_path(Animation *p_animation, const AnimationPlayer *p_animation_player, const int &p_track_index) const;
+
+	static void mirror_position_track(Animation *p_animation, const int &p_track_index);
+	static void mirror_rotation_track(Animation *p_animation, const int &p_track_index);
+};
+
+#endif // TOOLS_ENABLED
+#endif // POST_IMPORT_PLUGIN_ANIMATION_MIRROR_H

--- a/modules/mirror_animations/register_types.cpp
+++ b/modules/mirror_animations/register_types.cpp
@@ -1,0 +1,37 @@
+#include "register_types.h"
+#include "core/object/ref_counted.h"
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/editor_node.h"
+#include "editor/post_import_plugin_animation_mirror.h"
+
+#endif
+
+#ifdef TOOLS_ENABLED
+
+static void _editor_init() {
+	const Ref<PostImportPluginAnimationMirror> post_importer_animation_mirror = memnew(PostImportPluginAnimationMirror);
+	ResourceImporterScene::add_post_importer_plugin(post_importer_animation_mirror);
+}
+
+#endif
+
+void initialize_mirror_animations_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		// Editor-specific API.
+		ClassDB::APIType prev_api = ClassDB::get_current_api();
+		ClassDB::set_current_api(ClassDB::API_EDITOR);
+
+		GDREGISTER_CLASS(PostImportPluginAnimationMirror)
+
+		ClassDB::set_current_api(prev_api);
+		EditorNode::add_init_callback(_editor_init);
+	}
+#endif
+}
+
+void uninitialize_mirror_animations_module(ModuleInitializationLevel p_level) {
+
+}

--- a/modules/mirror_animations/register_types.h
+++ b/modules/mirror_animations/register_types.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_mirror_animations_module(ModuleInitializationLevel p_level);
+void uninitialize_mirror_animations_module(ModuleInitializationLevel p_level);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -439,18 +439,19 @@ String Skeleton3D::get_bone_name(int p_bone) const {
 	return bones[p_bone].name;
 }
 
-void Skeleton3D::set_bone_name(int p_bone, const String &p_name) {
+String Skeleton3D::get_bone_counterpart_name(int p_bone) const {
+	const int bone_size = bones.size();
+	ERR_FAIL_INDEX_V(p_bone, bone_size, "");
+	return bones[p_bone].counterpart_name;
+}
+
+void Skeleton3D::set_bone_name(int p_bone, const String &p_name, const String& p_counterpart_name ) {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 
-	const int *bone_index_ptr = name_to_bone_index.getptr(p_name);
-	if (bone_index_ptr != nullptr) {
-		ERR_FAIL_COND_MSG(*bone_index_ptr != p_bone, "Skeleton3D: '" + get_name() + "', bone name:  '" + p_name + "' already exists.");
-		return; // No need to rename, the bone already has the given name.
-	}
-
 	name_to_bone_index.erase(bones[p_bone].name);
 	bones.write[p_bone].name = p_name;
+	bones.write[p_bone].counterpart_name = p_counterpart_name;
 	name_to_bone_index.insert(p_name, p_bone);
 
 	version++;

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -71,6 +71,7 @@ private:
 
 	struct Bone {
 		String name;
+		String counterpart_name;
 
 		bool enabled;
 		int parent;
@@ -162,7 +163,10 @@ public:
 	int add_bone(const String &p_name);
 	int find_bone(const String &p_name) const;
 	String get_bone_name(int p_bone) const;
-	void set_bone_name(int p_bone, const String &p_name);
+	void set_bone_name(int p_bone, const String &p_name, const String& p_counterpart_name = "");
+
+	String get_bone_counterpart_name(int p_bone) const;
+
 
 	bool is_bone_parent_of(int p_bone_id, int p_parent_bone_id) const;
 

--- a/scene/resources/bone_map.cpp
+++ b/scene/resources/bone_map.cpp
@@ -105,6 +105,15 @@ StringName BoneMap::find_profile_bone_name(const StringName &p_skeleton_bone_nam
 	return profile_bone_name;
 }
 
+StringName BoneMap::get_bone_counterpart_name(const StringName &p_skeleton_bone_name) const {
+	const auto bone_index = profile->find_bone(p_skeleton_bone_name);
+	if (bone_index < 0) {
+		return StringName();
+	}
+
+	return profile->get_bone_counterpart_name(bone_index);
+}
+
 int BoneMap::get_skeleton_bone_name_count(const StringName &p_skeleton_bone_name) const {
 	int count = 0;
 	HashMap<StringName, StringName>::ConstIterator E = bone_map.begin();

--- a/scene/resources/bone_map.h
+++ b/scene/resources/bone_map.h
@@ -60,6 +60,7 @@ public:
 	void _set_skeleton_bone_name(const StringName &p_profile_bone_name, const StringName &p_skeleton_bone_name); // Avoid to emit signal for editor.
 
 	StringName find_profile_bone_name(const StringName &p_skeleton_bone_name) const;
+	StringName get_bone_counterpart_name(const StringName &p_skeleton_bone_name) const;
 
 	BoneMap();
 	~BoneMap();

--- a/scene/resources/skeleton_profile.cpp
+++ b/scene/resources/skeleton_profile.cpp
@@ -55,6 +55,8 @@ bool SkeletonProfile::_set(const StringName &p_path, const Variant &p_value) {
 
 		if (what == "bone_name") {
 			set_bone_name(which, p_value);
+		} else if (what == "bone_counterpart_name") {
+			set_bone_counterpart_name(which, p_value);
 		} else if (what == "bone_parent") {
 			set_bone_parent(which, p_value);
 		} else if (what == "tail_direction") {
@@ -100,6 +102,8 @@ bool SkeletonProfile::_get(const StringName &p_path, Variant &r_ret) const {
 
 		if (what == "bone_name") {
 			r_ret = get_bone_name(which);
+		} else if (what == "bone_counterpart_name") {
+			r_ret = get_bone_counterpart_name(which);
 		} else if (what == "bone_parent") {
 			r_ret = get_bone_parent(which);
 		} else if (what == "tail_direction") {
@@ -162,6 +166,7 @@ void SkeletonProfile::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (int i = 0; i < bones.size(); i++) {
 		String path = "bones/" + itos(i) + "/";
 		p_list->push_back(PropertyInfo(Variant::STRING_NAME, path + "bone_name"));
+		p_list->push_back(PropertyInfo(Variant::STRING_NAME, path + "bone_counterpart_name"));
 		p_list->push_back(PropertyInfo(Variant::STRING_NAME, path + "bone_parent"));
 		p_list->push_back(PropertyInfo(Variant::INT, path + "tail_direction", PROPERTY_HINT_ENUM, "AverageChildren,SpecificChild,End"));
 		p_list->push_back(PropertyInfo(Variant::STRING_NAME, path + "bone_tail"));
@@ -277,6 +282,20 @@ void SkeletonProfile::set_bone_name(int p_bone_idx, const StringName &p_bone_nam
 	}
 	ERR_FAIL_INDEX(p_bone_idx, bones.size());
 	bones.write[p_bone_idx].bone_name = p_bone_name;
+	emit_signal("profile_updated");
+}
+
+StringName SkeletonProfile::get_bone_counterpart_name(int p_bone_idx) const {
+	ERR_FAIL_INDEX_V(p_bone_idx, bones.size(), StringName());
+	return bones[p_bone_idx].bone_counterpart;
+}
+
+void SkeletonProfile::set_bone_counterpart_name(int p_bone_idx, const StringName &p_bone_name) {
+	if (is_read_only) {
+		return;
+	}
+	ERR_FAIL_INDEX(p_bone_idx, bones.size());
+	bones.write[p_bone_idx].bone_counterpart = p_bone_name;
 	emit_signal("profile_updated");
 }
 
@@ -414,6 +433,9 @@ void SkeletonProfile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bone_name", "bone_idx"), &SkeletonProfile::get_bone_name);
 	ClassDB::bind_method(D_METHOD("set_bone_name", "bone_idx", "bone_name"), &SkeletonProfile::set_bone_name);
 
+	ClassDB::bind_method(D_METHOD("get_bone_counterpart_name", "bone_idx"), &SkeletonProfile::get_bone_counterpart_name);
+	ClassDB::bind_method(D_METHOD("set_bone_counterpart_name", "bone_idx", "bone_name"), &SkeletonProfile::set_bone_counterpart_name);
+
 	ClassDB::bind_method(D_METHOD("get_bone_parent", "bone_idx"), &SkeletonProfile::get_bone_parent);
 	ClassDB::bind_method(D_METHOD("set_bone_parent", "bone_idx", "bone_parent"), &SkeletonProfile::set_bone_parent);
 
@@ -517,12 +539,14 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[6].require = true;
 
 	bones.write[7].bone_name = "LeftEye";
+	bones.write[7].bone_counterpart = "RightEye";
 	bones.write[7].bone_parent = "Head";
 	bones.write[7].reference_pose = Transform3D(1, 0, 0, 0, 0, -1, 0, 1, 0, 0.05, 0.15, 0);
 	bones.write[7].handle_offset = Vector2(0.6, 0.46);
 	bones.write[7].group = "Face";
 
 	bones.write[8].bone_name = "RightEye";
+	bones.write[8].bone_counterpart = "LeftEye";
 	bones.write[8].bone_parent = "Head";
 	bones.write[8].reference_pose = Transform3D(1, 0, 0, 0, 0, -1, 0, 1, 0, -0.05, 0.15, 0);
 	bones.write[8].handle_offset = Vector2(0.37, 0.46);
@@ -535,6 +559,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[9].group = "Face";
 
 	bones.write[10].bone_name = "LeftShoulder";
+	bones.write[10].bone_counterpart = "RightShoulder";
 	bones.write[10].bone_parent = "UpperChest";
 	bones.write[10].reference_pose = Transform3D(0, 1, 0, 0, 0, 1, 1, 0, 0, 0.05, 0.1, 0);
 	bones.write[10].handle_offset = Vector2(0.55, 0.235);
@@ -542,6 +567,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[10].require = true;
 
 	bones.write[11].bone_name = "LeftUpperArm";
+	bones.write[11].bone_counterpart = "RightUpperArm";
 	bones.write[11].bone_parent = "LeftShoulder";
 	bones.write[11].reference_pose = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.05, 0);
 	bones.write[11].handle_offset = Vector2(0.6, 0.24);
@@ -549,6 +575,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[11].require = true;
 
 	bones.write[12].bone_name = "LeftLowerArm";
+	bones.write[12].bone_counterpart = "RightLowerArm";
 	bones.write[12].bone_parent = "LeftUpperArm";
 	bones.write[12].reference_pose = Transform3D(0, 0, -1, 0, 1, 0, 1, 0, 0, 0, 0.25, 0);
 	bones.write[12].handle_offset = Vector2(0.7, 0.24);
@@ -556,6 +583,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[12].require = true;
 
 	bones.write[13].bone_name = "LeftHand";
+	bones.write[13].bone_counterpart = "RightHand";
 	bones.write[13].bone_parent = "LeftLowerArm";
 	bones.write[13].tail_direction = TAIL_DIRECTION_SPECIFIC_CHILD;
 	bones.write[13].bone_tail = "LeftMiddleProximal";
@@ -565,96 +593,112 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[13].require = true;
 
 	bones.write[14].bone_name = "LeftThumbMetacarpal";
+	bones.write[14].bone_counterpart = "RightThumbMetacarpal";
 	bones.write[14].bone_parent = "LeftHand";
 	bones.write[14].reference_pose = Transform3D(0, -0.577, 0.816, 0, 0.816, 0.577, -1, 0, 0, -0.025, 0.025, 0);
 	bones.write[14].handle_offset = Vector2(0.4, 0.8);
 	bones.write[14].group = "LeftHand";
 
 	bones.write[15].bone_name = "LeftThumbProximal";
+	bones.write[15].bone_counterpart = "RightThumbProximal";
 	bones.write[15].bone_parent = "LeftThumbMetacarpal";
 	bones.write[15].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.043, 0);
 	bones.write[15].handle_offset = Vector2(0.3, 0.69);
 	bones.write[15].group = "LeftHand";
 
 	bones.write[16].bone_name = "LeftThumbDistal";
+	bones.write[16].bone_counterpart = "RightThumbDistal";
 	bones.write[16].bone_parent = "LeftThumbProximal";
 	bones.write[16].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.043, 0);
 	bones.write[16].handle_offset = Vector2(0.23, 0.555);
 	bones.write[16].group = "LeftHand";
 
 	bones.write[17].bone_name = "LeftIndexProximal";
+	bones.write[17].bone_counterpart = "RightIndexProximal";
 	bones.write[17].bone_parent = "LeftHand";
 	bones.write[17].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.025, 0.075, 0);
 	bones.write[17].handle_offset = Vector2(0.413, 0.52);
 	bones.write[17].group = "LeftHand";
 
 	bones.write[18].bone_name = "LeftIndexIntermediate";
+	bones.write[18].bone_counterpart = "RightIndexIntermediate";
 	bones.write[18].bone_parent = "LeftIndexProximal";
 	bones.write[18].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0);
 	bones.write[18].handle_offset = Vector2(0.403, 0.36);
 	bones.write[18].group = "LeftHand";
 
 	bones.write[19].bone_name = "LeftIndexDistal";
+	bones.write[19].bone_counterpart = "RightIndexDistal";
 	bones.write[19].bone_parent = "LeftIndexIntermediate";
 	bones.write[19].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[19].handle_offset = Vector2(0.403, 0.255);
 	bones.write[19].group = "LeftHand";
 
 	bones.write[20].bone_name = "LeftMiddleProximal";
+	bones.write[20].bone_counterpart = "RightMiddleProximal";
 	bones.write[20].bone_parent = "LeftHand";
 	bones.write[20].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.075, 0);
 	bones.write[20].handle_offset = Vector2(0.5, 0.51);
 	bones.write[20].group = "LeftHand";
 
 	bones.write[21].bone_name = "LeftMiddleIntermediate";
+	bones.write[21].bone_counterpart = "RightMiddleIntermediate";
 	bones.write[21].bone_parent = "LeftMiddleProximal";
 	bones.write[21].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.075, 0);
 	bones.write[21].handle_offset = Vector2(0.5, 0.345);
 	bones.write[21].group = "LeftHand";
 
 	bones.write[22].bone_name = "LeftMiddleDistal";
+	bones.write[22].bone_counterpart = "RightMiddleDistal";
 	bones.write[22].bone_parent = "LeftMiddleIntermediate";
 	bones.write[22].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[22].handle_offset = Vector2(0.5, 0.22);
 	bones.write[22].group = "LeftHand";
 
 	bones.write[23].bone_name = "LeftRingProximal";
+	bones.write[23].bone_counterpart = "RightRingProximal";
 	bones.write[23].bone_parent = "LeftHand";
 	bones.write[23].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.025, 0.075, 0);
 	bones.write[23].handle_offset = Vector2(0.586, 0.52);
 	bones.write[23].group = "LeftHand";
 
 	bones.write[24].bone_name = "LeftRingIntermediate";
+	bones.write[24].bone_counterpart = "RightRingIntermediate";
 	bones.write[24].bone_parent = "LeftRingProximal";
 	bones.write[24].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0);
 	bones.write[24].handle_offset = Vector2(0.59, 0.36);
 	bones.write[24].group = "LeftHand";
 
 	bones.write[25].bone_name = "LeftRingDistal";
+	bones.write[25].bone_counterpart = "RightRingDistal";
 	bones.write[25].bone_parent = "LeftRingIntermediate";
 	bones.write[25].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[25].handle_offset = Vector2(0.591, 0.25);
 	bones.write[25].group = "LeftHand";
 
 	bones.write[26].bone_name = "LeftLittleProximal";
+	bones.write[26].bone_counterpart = "RightLittleProximal";
 	bones.write[26].bone_parent = "LeftHand";
 	bones.write[26].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.05, 0.05, 0);
 	bones.write[26].handle_offset = Vector2(0.663, 0.543);
 	bones.write[26].group = "LeftHand";
 
 	bones.write[27].bone_name = "LeftLittleIntermediate";
+	bones.write[27].bone_counterpart = "RightLittleIntermediate";
 	bones.write[27].bone_parent = "LeftLittleProximal";
 	bones.write[27].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0);
 	bones.write[27].handle_offset = Vector2(0.672, 0.415);
 	bones.write[27].group = "LeftHand";
 
 	bones.write[28].bone_name = "LeftLittleDistal";
+	bones.write[28].bone_counterpart = "RightLittleDistal";
 	bones.write[28].bone_parent = "LeftLittleIntermediate";
 	bones.write[28].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[28].handle_offset = Vector2(0.672, 0.32);
 	bones.write[28].group = "LeftHand";
 
 	bones.write[29].bone_name = "RightShoulder";
+	bones.write[29].bone_counterpart = "LeftShoulder";
 	bones.write[29].bone_parent = "UpperChest";
 	bones.write[29].reference_pose = Transform3D(0, -1, 0, 0, 0, 1, -1, 0, 0, -0.05, 0.1, 0);
 	bones.write[29].handle_offset = Vector2(0.45, 0.235);
@@ -662,6 +706,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[29].require = true;
 
 	bones.write[30].bone_name = "RightUpperArm";
+	bones.write[30].bone_counterpart = "LeftUpperArm";
 	bones.write[30].bone_parent = "RightShoulder";
 	bones.write[30].reference_pose = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.05, 0);
 	bones.write[30].handle_offset = Vector2(0.4, 0.24);
@@ -669,6 +714,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[30].require = true;
 
 	bones.write[31].bone_name = "RightLowerArm";
+	bones.write[31].bone_counterpart = "LeftLowerArm";
 	bones.write[31].bone_parent = "RightUpperArm";
 	bones.write[31].reference_pose = Transform3D(0, 0, 1, 0, 1, 0, -1, 0, 0, 0, 0.25, 0);
 	bones.write[31].handle_offset = Vector2(0.3, 0.24);
@@ -676,6 +722,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[31].require = true;
 
 	bones.write[32].bone_name = "RightHand";
+	bones.write[32].bone_counterpart = "LeftHand";
 	bones.write[32].bone_parent = "RightLowerArm";
 	bones.write[32].tail_direction = TAIL_DIRECTION_SPECIFIC_CHILD;
 	bones.write[32].bone_tail = "RightMiddleProximal";
@@ -685,96 +732,112 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[32].require = true;
 
 	bones.write[33].bone_name = "RightThumbMetacarpal";
+	bones.write[33].bone_counterpart = "LeftThumbMetacarpal";
 	bones.write[33].bone_parent = "RightHand";
 	bones.write[33].reference_pose = Transform3D(0, 0.577, -0.816, 0, 0.816, 0.577, 1, 0, 0, 0.025, 0.025, 0);
 	bones.write[33].handle_offset = Vector2(0.6, 0.8);
 	bones.write[33].group = "RightHand";
 
 	bones.write[34].bone_name = "RightThumbProximal";
+	bones.write[34].bone_counterpart = "LeftThumbProximal";
 	bones.write[34].bone_parent = "RightThumbMetacarpal";
 	bones.write[34].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.043, 0);
 	bones.write[34].handle_offset = Vector2(0.7, 0.69);
 	bones.write[34].group = "RightHand";
 
 	bones.write[35].bone_name = "RightThumbDistal";
+	bones.write[35].bone_counterpart = "LeftThumbDistal";
 	bones.write[35].bone_parent = "RightThumbProximal";
 	bones.write[35].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.043, 0);
 	bones.write[35].handle_offset = Vector2(0.77, 0.555);
 	bones.write[35].group = "RightHand";
 
 	bones.write[36].bone_name = "RightIndexProximal";
+	bones.write[36].bone_counterpart = "LeftIndexProximal";
 	bones.write[36].bone_parent = "RightHand";
 	bones.write[36].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.025, 0.075, 0);
 	bones.write[36].handle_offset = Vector2(0.587, 0.52);
 	bones.write[36].group = "RightHand";
 
 	bones.write[37].bone_name = "RightIndexIntermediate";
+	bones.write[37].bone_counterpart = "LeftIndexIntermediate"; // Counterpart bone
 	bones.write[37].bone_parent = "RightIndexProximal";
 	bones.write[37].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0);
 	bones.write[37].handle_offset = Vector2(0.597, 0.36);
 	bones.write[37].group = "RightHand";
 
 	bones.write[38].bone_name = "RightIndexDistal";
+	bones.write[38].bone_counterpart = "LeftIndexDistal"; // Counterpart bone
 	bones.write[38].bone_parent = "RightIndexIntermediate";
 	bones.write[38].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[38].handle_offset = Vector2(0.597, 0.255);
 	bones.write[38].group = "RightHand";
 
 	bones.write[39].bone_name = "RightMiddleProximal";
+	bones.write[39].bone_counterpart = "LeftMiddleProximal";
 	bones.write[39].bone_parent = "RightHand";
 	bones.write[39].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.075, 0);
 	bones.write[39].handle_offset = Vector2(0.5, 0.51);
 	bones.write[39].group = "RightHand";
 
 	bones.write[40].bone_name = "RightMiddleIntermediate";
+	bones.write[40].bone_counterpart = "LeftMiddleIntermediate"; // Counterpart bone
 	bones.write[40].bone_parent = "RightMiddleProximal";
 	bones.write[40].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.075, 0);
 	bones.write[40].handle_offset = Vector2(0.5, 0.345);
 	bones.write[40].group = "RightHand";
 
 	bones.write[41].bone_name = "RightMiddleDistal";
+	bones.write[41].bone_counterpart = "LeftMiddleDistal"; // Counterpart bone
 	bones.write[41].bone_parent = "RightMiddleIntermediate";
 	bones.write[41].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[41].handle_offset = Vector2(0.5, 0.22);
 	bones.write[41].group = "RightHand";
 
 	bones.write[42].bone_name = "RightRingProximal";
+	bones.write[42].bone_counterpart = "LeftRingProximal";
 	bones.write[42].bone_parent = "RightHand";
 	bones.write[42].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.025, 0.075, 0);
 	bones.write[42].handle_offset = Vector2(0.414, 0.52);
 	bones.write[42].group = "RightHand";
 
 	bones.write[43].bone_name = "RightRingIntermediate";
+	bones.write[43].bone_counterpart = "LeftRingIntermediate"; // Counterpart bone
 	bones.write[43].bone_parent = "RightRingProximal";
 	bones.write[43].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0);
 	bones.write[43].handle_offset = Vector2(0.41, 0.36);
 	bones.write[43].group = "RightHand";
 
 	bones.write[44].bone_name = "RightRingDistal";
+	bones.write[44].bone_counterpart = "LeftRingDistal"; // Counterpart bone
 	bones.write[44].bone_parent = "RightRingIntermediate";
 	bones.write[44].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[44].handle_offset = Vector2(0.409, 0.25);
 	bones.write[44].group = "RightHand";
 
 	bones.write[45].bone_name = "RightLittleProximal";
+	bones.write[45].bone_counterpart = "LeftLittleProximal";
 	bones.write[45].bone_parent = "RightHand";
 	bones.write[45].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.05, 0.05, 0);
 	bones.write[45].handle_offset = Vector2(0.337, 0.543);
 	bones.write[45].group = "RightHand";
 
 	bones.write[46].bone_name = "RightLittleIntermediate";
+	bones.write[46].bone_counterpart = "LeftLittleIntermediate"; // Counterpart bone
 	bones.write[46].bone_parent = "RightLittleProximal";
 	bones.write[46].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0);
 	bones.write[46].handle_offset = Vector2(0.328, 0.415);
 	bones.write[46].group = "RightHand";
 
 	bones.write[47].bone_name = "RightLittleDistal";
+	bones.write[47].bone_counterpart = "LeftLittleDistal"; // Counterpart bone
 	bones.write[47].bone_parent = "RightLittleIntermediate";
 	bones.write[47].reference_pose = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.025, 0);
 	bones.write[47].handle_offset = Vector2(0.328, 0.32);
 	bones.write[47].group = "RightHand";
 
 	bones.write[48].bone_name = "LeftUpperLeg";
+	bones.write[48].bone_counterpart = "RightUpperLeg"; // Counterpart bone
 	bones.write[48].bone_parent = "Hips";
 	bones.write[48].reference_pose = Transform3D(-1, 0, 0, 0, -1, 0, 0, 0, 1, 0.1, 0, 0);
 	bones.write[48].handle_offset = Vector2(0.549, 0.49);
@@ -782,6 +845,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[48].require = true;
 
 	bones.write[49].bone_name = "LeftLowerLeg";
+	bones.write[49].bone_counterpart = "RightLowerLeg"; // Counterpart bone
 	bones.write[49].bone_parent = "LeftUpperLeg";
 	bones.write[49].reference_pose = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.375, 0);
 	bones.write[49].handle_offset = Vector2(0.548, 0.683);
@@ -789,6 +853,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[49].require = true;
 
 	bones.write[50].bone_name = "LeftFoot";
+	bones.write[50].bone_counterpart = "RightFoot"; // Counterpart bone
 	bones.write[50].bone_parent = "LeftLowerLeg";
 	bones.write[50].reference_pose = Transform3D(-1, 0, 0, 0, 0, -1, 0, -1, 0, 0, 0.375, 0);
 	bones.write[50].handle_offset = Vector2(0.545, 0.9);
@@ -796,12 +861,14 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[50].require = true;
 
 	bones.write[51].bone_name = "LeftToes";
+	bones.write[51].bone_counterpart = "RightToes"; // Counterpart bone
 	bones.write[51].bone_parent = "LeftFoot";
 	bones.write[51].reference_pose = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.15, 0);
 	bones.write[51].handle_offset = Vector2(0.545, 0.95);
 	bones.write[51].group = "Body";
 
 	bones.write[52].bone_name = "RightUpperLeg";
+	bones.write[52].bone_counterpart = "LeftUpperLeg"; // Counterpart bone
 	bones.write[52].bone_parent = "Hips";
 	bones.write[52].reference_pose = Transform3D(-1, 0, 0, 0, -1, 0, 0, 0, 1, -0.1, 0, 0);
 	bones.write[52].handle_offset = Vector2(0.451, 0.49);
@@ -809,6 +876,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[52].require = true;
 
 	bones.write[53].bone_name = "RightLowerLeg";
+	bones.write[53].bone_counterpart = "LeftLowerLeg"; // Counterpart bone
 	bones.write[53].bone_parent = "RightUpperLeg";
 	bones.write[53].reference_pose = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.375, 0);
 	bones.write[53].handle_offset = Vector2(0.452, 0.683);
@@ -816,6 +884,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[53].require = true;
 
 	bones.write[54].bone_name = "RightFoot";
+	bones.write[54].bone_counterpart = "LeftFoot"; // Counterpart bone
 	bones.write[54].bone_parent = "RightLowerLeg";
 	bones.write[54].reference_pose = Transform3D(-1, 0, 0, 0, 0, -1, 0, -1, 0, 0, 0.375, 0);
 	bones.write[54].handle_offset = Vector2(0.455, 0.9);
@@ -823,6 +892,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 	bones.write[54].require = true;
 
 	bones.write[55].bone_name = "RightToes";
+	bones.write[55].bone_counterpart = "LeftToes"; // Counterpart bone
 	bones.write[55].bone_parent = "RightFoot";
 	bones.write[55].reference_pose = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0.15, 0);
 	bones.write[55].handle_offset = Vector2(0.455, 0.95);

--- a/scene/resources/skeleton_profile.h
+++ b/scene/resources/skeleton_profile.h
@@ -56,6 +56,7 @@ protected:
 	struct SkeletonProfileBone {
 		StringName bone_name;
 		StringName bone_parent;
+		StringName bone_counterpart;
 		TailDirection tail_direction = TAIL_DIRECTION_AVERAGE_CHILDREN;
 		StringName bone_tail;
 		Transform3D reference_pose;
@@ -99,6 +100,9 @@ public:
 
 	StringName get_bone_name(int p_bone_idx) const;
 	void set_bone_name(int p_bone_idx, const StringName &p_bone_name);
+
+	StringName get_bone_counterpart_name(int p_bone_idx) const;
+	void set_bone_counterpart_name(int p_bone_idx, const StringName &p_bone_name);
 
 	StringName get_bone_parent(int p_bone_idx) const;
 	void set_bone_parent(int p_bone_idx, const StringName &p_bone_parent);


### PR DESCRIPTION
This PR adds two things to Godot:

 - Counterparts for all bones in `SkeletonProfileHumanoid` which can be mirror (like `LeftHand` <> `RightHand`)
 - `get_bone_counterpart_name` to `BoneMap` and `Skeleton3D` so we can retrieve a bones counterpart name
 - A module which adds the option and logic to mirror animations via post import plugin

However, during development I've discovered that animations whose rest pose is not in T-Pose will be heavily broken by this implementation.
I think the reason why this works in Unity is that they have an Avatar system which contains a models T-Pose.
Since this avatar is then by individual animations they can always figure out the correct rest pose.

Maybe there is a fix for this problem but I don't have one yet, maybe someone else knows more about this.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8478.*
