### PR TITLE
[TextServer] Fix fallback line breaking code adding two breaks for CR-LF.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5360,11 +5360,14 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 				// No data loaded - use fallback.
 				for (int j = r_start; j < r_end; j++) {
 					char32_t c = sd->text[j - sd->start];
+					char32_t c_next = (j < r_end) ? sd->text[j - sd->start + 1] : 0x0000;
 					if (is_whitespace(c)) {
 						sd->breaks[j + 1] = false;
 					}
 					if (is_linebreak(c)) {
-						sd->breaks[j + 1] = true;
+						if (c != 0x000D || c_next != 0x000A) { // Skip first hard break in CR-LF pair.
+							sd->breaks[j + 1] = true;
+						}
 					}
 				}
 			} else {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3617,6 +3617,7 @@ bool TextServerFallback::_shaped_text_update_breaks(const RID &p_shaped) {
 	for (int i = 0; i < sd_size; i++) {
 		if (sd_glyphs[i].count > 0) {
 			char32_t c = sd->text[sd_glyphs[i].start - sd->start];
+			char32_t c_next = i < sd_size ? sd->text[sd_glyphs[i].start - sd->start + 1] : 0x0000;
 			if (c_punct_size == 0) {
 				if (is_punct(c) && c != 0x005F && c != ' ') {
 					sd_glyphs[i].flags |= GRAPHEME_IS_PUNCTUATION;
@@ -3640,7 +3641,9 @@ bool TextServerFallback::_shaped_text_update_breaks(const RID &p_shaped) {
 			}
 			if (is_linebreak(c)) {
 				sd_glyphs[i].flags |= GRAPHEME_IS_SPACE;
-				sd_glyphs[i].flags |= GRAPHEME_IS_BREAK_HARD;
+				if (c != 0x000D || c_next != 0x000A) { // Skip first hard break in CR-LF pair.
+					sd_glyphs[i].flags |= GRAPHEME_IS_BREAK_HARD;
+				}
 			}
 			if (c == 0x0009 || c == 0x000b) {
 				sd_glyphs[i].flags |= GRAPHEME_IS_TAB;


### PR DESCRIPTION
Fixes fallback line breaking code (export with disabled ICU data or fallback text server) adding two breaks for CR-LF instead of one.

Fixes https://github.com/godotengine/godot/issues/89125