### PR TITLE
 WAV importer: Use cubic interpolation on resampler 

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -328,7 +328,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			int ipos = 0;
 
 			for (int i = 0; i < new_data_frames; i++) {
-				//simple cubic interpolation should be enough.
+				// Cubic interpolation should be enough.
 
 				float mu = frac;
 
@@ -337,15 +337,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 				float y2 = data[MIN(frames - 1, ipos + 1) * format_channels + c];
 				float y3 = data[MIN(frames - 1, ipos + 2) * format_channels + c];
 
-				float mu2 = mu * mu;
-				float a0 = y3 - y2 - y0 + y1;
-				float a1 = y0 - y1 - a0;
-				float a2 = y2 - y0;
-				float a3 = y1;
-
-				float res = (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3);
-
-				new_data.write[i * format_channels + c] = res;
+				new_data.write[i * format_channels + c] = Math::cubic_interpolate(y1, y2, y0, y3, mu);
 
 				// update position and always keep fractional part within ]0...1]
 				// in order to avoid 32bit floating point precision errors


### PR DESCRIPTION
I found this while playing around with ResourceImporterWAV's resampling procedure.

After importing one of [Kenney's Interface Sounds](https://kenney.nl/assets/interface-sounds) (specifically confirm2, converted to WAV) with a mix rate at 32000Hz, I noticed a significant distortion on the sound from the original.

I thought that was a side effect of downsampling, and decided to play around with the resampling code (because why not, maybe I could accidentally find a way to improve it). At one point however, I found a cubic interpolation function online that was different than the one in the importer, and decided to replace the one in resampling with it out of curiosity.

With this new cubic interpolation, the distortion became much less noticeable after reimporting. There is still a bit of distortion, the quality isn't anywhere close to libsamplerate's sinc interpolators, which would be the ideal approach for an importer, but it's still better than before.

In the end, I accidentally found a way of improving it. Since it's just 3 lines of code (+ one comment) I decided to submit.

Due to simplicity, I think this is cherrypickable for 3.x.

*Edit: after finding the same algorithm was already used in AudioStreamPlaybackResampled, I decided to copypaste it into ResourceImporterWAV.*

*Edit 2: The algorithm used in AudioStreamPlaybackResampled was an adaptation from `Math::cubic_interpolate()` to be used with AudioFrames. Changed to use that instead.*

**In few words: all this PR does is replacing the resample interpolation in ResourceImporterWAV with `Math::cubic_interpolate()`, which yields much better results.**