### PR TITLE
Fix AssetLibrary not going online when clicking button

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -680,7 +680,7 @@ void EditorAssetLibrary::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("asset_library") &&
-					!EditorSettings::get_singleton()->check_changed_settings_in_group("netweork")) {
+					!EditorSettings::get_singleton()->check_changed_settings_in_group("network")) {
 				break;
 			}
 


### PR DESCRIPTION
e