### PR TITLE
Fix `RandomNumberGenerator::rand_weighted` return type

### DIFF
--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -57,7 +57,7 @@ public:
 	_FORCE_INLINE_ real_t randfn(real_t p_mean = 0.0, real_t p_deviation = 1.0) { return randbase.randfn(p_mean, p_deviation); }
 	_FORCE_INLINE_ int randi_range(int p_from, int p_to) { return randbase.random(p_from, p_to); }
 
-	_FORCE_INLINE_ int rand_weighted(const Vector<float> &p_weights) { return randbase.rand_weighted(p_weights); }
+	_FORCE_INLINE_ int64_t rand_weighted(const Vector<float> &p_weights) { return randbase.rand_weighted(p_weights); }
 
 	RandomNumberGenerator() { randbase.randomize(); }
 };

--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -43,7 +43,7 @@ void RandomPCG::randomize() {
 	seed(((uint64_t)OS::get_singleton()->get_unix_time() + OS::get_singleton()->get_ticks_usec()) * pcg.state + PCG_DEFAULT_INC_64);
 }
 
-int RandomPCG::rand_weighted(const Vector<float> &p_weights) {
+int64_t RandomPCG::rand_weighted(const Vector<float> &p_weights) {
 	ERR_FAIL_COND_V_MSG(p_weights.is_empty(), -1, "Weights array is empty.");
 	int64_t weights_size = p_weights.size();
 	const float *weights = p_weights.ptr();

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -90,7 +90,7 @@ public:
 		return pcg32_boundedrand_r(&pcg, bounds);
 	}
 
-	int rand_weighted(const Vector<float> &p_weights);
+	int64_t rand_weighted(const Vector<float> &p_weights);
 
 	// Obtaining floating point numbers in [0, 1] range with "good enough" uniformity.
 	// These functions sample the output of rand() as the fraction part of an infinite binary number,

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -24,13 +24,13 @@
 				Returns a random index with non-uniform weights. Prints an error and returns [code]-1[/code] if the array is empty.
 				[codeblocks]
 				[gdscript]
-				var rnd = RandomNumberGenerator.new()
+				var rng = RandomNumberGenerator.new()
 
-				var my_array = ["one", "two", "three, "four"]
+				var my_array = ["one", "two", "three", "four"]
 				var weights = PackedFloat32Array([0.5, 1, 1, 2])
 
 				# Prints one of the four elements in `my_array`.
-				# It is more likely to print "four", and less likely to print "two".
+				# It is more likely to print "four", and less likely to print "one".
 				print(my_array[rng.rand_weighted(weights)])
 				[/gdscript]
 				[/codeblocks]


### PR DESCRIPTION
Fixes wrong return type introduced in #88883:

`RandomNumberGenerator::rand_weighted` returns `int` instead of `int64_t` (the returned value `i` is defined as `int64_t` inside the `for` loop).

Also made minor changes to the documentation example (few typos).

As a side note, can we change the internal `RandomPCG::rand_weighted` method name to `random_weighted` (all other methods here are just called `random`)? The exposed one from `RandomNumberGenerator` would remain the same `rand_weighted`.