### PR TITLE
Fix XRHandModifier3D scaling

### DIFF
--- a/doc/classes/XRHandModifier3D.xml
+++ b/doc/classes/XRHandModifier3D.xml
@@ -5,6 +5,8 @@
 	</brief_description>
 	<description>
 		This node uses hand tracking data from a [XRHandTracker] to animate the skeleton of a hand mesh.
+		This node positions itself at the [constant XRHandTracker.HAND_JOINT_PALM] position and scales itself to [member XRServer.world_scale]. Adding the hand model as a child of this node will result in the model being positioned and scaled correctly for XR experiences.
+		The hand tracking position-data is scaled by [member Skeleton3D.motion_scale] when applied to the skeleton, which can be used to adjust the tracked hand to match the scale of the hand model.
 	</description>
 	<tutorials>
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>


### PR DESCRIPTION
The XRHandModifier3D scaling needs to be fixed to correctly apply the Skeleton3D.motion_scale and XRServer.world_scale - this is similar to the work in https://github.com/godotengine/godot/pull/89103.

Attempting to set XRServer.world_scale before this PR would not uniformly scale the hands with the rest of the player, but would instead only stretch the bones resulting in distorted the hands with spindly fingers:

![image](https://github.com/godotengine/godot/assets/1863707/f5a190fd-396b-4e67-bce4-741bf56b3f9b)

This PR changes the scaling as follows:
- Joint tracking data is scaled using the Skeleton3D.motion_scale to be applied to the skeleton
- The XRHandModifier3D is positioned at the tracked palm location and scaled with the XRServer.world_scale

The following video demonstrates the results:

https://github.com/godotengine/godot/assets/1863707/b05106a8-6b56-4689-a786-0db3c455ef0f

There's also a test project at https://github.com/Malcolmnixon/GodotXROpenXRTracker to play with the results.