### PR TITLE
Do not attempt to set cursor shape in headless mode.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6191,7 +6191,9 @@ EditorNode::EditorNode() {
 			// Only if no touchscreen ui hint, disable emulation just in case.
 			Input::get_singleton()->set_emulate_touch_from_mouse(false);
 		}
-		DisplayServer::get_singleton()->cursor_set_custom_image(Ref<Resource>());
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CUSTOM_CURSOR_SHAPE)) {
+			DisplayServer::get_singleton()->cursor_set_custom_image(Ref<Resource>());
+		}
 	}
 
 	SceneState::set_disable_placeholders(true);


### PR DESCRIPTION
Every time I run anything in `--headless` mode I receive this warning:

**WARNING: Custom cursor shape not supported by this display server.**

This does not seem helpful or useful to me. Instead it distracts from the process and encourages us to get used to ignoring errors and warnings without reading them each time.

My, possibly naive, interpretation of the code is that it can skip this step always when running `--headless` with no negative effect, but if I'm wrong, feel free to reject.

It seems to work for me.