### PR TITLE
Speed up inspector updates for TileMap

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -425,7 +425,7 @@ RID Resource::get_rid() const {
 
 #ifdef TOOLS_ENABLED
 
-uint32_t Resource::hash_edited_version() const {
+uint32_t Resource::hash_edited_version_for_preview() const {
 	uint32_t hash = hash_murmur3_one_32(get_edited_version());
 
 	List<PropertyInfo> plist;
@@ -435,7 +435,7 @@ uint32_t Resource::hash_edited_version() const {
 		if (E.usage & PROPERTY_USAGE_STORAGE && E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 			Ref<Resource> res = get(E.name);
 			if (res.is_valid()) {
-				hash = hash_murmur3_one_32(res->hash_edited_version(), hash);
+				hash = hash_murmur3_one_32(res->hash_edited_version_for_preview(), hash);
 			}
 		}
 	}

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -125,7 +125,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 
-	uint32_t hash_edited_version() const;
+	virtual uint32_t hash_edited_version_for_preview() const;
 
 	virtual void set_last_modified_time(uint64_t p_time) { last_modified_time = p_time; }
 	uint64_t get_last_modified_time() const { return last_modified_time; }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2009,6 +2009,10 @@ Array EditorInspectorArray::_extract_properties_as_array(const List<PropertyInfo
 	Array output;
 
 	for (const PropertyInfo &pi : p_list) {
+		if (!(pi.usage & PROPERTY_USAGE_EDITOR)) {
+			continue;
+		}
+
 		if (pi.name.begins_with(array_element_prefix)) {
 			String str = pi.name.trim_prefix(array_element_prefix);
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -269,7 +269,7 @@ void EditorResourcePreview::_iterate() {
 	if (item.resource.is_valid()) {
 		Dictionary preview_metadata;
 		_generate_preview(texture, small_texture, item, String(), preview_metadata);
-		_preview_ready(item.path, item.resource->hash_edited_version(), texture, small_texture, item.id, item.function, item.userdata, preview_metadata);
+		_preview_ready(item.path, item.resource->hash_edited_version_for_preview(), texture, small_texture, item.id, item.function, item.userdata, preview_metadata);
 		return;
 	}
 
@@ -407,7 +407,7 @@ void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p
 
 		String path_id = "ID:" + itos(p_res->get_instance_id());
 
-		if (cache.has(path_id) && cache[path_id].last_hash == p_res->hash_edited_version()) {
+		if (cache.has(path_id) && cache[path_id].last_hash == p_res->hash_edited_version_for_preview()) {
 			cache[path_id].order = order++;
 			p_receiver->call(p_receiver_func, path_id, cache[path_id].preview, cache[path_id].small_preview, p_userdata);
 			return;

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -299,6 +299,10 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _validate_property(PropertyInfo &p_property) const;
 
+#ifdef TOOLS_ENABLED
+	virtual uint32_t hash_edited_version_for_preview() const override { return 0; } // Not using preview, so disable it for performance.
+#endif
+
 private:
 	// --- TileSet data ---
 	// Basic shape and layout.


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/godotengine/godot/pull/89179#issuecomment-1979027735 (it also applies to current TileMap, but somehow it's less visible)

The main culprits were TileSet hashing all its sources for generating preview and EditorInspectorArray trying to show `tile_data`.