### PR TITLE
Expose get_autoload_list to gdscript

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1480,6 +1480,19 @@ const HashMap<StringName, ProjectSettings::AutoloadInfo> &ProjectSettings::get_a
 	return autoloads;
 }
 
+TypedArray<Dictionary> ProjectSettings::_get_autoload_list_bind() const {
+	TypedArray<Dictionary> result;
+	for (const KeyValue<StringName, AutoloadInfo> &kv : autoloads) {
+		Dictionary kv_data;
+		kv_data["name"] = kv.value.name;
+		kv_data["path"] = kv.value.path;
+		kv_data["is_global_variable"] = kv.value.is_singleton;
+		result.append(kv_data);
+	}
+
+	return result;
+}
+
 void ProjectSettings::add_autoload(const AutoloadInfo &p_autoload, bool p_front_insert) {
 	ERR_FAIL_COND_MSG(p_autoload.name == StringName(), "Trying to add autoload with no name.");
 	if (p_front_insert) {
@@ -1631,6 +1644,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
+	ClassDB::bind_method(D_METHOD("get_autoload_list"), &ProjectSettings::_get_autoload_list_bind);
 
 	// Change tracking methods
 	ClassDB::bind_method(D_METHOD("get_changed_settings"), &ProjectSettings::get_changed_settings);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -148,6 +148,7 @@ protected:
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
 
 	void _add_property_info_bind(const Dictionary &p_info);
+	TypedArray<Dictionary> _get_autoload_list_bind() const;
 
 	Error _setup(const String &p_path, const String &p_main_pack, bool p_upwards = false, bool p_ignore_override = false);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -68,6 +68,16 @@
 				Clears the whole configuration (not recommended, may break things).
 			</description>
 		</method>
+		<method name="get_autoload_list" qualifiers="const">
+			<return type="Dictionary[]" />
+			<description>
+				Returns an [Array] of registered autoloads. Each entry is represented as a [Dictionary] that contains the following entries:
+				- [code]name[/code] is the name for both the node and the global variable of the autoload;
+				- [code]path[/code] is the path to the autoloaded resource;
+				- [code]is_global_variable[/code] is [code]true[/code] if the autoload can be accessed as a global variable, otherwise it is [code]false[/code];
+				[b]Note:[/b] The script path is local to the project filesystem, i.e. it starts with [code]res://[/code].
+			</description>
+		</method>
 		<method name="get_changed_settings" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>


### PR DESCRIPTION
Expose get_autoload_list as a typed array to gdscript, since gdscript does not have an ordered array type. It's useful in GDScript too (I'd just tried to find something like this for my own project and saw it wasn't available in GDScript), so it should probably be available.