### PR TITLE
Fix POT generation missing some strings when built-in ones are enabled

### DIFF
--- a/editor/SCsub
+++ b/editor/SCsub
@@ -104,6 +104,7 @@ if env.editor_build:
 
     # Extractable translations
     tlist = glob.glob(env.Dir("#editor/translations/extractable").abspath + "/*.po")
+    tlist.extend(glob.glob(env.Dir("#editor/translations/extractable").abspath + "/extractable.pot"))
     env.Depends("#editor/extractable_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/extractable_translations.gen.h",

--- a/editor/editor_translation.cpp
+++ b/editor/editor_translation.cpp
@@ -160,20 +160,22 @@ List<StringName> get_extractable_message_list() {
 	ExtractableTranslationList *etl = _extractable_translations;
 	List<StringName> msgids;
 	while (etl->data) {
-		Vector<uint8_t> data;
-		data.resize(etl->uncomp_size);
-		int ret = Compression::decompress(data.ptrw(), etl->uncomp_size, etl->data, etl->comp_size, Compression::MODE_DEFLATE);
-		ERR_FAIL_COND_V_MSG(ret == -1, msgids, "Compressed file is corrupt.");
+		if (!strcmp(etl->lang, "source")) {
+			Vector<uint8_t> data;
+			data.resize(etl->uncomp_size);
+			int ret = Compression::decompress(data.ptrw(), etl->uncomp_size, etl->data, etl->comp_size, Compression::MODE_DEFLATE);
+			ERR_FAIL_COND_V_MSG(ret == -1, msgids, "Compressed file is corrupt.");
 
-		Ref<FileAccessMemory> fa;
-		fa.instantiate();
-		fa->open_custom(data.ptr(), data.size());
+			Ref<FileAccessMemory> fa;
+			fa.instantiate();
+			fa->open_custom(data.ptr(), data.size());
 
-		Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
 
-		if (tr.is_valid()) {
-			tr->get_message_list(&msgids);
-			break;
+			if (tr.is_valid()) {
+				tr->get_message_list(&msgids);
+				break;
+			}
 		}
 
 		etl++;


### PR DESCRIPTION
Back when I was adding this feature to the editor, I assumed that the PO files still kept all message sources, even when they weren't translated. I was incorrect.

This PR now makes it grab the messages from the POT file itself, which needs https://github.com/godotengine/godot-editor-l10n/pull/19 to be merged in order to work. Having https://github.com/godotengine/godot-editor-l10n/pull/18 be merged too would also be appreciated.

It's a little hacky, as I'm not very experienced with SCons. I welcome suggestions to make the code better.