### PR TITLE
[Docs] [C#] Use `PropertyName` constants in more places

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -643,7 +643,7 @@
 				[csharp]
 				var node = new Node2D();
 				node.Rotation = 1.5f;
-				var a = node.Get("rotation"); // a is 1.5
+				var a = node.Get(Node2D.PropertyName.Rotation); // a is 1.5
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties. Prefer using the names exposed in the [code]PropertyName[/code] class to avoid allocating a new [StringName] on each call.
@@ -911,7 +911,7 @@
 				[/gdscript]
 				[csharp]
 				var node = new Node2D();
-				node.Set("global_scale", new Vector2(8, 2.5));
+				node.Set(Node2D.PropertyName.GlobalScale, new Vector2(8, 2.5));
 				GD.Print(node.GlobalScale); // Prints Vector2(8, 2.5)
 				[/csharp]
 				[/codeblocks]
@@ -936,21 +936,21 @@
 				var node = Node2D.new()
 				add_child(node)
 
-				node.rotation = 45.0
-				node.set_deferred("rotation", 90.0)
-				print(node.rotation) # Prints 45.0
+				node.rotation = 1.5
+				node.set_deferred("rotation", 3.0)
+				print(node.rotation) # Prints 1.5
 
 				await get_tree().process_frame
-				print(node.rotation) # Prints 90.0
+				print(node.rotation) # Prints 3.0
 				[/gdscript]
 				[csharp]
 				var node = new Node2D();
-				node.Rotation = 45f;
-				node.SetDeferred("rotation", 90f);
-				GD.Print(node.Rotation); // Prints 45.0
+				node.Rotation = 1.5f;
+				node.SetDeferred(Node2D.PropertyName.Rotation, 3f);
+				GD.Print(node.Rotation); // Prints 1.5
 
 				await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
-				GD.Print(node.Rotation); // Prints 90.0
+				GD.Print(node.Rotation); // Prints 3.0
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties. Prefer using the names exposed in the [code]PropertyName[/code] class to avoid allocating a new [StringName] on each call.


### PR DESCRIPTION
Also fixed units for the `rotation` example, not entirely critical but could be confusing as it's not in degrees

Didn't touch the `_indexed` methods as they use both plain paths and sub-paths, unsure how to deal with those

Could add it to `Tween` as well but it doesn't have as clear a connection with any one class, added these to where there were already a note about using the `PropertyName` feature
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
