### PR TITLE
Fix `USERDATA` built-ins for GLES3 particle shaders

### DIFF
--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -112,22 +112,22 @@ layout(location = 4) in highp vec4 xform_2;
 layout(location = 5) in highp vec4 xform_3;
 #endif
 #ifdef USERDATA1_USED
-layout(location = 6) in highp vec4 userdata1;
+in highp vec4 userdata1;
 #endif
 #ifdef USERDATA2_USED
-layout(location = 7) in highp vec4 userdata2;
+in highp vec4 userdata2;
 #endif
 #ifdef USERDATA3_USED
-layout(location = 8) in highp vec4 userdata3;
+in highp vec4 userdata3;
 #endif
 #ifdef USERDATA4_USED
-layout(location = 9) in highp vec4 userdata4;
+in highp vec4 userdata4;
 #endif
 #ifdef USERDATA5_USED
-layout(location = 10) in highp vec4 userdata5;
+in highp vec4 userdata5;
 #endif
 #ifdef USERDATA6_USED
-layout(location = 11) in highp vec4 userdata6;
+in highp vec4 userdata6;
 #endif
 
 out highp vec4 out_color; //tfb:
@@ -219,6 +219,24 @@ void main() {
 #endif
 		xform = transpose(xform);
 		flags = floatBitsToUint(velocity_flags.w);
+#ifdef USERDATA1_USED
+		out_userdata1 = userdata1;
+#endif
+#ifdef USERDATA2_USED
+		out_userdata2 = userdata2;
+#endif
+#ifdef USERDATA3_USED
+		out_userdata3 = userdata3;
+#endif
+#ifdef USERDATA4_USED
+		out_userdata4 = userdata4;
+#endif
+#ifdef USERDATA5_USED
+		out_userdata5 = userdata5;
+#endif
+#ifdef USERDATA6_USED
+		out_userdata6 = userdata6;
+#endif
 	}
 
 	//clear started flag if set

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -728,8 +728,10 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	ParticlesShaderGLES3::ShaderVariant variant = ParticlesShaderGLES3::MODE_DEFAULT;
 
 	uint32_t specialization = 0;
-	for (uint32_t i = 0; i < p_particles->userdata_count; i++) {
-		specialization |= (1 << i);
+	for (uint32_t i = 0; i < PARTICLES_MAX_USERDATAS; i++) {
+		if (m->shader_data->userdatas_used[i]) {
+			specialization |= ParticlesShaderGLES3::USERDATA1_USED << i;
+		}
 	}
 
 	if (p_particles->mode == RS::ParticlesMode::PARTICLES_MODE_3D) {


### PR DESCRIPTION
When using any of USERDATA1-6 in a particle shader with the compatibility renderer, every particle except the first one would glitch out due to a buffer stride mismatch.

This PR addresses that and some related issues:

1. When setting flags in `specialization` for active userdatas, the wrong bit offset was used.
2. Userdata values were not carried over between frames.
3. Enabling individual userdatas was done only based on the count of userdatas in the particle shader. So if the shader only used for example `USERDATA6` that would give a count of one and hence `USERDATA1` was enabled instead, causing the shader to fail to compile.

NOTE: To make it possible to use any of the six userdatas without requiring that 1 is used before 2 and so on, I had to remove the layout locations on the inputs. I don't have nearly enough knowledge to understand if that is safe or if there is a better way. I need a maintainer to give feedback on this.
