### PR TITLE
Documentation: Add support for typed array and dictionary links

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1885,8 +1885,29 @@ def format_text_block(
         escape_pre = False
         escape_post = False
 
+        # Tag is a reference to a typed array or dictionary.
+        if tag_text.startswith("Array[") or tag_text.startswith("Dictionary["):
+            if endq_pos + 1 < len(text) and text[endq_pos + 1] == "]":
+                endq_pos += 1
+                post_text = post_text[1:]
+                tag_text += "]"
+
+                if tag_text.startswith("Array["):
+                    tag_text = tag_text[len("Array[") : -len("]")] + "[]"
+
+                tag_text = make_type(tag_text, state)
+
+                escape_pre = True
+                escape_post = True
+            else:
+                print_error(
+                    f"{state.current_class}.xml: Invalid typed array/dictionary reference.",
+                    state,
+                )
+                return ""
+
         # Tag is a reference to a class.
-        if tag_text in state.classes and not inside_code:
+        elif tag_text in state.classes and not inside_code:
             if tag_text == state.current_class:
                 # Don't create a link to the same class, format it as strong emphasis.
                 tag_text = f"**{tag_text}**"

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -680,6 +680,14 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				c.signals.sort_custom<MethodCompare>();
 			}
 
+			List<StringName> enum_list;
+			ClassDB::get_enum_list(name, &enum_list, true);
+
+			for (const StringName &E : enum_list) {
+				DocData::EnumDoc enum_doc;
+				c.enums[E] = enum_doc;
+			}
+
 			List<String> constant_list;
 			ClassDB::get_integer_constant_list(name, &constant_list, true);
 

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -366,9 +366,9 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 				}
 			}
 
-			if (link.contains_char('.')) {
-				const int class_end = link.rfind_char('.');
-				emit_signal(SNAME("go_to_help"), topic + ":" + link.left(class_end) + ":" + link.substr(class_end + 1));
+			const int dot_pos = link.rfind_char('.');
+			if (dot_pos >= 0) {
+				emit_signal(SNAME("go_to_help"), topic + ":" + link.left(dot_pos) + ":" + link.substr(dot_pos + 1));
 			}
 		}
 	} else if (p_select.begins_with("http:") || p_select.begins_with("https:")) {
@@ -478,6 +478,50 @@ static void _add_type_to_rt(const String &p_type, const String &p_enum, bool p_i
 		}
 	}
 	p_rt->pop(); // color
+}
+
+static void _add_container_type_to_rt(const String &p_type, const Color &p_type_color, RichTextLabel *p_rt, const String &p_class) {
+	String type_link;
+	if (!p_class.is_empty()) {
+		const String globalized_type = p_class + "." + p_type;
+		if (EditorHelp::has_doc(globalized_type)) {
+			type_link = "#" + globalized_type;
+		} else {
+			const int dot_pos = globalized_type.rfind_char('.');
+			if (dot_pos >= 0) {
+				const DocData::ClassDoc *cd = EditorHelp::get_doc(globalized_type.left(dot_pos));
+				if (cd && cd->enums.has(globalized_type.substr(dot_pos + 1))) {
+					type_link = "$" + globalized_type;
+				}
+			}
+		}
+	}
+	if (type_link.is_empty()) {
+		if (EditorHelp::has_doc(p_type)) {
+			type_link = "#" + p_type;
+		} else {
+			const int dot_pos = p_type.rfind_char('.');
+			if (dot_pos >= 0) {
+				const DocData::ClassDoc *cd = EditorHelp::get_doc(p_type.left(dot_pos));
+				if (cd && cd->enums.has(p_type.substr(dot_pos + 1))) {
+					type_link = "$" + p_type;
+				}
+			}
+		}
+	}
+	if (type_link.is_empty() && CoreConstants::is_global_enum(p_type)) {
+		type_link = "@enum " + p_type;
+	}
+
+	if (type_link.is_empty()) {
+		p_rt->push_color(Color(p_type_color, 0.5));
+		p_rt->add_text(p_type);
+		p_rt->pop(); // color
+	} else {
+		p_rt->push_meta(type_link, RichTextLabel::META_UNDERLINE_ON_HOVER);
+		p_rt->add_text(p_type);
+		p_rt->pop(); // meta
+	}
 }
 
 void EditorHelp::_add_type(const String &p_type, const String &p_enum, bool p_is_bitfield) {
@@ -2648,9 +2692,23 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->pop(); // font
 
 			pos = brk_end + 1;
+		} else if (!p_class.is_empty() && EditorHelp::has_doc(p_class + "." + tag)) {
+			// Use a monospace font for class reference tags such as [InnerClass].
+			p_rt->push_font(doc_code_font);
+			p_rt->push_font_size(doc_code_font_size);
+			p_rt->push_color(type_color);
+			p_rt->push_meta("#" + p_class + "." + tag, RichTextLabel::META_UNDERLINE_ON_HOVER);
+
+			p_rt->add_text(tag);
+
+			p_rt->pop(); // meta
+			p_rt->pop(); // color
+			p_rt->pop(); // font_size
+			p_rt->pop(); // font
+
+			pos = brk_end + 1;
 		} else if (EditorHelp::has_doc(tag)) {
 			// Use a monospace font for class reference tags such as [Node2D] or [SceneTree].
-
 			p_rt->push_font(doc_code_font);
 			p_rt->push_font_size(doc_code_font_size);
 			p_rt->push_color(type_color);
@@ -2664,6 +2722,79 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->pop(); // font
 
 			pos = brk_end + 1;
+		} else if (tag.begins_with("Array[")) {
+			// Expected:
+			//   [Array[String]]
+			//   ^ brk_pos    ^ brk_end
+			// Nested types (like `Array[Array[int]]`) are not currently supported.
+			if (brk_end + 1 < bbcode.length() && bbcode[brk_end + 1] == ']') {
+				String elem_type = tag.substr(6); // len("Array[") == 6
+				if (elem_type.is_empty()) {
+					elem_type = "Variant";
+				}
+
+				p_rt->push_font(doc_code_font);
+				p_rt->push_font_size(doc_code_font_size);
+				p_rt->push_color(type_color);
+
+				p_rt->push_meta("#Array", RichTextLabel::META_UNDERLINE_ON_HOVER);
+				p_rt->add_text("Array");
+				p_rt->pop(); // meta
+
+				p_rt->add_text("[");
+				_add_container_type_to_rt(elem_type, type_color, p_rt, p_class);
+				p_rt->add_text("]");
+
+				p_rt->pop(); // color
+				p_rt->pop(); // font_size
+				p_rt->pop(); // font
+
+				pos = brk_end + 2;
+			} else {
+				p_rt->add_text("["); // Ignore.
+				pos = brk_pos + 1;
+			}
+		} else if (tag.begins_with("Dictionary[")) {
+			// Expected:
+			//   [Dictionary[int, int]]
+			//   ^ brk_pos           ^ brk_end
+			// Nested types (like `Dictionary[int, Array[int]]`) are not currently supported.
+			if (brk_end + 1 < bbcode.length() && bbcode[brk_end + 1] == ']') {
+				const Vector<String> types = tag.substr(11).split(",", true, 1); // len("Dictionary[") == 11
+
+				String key_type = types[0].strip_edges(); // Safe since `types` cannot be empty.
+				if (key_type.is_empty()) {
+					key_type = "Variant";
+				}
+
+				String value_type = (types.size() > 1) ? types[1].strip_edges() : String();
+				if (value_type.is_empty()) {
+					value_type = "Variant";
+				}
+
+				p_rt->push_font(doc_code_font);
+				p_rt->push_font_size(doc_code_font_size);
+				p_rt->push_color(type_color);
+
+				p_rt->push_meta("#Dictionary", RichTextLabel::META_UNDERLINE_ON_HOVER);
+				p_rt->add_text("Dictionary");
+				p_rt->pop(); // meta
+
+				p_rt->add_text("[");
+				_add_container_type_to_rt(key_type, type_color, p_rt, p_class);
+				p_rt->add_text(", ");
+				_add_container_type_to_rt(value_type, type_color, p_rt, p_class);
+				p_rt->add_text("]");
+
+				p_rt->pop(); // color
+				p_rt->pop(); // font_size
+				p_rt->pop(); // font
+
+				pos = brk_end + 2;
+			} else {
+				p_rt->add_text("["); // Ignore.
+				pos = brk_pos + 1;
+			}
 		} else if (tag == "b") {
 			// Use bold font.
 			p_rt->push_font(doc_bold_font);

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -371,7 +371,7 @@
 		<annotation name="@export_color_no_alpha">
 			<return type="void" />
 			<description>
-				Export a [Color], [Array][lb][Color][rb], or [PackedColorArray] property without allowing its transparency ([member Color.a]) to be edited.
+				Export a [Color], [Array[Color]], or [PackedColorArray] property without allowing its transparency ([member Color.a]) to be edited.
 				See also [constant PROPERTY_HINT_COLOR_NO_ALPHA].
 				[codeblock]
 				@export_color_no_alpha var dye_color: Color
@@ -395,7 +395,7 @@
 		<annotation name="@export_dir">
 			<return type="void" />
 			<description>
-				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as a path to a directory. The path will be limited to the project folder and its subfolders. See [annotation @export_global_dir] to allow picking from the entire filesystem.
+				Export a [String], [Array[String]], or [PackedStringArray] property as a path to a directory. The path will be limited to the project folder and its subfolders. See [annotation @export_global_dir] to allow picking from the entire filesystem.
 				See also [constant PROPERTY_HINT_DIR].
 				[codeblock]
 				@export_dir var sprite_folder_path: String
@@ -407,7 +407,7 @@
 			<return type="void" />
 			<param index="0" name="names" type="String" />
 			<description>
-				Export an [int], [String], [Array][lb][int][rb], [Array][lb][String][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], or [PackedStringArray] property as an enumerated list of options (or an array of options). If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
+				Export an [int], [String], [Array[int]], [Array[String]], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], or [PackedStringArray] property as an enumerated list of options (or an array of options). If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
 				See also [constant PROPERTY_HINT_ENUM].
 				[codeblock]
 				@export_enum("Warrior", "Magician", "Thief") var character_class: int
@@ -449,7 +449,7 @@
 			<return type="void" />
 			<param index="0" name="filter" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as a path to a file. The path will be limited to the project folder and its subfolders. See [annotation @export_global_file] to allow picking from the entire filesystem.
+				Export a [String], [Array[String]], or [PackedStringArray] property as a path to a file. The path will be limited to the project folder and its subfolders. See [annotation @export_global_file] to allow picking from the entire filesystem.
 				If [param filter] is provided, only matching files will be available for picking.
 				See also [constant PROPERTY_HINT_FILE].
 				[codeblock]
@@ -490,7 +490,7 @@
 				[codeblock]
 				@export_flags("A:16", "B", "C") var x
 				[/codeblock]
-				You can also use the annotation on [Array][lb][int][rb], [PackedByteArray], [PackedInt32Array], and [PackedInt64Array]
+				You can also use the annotation on [Array[int]], [PackedByteArray], [PackedInt32Array], and [PackedInt64Array]
 				[codeblock]
 				@export_flags("Fire", "Water", "Earth", "Wind") var phase_elements: Array[int]
 				[/codeblock]
@@ -576,7 +576,7 @@
 		<annotation name="@export_global_dir">
 			<return type="void" />
 			<description>
-				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as an absolute path to a directory. The path can be picked from the entire filesystem. See [annotation @export_dir] to limit it to the project folder and its subfolders.
+				Export a [String], [Array[String]], or [PackedStringArray] property as an absolute path to a directory. The path can be picked from the entire filesystem. See [annotation @export_dir] to limit it to the project folder and its subfolders.
 				See also [constant PROPERTY_HINT_GLOBAL_DIR].
 				[codeblock]
 				@export_global_dir var sprite_folder_path: String
@@ -588,7 +588,7 @@
 			<return type="void" />
 			<param index="0" name="filter" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property as an absolute path to a file. The path can be picked from the entire filesystem. See [annotation @export_file] to limit it to the project folder and its subfolders.
+				Export a [String], [Array[String]], or [PackedStringArray] property as an absolute path to a file. The path can be picked from the entire filesystem. See [annotation @export_file] to limit it to the project folder and its subfolders.
 				If [param filter] is provided, only matching files will be available for picking.
 				See also [constant PROPERTY_HINT_GLOBAL_FILE].
 				[codeblock]
@@ -625,7 +625,7 @@
 			<return type="void" />
 			<param index="0" name="hint" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [String], [Array][lb][String][rb], [PackedStringArray], [Dictionary] or [Array][lb][Dictionary][rb] property with a large [TextEdit] widget instead of a [LineEdit]. This adds support for multiline content and makes it easier to edit large amount of text stored in the property.
+				Export a [String], [Array[String]], [PackedStringArray], [Dictionary] or [Array[Dictionary]] property with a large [TextEdit] widget instead of a [LineEdit]. This adds support for multiline content and makes it easier to edit large amount of text stored in the property.
 				See also [constant PROPERTY_HINT_MULTILINE_TEXT].
 				[codeblock]
 				@export_multiline var character_biography
@@ -638,7 +638,7 @@
 			<return type="void" />
 			<param index="0" name="type" type="String" default="&quot;&quot;" />
 			<description>
-				Export a [NodePath] or [Array][lb][NodePath][rb] property with a filter for allowed node types.
+				Export a [NodePath] or [Array[NodePath]] property with a filter for allowed node types.
 				See also [constant PROPERTY_HINT_NODE_PATH_VALID_TYPES].
 				[codeblock]
 				@export_node_path("Button", "TouchScreenButton") var some_button
@@ -651,7 +651,7 @@
 			<return type="void" />
 			<param index="0" name="placeholder" type="String" />
 			<description>
-				Export a [String], [Array][lb][String][rb], or [PackedStringArray] property with a placeholder text displayed in the editor widget when no value is present.
+				Export a [String], [Array[String]], or [PackedStringArray] property with a placeholder text displayed in the editor widget when no value is present.
 				See also [constant PROPERTY_HINT_PLACEHOLDER_TEXT].
 				[codeblock]
 				@export_placeholder("Name in lowercase") var character_id: String
@@ -666,7 +666,7 @@
 			<param index="2" name="step" type="float" default="1.0" />
 			<param index="3" name="extra_hints" type="String" default="&quot;&quot;" />
 			<description>
-				Export an [int], [float], [Array][lb][int][rb], [Array][lb][float][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], or [PackedFloat64Array] property as a range value. The range must be defined by [param min] and [param max], as well as an optional [param step] and a variety of extra hints. The [param step] defaults to [code]1[/code] for integer properties. For floating-point numbers this value depends on your [member EditorSettings.interface/inspector/default_float_step] setting.
+				Export an [int], [float], [Array[int]], [Array[float]], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], [PackedFloat32Array], or [PackedFloat64Array] property as a range value. The range must be defined by [param min] and [param max], as well as an optional [param step] and a variety of extra hints. The [param step] defaults to [code]1[/code] for integer properties. For floating-point numbers this value depends on your [member EditorSettings.interface/inspector/default_float_step] setting.
 				If hints [code]"or_greater"[/code] and [code]"or_less"[/code] are provided, the editor widget will not cap the value at range boundaries. The [code]"exp"[/code] hint will make the edited values on range to change exponentially. The [code]"prefer_slider"[/code] hint will make integer values use the slider instead of arrows for editing, while [code]"hide_control"[/code] will hide the element controlling the value of the editor widget.
 				Hints also allow to indicate the units for the edited value. Using [code]"radians_as_degrees"[/code] you can specify that the actual value is in radians, but should be displayed in degrees in the Inspector dock (the range values are also in degrees). [code]"degrees"[/code] allows to add a degree sign as a unit suffix (the value is unchanged). Finally, a custom suffix can be provided using [code]"suffix:unit"[/code], where "unit" can be any string.
 				See also [constant PROPERTY_HINT_RANGE].

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -177,6 +177,139 @@ static String fix_doc_description(const String &p_bbcode) {
 			.strip_edges();
 }
 
+void BindingsGenerator::bbcode_type_to_text(const String &p_type, StringBuilder &p_output) {
+	if (p_type == "Array" || p_type == "Dictionary") {
+		p_output.append("'" BINDINGS_NAMESPACE_COLLECTIONS ".");
+		p_output.append(p_type);
+		p_output.append("'");
+	} else if (p_type == "bool" || p_type == "int") {
+		p_output.append(p_type);
+	} else if (p_type == "float") {
+		p_output.append(
+#ifdef REAL_T_IS_DOUBLE
+				"double"
+#else
+				"float"
+#endif
+		);
+	} else if (p_type == "Variant") {
+		p_output.append("'Godot.Variant'");
+	} else if (p_type == "String") {
+		p_output.append("string");
+	} else if (p_type == "Nil") {
+		p_output.append("null");
+	} else if (p_type.begins_with("@")) {
+		// @GlobalScope, @GDScript, etc.
+		p_output.append("'" + p_type + "'");
+	} else if (p_type == "PackedByteArray") {
+		p_output.append("byte[]");
+	} else if (p_type == "PackedInt32Array") {
+		p_output.append("int[]");
+	} else if (p_type == "PackedInt64Array") {
+		p_output.append("long[]");
+	} else if (p_type == "PackedFloat32Array") {
+		p_output.append("float[]");
+	} else if (p_type == "PackedFloat64Array") {
+		p_output.append("double[]");
+	} else if (p_type == "PackedStringArray") {
+		p_output.append("string[]");
+	} else if (p_type == "PackedVector2Array") {
+		p_output.append("'" BINDINGS_NAMESPACE ".Vector2[]'");
+	} else if (p_type == "PackedVector3Array") {
+		p_output.append("'" BINDINGS_NAMESPACE ".Vector3[]'");
+	} else if (p_type == "PackedColorArray") {
+		p_output.append("'" BINDINGS_NAMESPACE ".Color[]'");
+	} else if (p_type == "PackedVector4Array") {
+		p_output.append("'" BINDINGS_NAMESPACE ".Vector4[]'");
+	} else {
+		const TypeInterface *target_itype = _get_type_or_null(TypeReference(p_type));
+
+		if (!target_itype) {
+			target_itype = _get_type_or_null(TypeReference("_" + p_type));
+		}
+
+		if (target_itype) {
+			p_output.append("'" + target_itype->proxy_name + "'");
+		} else {
+			ERR_PRINT("Cannot resolve type reference in documentation: '" + p_type + "'.");
+			p_output.append("'" + p_type + "'");
+		}
+	}
+}
+
+void BindingsGenerator::bbcode_type_to_xml(const String &p_type, StringBuilder &p_xml_output, const TypeInterface *p_itype) {
+	if (p_type == "Array" || p_type == "Dictionary") {
+		p_xml_output.append("<see cref=\"" BINDINGS_NAMESPACE_COLLECTIONS ".");
+		p_xml_output.append(p_type);
+		p_xml_output.append("\"/>");
+	} else if (p_type == "bool" || p_type == "int") {
+		p_xml_output.append("<see cref=\"");
+		p_xml_output.append(p_type);
+		p_xml_output.append("\"/>");
+	} else if (p_type == "float") {
+		p_xml_output.append("<see cref=\""
+#ifdef REAL_T_IS_DOUBLE
+							"double"
+#else
+							"float"
+#endif
+							"\"/>");
+	} else if (p_type == "Variant") {
+		p_xml_output.append("<see cref=\"Godot.Variant\"/>");
+	} else if (p_type == "String") {
+		p_xml_output.append("<see cref=\"string\"/>");
+	} else if (p_type == "Nil") {
+		p_xml_output.append("<see langword=\"null\"/>");
+	} else if (p_type.begins_with("@")) {
+		// @GlobalScope, @GDScript, etc.
+		p_xml_output.append("<c>");
+		p_xml_output.append(p_type);
+		p_xml_output.append("</c>");
+	} else if (p_type == "PackedByteArray") {
+		p_xml_output.append("<see cref=\"byte\"/>[]");
+	} else if (p_type == "PackedInt32Array") {
+		p_xml_output.append("<see cref=\"int\"/>[]");
+	} else if (p_type == "PackedInt64Array") {
+		p_xml_output.append("<see cref=\"long\"/>[]");
+	} else if (p_type == "PackedFloat32Array") {
+		p_xml_output.append("<see cref=\"float\"/>[]");
+	} else if (p_type == "PackedFloat64Array") {
+		p_xml_output.append("<see cref=\"double\"/>[]");
+	} else if (p_type == "PackedStringArray") {
+		p_xml_output.append("<see cref=\"string\"/>[]");
+	} else if (p_type == "PackedVector2Array") {
+		p_xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Vector2\"/>[]");
+	} else if (p_type == "PackedVector3Array") {
+		p_xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Vector3\"/>[]");
+	} else if (p_type == "PackedColorArray") {
+		p_xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Color\"/>[]");
+	} else if (p_type == "PackedVector4Array") {
+		p_xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Vector4\"/>[]");
+	} else {
+		const TypeInterface *target_itype = _get_type_or_null(TypeReference(p_type));
+
+		if (!target_itype) {
+			target_itype = _get_type_or_null(TypeReference("_" + p_type));
+		}
+
+		if (target_itype) {
+			if (!_validate_api_type(target_itype, p_itype)) {
+				_append_xml_undeclared(p_xml_output, target_itype->proxy_name);
+			} else {
+				p_xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".");
+				p_xml_output.append(target_itype->proxy_name);
+				p_xml_output.append("\"/>");
+			}
+		} else {
+			ERR_PRINT("Cannot resolve type reference in documentation: '" + p_type + "'.");
+
+			p_xml_output.append("<c>");
+			p_xml_output.append(p_type);
+			p_xml_output.append("</c>");
+		}
+	}
+}
+
 String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype) {
 	// Based on the version in EditorHelp.
 
@@ -300,66 +433,55 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 			}
 
 			pos = brk_end + 1;
-		} else if (doc->class_list.has(tag)) {
-			if (tag == "Array" || tag == "Dictionary") {
-				output.append("'" BINDINGS_NAMESPACE_COLLECTIONS ".");
-				output.append(tag);
-				output.append("'");
-			} else if (tag == "bool" || tag == "int") {
-				output.append(tag);
-			} else if (tag == "float") {
-				output.append(
-#ifdef REAL_T_IS_DOUBLE
-						"double"
-#else
-						"float"
-#endif
-				);
-			} else if (tag == "Variant") {
-				output.append("'Godot.Variant'");
-			} else if (tag == "String") {
-				output.append("string");
-			} else if (tag == "Nil") {
-				output.append("null");
-			} else if (tag.begins_with("@")) {
-				// @GlobalScope, @GDScript, etc.
-				output.append("'" + tag + "'");
-			} else if (tag == "PackedByteArray") {
-				output.append("byte[]");
-			} else if (tag == "PackedInt32Array") {
-				output.append("int[]");
-			} else if (tag == "PackedInt64Array") {
-				output.append("long[]");
-			} else if (tag == "PackedFloat32Array") {
-				output.append("float[]");
-			} else if (tag == "PackedFloat64Array") {
-				output.append("double[]");
-			} else if (tag == "PackedStringArray") {
-				output.append("string[]");
-			} else if (tag == "PackedVector2Array") {
-				output.append("'" BINDINGS_NAMESPACE ".Vector2[]'");
-			} else if (tag == "PackedVector3Array") {
-				output.append("'" BINDINGS_NAMESPACE ".Vector3[]'");
-			} else if (tag == "PackedColorArray") {
-				output.append("'" BINDINGS_NAMESPACE ".Color[]'");
-			} else if (tag == "PackedVector4Array") {
-				output.append("'" BINDINGS_NAMESPACE ".Vector4[]'");
-			} else {
-				const TypeInterface *target_itype = _get_type_or_null(TypeReference(tag));
-
-				if (!target_itype) {
-					target_itype = _get_type_or_null(TypeReference("_" + tag));
-				}
-
-				if (target_itype) {
-					output.append("'" + target_itype->proxy_name + "'");
-				} else {
-					ERR_PRINT("Cannot resolve type reference in documentation: '" + tag + "'.");
-					output.append("'" + tag + "'");
-				}
-			}
-
+		} else if (p_itype && doc->class_list.has(p_itype->name + "." + tag)) {
+			bbcode_type_to_text(p_itype->name + "." + tag, output);
 			pos = brk_end + 1;
+		} else if (doc->class_list.has(tag)) {
+			bbcode_type_to_text(tag, output);
+			pos = brk_end + 1;
+		} else if (tag.begins_with("Array[")) {
+			if (brk_end + 1 < bbcode.length() && bbcode[brk_end + 1] == ']') {
+				String elem_type = tag.substr(6); // len("Array[") == 6
+				if (elem_type.is_empty()) {
+					elem_type = "Variant";
+				}
+
+				bbcode_type_to_text("Array", output);
+				output.append("<");
+				bbcode_type_to_text(elem_type, output);
+				output.append(">");
+
+				pos = brk_end + 2;
+			} else {
+				output.append("["); // Ignore.
+				pos = brk_pos + 1;
+			}
+		} else if (tag.begins_with("Dictionary[")) {
+			if (brk_end + 1 < bbcode.length() && bbcode[brk_end + 1] == ']') {
+				const Vector<String> types = tag.substr(11).split(",", true, 1); // len("Dictionary[") == 11
+
+				String key_type = types[0].strip_edges(); // Safe since `types` cannot be empty.
+				if (key_type.is_empty()) {
+					key_type = "Variant";
+				}
+
+				String value_type = (types.size() > 1) ? types[1].strip_edges() : String();
+				if (value_type.is_empty()) {
+					value_type = "Variant";
+				}
+
+				bbcode_type_to_text("Dictionary", output);
+				output.append("<");
+				bbcode_type_to_text(key_type, output);
+				output.append(", ");
+				bbcode_type_to_text(value_type, output);
+				output.append(">");
+
+				pos = brk_end + 2;
+			} else {
+				output.append("["); // Ignore.
+				pos = brk_pos + 1;
+			}
 		} else if (tag == "b") {
 			// Bold is not supported.
 			pos = brk_end + 1;
@@ -617,79 +739,55 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			}
 
 			pos = brk_end + 1;
-		} else if (doc->class_list.has(tag)) {
-			if (tag == "Array" || tag == "Dictionary") {
-				xml_output.append("<see cref=\"" BINDINGS_NAMESPACE_COLLECTIONS ".");
-				xml_output.append(tag);
-				xml_output.append("\"/>");
-			} else if (tag == "bool" || tag == "int") {
-				xml_output.append("<see cref=\"");
-				xml_output.append(tag);
-				xml_output.append("\"/>");
-			} else if (tag == "float") {
-				xml_output.append("<see cref=\""
-#ifdef REAL_T_IS_DOUBLE
-								  "double"
-#else
-								  "float"
-#endif
-								  "\"/>");
-			} else if (tag == "Variant") {
-				xml_output.append("<see cref=\"Godot.Variant\"/>");
-			} else if (tag == "String") {
-				xml_output.append("<see cref=\"string\"/>");
-			} else if (tag == "Nil") {
-				xml_output.append("<see langword=\"null\"/>");
-			} else if (tag.begins_with("@")) {
-				// @GlobalScope, @GDScript, etc.
-				xml_output.append("<c>");
-				xml_output.append(tag);
-				xml_output.append("</c>");
-			} else if (tag == "PackedByteArray") {
-				xml_output.append("<see cref=\"byte\"/>[]");
-			} else if (tag == "PackedInt32Array") {
-				xml_output.append("<see cref=\"int\"/>[]");
-			} else if (tag == "PackedInt64Array") {
-				xml_output.append("<see cref=\"long\"/>[]");
-			} else if (tag == "PackedFloat32Array") {
-				xml_output.append("<see cref=\"float\"/>[]");
-			} else if (tag == "PackedFloat64Array") {
-				xml_output.append("<see cref=\"double\"/>[]");
-			} else if (tag == "PackedStringArray") {
-				xml_output.append("<see cref=\"string\"/>[]");
-			} else if (tag == "PackedVector2Array") {
-				xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Vector2\"/>[]");
-			} else if (tag == "PackedVector3Array") {
-				xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Vector3\"/>[]");
-			} else if (tag == "PackedColorArray") {
-				xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Color\"/>[]");
-			} else if (tag == "PackedVector4Array") {
-				xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".Vector4\"/>[]");
-			} else {
-				const TypeInterface *target_itype = _get_type_or_null(TypeReference(tag));
-
-				if (!target_itype) {
-					target_itype = _get_type_or_null(TypeReference("_" + tag));
-				}
-
-				if (target_itype) {
-					if (!_validate_api_type(target_itype, p_itype)) {
-						_append_xml_undeclared(xml_output, target_itype->proxy_name);
-					} else {
-						xml_output.append("<see cref=\"" BINDINGS_NAMESPACE ".");
-						xml_output.append(target_itype->proxy_name);
-						xml_output.append("\"/>");
-					}
-				} else {
-					ERR_PRINT("Cannot resolve type reference in documentation: '" + tag + "'.");
-
-					xml_output.append("<c>");
-					xml_output.append(tag);
-					xml_output.append("</c>");
-				}
-			}
-
+		} else if (p_itype && doc->class_list.has(p_itype->name + "." + tag)) {
+			bbcode_type_to_xml(p_itype->name + "." + tag, xml_output, p_itype);
 			pos = brk_end + 1;
+		} else if (doc->class_list.has(tag)) {
+			bbcode_type_to_xml(tag, xml_output, p_itype);
+			pos = brk_end + 1;
+		} else if (tag.begins_with("Array[")) {
+			if (brk_end + 1 < bbcode.length() && bbcode[brk_end + 1] == ']') {
+				String elem_type = tag.substr(6); // len("Array[") == 6
+				if (elem_type.is_empty()) {
+					elem_type = "Variant";
+				}
+
+				bbcode_type_to_xml("Array", xml_output, p_itype);
+				xml_output.append("&lt;");
+				bbcode_type_to_xml(elem_type, xml_output, p_itype);
+				xml_output.append("&gt;");
+
+				pos = brk_end + 2;
+			} else {
+				xml_output.append("["); // Ignore.
+				pos = brk_pos + 1;
+			}
+		} else if (tag.begins_with("Dictionary[")) {
+			if (brk_end + 1 < bbcode.length() && bbcode[brk_end + 1] == ']') {
+				const Vector<String> types = tag.substr(11).split(",", true, 1); // len("Dictionary[") == 11
+
+				String key_type = types[0].strip_edges(); // Safe since `types` cannot be empty.
+				if (key_type.is_empty()) {
+					key_type = "Variant";
+				}
+
+				String value_type = (types.size() > 1) ? types[1].strip_edges() : String();
+				if (value_type.is_empty()) {
+					value_type = "Variant";
+				}
+
+				bbcode_type_to_xml("Dictionary", xml_output, p_itype);
+				xml_output.append("&lt;");
+				bbcode_type_to_xml(key_type, xml_output, p_itype);
+				xml_output.append(", ");
+				bbcode_type_to_xml(value_type, xml_output, p_itype);
+				xml_output.append("&gt;");
+
+				pos = brk_end + 2;
+			} else {
+				xml_output.append("["); // Ignore.
+				pos = brk_pos + 1;
+			}
 		} else if (tag == "b") {
 			xml_output.append("<b>");
 

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -790,6 +790,9 @@ class BindingsGenerator {
 		return p_type->name;
 	}
 
+	void bbcode_type_to_text(const String &p_type, StringBuilder &p_output);
+	void bbcode_type_to_xml(const String &p_type, StringBuilder &p_xml_output, const TypeInterface *p_itype);
+
 	String bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype);
 	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype, bool p_is_signal = false);
 


### PR DESCRIPTION
In #82952 I noticed that we don't have a convenient way to link a typed array. You can add brackets like `[Array][[int]]`, but it's still not very good:

```gdscript
## [code]Array[int][/code][br]
## [Array][lb][int][rb][br]
## [Array][[int]][br]
## [Array[int]][br]
```

![](https://github.com/godotengine/godot/assets/47700418/94de7c52-3ba7-4775-be24-c346011e4122)

```gdscript
## [Array[int]][br]
## [Array[Variant.Type]][br]
## [Array[Side]][br]
## [Array[Error]][br]
## [Array[Variant.Operator]][br]
## [Array[Tsdtudtu]][br]
## [Array[Node.ProcessMode]] [enum Node.ProcessMode][br]
## [Array[MyEnum]] [enum MyEnum][br]
## [Array[InnerClass]] [InnerClass][br]
## [Array["node.gd".Test]] [enum "node.gd".Test][br]
```

![](https://github.com/godotengine/godot/assets/47700418/fc31d241-f415-4e59-b431-3197232921da)
