### PR TITLE
Fix audio listener crash in stream player

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -140,6 +140,7 @@ void AudioStreamPlayer2D::_update_panning() {
 
 		//screen in global is used for attenuation
 		AudioListener2D *listener = vp->get_audio_listener_2d();
+		ERR_FAIL_NULL(listener);
 		Transform2D full_canvas_transform = vp->get_global_canvas_transform() * vp->get_canvas_transform();
 		if (listener) {
 			listener_in_global = listener->get_global_position();


### PR DESCRIPTION
Fixes the crash in #89212
This is probably a deeper issue though. `is_audio_listener_2d()` is supposed to ensure that listener exists, but it doesn't. Maybe there is some threading involved here.
The problem seems to exist only in 2D.