### PR TITLE
[TextServer] Use GDVIRTUAL_REQUIRED_CALL for required extensions methods, update extension docs.

### DIFF
--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -42,7 +42,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				Removes all rendered glyphs information from the cache entry.
+				Removes all rendered glyph information from the cache entry.
 				[b]Note:[/b] This function will not remove textures associated with the glyphs, use [method remove_texture] to remove them manually.
 			</description>
 		</method>
@@ -579,7 +579,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
-				Sets 2D transform, applied to the font outlines, can be used for slanting, flipping and rotating glyphs.
+				Sets 2D transform, applied to the font outlines, can be used for slanting, flipping, and rotating glyphs.
 			</description>
 		</method>
 		<method name="set_variation_coordinates">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -27,7 +27,7 @@
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Creates new buffer for complex text layout, with the given [param direction] and [param orientation]. To free the resulting buffer, use [method free_rid] method.
+				Creates a new buffer for complex text layout, with the given [param direction] and [param orientation]. To free the resulting buffer, use [method free_rid] method.
 				[b]Note:[/b] Direction is ignored if server does not support [constant FEATURE_BIDI_LAYOUT] feature (supported by [TextServerAdvanced]).
 				[b]Note:[/b] Orientation is ignored if server does not support [constant FEATURE_VERTICAL_LAYOUT] feature (supported by [TextServerAdvanced]).
 			</description>
@@ -48,7 +48,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				Removes all rendered glyphs information from the cache entry.
+				Removes all rendered glyph information from the cache entry.
 				[b]Note:[/b] This function will not remove textures associated with the glyphs, use [method font_remove_texture] to remove them manually.
 			</description>
 		</method>
@@ -956,7 +956,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
-				Sets 2D transform, applied to the font outlines, can be used for slanting, flipping and rotating glyphs.
+				Sets 2D transform, applied to the font outlines, can be used for slanting, flipping, and rotating glyphs.
 				For example, to simulate italic typeface by slanting, apply the following transform [code]Transform2D(1.0, slant, 0.0, 1.0, 0.0, 0.0)[/code].
 			</description>
 		</method>
@@ -1115,7 +1115,7 @@
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Converts readable feature, variation, script or language name to OpenType tag.
+				Converts readable feature, variation, script, or language name to OpenType tag.
 			</description>
 		</method>
 		<method name="parse_number" qualifiers="const">
@@ -1173,7 +1173,7 @@
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" default="{}" />
 			<description>
-				Changes text span font, font size and OpenType features, without changing the text.
+				Changes text span font, font size, and OpenType features, without changing the text.
 			</description>
 		</method>
 		<method name="shaped_text_add_object">
@@ -1758,7 +1758,7 @@
 			<return type="String" />
 			<param index="0" name="tag" type="int" />
 			<description>
-				Converts OpenType tag to readable feature, variation, script or language name.
+				Converts OpenType tag to readable feature, variation, script, or language name.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -12,17 +12,23 @@
 		<method name="_cleanup" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				[b]Optional.[/b]
+				This method is called before text server is unregistered.
 			</description>
 		</method>
 		<method name="_create_font" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				[b]Required.[/b]
+				Creates a new, empty font cache entry resource.
 			</description>
 		</method>
 		<method name="_create_font_linked_variation" qualifiers="virtual">
 			<return type="RID" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				Optional, implement if font supports extra spacing or baseline offset.
+				Creates a new variation existing font which is reusing the same glyph cache and font data.
 			</description>
 		</method>
 		<method name="_create_shaped_text" qualifiers="virtual">
@@ -30,6 +36,8 @@
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
 			<description>
+				[b]Required.[/b]
+				Creates a new buffer for complex text layout, with the given [param direction] and [param orientation].
 			</description>
 		</method>
 		<method name="_draw_hex_code_box" qualifiers="virtual const">
@@ -40,6 +48,8 @@
 			<param index="3" name="index" type="int" />
 			<param index="4" name="color" type="Color" />
 			<description>
+				[b]Optional.[/b]
+				Draws box displaying character hexadecimal code.
 			</description>
 		</method>
 		<method name="_font_clear_glyphs" qualifiers="virtual">
@@ -47,6 +57,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
+				[b]Required.[/b]
+				Removes all rendered glyph information from the cache entry.
 			</description>
 		</method>
 		<method name="_font_clear_kerning_map" qualifiers="virtual">
@@ -54,12 +66,16 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Removes all kerning overrides.
 			</description>
 		</method>
 		<method name="_font_clear_size_cache" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Removes all font sizes from the cache entry.
 			</description>
 		</method>
 		<method name="_font_clear_textures" qualifiers="virtual">
@@ -67,6 +83,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
+				[b]Required.[/b]
+				Removes all textures from font cache entry.
 			</description>
 		</method>
 		<method name="_font_draw_glyph" qualifiers="virtual const">
@@ -78,6 +96,8 @@
 			<param index="4" name="index" type="int" />
 			<param index="5" name="color" type="Color" />
 			<description>
+				[b]Required.[/b]
+				Draws single glyph into a canvas item at the position, using [param font_rid] at the size [param size].
 			</description>
 		</method>
 		<method name="_font_draw_glyph_outline" qualifiers="virtual const">
@@ -90,12 +110,16 @@
 			<param index="5" name="index" type="int" />
 			<param index="6" name="color" type="Color" />
 			<description>
+				[b]Required.[/b]
+				Draws single glyph outline of size [param outline_size] into a canvas item at the position, using [param font_rid] at the size [param size].
 			</description>
 		</method>
 		<method name="_font_get_antialiasing" qualifiers="virtual const">
 			<return type="int" enum="TextServer.FontAntialiasing" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font anti-aliasing mode.
 			</description>
 		</method>
 		<method name="_font_get_ascent" qualifiers="virtual const">
@@ -103,12 +127,16 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
 		<method name="_font_get_baseline_offset" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns extra baseline offset (as a fraction of font height).
 			</description>
 		</method>
 		<method name="_font_get_char_from_glyph_index" qualifiers="virtual const">
@@ -117,6 +145,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_index" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns character code associated with [param glyph_index], or [code]0[/code] if [param glyph_index] is invalid.
 			</description>
 		</method>
 		<method name="_font_get_descent" qualifiers="virtual const">
@@ -124,53 +154,71 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns the font descent (number of pixels below the baseline).
 			</description>
 		</method>
 		<method name="_font_get_disable_embedded_bitmaps" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns whether the font's embedded bitmap loading is disabled.
 			</description>
 		</method>
 		<method name="_font_get_embolden" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font embolden strength.
 			</description>
 		</method>
 		<method name="_font_get_face_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns number of faces in the TrueType / OpenType collection.
 			</description>
 		</method>
 		<method name="_font_get_face_index" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns an active face index in the TrueType / OpenType collection.
 			</description>
 		</method>
 		<method name="_font_get_fixed_size" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns bitmap font fixed size.
 			</description>
 		</method>
 		<method name="_font_get_fixed_size_scale_mode" qualifiers="virtual const">
 			<return type="int" enum="TextServer.FixedSizeScaleMode" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns bitmap font scaling mode.
 			</description>
 		</method>
 		<method name="_font_get_generate_mipmaps" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if font texture mipmap generation is enabled.
 			</description>
 		</method>
 		<method name="_font_get_global_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<description>
+				[b]Optional.[/b]
+				Returns the font oversampling factor, shared by all fonts in the TextServer.
 			</description>
 		</method>
 		<method name="_font_get_glyph_advance" qualifiers="virtual const">
@@ -179,6 +227,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns glyph advance (offset of the next glyph).
 			</description>
 		</method>
 		<method name="_font_get_glyph_contours" qualifiers="virtual const">
@@ -187,6 +237,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="index" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns outline contours of the glyph.
 			</description>
 		</method>
 		<method name="_font_get_glyph_index" qualifiers="virtual const">
@@ -196,6 +248,8 @@
 			<param index="2" name="char" type="int" />
 			<param index="3" name="variation_selector" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
 		<method name="_font_get_glyph_list" qualifiers="virtual const">
@@ -203,6 +257,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
+				[b]Required.[/b]
+				Returns list of rendered glyphs in the cache entry.
 			</description>
 		</method>
 		<method name="_font_get_glyph_offset" qualifiers="virtual const">
@@ -211,6 +267,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns glyph offset from the baseline.
 			</description>
 		</method>
 		<method name="_font_get_glyph_size" qualifiers="virtual const">
@@ -219,6 +277,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns size of the glyph.
 			</description>
 		</method>
 		<method name="_font_get_glyph_texture_idx" qualifiers="virtual const">
@@ -227,6 +287,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns index of the cache texture containing the glyph.
 			</description>
 		</method>
 		<method name="_font_get_glyph_texture_rid" qualifiers="virtual const">
@@ -235,6 +297,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns resource ID of the cache texture containing the glyph.
 			</description>
 		</method>
 		<method name="_font_get_glyph_texture_size" qualifiers="virtual const">
@@ -243,6 +307,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns size of the cache texture containing the glyph.
 			</description>
 		</method>
 		<method name="_font_get_glyph_uv_rect" qualifiers="virtual const">
@@ -251,12 +317,16 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns rectangle in the cache texture containing the glyph.
 			</description>
 		</method>
 		<method name="_font_get_hinting" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Hinting" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns the font hinting mode. Used by dynamic fonts only.
 			</description>
 		</method>
 		<method name="_font_get_kerning" qualifiers="virtual const">
@@ -265,6 +335,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<description>
+				[b]Optional.[/b]
+				Returns kerning for the pair of glyphs.
 			</description>
 		</method>
 		<method name="_font_get_kerning_list" qualifiers="virtual const">
@@ -272,6 +344,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns list of the kerning overrides.
 			</description>
 		</method>
 		<method name="_font_get_language_support_override" qualifiers="virtual">
@@ -279,48 +353,64 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if support override is enabled for the [param language].
 			</description>
 		</method>
 		<method name="_font_get_language_support_overrides" qualifiers="virtual">
 			<return type="PackedStringArray" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns list of language support overrides.
 			</description>
 		</method>
 		<method name="_font_get_msdf_pixel_range" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns the width of the range around the shape between the minimum and maximum representable signed distance.
 			</description>
 		</method>
 		<method name="_font_get_msdf_size" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns source font size used to generate MSDF textures.
 			</description>
 		</method>
 		<method name="_font_get_name" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font family name.
 			</description>
 		</method>
 		<method name="_font_get_opentype_feature_overrides" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font OpenType feature set override.
 			</description>
 		</method>
 		<method name="_font_get_ot_name_strings" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [Dictionary] with OpenType font name strings (localized font names, version, description, license information, sample text, etc.).
 			</description>
 		</method>
 		<method name="_font_get_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
 		<method name="_font_get_scale" qualifiers="virtual const">
@@ -328,6 +418,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns scaling factor of the color bitmap font.
 			</description>
 		</method>
 		<method name="_font_get_script_support_override" qualifiers="virtual">
@@ -335,18 +427,24 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if support override is enabled for the [param script].
 			</description>
 		</method>
 		<method name="_font_get_script_support_overrides" qualifiers="virtual">
 			<return type="PackedStringArray" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns list of script support overrides.
 			</description>
 		</method>
 		<method name="_font_get_size_cache_list" qualifiers="virtual const">
 			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns list of the font sizes in the cache. Each size is [Vector2i] with font size and outline size.
 			</description>
 		</method>
 		<method name="_font_get_spacing" qualifiers="virtual const">
@@ -354,36 +452,48 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
+				[b]Optional.[/b]
+				Returns the spacing for [param spacing] (see [enum TextServer.SpacingType]) in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="_font_get_stretch" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font stretch amount, compared to a normal width. A percentage value between [code]50%[/code] and [code]200%[/code].
 			</description>
 		</method>
 		<method name="_font_get_style" qualifiers="virtual const">
 			<return type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font style flags, see [enum TextServer.FontStyle].
 			</description>
 		</method>
 		<method name="_font_get_style_name" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font style name.
 			</description>
 		</method>
 		<method name="_font_get_subpixel_positioning" qualifiers="virtual const">
 			<return type="int" enum="TextServer.SubpixelPositioning" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns font subpixel glyph positioning mode.
 			</description>
 		</method>
 		<method name="_font_get_supported_chars" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns a string containing all the characters available in the font.
 			</description>
 		</method>
 		<method name="_font_get_texture_count" qualifiers="virtual const">
@@ -391,6 +501,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
+				[b]Required.[/b]
+				Returns number of textures used by font cache entry.
 			</description>
 		</method>
 		<method name="_font_get_texture_image" qualifiers="virtual const">
@@ -399,6 +511,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns font cache texture image data.
 			</description>
 		</method>
 		<method name="_font_get_texture_offsets" qualifiers="virtual const">
@@ -407,12 +521,16 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns array containing glyph packing data.
 			</description>
 		</method>
 		<method name="_font_get_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns 2D transform applied to the font outlines.
 			</description>
 		</method>
 		<method name="_font_get_underline_position" qualifiers="virtual const">
@@ -420,6 +538,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns pixel offset of the underline below the baseline.
 			</description>
 		</method>
 		<method name="_font_get_underline_thickness" qualifiers="virtual const">
@@ -427,18 +547,24 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns thickness of the underline in pixels.
 			</description>
 		</method>
 		<method name="_font_get_variation_coordinates" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns variation coordinates for the specified font cache entry.
 			</description>
 		</method>
 		<method name="_font_get_weight" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns weight (boldness) of the font. A value in the [code]100...999[/code] range, normal font weight is [code]400[/code], bold font weight is [code]700[/code].
 			</description>
 		</method>
 		<method name="_font_has_char" qualifiers="virtual const">
@@ -446,18 +572,24 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="char" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if a Unicode [param char] is available in the font.
 			</description>
 		</method>
 		<method name="_font_is_allow_system_fallback" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if system fonts can be automatically used as fallbacks.
 			</description>
 		</method>
 		<method name="_font_is_force_autohinter" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if auto-hinting is supported and preferred over font built-in hinting.
 			</description>
 		</method>
 		<method name="_font_is_language_supported" qualifiers="virtual const">
@@ -465,12 +597,16 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code], if font supports given language ([url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
 			</description>
 		</method>
 		<method name="_font_is_multichannel_signed_distance_field" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
 			</description>
 		</method>
 		<method name="_font_is_script_supported" qualifiers="virtual const">
@@ -478,6 +614,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code], if font supports given script (ISO 15924 code).
 			</description>
 		</method>
 		<method name="_font_remove_glyph" qualifiers="virtual">
@@ -486,6 +624,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
+				[b]Required.[/b]
+				Removes specified rendered glyph information from the cache entry.
 			</description>
 		</method>
 		<method name="_font_remove_kerning" qualifiers="virtual">
@@ -494,6 +634,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<description>
+				[b]Optional.[/b]
+				Removes kerning override for the pair of glyphs.
 			</description>
 		</method>
 		<method name="_font_remove_language_support_override" qualifiers="virtual">
@@ -501,6 +643,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Remove language support override.
 			</description>
 		</method>
 		<method name="_font_remove_script_support_override" qualifiers="virtual">
@@ -508,6 +652,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Removes script support override.
 			</description>
 		</method>
 		<method name="_font_remove_size_cache" qualifiers="virtual">
@@ -515,6 +661,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
+				[b]Required.[/b]
+				Removes specified font size from the cache entry.
 			</description>
 		</method>
 		<method name="_font_remove_texture" qualifiers="virtual">
@@ -523,6 +671,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<description>
+				[b]Required.[/b]
+				Removes specified texture from the cache entry.
 			</description>
 		</method>
 		<method name="_font_render_glyph" qualifiers="virtual">
@@ -531,6 +681,8 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="index" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Renders specified glyph to the font cache texture.
 			</description>
 		</method>
 		<method name="_font_render_range" qualifiers="virtual">
@@ -540,6 +692,8 @@
 			<param index="2" name="start" type="int" />
 			<param index="3" name="end" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Renders the range of characters to the font cache texture.
 			</description>
 		</method>
 		<method name="_font_set_allow_system_fallback" qualifiers="virtual">
@@ -547,6 +701,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="allow_system_fallback" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code], system fonts can be automatically used as fallbacks.
 			</description>
 		</method>
 		<method name="_font_set_antialiasing" qualifiers="virtual">
@@ -554,6 +710,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="antialiasing" type="int" enum="TextServer.FontAntialiasing" />
 			<description>
+				[b]Optional.[/b]
+				Sets font anti-aliasing mode.
 			</description>
 		</method>
 		<method name="_font_set_ascent" qualifiers="virtual">
@@ -562,6 +720,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="ascent" type="float" />
 			<description>
+				[b]Required.[/b]
+				Sets the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
 		<method name="_font_set_baseline_offset" qualifiers="virtual">
@@ -569,6 +729,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="baseline_offset" type="float" />
 			<description>
+				[b]Optional.[/b]
+				Sets extra baseline offset (as a fraction of font height).
 			</description>
 		</method>
 		<method name="_font_set_data" qualifiers="virtual">
@@ -576,6 +738,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="data" type="PackedByteArray" />
 			<description>
+				[b]Optional.[/b]
+				Sets font source data, e.g contents of the dynamic font source file.
 			</description>
 		</method>
 		<method name="_font_set_data_ptr" qualifiers="virtual">
@@ -584,6 +748,8 @@
 			<param index="1" name="data_ptr" type="const uint8_t*" />
 			<param index="2" name="data_size" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets pointer to the font source data, e.g contents of the dynamic font source file.
 			</description>
 		</method>
 		<method name="_font_set_descent" qualifiers="virtual">
@@ -592,6 +758,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="descent" type="float" />
 			<description>
+				[b]Required.[/b]
+				Sets the font descent (number of pixels below the baseline).
 			</description>
 		</method>
 		<method name="_font_set_disable_embedded_bitmaps" qualifiers="virtual">
@@ -599,6 +767,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="disable_embedded_bitmaps" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code], embedded font bitmap loading is disabled.
 			</description>
 		</method>
 		<method name="_font_set_embolden" qualifiers="virtual">
@@ -606,6 +776,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="strength" type="float" />
 			<description>
+				Sets font embolden strength. If [param strength] is not equal to zero, emboldens the font outlines. Negative values reduce the outline thickness.
 			</description>
 		</method>
 		<method name="_font_set_face_index" qualifiers="virtual">
@@ -613,6 +784,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="face_index" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets an active face index in the TrueType / OpenType collection.
 			</description>
 		</method>
 		<method name="_font_set_fixed_size" qualifiers="virtual">
@@ -620,6 +793,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="fixed_size" type="int" />
 			<description>
+				[b]Required.[/b]
+				Sets bitmap font fixed size. If set to value greater than zero, same cache entry will be used for all font sizes.
 			</description>
 		</method>
 		<method name="_font_set_fixed_size_scale_mode" qualifiers="virtual">
@@ -627,6 +802,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="fixed_size_scale_mode" type="int" enum="TextServer.FixedSizeScaleMode" />
 			<description>
+				[b]Required.[/b]
+				Sets bitmap font scaling mode. This property is used only if [code]fixed_size[/code] is greater than zero.
 			</description>
 		</method>
 		<method name="_font_set_force_autohinter" qualifiers="virtual">
@@ -634,6 +811,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="force_autohinter" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code] auto-hinting is preferred over font built-in hinting.
 			</description>
 		</method>
 		<method name="_font_set_generate_mipmaps" qualifiers="virtual">
@@ -641,12 +820,16 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="generate_mipmaps" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code] font texture mipmap generation is enabled.
 			</description>
 		</method>
 		<method name="_font_set_global_oversampling" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="oversampling" type="float" />
 			<description>
+				[b]Optional.[/b]
+				Sets oversampling factor, shared by all font in the TextServer.
 			</description>
 		</method>
 		<method name="_font_set_glyph_advance" qualifiers="virtual">
@@ -656,6 +839,8 @@
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="advance" type="Vector2" />
 			<description>
+				[b]Required.[/b]
+				Sets glyph advance (offset of the next glyph).
 			</description>
 		</method>
 		<method name="_font_set_glyph_offset" qualifiers="virtual">
@@ -665,6 +850,8 @@
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="offset" type="Vector2" />
 			<description>
+				[b]Required.[/b]
+				Sets glyph offset from the baseline.
 			</description>
 		</method>
 		<method name="_font_set_glyph_size" qualifiers="virtual">
@@ -674,6 +861,8 @@
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="gl_size" type="Vector2" />
 			<description>
+				[b]Required.[/b]
+				Sets size of the glyph.
 			</description>
 		</method>
 		<method name="_font_set_glyph_texture_idx" qualifiers="virtual">
@@ -683,6 +872,8 @@
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="texture_idx" type="int" />
 			<description>
+				[b]Required.[/b]
+				Sets index of the cache texture containing the glyph.
 			</description>
 		</method>
 		<method name="_font_set_glyph_uv_rect" qualifiers="virtual">
@@ -692,6 +883,8 @@
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="uv_rect" type="Rect2" />
 			<description>
+				[b]Required.[/b]
+				Sets rectangle in the cache texture containing the glyph.
 			</description>
 		</method>
 		<method name="_font_set_hinting" qualifiers="virtual">
@@ -699,6 +892,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="hinting" type="int" enum="TextServer.Hinting" />
 			<description>
+				[b]Optional.[/b]
+				Sets font hinting mode. Used by dynamic fonts only.
 			</description>
 		</method>
 		<method name="_font_set_kerning" qualifiers="virtual">
@@ -708,6 +903,8 @@
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<param index="3" name="kerning" type="Vector2" />
 			<description>
+				[b]Optional.[/b]
+				Sets kerning for the pair of glyphs.
 			</description>
 		</method>
 		<method name="_font_set_language_support_override" qualifiers="virtual">
@@ -716,6 +913,8 @@
 			<param index="1" name="language" type="String" />
 			<param index="2" name="supported" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				Adds override for [method _font_is_language_supported].
 			</description>
 		</method>
 		<method name="_font_set_msdf_pixel_range" qualifiers="virtual">
@@ -723,6 +922,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf_pixel_range" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets the width of the range around the shape between the minimum and maximum representable signed distance.
 			</description>
 		</method>
 		<method name="_font_set_msdf_size" qualifiers="virtual">
@@ -730,6 +931,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf_size" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets source font size used to generate MSDF textures.
 			</description>
 		</method>
 		<method name="_font_set_multichannel_signed_distance_field" qualifiers="virtual">
@@ -737,6 +940,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data. MSDF rendering allows displaying the font at any scaling factor without blurriness, and without incurring a CPU cost when the font size changes (since the font no longer needs to be rasterized on the CPU). As a downside, font hinting is not available with MSDF. The lack of font hinting may result in less crisp and less readable fonts at small sizes.
 			</description>
 		</method>
 		<method name="_font_set_name" qualifiers="virtual">
@@ -744,6 +949,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="name" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Sets the font family name.
 			</description>
 		</method>
 		<method name="_font_set_opentype_feature_overrides" qualifiers="virtual">
@@ -751,6 +958,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="overrides" type="Dictionary" />
 			<description>
+				[b]Optional.[/b]
+				Sets font OpenType feature set override.
 			</description>
 		</method>
 		<method name="_font_set_oversampling" qualifiers="virtual">
@@ -758,6 +967,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="oversampling" type="float" />
 			<description>
+				[b]Optional.[/b]
+				Sets font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
 		<method name="_font_set_scale" qualifiers="virtual">
@@ -766,6 +977,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="scale" type="float" />
 			<description>
+				[b]Required.[/b]
+				Sets scaling factor of the color bitmap font.
 			</description>
 		</method>
 		<method name="_font_set_script_support_override" qualifiers="virtual">
@@ -774,6 +987,8 @@
 			<param index="1" name="script" type="String" />
 			<param index="2" name="supported" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				Adds override for [method _font_is_script_supported].
 			</description>
 		</method>
 		<method name="_font_set_spacing" qualifiers="virtual">
@@ -782,6 +997,8 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets the spacing for [param spacing] (see [enum TextServer.SpacingType]) to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
 		<method name="_font_set_stretch" qualifiers="virtual">
@@ -789,6 +1006,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="stretch" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets font stretch amount, compared to a normal width. A percentage value between [code]50%[/code] and [code]200%[/code].
 			</description>
 		</method>
 		<method name="_font_set_style" qualifiers="virtual">
@@ -796,6 +1015,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="style" type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<description>
+				[b]Optional.[/b]
+				Sets the font style flags, see [enum TextServer.FontStyle].
 			</description>
 		</method>
 		<method name="_font_set_style_name" qualifiers="virtual">
@@ -803,6 +1024,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="name_style" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Sets the font style name.
 			</description>
 		</method>
 		<method name="_font_set_subpixel_positioning" qualifiers="virtual">
@@ -810,6 +1033,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="subpixel_positioning" type="int" enum="TextServer.SubpixelPositioning" />
 			<description>
+				[b]Optional.[/b]
+				Sets font subpixel glyph positioning mode.
 			</description>
 		</method>
 		<method name="_font_set_texture_image" qualifiers="virtual">
@@ -819,6 +1044,8 @@
 			<param index="2" name="texture_index" type="int" />
 			<param index="3" name="image" type="Image" />
 			<description>
+				[b]Required.[/b]
+				Sets font cache texture image data.
 			</description>
 		</method>
 		<method name="_font_set_texture_offsets" qualifiers="virtual">
@@ -828,6 +1055,8 @@
 			<param index="2" name="texture_index" type="int" />
 			<param index="3" name="offset" type="PackedInt32Array" />
 			<description>
+				[b]Optional.[/b]
+				Sets array containing glyph packing data.
 			</description>
 		</method>
 		<method name="_font_set_transform" qualifiers="virtual">
@@ -835,6 +1064,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
+				[b]Optional.[/b]
+				Sets 2D transform, applied to the font outlines, can be used for slanting, flipping, and rotating glyphs.
 			</description>
 		</method>
 		<method name="_font_set_underline_position" qualifiers="virtual">
@@ -843,6 +1074,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_position" type="float" />
 			<description>
+				[b]Required.[/b]
+				Sets pixel offset of the underline below the baseline.
 			</description>
 		</method>
 		<method name="_font_set_underline_thickness" qualifiers="virtual">
@@ -851,6 +1084,8 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_thickness" type="float" />
 			<description>
+				[b]Required.[/b]
+				Sets thickness of the underline in pixels.
 			</description>
 		</method>
 		<method name="_font_set_variation_coordinates" qualifiers="virtual">
@@ -858,6 +1093,8 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="variation_coordinates" type="Dictionary" />
 			<description>
+				[b]Optional.[/b]
+				Sets variation coordinates for the specified font cache entry.
 			</description>
 		</method>
 		<method name="_font_set_weight" qualifiers="virtual">
@@ -865,36 +1102,48 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="weight" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets weight (boldness) of the font. A value in the [code]100...999[/code] range, normal font weight is [code]400[/code], bold font weight is [code]700[/code].
 			</description>
 		</method>
 		<method name="_font_supported_feature_list" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns the dictionary of the supported OpenType features.
 			</description>
 		</method>
 		<method name="_font_supported_variation_list" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns the dictionary of the supported OpenType variation coordinates.
 			</description>
 		</method>
 		<method name="_format_number" qualifiers="virtual const">
 			<return type="String" />
-			<param index="0" name="string" type="String" />
+			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Converts a number from the Western Arabic (0..9) to the numeral systems used in [param language].
 			</description>
 		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Frees an object created by this [TextServer].
 			</description>
 		</method>
 		<method name="_get_features" qualifiers="virtual const">
 			<return type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns text server features, see [enum TextServer.Feature].
 			</description>
 		</method>
 		<method name="_get_hex_code_box_size" qualifiers="virtual const">
@@ -902,33 +1151,45 @@
 			<param index="0" name="size" type="int" />
 			<param index="1" name="index" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns size of the replacement character (box with character hexadecimal code that is drawn in place of invalid characters).
 			</description>
 		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>
+				[b]Required.[/b]
+				Returns the name of the server interface.
 			</description>
 		</method>
 		<method name="_get_support_data_filename" qualifiers="virtual const">
 			<return type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns default TextServer database (e.g. ICU break iterators and dictionaries) filename.
 			</description>
 		</method>
 		<method name="_get_support_data_info" qualifiers="virtual const">
 			<return type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns TextServer database (e.g. ICU break iterators and dictionaries) description.
 			</description>
 		</method>
 		<method name="_has" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="rid" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if [param rid] is valid resource owned by this text server.
 			</description>
 		</method>
 		<method name="_has_feature" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="feature" type="int" enum="TextServer.Feature" />
 			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if the server supports a feature.
 			</description>
 		</method>
 		<method name="_is_confusable" qualifiers="virtual const">
@@ -936,37 +1197,49 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="dict" type="PackedStringArray" />
 			<description>
+				[b]Optional.[/b]
+				Returns index of the first string in [param dict] which is visually confusable with the [param string], or [code]-1[/code] if none is found.
 			</description>
 		</method>
 		<method name="_is_locale_right_to_left" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="locale" type="String" />
 			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if locale is right-to-left.
 			</description>
 		</method>
 		<method name="_is_valid_identifier" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if [param string] is a valid identifier.
 			</description>
 		</method>
 		<method name="_load_support_data" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="filename" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Loads optional TextServer database (e.g. ICU break iterators and dictionaries).
 			</description>
 		</method>
 		<method name="_name_to_tag" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Converts readable feature, variation, script, or language name to OpenType tag.
 			</description>
 		</method>
 		<method name="_parse_number" qualifiers="virtual const">
 			<return type="String" />
-			<param index="0" name="string" type="String" />
+			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Converts [param number] from the numeral systems used in [param language] to Western Arabic (0..9).
 			</description>
 		</method>
 		<method name="_parse_structured_text" qualifiers="virtual const">
@@ -975,24 +1248,32 @@
 			<param index="1" name="args" type="Array" />
 			<param index="2" name="text" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Default implementation of the BiDi algorithm override function. See [enum TextServer.StructuredTextParser] for more info.
 			</description>
 		</method>
 		<method name="_percent_sign" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns percent sign used in the [param language].
 			</description>
 		</method>
 		<method name="_save_support_data" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="filename" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Saves optional TextServer database (e.g. ICU break iterators and dictionaries) to the file.
 			</description>
 		</method>
 		<method name="_shaped_get_span_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns number of text spans added using [method _shaped_text_add_string] or [method _shaped_text_add_object].
 			</description>
 		</method>
 		<method name="_shaped_get_span_meta" qualifiers="virtual const">
@@ -1000,6 +1281,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns text span metadata.
 			</description>
 		</method>
 		<method name="_shaped_set_span_update_font" qualifiers="virtual">
@@ -1010,6 +1293,8 @@
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" />
 			<description>
+				[b]Required.[/b]
+				Changes text span font, font size, and OpenType features, without changing the text.
 			</description>
 		</method>
 		<method name="_shaped_text_add_object" qualifiers="virtual">
@@ -1021,6 +1306,8 @@
 			<param index="4" name="length" type="int" />
 			<param index="5" name="baseline" type="float" />
 			<description>
+				[b]Required.[/b]
+				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
 		<method name="_shaped_text_add_string" qualifiers="virtual">
@@ -1033,12 +1320,16 @@
 			<param index="5" name="language" type="String" />
 			<param index="6" name="meta" type="Variant" />
 			<description>
+				[b]Required.[/b]
+				Adds text span and font to draw it to the text buffer.
 			</description>
 		</method>
 		<method name="_shaped_text_clear" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Clears text buffer (removes text and inline objects).
 			</description>
 		</method>
 		<method name="_shaped_text_closest_character_pos" qualifiers="virtual const">
@@ -1046,6 +1337,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns composite character position closest to the [param pos].
 			</description>
 		</method>
 		<method name="_shaped_text_draw" qualifiers="virtual const">
@@ -1057,6 +1350,8 @@
 			<param index="4" name="clip_r" type="float" />
 			<param index="5" name="color" type="Color" />
 			<description>
+				[b]Optional.[/b]
+				Draw shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 			</description>
 		</method>
 		<method name="_shaped_text_draw_outline" qualifiers="virtual const">
@@ -1069,6 +1364,8 @@
 			<param index="5" name="outline_size" type="int" />
 			<param index="6" name="color" type="Color" />
 			<description>
+				[b]Optional.[/b]
+				Draw the outline of the shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 			</description>
 		</method>
 		<method name="_shaped_text_fit_to_width" qualifiers="virtual">
@@ -1077,12 +1374,16 @@
 			<param index="1" name="width" type="float" />
 			<param index="2" name="justification_flags" type="int" enum="TextServer.JustificationFlag" is_bitfield="true" />
 			<description>
+				[b]Optional.[/b]
+				Adjusts text width to fit to specified width, returns new text width.
 			</description>
 		</method>
 		<method name="_shaped_text_get_ascent" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns the text ascent (number of pixels above the baseline for horizontal layout or to the left of baseline for vertical).
 			</description>
 		</method>
 		<method name="_shaped_text_get_carets" qualifiers="virtual const">
@@ -1091,36 +1392,48 @@
 			<param index="1" name="position" type="int" />
 			<param index="2" name="caret" type="CaretInfo*" />
 			<description>
+				[b]Optional.[/b]
+				Returns shapes of the carets corresponding to the character offset [param position] in the text. Returned caret shape is 1 pixel wide rectangle.
 			</description>
 		</method>
 		<method name="_shaped_text_get_character_breaks" qualifiers="virtual const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns array of the composite character boundaries.
 			</description>
 		</method>
 		<method name="_shaped_text_get_custom_ellipsis" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns ellipsis character used for text clipping.
 			</description>
 		</method>
 		<method name="_shaped_text_get_custom_punctuation" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns custom punctuation character list, used for word breaking. If set to empty string, server defaults are used.
 			</description>
 		</method>
 		<method name="_shaped_text_get_descent" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns the text descent (number of pixels below the baseline for horizontal layout or to the right of baseline for vertical).
 			</description>
 		</method>
 		<method name="_shaped_text_get_direction" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Direction" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns direction of the text.
 			</description>
 		</method>
 		<method name="_shaped_text_get_dominant_direction_in_range" qualifiers="virtual const">
@@ -1129,36 +1442,48 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="end" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns dominant direction of in the range of text.
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_glyph_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns number of glyphs in the ellipsis.
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_glyphs" qualifiers="virtual const">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns array of the glyphs in the ellipsis.
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns position of the ellipsis.
 			</description>
 		</method>
 		<method name="_shaped_text_get_glyph_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns number of glyphs in the buffer.
 			</description>
 		</method>
 		<method name="_shaped_text_get_glyphs" qualifiers="virtual const">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns an array of glyphs in the visual order.
 			</description>
 		</method>
 		<method name="_shaped_text_get_grapheme_bounds" qualifiers="virtual const">
@@ -1166,12 +1491,16 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns composite character's bounds as offsets from the start of the line.
 			</description>
 		</method>
 		<method name="_shaped_text_get_inferred_direction" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Direction" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns direction of the text, inferred by the BiDi algorithm.
 			</description>
 		</method>
 		<method name="_shaped_text_get_line_breaks" qualifiers="virtual const">
@@ -1181,6 +1510,8 @@
 			<param index="2" name="start" type="int" />
 			<param index="3" name="break_flags" type="int" enum="TextServer.LineBreakFlag" is_bitfield="true" />
 			<description>
+				[b]Optional.[/b]
+				Breaks text to the lines and returns character ranges for each line.
 			</description>
 		</method>
 		<method name="_shaped_text_get_line_breaks_adv" qualifiers="virtual const">
@@ -1191,6 +1522,8 @@
 			<param index="3" name="once" type="bool" />
 			<param index="4" name="break_flags" type="int" enum="TextServer.LineBreakFlag" is_bitfield="true" />
 			<description>
+				[b]Optional.[/b]
+				Breaks text to the lines and columns. Returns character ranges for each segment.
 			</description>
 		</method>
 		<method name="_shaped_text_get_object_glyph" qualifiers="virtual const">
@@ -1198,6 +1531,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
 			<description>
+				[b]Required.[/b]
+				Returns the glyph index of the inline object.
 			</description>
 		</method>
 		<method name="_shaped_text_get_object_range" qualifiers="virtual const">
@@ -1205,6 +1540,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
 			<description>
+				[b]Required.[/b]
+				Returns the character range of the inline object.
 			</description>
 		</method>
 		<method name="_shaped_text_get_object_rect" qualifiers="virtual const">
@@ -1212,42 +1549,56 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
 			<description>
+				[b]Required.[/b]
+				Returns bounding rectangle of the inline object.
 			</description>
 		</method>
 		<method name="_shaped_text_get_objects" qualifiers="virtual const">
 			<return type="Array" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns array of inline objects.
 			</description>
 		</method>
 		<method name="_shaped_text_get_orientation" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Orientation" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns text orientation.
 			</description>
 		</method>
 		<method name="_shaped_text_get_parent" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns the parent buffer from which the substring originates.
 			</description>
 		</method>
 		<method name="_shaped_text_get_preserve_control" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if text buffer is configured to display control characters.
 			</description>
 		</method>
 		<method name="_shaped_text_get_preserve_invalid" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if text buffer is configured to display hexadecimal codes in place of invalid characters.
 			</description>
 		</method>
 		<method name="_shaped_text_get_range" qualifiers="virtual const">
 			<return type="Vector2i" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns substring buffer character range in the parent buffer.
 			</description>
 		</method>
 		<method name="_shaped_text_get_selection" qualifiers="virtual const">
@@ -1256,12 +1607,16 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="end" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns selection rectangles for the specified character range.
 			</description>
 		</method>
 		<method name="_shaped_text_get_size" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns size of the text.
 			</description>
 		</method>
 		<method name="_shaped_text_get_spacing" qualifiers="virtual const">
@@ -1269,30 +1624,40 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
+				[b]Optional.[/b]
+				Returns extra spacing added between glyphs or lines in pixels.
 			</description>
 		</method>
 		<method name="_shaped_text_get_trim_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns the position of the overrun trim.
 			</description>
 		</method>
 		<method name="_shaped_text_get_underline_position" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns pixel offset of the underline below the baseline.
 			</description>
 		</method>
 		<method name="_shaped_text_get_underline_thickness" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns thickness of the underline.
 			</description>
 		</method>
 		<method name="_shaped_text_get_width" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns width (for horizontal layout) or height (for vertical) of the text.
 			</description>
 		</method>
 		<method name="_shaped_text_get_word_breaks" qualifiers="virtual const">
@@ -1300,6 +1665,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="grapheme_flags" type="int" enum="TextServer.GraphemeFlag" is_bitfield="true" />
 			<description>
+				[b]Optional.[/b]
+				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking (see [enum TextServer.GraphemeFlag]).
 			</description>
 		</method>
 		<method name="_shaped_text_hit_test_grapheme" qualifiers="virtual const">
@@ -1307,6 +1674,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="coord" type="float" />
 			<description>
+				[b]Optional.[/b]
+				Returns grapheme index at the specified pixel offset at the baseline, or [code]-1[/code] if none is found.
 			</description>
 		</method>
 		<method name="_shaped_text_hit_test_position" qualifiers="virtual const">
@@ -1314,12 +1683,16 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="coord" type="float" />
 			<description>
+				[b]Optional.[/b]
+				Returns caret character offset at the specified pixel offset at the baseline. This function always returns a valid position.
 			</description>
 		</method>
 		<method name="_shaped_text_is_ready" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns [code]true[/code] if buffer is successfully shaped.
 			</description>
 		</method>
 		<method name="_shaped_text_next_character_pos" qualifiers="virtual const">
@@ -1327,6 +1700,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns composite character end position closest to the [param pos].
 			</description>
 		</method>
 		<method name="_shaped_text_next_grapheme_pos" qualifiers="virtual const">
@@ -1334,6 +1709,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns grapheme end position closest to the [param pos].
 			</description>
 		</method>
 		<method name="_shaped_text_overrun_trim_to_width" qualifiers="virtual">
@@ -1342,6 +1719,8 @@
 			<param index="1" name="width" type="float" />
 			<param index="2" name="trim_flags" type="int" enum="TextServer.TextOverrunFlag" is_bitfield="true" />
 			<description>
+				[b]Optional.[/b]
+				Trims text if it exceeds the given width.
 			</description>
 		</method>
 		<method name="_shaped_text_prev_character_pos" qualifiers="virtual const">
@@ -1349,6 +1728,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns composite character start position closest to the [param pos].
 			</description>
 		</method>
 		<method name="_shaped_text_prev_grapheme_pos" qualifiers="virtual const">
@@ -1356,6 +1737,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns grapheme start position closest to the [param pos].
 			</description>
 		</method>
 		<method name="_shaped_text_resize_object" qualifiers="virtual">
@@ -1366,6 +1749,8 @@
 			<param index="3" name="inline_align" type="int" enum="InlineAlignment" />
 			<param index="4" name="baseline" type="float" />
 			<description>
+				[b]Required.[/b]
+				Sets new size and alignment of embedded object.
 			</description>
 		</method>
 		<method name="_shaped_text_set_bidi_override" qualifiers="virtual">
@@ -1373,6 +1758,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="override" type="Array" />
 			<description>
+				[b]Optional.[/b]
+				Overrides BiDi for the structured text.
 			</description>
 		</method>
 		<method name="_shaped_text_set_custom_ellipsis" qualifiers="virtual">
@@ -1380,6 +1767,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="char" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets ellipsis character used for text clipping.
 			</description>
 		</method>
 		<method name="_shaped_text_set_custom_punctuation" qualifiers="virtual">
@@ -1387,6 +1776,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="punct" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Sets custom punctuation character list, used for word breaking. If set to empty string, server defaults are used.
 			</description>
 		</method>
 		<method name="_shaped_text_set_direction" qualifiers="virtual">
@@ -1394,6 +1785,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="direction" type="int" enum="TextServer.Direction" />
 			<description>
+				[b]Optional.[/b]
+				Sets desired text direction. If set to [constant TextServer.DIRECTION_AUTO], direction will be detected based on the buffer contents and current locale.
 			</description>
 		</method>
 		<method name="_shaped_text_set_orientation" qualifiers="virtual">
@@ -1401,6 +1794,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
 			<description>
+				[b]Optional.[/b]
+				Sets desired text orientation.
 			</description>
 		</method>
 		<method name="_shaped_text_set_preserve_control" qualifiers="virtual">
@@ -1408,6 +1803,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code] text buffer will display control characters.
 			</description>
 		</method>
 		<method name="_shaped_text_set_preserve_invalid" qualifiers="virtual">
@@ -1415,6 +1812,8 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
+				[b]Optional.[/b]
+				If set to [code]true[/code] text buffer will display invalid characters as hexadecimal codes, otherwise nothing is displayed.
 			</description>
 		</method>
 		<method name="_shaped_text_set_spacing" qualifiers="virtual">
@@ -1423,18 +1822,24 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Sets extra spacing added between glyphs or lines in pixels.
 			</description>
 		</method>
 		<method name="_shaped_text_shape" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Shapes buffer if it's not shaped. Returns [code]true[/code] if the string is shaped successfully.
 			</description>
 		</method>
 		<method name="_shaped_text_sort_logical" qualifiers="virtual">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Required.[/b]
+				Returns text glyphs in the logical order.
 			</description>
 		</method>
 		<method name="_shaped_text_substr" qualifiers="virtual const">
@@ -1443,6 +1848,8 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="length" type="int" />
 			<description>
+				[b]Required.[/b]
+				Returns text buffer for the substring of the text in the [param shaped] text buffer (including inline objects).
 			</description>
 		</method>
 		<method name="_shaped_text_tab_align" qualifiers="virtual">
@@ -1450,24 +1857,32 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="tab_stops" type="PackedFloat32Array" />
 			<description>
+				[b]Optional.[/b]
+				Aligns shaped text to the given tab-stops.
 			</description>
 		</method>
 		<method name="_shaped_text_update_breaks" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Updates break points in the shaped text. This method is called by default implementation of text breaking functions.
 			</description>
 		</method>
 		<method name="_shaped_text_update_justification_ops" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
+				[b]Optional.[/b]
+				Updates justification points in the shaped text. This method is called by default implementation of text justification functions.
 			</description>
 		</method>
 		<method name="_spoof_check" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if [param string] is likely to be an attempt at confusing the reader.
 			</description>
 		</method>
 		<method name="_string_get_character_breaks" qualifiers="virtual const">
@@ -1475,6 +1890,8 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns array of the composite character boundaries.
 			</description>
 		</method>
 		<method name="_string_get_word_breaks" qualifiers="virtual const">
@@ -1483,6 +1900,8 @@
 			<param index="1" name="language" type="String" />
 			<param index="2" name="chars_per_line" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Returns an array of the word break boundaries. Elements in the returned array are the offsets of the start and end of words. Therefore the length of the array is always even.
 			</description>
 		</method>
 		<method name="_string_to_lower" qualifiers="virtual const">
@@ -1490,6 +1909,8 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns the string converted to lowercase.
 			</description>
 		</method>
 		<method name="_string_to_upper" qualifiers="virtual const">
@@ -1497,18 +1918,24 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Returns the string converted to uppercase.
 			</description>
 		</method>
 		<method name="_strip_diacritics" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />
 			<description>
+				[b]Optional.[/b]
+				Strips diacritics from the string.
 			</description>
 		</method>
 		<method name="_tag_to_name" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="tag" type="int" />
 			<description>
+				[b]Optional.[/b]
+				Converts OpenType tag to readable feature, variation, script, or language name.
 			</description>
 		</method>
 	</methods>

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -73,8 +73,6 @@ using namespace godot;
 
 /*************************************************************************/
 
-#define OT_TAG(c1, c2, c3, c4) ((int32_t)((((uint32_t)(c1) & 0xff) << 24) | (((uint32_t)(c2) & 0xff) << 16) | (((uint32_t)(c3) & 0xff) << 8) | ((uint32_t)(c4) & 0xff)))
-
 bool TextServerFallback::_has_feature(Feature p_feature) const {
 	switch (p_feature) {
 		case FEATURE_SIMPLE_LAYOUT:
@@ -907,8 +905,8 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_f
 					coords.write[i] = CLAMP(var_value * 65536.0, amaster->axis[i].minimum, amaster->axis[i].maximum);
 				}
 
-				if (p_font_data->variation_coordinates.has(_tag_to_name(var_tag))) {
-					var_value = p_font_data->variation_coordinates[_tag_to_name(var_tag)];
+				if (p_font_data->variation_coordinates.has(tag_to_name(var_tag))) {
+					var_value = p_font_data->variation_coordinates[tag_to_name(var_tag)];
 					coords.write[i] = CLAMP(var_value * 65536.0, amaster->axis[i].minimum, amaster->axis[i].maximum);
 				}
 			}
@@ -3704,9 +3702,9 @@ RID TextServerFallback::_find_sys_font_for_text(const RID &p_fdef, const String 
 		int font_weight = _font_get_weight(p_fdef);
 		int font_stretch = _font_get_stretch(p_fdef);
 		Dictionary dvar = _font_get_variation_coordinates(p_fdef);
-		static int64_t wgth_tag = _name_to_tag("weight");
-		static int64_t wdth_tag = _name_to_tag("width");
-		static int64_t ital_tag = _name_to_tag("italic");
+		static int64_t wgth_tag = name_to_tag("weight");
+		static int64_t wdth_tag = name_to_tag("width");
+		static int64_t ital_tag = name_to_tag("italic");
 		if (dvar.has(wgth_tag)) {
 			font_weight = dvar[wgth_tag].operator int();
 		}

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -40,9 +40,87 @@ class TextServerDummy : public TextServerExtension {
 	_THREAD_SAFE_CLASS_
 
 public:
-	virtual String get_name() const override {
-		return "Dummy";
-	}
+	virtual bool has_feature(Feature p_feature) const override { return false; }
+	virtual String get_name() const override { return "Dummy"; }
+	virtual int64_t get_features() const override { return 0; }
+	virtual void free_rid(const RID &p_rid) override {}
+	virtual bool has(const RID &p_rid) override { return false; }
+
+	virtual RID create_font() override { return RID(); }
+	virtual void font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) override {}
+	virtual int64_t font_get_fixed_size(const RID &p_font_rid) const override { return 0; }
+	virtual void font_set_fixed_size_scale_mode(const RID &p_font_rid, TextServer::FixedSizeScaleMode p_fixed_size_scale_mode) override {}
+	virtual TextServer::FixedSizeScaleMode font_get_fixed_size_scale_mode(const RID &p_font_rid) const override { return FIXED_SIZE_SCALE_DISABLE; }
+	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override { return TypedArray<Vector2i>(); }
+	virtual void font_clear_size_cache(const RID &p_font_rid) override {}
+	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) override {}
+	virtual void font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) override {}
+	virtual double font_get_ascent(const RID &p_font_rid, int64_t p_size) const override { return 0; }
+	virtual void font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) override {}
+	virtual double font_get_descent(const RID &p_font_rid, int64_t p_size) const override { return 0; }
+	virtual void font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) override {}
+	virtual double font_get_underline_position(const RID &p_font_rid, int64_t p_size) const override { return 0; }
+	virtual void font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) override {}
+	virtual double font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const override { return 0; }
+	virtual void font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) override {}
+	virtual double font_get_scale(const RID &p_font_rid, int64_t p_size) const override { return 0; }
+	virtual int64_t font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const override { return 0; }
+	virtual void font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) override {}
+	virtual void font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) override {}
+	virtual void font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) override {}
+	virtual Ref<Image> font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override { return Ref<Image>(); }
+	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override { return PackedInt32Array(); }
+	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) override {}
+	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) override {}
+	virtual Vector2 font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const override { return Vector2(); }
+	virtual void font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) override {}
+	virtual Vector2 font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return Vector2(); }
+	virtual void font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) override {}
+	virtual Vector2 font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return Vector2(); }
+	virtual void font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) override {}
+	virtual Rect2 font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return Rect2(); }
+	virtual void font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) override {}
+	virtual int64_t font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return 0; }
+	virtual void font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) override {}
+	virtual RID font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return RID(); }
+	virtual Size2 font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return Size2(); }
+	virtual int64_t font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const override { return 0; }
+	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const override { return 0; }
+	virtual bool font_has_char(const RID &p_font_rid, int64_t p_char) const override { return false; }
+	virtual String font_get_supported_chars(const RID &p_font_rid) const override { return String(); }
+	virtual void font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override {}
+	virtual void font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override {}
+
+	virtual RID create_shaped_text(TextServer::Direction p_direction, TextServer::Orientation p_orientation) override { return RID(); }
+	virtual void shaped_text_clear(const RID &p_shaped) override {}
+	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) override { return false; }
+	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int64_t p_length, double p_baseline) override { return false; }
+	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, double p_baseline) override { return false; }
+	virtual int64_t shaped_get_span_count(const RID &p_shaped) const override { return 0; }
+	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const override { return Variant(); }
+	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) override {}
+	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const override { return RID(); }
+	virtual RID shaped_text_get_parent(const RID &p_shaped) const override { return RID(); }
+	virtual bool shaped_text_shape(const RID &p_shaped) override { return false; }
+	virtual bool shaped_text_is_ready(const RID &p_shaped) const override { return false; }
+	virtual const Glyph *shaped_text_get_glyphs(const RID &p_shaped) const override { return nullptr; }
+	virtual const Glyph *shaped_text_sort_logical(const RID &p_shaped) override { return nullptr; }
+	virtual int64_t shaped_text_get_glyph_count(const RID &p_shaped) const override { return 0; }
+	virtual Vector2i shaped_text_get_range(const RID &p_shaped) const override { return Vector2i(); }
+	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped) const override { return -1; }
+	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped) const override { return -1; }
+	virtual const Glyph *shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const override { return nullptr; }
+	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const override { return -1; }
+	virtual Array shaped_text_get_objects(const RID &p_shaped) const override { return Array(); }
+	virtual Rect2 shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const override { return Rect2(); }
+	virtual Vector2i shaped_text_get_object_range(const RID &p_shaped, const Variant &p_key) const override { return Vector2i(); }
+	virtual int64_t shaped_text_get_object_glyph(const RID &p_shaped, const Variant &p_key) const override { return -1; }
+	virtual Size2 shaped_text_get_size(const RID &p_shaped) const override { return Size2(); }
+	virtual double shaped_text_get_ascent(const RID &p_shaped) const override { return 0; }
+	virtual double shaped_text_get_descent(const RID &p_shaped) const override { return 0; }
+	virtual double shaped_text_get_width(const RID &p_shaped) const override { return 0; }
+	virtual double shaped_text_get_underline_position(const RID &p_shaped) const override { return 0; }
+	virtual double shaped_text_get_underline_thickness(const RID &p_shaped) const override { return 0; }
 };
 
 #endif // TEXT_SERVER_DUMMY_H

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -326,8 +326,8 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shaped_text_prev_character_pos, "shaped", "pos");
 	GDVIRTUAL_BIND(_shaped_text_closest_character_pos, "shaped", "pos");
 
-	GDVIRTUAL_BIND(_format_number, "string", "language");
-	GDVIRTUAL_BIND(_parse_number, "string", "language");
+	GDVIRTUAL_BIND(_format_number, "number", "language");
+	GDVIRTUAL_BIND(_parse_number, "number", "language");
 	GDVIRTUAL_BIND(_percent_sign, "language");
 
 	GDVIRTUAL_BIND(_strip_diacritics, "string");
@@ -349,29 +349,29 @@ void TextServerExtension::_bind_methods() {
 
 bool TextServerExtension::has_feature(Feature p_feature) const {
 	bool ret = false;
-	GDVIRTUAL_CALL(_has_feature, p_feature, ret);
+	GDVIRTUAL_REQUIRED_CALL(_has_feature, p_feature, ret);
 	return ret;
 }
 
 String TextServerExtension::get_name() const {
 	String ret = "Unknown";
-	GDVIRTUAL_CALL(_get_name, ret);
+	GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::get_features() const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_get_features, ret);
+	GDVIRTUAL_REQUIRED_CALL(_get_features, ret);
 	return ret;
 }
 
 void TextServerExtension::free_rid(const RID &p_rid) {
-	GDVIRTUAL_CALL(_free_rid, p_rid);
+	GDVIRTUAL_REQUIRED_CALL(_free_rid, p_rid);
 }
 
 bool TextServerExtension::has(const RID &p_rid) {
 	bool ret = false;
-	GDVIRTUAL_CALL(_has, p_rid, ret);
+	GDVIRTUAL_REQUIRED_CALL(_has, p_rid, ret);
 	return ret;
 }
 
@@ -407,14 +407,18 @@ bool TextServerExtension::is_locale_right_to_left(const String &p_locale) const 
 
 int64_t TextServerExtension::name_to_tag(const String &p_name) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_name_to_tag, p_name, ret);
-	return ret;
+	if (GDVIRTUAL_CALL(_name_to_tag, p_name, ret)) {
+		return ret;
+	}
+	return TextServer::name_to_tag(p_name);
 }
 
 String TextServerExtension::tag_to_name(int64_t p_tag) const {
 	String ret;
-	GDVIRTUAL_CALL(_tag_to_name, p_tag, ret);
-	return ret;
+	if (GDVIRTUAL_CALL(_tag_to_name, p_tag, ret)) {
+		return ret;
+	}
+	return TextServer::tag_to_name(p_tag);
 }
 
 /*************************************************************************/
@@ -423,7 +427,7 @@ String TextServerExtension::tag_to_name(int64_t p_tag) const {
 
 RID TextServerExtension::create_font() {
 	RID ret;
-	GDVIRTUAL_CALL(_create_font, ret);
+	GDVIRTUAL_REQUIRED_CALL(_create_font, ret);
 	return ret;
 }
 
@@ -452,7 +456,7 @@ int64_t TextServerExtension::font_get_face_index(const RID &p_font_rid) const {
 }
 
 int64_t TextServerExtension::font_get_face_count(const RID &p_font_rid) const {
-	int64_t ret = 0;
+	int64_t ret = 1;
 	GDVIRTUAL_CALL(_font_get_face_count, p_font_rid, ret);
 	return ret;
 }
@@ -574,22 +578,22 @@ int64_t TextServerExtension::font_get_msdf_size(const RID &p_font_rid) const {
 }
 
 void TextServerExtension::font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) {
-	GDVIRTUAL_CALL(_font_set_fixed_size, p_font_rid, p_fixed_size);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_fixed_size, p_font_rid, p_fixed_size);
 }
 
 int64_t TextServerExtension::font_get_fixed_size(const RID &p_font_rid) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_font_get_fixed_size, p_font_rid, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_fixed_size, p_font_rid, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_fixed_size_scale_mode(const RID &p_font_rid, TextServer::FixedSizeScaleMode p_fixed_size_scale_mode) {
-	GDVIRTUAL_CALL(_font_set_fixed_size_scale_mode, p_font_rid, p_fixed_size_scale_mode);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_fixed_size_scale_mode, p_font_rid, p_fixed_size_scale_mode);
 }
 
 TextServer::FixedSizeScaleMode TextServerExtension::font_get_fixed_size_scale_mode(const RID &p_font_rid) const {
 	FixedSizeScaleMode ret = FIXED_SIZE_SCALE_DISABLE;
-	GDVIRTUAL_CALL(_font_get_fixed_size_scale_mode, p_font_rid, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_fixed_size_scale_mode, p_font_rid, ret);
 	return ret;
 }
 
@@ -695,89 +699,89 @@ double TextServerExtension::font_get_oversampling(const RID &p_font_rid) const {
 
 TypedArray<Vector2i> TextServerExtension::font_get_size_cache_list(const RID &p_font_rid) const {
 	TypedArray<Vector2i> ret;
-	GDVIRTUAL_CALL(_font_get_size_cache_list, p_font_rid, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_size_cache_list, p_font_rid, ret);
 	return ret;
 }
 
 void TextServerExtension::font_clear_size_cache(const RID &p_font_rid) {
-	GDVIRTUAL_CALL(_font_clear_size_cache, p_font_rid);
+	GDVIRTUAL_REQUIRED_CALL(_font_clear_size_cache, p_font_rid);
 }
 
 void TextServerExtension::font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) {
-	GDVIRTUAL_CALL(_font_remove_size_cache, p_font_rid, p_size);
+	GDVIRTUAL_REQUIRED_CALL(_font_remove_size_cache, p_font_rid, p_size);
 }
 
 void TextServerExtension::font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) {
-	GDVIRTUAL_CALL(_font_set_ascent, p_font_rid, p_size, p_ascent);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_ascent, p_font_rid, p_size, p_ascent);
 }
 
 double TextServerExtension::font_get_ascent(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_font_get_ascent, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_ascent, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) {
-	GDVIRTUAL_CALL(_font_set_descent, p_font_rid, p_size, p_descent);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_descent, p_font_rid, p_size, p_descent);
 }
 
 double TextServerExtension::font_get_descent(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_font_get_descent, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_descent, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) {
-	GDVIRTUAL_CALL(_font_set_underline_position, p_font_rid, p_size, p_underline_position);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_underline_position, p_font_rid, p_size, p_underline_position);
 }
 
 double TextServerExtension::font_get_underline_position(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_font_get_underline_position, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_underline_position, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) {
-	GDVIRTUAL_CALL(_font_set_underline_thickness, p_font_rid, p_size, p_underline_thickness);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_underline_thickness, p_font_rid, p_size, p_underline_thickness);
 }
 
 double TextServerExtension::font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_font_get_underline_thickness, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_underline_thickness, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) {
-	GDVIRTUAL_CALL(_font_set_scale, p_font_rid, p_size, p_scale);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_scale, p_font_rid, p_size, p_scale);
 }
 
 double TextServerExtension::font_get_scale(const RID &p_font_rid, int64_t p_size) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_font_get_scale, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_scale, p_font_rid, p_size, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_font_get_texture_count, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_texture_count, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) {
-	GDVIRTUAL_CALL(_font_clear_textures, p_font_rid, p_size);
+	GDVIRTUAL_REQUIRED_CALL(_font_clear_textures, p_font_rid, p_size);
 }
 
 void TextServerExtension::font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) {
-	GDVIRTUAL_CALL(_font_remove_texture, p_font_rid, p_size, p_texture_index);
+	GDVIRTUAL_REQUIRED_CALL(_font_remove_texture, p_font_rid, p_size, p_texture_index);
 }
 
 void TextServerExtension::font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) {
-	GDVIRTUAL_CALL(_font_set_texture_image, p_font_rid, p_size, p_texture_index, p_image);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_texture_image, p_font_rid, p_size, p_texture_index, p_image);
 }
 
 Ref<Image> TextServerExtension::font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
 	Ref<Image> ret;
-	GDVIRTUAL_CALL(_font_get_texture_image, p_font_rid, p_size, p_texture_index, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_texture_image, p_font_rid, p_size, p_texture_index, ret);
 	return ret;
 }
 
@@ -793,77 +797,77 @@ PackedInt32Array TextServerExtension::font_get_texture_offsets(const RID &p_font
 
 PackedInt32Array TextServerExtension::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
 	PackedInt32Array ret;
-	GDVIRTUAL_CALL(_font_get_glyph_list, p_font_rid, p_size, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_list, p_font_rid, p_size, ret);
 	return ret;
 }
 
 void TextServerExtension::font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) {
-	GDVIRTUAL_CALL(_font_clear_glyphs, p_font_rid, p_size);
+	GDVIRTUAL_REQUIRED_CALL(_font_clear_glyphs, p_font_rid, p_size);
 }
 
 void TextServerExtension::font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) {
-	GDVIRTUAL_CALL(_font_remove_glyph, p_font_rid, p_size, p_glyph);
+	GDVIRTUAL_REQUIRED_CALL(_font_remove_glyph, p_font_rid, p_size, p_glyph);
 }
 
 Vector2 TextServerExtension::font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	GDVIRTUAL_CALL(_font_get_glyph_advance, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_advance, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) {
-	GDVIRTUAL_CALL(_font_set_glyph_advance, p_font_rid, p_size, p_glyph, p_advance);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_advance, p_font_rid, p_size, p_glyph, p_advance);
 }
 
 Vector2 TextServerExtension::font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	GDVIRTUAL_CALL(_font_get_glyph_offset, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_offset, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) {
-	GDVIRTUAL_CALL(_font_set_glyph_offset, p_font_rid, p_size, p_glyph, p_offset);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_offset, p_font_rid, p_size, p_glyph, p_offset);
 }
 
 Vector2 TextServerExtension::font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	GDVIRTUAL_CALL(_font_get_glyph_size, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_size, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) {
-	GDVIRTUAL_CALL(_font_set_glyph_size, p_font_rid, p_size, p_glyph, p_gl_size);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_size, p_font_rid, p_size, p_glyph, p_gl_size);
 }
 
 Rect2 TextServerExtension::font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Rect2 ret;
-	GDVIRTUAL_CALL(_font_get_glyph_uv_rect, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_uv_rect, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) {
-	GDVIRTUAL_CALL(_font_set_glyph_uv_rect, p_font_rid, p_size, p_glyph, p_uv_rect);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_uv_rect, p_font_rid, p_size, p_glyph, p_uv_rect);
 }
 
 int64_t TextServerExtension::font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_font_get_glyph_texture_idx, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_texture_idx, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 void TextServerExtension::font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) {
-	GDVIRTUAL_CALL(_font_set_glyph_texture_idx, p_font_rid, p_size, p_glyph, p_texture_idx);
+	GDVIRTUAL_REQUIRED_CALL(_font_set_glyph_texture_idx, p_font_rid, p_size, p_glyph, p_texture_idx);
 }
 
 RID TextServerExtension::font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	RID ret;
-	GDVIRTUAL_CALL(_font_get_glyph_texture_rid, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_texture_rid, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
 Size2 TextServerExtension::font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Size2 ret;
-	GDVIRTUAL_CALL(_font_get_glyph_texture_size, p_font_rid, p_size, p_glyph, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_texture_size, p_font_rid, p_size, p_glyph, ret);
 	return ret;
 }
 
@@ -899,25 +903,25 @@ Vector2 TextServerExtension::font_get_kerning(const RID &p_font_rid, int64_t p_s
 
 int64_t TextServerExtension::font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_font_get_glyph_index, p_font_rid, p_size, p_char, p_variation_selector, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_glyph_index, p_font_rid, p_size, p_char, p_variation_selector, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_font_get_char_from_glyph_index, p_font_rid, p_size, p_glyph_index, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_char_from_glyph_index, p_font_rid, p_size, p_glyph_index, ret);
 	return ret;
 }
 
 bool TextServerExtension::font_has_char(const RID &p_font_rid, int64_t p_char) const {
 	bool ret = false;
-	GDVIRTUAL_CALL(_font_has_char, p_font_rid, p_char, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_has_char, p_font_rid, p_char, ret);
 	return ret;
 }
 
 String TextServerExtension::font_get_supported_chars(const RID &p_font_rid) const {
 	String ret;
-	GDVIRTUAL_CALL(_font_get_supported_chars, p_font_rid, ret);
+	GDVIRTUAL_REQUIRED_CALL(_font_get_supported_chars, p_font_rid, ret);
 	return ret;
 }
 
@@ -930,11 +934,11 @@ void TextServerExtension::font_render_glyph(const RID &p_font_rid, const Vector2
 }
 
 void TextServerExtension::font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
-	GDVIRTUAL_CALL(_font_draw_glyph, p_font_rid, p_canvas, p_size, p_pos, p_index, p_color);
+	GDVIRTUAL_REQUIRED_CALL(_font_draw_glyph, p_font_rid, p_canvas, p_size, p_pos, p_index, p_color);
 }
 
 void TextServerExtension::font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
-	GDVIRTUAL_CALL(_font_draw_glyph_outline, p_font_rid, p_canvas, p_size, p_outline_size, p_pos, p_index, p_color);
+	GDVIRTUAL_REQUIRED_CALL(_font_draw_glyph_outline, p_font_rid, p_canvas, p_size, p_outline_size, p_pos, p_index, p_color);
 }
 
 bool TextServerExtension::font_is_language_supported(const RID &p_font_rid, const String &p_language) const {
@@ -1041,12 +1045,12 @@ void TextServerExtension::draw_hex_code_box(const RID &p_canvas, int64_t p_size,
 
 RID TextServerExtension::create_shaped_text(TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
 	RID ret;
-	GDVIRTUAL_CALL(_create_shaped_text, p_direction, p_orientation, ret);
+	GDVIRTUAL_REQUIRED_CALL(_create_shaped_text, p_direction, p_orientation, ret);
 	return ret;
 }
 
 void TextServerExtension::shaped_text_clear(const RID &p_shaped) {
-	GDVIRTUAL_CALL(_shaped_text_clear, p_shaped);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_clear, p_shaped);
 }
 
 void TextServerExtension::shaped_text_set_direction(const RID &p_shaped, TextServer::Direction p_direction) {
@@ -1131,47 +1135,47 @@ int64_t TextServerExtension::shaped_text_get_spacing(const RID &p_shaped, TextSe
 
 bool TextServerExtension::shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
 	bool ret = false;
-	GDVIRTUAL_CALL(_shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret);
 	return ret;
 }
 
 bool TextServerExtension::shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int64_t p_length, double p_baseline) {
 	bool ret = false;
-	GDVIRTUAL_CALL(_shaped_text_add_object, p_shaped, p_key, p_size, p_inline_align, p_length, p_baseline, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_add_object, p_shaped, p_key, p_size, p_inline_align, p_length, p_baseline, ret);
 	return ret;
 }
 
 bool TextServerExtension::shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, double p_baseline) {
 	bool ret = false;
-	GDVIRTUAL_CALL(_shaped_text_resize_object, p_shaped, p_key, p_size, p_inline_align, p_baseline, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_resize_object, p_shaped, p_key, p_size, p_inline_align, p_baseline, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_get_span_count(const RID &p_shaped) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_shaped_get_span_count, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_get_span_count, p_shaped, ret);
 	return ret;
 }
 
 Variant TextServerExtension::shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const {
 	Variant ret = false;
-	GDVIRTUAL_CALL(_shaped_get_span_meta, p_shaped, p_index, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_get_span_meta, p_shaped, p_index, ret);
 	return ret;
 }
 
 void TextServerExtension::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
-	GDVIRTUAL_CALL(_shaped_set_span_update_font, p_shaped, p_index, p_fonts, p_size, p_opentype_features);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_set_span_update_font, p_shaped, p_index, p_fonts, p_size, p_opentype_features);
 }
 
 RID TextServerExtension::shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const {
 	RID ret;
-	GDVIRTUAL_CALL(_shaped_text_substr, p_shaped, p_start, p_length, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_substr, p_shaped, p_start, p_length, ret);
 	return ret;
 }
 
 RID TextServerExtension::shaped_text_get_parent(const RID &p_shaped) const {
 	RID ret;
-	GDVIRTUAL_CALL(_shaped_text_get_parent, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_parent, p_shaped, ret);
 	return ret;
 }
 
@@ -1189,7 +1193,7 @@ double TextServerExtension::shaped_text_tab_align(const RID &p_shaped, const Pac
 
 bool TextServerExtension::shaped_text_shape(const RID &p_shaped) {
 	bool ret = false;
-	GDVIRTUAL_CALL(_shaped_text_shape, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_shape, p_shaped, ret);
 	return ret;
 }
 
@@ -1207,31 +1211,31 @@ bool TextServerExtension::shaped_text_update_justification_ops(const RID &p_shap
 
 bool TextServerExtension::shaped_text_is_ready(const RID &p_shaped) const {
 	bool ret = false;
-	GDVIRTUAL_CALL(_shaped_text_is_ready, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_is_ready, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_get_glyphs(const RID &p_shaped) const {
 	GDExtensionConstPtr<const Glyph> ret;
-	GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_glyphs, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_sort_logical(const RID &p_shaped) {
 	GDExtensionConstPtr<const Glyph> ret;
-	GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_sort_logical, p_shaped, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_glyph_count(const RID &p_shaped) const {
 	int64_t ret = 0;
-	GDVIRTUAL_CALL(_shaped_text_get_glyph_count, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_glyph_count, p_shaped, ret);
 	return ret;
 }
 
 Vector2i TextServerExtension::shaped_text_get_range(const RID &p_shaped) const {
 	Vector2i ret;
-	GDVIRTUAL_CALL(_shaped_text_get_range, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_range, p_shaped, ret);
 	return ret;
 }
 
@@ -1261,25 +1265,25 @@ PackedInt32Array TextServerExtension::shaped_text_get_word_breaks(const RID &p_s
 
 int64_t TextServerExtension::shaped_text_get_trim_pos(const RID &p_shaped) const {
 	int64_t ret = -1;
-	GDVIRTUAL_CALL(_shaped_text_get_trim_pos, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_trim_pos, p_shaped, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_ellipsis_pos(const RID &p_shaped) const {
 	int64_t ret = -1;
-	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const {
 	GDExtensionConstPtr<const Glyph> ret;
-	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const {
 	int64_t ret = -1;
-	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyph_count, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ellipsis_glyph_count, p_shaped, ret);
 	return ret;
 }
 
@@ -1289,61 +1293,61 @@ void TextServerExtension::shaped_text_overrun_trim_to_width(const RID &p_shaped_
 
 Array TextServerExtension::shaped_text_get_objects(const RID &p_shaped) const {
 	Array ret;
-	GDVIRTUAL_CALL(_shaped_text_get_objects, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_objects, p_shaped, ret);
 	return ret;
 }
 
 Rect2 TextServerExtension::shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const {
 	Rect2 ret;
-	GDVIRTUAL_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret);
 	return ret;
 }
 
 Vector2i TextServerExtension::shaped_text_get_object_range(const RID &p_shaped, const Variant &p_key) const {
 	Vector2i ret;
-	GDVIRTUAL_CALL(_shaped_text_get_object_range, p_shaped, p_key, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_object_range, p_shaped, p_key, ret);
 	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_object_glyph(const RID &p_shaped, const Variant &p_key) const {
 	int64_t ret = -1;
-	GDVIRTUAL_CALL(_shaped_text_get_object_glyph, p_shaped, p_key, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_object_glyph, p_shaped, p_key, ret);
 	return ret;
 }
 
 Size2 TextServerExtension::shaped_text_get_size(const RID &p_shaped) const {
 	Size2 ret;
-	GDVIRTUAL_CALL(_shaped_text_get_size, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_size, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_ascent(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_shaped_text_get_ascent, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_ascent, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_descent(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_shaped_text_get_descent, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_descent, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_width(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_shaped_text_get_width, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_width, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_underline_position(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_shaped_text_get_underline_position, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_underline_position, p_shaped, ret);
 	return ret;
 }
 
 double TextServerExtension::shaped_text_get_underline_thickness(const RID &p_shaped) const {
 	double ret = 0;
-	GDVIRTUAL_CALL(_shaped_text_get_underline_thickness, p_shaped, ret);
+	GDVIRTUAL_REQUIRED_CALL(_shaped_text_get_underline_thickness, p_shaped, ret);
 	return ret;
 }
 
@@ -1513,8 +1517,10 @@ String TextServerExtension::string_to_lower(const String &p_string, const String
 
 TypedArray<Vector3i> TextServerExtension::parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
 	TypedArray<Vector3i> ret;
-	GDVIRTUAL_CALL(_parse_structured_text, p_parser_type, p_args, p_text, ret);
-	return ret;
+	if (GDVIRTUAL_CALL(_parse_structured_text, p_parser_type, p_args, p_text, ret)) {
+		return ret;
+	}
+	return TextServer::parse_structured_text(p_parser_type, p_args, p_text);
 }
 
 PackedInt32Array TextServerExtension::string_get_word_breaks(const String &p_string, const String &p_language, int64_t p_chars_per_line) const {

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -642,6 +642,48 @@ void TextServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FIXED_SIZE_SCALE_ENABLED);
 }
 
+_FORCE_INLINE_ int32_t ot_tag_from_string(const char *p_str, int p_len) {
+	char tag[4];
+	uint32_t i;
+
+	if (!p_str || !p_len || !*p_str) {
+		return OT_TAG(0, 0, 0, 0);
+	}
+
+	if (p_len < 0 || p_len > 4) {
+		p_len = 4;
+	}
+	for (i = 0; i < (uint32_t)p_len && p_str[i]; i++) {
+		tag[i] = p_str[i];
+	}
+
+	for (; i < 4; i++) {
+		tag[i] = ' ';
+	}
+
+	return OT_TAG(tag[0], tag[1], tag[2], tag[3]);
+}
+
+int64_t TextServer::name_to_tag(const String &p_name) const {
+	// No readable name, use tag string.
+	return ot_tag_from_string(p_name.replace("custom_", "").ascii().get_data(), -1);
+}
+
+_FORCE_INLINE_ void ot_tag_to_string(int32_t p_tag, char *p_buf) {
+	p_buf[0] = (char)(uint8_t)(p_tag >> 24);
+	p_buf[1] = (char)(uint8_t)(p_tag >> 16);
+	p_buf[2] = (char)(uint8_t)(p_tag >> 8);
+	p_buf[3] = (char)(uint8_t)(p_tag >> 0);
+}
+
+String TextServer::tag_to_name(int64_t p_tag) const {
+	// No readable name, use tag string.
+	char name[5];
+	memset(name, 0, 5);
+	ot_tag_to_string(p_tag, name);
+	return String("custom_") + String(name);
+}
+
 Vector2 TextServer::get_hex_code_box_size(int64_t p_size, int64_t p_index) const {
 	int w = ((p_index <= 0xFF) ? 1 : ((p_index <= 0xFFFF) ? 2 : 3));
 	int sp = MAX(0, w - 1);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -43,6 +43,8 @@ class TypedArray;
 struct Glyph;
 struct CaretInfo;
 
+#define OT_TAG(m_c1, m_c2, m_c3, m_c4) ((int32_t)((((uint32_t)(m_c1) & 0xff) << 24) | (((uint32_t)(m_c2) & 0xff) << 16) | (((uint32_t)(m_c3) & 0xff) << 8) | ((uint32_t)(m_c4) & 0xff)))
+
 class TextServer : public RefCounted {
 	GDCLASS(TextServer, RefCounted);
 
@@ -239,8 +241,8 @@ public:
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const = 0;
 
-	virtual int64_t name_to_tag(const String &p_name) const { return 0; };
-	virtual String tag_to_name(int64_t p_tag) const { return ""; };
+	virtual int64_t name_to_tag(const String &p_name) const;
+	virtual String tag_to_name(int64_t p_tag) const;
 
 	/* Font interface */
 


### PR DESCRIPTION
- Adds `GDVIRTUAL_REQUIRED_CALL` to required methods.
- Updates extension docs.
- Updates dummy text server to implement required methods.
