### PR TITLE
[NativeMenu] Add checks to avoid unnecessary warnings.

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1590,6 +1590,10 @@
 		<member name="Marshalls" type="Marshalls" setter="" getter="">
 			The [Marshalls] singleton.
 		</member>
+		<member name="NativeMenu" type="NativeMenu" setter="" getter="">
+			The [NativeMenu] singleton.
+			[b]Note:[/b] Only implemented on macOS.
+		</member>
 		<member name="NavigationMeshGenerator" type="NavigationMeshGenerator" setter="" getter="">
 			The [NavigationMeshGenerator] singleton.
 		</member>

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -288,8 +288,8 @@ void MenuBar::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			NativeMenu *nmenu = NativeMenu::get_singleton();
-			RID main_menu = nmenu->get_system_menu(NativeMenu::MAIN_MENU_ID);
 			bool is_global = !global_menu_tag.is_empty();
+			RID main_menu = is_global ? nmenu->get_system_menu(NativeMenu::MAIN_MENU_ID) : RID();
 			for (int i = 0; i < menu_cache.size(); i++) {
 				shape(menu_cache.write[i]);
 				if (is_global && menu_cache[i].global_index >= 0) {
@@ -492,8 +492,8 @@ void MenuBar::shape(Menu &p_menu) {
 
 void MenuBar::_refresh_menu_names() {
 	NativeMenu *nmenu = NativeMenu::get_singleton();
-	RID main_menu = nmenu->get_system_menu(NativeMenu::MAIN_MENU_ID);
 	bool is_global = !global_menu_tag.is_empty();
+	RID main_menu = is_global ? nmenu->get_system_menu(NativeMenu::MAIN_MENU_ID) : RID();
 
 	Vector<PopupMenu *> popups = _get_popups();
 	for (int i = 0; i < popups.size(); i++) {

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -51,6 +51,8 @@ private:
 		return memnew(DisplayServerHeadless());
 	}
 
+	NativeMenu *native_menu = nullptr;
+
 public:
 	bool has_feature(Feature p_feature) const override { return false; }
 	String get_name() const override { return "headless"; }
@@ -132,8 +134,15 @@ public:
 
 	void set_icon(const Ref<Image> &p_icon) override {}
 
-	DisplayServerHeadless() {}
-	~DisplayServerHeadless() {}
+	DisplayServerHeadless() {
+		native_menu = memnew(NativeMenu);
+	}
+	~DisplayServerHeadless() {
+		if (native_menu) {
+			memdelete(native_menu);
+			native_menu = nullptr;
+		}
+	}
 };
 
 #endif // DISPLAY_SERVER_HEADLESS_H


### PR DESCRIPTION
Adds few checks missed in https://github.com/godotengine/godot/pull/87452, that can cause unnecessary warning messages if native menu is not supported.

*Added by @akien-mga:* Add dummy NativeMenu to DisplayServerHeadless, fixing crashes when using `--headless`.