### PR TITLE
Vulkan: Don't warn about invalid pipelines cache if missing

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -3828,7 +3828,9 @@ bool RenderingDeviceDriverVulkan::pipeline_cache_create(const Vector<uint8_t> &p
 
 	// Parse.
 	{
-		if (p_data.size() <= (int)sizeof(PipelineCacheHeader)) {
+		if (p_data.is_empty()) {
+			// No pre-existing cache, just create it.
+		} else if (p_data.size() <= (int)sizeof(PipelineCacheHeader)) {
 			WARN_PRINT("Invalid/corrupt pipelines cache.");
 		} else {
 			const PipelineCacheHeader *loaded_header = reinterpret_cast<const PipelineCacheHeader *>(p_data.ptr());

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -5091,12 +5091,12 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 
 	if (main_instance) {
 		// Only the instance that is not a local device and is also the singleton is allowed to manage a pipeline cache.
-		pipeline_cache_file_path = "user://vulkan/pipelines";
-		pipeline_cache_file_path += "." + device.name.validate_filename().replace(" ", "_").to_lower();
+		pipeline_cache_file_path = vformat("user://vulkan/pipelines.%s.%s",
+				OS::get_singleton()->get_current_rendering_method(),
+				device.name.validate_filename().replace(" ", "_").to_lower());
 		if (Engine::get_singleton()->is_editor_hint()) {
 			pipeline_cache_file_path += ".editor";
 		}
-
 		pipeline_cache_file_path += ".cache";
 
 		Vector<uint8_t> cache_data = _load_pipeline_cache();


### PR DESCRIPTION
It used to warn when opening a new project because no cache pre-exists,
which isn't particularly helpful.

See https://github.com/godotengine/godot/issues/81150#issuecomment-1978698527

Also include the rendering method in the cache filename, as it differs
between Forward+ and Mobile for a same GPU.

Full set of pipelines caches on my laptop with integrated AMD and discrete AMD GPUs, editing both Forward+ and Mobile versions of a blank Vulkan project.

```
$ ls -l ~/.local/share/godot/app_userdata/TestVulkan/vulkan/
total 1800
-rw-rw-rw-. 1 akien akien 722500 Mar  5 14:23 'pipelines.forward_plus.amd_radeon_graphics_(radv_gfx1103_r1).editor.cache'
-rw-rw-rw-. 1 akien akien 722500 Mar  5 14:24 'pipelines.forward_plus.amd_radeon_rx_7600m_xt_(radv_navi33).editor.cache'
-rw-rw-rw-. 1 akien akien 195624 Mar  5 14:21 'pipelines.mobile.amd_radeon_graphics_(radv_gfx1103_r1).editor.cache'
-rw-rw-rw-. 1 akien akien 195624 Mar  5 14:21 'pipelines.mobile.amd_radeon_rx_7600m_xt_(radv_navi33).editor.cache'

$ md5sum ~/.local/share/godot/app_userdata/TestVulkan/vulkan/*
2ecc1c142a674127d8417136d43162d4  /home/akien/.local/share/godot/app_userdata/TestVulkan/vulkan/pipelines.forward_plus.amd_radeon_graphics_(radv_gfx1103_r1).editor.cache
19fb5379fb8254e22f4f04144970e82a  /home/akien/.local/share/godot/app_userdata/TestVulkan/vulkan/pipelines.forward_plus.amd_radeon_rx_7600m_xt_(radv_navi33).editor.cache
690d563e72ef52973ac18370e5ff5183  /home/akien/.local/share/godot/app_userdata/TestVulkan/vulkan/pipelines.mobile.amd_radeon_graphics_(radv_gfx1103_r1).editor.cache
088f86d4dc5dfc06a04de1b9b87b2bc1  /home/akien/.local/share/godot/app_userdata/TestVulkan/vulkan/pipelines.mobile.amd_radeon_rx_7600m_xt_(radv_navi33).editor.cache
```