### PR TITLE
Editor Help: Add syntax highlighting for code blocks

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -44,6 +44,8 @@
 #include "scene/gui/text_edit.h"
 #include "scene/main/timer.h"
 
+#include "modules/modules_enabled.gen.h" // For gdscript, mono.
+
 class FindBar : public HBoxContainer {
 	GDCLASS(FindBar, HBoxContainer);
 
@@ -265,6 +267,7 @@ class EditorHelpBit : public MarginContainer {
 	String text;
 
 protected:
+	String doc_class_name;
 	String custom_description;
 
 	static void _bind_methods();
@@ -296,5 +299,42 @@ public:
 
 	EditorHelpTooltip(const String &p_text = String(), const String &p_custom_description = String());
 };
+
+#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
+class EditorSyntaxHighlighter;
+
+class EditorHelpHighlighter {
+public:
+	enum Language {
+		LANGUAGE_GDSCRIPT,
+		LANGUAGE_CSHARP,
+		LANGUAGE_MAX,
+	};
+
+private:
+	using HighlightData = Vector<Pair<int, Color>>;
+
+	static EditorHelpHighlighter *singleton;
+
+	HashMap<String, HighlightData> highlight_data_caches[LANGUAGE_MAX];
+
+	TextEdit *text_edits[LANGUAGE_MAX];
+	Ref<Script> scripts[LANGUAGE_MAX];
+	Ref<EditorSyntaxHighlighter> highlighters[LANGUAGE_MAX];
+
+	HighlightData _get_highlight_data(Language p_language, const String &p_source, bool p_use_cache);
+
+public:
+	static void create_singleton();
+	static void free_singleton();
+	static EditorHelpHighlighter *get_singleton();
+
+	void highlight(RichTextLabel *p_rich_text_label, Language p_language, const String &p_source, bool p_use_cache);
+	void reset_cache();
+
+	EditorHelpHighlighter();
+	virtual ~EditorHelpHighlighter();
+};
+#endif // defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
 
 #endif // EDITOR_HELP_H

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -165,6 +165,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "modules/modules_enabled.gen.h" // For gdscript, mono.
+
 EditorNode *EditorNode::singleton = nullptr;
 
 static const String EDITOR_NODE_CONFIG_SECTION = "EditorNode";
@@ -576,6 +578,9 @@ void EditorNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
 			EditorHelp::generate_doc();
+#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
+			EditorHelpHighlighter::create_singleton();
+#endif
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -801,6 +806,12 @@ void EditorNode::_notification(int p_what) {
 				_update_update_spinner();
 				_update_vsync_mode();
 			}
+
+#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme/highlighting")) {
+				EditorHelpHighlighter::get_singleton()->reset_cache();
+			}
+#endif
 		} break;
 	}
 }
@@ -7420,6 +7431,9 @@ EditorNode::~EditorNode() {
 
 	remove_print_handler(&print_handler);
 	EditorHelp::cleanup_doc();
+#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
+	EditorHelpHighlighter::free_singleton();
+#endif
 	memdelete(editor_selection);
 	memdelete(editor_plugins_over);
 	memdelete(editor_plugins_force_over);

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -95,7 +95,7 @@
 				    print(get_stack())
 				[/codeblock]
 				Starting from [code]_ready()[/code], [code]bar()[/code] would print:
-				[codeblock]
+				[codeblock lang=text]
 				[{function:bar, line:12, source:res://script.gd}, {function:foo, line:9, source:res://script.gd}, {function:_ready, line:6, source:res://script.gd}]
 				[/codeblock]
 				[b]Note:[/b] This function only works if the running instance is connected to a debugging server (i.e. an editor instance). [method get_stack] will not work in projects exported in release mode, or in projects exported in debug mode if not connected to a debugging server.
@@ -116,7 +116,7 @@
 				    print(d.values())
 				[/codeblock]
 				Prints out:
-				[codeblock]
+				[codeblock lang=text]
 				[@subpath, @path, foo]
 				[, res://test.gd, bar]
 				[/codeblock]
@@ -190,7 +190,7 @@
 			<description>
 				Like [method @GlobalScope.print], but includes the current stack frame when running with the debugger turned on.
 				The output in the console may look like the following:
-				[codeblock]
+				[codeblock lang=text]
 				Test print
 				At: res://test.gd:15:_process()
 				[/codeblock]
@@ -202,7 +202,7 @@
 			<description>
 				Prints a stack trace at the current code location. See also [method get_stack].
 				The output in the console may look like the following:
-				[codeblock]
+				[codeblock lang=text]
 				Frame 0 - res://test.gd:16 in function '_process'
 				[/codeblock]
 				[b]Note:[/b] This function only works if the running instance is connected to a debugging server (i.e. an editor instance). [method print_stack] will not work in projects exported in release mode, or in projects exported in debug mode if not connected to a debugging server.
@@ -232,7 +232,7 @@
 				    print(array[i])
 				[/codeblock]
 				Output:
-				[codeblock]
+				[codeblock lang=text]
 				9
 				6
 				3
@@ -243,7 +243,7 @@
 				    print(i / 10.0)
 				[/codeblock]
 				Output:
-				[codeblock]
+				[codeblock lang=text]
 				0.3
 				0.2
 				0.1


### PR DESCRIPTION
* Closes godotengine/godot-proposals#7617.

![](https://github.com/godotengine/godot/assets/47700418/965025b9-2c93-47fe-93b6-63777a101d5b)

![](https://github.com/godotengine/godot/assets/47700418/ffa06fe8-08b0-43c5-9bfc-ba056132a4cf)

```gdscript
## [codeblock]
## func test():
##     pass
## [/codeblock]
## [codeblock lang=text]
## func test():
##     pass
## [/codeblock]
func _run():
    pass
```

![](https://github.com/godotengine/godot/assets/47700418/4c2c0eb8-3040-44c7-ae05-ab5bc36946b6)