### PR TITLE
Allow connecting signals to existing methods without opening the script editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1014,6 +1014,9 @@
 		<member name="text_editor/behavior/navigation/move_caret_on_right_click" type="bool" setter="" getter="">
 			If [code]true[/code], the caret will be moved when right-clicking somewhere in the script editor (like when left-clicking or middle-clicking). If [code]false[/code], the caret will only be moved when left-clicking or middle-clicking somewhere.
 		</member>
+		<member name="text_editor/behavior/navigation/open_script_when_connecting_signal_to_existing_method" type="bool" setter="" getter="">
+			If [code]true[/code], opens the script editor when connecting a signal to an existing script method from the Node dock.
+		</member>
 		<member name="text_editor/behavior/navigation/scroll_past_end_of_file" type="bool" setter="" getter="">
 			If [code]true[/code], allows scrolling past the end of the file.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -626,6 +626,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/navigation/v_scroll_speed", 80, "1,10000,1")
 	_initial_set("text_editor/behavior/navigation/drag_and_drop_selection", true);
 	_initial_set("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected", true);
+	_initial_set("text_editor/behavior/navigation/open_script_when_connecting_signal_to_existing_method", true);
 
 	// Behavior: Indent
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8351

Adds an editor setting to prevent the script editor from opening when connecting a signal to an existing method

<img width="933" alt="Screenshot 2024-03-08 at 03 40 27" src="https://github.com/godotengine/godot/assets/60579014/c519c09f-7ce5-44ff-9e8b-a0404c02a3ad">

Note that script editor opening when connecting to an existing method [was a bug](https://github.com/godotengine/godot-proposals/issues/8351#issuecomment-1893996727), but we're preserving that behavior by default

_EDIT: Switched from doing this by holding Ctrl when pressing Connect to an editor setting_