### PR TITLE
Fix fundamental type misuse in math arguments

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -907,7 +907,7 @@ void Basis::_set_diagonal(const Vector3 &p_diag) {
 	rows[2][2] = p_diag.z;
 }
 
-Basis Basis::lerp(const Basis &p_to, const real_t &p_weight) const {
+Basis Basis::lerp(const Basis &p_to, real_t p_weight) const {
 	Basis b;
 	b.rows[0] = rows[0].lerp(p_to.rows[0], p_weight);
 	b.rows[1] = rows[1].lerp(p_to.rows[1], p_weight);
@@ -916,7 +916,7 @@ Basis Basis::lerp(const Basis &p_to, const real_t &p_weight) const {
 	return b;
 }
 
-Basis Basis::slerp(const Basis &p_to, const real_t &p_weight) const {
+Basis Basis::slerp(const Basis &p_to, real_t p_weight) const {
 	//consider scale
 	Quaternion from(*this);
 	Quaternion to(p_to);

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -134,10 +134,10 @@ struct _NO_DISCARD_ Basis {
 	_FORCE_INLINE_ Basis operator+(const Basis &p_matrix) const;
 	_FORCE_INLINE_ void operator-=(const Basis &p_matrix);
 	_FORCE_INLINE_ Basis operator-(const Basis &p_matrix) const;
-	_FORCE_INLINE_ void operator*=(const real_t p_val);
-	_FORCE_INLINE_ Basis operator*(const real_t p_val) const;
-	_FORCE_INLINE_ void operator/=(const real_t p_val);
-	_FORCE_INLINE_ Basis operator/(const real_t p_val) const;
+	_FORCE_INLINE_ void operator*=(real_t p_val);
+	_FORCE_INLINE_ Basis operator*(real_t p_val) const;
+	_FORCE_INLINE_ void operator/=(real_t p_val);
+	_FORCE_INLINE_ Basis operator/(real_t p_val) const;
 
 	bool is_orthogonal() const;
 	bool is_orthonormal() const;
@@ -145,8 +145,8 @@ struct _NO_DISCARD_ Basis {
 	bool is_diagonal() const;
 	bool is_rotation() const;
 
-	Basis lerp(const Basis &p_to, const real_t &p_weight) const;
-	Basis slerp(const Basis &p_to, const real_t &p_weight) const;
+	Basis lerp(const Basis &p_to, real_t p_weight) const;
+	Basis slerp(const Basis &p_to, real_t p_weight) const;
 	void rotate_sh(real_t *p_values);
 
 	operator String() const;
@@ -279,25 +279,25 @@ _FORCE_INLINE_ Basis Basis::operator-(const Basis &p_matrix) const {
 	return ret;
 }
 
-_FORCE_INLINE_ void Basis::operator*=(const real_t p_val) {
+_FORCE_INLINE_ void Basis::operator*=(real_t p_val) {
 	rows[0] *= p_val;
 	rows[1] *= p_val;
 	rows[2] *= p_val;
 }
 
-_FORCE_INLINE_ Basis Basis::operator*(const real_t p_val) const {
+_FORCE_INLINE_ Basis Basis::operator*(real_t p_val) const {
 	Basis ret(*this);
 	ret *= p_val;
 	return ret;
 }
 
-_FORCE_INLINE_ void Basis::operator/=(const real_t p_val) {
+_FORCE_INLINE_ void Basis::operator/=(real_t p_val) {
 	rows[0] /= p_val;
 	rows[1] /= p_val;
 	rows[2] /= p_val;
 }
 
-_FORCE_INLINE_ Basis Basis::operator/(const real_t p_val) const {
+_FORCE_INLINE_ Basis Basis::operator/(real_t p_val) const {
 	Basis ret(*this);
 	ret /= p_val;
 	return ret;

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -64,7 +64,7 @@ public:
 		}
 	};
 
-	static Triangle create_triangle(const Vector<Vector2> &p_vertices, const int &p_a, const int &p_b, const int &p_c) {
+	static Triangle create_triangle(const Vector<Vector2> &p_vertices, int p_a, int p_b, int p_c) {
 		Triangle triangle = Triangle(p_a, p_b, p_c);
 
 		// Get the values of the circumcircle and store them inside the triangle object.

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -55,12 +55,12 @@ struct _NO_DISCARD_ Projection {
 
 	Vector4 columns[4];
 
-	_FORCE_INLINE_ const Vector4 &operator[](const int p_axis) const {
+	_FORCE_INLINE_ const Vector4 &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return columns[p_axis];
 	}
 
-	_FORCE_INLINE_ Vector4 &operator[](const int p_axis) {
+	_FORCE_INLINE_ Vector4 &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return columns[p_axis];
 	}

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -110,7 +110,7 @@ Quaternion Quaternion::exp() const {
 	return Quaternion(src_v, theta);
 }
 
-Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) const {
+Quaternion Quaternion::slerp(const Quaternion &p_to, real_t p_weight) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion " + operator String() + " must be normalized.");
 	ERR_FAIL_COND_V_MSG(!p_to.is_normalized(), Quaternion(), "The end quaternion " + p_to.operator String() + " must be normalized.");
@@ -151,7 +151,7 @@ Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) con
 			scale0 * w + scale1 * to1.w);
 }
 
-Quaternion Quaternion::slerpni(const Quaternion &p_to, const real_t &p_weight) const {
+Quaternion Quaternion::slerpni(const Quaternion &p_to, real_t p_weight) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion " + operator String() + " must be normalized.");
 	ERR_FAIL_COND_V_MSG(!p_to.is_normalized(), Quaternion(), "The end quaternion " + p_to.operator String() + " must be normalized.");
@@ -175,7 +175,7 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, const real_t &p_weight) c
 			invFactor * from.w + newFactor * p_to.w);
 }
 
-Quaternion Quaternion::spherical_cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const {
+Quaternion Quaternion::spherical_cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, real_t p_weight) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion " + operator String() + " must be normalized.");
 	ERR_FAIL_COND_V_MSG(!p_b.is_normalized(), Quaternion(), "The end quaternion " + p_b.operator String() + " must be normalized.");
@@ -225,8 +225,8 @@ Quaternion Quaternion::spherical_cubic_interpolate(const Quaternion &p_b, const 
 	return q1.slerp(q2, p_weight);
 }
 
-Quaternion Quaternion::spherical_cubic_interpolate_in_time(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight,
-		const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+Quaternion Quaternion::spherical_cubic_interpolate_in_time(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, real_t p_weight,
+		real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion " + operator String() + " must be normalized.");
 	ERR_FAIL_COND_V_MSG(!p_b.is_normalized(), Quaternion(), "The end quaternion " + p_b.operator String() + " must be normalized.");

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -68,10 +68,10 @@ struct _NO_DISCARD_ Quaternion {
 	Vector3 get_euler(EulerOrder p_order = EulerOrder::YXZ) const;
 	static Quaternion from_euler(const Vector3 &p_euler);
 
-	Quaternion slerp(const Quaternion &p_to, const real_t &p_weight) const;
-	Quaternion slerpni(const Quaternion &p_to, const real_t &p_weight) const;
-	Quaternion spherical_cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const;
-	Quaternion spherical_cubic_interpolate_in_time(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
+	Quaternion slerp(const Quaternion &p_to, real_t p_weight) const;
+	Quaternion slerpni(const Quaternion &p_to, real_t p_weight) const;
+	Quaternion spherical_cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, real_t p_weight) const;
+	Quaternion spherical_cubic_interpolate_in_time(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
 
 	Vector3 get_axis() const;
 	real_t get_angle() const;
@@ -102,13 +102,13 @@ struct _NO_DISCARD_ Quaternion {
 
 	_FORCE_INLINE_ void operator+=(const Quaternion &p_q);
 	_FORCE_INLINE_ void operator-=(const Quaternion &p_q);
-	_FORCE_INLINE_ void operator*=(const real_t &s);
-	_FORCE_INLINE_ void operator/=(const real_t &s);
+	_FORCE_INLINE_ void operator*=(real_t s);
+	_FORCE_INLINE_ void operator/=(real_t s);
 	_FORCE_INLINE_ Quaternion operator+(const Quaternion &q2) const;
 	_FORCE_INLINE_ Quaternion operator-(const Quaternion &q2) const;
 	_FORCE_INLINE_ Quaternion operator-() const;
-	_FORCE_INLINE_ Quaternion operator*(const real_t &s) const;
-	_FORCE_INLINE_ Quaternion operator/(const real_t &s) const;
+	_FORCE_INLINE_ Quaternion operator*(real_t s) const;
+	_FORCE_INLINE_ Quaternion operator/(real_t s) const;
 
 	_FORCE_INLINE_ bool operator==(const Quaternion &p_quaternion) const;
 	_FORCE_INLINE_ bool operator!=(const Quaternion &p_quaternion) const;
@@ -183,14 +183,14 @@ void Quaternion::operator-=(const Quaternion &p_q) {
 	w -= p_q.w;
 }
 
-void Quaternion::operator*=(const real_t &s) {
+void Quaternion::operator*=(real_t s) {
 	x *= s;
 	y *= s;
 	z *= s;
 	w *= s;
 }
 
-void Quaternion::operator/=(const real_t &s) {
+void Quaternion::operator/=(real_t s) {
 	*this *= 1.0f / s;
 }
 
@@ -209,11 +209,11 @@ Quaternion Quaternion::operator-() const {
 	return Quaternion(-q2.x, -q2.y, -q2.z, -q2.w);
 }
 
-Quaternion Quaternion::operator*(const real_t &s) const {
+Quaternion Quaternion::operator*(real_t s) const {
 	return Quaternion(x * s, y * s, z * s, w * s);
 }
 
-Quaternion Quaternion::operator/(const real_t &s) const {
+Quaternion Quaternion::operator/(real_t s) const {
 	return *this * (1.0f / s);
 }
 
@@ -225,7 +225,7 @@ bool Quaternion::operator!=(const Quaternion &p_quaternion) const {
 	return x != p_quaternion.x || y != p_quaternion.y || z != p_quaternion.z || w != p_quaternion.w;
 }
 
-_FORCE_INLINE_ Quaternion operator*(const real_t &p_real, const Quaternion &p_quaternion) {
+_FORCE_INLINE_ Quaternion operator*(real_t p_real, const Quaternion &p_quaternion) {
 	return p_quaternion * p_real;
 }
 

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -51,7 +51,7 @@ struct _NO_DISCARD_ Rect2 {
 
 	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5f); }
 
-	inline bool intersects(const Rect2 &p_rect, const bool p_include_borders = false) const {
+	inline bool intersects(const Rect2 &p_rect, bool p_include_borders = false) const {
 #ifdef MATH_CHECKS
 		if (unlikely(size.x < 0 || size.y < 0 || p_rect.size.x < 0 || p_rect.size.y < 0)) {
 			ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -65,7 +65,7 @@ Transform2D Transform2D::affine_inverse() const {
 	return inv;
 }
 
-void Transform2D::rotate(const real_t p_angle) {
+void Transform2D::rotate(real_t p_angle) {
 	*this = Transform2D(p_angle, Vector2()) * (*this);
 }
 
@@ -74,7 +74,7 @@ real_t Transform2D::get_skew() const {
 	return Math::acos(columns[0].normalized().dot(SIGN(det) * columns[1].normalized())) - (real_t)Math_PI * 0.5f;
 }
 
-void Transform2D::set_skew(const real_t p_angle) {
+void Transform2D::set_skew(real_t p_angle) {
 	real_t det = determinant();
 	columns[1] = SIGN(det) * columns[0].rotated(((real_t)Math_PI * 0.5f + p_angle)).normalized() * columns[1].length();
 }
@@ -83,7 +83,7 @@ real_t Transform2D::get_rotation() const {
 	return Math::atan2(columns[0].y, columns[0].x);
 }
 
-void Transform2D::set_rotation(const real_t p_rot) {
+void Transform2D::set_rotation(real_t p_rot) {
 	Size2 scale = get_scale();
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
@@ -94,7 +94,7 @@ void Transform2D::set_rotation(const real_t p_rot) {
 	set_scale(scale);
 }
 
-Transform2D::Transform2D(const real_t p_rot, const Vector2 &p_pos) {
+Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
 	columns[0][0] = cr;
@@ -104,7 +104,7 @@ Transform2D::Transform2D(const real_t p_rot, const Vector2 &p_pos) {
 	columns[2] = p_pos;
 }
 
-Transform2D::Transform2D(const real_t p_rot, const Size2 &p_scale, const real_t p_skew, const Vector2 &p_pos) {
+Transform2D::Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos) {
 	columns[0][0] = Math::cos(p_rot) * p_scale.x;
 	columns[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
 	columns[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;
@@ -136,7 +136,7 @@ void Transform2D::scale_basis(const Size2 &p_scale) {
 	columns[1][1] *= p_scale.y;
 }
 
-void Transform2D::translate_local(const real_t p_tx, const real_t p_ty) {
+void Transform2D::translate_local(real_t p_tx, real_t p_ty) {
 	translate_local(Vector2(p_tx, p_ty));
 }
 
@@ -261,12 +261,12 @@ Transform2D Transform2D::translated_local(const Vector2 &p_offset) const {
 	return Transform2D(columns[0], columns[1], columns[2] + basis_xform(p_offset));
 }
 
-Transform2D Transform2D::rotated(const real_t p_angle) const {
+Transform2D Transform2D::rotated(real_t p_angle) const {
 	// Equivalent to left multiplication
 	return Transform2D(p_angle, Vector2()) * (*this);
 }
 
-Transform2D Transform2D::rotated_local(const real_t p_angle) const {
+Transform2D Transform2D::rotated_local(real_t p_angle) const {
 	// Equivalent to right multiplication
 	return (*this) * Transform2D(p_angle, Vector2()); // Could be optimized, because origin transform can be skipped.
 }
@@ -275,7 +275,7 @@ real_t Transform2D::determinant() const {
 	return columns[0].x * columns[1].y - columns[0].y * columns[1].x;
 }
 
-Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, const real_t p_weight) const {
+Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t p_weight) const {
 	return Transform2D(
 			Math::lerp_angle(get_rotation(), p_transform.get_rotation(), p_weight),
 			get_scale().lerp(p_transform.get_scale(), p_weight),
@@ -283,25 +283,25 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, const 
 			get_origin().lerp(p_transform.get_origin(), p_weight));
 }
 
-void Transform2D::operator*=(const real_t p_val) {
+void Transform2D::operator*=(real_t p_val) {
 	columns[0] *= p_val;
 	columns[1] *= p_val;
 	columns[2] *= p_val;
 }
 
-Transform2D Transform2D::operator*(const real_t p_val) const {
+Transform2D Transform2D::operator*(real_t p_val) const {
 	Transform2D ret(*this);
 	ret *= p_val;
 	return ret;
 }
 
-void Transform2D::operator/=(const real_t p_val) {
+void Transform2D::operator/=(real_t p_val) {
 	columns[0] /= p_val;
 	columns[1] /= p_val;
 	columns[2] /= p_val;
 }
 
-Transform2D Transform2D::operator/(const real_t p_val) const {
+Transform2D Transform2D::operator/(real_t p_val) const {
 	Transform2D ret(*this);
 	ret /= p_val;
 	return ret;

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -64,17 +64,17 @@ struct _NO_DISCARD_ Transform2D {
 	void affine_invert();
 	Transform2D affine_inverse() const;
 
-	void set_rotation(const real_t p_rot);
+	void set_rotation(real_t p_rot);
 	real_t get_rotation() const;
 	real_t get_skew() const;
-	void set_skew(const real_t p_angle);
-	_FORCE_INLINE_ void set_rotation_and_scale(const real_t p_rot, const Size2 &p_scale);
-	_FORCE_INLINE_ void set_rotation_scale_and_skew(const real_t p_rot, const Size2 &p_scale, const real_t p_skew);
-	void rotate(const real_t p_angle);
+	void set_skew(real_t p_angle);
+	_FORCE_INLINE_ void set_rotation_and_scale(real_t p_rot, const Size2 &p_scale);
+	_FORCE_INLINE_ void set_rotation_scale_and_skew(real_t p_rot, const Size2 &p_scale, real_t p_skew);
+	void rotate(real_t p_angle);
 
 	void scale(const Size2 &p_scale);
 	void scale_basis(const Size2 &p_scale);
-	void translate_local(const real_t p_tx, const real_t p_ty);
+	void translate_local(real_t p_tx, real_t p_ty);
 	void translate_local(const Vector2 &p_translation);
 
 	real_t determinant() const;
@@ -89,8 +89,8 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D scaled_local(const Size2 &p_scale) const;
 	Transform2D translated(const Vector2 &p_offset) const;
 	Transform2D translated_local(const Vector2 &p_offset) const;
-	Transform2D rotated(const real_t p_angle) const;
-	Transform2D rotated_local(const real_t p_angle) const;
+	Transform2D rotated(real_t p_angle) const;
+	Transform2D rotated_local(real_t p_angle) const;
 
 	Transform2D untranslated() const;
 
@@ -107,12 +107,12 @@ struct _NO_DISCARD_ Transform2D {
 
 	void operator*=(const Transform2D &p_transform);
 	Transform2D operator*(const Transform2D &p_transform) const;
-	void operator*=(const real_t p_val);
-	Transform2D operator*(const real_t p_val) const;
-	void operator/=(const real_t p_val);
-	Transform2D operator/(const real_t p_val) const;
+	void operator*=(real_t p_val);
+	Transform2D operator*(real_t p_val) const;
+	void operator/=(real_t p_val);
+	Transform2D operator/(real_t p_val) const;
 
-	Transform2D interpolate_with(const Transform2D &p_transform, const real_t p_c) const;
+	Transform2D interpolate_with(const Transform2D &p_transform, real_t p_c) const;
 
 	_FORCE_INLINE_ Vector2 basis_xform(const Vector2 &p_vec) const;
 	_FORCE_INLINE_ Vector2 basis_xform_inv(const Vector2 &p_vec) const;
@@ -140,9 +140,9 @@ struct _NO_DISCARD_ Transform2D {
 		columns[2] = p_origin;
 	}
 
-	Transform2D(const real_t p_rot, const Vector2 &p_pos);
+	Transform2D(real_t p_rot, const Vector2 &p_pos);
 
-	Transform2D(const real_t p_rot, const Size2 &p_scale, const real_t p_skew, const Vector2 &p_pos);
+	Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos);
 
 	Transform2D() {
 		columns[0][0] = 1.0;
@@ -190,14 +190,14 @@ Rect2 Transform2D::xform(const Rect2 &p_rect) const {
 	return new_rect;
 }
 
-void Transform2D::set_rotation_and_scale(const real_t p_rot, const Size2 &p_scale) {
+void Transform2D::set_rotation_and_scale(real_t p_rot, const Size2 &p_scale) {
 	columns[0][0] = Math::cos(p_rot) * p_scale.x;
 	columns[1][1] = Math::cos(p_rot) * p_scale.y;
 	columns[1][0] = -Math::sin(p_rot) * p_scale.y;
 	columns[0][1] = Math::sin(p_rot) * p_scale.x;
 }
 
-void Transform2D::set_rotation_scale_and_skew(const real_t p_rot, const Size2 &p_scale, const real_t p_skew) {
+void Transform2D::set_rotation_scale_and_skew(real_t p_rot, const Size2 &p_scale, real_t p_skew) {
 	columns[0][0] = Math::cos(p_rot) * p_scale.x;
 	columns[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
 	columns[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -197,23 +197,23 @@ Transform3D Transform3D::operator*(const Transform3D &p_transform) const {
 	return t;
 }
 
-void Transform3D::operator*=(const real_t p_val) {
+void Transform3D::operator*=(real_t p_val) {
 	origin *= p_val;
 	basis *= p_val;
 }
 
-Transform3D Transform3D::operator*(const real_t p_val) const {
+Transform3D Transform3D::operator*(real_t p_val) const {
 	Transform3D ret(*this);
 	ret *= p_val;
 	return ret;
 }
 
-void Transform3D::operator/=(const real_t p_val) {
+void Transform3D::operator/=(real_t p_val) {
 	basis /= p_val;
 	origin /= p_val;
 }
 
-Transform3D Transform3D::operator/(const real_t p_val) const {
+Transform3D Transform3D::operator/(real_t p_val) const {
 	Transform3D ret(*this);
 	ret /= p_val;
 	return ret;

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -102,10 +102,10 @@ struct _NO_DISCARD_ Transform3D {
 
 	void operator*=(const Transform3D &p_transform);
 	Transform3D operator*(const Transform3D &p_transform) const;
-	void operator*=(const real_t p_val);
-	Transform3D operator*(const real_t p_val) const;
-	void operator/=(const real_t p_val);
-	Transform3D operator/(const real_t p_val) const;
+	void operator*=(real_t p_val);
+	Transform3D operator*(real_t p_val) const;
+	void operator/=(real_t p_val);
+	Transform3D operator/(real_t p_val) const;
 
 	Transform3D interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -37,7 +37,7 @@ real_t Vector2::angle() const {
 	return Math::atan2(y, x);
 }
 
-Vector2 Vector2::from_angle(const real_t p_angle) {
+Vector2 Vector2::from_angle(real_t p_angle) {
 	return Vector2(Math::cos(p_angle), Math::sin(p_angle));
 }
 
@@ -109,7 +109,7 @@ Vector2 Vector2::round() const {
 	return Vector2(Math::round(x), Math::round(y));
 }
 
-Vector2 Vector2::rotated(const real_t p_by) const {
+Vector2 Vector2::rotated(real_t p_by) const {
 	real_t sine = Math::sin(p_by);
 	real_t cosi = Math::cos(p_by);
 	return Vector2(
@@ -117,7 +117,7 @@ Vector2 Vector2::rotated(const real_t p_by) const {
 			x * sine + y * cosi);
 }
 
-Vector2 Vector2::posmod(const real_t p_mod) const {
+Vector2 Vector2::posmod(real_t p_mod) const {
 	return Vector2(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod));
 }
 
@@ -141,7 +141,7 @@ Vector2 Vector2::snapped(const Vector2 &p_step) const {
 			Math::snapped(y, p_step.y));
 }
 
-Vector2 Vector2::limit_length(const real_t p_len) const {
+Vector2 Vector2::limit_length(real_t p_len) const {
 	const real_t l = length();
 	Vector2 v = *this;
 	if (l > 0 && p_len < l) {
@@ -152,7 +152,7 @@ Vector2 Vector2::limit_length(const real_t p_len) const {
 	return v;
 }
 
-Vector2 Vector2::move_toward(const Vector2 &p_to, const real_t p_delta) const {
+Vector2 Vector2::move_toward(const Vector2 &p_to, real_t p_delta) const {
 	Vector2 v = *this;
 	Vector2 vd = p_to - v;
 	real_t len = vd.length();

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -83,7 +83,7 @@ struct _NO_DISCARD_ Vector2 {
 
 	real_t length() const;
 	real_t length_squared() const;
-	Vector2 limit_length(const real_t p_len = 1.0) const;
+	Vector2 limit_length(real_t p_len = 1.0) const;
 
 	Vector2 min(const Vector2 &p_vector2) const {
 		return Vector2(MIN(x, p_vector2.x), MIN(y, p_vector2.y));
@@ -101,20 +101,20 @@ struct _NO_DISCARD_ Vector2 {
 
 	real_t dot(const Vector2 &p_other) const;
 	real_t cross(const Vector2 &p_other) const;
-	Vector2 posmod(const real_t p_mod) const;
+	Vector2 posmod(real_t p_mod) const;
 	Vector2 posmodv(const Vector2 &p_modv) const;
 	Vector2 project(const Vector2 &p_to) const;
 
-	Vector2 plane_project(const real_t p_d, const Vector2 &p_vec) const;
+	Vector2 plane_project(real_t p_d, const Vector2 &p_vec) const;
 
-	_FORCE_INLINE_ Vector2 lerp(const Vector2 &p_to, const real_t p_weight) const;
-	_FORCE_INLINE_ Vector2 slerp(const Vector2 &p_to, const real_t p_weight) const;
-	_FORCE_INLINE_ Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight) const;
-	_FORCE_INLINE_ Vector2 cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
-	_FORCE_INLINE_ Vector2 bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const;
-	_FORCE_INLINE_ Vector2 bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const;
+	_FORCE_INLINE_ Vector2 lerp(const Vector2 &p_to, real_t p_weight) const;
+	_FORCE_INLINE_ Vector2 slerp(const Vector2 &p_to, real_t p_weight) const;
+	_FORCE_INLINE_ Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_weight) const;
+	_FORCE_INLINE_ Vector2 cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
+	_FORCE_INLINE_ Vector2 bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, real_t p_t) const;
+	_FORCE_INLINE_ Vector2 bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, real_t p_t) const;
 
-	Vector2 move_toward(const Vector2 &p_to, const real_t p_delta) const;
+	Vector2 move_toward(const Vector2 &p_to, real_t p_delta) const;
 
 	Vector2 slide(const Vector2 &p_normal) const;
 	Vector2 bounce(const Vector2 &p_normal) const;
@@ -130,15 +130,15 @@ struct _NO_DISCARD_ Vector2 {
 	void operator-=(const Vector2 &p_v);
 	Vector2 operator*(const Vector2 &p_v1) const;
 
-	Vector2 operator*(const real_t &rvalue) const;
-	void operator*=(const real_t &rvalue);
+	Vector2 operator*(real_t rvalue) const;
+	void operator*=(real_t rvalue);
 	void operator*=(const Vector2 &rvalue) { *this = *this * rvalue; }
 
 	Vector2 operator/(const Vector2 &p_v1) const;
 
-	Vector2 operator/(const real_t &rvalue) const;
+	Vector2 operator/(real_t rvalue) const;
 
-	void operator/=(const real_t &rvalue);
+	void operator/=(real_t rvalue);
 	void operator/=(const Vector2 &rvalue) { *this = *this / rvalue; }
 
 	Vector2 operator-() const;
@@ -152,13 +152,13 @@ struct _NO_DISCARD_ Vector2 {
 	bool operator>=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
 
 	real_t angle() const;
-	static Vector2 from_angle(const real_t p_angle);
+	static Vector2 from_angle(real_t p_angle);
 
 	_FORCE_INLINE_ Vector2 abs() const {
 		return Vector2(Math::abs(x), Math::abs(y));
 	}
 
-	Vector2 rotated(const real_t p_by) const;
+	Vector2 rotated(real_t p_by) const;
 	Vector2 orthogonal() const {
 		return Vector2(y, -x);
 	}
@@ -175,13 +175,13 @@ struct _NO_DISCARD_ Vector2 {
 	operator Vector2i() const;
 
 	_FORCE_INLINE_ Vector2() {}
-	_FORCE_INLINE_ Vector2(const real_t p_x, const real_t p_y) {
+	_FORCE_INLINE_ Vector2(real_t p_x, real_t p_y) {
 		x = p_x;
 		y = p_y;
 	}
 };
 
-_FORCE_INLINE_ Vector2 Vector2::plane_project(const real_t p_d, const Vector2 &p_vec) const {
+_FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {
 	return p_vec - *this * (dot(p_vec) - p_d);
 }
 
@@ -207,11 +207,11 @@ _FORCE_INLINE_ Vector2 Vector2::operator*(const Vector2 &p_v1) const {
 	return Vector2(x * p_v1.x, y * p_v1.y);
 }
 
-_FORCE_INLINE_ Vector2 Vector2::operator*(const real_t &rvalue) const {
+_FORCE_INLINE_ Vector2 Vector2::operator*(real_t rvalue) const {
 	return Vector2(x * rvalue, y * rvalue);
 }
 
-_FORCE_INLINE_ void Vector2::operator*=(const real_t &rvalue) {
+_FORCE_INLINE_ void Vector2::operator*=(real_t rvalue) {
 	x *= rvalue;
 	y *= rvalue;
 }
@@ -220,11 +220,11 @@ _FORCE_INLINE_ Vector2 Vector2::operator/(const Vector2 &p_v1) const {
 	return Vector2(x / p_v1.x, y / p_v1.y);
 }
 
-_FORCE_INLINE_ Vector2 Vector2::operator/(const real_t &rvalue) const {
+_FORCE_INLINE_ Vector2 Vector2::operator/(real_t rvalue) const {
 	return Vector2(x / rvalue, y / rvalue);
 }
 
-_FORCE_INLINE_ void Vector2::operator/=(const real_t &rvalue) {
+_FORCE_INLINE_ void Vector2::operator/=(real_t rvalue) {
 	x /= rvalue;
 	y /= rvalue;
 }
@@ -241,14 +241,14 @@ _FORCE_INLINE_ bool Vector2::operator!=(const Vector2 &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
 }
 
-Vector2 Vector2::lerp(const Vector2 &p_to, const real_t p_weight) const {
+Vector2 Vector2::lerp(const Vector2 &p_to, real_t p_weight) const {
 	Vector2 res = *this;
 	res.x = Math::lerp(res.x, p_to.x, p_weight);
 	res.y = Math::lerp(res.y, p_to.y, p_weight);
 	return res;
 }
 
-Vector2 Vector2::slerp(const Vector2 &p_to, const real_t p_weight) const {
+Vector2 Vector2::slerp(const Vector2 &p_to, real_t p_weight) const {
 	real_t start_length_sq = length_squared();
 	real_t end_length_sq = p_to.length_squared();
 	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
@@ -261,28 +261,28 @@ Vector2 Vector2::slerp(const Vector2 &p_to, const real_t p_weight) const {
 	return rotated(angle * p_weight) * (result_length / start_length);
 }
 
-Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight) const {
+Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_weight) const {
 	Vector2 res = *this;
 	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
 	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
 	return res;
 }
 
-Vector2 Vector2::cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+Vector2 Vector2::cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const {
 	Vector2 res = *this;
 	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	return res;
 }
 
-Vector2 Vector2::bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const {
+Vector2 Vector2::bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, real_t p_t) const {
 	Vector2 res = *this;
 	res.x = Math::bezier_interpolate(res.x, p_control_1.x, p_control_2.x, p_end.x, p_t);
 	res.y = Math::bezier_interpolate(res.y, p_control_1.y, p_control_2.y, p_end.y, p_t);
 	return res;
 }
 
-Vector2 Vector2::bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const {
+Vector2 Vector2::bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, real_t p_t) const {
 	Vector2 res = *this;
 	res.x = Math::bezier_derivative(res.x, p_control_1.x, p_control_2.x, p_end.x, p_t);
 	res.y = Math::bezier_derivative(res.y, p_control_1.y, p_control_2.y, p_end.y, p_t);
@@ -298,19 +298,19 @@ Vector2 Vector2::direction_to(const Vector2 &p_to) const {
 // Multiplication operators required to workaround issues with LLVM using implicit conversion
 // to Vector2i instead for integers where it should not.
 
-_FORCE_INLINE_ Vector2 operator*(const float p_scalar, const Vector2 &p_vec) {
+_FORCE_INLINE_ Vector2 operator*(float p_scalar, const Vector2 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector2 operator*(const double p_scalar, const Vector2 &p_vec) {
+_FORCE_INLINE_ Vector2 operator*(double p_scalar, const Vector2 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector2 operator*(const int32_t p_scalar, const Vector2 &p_vec) {
+_FORCE_INLINE_ Vector2 operator*(int32_t p_scalar, const Vector2 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector2 operator*(const int64_t p_scalar, const Vector2 &p_vec) {
+_FORCE_INLINE_ Vector2 operator*(int64_t p_scalar, const Vector2 &p_vec) {
 	return p_vec * p_scalar;
 }
 

--- a/core/math/vector2i.cpp
+++ b/core/math/vector2i.cpp
@@ -75,11 +75,11 @@ Vector2i Vector2i::operator*(const Vector2i &p_v1) const {
 	return Vector2i(x * p_v1.x, y * p_v1.y);
 }
 
-Vector2i Vector2i::operator*(const int32_t &rvalue) const {
+Vector2i Vector2i::operator*(int32_t rvalue) const {
 	return Vector2i(x * rvalue, y * rvalue);
 }
 
-void Vector2i::operator*=(const int32_t &rvalue) {
+void Vector2i::operator*=(int32_t rvalue) {
 	x *= rvalue;
 	y *= rvalue;
 }
@@ -88,11 +88,11 @@ Vector2i Vector2i::operator/(const Vector2i &p_v1) const {
 	return Vector2i(x / p_v1.x, y / p_v1.y);
 }
 
-Vector2i Vector2i::operator/(const int32_t &rvalue) const {
+Vector2i Vector2i::operator/(int32_t rvalue) const {
 	return Vector2i(x / rvalue, y / rvalue);
 }
 
-void Vector2i::operator/=(const int32_t &rvalue) {
+void Vector2i::operator/=(int32_t rvalue) {
 	x /= rvalue;
 	y /= rvalue;
 }
@@ -101,11 +101,11 @@ Vector2i Vector2i::operator%(const Vector2i &p_v1) const {
 	return Vector2i(x % p_v1.x, y % p_v1.y);
 }
 
-Vector2i Vector2i::operator%(const int32_t &rvalue) const {
+Vector2i Vector2i::operator%(int32_t rvalue) const {
 	return Vector2i(x % rvalue, y % rvalue);
 }
 
-void Vector2i::operator%=(const int32_t &rvalue) {
+void Vector2i::operator%=(int32_t rvalue) {
 	x %= rvalue;
 	y %= rvalue;
 }

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -99,16 +99,16 @@ struct _NO_DISCARD_ Vector2i {
 	void operator-=(const Vector2i &p_v);
 	Vector2i operator*(const Vector2i &p_v1) const;
 
-	Vector2i operator*(const int32_t &rvalue) const;
-	void operator*=(const int32_t &rvalue);
+	Vector2i operator*(int32_t rvalue) const;
+	void operator*=(int32_t rvalue);
 
 	Vector2i operator/(const Vector2i &p_v1) const;
-	Vector2i operator/(const int32_t &rvalue) const;
-	void operator/=(const int32_t &rvalue);
+	Vector2i operator/(int32_t rvalue) const;
+	void operator/=(int32_t rvalue);
 
 	Vector2i operator%(const Vector2i &p_v1) const;
-	Vector2i operator%(const int32_t &rvalue) const;
-	void operator%=(const int32_t &rvalue);
+	Vector2i operator%(int32_t rvalue) const;
+	void operator%=(int32_t rvalue);
 
 	Vector2i operator-() const;
 	bool operator<(const Vector2i &p_vec2) const { return (x == p_vec2.x) ? (y < p_vec2.y) : (x < p_vec2.x); }
@@ -133,7 +133,7 @@ struct _NO_DISCARD_ Vector2i {
 	operator Vector2() const;
 
 	inline Vector2i() {}
-	inline Vector2i(const int32_t p_x, const int32_t p_y) {
+	inline Vector2i(int32_t p_x, int32_t p_y) {
 		x = p_x;
 		y = p_y;
 	}
@@ -141,19 +141,19 @@ struct _NO_DISCARD_ Vector2i {
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.
 
-_FORCE_INLINE_ Vector2i operator*(const int32_t p_scalar, const Vector2i &p_vector) {
+_FORCE_INLINE_ Vector2i operator*(int32_t p_scalar, const Vector2i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector2i operator*(const int64_t p_scalar, const Vector2i &p_vector) {
+_FORCE_INLINE_ Vector2i operator*(int64_t p_scalar, const Vector2i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector2i operator*(const float p_scalar, const Vector2i &p_vector) {
+_FORCE_INLINE_ Vector2i operator*(float p_scalar, const Vector2i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector2i operator*(const double p_scalar, const Vector2i &p_vector) {
+_FORCE_INLINE_ Vector2i operator*(double p_scalar, const Vector2i &p_vector) {
 	return p_vector * p_scalar;
 }
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -35,11 +35,11 @@
 #include "core/math/vector3i.h"
 #include "core/string/ustring.h"
 
-void Vector3::rotate(const Vector3 &p_axis, const real_t p_angle) {
+void Vector3::rotate(const Vector3 &p_axis, real_t p_angle) {
 	*this = Basis(p_axis, p_angle).xform(*this);
 }
 
-Vector3 Vector3::rotated(const Vector3 &p_axis, const real_t p_angle) const {
+Vector3 Vector3::rotated(const Vector3 &p_axis, real_t p_angle) const {
 	Vector3 r = *this;
 	r.rotate(p_axis, p_angle);
 	return r;
@@ -52,19 +52,19 @@ Vector3 Vector3::clamp(const Vector3 &p_min, const Vector3 &p_max) const {
 			CLAMP(z, p_min.z, p_max.z));
 }
 
-void Vector3::snap(const Vector3 p_step) {
+void Vector3::snap(const Vector3 &p_step) {
 	x = Math::snapped(x, p_step.x);
 	y = Math::snapped(y, p_step.y);
 	z = Math::snapped(z, p_step.z);
 }
 
-Vector3 Vector3::snapped(const Vector3 p_step) const {
+Vector3 Vector3::snapped(const Vector3 &p_step) const {
 	Vector3 v = *this;
 	v.snap(p_step);
 	return v;
 }
 
-Vector3 Vector3::limit_length(const real_t p_len) const {
+Vector3 Vector3::limit_length(real_t p_len) const {
 	const real_t l = length();
 	Vector3 v = *this;
 	if (l > 0 && p_len < l) {
@@ -75,7 +75,7 @@ Vector3 Vector3::limit_length(const real_t p_len) const {
 	return v;
 }
 
-Vector3 Vector3::move_toward(const Vector3 &p_to, const real_t p_delta) const {
+Vector3 Vector3::move_toward(const Vector3 &p_to, real_t p_delta) const {
 	Vector3 v = *this;
 	Vector3 vd = p_to - v;
 	real_t len = vd.length();

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -58,12 +58,12 @@ struct _NO_DISCARD_ Vector3 {
 		real_t coord[3] = { 0 };
 	};
 
-	_FORCE_INLINE_ const real_t &operator[](const int p_axis) const {
+	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
 
-	_FORCE_INLINE_ real_t &operator[](const int p_axis) {
+	_FORCE_INLINE_ real_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
@@ -91,26 +91,26 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ Vector3 normalized() const;
 	_FORCE_INLINE_ bool is_normalized() const;
 	_FORCE_INLINE_ Vector3 inverse() const;
-	Vector3 limit_length(const real_t p_len = 1.0) const;
+	Vector3 limit_length(real_t p_len = 1.0) const;
 
 	_FORCE_INLINE_ void zero();
 
-	void snap(const Vector3 p_val);
-	Vector3 snapped(const Vector3 p_val) const;
+	void snap(const Vector3 &p_val);
+	Vector3 snapped(const Vector3 &p_val) const;
 
-	void rotate(const Vector3 &p_axis, const real_t p_angle);
-	Vector3 rotated(const Vector3 &p_axis, const real_t p_angle) const;
+	void rotate(const Vector3 &p_axis, real_t p_angle);
+	Vector3 rotated(const Vector3 &p_axis, real_t p_angle) const;
 
 	/* Static Methods between 2 vector3s */
 
-	_FORCE_INLINE_ Vector3 lerp(const Vector3 &p_to, const real_t p_weight) const;
-	_FORCE_INLINE_ Vector3 slerp(const Vector3 &p_to, const real_t p_weight) const;
-	_FORCE_INLINE_ Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const;
-	_FORCE_INLINE_ Vector3 cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
-	_FORCE_INLINE_ Vector3 bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const;
-	_FORCE_INLINE_ Vector3 bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const;
+	_FORCE_INLINE_ Vector3 lerp(const Vector3 &p_to, real_t p_weight) const;
+	_FORCE_INLINE_ Vector3 slerp(const Vector3 &p_to, real_t p_weight) const;
+	_FORCE_INLINE_ Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const;
+	_FORCE_INLINE_ Vector3 cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
+	_FORCE_INLINE_ Vector3 bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const;
+	_FORCE_INLINE_ Vector3 bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const;
 
-	Vector3 move_toward(const Vector3 &p_to, const real_t p_delta) const;
+	Vector3 move_toward(const Vector3 &p_to, real_t p_delta) const;
 
 	Vector2 octahedron_encode() const;
 	static Vector3 octahedron_decode(const Vector2 &p_oct);
@@ -131,7 +131,7 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
 	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;
 
-	_FORCE_INLINE_ Vector3 posmod(const real_t p_mod) const;
+	_FORCE_INLINE_ Vector3 posmod(real_t p_mod) const;
 	_FORCE_INLINE_ Vector3 posmodv(const Vector3 &p_modv) const;
 	_FORCE_INLINE_ Vector3 project(const Vector3 &p_to) const;
 
@@ -158,10 +158,10 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ Vector3 &operator/=(const Vector3 &p_v);
 	_FORCE_INLINE_ Vector3 operator/(const Vector3 &p_v) const;
 
-	_FORCE_INLINE_ Vector3 &operator*=(const real_t p_scalar);
-	_FORCE_INLINE_ Vector3 operator*(const real_t p_scalar) const;
-	_FORCE_INLINE_ Vector3 &operator/=(const real_t p_scalar);
-	_FORCE_INLINE_ Vector3 operator/(const real_t p_scalar) const;
+	_FORCE_INLINE_ Vector3 &operator*=(real_t p_scalar);
+	_FORCE_INLINE_ Vector3 operator*(real_t p_scalar) const;
+	_FORCE_INLINE_ Vector3 &operator/=(real_t p_scalar);
+	_FORCE_INLINE_ Vector3 operator/(real_t p_scalar) const;
 
 	_FORCE_INLINE_ Vector3 operator-() const;
 
@@ -176,7 +176,7 @@ struct _NO_DISCARD_ Vector3 {
 	operator Vector3i() const;
 
 	_FORCE_INLINE_ Vector3() {}
-	_FORCE_INLINE_ Vector3(const real_t p_x, const real_t p_y, const real_t p_z) {
+	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) {
 		x = p_x;
 		y = p_y;
 		z = p_z;
@@ -216,7 +216,7 @@ Vector3 Vector3::round() const {
 	return Vector3(Math::round(x), Math::round(y), Math::round(z));
 }
 
-Vector3 Vector3::lerp(const Vector3 &p_to, const real_t p_weight) const {
+Vector3 Vector3::lerp(const Vector3 &p_to, real_t p_weight) const {
 	Vector3 res = *this;
 	res.x = Math::lerp(res.x, p_to.x, p_weight);
 	res.y = Math::lerp(res.y, p_to.y, p_weight);
@@ -224,7 +224,7 @@ Vector3 Vector3::lerp(const Vector3 &p_to, const real_t p_weight) const {
 	return res;
 }
 
-Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
+Vector3 Vector3::slerp(const Vector3 &p_to, real_t p_weight) const {
 	// This method seems more complicated than it really is, since we write out
 	// the internals of some methods for efficiency (mainly, checking length).
 	real_t start_length_sq = length_squared();
@@ -246,7 +246,7 @@ Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
 	return rotated(axis, angle * p_weight) * (result_length / start_length);
 }
 
-Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const {
+Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight) const {
 	Vector3 res = *this;
 	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
 	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
@@ -254,7 +254,7 @@ Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, c
 	return res;
 }
 
-Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const {
 	Vector3 res = *this;
 	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
@@ -262,7 +262,7 @@ Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_
 	return res;
 }
 
-Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const {
 	Vector3 res = *this;
 	res.x = Math::bezier_interpolate(res.x, p_control_1.x, p_control_2.x, p_end.x, p_t);
 	res.y = Math::bezier_interpolate(res.y, p_control_1.y, p_control_2.y, p_end.y, p_t);
@@ -270,7 +270,7 @@ Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p
 	return res;
 }
 
-Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, real_t p_t) const {
 	Vector3 res = *this;
 	res.x = Math::bezier_derivative(res.x, p_control_1.x, p_control_2.x, p_end.x, p_t);
 	res.y = Math::bezier_derivative(res.y, p_control_1.y, p_control_2.y, p_end.y, p_t);
@@ -286,7 +286,7 @@ real_t Vector3::distance_squared_to(const Vector3 &p_to) const {
 	return (p_to - *this).length_squared();
 }
 
-Vector3 Vector3::posmod(const real_t p_mod) const {
+Vector3 Vector3::posmod(real_t p_mod) const {
 	return Vector3(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod));
 }
 
@@ -361,7 +361,7 @@ Vector3 Vector3::operator/(const Vector3 &p_v) const {
 	return Vector3(x / p_v.x, y / p_v.y, z / p_v.z);
 }
 
-Vector3 &Vector3::operator*=(const real_t p_scalar) {
+Vector3 &Vector3::operator*=(real_t p_scalar) {
 	x *= p_scalar;
 	y *= p_scalar;
 	z *= p_scalar;
@@ -371,34 +371,34 @@ Vector3 &Vector3::operator*=(const real_t p_scalar) {
 // Multiplication operators required to workaround issues with LLVM using implicit conversion
 // to Vector3i instead for integers where it should not.
 
-_FORCE_INLINE_ Vector3 operator*(const float p_scalar, const Vector3 &p_vec) {
+_FORCE_INLINE_ Vector3 operator*(float p_scalar, const Vector3 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector3 operator*(const double p_scalar, const Vector3 &p_vec) {
+_FORCE_INLINE_ Vector3 operator*(double p_scalar, const Vector3 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector3 operator*(const int32_t p_scalar, const Vector3 &p_vec) {
+_FORCE_INLINE_ Vector3 operator*(int32_t p_scalar, const Vector3 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector3 operator*(const int64_t p_scalar, const Vector3 &p_vec) {
+_FORCE_INLINE_ Vector3 operator*(int64_t p_scalar, const Vector3 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-Vector3 Vector3::operator*(const real_t p_scalar) const {
+Vector3 Vector3::operator*(real_t p_scalar) const {
 	return Vector3(x * p_scalar, y * p_scalar, z * p_scalar);
 }
 
-Vector3 &Vector3::operator/=(const real_t p_scalar) {
+Vector3 &Vector3::operator/=(real_t p_scalar) {
 	x /= p_scalar;
 	y /= p_scalar;
 	z /= p_scalar;
 	return *this;
 }
 
-Vector3 Vector3::operator/(const real_t p_scalar) const {
+Vector3 Vector3::operator/(real_t p_scalar) const {
 	return Vector3(x / p_scalar, y / p_scalar, z / p_scalar);
 }
 

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -56,12 +56,12 @@ struct _NO_DISCARD_ Vector3i {
 		int32_t coord[3] = { 0 };
 	};
 
-	_FORCE_INLINE_ const int32_t &operator[](const int p_axis) const {
+	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
 
-	_FORCE_INLINE_ int32_t &operator[](const int p_axis) {
+	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
@@ -103,12 +103,12 @@ struct _NO_DISCARD_ Vector3i {
 	_FORCE_INLINE_ Vector3i &operator%=(const Vector3i &p_v);
 	_FORCE_INLINE_ Vector3i operator%(const Vector3i &p_v) const;
 
-	_FORCE_INLINE_ Vector3i &operator*=(const int32_t p_scalar);
-	_FORCE_INLINE_ Vector3i operator*(const int32_t p_scalar) const;
-	_FORCE_INLINE_ Vector3i &operator/=(const int32_t p_scalar);
-	_FORCE_INLINE_ Vector3i operator/(const int32_t p_scalar) const;
-	_FORCE_INLINE_ Vector3i &operator%=(const int32_t p_scalar);
-	_FORCE_INLINE_ Vector3i operator%(const int32_t p_scalar) const;
+	_FORCE_INLINE_ Vector3i &operator*=(int32_t p_scalar);
+	_FORCE_INLINE_ Vector3i operator*(int32_t p_scalar) const;
+	_FORCE_INLINE_ Vector3i &operator/=(int32_t p_scalar);
+	_FORCE_INLINE_ Vector3i operator/(int32_t p_scalar) const;
+	_FORCE_INLINE_ Vector3i &operator%=(int32_t p_scalar);
+	_FORCE_INLINE_ Vector3i operator%(int32_t p_scalar) const;
 
 	_FORCE_INLINE_ Vector3i operator-() const;
 
@@ -123,7 +123,7 @@ struct _NO_DISCARD_ Vector3i {
 	operator Vector3() const;
 
 	_FORCE_INLINE_ Vector3i() {}
-	_FORCE_INLINE_ Vector3i(const int32_t p_x, const int32_t p_y, const int32_t p_z) {
+	_FORCE_INLINE_ Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) {
 		x = p_x;
 		y = p_y;
 		z = p_z;
@@ -211,54 +211,54 @@ Vector3i Vector3i::operator%(const Vector3i &p_v) const {
 	return Vector3i(x % p_v.x, y % p_v.y, z % p_v.z);
 }
 
-Vector3i &Vector3i::operator*=(const int32_t p_scalar) {
+Vector3i &Vector3i::operator*=(int32_t p_scalar) {
 	x *= p_scalar;
 	y *= p_scalar;
 	z *= p_scalar;
 	return *this;
 }
 
-Vector3i Vector3i::operator*(const int32_t p_scalar) const {
+Vector3i Vector3i::operator*(int32_t p_scalar) const {
 	return Vector3i(x * p_scalar, y * p_scalar, z * p_scalar);
 }
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.
 
-_FORCE_INLINE_ Vector3i operator*(const int32_t p_scalar, const Vector3i &p_vector) {
+_FORCE_INLINE_ Vector3i operator*(int32_t p_scalar, const Vector3i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector3i operator*(const int64_t p_scalar, const Vector3i &p_vector) {
+_FORCE_INLINE_ Vector3i operator*(int64_t p_scalar, const Vector3i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector3i operator*(const float p_scalar, const Vector3i &p_vector) {
+_FORCE_INLINE_ Vector3i operator*(float p_scalar, const Vector3i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector3i operator*(const double p_scalar, const Vector3i &p_vector) {
+_FORCE_INLINE_ Vector3i operator*(double p_scalar, const Vector3i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-Vector3i &Vector3i::operator/=(const int32_t p_scalar) {
+Vector3i &Vector3i::operator/=(int32_t p_scalar) {
 	x /= p_scalar;
 	y /= p_scalar;
 	z /= p_scalar;
 	return *this;
 }
 
-Vector3i Vector3i::operator/(const int32_t p_scalar) const {
+Vector3i Vector3i::operator/(int32_t p_scalar) const {
 	return Vector3i(x / p_scalar, y / p_scalar, z / p_scalar);
 }
 
-Vector3i &Vector3i::operator%=(const int32_t p_scalar) {
+Vector3i &Vector3i::operator%=(int32_t p_scalar) {
 	x %= p_scalar;
 	y %= p_scalar;
 	z %= p_scalar;
 	return *this;
 }
 
-Vector3i Vector3i::operator%(const int32_t p_scalar) const {
+Vector3i Vector3i::operator%(int32_t p_scalar) const {
 	return Vector3i(x % p_scalar, y % p_scalar, z % p_scalar);
 }
 

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -129,7 +129,7 @@ Vector4 Vector4::round() const {
 	return Vector4(Math::round(x), Math::round(y), Math::round(z), Math::round(w));
 }
 
-Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
+Vector4 Vector4::lerp(const Vector4 &p_to, real_t p_weight) const {
 	Vector4 res = *this;
 	res.x = Math::lerp(res.x, p_to.x, p_weight);
 	res.y = Math::lerp(res.y, p_to.y, p_weight);
@@ -138,7 +138,7 @@ Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
 	return res;
 }
 
-Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const {
+Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, real_t p_weight) const {
 	Vector4 res = *this;
 	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
 	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
@@ -147,7 +147,7 @@ Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, c
 	return res;
 }
 
-Vector4 Vector4::cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+Vector4 Vector4::cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const {
 	Vector4 res = *this;
 	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
@@ -156,7 +156,7 @@ Vector4 Vector4::cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_
 	return res;
 }
 
-Vector4 Vector4::posmod(const real_t p_mod) const {
+Vector4 Vector4::posmod(real_t p_mod) const {
 	return Vector4(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod), Math::fposmod(w, p_mod));
 }
 

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -56,11 +56,11 @@ struct _NO_DISCARD_ Vector4 {
 		real_t components[4] = { 0, 0, 0, 0 };
 	};
 
-	_FORCE_INLINE_ real_t &operator[](const int p_axis) {
+	_FORCE_INLINE_ real_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return components[p_axis];
 	}
-	_FORCE_INLINE_ const real_t &operator[](const int p_axis) const {
+	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return components[p_axis];
 	}
@@ -94,11 +94,11 @@ struct _NO_DISCARD_ Vector4 {
 	Vector4 floor() const;
 	Vector4 ceil() const;
 	Vector4 round() const;
-	Vector4 lerp(const Vector4 &p_to, const real_t p_weight) const;
-	Vector4 cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const;
-	Vector4 cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
+	Vector4 lerp(const Vector4 &p_to, real_t p_weight) const;
+	Vector4 cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, real_t p_weight) const;
+	Vector4 cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
 
-	Vector4 posmod(const real_t p_mod) const;
+	Vector4 posmod(real_t p_mod) const;
 	Vector4 posmodv(const Vector4 &p_modv) const;
 	void snap(const Vector4 &p_step);
 	Vector4 snapped(const Vector4 &p_step) const;
@@ -111,15 +111,15 @@ struct _NO_DISCARD_ Vector4 {
 	_FORCE_INLINE_ void operator-=(const Vector4 &p_vec4);
 	_FORCE_INLINE_ void operator*=(const Vector4 &p_vec4);
 	_FORCE_INLINE_ void operator/=(const Vector4 &p_vec4);
-	_FORCE_INLINE_ void operator*=(const real_t &s);
-	_FORCE_INLINE_ void operator/=(const real_t &s);
+	_FORCE_INLINE_ void operator*=(real_t s);
+	_FORCE_INLINE_ void operator/=(real_t s);
 	_FORCE_INLINE_ Vector4 operator+(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ Vector4 operator-(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ Vector4 operator*(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ Vector4 operator/(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ Vector4 operator-() const;
-	_FORCE_INLINE_ Vector4 operator*(const real_t &s) const;
-	_FORCE_INLINE_ Vector4 operator/(const real_t &s) const;
+	_FORCE_INLINE_ Vector4 operator*(real_t s) const;
+	_FORCE_INLINE_ Vector4 operator/(real_t s) const;
 
 	_FORCE_INLINE_ bool operator==(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ bool operator!=(const Vector4 &p_vec4) const;
@@ -189,14 +189,14 @@ void Vector4::operator/=(const Vector4 &p_vec4) {
 	z /= p_vec4.z;
 	w /= p_vec4.w;
 }
-void Vector4::operator*=(const real_t &s) {
+void Vector4::operator*=(real_t s) {
 	x *= s;
 	y *= s;
 	z *= s;
 	w *= s;
 }
 
-void Vector4::operator/=(const real_t &s) {
+void Vector4::operator/=(real_t s) {
 	*this *= 1.0f / s;
 }
 
@@ -220,11 +220,11 @@ Vector4 Vector4::operator-() const {
 	return Vector4(-x, -y, -z, -w);
 }
 
-Vector4 Vector4::operator*(const real_t &s) const {
+Vector4 Vector4::operator*(real_t s) const {
 	return Vector4(x * s, y * s, z * s, w * s);
 }
 
-Vector4 Vector4::operator/(const real_t &s) const {
+Vector4 Vector4::operator/(real_t s) const {
 	return *this * (1.0f / s);
 }
 
@@ -288,19 +288,19 @@ bool Vector4::operator>=(const Vector4 &p_v) const {
 	return x > p_v.x;
 }
 
-_FORCE_INLINE_ Vector4 operator*(const float p_scalar, const Vector4 &p_vec) {
+_FORCE_INLINE_ Vector4 operator*(float p_scalar, const Vector4 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector4 operator*(const double p_scalar, const Vector4 &p_vec) {
+_FORCE_INLINE_ Vector4 operator*(double p_scalar, const Vector4 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector4 operator*(const int32_t p_scalar, const Vector4 &p_vec) {
+_FORCE_INLINE_ Vector4 operator*(int32_t p_scalar, const Vector4 &p_vec) {
 	return p_vec * p_scalar;
 }
 
-_FORCE_INLINE_ Vector4 operator*(const int64_t p_scalar, const Vector4 &p_vec) {
+_FORCE_INLINE_ Vector4 operator*(int64_t p_scalar, const Vector4 &p_vec) {
 	return p_vec * p_scalar;
 }
 

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -58,12 +58,12 @@ struct _NO_DISCARD_ Vector4i {
 		int32_t coord[4] = { 0 };
 	};
 
-	_FORCE_INLINE_ const int32_t &operator[](const int p_axis) const {
+	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return coord[p_axis];
 	}
 
-	_FORCE_INLINE_ int32_t &operator[](const int p_axis) {
+	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return coord[p_axis];
 	}
@@ -105,12 +105,12 @@ struct _NO_DISCARD_ Vector4i {
 	_FORCE_INLINE_ Vector4i &operator%=(const Vector4i &p_v);
 	_FORCE_INLINE_ Vector4i operator%(const Vector4i &p_v) const;
 
-	_FORCE_INLINE_ Vector4i &operator*=(const int32_t p_scalar);
-	_FORCE_INLINE_ Vector4i operator*(const int32_t p_scalar) const;
-	_FORCE_INLINE_ Vector4i &operator/=(const int32_t p_scalar);
-	_FORCE_INLINE_ Vector4i operator/(const int32_t p_scalar) const;
-	_FORCE_INLINE_ Vector4i &operator%=(const int32_t p_scalar);
-	_FORCE_INLINE_ Vector4i operator%(const int32_t p_scalar) const;
+	_FORCE_INLINE_ Vector4i &operator*=(int32_t p_scalar);
+	_FORCE_INLINE_ Vector4i operator*(int32_t p_scalar) const;
+	_FORCE_INLINE_ Vector4i &operator/=(int32_t p_scalar);
+	_FORCE_INLINE_ Vector4i operator/(int32_t p_scalar) const;
+	_FORCE_INLINE_ Vector4i &operator%=(int32_t p_scalar);
+	_FORCE_INLINE_ Vector4i operator%(int32_t p_scalar) const;
 
 	_FORCE_INLINE_ Vector4i operator-() const;
 
@@ -126,7 +126,7 @@ struct _NO_DISCARD_ Vector4i {
 
 	_FORCE_INLINE_ Vector4i() {}
 	Vector4i(const Vector4 &p_vec4);
-	_FORCE_INLINE_ Vector4i(const int32_t p_x, const int32_t p_y, const int32_t p_z, const int32_t p_w) {
+	_FORCE_INLINE_ Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) {
 		x = p_x;
 		y = p_y;
 		z = p_z;
@@ -220,7 +220,7 @@ Vector4i Vector4i::operator%(const Vector4i &p_v) const {
 	return Vector4i(x % p_v.x, y % p_v.y, z % p_v.z, w % p_v.w);
 }
 
-Vector4i &Vector4i::operator*=(const int32_t p_scalar) {
+Vector4i &Vector4i::operator*=(int32_t p_scalar) {
 	x *= p_scalar;
 	y *= p_scalar;
 	z *= p_scalar;
@@ -228,29 +228,29 @@ Vector4i &Vector4i::operator*=(const int32_t p_scalar) {
 	return *this;
 }
 
-Vector4i Vector4i::operator*(const int32_t p_scalar) const {
+Vector4i Vector4i::operator*(int32_t p_scalar) const {
 	return Vector4i(x * p_scalar, y * p_scalar, z * p_scalar, w * p_scalar);
 }
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.
 
-_FORCE_INLINE_ Vector4i operator*(const int32_t p_scalar, const Vector4i &p_vector) {
+_FORCE_INLINE_ Vector4i operator*(int32_t p_scalar, const Vector4i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector4i operator*(const int64_t p_scalar, const Vector4i &p_vector) {
+_FORCE_INLINE_ Vector4i operator*(int64_t p_scalar, const Vector4i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector4i operator*(const float p_scalar, const Vector4i &p_vector) {
+_FORCE_INLINE_ Vector4i operator*(float p_scalar, const Vector4i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-_FORCE_INLINE_ Vector4i operator*(const double p_scalar, const Vector4i &p_vector) {
+_FORCE_INLINE_ Vector4i operator*(double p_scalar, const Vector4i &p_vector) {
 	return p_vector * p_scalar;
 }
 
-Vector4i &Vector4i::operator/=(const int32_t p_scalar) {
+Vector4i &Vector4i::operator/=(int32_t p_scalar) {
 	x /= p_scalar;
 	y /= p_scalar;
 	z /= p_scalar;
@@ -258,11 +258,11 @@ Vector4i &Vector4i::operator/=(const int32_t p_scalar) {
 	return *this;
 }
 
-Vector4i Vector4i::operator/(const int32_t p_scalar) const {
+Vector4i Vector4i::operator/(int32_t p_scalar) const {
 	return Vector4i(x / p_scalar, y / p_scalar, z / p_scalar, w / p_scalar);
 }
 
-Vector4i &Vector4i::operator%=(const int32_t p_scalar) {
+Vector4i &Vector4i::operator%=(int32_t p_scalar) {
 	x %= p_scalar;
 	y %= p_scalar;
 	z %= p_scalar;
@@ -270,7 +270,7 @@ Vector4i &Vector4i::operator%=(const int32_t p_scalar) {
 	return *this;
 }
 
-Vector4i Vector4i::operator%(const int32_t p_scalar) const {
+Vector4i Vector4i::operator%(int32_t p_scalar) const {
 	return Vector4i(x % p_scalar, y % p_scalar, z % p_scalar, w % p_scalar);
 }
 


### PR DESCRIPTION
A handful of the core math classes were using their fundamental type arguments inappropriately, generally through unnecessary `const` and/or passing by reference. This PR sweeps through all those files, ensuring fundamental type arguments aren't `const` & get passed by value (unless deliberately functioning as an "out" reference). Besides that, the only other change made is to Vector3's `snap` and `snapped` functions to fix the opposite issue, where Vector3 *wasn't* passed by reference previously.