### PR TITLE
Fix reporting exit code when command line export fails

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -995,7 +995,9 @@ void EditorNode::_fs_changed() {
 		if (err != OK) {
 			ERR_PRINT(export_error);
 			_exit_editor(EXIT_FAILURE);
-		} else if (!export_error.is_empty()) {
+			return;
+		}
+		if (!export_error.is_empty()) {
 			WARN_PRINT(export_error);
 		}
 		_exit_editor(EXIT_SUCCESS);


### PR DESCRIPTION
- Fixes #83042.

See https://github.com/godotengine/godot/pull/89229#issuecomment-1981987490 for the reasoning that led me there... turns out it was a simple issue of wrong use of `if` / `else` branches...