### PR TITLE
[Core] Move `#includes` from `project_settings.h` into `project_settings.cpp`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -39,6 +39,7 @@
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
 #include "core/os/keyboard.h"
+#include "core/templates/rb_set.h"
 #include "core/variant/typed_array.h"
 #include "core/variant/variant_parser.h"
 #include "core/version.h"

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -32,10 +32,6 @@
 #define PROJECT_SETTINGS_H
 
 #include "core/object/class_db.h"
-#include "core/os/thread_safe.h"
-#include "core/templates/hash_map.h"
-#include "core/templates/local_vector.h"
-#include "core/templates/rb_set.h"
 
 template <typename T>
 class TypedArray;


### PR DESCRIPTION
Just looked at the core code and saw that extra includes can be moved to `.cpp`. I moved it and the project compiled without errors