### PR TITLE
Add `FolderCreate` icon to the project dialog

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -772,6 +772,10 @@ void ProjectDialog::show_dialog() {
 
 void ProjectDialog::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			create_dir->set_icon(get_editor_theme_icon(SNAME("FolderCreate")));
+		} break;
+
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			_remove_created_folder();
 		} break;


### PR DESCRIPTION
Adds the `FolderCreate` icon (![FolderCreate](https://github.com/godotengine/godot/assets/270928/d0caa1a4-8c44-466a-8a40-2a33b91d3c78)) to the "Create Folder" button inside the "Create a project" dialog.

| Before | After |
| :--: | :--: |
| ![Capture d’écran du 2024-03-06 21-36-34](https://github.com/godotengine/godot/assets/270928/cb6ee63d-e2b6-48a6-a19f-5dc11ff4b218) | ![Capture d’écran du 2024-03-06 21-35-13](https://github.com/godotengine/godot/assets/270928/84d0d21d-e8f8-46be-a883-26e502d838a4) |

See https://github.com/godotengine/godot/pull/88825#issuecomment-1981861105 for more details about the choice of the combined text and icon.

Follow up to #88825