### PR TITLE
Fix crash GPU particles on ios

### DIFF
--- a/drivers/gles3/shaders/particles_copy.glsl
+++ b/drivers/gles3/shaders/particles_copy.glsl
@@ -57,45 +57,38 @@ void main() {
 		txform = transpose(mat4(xform_1, xform_2, vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0)));
 #endif
 
-		switch (align_mode) {
-			case TRANSFORM_ALIGN_DISABLED: {
-			} break; //nothing
-			case TRANSFORM_ALIGN_Z_BILLBOARD: {
-				mat3 local = mat3(normalize(cross(align_up, sort_direction)), align_up, sort_direction);
-				local = local * mat3(txform);
-				txform[0].xyz = local[0];
-				txform[1].xyz = local[1];
-				txform[2].xyz = local[2];
+		if (align_mode == TRANSFORM_ALIGN_Z_BILLBOARD) {
+			mat3 local = mat3(normalize(cross(align_up, sort_direction)), align_up, sort_direction);
+			local = local * mat3(txform);
+			txform[0].xyz = local[0];
+			txform[1].xyz = local[1];
+			txform[2].xyz = local[2];
 
-			} break;
-			case TRANSFORM_ALIGN_Y_TO_VELOCITY: {
-				vec3 v = velocity_flags.xyz;
-				float s = (length(txform[0]) + length(txform[1]) + length(txform[2])) / 3.0;
-				if (length(v) > 0.0) {
-					txform[1].xyz = normalize(v);
-				} else {
-					txform[1].xyz = normalize(txform[1].xyz);
-				}
+		} else if (align_mode == TRANSFORM_ALIGN_Y_TO_VELOCITY) {
+			vec3 v = velocity_flags.xyz;
+			float s = (length(txform[0]) + length(txform[1]) + length(txform[2])) / 3.0;
+			if (length(v) > 0.0) {
+				txform[1].xyz = normalize(v);
+			} else {
+				txform[1].xyz = normalize(txform[1].xyz);
+			}
 
-				txform[0].xyz = normalize(cross(txform[1].xyz, txform[2].xyz));
-				txform[2].xyz = vec3(0.0, 0.0, 1.0) * s;
-				txform[0].xyz *= s;
-				txform[1].xyz *= s;
-			} break;
-			case TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY: {
-				vec3 sv = velocity_flags.xyz - sort_direction * dot(sort_direction, velocity_flags.xyz); //screen velocity
+			txform[0].xyz = normalize(cross(txform[1].xyz, txform[2].xyz));
+			txform[2].xyz = vec3(0.0, 0.0, 1.0) * s;
+			txform[0].xyz *= s;
+			txform[1].xyz *= s;
+		} else if (align_mode == TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY) {
+			vec3 sv = velocity_flags.xyz - sort_direction * dot(sort_direction, velocity_flags.xyz); //screen velocity
 
-				if (length(sv) == 0.0) {
-					sv = align_up;
-				}
+			if (length(sv) == 0.0) {
+				sv = align_up;
+			}
 
-				sv = normalize(sv);
+			sv = normalize(sv);
 
-				txform[0].xyz = normalize(cross(sv, sort_direction)) * length(txform[0]);
-				txform[1].xyz = sv * length(txform[1]);
-				txform[2].xyz = sort_direction * length(txform[2]);
-
-			} break;
+			txform[0].xyz = normalize(cross(sv, sort_direction)) * length(txform[0]);
+			txform[1].xyz = sv * length(txform[1]);
+			txform[2].xyz = sort_direction * length(txform[2]);
 		}
 
 		txform[3].xyz += velocity_flags.xyz * frame_remainder;


### PR DESCRIPTION
This will fix crash engine when use GPU particles on ios, tested on 4.0.x, 4.1.x, 4.2.x (issue #72469). With this fix both 3D and 2D GPU particles won't crash on ios but only 2D particles work (on 4.1.2 and 4.2.1 require this #88745 which merged to master branch or it won't show anything). 
For 3D GPU particles on ios don't show anything, seem like there is another bug when core run into restart state of particles.glsl and code won't run if xform[3].xyz and out_velocity_flags.xyz == vec3(0.0). So if you add a simple code to prevent it become zero then 3D GPU particles will work on ios
![image](https://github.com/godotengine/godot/assets/1473739/7ec83775-3cee-413c-884c-3d5b57a2ccfa)

```c++
	if (restart && particle_active) {
#CODE : START
        if(length(out_velocity_flags) == 0.0)
            out_velocity_flags.xyz = (emission_transform * vec4(0.0, 0.0001, 0.0, 0.0)).xyz;
        xform[3].xyz += out_velocity_flags.xyz * 0.0001;
	}
``` 
but I don't fully understand all those shader code in particles.glsl so may need someone else who fully understand it to make a better fix
