### PR TITLE
[MP] Fix replication config reload error

### DIFF
--- a/modules/multiplayer/scene_replication_config.cpp
+++ b/modules/multiplayer/scene_replication_config.cpp
@@ -103,6 +103,14 @@ void SceneReplicationConfig::_get_property_list(List<PropertyInfo> *p_list) cons
 	}
 }
 
+void SceneReplicationConfig::reset_state() {
+	dirty = false;
+	properties.clear();
+	sync_props.clear();
+	spawn_props.clear();
+	watch_props.clear();
+}
+
 TypedArray<NodePath> SceneReplicationConfig::get_properties() const {
 	TypedArray<NodePath> paths;
 	for (const ReplicationProperty &prop : properties) {

--- a/modules/multiplayer/scene_replication_config.h
+++ b/modules/multiplayer/scene_replication_config.h
@@ -79,6 +79,8 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
+	virtual void reset_state() override; // Required since we use variable amount of properties.
+
 	TypedArray<NodePath> get_properties() const;
 
 	void add_property(const NodePath &p_path, int p_index = -1);


### PR DESCRIPTION
Override the `reset_state` method to properly handle reloading the resource from disk.

Fixes #89026