### PR TITLE
[Core] Move `Vector3` complex methods to `.cpp` file

### DIFF
--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -153,7 +153,7 @@ Vector3::operator Vector3i() const {
 	return Vector3i(x, y, z);
 }
 
-Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
+Vector3 Vector3::slerp(const Vector3 &p_to, real_t p_weight) const {
 	// This method seems more complicated than it really is, since we write out
 	// the internals of some methods for efficiency (mainly, checking length).
 	real_t start_length_sq = length_squared();
@@ -175,35 +175,35 @@ Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
 	return rotated(axis, angle * p_weight) * (result_length / start_length);
 }
 
-Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const {
+Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
 	return Vector3(
 			Math::cubic_interpolate(x, p_b.x, p_pre_a.x, p_post_b.x, p_weight),
 			Math::cubic_interpolate(y, p_b.y, p_pre_a.y, p_post_b.y, p_weight),
 			Math::cubic_interpolate(z, p_b.z, p_pre_a.z, p_post_b.z, p_weight));
 }
 
-Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const {
 	return Vector3(
 			Math::cubic_interpolate_in_time(x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t),
 			Math::cubic_interpolate_in_time(y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t),
 			Math::cubic_interpolate_in_time(z, p_b.z, p_pre_a.z, p_post_b.z, p_weight, p_b_t, p_pre_a_t, p_post_b_t));
 }
 
-Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const {
 	return Vector3(
 			Math::bezier_interpolate(x, p_control_1.x, p_control_2.x, p_end.x, p_t),
 			Math::bezier_interpolate(y, p_control_1.y, p_control_2.y, p_end.y, p_t),
 			Math::bezier_interpolate(z, p_control_1.z, p_control_2.z, p_end.z, p_t));
 }
 
-Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const {
 	return Vector3(
 			Math::bezier_derivative(x, p_control_1.x, p_control_2.x, p_end.x, p_t),
 			Math::bezier_derivative(y, p_control_1.y, p_control_2.y, p_end.y, p_t),
 			Math::bezier_derivative(z, p_control_1.z, p_control_2.z, p_end.z, p_t));
 }
 
-Vector3 Vector3::posmod(const real_t p_mod) const {
+Vector3 Vector3::posmod(real_t p_mod) const {
 	return Vector3(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod));
 }
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -152,3 +152,91 @@ Vector3::operator String() const {
 Vector3::operator Vector3i() const {
 	return Vector3i(x, y, z);
 }
+
+Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
+	// This method seems more complicated than it really is, since we write out
+	// the internals of some methods for efficiency (mainly, checking length).
+	real_t start_length_sq = length_squared();
+	real_t end_length_sq = p_to.length_squared();
+	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
+		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
+		return lerp(p_to, p_weight);
+	}
+	Vector3 axis = cross(p_to);
+	real_t axis_length_sq = axis.length_squared();
+	if (unlikely(axis_length_sq == 0.0f)) {
+		// Colinear vectors have no rotation axis or angle between them, so the best we can do is lerp.
+		return lerp(p_to, p_weight);
+	}
+	axis /= Math::sqrt(axis_length_sq);
+	real_t start_length = Math::sqrt(start_length_sq);
+	real_t result_length = Math::lerp(start_length, Math::sqrt(end_length_sq), p_weight);
+	real_t angle = angle_to(p_to);
+	return rotated(axis, angle * p_weight) * (result_length / start_length);
+}
+
+Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const {
+	return Vector3(
+			Math::cubic_interpolate(x, p_b.x, p_pre_a.x, p_post_b.x, p_weight),
+			Math::cubic_interpolate(y, p_b.y, p_pre_a.y, p_post_b.y, p_weight),
+			Math::cubic_interpolate(z, p_b.z, p_pre_a.z, p_post_b.z, p_weight));
+}
+
+Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+	return Vector3(
+			Math::cubic_interpolate_in_time(x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t),
+			Math::cubic_interpolate_in_time(y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t),
+			Math::cubic_interpolate_in_time(z, p_b.z, p_pre_a.z, p_post_b.z, p_weight, p_b_t, p_pre_a_t, p_post_b_t));
+}
+
+Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+	return Vector3(
+			Math::bezier_interpolate(x, p_control_1.x, p_control_2.x, p_end.x, p_t),
+			Math::bezier_interpolate(y, p_control_1.y, p_control_2.y, p_end.y, p_t),
+			Math::bezier_interpolate(z, p_control_1.z, p_control_2.z, p_end.z, p_t));
+}
+
+Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+	return Vector3(
+			Math::bezier_derivative(x, p_control_1.x, p_control_2.x, p_end.x, p_t),
+			Math::bezier_derivative(y, p_control_1.y, p_control_2.y, p_end.y, p_t),
+			Math::bezier_derivative(z, p_control_1.z, p_control_2.z, p_end.z, p_t));
+}
+
+Vector3 Vector3::posmod(const real_t p_mod) const {
+	return Vector3(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod));
+}
+
+Vector3 Vector3::posmodv(const Vector3 &p_modv) const {
+	return Vector3(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y), Math::fposmod(z, p_modv.z));
+}
+
+real_t Vector3::angle_to(const Vector3 &p_to) const {
+	return Math::atan2(cross(p_to).length(), dot(p_to));
+}
+
+real_t Vector3::signed_angle_to(const Vector3 &p_to, const Vector3 &p_axis) const {
+	Vector3 cross_to = cross(p_to);
+	real_t unsigned_angle = Math::atan2(cross_to.length(), dot(p_to));
+	real_t sign = cross_to.dot(p_axis);
+	return (sign < 0) ? -unsigned_angle : unsigned_angle;
+}
+
+// slide returns the component of the vector along the given plane, specified by its normal vector.
+Vector3 Vector3::slide(const Vector3 &p_normal) const {
+#ifdef MATH_CHECKS
+	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 " + p_normal.operator String() + " must be normalized.");
+#endif
+	return *this - p_normal * dot(p_normal);
+}
+
+Vector3 Vector3::bounce(const Vector3 &p_normal) const {
+	return -reflect(p_normal);
+}
+
+Vector3 Vector3::reflect(const Vector3 &p_normal) const {
+#ifdef MATH_CHECKS
+	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 " + p_normal.operator String() + " must be normalized.");
+#endif
+	return 2.0f * p_normal * dot(p_normal) - *this;
+}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -37,7 +37,7 @@
 struct Basis;
 struct Vector2;
 struct Vector3i;
-struct String;
+class String;
 
 struct _NO_DISCARD_ Vector3 {
 	static const int AXIS_COUNT = 3;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -33,11 +33,11 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
-#include "core/string/ustring.h"
 
 struct Basis;
 struct Vector2;
 struct Vector3i;
+struct String;
 
 struct _NO_DISCARD_ Vector3 {
 	static const int AXIS_COUNT = 3;
@@ -104,11 +104,11 @@ struct _NO_DISCARD_ Vector3 {
 	/* Static Methods between 2 vector3s */
 
 	_FORCE_INLINE_ Vector3 lerp(const Vector3 &p_to, real_t p_weight) const;
-	_FORCE_INLINE_ Vector3 slerp(const Vector3 &p_to, real_t p_weight) const;
-	_FORCE_INLINE_ Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const;
-	_FORCE_INLINE_ Vector3 cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
-	_FORCE_INLINE_ Vector3 bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const;
-	_FORCE_INLINE_ Vector3 bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const;
+	Vector3 slerp(const Vector3 &p_to, real_t p_weight) const;
+	Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const;
+	Vector3 cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
+	Vector3 bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const;
+	Vector3 bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const;
 
 	Vector3 move_toward(const Vector3 &p_to, real_t p_delta) const;
 
@@ -131,17 +131,19 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
 	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;
 
-	_FORCE_INLINE_ Vector3 posmod(real_t p_mod) const;
-	_FORCE_INLINE_ Vector3 posmodv(const Vector3 &p_modv) const;
+
+	Vector3 posmod(real_t p_mod) const;
+	Vector3 posmodv(const Vector3 &p_modv) const;
+
 	_FORCE_INLINE_ Vector3 project(const Vector3 &p_to) const;
 
-	_FORCE_INLINE_ real_t angle_to(const Vector3 &p_to) const;
-	_FORCE_INLINE_ real_t signed_angle_to(const Vector3 &p_to, const Vector3 &p_axis) const;
+	real_t angle_to(const Vector3 &p_to) const;
+	real_t signed_angle_to(const Vector3 &p_to, const Vector3 &p_axis) const;
 	_FORCE_INLINE_ Vector3 direction_to(const Vector3 &p_to) const;
 
-	_FORCE_INLINE_ Vector3 slide(const Vector3 &p_normal) const;
-	_FORCE_INLINE_ Vector3 bounce(const Vector3 &p_normal) const;
-	_FORCE_INLINE_ Vector3 reflect(const Vector3 &p_normal) const;
+	Vector3 slide(const Vector3 &p_normal) const;
+	Vector3 bounce(const Vector3 &p_normal) const;
+	Vector3 reflect(const Vector3 &p_normal) const;
 
 	bool is_equal_approx(const Vector3 &p_v) const;
 	bool is_zero_approx() const;
@@ -224,60 +226,6 @@ Vector3 Vector3::lerp(const Vector3 &p_to, real_t p_weight) const {
 	return res;
 }
 
-Vector3 Vector3::slerp(const Vector3 &p_to, real_t p_weight) const {
-	// This method seems more complicated than it really is, since we write out
-	// the internals of some methods for efficiency (mainly, checking length).
-	real_t start_length_sq = length_squared();
-	real_t end_length_sq = p_to.length_squared();
-	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
-		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
-		return lerp(p_to, p_weight);
-	}
-	Vector3 axis = cross(p_to);
-	real_t axis_length_sq = axis.length_squared();
-	if (unlikely(axis_length_sq == 0.0f)) {
-		// Colinear vectors have no rotation axis or angle between them, so the best we can do is lerp.
-		return lerp(p_to, p_weight);
-	}
-	axis /= Math::sqrt(axis_length_sq);
-	real_t start_length = Math::sqrt(start_length_sq);
-	real_t result_length = Math::lerp(start_length, Math::sqrt(end_length_sq), p_weight);
-	real_t angle = angle_to(p_to);
-	return rotated(axis, angle * p_weight) * (result_length / start_length);
-}
-
-Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
-	Vector3 res = *this;
-	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
-	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
-	res.z = Math::cubic_interpolate(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight);
-	return res;
-}
-
-Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const {
-	Vector3 res = *this;
-	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
-	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
-	res.z = Math::cubic_interpolate_in_time(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
-	return res;
-}
-
-Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const {
-	Vector3 res = *this;
-	res.x = Math::bezier_interpolate(res.x, p_control_1.x, p_control_2.x, p_end.x, p_t);
-	res.y = Math::bezier_interpolate(res.y, p_control_1.y, p_control_2.y, p_end.y, p_t);
-	res.z = Math::bezier_interpolate(res.z, p_control_1.z, p_control_2.z, p_end.z, p_t);
-	return res;
-}
-
-Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const {
-	Vector3 res = *this;
-	res.x = Math::bezier_derivative(res.x, p_control_1.x, p_control_2.x, p_end.x, p_t);
-	res.y = Math::bezier_derivative(res.y, p_control_1.y, p_control_2.y, p_end.y, p_t);
-	res.z = Math::bezier_derivative(res.z, p_control_1.z, p_control_2.z, p_end.z, p_t);
-	return res;
-}
-
 real_t Vector3::distance_to(const Vector3 &p_to) const {
 	return (p_to - *this).length();
 }
@@ -286,27 +234,8 @@ real_t Vector3::distance_squared_to(const Vector3 &p_to) const {
 	return (p_to - *this).length_squared();
 }
 
-Vector3 Vector3::posmod(real_t p_mod) const {
-	return Vector3(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod));
-}
-
-Vector3 Vector3::posmodv(const Vector3 &p_modv) const {
-	return Vector3(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y), Math::fposmod(z, p_modv.z));
-}
-
 Vector3 Vector3::project(const Vector3 &p_to) const {
 	return p_to * (dot(p_to) / p_to.length_squared());
-}
-
-real_t Vector3::angle_to(const Vector3 &p_to) const {
-	return Math::atan2(cross(p_to).length(), dot(p_to));
-}
-
-real_t Vector3::signed_angle_to(const Vector3 &p_to, const Vector3 &p_axis) const {
-	Vector3 cross_to = cross(p_to);
-	real_t unsigned_angle = Math::atan2(cross_to.length(), dot(p_to));
-	real_t sign = cross_to.dot(p_axis);
-	return (sign < 0) ? -unsigned_angle : unsigned_angle;
 }
 
 Vector3 Vector3::direction_to(const Vector3 &p_to) const {
@@ -507,25 +436,6 @@ Vector3 Vector3::inverse() const {
 
 void Vector3::zero() {
 	x = y = z = 0;
-}
-
-// slide returns the component of the vector along the given plane, specified by its normal vector.
-Vector3 Vector3::slide(const Vector3 &p_normal) const {
-#ifdef MATH_CHECKS
-	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 " + p_normal.operator String() + " must be normalized.");
-#endif
-	return *this - p_normal * dot(p_normal);
-}
-
-Vector3 Vector3::bounce(const Vector3 &p_normal) const {
-	return -reflect(p_normal);
-}
-
-Vector3 Vector3::reflect(const Vector3 &p_normal) const {
-#ifdef MATH_CHECKS
-	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 " + p_normal.operator String() + " must be normalized.");
-#endif
-	return 2.0f * p_normal * dot(p_normal) - *this;
 }
 
 #endif // VECTOR3_H

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -131,7 +131,6 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
 	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;
 
-
 	Vector3 posmod(real_t p_mod) const;
 	Vector3 posmodv(const Vector3 &p_modv) const;
 


### PR DESCRIPTION
I also removed an unnecessary include ustring that was not present in other vectors