### PR TITLE
Fix how scripts reload outside of ScriptEditor

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -204,6 +204,7 @@ Error Resource::copy_from(const Ref<Resource> &p_resource) {
 	}
 	return OK;
 }
+
 void Resource::reload_from_file() {
 	String path = get_path();
 	if (!path.is_resource_file()) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -34,6 +34,7 @@
 #include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/io/resource_loader.h"
 
 #include <stdint.h>
 
@@ -152,6 +153,24 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
+}
+
+void Script::reload_from_file() {
+#ifdef TOOLS_ENABLED
+	// Replicates how the ScriptEditor reloads script resources, which generally handles it.
+	// However, when scripts are to be reloaded but aren't open in the internal editor, we go through here instead.
+	const Ref<Script> rel = ResourceLoader::load(ResourceLoader::path_remap(get_path()), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	if (rel.is_null()) {
+		return;
+	}
+
+	set_source_code(rel->get_source_code());
+	set_last_modified_time(rel->get_last_modified_time());
+
+	reload();
+#else
+	Resource::reload_from_file();
+#endif
 }
 
 void ScriptServer::set_scripting_enabled(bool p_enabled) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -125,6 +125,8 @@ protected:
 	Dictionary _get_script_constant_map();
 
 public:
+	virtual void reload_from_file() override;
+
 	virtual bool can_instantiate() const = 0;
 
 	virtual Ref<Script> get_base_script() const = 0; //for script inheritance


### PR DESCRIPTION
- Relates to #82113
- Fixes #89239
- Fixes #89029

#82113 made script being reloaded from outside `ScriptEditor`. The current `Resource::reload_from_file()` implementation indirectly calls `Object::set_edited(true)` on the script resource, so any script reloaded that way ends up being overwritten by the engine when a scene they are in is saved.  

This is simply making sure we apply the same logic in `Script::reload_from_file()` as in `ScriptEditor::reload_scripts()`. Although, it feels quite weird that we purposefully call that method when `Script::editor_can_reload_from_file()` returns `false`.