### PR TITLE
Fix `String::begins_with` when both strings are empty

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3329,8 +3329,12 @@ bool String::begins_with(const String &p_string) const {
 
 bool String::begins_with(const char *p_string) const {
 	int l = length();
-	if (l == 0 || !p_string) {
+	if (!p_string) {
 		return false;
+	}
+
+	if (l == 0) {
+		return *p_string == 0;
 	}
 
 	const char32_t *str = &operator[](0);

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -642,48 +642,59 @@ struct test_27_data {
 
 TEST_CASE("[String] Begins with") {
 	test_27_data tc[] = {
+		// Test cases for true:
 		{ "res://foobar", "res://", true },
+		{ "abc", "abc", true },
+		{ "abc", "", true },
+		{ "", "", true },
+		// Test cases for false:
 		{ "res", "res://", false },
-		{ "abc", "abc", true }
+		{ "abcdef", "foo", false },
+		{ "abc", "ax", false },
+		{ "", "abc", false }
 	};
 	size_t count = sizeof(tc) / sizeof(tc[0]);
 	bool state = true;
-	for (size_t i = 0; state && i < count; ++i) {
+	for (size_t i = 0; i < count; ++i) {
 		String s = tc[i].data;
 		state = s.begins_with(tc[i].part) == tc[i].expected;
-		if (state) {
-			String sb = tc[i].part;
-			state = s.begins_with(sb) == tc[i].expected;
-		}
-		CHECK(state);
-		if (!state) {
-			break;
-		}
-	};
-	CHECK(state);
+		CHECK_MESSAGE(state, "first check failed at: ", i);
+
+		String sb = tc[i].part;
+		state = s.begins_with(sb) == tc[i].expected;
+		CHECK_MESSAGE(state, "second check failed at: ", i);
+	}
+
+	// Test "const char *" version also with nullptr.
+	String s("foo");
+	state = s.begins_with(nullptr) == false;
+	CHECK_MESSAGE(state, "nullptr check failed");
+
+	String empty("");
+	state = empty.begins_with(nullptr) == false;
+	CHECK_MESSAGE(state, "nullptr check with empty string failed");
 }
 
 TEST_CASE("[String] Ends with") {
 	test_27_data tc[] = {
+		// test cases for true:
 		{ "res://foobar", "foobar", true },
+		{ "abc", "abc", true },
+		{ "abc", "", true },
+		{ "", "", true },
+		// test cases for false:
 		{ "res", "res://", false },
-		{ "abc", "abc", true }
+		{ "", "abc", false },
+		{ "abcdef", "foo", false },
+		{ "abc", "xc", false }
 	};
 	size_t count = sizeof(tc) / sizeof(tc[0]);
-	bool state = true;
-	for (size_t i = 0; state && i < count; ++i) {
+	for (size_t i = 0; i < count; ++i) {
 		String s = tc[i].data;
-		state = s.ends_with(tc[i].part) == tc[i].expected;
-		if (state) {
-			String sb = tc[i].part;
-			state = s.ends_with(sb) == tc[i].expected;
-		}
-		CHECK(state);
-		if (!state) {
-			break;
-		}
-	};
-	CHECK(state);
+		String sb = tc[i].part;
+		bool state = s.ends_with(sb) == tc[i].expected;
+		CHECK_MESSAGE(state, "check failed at: ", i);
+	}
 }
 
 TEST_CASE("[String] format") {


### PR DESCRIPTION
There are two versions of `String::begins_with`:

```c++
bool String::begins_with(const String &p_string) const
bool String::begins_with(const char *p_string) const
```

In master, they work differently when checking if `"".begins_with("")`.

```c++
String empty("");
bool b1 = empty.begins_with(empty);
bool b2 = empty.begins_with("");
```

`b1` will be `true,` but `b2` will be incorrectly `false`.

This PR adds more tests for `begins_with` and fixes the version using a `const char *` parameter.

I also added tests for cases where the parameter is null. Null parameter is possible only with the version using `const char *` parameter. `anything.begins_with(nullptr)` is expected to return `false`.

I added more tests also for `ends_with` and made some simplifications for the test case.

It is possible that this breaks something if there exists code that expects `"".begins_with("")` returning false.