### PR TITLE
Add AudioEffectHardLimiter as a rework of audio limiter effect

### DIFF
--- a/doc/classes/AudioEffectHardLimiter.xml
+++ b/doc/classes/AudioEffectHardLimiter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectHardLimiter" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Adds a hard limiter audio effect to an Audio bus.
+	</brief_description>
+	<description>
+		A limiter is an effect designed to disallow sound from going over a given dB threshold. Hard limiters predict volume peaks, and will smoothly apply gain reduction when a peak crosses the ceiling threshold to prevent clipping and distortion. It preserves the waveform and prevents it from crossing the ceiling threshold. Adding one in the Master bus is recommended as a safety measure to prevent sudden volume peaks from occurring, and to prevent distortion caused by clipping.
+	</description>
+	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+	</tutorials>
+	<members>
+		<member name="ceiling_db" type="float" setter="set_ceiling_db" getter="get_ceiling_db" default="-0.3">
+			The waveform's maximum allowed value, in decibels. This value can range from [code]-24.0[/code] to [code]0.0[/code].
+			The default value of [code]-0.3[/code] prevents potential inter-sample peaks (ISP) from crossing over 0 dB, which can cause slight distortion on some older hardware.
+		</member>
+		<member name="pre_gain_db" type="float" setter="set_pre_gain_db" getter="get_pre_gain_db" default="0.0">
+			Gain to apply before limiting, in decibels.
+		</member>
+		<member name="release" type="float" setter="set_release" getter="get_release" default="0.1">
+			Time it takes in seconds for the gain reduction to fully release.
+		</member>
+	</members>
+</class>

--- a/doc/classes/AudioEffectLimiter.xml
+++ b/doc/classes/AudioEffectLimiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AudioEffectLimiter" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AudioEffectLimiter" inherits="AudioEffect" deprecated="Use [AudioEffectHardLimiter] instead." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Adds a soft-clip limiter audio effect to an Audio bus.
 	</brief_description>

--- a/servers/audio/effects/audio_effect_hard_limiter.cpp
+++ b/servers/audio/effects/audio_effect_hard_limiter.cpp
@@ -1,0 +1,161 @@
+/**************************************************************************/
+/*  audio_effect_hard_limiter.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "audio_effect_hard_limiter.h"
+
+#include "servers/audio_server.h"
+
+void AudioEffectHardLimiterInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+	float sample_rate = AudioServer::get_singleton()->get_mix_rate();
+
+	float ceiling = Math::db_to_linear(base->ceiling);
+	float release = base->release;
+	float attack = base->attack;
+	float pre_gain = Math::db_to_linear(base->pre_gain);
+
+	for (int i = 0; i < p_frame_count; i++) {
+		float sample_left = p_src_frames[i].left;
+		float sample_right = p_src_frames[i].right;
+
+		sample_left *= pre_gain;
+		sample_right *= pre_gain;
+
+		float largest_sample = MAX(ABS(sample_left), ABS(sample_right));
+
+		release_factor = MAX(0.0, release_factor - 1.0 / sample_rate);
+		release_factor = MIN(release_factor, release);
+
+		if (release_factor > 0.0) {
+			gain = Math::lerp(gain_target, 1.0f, 1.0f - release_factor / release);
+		}
+
+		if (largest_sample * gain > ceiling) {
+			gain_target = ceiling / largest_sample;
+			release_factor = release;
+			attack_factor = attack;
+		}
+
+		// Lerp gain over attack time to avoid distortion.
+		attack_factor = MAX(0.0f, attack_factor - 1.0f / sample_rate);
+		if (attack_factor > 0.0) {
+			gain = Math::lerp(gain_target, gain, 1.0f - attack_factor / attack);
+		}
+
+		int bucket_id = gain_bucket_cursor / gain_bucket_size;
+
+		// If first item within the current bucket, reset the bucket.
+		if (gain_bucket_cursor % gain_bucket_size == 0) {
+			gain_buckets[bucket_id] = 1.0f;
+		}
+
+		gain_buckets[bucket_id] = MIN(gain_buckets[bucket_id], gain);
+
+		gain_bucket_cursor = (gain_bucket_cursor + 1) % gain_samples_to_store;
+
+		for (int j = 0; j < (int)gain_buckets.size(); j++) {
+			gain = MIN(gain, gain_buckets[j]);
+		}
+
+		// Introduce latency by grabbing the AudioFrame stored previously,
+		// then overwrite it with current audioframe, then update circular
+		// buffer cursor.
+		float dst_buffer_left = sample_buffer_left[sample_cursor];
+		float dst_buffer_right = sample_buffer_right[sample_cursor];
+
+		sample_buffer_left[sample_cursor] = sample_left;
+		sample_buffer_right[sample_cursor] = sample_right;
+
+		sample_cursor = (sample_cursor + 1) % sample_buffer_left.size();
+
+		p_dst_frames[i].left = dst_buffer_left * gain;
+		p_dst_frames[i].right = dst_buffer_right * gain;
+	}
+}
+
+Ref<AudioEffectInstance> AudioEffectHardLimiter::instantiate() {
+	Ref<AudioEffectHardLimiterInstance> ins;
+	ins.instantiate();
+	ins->base = Ref<AudioEffectHardLimiter>(this);
+
+	float mix_rate = AudioServer::get_singleton()->get_mix_rate();
+
+	for (int i = 0; i < (int)Math::ceil(mix_rate * attack) + 1; i++) {
+		ins->sample_buffer_left.push_back(0.0f);
+		ins->sample_buffer_right.push_back(0.0f);
+	}
+
+	ins->gain_samples_to_store = (int)Math::ceil(mix_rate * (attack + sustain) + 1);
+	ins->gain_bucket_size = (int)(mix_rate * attack);
+
+	for (int i = 0; i < ins->gain_samples_to_store; i += ins->gain_bucket_size) {
+		ins->gain_buckets.push_back(1.0f);
+	}
+
+	return ins;
+}
+
+void AudioEffectHardLimiter::set_ceiling_db(float p_ceiling) {
+	ceiling = p_ceiling;
+}
+
+float AudioEffectHardLimiter::get_ceiling_db() const {
+	return ceiling;
+}
+
+float AudioEffectHardLimiter::get_pre_gain_db() const {
+	return pre_gain;
+}
+
+void AudioEffectHardLimiter::set_pre_gain_db(const float p_pre_gain) {
+	pre_gain = p_pre_gain;
+}
+
+float AudioEffectHardLimiter::get_release() const {
+	return release;
+}
+
+void AudioEffectHardLimiter::set_release(const float p_release) {
+	release = p_release;
+}
+
+void AudioEffectHardLimiter::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_ceiling_db", "ceiling"), &AudioEffectHardLimiter::set_ceiling_db);
+	ClassDB::bind_method(D_METHOD("get_ceiling_db"), &AudioEffectHardLimiter::get_ceiling_db);
+
+	ClassDB::bind_method(D_METHOD("set_pre_gain_db", "p_pre_gain"), &AudioEffectHardLimiter::set_pre_gain_db);
+	ClassDB::bind_method(D_METHOD("get_pre_gain_db"), &AudioEffectHardLimiter::get_pre_gain_db);
+
+	ClassDB::bind_method(D_METHOD("set_release", "p_release"), &AudioEffectHardLimiter::set_release);
+	ClassDB::bind_method(D_METHOD("get_release"), &AudioEffectHardLimiter::get_release);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pre_gain_db", PROPERTY_HINT_RANGE, "-24,24,0.01,suffix:dB"), "set_pre_gain_db", "get_pre_gain_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ceiling_db", PROPERTY_HINT_RANGE, "-24,0.0,0.01,suffix:dB"), "set_ceiling_db", "get_ceiling_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "release", PROPERTY_HINT_RANGE, "0.01,3,0.01"), "set_release", "get_release");
+}

--- a/servers/audio/effects/audio_effect_hard_limiter.h
+++ b/servers/audio/effects/audio_effect_hard_limiter.h
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  audio_effect_hard_limiter.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef AUDIO_EFFECT_HARD_LIMITER_H
+#define AUDIO_EFFECT_HARD_LIMITER_H
+
+#include "servers/audio/audio_effect.h"
+
+class AudioEffectHardLimiter;
+
+class AudioEffectHardLimiterInstance : public AudioEffectInstance {
+	GDCLASS(AudioEffectHardLimiterInstance, AudioEffectInstance);
+	friend class AudioEffectHardLimiter;
+	Ref<AudioEffectHardLimiter> base;
+
+private:
+	int sample_cursor = 0;
+
+	float release_factor = 0;
+	float attack_factor = 0;
+	float gain = 1;
+	float gain_target = 1;
+
+	LocalVector<float> sample_buffer_left;
+	LocalVector<float> sample_buffer_right;
+
+	int gain_samples_to_store = 0;
+	int gain_bucket_cursor = 0;
+	int gain_bucket_size = 0;
+	LocalVector<float> gain_buckets;
+
+public:
+	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
+};
+
+class AudioEffectHardLimiter : public AudioEffect {
+	GDCLASS(AudioEffectHardLimiter, AudioEffect);
+
+	friend class AudioEffectHardLimiterInstance;
+	float pre_gain = 0.0f;
+	float ceiling = -0.3f;
+	float sustain = 0.02f;
+	float release = 0.1f;
+	const float attack = 0.002;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_ceiling_db(float p_ceiling);
+	float get_ceiling_db() const;
+
+	void set_release(float p_release);
+	float get_release() const;
+
+	void set_pre_gain_db(float p_pre_gain);
+	float get_pre_gain_db() const;
+
+	Ref<AudioEffectInstance> instantiate() override;
+};
+
+#endif // AUDIO_EFFECT_HARD_LIMITER_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -43,6 +43,7 @@
 #include "audio/effects/audio_effect_distortion.h"
 #include "audio/effects/audio_effect_eq.h"
 #include "audio/effects/audio_effect_filter.h"
+#include "audio/effects/audio_effect_hard_limiter.h"
 #include "audio/effects/audio_effect_limiter.h"
 #include "audio/effects/audio_effect_panner.h"
 #include "audio/effects/audio_effect_phaser.h"
@@ -210,6 +211,7 @@ void register_server_types() {
 		GDREGISTER_CLASS(AudioEffectDelay);
 		GDREGISTER_CLASS(AudioEffectCompressor);
 		GDREGISTER_CLASS(AudioEffectLimiter);
+		GDREGISTER_CLASS(AudioEffectHardLimiter);
 		GDREGISTER_CLASS(AudioEffectPitchShift);
 		GDREGISTER_CLASS(AudioEffectPhaser);
 


### PR DESCRIPTION
This pull request entirely replaces the limiter that was initially implemented. The reason for this is the old limiter boosted the signal and limited through hard clipping, this introduced harsh distortions, reported in #36631. Because this is essentially a complete replacement of a feature and breaks compatibility, I'll try to be thorough in this pull request.

Setting up the old limiter with a Ceiling dB of -12 dB, and a threshold of 0 dB does not limit the signal, but reduces all samples going through by 12dB. When changing the Threshold dB property, the overall signal strength gets boosted, and when a sample crosses this threshold, it multiplies the incoming signal by ceiling/sample. This results in a sample that is exactly the same value as the ceiling (aka hard clipping). This drastically changes the waveform of the sound coming through and thus introduces distortion. This meant this limiter couldn't be used for limiting, as it would either simply lower the volume, or boost the signal and introduce distortions.

Because not everyone is as familiar with audio processing and audio effects, I'll attempt to give a brief overview over what a limiter aims to do, how it works, and how I've implemented it.

### Brief overview of a limiter:
The goal of a limiter is to ensure no sound crosses a threshold, and is generally put on the master bus. This is important to have in any software that allows various audio processing effects like boosting and distorting signals to:
- Avoid distorting the outputted sound when it crosses 0dB.
- Protect the hearing of users against unexpected loud signals.

A limiter should always only affect the volume, and preserve the waveform as much as possible. It works as follows:
It makes use of lookahead, which introduces a small amount of latency to the sound, typically 1-2ms. This allows the limiter to smoothly apply a gain reduction over time, before the actual peak is reached, which makes it so the waveform is preserved and undistorted. It stores the maximum gain reduction for all last played samples within a certain sustain time period in a buffer, and will always apply the largest amount of gain reduction present within this buffer.
When reducing the amount of gain reduction happening, a smooth release is done moving back to no gain reduction, or whichever minimum gain-reduction amount is present in the sustain buffer.

For further (more in-depth) information on how limiters work I recommend this incredible blog post by Geraint Luff: https://signalsmith-audio.co.uk/writing/2022/limiter/

### My implementation:
I have commented the various steps in my code to try to make this easier to read for those unfamiliar with signal processing, but here is a quick extra explanation specifically on the buffers and buckets.

For context: the gain variable in my implementation is used to multiply the final output to get the desired volume reduction.
Firstly, three arrays are filled with some initial values: Two for the left- and right-samples so we can delay the sound. The size of these arrays depend on how long the attack time is set. Then a third one based on the attack+sustain time called gain_buckets. To avoid having to check over hundreds/thousands of samples to determine what the current gain reduction should be each sample, we simplify this buffer by comparing ranges of samples and storing a single minimum float in a bucket. To determine what value to store in a bucket, each sample we compare the gain of the current sample to the gain stored in the bucket, we store whichever is smaller. We can then run a small for-loop comparing all the buckets and taking the lowest gain value. This gives us an efficient approximation of the desired sustain functionality (See the peak-hold section in Geraints blog post).

Unlike the old limiter which changed the output volume based on the ceiling dB set, this implementation keeps a constant volume, and only affects the volume when peaks cross the ceiling.

I adjusted some pre-existing values:
- Ceiling_dB default from -0.1 to -0.3
Limiters are often set slightly below 0 by default because of something called the inter-sample-peak (ISP). Audio samples aren't a complete representation of a signal, and it is possible when converting a digital signal to an analog signal (i.e. converting to the electrical signal for a speakers driver) for a peak to exist in between the samples describing a signal that is louder than the samples around it. This ISP can be a cause for distortion on some hardware. Some limiters implement ISP detection, and some just set a default ceiling value of -0.3dB. This seems to be a widely accepted default ceiling value for limiters across various DAWs and limiter plugins, so I think it is a good idea to follow this standard, and adjust our default value accordingly.

- Ceiling_dB minimum from -20 to -24
Every 6 decibels describe a halving or doubling of volume, so to me it makes more sense for the minimum of this range to be divisible by 6.

### Results and comparisons:
My comparisons and tests were done using a sine wave generated in Ableton, linearly fading from amplitude 1 to 0.
This test-signal unaffected looks like this:
![01-input-signal](https://github.com/godotengine/godot/assets/31851431/9393b9c0-2beb-4fb2-aca1-dab565aa6f7c)
Sound file is test-beep.wav (in the attached zip), check your volume since this beep goes from max volume to 0 volume, and can be quite loud.

We expect anywhere where this signal is louder than the ceiling to be limited to the ceiling, keeping the waveshape/form of the sound the same. The ceiling in these examples for both limiters were set at -6dB, threshold for old limiter at -3.
The old limiter on the sound-beep is test-beep-old-limiter.wav
This new implementation on the sound-beep is test-beep-new-limiter.wav

Zooming into those limited signals, we can see a drastic difference. The first (old limiter) cuts off the peaks of the signal, turning a signal that used to be a sine wave into something more akin to a square wave, while the second preserves the wave shape, simply scaling it down evenly to decrease the volume.
![03-limited-signal-zoom](https://github.com/godotengine/godot/assets/31851431/09a5e32c-3e83-44f4-b6b0-a0e0042ce848)

Edit:
Looks like I messed up adding the example audiofiles.
[godot-limiter-comparison.zip](https://github.com/godotengine/godot/files/14470060/godot-limiter-comparison.zip)
