### PR TITLE
Fix: load autoloads before external scripts

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3410,7 +3410,6 @@ bool Main::start() {
 	}
 #endif
 
-	
 	List<Node *> autoloads_to_add;
 
 	if (!project_manager && !editor) { // game
@@ -3429,7 +3428,7 @@ bool Main::start() {
 					}
 				}
 			}
-			
+
 			//second pass, load into global constants
 			for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
 				const ProjectSettings::AutoloadInfo &info = E.value;
@@ -3475,7 +3474,7 @@ bool Main::start() {
 						ScriptServer::get_language(i)->add_global_constant(info.name, n);
 					}
 				}
-			}			
+			}
 		}
 	}
 
@@ -3601,7 +3600,7 @@ bool Main::start() {
 		ResourceSaver::add_custom_savers();
 
 		if (!project_manager && !editor) { // game
-			if (!game_path.is_empty() || !script.is_empty()) {				
+			if (!game_path.is_empty() || !script.is_empty()) {
 				for (Node *E : autoloads_to_add) {
 					sml->get_root()->add_child(E);
 				}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3410,6 +3410,75 @@ bool Main::start() {
 	}
 #endif
 
+	
+	List<Node *> autoloads_to_add;
+
+	if (!project_manager && !editor) { // game
+		if (!game_path.is_empty() || !script.is_empty()) {
+			//autoload
+			OS::get_singleton()->benchmark_begin_measure("Startup", "Load Autoloads");
+			HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+
+			//first pass, add the constants so they exist before any script is loaded
+			for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
+				const ProjectSettings::AutoloadInfo &info = E.value;
+
+				if (info.is_singleton) {
+					for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+						ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
+					}
+				}
+			}
+			
+			//second pass, load into global constants
+			for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
+				const ProjectSettings::AutoloadInfo &info = E.value;
+
+				Node *n = nullptr;
+				if (ResourceLoader::get_resource_type(info.path) == "PackedScene") {
+					// Cache the scene reference before loading it (for cyclic references)
+					Ref<PackedScene> scn;
+					scn.instantiate();
+					scn->set_path(info.path);
+					scn->reload_from_file();
+					ERR_CONTINUE_MSG(!scn.is_valid(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
+
+					if (scn.is_valid()) {
+						n = scn->instantiate();
+					}
+				} else {
+					Ref<Resource> res = ResourceLoader::load(info.path);
+					ERR_CONTINUE_MSG(res.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
+
+					Ref<Script> script_res = res;
+					if (script_res.is_valid()) {
+						StringName ibt = script_res->get_instance_base_type();
+						bool valid_type = ClassDB::is_parent_class(ibt, "Node");
+						ERR_CONTINUE_MSG(!valid_type, vformat("Failed to instantiate an autoload, script '%s' does not inherit from 'Node'.", info.path));
+
+						Object *obj = ClassDB::instantiate(ibt);
+						ERR_CONTINUE_MSG(!obj, vformat("Failed to instantiate an autoload, cannot instantiate '%s'.", ibt));
+
+						n = Object::cast_to<Node>(obj);
+						n->set_script(script_res);
+					}
+				}
+
+				ERR_CONTINUE_MSG(!n, vformat("Failed to instantiate an autoload, path is not pointing to a scene or a script: %s.", info.path));
+				n->set_name(info.name);
+
+				//defer so references are all valid on _ready()
+				autoloads_to_add.push_back(n);
+
+				if (info.is_singleton) {
+					for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+						ScriptServer::get_language(i)->add_global_constant(info.name, n);
+					}
+				}
+			}			
+		}
+	}
+
 	MainLoop *main_loop = nullptr;
 	if (editor) {
 		main_loop = memnew(SceneTree);
@@ -3532,71 +3601,8 @@ bool Main::start() {
 		ResourceSaver::add_custom_savers();
 
 		if (!project_manager && !editor) { // game
-			if (!game_path.is_empty() || !script.is_empty()) {
-				//autoload
-				OS::get_singleton()->benchmark_begin_measure("Startup", "Load Autoloads");
-				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
-
-				//first pass, add the constants so they exist before any script is loaded
-				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-					const ProjectSettings::AutoloadInfo &info = E.value;
-
-					if (info.is_singleton) {
-						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
-						}
-					}
-				}
-
-				//second pass, load into global constants
-				List<Node *> to_add;
-				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-					const ProjectSettings::AutoloadInfo &info = E.value;
-
-					Node *n = nullptr;
-					if (ResourceLoader::get_resource_type(info.path) == "PackedScene") {
-						// Cache the scene reference before loading it (for cyclic references)
-						Ref<PackedScene> scn;
-						scn.instantiate();
-						scn->set_path(info.path);
-						scn->reload_from_file();
-						ERR_CONTINUE_MSG(!scn.is_valid(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
-
-						if (scn.is_valid()) {
-							n = scn->instantiate();
-						}
-					} else {
-						Ref<Resource> res = ResourceLoader::load(info.path);
-						ERR_CONTINUE_MSG(res.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
-
-						Ref<Script> script_res = res;
-						if (script_res.is_valid()) {
-							StringName ibt = script_res->get_instance_base_type();
-							bool valid_type = ClassDB::is_parent_class(ibt, "Node");
-							ERR_CONTINUE_MSG(!valid_type, vformat("Failed to instantiate an autoload, script '%s' does not inherit from 'Node'.", info.path));
-
-							Object *obj = ClassDB::instantiate(ibt);
-							ERR_CONTINUE_MSG(!obj, vformat("Failed to instantiate an autoload, cannot instantiate '%s'.", ibt));
-
-							n = Object::cast_to<Node>(obj);
-							n->set_script(script_res);
-						}
-					}
-
-					ERR_CONTINUE_MSG(!n, vformat("Failed to instantiate an autoload, path is not pointing to a scene or a script: %s.", info.path));
-					n->set_name(info.name);
-
-					//defer so references are all valid on _ready()
-					to_add.push_back(n);
-
-					if (info.is_singleton) {
-						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, n);
-						}
-					}
-				}
-
-				for (Node *E : to_add) {
+			if (!game_path.is_empty() || !script.is_empty()) {				
+				for (Node *E : autoloads_to_add) {
 					sml->get_root()->add_child(E);
 				}
 				OS::get_singleton()->benchmark_end_measure("Startup", "Load Autoloads");


### PR DESCRIPTION
Fixes #80319

Disclaimer: the idea is to get the ball rolling on a possible fix for this issue. I'm aware that the implementation CAN be refactored to avoid some repeated checks, but I'd like first to get the approach approved, and someone with more experience on this part of the engine to help me figure out the best way to refactor. Otherwise I risk moving too much stuff around and making it too hard to reason about the implications of the changes.

### Explanation:

The previous behavior was the following:

1. Assign `main_loop`. If the `-s` option was passed, the script is loaded (compiled), instantiated, and set as the main_loop
2. If the main loop is a SceneTree:
  a. Get autoloads from project settings and register their names as global, pointing to the corresponding instantiated autoloads
  b. Add autoload nodes to the tree

This caused external scripts to be compiled and instantiated before autoloads were registered, causing compilation errors (and also eventual runtime errors if the autoload in question was being used during the script initialization)

My proposed changes result in this:

1. If there is a script (or game path):
  a. Get autoloads from project settings and register their names as global, pointing to the corresponding instantiated autoloads
2. Assign `main_loop`. If the `-s` option was passed, the script is loaded (compiled), instantiated, and set as the main_loop
3. If the main loop is a SceneTree:
  a. Add autoload nodes to the tree


### Implications:

Running a script that references an autoload with `-s` will now compile correctly, and references to the autoload nodes will also exist on initialization. The autoloads won't be added to the tree until after the script is initialized, since we might not even have a tree if the script inherits directly from `MainLoop`, and there's no (easy) way to know that until the script has been instantiated. That means that if a script is depending on functionality of an autoload that depends on said autoload being in the tree, it won't function as intended in two scenarios:
- If the script inherits from MainLoop
- If the script inherits from SceneTree but is calling the autoload's functionality in its `_init` method


### Possible pitfalls:

- There might be a chance that my implementation causes autoloads to be loaded in a scenario where they shouldn't be loaded (I tried to mimic the existing checks, but I'm not entirely sure of the implications of the `game_path` variable, and the engine's code is quite complex so I'm always skeptical of my ability to understand it in full)
- The "Load Autoloads" benchmark is now not as accurate as before because it now accounts for code that is unrelated to autoloads in between. Is there a way to start a benchmark, pause it, and resume it later?
- It is entirely possible that from an engine design perspective you might not want autoloads to be floating around untethered to the tree in the case where the user is running a script that extends from `MainLoop`. I figured it was better to have access to the autoloads, even if limited, than not at all. We could maybe document this behavior. Otherwise, it's a matter of separating the two autoload steps, performing the name registration before loading and instantiating the script, and the autoload instantiation and re-registration as it was done before (right before adding them to the tree). In any case, I think it should also be documented that in that scenario, autoloads won't be available on script initialization (or at all if the script doesn't inherit from `SceneTree`)