### PR TITLE
[Wayland] Fix tilt handling

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2424,8 +2424,7 @@ void WaylandThread::_wp_tablet_tool_on_frame(void *data, struct zwp_tablet_tool_
 		// According to the tablet proto spec, tilt is expressed in degrees relative
 		// to the Z axis of the tablet, so it shouldn't go over 90 degrees either way,
 		// I think. We'll clamp it just in case.
-		td.tilt.x = CLAMP(td.tilt.x, -90, 90);
-		td.tilt.y = CLAMP(td.tilt.x, -90, 90);
+		td.tilt = td.tilt.clamp(Vector2(-90, -90), Vector2(90, 90));
 
 		mm->set_tilt(td.tilt / 90);
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -308,7 +308,7 @@ public:
 
 	struct TabletToolData {
 		Point2i position;
-		Vector2i tilt;
+		Vector2 tilt;
 		uint32_t pressure = 0;
 
 		BitField<MouseButtonMask> pressed_button_mask;


### PR DESCRIPTION
Haven't seen any reports on this but assuming this is a typo, replaced with `Vector2::clamp` for safety (discovered while working on https://github.com/godotengine/godot/pull/89111, and does if this is a bug show the value of that IMO)
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
