### PR TITLE
Move `snap_controls_to_pixels` from process to projects settings changed method

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3911,16 +3911,19 @@ void CanvasItemEditor::_update_editor_settings() {
 	warped_panning = bool(EDITOR_GET("editors/panning/warped_mouse_panning"));
 }
 
+void CanvasItemEditor::_project_settings_changed() {
+	EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
+}
+
 void CanvasItemEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &CanvasItemEditor::_update_override_camera_button).bind(true));
 			EditorRunBar::get_singleton()->connect("stop_pressed", callable_mp(this, &CanvasItemEditor::_update_override_camera_button).bind(false));
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CanvasItemEditor::_project_settings_changed));
 		} break;
 
 		case NOTIFICATION_PROCESS: {
-			EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
-
 			int nb_having_pivot = 0;
 
 			// Update the viewport if the canvas_item changes

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -483,6 +483,8 @@ private:
 	void _focus_selection(int p_op);
 	void _reset_drag();
 
+	void _project_settings_changed();
+
 	SnapTarget snap_target[2];
 	Transform2D snap_transform;
 	void _snap_if_closer_float(


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Follow up to: https://github.com/godotengine/godot/pull/87886#discussion_r1514417189

Basically, just copied 3D: https://github.com/godotengine/godot/blob/aef11a14274f6f9e74ad91ead1d7c07ea1dd7f5f/editor/plugins/node_3d_editor_plugin.cpp#L2680-L2682

https://github.com/godotengine/godot/blob/aef11a14274f6f9e74ad91ead1d7c07ea1dd7f5f/editor/plugins/node_3d_editor_plugin.cpp#L2735-L2739