### PR TITLE
Allow `Nil` as dictionary key in inspector

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -776,25 +776,26 @@ void EditorPropertyDictionary::_change_type(Object *p_button, int p_index) {
 }
 
 void EditorPropertyDictionary::_add_key_value() {
-	// Do not allow nil as valid key. I experienced errors with this
-	if (object->get_new_item_key().get_type() == Variant::NIL) {
-		return;
+	Dictionary dict = object->get_dict().duplicate();
+	Variant key = object->get_new_item_key();
+	Variant value = object->get_new_item_value();
+	Variant::Type key_type = key.get_type();
+	Variant::Type value_type = value.get_type();
+
+	// Treat empty object key as nil to prevent editor-only duplicates.
+	if (key_type == Variant::OBJECT && key.is_null()) {
+		dict[Variant()] = value;
+	} else {
+		dict[key] = value;
 	}
 
-	Dictionary dict = object->get_dict().duplicate();
-	Variant new_key = object->get_new_item_key();
-	Variant new_value = object->get_new_item_value();
-	dict[new_key] = new_value;
+	key.zero();
+	VariantInternal::initialize(&key, key_type);
+	object->set_new_item_key(key);
 
-	Variant::Type type = new_key.get_type();
-	new_key.zero();
-	VariantInternal::initialize(&new_key, type);
-	object->set_new_item_key(new_key);
-
-	type = new_value.get_type();
-	new_value.zero();
-	VariantInternal::initialize(&new_value, type);
-	object->set_new_item_value(new_value);
+	value.zero();
+	VariantInternal::initialize(&value, value_type);
+	object->set_new_item_value(value);
 
 	emit_changed(get_edited_property(), dict, "", false);
 	update_property();


### PR DESCRIPTION
Despite Godot's dictionaries treating `null` as a valid key, the editor inspector currently doesn't allow setting `Nil` as a key. It's likely this restriction was initially made because the editor erroneously treated `Nil` and an empty `Object` as different values, displaying what appears to be two separate `null` keys in the inspector. Moreover, it *is* possible to circumvent this restriction in editor by simply adding an empty `Object`, as that's functionally identical to `Nil` as far as Godot is concerned.

This PR removes the need for restrictions and circumventions with the following changes:
1. Allow `Nil` as a valid key outright
2. Convert attempted empty `Object` keys to `Nil`

This removes the duplicate `null` bug & matches the expected functionality for dictionary keys. There's probably a broader discussion to be had on if this behavior is appropriate, but that's well outside the scope of this PR; this is strictly for allowing the inspector to create the same kinds of dictionaries that can be created in script.