### PR TITLE
Fix issues with text clearing in `RichTextLabel`

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -55,8 +55,8 @@
 		<method name="clear">
 			<return type="void" />
 			<description>
-				Clears the tag stack.
-				[b]Note:[/b] This method will not modify [member text], but setting [member text] to an empty string also clears the stack.
+				Clears the tag stack, causing the label to display nothing.
+				[b]Note:[/b] This method does not affect [member text], and its contents will show again if the label is redrawn. However, setting [member text] to an empty [String] also clears the stack.
 			</description>
 		</method>
 		<method name="deselect">
@@ -594,6 +594,7 @@
 		</member>
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" default="false">
 			If [code]true[/code], the label uses BBCode formatting.
+			[b]Note:[/b] This only affects the contents of [member text], not the tag stack.
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled" default="false">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1901,7 +1901,11 @@ void RichTextLabel::_notification(int p_what) {
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			_apply_translation();
+			// If `text` is empty, it could mean that the tag stack is being used instead. Leave it be.
+			if (!text.is_empty()) {
+				_apply_translation();
+			}
+
 			queue_redraw();
 		} break;
 
@@ -5667,19 +5671,16 @@ int RichTextLabel::get_selection_to() const {
 }
 
 void RichTextLabel::set_text(const String &p_bbcode) {
-	if (text == p_bbcode) {
+	// Allow clearing the tag stack.
+	if (!p_bbcode.is_empty() && text == p_bbcode) {
 		return;
 	}
+
 	text = p_bbcode;
 	_apply_translation();
 }
 
 void RichTextLabel::_apply_translation() {
-	// If `text` is empty, it could mean that the tag stack is being used instead. Leave it be.
-	if (text.is_empty()) {
-		return;
-	}
-
 	String xl_text = atr(text);
 	if (use_bbcode) {
 		parse_bbcode(xl_text);
@@ -5700,7 +5701,10 @@ void RichTextLabel::set_use_bbcode(bool p_enable) {
 	use_bbcode = p_enable;
 	notify_property_list_changed();
 
-	_apply_translation();
+	// If `text` is empty, it could mean that the tag stack is being used instead. Leave it be.
+	if (!text.is_empty()) {
+		_apply_translation();
+	}
 }
 
 bool RichTextLabel::is_using_bbcode() const {


### PR DESCRIPTION
This PR fixes a couple of bugs and adds some needed doc annotations to `RichTextLabel`.

- Fix clearing text contents with `text = ""` _(my bad)_. Closes #89091.
- Fix `text = ""` not clearing the tag stack if `text` is already empty.