### PR TITLE
Fix undo action names for node replacement

### DIFF
--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -86,7 +86,7 @@ void CPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 			gpu_particles->set_process_mode(particles->get_process_mode());
 
 			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-			ur->create_action(TTR("Convert to GPUParticles3D"));
+			ur->create_action(TTR("Convert to GPUParticles3D"), UndoRedo::MERGE_DISABLE, particles);
 			SceneTreeDock::get_singleton()->replace_node(particles, gpu_particles);
 			ur->commit_action(false);
 		} break;

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -72,7 +72,7 @@ void CPUParticles3DEditor::_menu_option(int p_option) {
 			gpu_particles->set_process_mode(node->get_process_mode());
 
 			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-			ur->create_action(TTR("Convert to GPUParticles3D"));
+			ur->create_action(TTR("Convert to GPUParticles3D"), UndoRedo::MERGE_DISABLE, node);
 			SceneTreeDock::get_singleton()->replace_node(node, gpu_particles);
 			ur->commit_action(false);
 

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -115,7 +115,7 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 			cpu_particles->set_z_index(particles->get_z_index());
 
 			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-			ur->create_action(TTR("Convert to CPUParticles2D"));
+			ur->create_action(TTR("Convert to CPUParticles2D"), UndoRedo::MERGE_DISABLE, particles);
 			SceneTreeDock::get_singleton()->replace_node(particles, cpu_particles);
 			ur->commit_action(false);
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -279,7 +279,7 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 			cpu_particles->set_process_mode(node->get_process_mode());
 
 			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-			ur->create_action(TTR("Convert to CPUParticles3D"));
+			ur->create_action(TTR("Convert to CPUParticles3D"), UndoRedo::MERGE_DISABLE, node);
 			SceneTreeDock::get_singleton()->replace_node(node, cpu_particles);
 			ur->commit_action(false);
 

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -339,7 +339,7 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 	mesh_instance->set_mesh(mesh);
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-	ur->create_action(TTR("Convert to MeshInstance2D"));
+	ur->create_action(TTR("Convert to MeshInstance2D"), UndoRedo::MERGE_DISABLE, node);
 	SceneTreeDock::get_singleton()->replace_node(node, mesh_instance);
 	ur->commit_action(false);
 }
@@ -394,7 +394,7 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 	polygon_2d_instance->set_polygons(polys);
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-	ur->create_action(TTR("Convert to Polygon2D"));
+	ur->create_action(TTR("Convert to Polygon2D"), UndoRedo::MERGE_DISABLE, node);
 	SceneTreeDock::get_singleton()->replace_node(node, polygon_2d_instance);
 	ur->commit_action(false);
 }


### PR DESCRIPTION
When using conversion plugins, like CPUParticles -> GPUParticles or Sprite2D -> Polygon2D, there is a specially named undo action, but what instead shows is generic "Change type of node(s)". It's caused by EditorUndoRedoManager quirk, which makes it not create action until first operation if there is no undo context, but since `replace_node()` creates its own action, the nesting doesn't happen and wrong action is used as base (while the original one is committed empty). The fix is to assign correct context when creating undo action, which this PR does.

Before:
![image](https://github.com/godotengine/godot/assets/2223172/94c941fc-2362-4639-82a4-187bddcf23a1)

After:
![image](https://github.com/godotengine/godot/assets/2223172/ea9b8001-7323-47b4-83e7-6692dfe37e5a)
