### PR TITLE
Fix editor crash when a file can't be instantiated in scene

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5936,6 +5936,10 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 				if (!preview_node->get_parent()) { // create preview only once
 					_create_preview(files);
 				}
+				if (preview_node->get_child_count() == 0) {
+					return false;
+				}
+
 				Transform2D trans = canvas_item_editor->get_canvas_transform();
 				preview_node->set_position((p_point - trans.get_origin()) / trans.get_scale().x);
 				String scene_file_path = preview_node->get_child(0)->get_scene_file_path();


### PR DESCRIPTION
Fixes #89093
Possibly introduced by #88829 as this added code to show more information when instantiating a node/resource into the scene. Unsupported files (such as `.tres` as shown in the issue) crash the editor due to an index out of bounds when trying to get the child of the `preview_node` (there are no children).

Following video shows the fix based on the MRP uploaded. I don't think this messes with the intended behavior. Let me know if I should check for more cases.

https://github.com/godotengine/godot/assets/55825613/7e05cc1b-97fe-439f-9734-70757b916ff4

