### PR TITLE
Make Overdraw, Lighting and Shadow Splits debug draw modes ignore decals

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4075,7 +4075,7 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 		scene_globals.default_shader = material_storage->shader_allocate();
 		material_storage->shader_initialize(scene_globals.default_shader);
 		material_storage->shader_set_code(scene_globals.default_shader, R"(
-// Default 3D material shader.
+// Default 3D material shader (Compatibility).
 
 shader_type spatial;
 
@@ -4100,11 +4100,11 @@ void fragment() {
 		scene_globals.overdraw_shader = material_storage->shader_allocate();
 		material_storage->shader_initialize(scene_globals.overdraw_shader);
 		material_storage->shader_set_code(scene_globals.overdraw_shader, R"(
-// 3D editor Overdraw debug draw mode shader.
+// 3D editor Overdraw debug draw mode shader (Compatibility).
 
 shader_type spatial;
 
-render_mode blend_add, unshaded;
+render_mode blend_add, unshaded, fog_disabled;
 
 void fragment() {
 	ALBEDO = vec3(0.4, 0.8, 0.8);

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -737,7 +737,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		default_shader = material_storage->shader_allocate();
 		material_storage->shader_initialize(default_shader);
 		material_storage->shader_set_code(default_shader, R"(
-// Default 3D material shader (clustered).
+// Default 3D material shader (Forward+).
 
 shader_type spatial;
 
@@ -768,11 +768,11 @@ void fragment() {
 		material_storage->shader_initialize(overdraw_material_shader);
 		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
 		material_storage->shader_set_code(overdraw_material_shader, R"(
-// 3D editor Overdraw debug draw mode shader (clustered).
+// 3D editor Overdraw debug draw mode shader (Forward+).
 
 shader_type spatial;
 
-render_mode blend_add, unshaded;
+render_mode blend_add, unshaded, fog_disabled;
 
 void fragment() {
 	ALBEDO = vec3(0.4, 0.8, 0.8);
@@ -792,11 +792,11 @@ void fragment() {
 		debug_shadow_splits_material_shader = material_storage->shader_allocate();
 		material_storage->shader_initialize(debug_shadow_splits_material_shader);
 		material_storage->shader_set_code(debug_shadow_splits_material_shader, R"(
-// 3D debug shadow splits mode shader(mobile).
+// 3D debug shadow splits mode shader (Forward+).
 
 shader_type spatial;
 
-render_mode debug_shadow_splits;
+render_mode debug_shadow_splits, fog_disabled;
 
 void fragment() {
 	ALBEDO = vec3(1.0, 1.0, 1.0);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -641,7 +641,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		default_shader = material_storage->shader_allocate();
 		material_storage->shader_initialize(default_shader);
 		material_storage->shader_set_code(default_shader, R"(
-// Default 3D material shader (mobile).
+// Default 3D material shader (Mobile).
 
 shader_type spatial;
 
@@ -671,11 +671,11 @@ void fragment() {
 		material_storage->shader_initialize(overdraw_material_shader);
 		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
 		material_storage->shader_set_code(overdraw_material_shader, R"(
-// 3D editor Overdraw debug draw mode shader (mobile).
+// 3D editor Overdraw debug draw mode shader (Mobile).
 
 shader_type spatial;
 
-render_mode blend_add, unshaded;
+render_mode blend_add, unshaded, fog_disabled;
 
 void fragment() {
 	ALBEDO = vec3(0.4, 0.8, 0.8);
@@ -696,11 +696,11 @@ void fragment() {
 		material_storage->shader_initialize(debug_shadow_splits_material_shader);
 		// Use relatively low opacity so that more "layers" of overlapping objects can be distinguished.
 		material_storage->shader_set_code(debug_shadow_splits_material_shader, R"(
-// 3D debug shadow splits mode shader(mobile).
+// 3D debug shadow splits mode shader (Mobile).
 
 shader_type spatial;
 
-render_mode debug_shadow_splits;
+render_mode debug_shadow_splits, fog_disabled;
 
 void fragment() {
 	ALBEDO = vec3(1.0, 1.0, 1.0);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1153,10 +1153,17 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 
 	PagedArray<RID> empty;
 
-	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_UNSHADED) {
+	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_UNSHADED || get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW) {
 		render_data.lights = &empty;
 		render_data.reflection_probes = &empty;
 		render_data.voxel_gi_instances = &empty;
+	}
+
+	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_UNSHADED ||
+			get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW ||
+			get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_LIGHTING ||
+			get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_PSSM_SPLITS) {
+		render_data.decals = &empty;
 	}
 
 	Color clear_color;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/89235.

This also makes the Overdraw and Shadow Splits debug draw modes ignore fog. The Lighting debug draw mode still displays fog as that debug draw mode is intended to preview scene lighting, and fog has an impact on how lighting is perceived.

- This closes https://github.com/godotengine/godot/issues/88773.

**Testing project:** [test_debug_draw_modes_decals.zip](https://github.com/godotengine/godot/files/14516943/test_debug_draw_modes_decals.zip)

## Preview

*Same appearance as https://github.com/godotengine/godot/pull/89235, although it's not possible to exclude specific materials from receiving decals with this PR (so ignore the cyan toruses here).*

### Forward+

Normal | Overdraw | Lighting | Shadow Splits
-|-|-|-
| | |
![Screenshot_20240307_004452](https://github.com/godotengine/godot/assets/180032/b4dbf1a8-1ea6-4605-bb6b-3913d084c26f) | ![Screenshot_20240307_004457](https://github.com/godotengine/godot/assets/180032/714605aa-1c3c-4616-a3e9-5d3e39ba6acc) | ![Screenshot_20240307_005526](https://github.com/godotengine/godot/assets/180032/e771fce1-40af-47cf-999c-12da9ee0d230) | ![Screenshot_20240307_004508](https://github.com/godotengine/godot/assets/180032/75429f21-922c-4efb-9313-6b10ead6730c)

### Mobile

Normal | Overdraw | Lighting | Shadow Splits
-|-|-|-
| | |
![Screenshot_20240307_005648](https://github.com/godotengine/godot/assets/180032/987f5a8a-70ac-4960-8ce6-9982e76d4989) | ![Screenshot_20240307_005654](https://github.com/godotengine/godot/assets/180032/d30d901b-a276-4e07-9492-56da29628383) | ![Screenshot_20240307_005659](https://github.com/godotengine/godot/assets/180032/18ccbc2f-bd66-46de-b85c-d5f62a6116b3) | ![Screenshot_20240307_005706](https://github.com/godotengine/godot/assets/180032/acb21b74-b58f-435d-bf3f-3cdf67ec76f4)

### Compatibility

Normal | Overdraw | Lighting | Shadow Splits[^1]
-|-|-|-
![Screenshot_20240307_005847](https://github.com/godotengine/godot/assets/180032/21ce102d-b13f-4759-8680-8ea69c055179) | ![Screenshot_20240307_005933](https://github.com/godotengine/godot/assets/180032/0422d8e5-4020-4fa5-a37e-e3638375606f) | ![Screenshot_20240307_005939](https://github.com/godotengine/godot/assets/180032/42628362-367f-4b0f-8666-cde202b838d0) | ![Not available](https://placehold.co/1152x648?text=Not%20available)

[^1]: Directional Shadow Splits debug draw mode isn't implemented in the Compatibility rendering method.
