### PR TITLE
Fix region section not ignoring #region and #endregion when in a string

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1861,12 +1861,18 @@ bool CodeEdit::is_line_code_region_start(int p_line) const {
 	if (code_region_start_string.is_empty()) {
 		return false;
 	}
+	if (is_in_string(p_line) != -1) {
+		return false;
+	}
 	return get_line(p_line).strip_edges().begins_with(code_region_start_string);
 }
 
 bool CodeEdit::is_line_code_region_end(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, get_line_count(), false);
 	if (code_region_start_string.is_empty()) {
+		return false;
+	}
+	if (is_in_string(p_line) != -1) {
 		return false;
 	}
 	return get_line(p_line).strip_edges().begins_with(code_region_end_string);

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3048,6 +3048,28 @@ TEST_CASE("[SceneTree][CodeEdit] region folding") {
 		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
 		code_edit->unfold_line(1);
 		CHECK_FALSE(code_edit->is_line_folded(0));
+
+		// Region start and end tags are ignored if in a string and at the start of the line.
+		code_edit->clear_comment_delimiters();
+		code_edit->add_comment_delimiter("#", "");
+		code_edit->clear_string_delimiters();
+		code_edit->add_string_delimiter("\"", "\"");
+		code_edit->set_text("#region region_name1\nline2\n\"\n#region region_name2\n#endregion\n\"\n#endregion\nvisible");
+		CHECK(code_edit->is_line_code_region_start(0));
+		CHECK(code_edit->is_line_code_region_end(6));
+		CHECK(code_edit->can_fold_line(0));
+		for (int i = 1; i < 7; i++) {
+			if (i == 2) {
+				continue;
+			}
+			CHECK_FALSE(code_edit->can_fold_line(i));
+		}
+		for (int i = 0; i < 7; i++) {
+			CHECK_FALSE(code_edit->is_line_folded(i));
+		}
+		code_edit->fold_line(0);
+		CHECK(code_edit->is_line_folded(0));
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 7);
 	}
 
 	memdelete(code_edit);


### PR DESCRIPTION
When using the script editor, if the keywords #region and #endregion where in a string and at the start of the line, the editor would not ignore them and count them as the actual keywords, which when folded, would only fold until the first #endregion in a string, for example.

By checking if these keywords were in a string, this commit now ensures the editor ignores strings and fold the section correctly.

Fixes #89115.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
