### PR TITLE
Fix billboarding of GPU particles in double precision builds

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1214,12 +1214,14 @@ void vertex() {)";
 		} break;
 		case BILLBOARD_PARTICLES: {
 			// Make billboard and rotated by rotation.
+			// `MAIN_CAM_INV_VIEW_MATRIX` is inverse of the camera, even on shadow passes.
+			// This ensures the billboard faces the camera when casting shadows.
 			code += R"(
 	// Billboard Mode: Particles
 	mat4 mat_world = mat4(
-			normalize(INV_VIEW_MATRIX[0]),
-			normalize(INV_VIEW_MATRIX[1]),
-			normalize(INV_VIEW_MATRIX[2]),
+			normalize(MAIN_CAM_INV_VIEW_MATRIX[0]),
+			normalize(MAIN_CAM_INV_VIEW_MATRIX[1]),
+			normalize(MAIN_CAM_INV_VIEW_MATRIX[2]),
 			MODEL_MATRIX[3]);
 	mat_world = mat_world * mat4(
 			vec4(cos(INSTANCE_CUSTOM.x), -sin(INSTANCE_CUSTOM.x), 0.0, 0.0),

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -253,6 +253,9 @@ void vertex_shader(vec3 vertex_input,
 	}
 
 	mat4 matrix;
+#ifdef USE_DOUBLE_PRECISION
+	vec3 matrix_translation;
+#endif
 	mat4 read_model_matrix = model_matrix;
 
 	if (sc_multimesh()) {
@@ -328,14 +331,13 @@ void vertex_shader(vec3 vertex_input,
 #endif
 		//transpose
 		matrix = transpose(matrix);
-#if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
-		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
-		// we avoid baking it in so we can emulate high precision.
+#ifdef USE_DOUBLE_PRECISION
+		// Strip the translation from the matrix for emulating high precision later.
+		matrix_translation = matrix[3].xyz;
+		matrix[3].xyz = vec3(0.0);
+#endif
 		read_model_matrix = model_matrix * matrix;
-#if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 		model_matrix = read_model_matrix;
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
@@ -420,10 +422,9 @@ void vertex_shader(vec3 vertex_input,
 	// We add the result to the vertex and ignore the final lost precision.
 	vec3 model_origin = model_matrix[3].xyz;
 	if (sc_multimesh()) {
-		vertex = mat3(matrix) * vertex;
-		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
+		model_origin = double_add_vec3(model_origin, model_precision, matrix_translation, vec3(0.0), model_precision);
 	}
-	vertex = mat3(inv_view_matrix * modelview) * vertex;
+	vertex = mat3(inv_view_matrix) * mat3(modelview) * vertex;
 	vec3 temp_precision; // Will be ignored.
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;


### PR DESCRIPTION
Resolves #76388 by applying the particle transformation matrix to the modelview matrix prior to the material's vertex shader code where billboarding is performed. Double precision emulation is still done for the translation component of the transformation. This also changes to use the main camera's inverse view transformation in the particle billboarding to correct the lighting as in review #72638.

![billboarding](https://github.com/godotengine/godot/assets/6766142/2500f5e4-4222-4ac9-b818-a480c6c68859)

The issue was caused by `matrix` being manually applied for `is_multimesh` objects after the material's vertex shader. In the case of billboarded particles, this resulted in a model rotational component not being accounted for when facing the object towards the main camera.

The `matrix` can be baked into the modelview matrix in both double and single precision cases. This removes the need for some preprocessor macros since now the `model_matrix` will be used in both configurations. For double precision, the translation component of `matrix` is removed to be used in the high precision calculations after the material's vertex shader.

I tested the following configurations in the minimal reproduction projects from #76388 and #89020:
- rendering backend: Mobile & Forward+
- precision: single & double
- billboarding: disabled & particle billboard

![rotated](https://github.com/godotengine/godot/assets/6766142/55fb744e-58af-49ee-8ca0-8657880e9d54)