### PR TITLE
Refactor OS exit code to be `EXIT_SUCCESS` by default

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -56,7 +56,8 @@ class OS {
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
 	String _local_clipboard;
-	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
+	// Assume success by default, all failure cases need to set EXIT_FAILURE explicitly.
+	int _exit_code = EXIT_SUCCESS;
 	bool _allow_hidpi = false;
 	bool _allow_layered = false;
 	bool _stdout_enabled = true;

--- a/main/main.h
+++ b/main/main.h
@@ -78,7 +78,7 @@ public:
 	static Error test_setup();
 	static void test_cleanup();
 #endif
-	static bool start();
+	static int start();
 
 	static bool iteration();
 	static void force_redraw();

--- a/platform/ios/godot_ios.mm
+++ b/platform/ios/godot_ios.mm
@@ -102,15 +102,16 @@ int ios_main(int argc, char **argv) {
 
 	Error err = Main::setup(fargv[0], argc - 1, &fargv[1], false);
 
-	if (err == ERR_HELP) { // Returned by --help and --version, so success.
-		return 0;
-	} else if (err != OK) {
-		return 255;
+	if (err != OK) {
+		if (err == ERR_HELP) { // Returned by --help and --version, so success.
+			return EXIT_SUCCESS;
+		}
+		return EXIT_FAILURE;
 	}
 
 	os->initialize_modules();
 
-	return 0;
+	return os->get_exit_code();
 }
 
 void ios_finish() {

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -72,18 +72,19 @@ int main(int argc, char *argv[]) {
 	char *ret = getcwd(cwd, PATH_MAX);
 
 	Error err = Main::setup(argv[0], argc - 1, &argv[1]);
+
 	if (err != OK) {
 		free(cwd);
-
 		if (err == ERR_HELP) { // Returned by --help and --version, so success.
-			return 0;
+			return EXIT_SUCCESS;
 		}
-		return 255;
+		return EXIT_FAILURE;
 	}
 
-	if (Main::start()) {
-		os.set_exit_code(EXIT_SUCCESS);
-		os.run(); // it is actually the OS that decides how to run
+	if (Main::start() == EXIT_SUCCESS) {
+		os.run();
+	} else {
+		os.set_exit_code(EXIT_FAILURE);
 	}
 	Main::cleanup();
 

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -69,18 +69,21 @@ int main(int argc, char **argv) {
 		err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
 	}
 
-	if (err == ERR_HELP) { // Returned by --help and --version, so success.
-		return 0;
-	} else if (err != OK) {
-		return 255;
+	if (err != OK) {
+		if (err == ERR_HELP) { // Returned by --help and --version, so success.
+			return EXIT_SUCCESS;
+		}
+		return EXIT_FAILURE;
 	}
 
-	bool ok;
+	int ret;
 	@autoreleasepool {
-		ok = Main::start();
+		ret = Main::start();
 	}
-	if (ok) {
-		os.run(); // It is actually the OS that decides how to run.
+	if (ret) {
+		os.run();
+	} else {
+		os.set_exit_code(EXIT_FAILURE);
 	}
 
 	@autoreleasepool {

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -171,13 +171,15 @@ int widechar_main(int argc, wchar_t **argv) {
 		delete[] argv_utf8;
 
 		if (err == ERR_HELP) { // Returned by --help and --version, so success.
-			return 0;
+			return EXIT_SUCCESS;
 		}
-		return 255;
+		return EXIT_FAILURE;
 	}
 
-	if (Main::start()) {
+	if (Main::start() == EXIT_SUCCESS) {
 		os.run();
+	} else {
+		os.set_exit_code(EXIT_FAILURE);
 	}
 	Main::cleanup();
 


### PR DESCRIPTION
We've had a number of issues and PRs in the past few years following #38929, which aimed at solving #30207. The issue was that Godot defaulted to a success exit code, so if any error condition that cause interruption of the process failed to set the error code properly, it would go unnoticed in systems that rely on error codes (like CI to mark the job as failed).

This caused a number of situations where Godot would wrongly report a failure code on exit, even though it's not failing. This was most prominent with the Linux headless build used on CI, leading to issue #62898 which was fixed by #67421. And a number of other PRs to fix special cases for command line options which were still wrongly treated as success or failure (e.g. `--help` and `--version` have been special cased).

But now Godot can run headless on any platform, so since the fix in #67421 was Linux specific, it doesn't work when doing e.g. command line import and exports on Windows or macOS. PRs #81518 and #83479 aim to work this around but they're again only workarounds, and we've been piling workarounds long enough already.

Time to go back to the drawing board and fix our exit code propagation.

So after discussing with @mihe and @reduz I drafted this to see how to clean things up, go back to `EXIT_SUCCESS` as the default exit code, and see how to ensure that all early exits/aborts will properly go through a pass that sets `EXIT_FAILURE` or another non-zero error code.

We still need to dig through all the reported issues and PRs, closed and open, and make sure that this doesn't regress in any situation. There's some good discussion in https://github.com/godotengine/godot/pull/81518#discussion_r1320836149 which should be continued here. We need to make test cases so we can have confidence about this approach.

To be clear, this may well turn out to be a wrong approach too, as @touilleMan flagged in #81518. We'll have to see if we can solve the other types of problems this approach would raise in a better way, or stick to defaulting to `EXIT_FAILURE` but make it more robust.

Some details about the `main.cpp` changes:

- `Main::setup` early exits (failure or `--help`/`--version`) now
  consistently return `EXIT_FAILURE` or `EXIT_SUCCESS` on all platforms,
  instead of 255 on some and a Godot Error code on others.
- `Main::start` now returns the exit code, simplifying the handling of early
  failures.
- `Main::iteration` needs to explicit set the exit code in OS if it errors
  out.
- Web and iOS now properly return `OS::get_exit_code()` instead of 0.
---

- Supersedes #81518.
- Supersedes #83479 (and doesn't seem to introduce the bug @Calinou outlined in https://github.com/godotengine/godot/pull/83479#pullrequestreview-1740045770).
- Should fix #83449, but needs testing.
- Fixes #88055.
- Reverts #67421.
- Doesn't seem to reintroduce #30207.
  * I tested scenarios where no main scene is defined, or the main scene points to a missing file.
  * I'm not sure how to reproduce the actual problem from the OP in #30207. It seemed to be a bug in export templates in 3.1 days, trying the same project on 3.5 or 4.3 doesn't terminate the Godot process, so there's no reason for the exit code to be non-zero.
  * Help welcome to identify other test cases for this.
- Doesn't reintroduce #62898 on Linux.
  * Worth testing on Windows and macOS too, help welcome there as I mostly use Linux.
- Related to https://github.com/godotengine/godot-proposals/issues/7557 (doesn't solve it).
- There might be more issues/PRs to consider while checking if this PR is a good approach. Please help me by linking them :)

CC @touilleMan @mihe @reduz @dalexeev @InfinitiesLoop @dreed-sd @ePirat