### PR TITLE
Add Enter shortcut to add a shader global in the editor

### DIFF
--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -398,6 +398,8 @@ void ShaderGlobalsEditor::_variable_added() {
 	undo_redo->add_do_method(this, "_changed");
 	undo_redo->add_undo_method(this, "_changed");
 	undo_redo->commit_action();
+
+	variable_name->clear();
 }
 
 void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
@@ -455,6 +457,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	variable_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	variable_name->set_clear_button_enabled(true);
 	variable_name->connect("text_changed", callable_mp(this, &ShaderGlobalsEditor::_variable_name_text_changed));
+	variable_name->connect("text_submitted", callable_mp(this, &ShaderGlobalsEditor::_variable_added).unbind(1));
 
 	add_menu_hb->add_child(variable_name);
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/81177.

___

- Clear the shader global name field when adding a new shader global to match the behavior of other tabs in the Project Settings dialog.

## Preview

*This is done entirely with the keyboard.*

https://github.com/godotengine/godot/assets/180032/07694d64-d587-4f92-ac38-730b90da7b85

