### PR TITLE
Add new Camera3D type: Oblique

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -93,6 +93,24 @@ Vector4 Projection::xform_inv(const Vector4 &p_vec4) const {
 			columns[3][0] * p_vec4.x + columns[3][1] * p_vec4.y + columns[3][2] * p_vec4.z + columns[3][3] * p_vec4.w);
 }
 
+void Projection::apply_oblique_plane(Vector4 p_oblique_plane) {
+	// Here goes oblique magic!
+	// Eric Lengyel Solution: http://terathon.com/code/oblique.html
+	Vector4 q;
+
+	q.x = (SIGN(p_oblique_plane.x) + columns[2][0]) / columns[0][0];
+	q.y = (SIGN(p_oblique_plane.y) + columns[2][1]) / columns[1][1];
+
+	q.z = -1.0F;
+	q.w = (1.0F + columns[2][2]) / columns[3][2];
+
+	Vector4 c = p_oblique_plane * (2.0F / p_oblique_plane.dot(q));
+	columns[0][2] = c.x - columns[0][3];
+	columns[1][2] = c.y - columns[1][3];
+	columns[2][2] = c.z - columns[2][3];
+	columns[3][2] = c.w - columns[3][3];
+}
+
 void Projection::adjust_perspective_znear(real_t p_new_znear) {
 	real_t zfar = get_z_far();
 	real_t znear = p_new_znear;

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -79,6 +79,7 @@ struct _NO_DISCARD_ Projection {
 	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);
 	void set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
 	void set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
+	void apply_oblique_plane(Vector4 p_oblique_plane);
 	void adjust_perspective_znear(real_t p_new_znear);
 
 	static Projection create_depth_correction(bool p_flip_y);

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -122,6 +122,13 @@
 				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [param size], an [param offset], and the [param z_near] and [param z_far] clip planes in world space units. See also [member frustum_offset].
 			</description>
 		</method>
+		<method name="set_oblique_plane_from_transform">
+			<return type="void" />
+			<param index="0" name="oblique_transform" type="Transform3D" />
+			<description>
+				Sets the [member oblique_normal] and [member oblique_position] values of an oblique projection camera using a the origin and forward vector of the transform argument. For ease of using plane meshes as portals and mirrors.
+			</description>
+		</method>
 		<method name="set_orthogonal">
 			<return type="void" />
 			<param index="0" name="size" type="float" />
@@ -202,11 +209,23 @@
 		<member name="near" type="float" setter="set_near" getter="get_near" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis. Lower values allow the camera to see objects more up close to its origin, at the cost of lower precision across the [i]entire[/i] range. Values lower than the default can lead to increased Z-fighting.
 		</member>
+		<member name="oblique_normal" type="Vector3" setter="set_oblique_normal" getter="get_oblique_normal" default="Vector3(0, 1, 0)">
+			The desired normal vector of the world space plane used by an oblique camera as an oblique near clipping plane.
+		</member>
+		<member name="oblique_offset" type="float" setter="set_oblique_offset" getter="get_oblique_offset" default="0.0">
+			The offset value for the oblique plane along its forward vector.
+		</member>
+		<member name="oblique_position" type="Vector3" setter="set_oblique_position" getter="get_oblique_position" default="Vector3(0, 0, 0)">
+			The world space position of the plane used by an oblique camera as an oblique near clipping plane.
+		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera3D.ProjectionType" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>
 		<member name="size" type="float" setter="set_size" getter="get_size" default="1.0">
 			The camera's size in meters measured as the diameter of the width or height, depending on [member keep_aspect]. Only applicable in orthogonal and frustum modes.
+		</member>
+		<member name="use_oblique_frustum" type="bool" setter="set_use_oblique_frustum" getter="get_use_oblique_frustum" default="false">
+			Toggle for applying oblique near plane frustum culling.
 		</member>
 		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
 			The vertical (Y) offset of the camera viewport.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -93,7 +93,7 @@
 				The normalization factor can be calculated from exposure value (EV100) as follows:
 				[codeblock]
 				func get_exposure_normalization(float ev100):
-				    			    return 1.0 / (pow(2.0, ev100) * 1.2)
+				                    return 1.0 / (pow(2.0, ev100) * 1.2)
 				[/codeblock]
 				The exposure value can be calculated from aperture (in f-stops), shutter speed (in seconds), and sensitivity (in ISO) as follows:
 				[codeblock]
@@ -151,6 +151,17 @@
 			<param index="4" name="z_far" type="float" />
 			<description>
 				Sets camera to use frustum projection. This mode allows adjusting the [param offset] argument to create "tilted frustum" effects.
+			</description>
+		</method>
+		<method name="camera_set_oblique_plane">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="use_oblique_frustum" type="bool" />
+			<param index="2" name="oblique_normal" type="Vector3" />
+			<param index="3" name="oblique_position" type="Vector3" />
+			<param index="4" name="oblique_offset" type="float" />
+			<description>
+				Sets the camera to use oblique near plane frustum culling.
 			</description>
 		</method>
 		<method name="camera_set_orthogonal">

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -66,6 +66,10 @@ private:
 	ProjectionType mode = PROJECTION_PERSPECTIVE;
 
 	real_t fov = 75.0;
+	bool use_oblique_frustum = false;
+	Vector3 oblique_normal = Vector3(0, 1, 0);
+	Vector3 oblique_position = Vector3();
+	real_t oblique_offset = 0;
 	real_t size = 1.0;
 	Vector2 frustum_offset;
 	// _ prefix to avoid conflict with Windows defines.
@@ -109,6 +113,7 @@ protected:
 	static void _bind_methods();
 
 	Projection _get_camera_projection(real_t p_near) const;
+	Vector4 _get_oblique_plane() const;
 
 public:
 	enum {
@@ -129,6 +134,10 @@ public:
 	RID get_camera() const;
 
 	real_t get_fov() const;
+	bool get_use_oblique_frustum() const;
+	Vector3 get_oblique_normal() const;
+	Vector3 get_oblique_position() const;
+	real_t get_oblique_offset() const;
 	real_t get_size() const;
 	real_t get_far() const;
 	real_t get_near() const;
@@ -137,6 +146,11 @@ public:
 	ProjectionType get_projection() const;
 
 	void set_fov(real_t p_fov);
+	void set_use_oblique_frustum(bool P_use_oblique_frustum);
+	void set_oblique_normal(Vector3 p_oblique_normal);
+	void set_oblique_position(Vector3 p_oblique_position);
+	void set_oblique_offset(real_t p_oblique_offset);
+	void set_oblique_plane_from_transform(Transform3D p_oblique_plane_transform);
 	void set_size(real_t p_size);
 	void set_far(real_t p_far);
 	void set_near(real_t p_near);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -71,6 +71,15 @@ void RendererSceneCull::camera_set_perspective(RID p_camera, float p_fovy_degree
 	camera->zfar = p_z_far;
 }
 
+void RendererSceneCull::camera_set_oblique_plane(RID p_camera, bool p_use_oblique_frustum, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	camera->use_oblique_frustum = p_use_oblique_frustum;
+	camera->oblique_normal = p_ob_normal;
+	camera->oblique_position = p_ob_position;
+	camera->oblique_offset = p_ob_offset;
+}
+
 void RendererSceneCull::camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) {
 	Camera *camera = camera_owner.get_or_null(p_camera);
 	ERR_FAIL_NULL(camera);
@@ -129,6 +138,18 @@ void RendererSceneCull::camera_set_use_vertical_aspect(RID p_camera, bool p_enab
 
 bool RendererSceneCull::is_camera(RID p_camera) const {
 	return camera_owner.owns(p_camera);
+}
+
+Vector4 RendererSceneCull::get_camera_oblique_plane(RID p_camera) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL_V(camera, Vector4());
+
+	int dot = int(camera->oblique_normal.dot(camera->oblique_position - camera->transform.origin) >= 0.0f ? 1.0f : -1.0f);
+	Vector3 cam_space_pos = camera->transform.xform_inv(camera->oblique_position);
+	Vector3 cam_space_normal = camera->transform.basis.xform_inv(camera->oblique_normal) * dot;
+	real_t cam_space_dst = -cam_space_pos.dot(cam_space_normal) + camera->oblique_offset;
+
+	return Vector4(cam_space_normal.x, cam_space_normal.y, cam_space_normal.z, cam_space_dst);
 }
 
 /* OCCLUDER API */
@@ -2148,7 +2169,6 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 
 		if (p_cam_orthogonal) {
 			Vector2 vp_he = p_cam_projection.get_viewport_half_extents();
-
 			camera_matrix.set_orthogonal(vp_he.y * 2.0, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], false);
 		} else {
 			real_t fov = p_cam_projection.get_fov(); //this is actually yfov, because set aspect tries to keep it
@@ -2570,13 +2590,14 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 	if (p_xr_interface.is_null()) {
 		// Normal camera
 		Transform3D transform = camera->transform;
-		Projection projection;
+		Projection main_projection;
+		Projection shadow_projection;
 		bool vaspect = camera->vaspect;
 		bool is_orthogonal = false;
 
 		switch (camera->type) {
 			case Camera::ORTHOGONAL: {
-				projection.set_orthogonal(
+				main_projection.set_orthogonal(
 						camera->size,
 						p_viewport_size.width / (float)p_viewport_size.height,
 						camera->znear,
@@ -2585,16 +2606,15 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 				is_orthogonal = true;
 			} break;
 			case Camera::PERSPECTIVE: {
-				projection.set_perspective(
+				main_projection.set_perspective(
 						camera->fov,
 						p_viewport_size.width / (float)p_viewport_size.height,
 						camera->znear,
 						camera->zfar,
 						camera->vaspect);
-
 			} break;
 			case Camera::FRUSTUM: {
-				projection.set_frustum(
+				main_projection.set_frustum(
 						camera->size,
 						p_viewport_size.width / (float)p_viewport_size.height,
 						camera->offset,
@@ -2604,7 +2624,11 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 			} break;
 		}
 
-		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, camera->visible_layers);
+		shadow_projection = main_projection;
+		if (camera->use_oblique_frustum) {
+			main_projection.apply_oblique_plane(get_camera_oblique_plane(p_camera));
+		}
+		camera_data.set_camera(transform, main_projection, shadow_projection, is_orthogonal, vaspect, jitter, camera->visible_layers);
 	} else {
 		// Setup our camera for our XR interface.
 		// We can support multiple views here each with their own camera
@@ -2626,7 +2650,7 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		}
 
 		if (view_count == 1) {
-			camera_data.set_camera(transforms[0], projections[0], false, camera->vaspect, jitter, camera->visible_layers);
+			camera_data.set_camera(transforms[0], projections[0], projections[0], false, camera->vaspect, jitter, camera->visible_layers);
 		} else if (view_count == 2) {
 			camera_data.set_multiview_camera(view_count, transforms, projections, false, camera->vaspect);
 		} else {
@@ -3025,7 +3049,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 	Instance *render_reflection_probe = instance_owner.get_or_null(p_reflection_probe); //if null, not rendering to it
 
 	// Prepare the light - camera volume culling system.
-	light_culler->prepare_camera(p_camera_data->main_transform, p_camera_data->main_projection);
+	light_culler->prepare_camera(p_camera_data->main_transform, p_camera_data->shadow_projection);
 
 	Scenario *scenario = scenario_owner.get_or_null(p_scenario);
 
@@ -3110,7 +3134,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		RSG::light_storage->set_directional_shadow_count(lights_with_shadow.size());
 
 		for (int i = 0; i < lights_with_shadow.size(); i++) {
-			_light_instance_setup_directional_shadow(i, lights_with_shadow[i], p_camera_data->main_transform, p_camera_data->main_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect);
+			_light_instance_setup_directional_shadow(i, lights_with_shadow[i], p_camera_data->main_transform, p_camera_data->shadow_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect);
 		}
 	}
 
@@ -3155,7 +3179,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		cull_data.visible_layers = p_visible_layers;
 		cull_data.render_reflection_probe = render_reflection_probe;
 		cull_data.occlusion_buffer = RendererSceneOcclusionCull::get_singleton()->buffer_get_ptr(p_viewport);
-		cull_data.camera_matrix = &p_camera_data->main_projection;
+		cull_data.camera_matrix = &p_camera_data->shadow_projection;
 		cull_data.visibility_viewport_mask = scenario->viewport_visibility_masks.has(p_viewport) ? scenario->viewport_visibility_masks[p_viewport] : 0;
 //#define DEBUG_CULL_TIME
 #ifdef DEBUG_CULL_TIME
@@ -3233,12 +3257,12 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 			{ //compute coverage
 
-				Transform3D cam_xf = p_camera_data->main_transform;
-				float zn = p_camera_data->main_projection.get_z_near();
+				Transform3D cam_xf = p_camera_data->shadow_projection;
+				float zn = p_camera_data->shadow_projection.get_z_near();
 				Plane p(-cam_xf.basis.get_column(2), cam_xf.origin + cam_xf.basis.get_column(2) * -zn); //camera near plane
 
 				// near plane half width and height
-				Vector2 vp_half_extents = p_camera_data->main_projection.get_viewport_half_extents();
+				Vector2 vp_half_extents = p_camera_data->shadow_projection.get_viewport_half_extents();
 
 				switch (RSG::light_storage->light_get_type(ins->base)) {
 					case RS::LIGHT_OMNI: {
@@ -3331,7 +3355,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 			if (redraw && max_shadows_used < MAX_UPDATE_SHADOWS) {
 				//must redraw!
 				RENDER_TIMESTAMP("> Render Light3D " + itos(i));
-				if (_light_instance_update_shadow(ins, p_camera_data->main_transform, p_camera_data->main_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect, p_shadow_atlas, scenario, p_screen_mesh_lod_threshold, p_visible_layers)) {
+				if (_light_instance_update_shadow(ins, p_camera_data->main_transform, p_camera_data->shadow_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect, p_shadow_atlas, scenario, p_screen_mesh_lod_threshold, p_visible_layers)) {
 					light->make_shadow_dirty();
 				}
 				RENDER_TIMESTAMP("< Render Light3D " + itos(i));
@@ -3467,7 +3491,7 @@ void RendererSceneCull::render_empty_scene(const Ref<RenderSceneBuffers> &p_rend
 	RENDER_TIMESTAMP("Render Empty 3D Scene");
 
 	RendererSceneRender::CameraData camera_data;
-	camera_data.set_camera(Transform3D(), Projection(), true, false);
+	camera_data.set_camera(Transform3D(), Projection(), Projection(), false, false);
 
 	scene_render->render_scene(p_render_buffers, &camera_data, &camera_data, PagedArray<RenderGeometryInstance *>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), environment, RID(), compositor, p_shadow_atlas, RID(), scenario->reflection_atlas, RID(), 0, 0, nullptr, 0, nullptr, 0, nullptr);
 #endif
@@ -3545,7 +3569,7 @@ bool RendererSceneCull::_render_reflection_probe_step(Instance *p_instance, int 
 
 		RENDER_TIMESTAMP("Render ReflectionProbe, Step " + itos(p_step));
 		RendererSceneRender::CameraData camera_data;
-		camera_data.set_camera(xform, cm, false, false);
+		camera_data.set_camera(xform, cm, cm, false, false);
 
 		Ref<RenderSceneBuffers> render_buffers = RSG::light_storage->reflection_probe_atlas_get_render_buffers(scenario->reflection_atlas);
 		_render_scene(&camera_data, render_buffers, environment, RID(), RID(), RSG::light_storage->reflection_probe_get_cull_mask(p_instance->base), p_instance->scenario->self, RID(), shadow_atlas, reflection_probe->instance, p_step, mesh_lod_threshold, use_shadows);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -32,6 +32,7 @@
 #define RENDERER_SCENE_CULL_H
 
 #include "core/math/dynamic_bvh.h"
+#include "core/math/vector4.h"
 #include "core/templates/bin_sorted_array.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/paged_allocator.h"
@@ -73,6 +74,12 @@ public:
 		};
 		Type type;
 		float fov;
+
+		bool use_oblique_frustum;
+		Vector3 oblique_normal;
+		Vector3 oblique_position;
+		float oblique_offset;
+
 		float znear, zfar;
 		float size;
 		Vector2 offset;
@@ -102,6 +109,7 @@ public:
 	virtual void camera_initialize(RID p_rid);
 
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
+	virtual void camera_set_oblique_plane(RID p_camera, bool p_use_oblique_frustum, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
@@ -111,6 +119,7 @@ public:
 	virtual void camera_set_compositor(RID p_camera, RID p_compositor);
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable);
 	virtual bool is_camera(RID p_camera) const;
+	virtual Vector4 get_camera_oblique_plane(RID p_camera);
 
 	/* OCCLUDER API */
 

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -33,17 +33,18 @@
 /////////////////////////////////////////////////////////////////////////////
 // CameraData
 
-void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, const uint32_t p_visible_layers) {
+void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_main_projection, const Projection p_shadow_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, const uint32_t p_visible_layers) {
 	view_count = 1;
 	is_orthogonal = p_is_orthogonal;
 	vaspect = p_vaspect;
 
 	main_transform = p_transform;
-	main_projection = p_projection;
+	main_projection = p_main_projection;
+	shadow_projection = p_shadow_projection;
 
 	visible_layers = p_visible_layers;
 	view_offset[0] = Transform3D();
-	view_projection[0] = p_projection;
+	view_projection[0] = p_main_projection;
 	taa_jitter = p_taa_jitter;
 }
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -303,12 +303,13 @@ public:
 		// Main/center projection
 		Transform3D main_transform;
 		Projection main_projection;
+		Projection shadow_projection;
 
 		Transform3D view_offset[RendererSceneRender::MAX_RENDER_VIEWS];
 		Projection view_projection[RendererSceneRender::MAX_RENDER_VIEWS];
 		Vector2 taa_jitter;
 
-		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), uint32_t p_visible_layers = 0xFFFFFFFF);
+		void set_camera(const Transform3D p_transform, const Projection p_main_projection, const Projection p_shadow_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), uint32_t p_visible_layers = 0xFFFFFFFF);
 		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect);
 	};
 

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -41,6 +41,7 @@ public:
 	virtual void camera_initialize(RID p_rid) = 0;
 
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_oblique_plane(RID p_camera, bool p_use_ob_frustum, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -585,6 +585,7 @@ public:
 
 	FUNCRIDSPLIT(camera)
 	FUNC4(camera_set_perspective, RID, float, float, float)
+	FUNC5(camera_set_oblique_plane, RID, bool, const Vector3 &, const Vector3 &, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
 	FUNC2(camera_set_transform, RID, const Transform3D &)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2758,6 +2758,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("camera_create"), &RenderingServer::camera_create);
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
+	ClassDB::bind_method(D_METHOD("camera_set_oblique_plane", "camera", "use_oblique_frustum", "oblique_normal", "oblique_position", "oblique_offset"), &RenderingServer::camera_set_oblique_plane);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -810,6 +810,7 @@ public:
 
 	virtual RID camera_create() = 0;
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_oblique_plane(RID p_camera, bool p_use_ob_frustum, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/501
Partial solution to this proposal: https://github.com/godotengine/godot-proposals/issues/2713

This PR should not necessarily be a reason to close the proposal 2713, it is merely a straightforward implementation of oblique near plane clipping to implement a portal--or other similar--mechanic.

This PR is essentially an update to my previous PR: https://github.com/godotengine/godot/pull/64876
The main difference is that shadows were fixed.

This other PR attempts to completely solve proposal 2713 mentioned above, but apparently is having issues with shadows. Considering that its commits try to implement custom projections by adding a new camera type like with my PRs, there is a good chance the way I fixed shadows could also work there too: https://github.com/godotengine/godot/pull/84454

The solution was that along with the main Oblique camera projection a separate, normal Perspective camera projection needed to be included with the `CameraData` used in the `RenderSceneCull::_render_scene()` that was used explicitly for lighting and shadows.

However, regarding the potential question of whether one PR should be included over the other as a solution, clearly the more general solution can see a wider range of uses. However, I believe this implementation of an Oblique Near Plane camera still has merit based on the majority use case of creating a portal mechanic, etc where oblique near clipping is necessary.

This is because the interface for the Oblique camera included in this PR has been simplified so that users are only required to provide at a minimum the transform of the plane they wish to use as the near clipping plane of the camera using `set_oblique_plane_from_transform()`.

Additionally, because all of the required math (especially the matrix math) is happening in C++, the effect is as efficient as possible, without requiring steps to first `camera.get_projection`, then doing matrix manipulation, then `camera.set_projection` all in GDScript.

Alternatively, because the Oblique Near Plane matrix manipulations "... can be applied to any projection matrix, ..." (https://terathon.com/lengyel/Lengyel-Oblique.pdf, pg. 2) it's possible that all camera types (including the other proposed custom projection camera) could benefit from a general `is_oblique_near_plane` boolean toggle instead of this dedicated oblique camera which only implements the algorithm for a Perspective projection.

Video 1: Current state of personal portal game mechanic
https://youtu.be/A_-2nTyKVkU
Notice that the portal viewports are not blocked by the surface the portal is on (the issue with using a standard perspective camera), and that shadows and lighting appear the same when looking through the portal (as evidenced by walking through the portal where a seamless transition occurs).

Video 2: Previous video showcasing dynamically the difference oblique near plane clipping makes
https://youtu.be/PipVd6wRnMk?si=lCThReaKyO-smBaP
Note that this older video did not properly handle shadows, and the viewport texture color and environment lighting were all wrong giving it that washed out look (both fixed in Video 1).

Image 1: Portal effect using Perspective camera
![image](https://github.com/godotengine/godot/assets/40372043/9d405b1a-6dab-4ab0-a72f-6a1d7765d8ca)

Image 2: Portal effect using Oblique camera
![image](https://github.com/godotengine/godot/assets/40372043/c7c52a6b-17be-4703-bb29-7bb0e4e5f843)

Image 3: Oblique camera editor interface
![image](https://github.com/godotengine/godot/assets/40372043/7e4a1896-324b-4bd0-96d7-44c463594f3f)