### PR TITLE
Don't store values when loading them

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -324,6 +324,7 @@ void EditorDebuggerNode::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			_update_debug_options();
+			initializing = false;
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -535,7 +536,9 @@ void EditorDebuggerNode::_menu_option(int p_id) {
 			bool ischecked = script_menu->get_popup()->is_item_checked(script_menu->get_popup()->get_item_index(DEBUG_WITH_EXTERNAL_EDITOR));
 			debug_with_external_editor = !ischecked;
 			script_menu->get_popup()->set_item_checked(script_menu->get_popup()->get_item_index(DEBUG_WITH_EXTERNAL_EDITOR), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "debug_with_external_editor", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "debug_with_external_editor", !ischecked);
+			}
 		} break;
 	}
 }

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -102,6 +102,7 @@ private:
 
 	Ref<Script> stack_script; // Why?!?
 
+	bool initializing = true;
 	int last_error_count = 0;
 	int last_warning_count = 0;
 

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -129,7 +129,8 @@ void EditorPropertyVectorN::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			if (linked->is_visible()) {
 				const String key = vformat("%s:%s", get_edited_object()->get_class(), get_edited_property());
-				linked->set_pressed(EditorSettings::get_singleton()->get_project_metadata("linked_properties", key, true));
+				linked->set_pressed_no_signal(EditorSettings::get_singleton()->get_project_metadata("linked_properties", key, true));
+				_update_ratio();
 			}
 		} break;
 

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -124,7 +124,9 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			}
 
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_FILE_SERVER), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
+			}
 
 		} break;
 		case RUN_LIVE_DEBUG: {
@@ -132,43 +134,57 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_LIVE_DEBUG), !ischecked);
 			EditorDebuggerNode::get_singleton()->set_live_debugging(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_live_debug", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_live_debug", !ischecked);
+			}
 
 		} break;
 		case RUN_DEPLOY_REMOTE_DEBUG: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEPLOY_REMOTE_DEBUG));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEPLOY_REMOTE_DEBUG), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_deploy_remote_debug", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_deploy_remote_debug", !ischecked);
+			}
 
 		} break;
 		case RUN_DEBUG_COLLISIONS: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_COLLISIONS));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_COLLISIONS), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_collisions", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_collisions", !ischecked);
+			}
 
 		} break;
 		case RUN_DEBUG_PATHS: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_paths", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_paths", !ischecked);
+			}
 
 		} break;
 		case RUN_DEBUG_NAVIGATION: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_NAVIGATION));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
+			}
 
 		} break;
 		case RUN_DEBUG_AVOIDANCE: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_AVOIDANCE));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_AVOIDANCE), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_avoidance", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_avoidance", !ischecked);
+			}
 
 		} break;
 		case RUN_DEBUG_CANVAS_REDRAW: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_CANVAS_REDRAW));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_CANVAS_REDRAW), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_canvas_redraw", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_canvas_redraw", !ischecked);
+			}
 
 		} break;
 		case RUN_RELOAD_SCRIPTS: {
@@ -176,7 +192,9 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_RELOAD_SCRIPTS), !ischecked);
 
 			ScriptEditor::get_singleton()->set_live_auto_reload_running_scripts(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_reload_scripts", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_reload_scripts", !ischecked);
+			}
 
 		} break;
 		case SERVER_KEEP_OPEN: {
@@ -184,7 +202,9 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			debug_menu->set_item_checked(debug_menu->get_item_index(SERVER_KEEP_OPEN), !ischecked);
 
 			EditorDebuggerNode::get_singleton()->set_keep_open(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "server_keep_open", !ischecked);
+			if (!initializing) {
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "server_keep_open", !ischecked);
+			}
 
 		} break;
 		case RUN_MULTIPLE_INSTANCES: {
@@ -198,6 +218,7 @@ void DebuggerEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			_update_debug_options();
+			initializing = false;
 		} break;
 
 		case NOTIFICATION_PROCESS: {

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -60,6 +60,8 @@ private:
 		RUN_MULTIPLE_INSTANCES,
 	};
 
+	bool initializing = true;
+
 	void _update_debug_options();
 	void _notification(int p_what);
 	void _menu_option(int p_option);

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -674,6 +674,11 @@ void GenericTilePolygonEditor::_set_snap_option(int p_index) {
 	current_snap_option = p_index;
 	button_pixel_snap->set_icon(button_pixel_snap->get_popup()->get_item_icon(p_index));
 	snap_subdivision->set_visible(p_index == SNAP_GRID);
+
+	if (initializing) {
+		return;
+	}
+
 	base_control->queue_redraw();
 	_store_snap_options();
 }
@@ -953,6 +958,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 
 	snap_subdivision->set_value_no_signal(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_snap_subdiv", 4));
 	_set_snap_option(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_snap_option", SNAP_NONE));
+	initializing = false;
 }
 
 void TileDataDefaultEditor::_property_value_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field) {

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -140,6 +140,7 @@ private:
 	EditorZoomWidget *editor_zoom_widget = nullptr;
 	Button *button_center_view = nullptr;
 	Vector2 panning;
+	bool initializing = true;
 
 	Ref<Texture2D> background_texture;
 	Rect2 background_region;

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -357,7 +357,10 @@ void TileSetEditor::_set_source_sort(int p_sort) {
 		}
 	}
 	_update_sources_list(old_selected);
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_source_sort", p_sort);
+
+	if (!first_edit) {
+		EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_source_sort", p_sort);
+	}
 }
 
 void TileSetEditor::_notification(int p_what) {
@@ -738,8 +741,8 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 
 		tile_set->connect_changed(callable_mp(this, &TileSetEditor::_tile_set_changed));
 		if (first_edit) {
-			first_edit = false;
 			_set_source_sort(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_source_sort", 0));
+			first_edit = false;
 		} else {
 			_update_sources_list();
 		}


### PR DESCRIPTION
I noticed some editor parts will read project metadata config and immediately write it to the same value, which is a faulty logic. This PR fixes all cases I could easily find.