### PR TITLE
Enforce template syntax `typename` over `class`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -51,3 +51,6 @@ bd282ff43f23fe845f29a3e25c8efc01bd65ffb0
 
 # Add "Godot Engine contributors" copyright line
 df61dc4b2bd54a5a40c515493c76f5a458e5b541
+
+# Enforce template syntax `typename` over `class`
+9903e6779b70fc03aae70a37b9cf053f4f355b91

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -70,7 +70,7 @@ protected:
 	AccessType get_access_type() const;
 	virtual String fix_path(const String &p_path) const;
 
-	template <class T>
+	template <typename T>
 	static Ref<DirAccess> _create_builtin() {
 		return memnew(T);
 	}
@@ -130,7 +130,7 @@ public:
 	static Ref<DirAccess> create(AccessType p_access);
 	static Error get_open_error();
 
-	template <class T>
+	template <typename T>
 	static void make_default(AccessType p_access) {
 		create_func[p_access] = _create_builtin<T>;
 	}

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -114,7 +114,7 @@ private:
 
 	AccessType _access_type = ACCESS_FILESYSTEM;
 	static CreateFunc create_func[ACCESS_MAX]; /** default file access creation function for a platform */
-	template <class T>
+	template <typename T>
 	static Ref<FileAccess> _create_builtin() {
 		return memnew(T);
 	}
@@ -226,7 +226,7 @@ public:
 	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
 	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
 
-	template <class T>
+	template <typename T>
 	static void make_default(AccessType p_access) {
 		create_func[p_access] = _create_builtin<T>;
 	}

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -679,7 +679,7 @@ static double _bicubic_interp_kernel(double x) {
 	return bc;
 }
 
-template <int CC, class T>
+template <int CC, typename T>
 static void _scale_cubic(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
 	// get source image size
 	int width = p_src_width;
@@ -766,7 +766,7 @@ static void _scale_cubic(const uint8_t *__restrict p_src, uint8_t *__restrict p_
 	}
 }
 
-template <int CC, class T>
+template <int CC, typename T>
 static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
 	enum {
 		FRAC_BITS = 8,
@@ -856,7 +856,7 @@ static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict
 	}
 }
 
-template <int CC, class T>
+template <int CC, typename T>
 static void _scale_nearest(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
 	for (uint32_t i = 0; i < p_dst_height; i++) {
 		uint32_t src_yofs = i * p_src_height / p_dst_height;
@@ -883,7 +883,7 @@ static float _lanczos(float p_x) {
 	return Math::abs(p_x) >= LANCZOS_TYPE ? 0 : Math::sincn(p_x) * Math::sincn(p_x / LANCZOS_TYPE);
 }
 
-template <int CC, class T>
+template <int CC, typename T>
 static void _scale_lanczos(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
 	int32_t src_width = p_src_width;
 	int32_t src_height = p_src_height;
@@ -1665,7 +1665,7 @@ bool Image::_can_modify(Format p_format) const {
 	return p_format <= FORMAT_RGBE9995;
 }
 
-template <class Component, int CC, bool renormalize,
+template <typename Component, int CC, bool renormalize,
 		void (*average_func)(Component &, const Component &, const Component &, const Component &, const Component &),
 		void (*renormalize_func)(Component *)>
 static void _generate_po2_mipmap(const Component *p_src, Component *p_dst, uint32_t p_width, uint32_t p_height) {

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -57,7 +57,7 @@
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>
 #define BVH_LOCKED_FUNCTION BVHLockedFunction _lock_guard(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
 
-template <class T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, class USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, class USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, class BOUNDS = AABB, class POINT = Vector3, bool BVH_THREAD_SAFE = true>
+template <typename T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, typename USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, typename USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, typename BOUNDS = AABB, typename POINT = Vector3, bool BVH_THREAD_SAFE = true>
 class BVH_Manager {
 public:
 	// note we are using uint32_t instead of BVHHandle, losing type safety, but this

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -32,7 +32,7 @@
 #define BVH_ABB_H
 
 // special optimized version of axis aligned bounding box
-template <class BOUNDS = AABB, class POINT = Vector3>
+template <typename BOUNDS = AABB, typename POINT = Vector3>
 struct BVH_ABB {
 	struct ConvexHull {
 		// convex hulls (optional)

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -106,7 +106,7 @@ struct BVHHandle {
 };
 
 // helper class to make iterative versions of recursive functions
-template <class T>
+template <typename T>
 class BVH_IterativeInfo {
 public:
 	enum {
@@ -152,7 +152,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class BVH_DummyPairTestFunction {
 public:
 	static bool user_collision_check(T *p_a, T *p_b) {
@@ -161,7 +161,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class BVH_DummyCullTestFunction {
 public:
 	static bool user_cull_check(T *p_a, T *p_b) {
@@ -170,7 +170,7 @@ public:
 	}
 };
 
-template <class T, int NUM_TREES, int MAX_CHILDREN, int MAX_ITEMS, class USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, class USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, bool USE_PAIRS = false, class BOUNDS = AABB, class POINT = Vector3>
+template <typename T, int NUM_TREES, int MAX_CHILDREN, int MAX_ITEMS, typename USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, typename USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, bool USE_PAIRS = false, typename BOUNDS = AABB, typename POINT = Vector3>
 class BVH_Tree {
 	friend class BVH;
 

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -35,7 +35,7 @@
 #include "core/templates/vector.h"
 
 /* This DisjointSet class uses Find with path compression and Union by rank */
-template <typename T, class H = HashMapHasherDefault, class C = HashMapComparatorDefault<T>, class AL = DefaultAllocator>
+template <typename T, typename H = HashMapHasherDefault, typename C = HashMapComparatorDefault<T>, typename AL = DefaultAllocator>
 class DisjointSet {
 	struct Element {
 		T object;
@@ -65,14 +65,14 @@ public:
 
 /* FUNCTIONS */
 
-template <typename T, class H, class C, class AL>
+template <typename T, typename H, typename C, typename AL>
 DisjointSet<T, H, C, AL>::~DisjointSet() {
 	for (KeyValue<T, Element *> &E : elements) {
 		memdelete_allocator<Element, AL>(E.value);
 	}
 }
 
-template <typename T, class H, class C, class AL>
+template <typename T, typename H, typename C, typename AL>
 typename DisjointSet<T, H, C, AL>::Element *DisjointSet<T, H, C, AL>::get_parent(Element *element) {
 	if (element->parent != element) {
 		element->parent = get_parent(element->parent);
@@ -81,7 +81,7 @@ typename DisjointSet<T, H, C, AL>::Element *DisjointSet<T, H, C, AL>::get_parent
 	return element->parent;
 }
 
-template <typename T, class H, class C, class AL>
+template <typename T, typename H, typename C, typename AL>
 typename DisjointSet<T, H, C, AL>::Element *DisjointSet<T, H, C, AL>::insert_or_get(T object) {
 	typename MapT::Iterator itr = elements.find(object);
 	if (itr != nullptr) {
@@ -96,7 +96,7 @@ typename DisjointSet<T, H, C, AL>::Element *DisjointSet<T, H, C, AL>::insert_or_
 	return new_element;
 }
 
-template <typename T, class H, class C, class AL>
+template <typename T, typename H, typename C, typename AL>
 void DisjointSet<T, H, C, AL>::create_union(T a, T b) {
 	Element *x = insert_or_get(a);
 	Element *y = insert_or_get(b);
@@ -121,7 +121,7 @@ void DisjointSet<T, H, C, AL>::create_union(T a, T b) {
 	}
 }
 
-template <typename T, class H, class C, class AL>
+template <typename T, typename H, typename C, typename AL>
 void DisjointSet<T, H, C, AL>::get_representatives(Vector<T> &out_representatives) {
 	for (KeyValue<T, Element *> &E : elements) {
 		Element *element = E.value;
@@ -131,7 +131,7 @@ void DisjointSet<T, H, C, AL>::get_representatives(Vector<T> &out_representative
 	}
 }
 
-template <typename T, class H, class C, class AL>
+template <typename T, typename H, typename C, typename AL>
 void DisjointSet<T, H, C, AL>::get_members(Vector<T> &out_members, T representative) {
 	typename MapT::Iterator rep_itr = elements.find(representative);
 	ERR_FAIL_NULL(rep_itr);

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -305,11 +305,11 @@ public:
 		virtual ~DefaultQueryResult() {}
 	};
 
-	template <class QueryResult>
+	template <typename QueryResult>
 	_FORCE_INLINE_ void aabb_query(const AABB &p_aabb, QueryResult &r_result);
-	template <class QueryResult>
+	template <typename QueryResult>
 	_FORCE_INLINE_ void convex_query(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, QueryResult &r_result);
-	template <class QueryResult>
+	template <typename QueryResult>
 	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result);
 
 	void set_index(uint32_t p_index);
@@ -318,7 +318,7 @@ public:
 	~DynamicBVH();
 };
 
-template <class QueryResult>
+template <typename QueryResult>
 void DynamicBVH::aabb_query(const AABB &p_box, QueryResult &r_result) {
 	if (!bvh_root) {
 		return;
@@ -363,7 +363,7 @@ void DynamicBVH::aabb_query(const AABB &p_box, QueryResult &r_result) {
 	} while (depth > 0);
 }
 
-template <class QueryResult>
+template <typename QueryResult>
 void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, QueryResult &r_result) {
 	if (!bvh_root) {
 		return;
@@ -420,7 +420,7 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 		}
 	} while (depth > 0);
 }
-template <class QueryResult>
+template <typename QueryResult>
 void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result) {
 	if (!bvh_root) {
 		return;

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -243,7 +243,7 @@ private:
 		}
 	};
 
-	template <class T>
+	template <typename T>
 	T *alloc_node() {
 		T *node = memnew(T);
 		node->next = nodes;

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -34,7 +34,7 @@
 #include "core/math/vector3.h"
 #include "core/math/vector4.h"
 
-template <class T>
+template <typename T>
 class Vector;
 
 struct AABB;

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -59,7 +59,7 @@ static int __bsr_clz32(uint32_t x) {
 #define LDEXPF(s, e) ldexp(s, e)
 #endif
 
-template <class T>
+template <typename T>
 class Vector;
 
 class RandomPCG {

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -77,7 +77,7 @@ public:
 	virtual uint32_t hash() const;
 };
 
-template <class T, class... P>
+template <typename T, typename... P>
 class CallableCustomMethodPointer : public CallableCustomMethodPointerBase {
 	struct Data {
 		T *instance;
@@ -107,7 +107,7 @@ public:
 	}
 };
 
-template <class T, class... P>
+template <typename T, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
 #ifdef DEBUG_METHODS_ENABLED
 		const char *p_func_text,
@@ -123,7 +123,7 @@ Callable create_custom_callable_function_pointer(T *p_instance,
 
 // VERSION WITH RETURN
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 class CallableCustomMethodPointerRet : public CallableCustomMethodPointerBase {
 	struct Data {
 		T *instance;
@@ -154,7 +154,7 @@ public:
 	}
 };
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
 #ifdef DEBUG_METHODS_ENABLED
 		const char *p_func_text,
@@ -170,7 +170,7 @@ Callable create_custom_callable_function_pointer(T *p_instance,
 
 // CONST VERSION WITH RETURN
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 class CallableCustomMethodPointerRetC : public CallableCustomMethodPointerBase {
 	struct Data {
 		T *instance;
@@ -201,7 +201,7 @@ public:
 	}
 };
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 Callable create_custom_callable_function_pointer(T *p_instance,
 #ifdef DEBUG_METHODS_ENABLED
 		const char *p_func_text,
@@ -223,7 +223,7 @@ Callable create_custom_callable_function_pointer(T *p_instance,
 
 // STATIC VERSIONS
 
-template <class... P>
+template <typename... P>
 class CallableCustomStaticMethodPointer : public CallableCustomMethodPointerBase {
 	struct Data {
 		void (*method)(P...);
@@ -250,7 +250,7 @@ public:
 	}
 };
 
-template <class T, class... P>
+template <typename T, typename... P>
 Callable create_custom_callable_static_function_pointer(
 #ifdef DEBUG_METHODS_ENABLED
 		const char *p_func_text,
@@ -264,7 +264,7 @@ Callable create_custom_callable_static_function_pointer(
 	return Callable(ccmp);
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 class CallableCustomStaticMethodPointerRet : public CallableCustomMethodPointerBase {
 	struct Data {
 		R(*method)
@@ -291,7 +291,7 @@ public:
 	}
 };
 
-template <class R, class... P>
+template <typename R, typename... P>
 Callable create_custom_callable_static_function_pointer(
 #ifdef DEBUG_METHODS_ENABLED
 		const char *p_func_text,

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -140,7 +140,7 @@ public:
 		~ClassInfo() {}
 	};
 
-	template <class T>
+	template <typename T>
 	static Object *creator() {
 		return memnew(T);
 	}
@@ -187,12 +187,12 @@ private:
 
 public:
 	// DO NOT USE THIS!!!!!! NEEDS TO BE PUBLIC BUT DO NOT USE NO MATTER WHAT!!!
-	template <class T>
+	template <typename T>
 	static void _add_class() {
 		_add_class2(T::get_class_static(), T::get_parent_class_static());
 	}
 
-	template <class T>
+	template <typename T>
 	static void register_class(bool p_virtual = false) {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
@@ -207,7 +207,7 @@ public:
 		T::register_custom_data_to_otdb();
 	}
 
-	template <class T>
+	template <typename T>
 	static void register_abstract_class() {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
@@ -220,7 +220,7 @@ public:
 		//nothing
 	}
 
-	template <class T>
+	template <typename T>
 	static void register_internal_class() {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
@@ -235,7 +235,7 @@ public:
 		T::register_custom_data_to_otdb();
 	}
 
-	template <class T>
+	template <typename T>
 	static void register_runtime_class() {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
@@ -255,12 +255,12 @@ public:
 	static void register_extension_class(ObjectGDExtension *p_extension);
 	static void unregister_extension_class(const StringName &p_class, bool p_free_method_binds = true);
 
-	template <class T>
+	template <typename T>
 	static Object *_create_ptr_func() {
 		return T::create();
 	}
 
-	template <class T>
+	template <typename T>
 	static void register_custom_instance_class() {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(types_are_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
@@ -314,7 +314,7 @@ public:
 		using return_type = R;
 	};
 
-	template <class N, class M, typename... VarArgs>
+	template <typename N, typename M, typename... VarArgs>
 	static MethodBind *bind_method(N p_method_name, M p_method, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 		const Variant *argptrs[sizeof...(p_args) + 1];
@@ -328,7 +328,7 @@ public:
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, false, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	template <class N, class M, typename... VarArgs>
+	template <typename N, typename M, typename... VarArgs>
 	static MethodBind *bind_static_method(const StringName &p_class, N p_method_name, M p_method, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 		const Variant *argptrs[sizeof...(p_args) + 1];
@@ -343,7 +343,7 @@ public:
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, false, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	template <class N, class M, typename... VarArgs>
+	template <typename N, typename M, typename... VarArgs>
 	static MethodBind *bind_compatibility_method(N p_method_name, M p_method, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 		const Variant *argptrs[sizeof...(p_args) + 1];
@@ -357,7 +357,7 @@ public:
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, true, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	template <class N, class M, typename... VarArgs>
+	template <typename N, typename M, typename... VarArgs>
 	static MethodBind *bind_compatibility_static_method(const StringName &p_class, N p_method_name, M p_method, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 		const Variant *argptrs[sizeof...(p_args) + 1];
@@ -372,7 +372,7 @@ public:
 		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, true, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	template <class M>
+	template <typename M>
 	static MethodBind *bind_vararg_method(uint32_t p_flags, const StringName &p_name, M p_method, const MethodInfo &p_info = MethodInfo(), const Vector<Variant> &p_default_args = Vector<Variant>(), bool p_return_nil_is_variant = true) {
 		GLOBAL_LOCK_FUNCTION;
 
@@ -385,7 +385,7 @@ public:
 		return _bind_vararg_method(bind, p_name, p_default_args, false);
 	}
 
-	template <class M>
+	template <typename M>
 	static MethodBind *bind_compatibility_vararg_method(uint32_t p_flags, const StringName &p_name, M p_method, const MethodInfo &p_info = MethodInfo(), const Vector<Variant> &p_default_args = Vector<Variant>(), bool p_return_nil_is_variant = true) {
 		GLOBAL_LOCK_FUNCTION;
 
@@ -497,13 +497,13 @@ _FORCE_INLINE_ void errarray_add_str(Vector<Error> &arr, const Error &p_err) {
 	arr.push_back(p_err);
 }
 
-template <class... P>
+template <typename... P>
 _FORCE_INLINE_ void errarray_add_str(Vector<Error> &arr, const Error &p_err, P... p_args) {
 	arr.push_back(p_err);
 	errarray_add_str(arr, p_args...);
 }
 
-template <class... P>
+template <typename... P>
 _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 	Vector<Error> arr;
 	errarray_add_str(arr, p_args...);

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -140,7 +140,7 @@ public:
 };
 
 // MethodBindVarArg base CRTP
-template <class Derived, class T, class R, bool should_returns>
+template <typename Derived, typename T, typename R, bool should_returns>
 class MethodBindVarArgBase : public MethodBind {
 protected:
 	R(T::*method)
@@ -219,7 +219,7 @@ private:
 };
 
 // variadic, no return
-template <class T>
+template <typename T>
 class MethodBindVarArgT : public MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false> {
 	friend class MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>;
 
@@ -245,7 +245,7 @@ private:
 	}
 };
 
-template <class T>
+template <typename T>
 MethodBind *create_vararg_method_bind(void (T::*p_method)(const Variant **, int, Callable::CallError &), const MethodInfo &p_info, bool p_return_nil_is_variant) {
 	MethodBind *a = memnew((MethodBindVarArgT<T>)(p_method, p_info, p_return_nil_is_variant));
 	a->set_instance_class(T::get_class_static());
@@ -253,7 +253,7 @@ MethodBind *create_vararg_method_bind(void (T::*p_method)(const Variant **, int,
 }
 
 // variadic, return
-template <class T, class R>
+template <typename T, typename R>
 class MethodBindVarArgTR : public MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true> {
 	friend class MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>;
 
@@ -287,7 +287,7 @@ private:
 	}
 };
 
-template <class T, class R>
+template <typename T, typename R>
 MethodBind *create_vararg_method_bind(R (T::*p_method)(const Variant **, int, Callable::CallError &), const MethodInfo &p_info, bool p_return_nil_is_variant) {
 	MethodBind *a = memnew((MethodBindVarArgTR<T, R>)(p_method, p_info, p_return_nil_is_variant));
 	a->set_instance_class(T::get_class_static());
@@ -305,9 +305,9 @@ class __UnexistingClass;
 
 // no return, not const
 #ifdef TYPED_METHOD_BIND
-template <class T, class... P>
+template <typename T, typename... P>
 #else
-template <class... P>
+template <typename... P>
 #endif
 class MethodBindT : public MethodBind {
 	void (MB_T::*method)(P...);
@@ -375,7 +375,7 @@ public:
 	}
 };
 
-template <class T, class... P>
+template <typename T, typename... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...)) {
 #ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindT<T, P...>)(p_method));
@@ -389,9 +389,9 @@ MethodBind *create_method_bind(void (T::*p_method)(P...)) {
 // no return, const
 
 #ifdef TYPED_METHOD_BIND
-template <class T, class... P>
+template <typename T, typename... P>
 #else
-template <class... P>
+template <typename... P>
 #endif
 class MethodBindTC : public MethodBind {
 	void (MB_T::*method)(P...) const;
@@ -460,7 +460,7 @@ public:
 	}
 };
 
-template <class T, class... P>
+template <typename T, typename... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...) const) {
 #ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTC<T, P...>)(p_method));
@@ -474,9 +474,9 @@ MethodBind *create_method_bind(void (T::*p_method)(P...) const) {
 // return, not const
 
 #ifdef TYPED_METHOD_BIND
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 #else
-template <class R, class... P>
+template <typename R, typename... P>
 #endif
 class MethodBindTR : public MethodBind {
 	R(MB_T::*method)
@@ -555,7 +555,7 @@ public:
 	}
 };
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 MethodBind *create_method_bind(R (T::*p_method)(P...)) {
 #ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTR<T, R, P...>)(p_method));
@@ -570,9 +570,9 @@ MethodBind *create_method_bind(R (T::*p_method)(P...)) {
 // return, const
 
 #ifdef TYPED_METHOD_BIND
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 #else
-template <class R, class... P>
+template <typename R, typename... P>
 #endif
 class MethodBindTRC : public MethodBind {
 	R(MB_T::*method)
@@ -652,7 +652,7 @@ public:
 	}
 };
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 MethodBind *create_method_bind(R (T::*p_method)(P...) const) {
 #ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTRC<T, R, P...>)(p_method));
@@ -667,7 +667,7 @@ MethodBind *create_method_bind(R (T::*p_method)(P...) const) {
 
 // no return
 
-template <class... P>
+template <typename... P>
 class MethodBindTS : public MethodBind {
 	void (*function)(P...);
 
@@ -717,7 +717,7 @@ public:
 	}
 };
 
-template <class... P>
+template <typename... P>
 MethodBind *create_static_method_bind(void (*p_method)(P...)) {
 	MethodBind *a = memnew((MethodBindTS<P...>)(p_method));
 	return a;
@@ -725,7 +725,7 @@ MethodBind *create_static_method_bind(void (*p_method)(P...)) {
 
 // return
 
-template <class R, class... P>
+template <typename R, typename... P>
 class MethodBindTRS : public MethodBind {
 	R(*function)
 	(P...);
@@ -784,7 +784,7 @@ public:
 	}
 };
 
-template <class R, class... P>
+template <typename R, typename... P>
 MethodBind *create_static_method_bind(R (*p_method)(P...)) {
 	MethodBind *a = memnew((MethodBindTRS<R, P...>)(p_method));
 	return a;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -796,12 +796,12 @@ public:
 	void detach_from_objectdb();
 	_FORCE_INLINE_ ObjectID get_instance_id() const { return _instance_id; }
 
-	template <class T>
+	template <typename T>
 	static T *cast_to(Object *p_object) {
 		return p_object ? dynamic_cast<T *>(p_object) : nullptr;
 	}
 
-	template <class T>
+	template <typename T>
 	static const T *cast_to(const Object *p_object) {
 		return p_object ? dynamic_cast<const T *>(p_object) : nullptr;
 	}

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -53,7 +53,7 @@ public:
 	~RefCounted() {}
 };
 
-template <class T>
+template <typename T>
 class Ref {
 	T *reference = nullptr;
 
@@ -117,7 +117,7 @@ public:
 		ref(p_from);
 	}
 
-	template <class T_Other>
+	template <typename T_Other>
 	void operator=(const Ref<T_Other> &p_from) {
 		RefCounted *refb = const_cast<RefCounted *>(static_cast<const RefCounted *>(p_from.ptr()));
 		if (!refb) {
@@ -149,7 +149,7 @@ public:
 		}
 	}
 
-	template <class T_Other>
+	template <typename T_Other>
 	void reference_ptr(T_Other *p_ptr) {
 		if (reference == p_ptr) {
 			return;
@@ -166,7 +166,7 @@ public:
 		ref(p_from);
 	}
 
-	template <class T_Other>
+	template <typename T_Other>
 	Ref(const Ref<T_Other> &p_from) {
 		RefCounted *refb = const_cast<RefCounted *>(static_cast<const RefCounted *>(p_from.ptr()));
 		if (!refb) {
@@ -240,7 +240,7 @@ public:
 	WeakRef() {}
 };
 
-template <class T>
+template <typename T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 		if (p_ptr == nullptr) {
@@ -258,7 +258,7 @@ struct PtrToArg<Ref<T>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
@@ -271,7 +271,7 @@ struct PtrToArg<const Ref<T> &> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct GetTypeInfo<Ref<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
@@ -281,7 +281,7 @@ struct GetTypeInfo<Ref<T>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct GetTypeInfo<const Ref<T> &> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
@@ -291,13 +291,13 @@ struct GetTypeInfo<const Ref<T> &> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantInternalAccessor<Ref<T>> {
 	static _FORCE_INLINE_ Ref<T> get(const Variant *v) { return Ref<T>(*VariantInternal::get_object(v)); }
 	static _FORCE_INLINE_ void set(Variant *v, const Ref<T> &p_ref) { VariantInternal::refcounted_object_assign(v, p_ref.ptr()); }
 };
 
-template <class T>
+template <typename T>
 struct VariantInternalAccessor<const Ref<T> &> {
 	static _FORCE_INLINE_ Ref<T> get(const Variant *v) { return Ref<T>(*VariantInternal::get_object(v)); }
 	static _FORCE_INLINE_ void set(Variant *v, const Ref<T> &p_ref) { VariantInternal::refcounted_object_assign(v, p_ref.ptr()); }

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -157,7 +157,7 @@ private:
 	TaskID _add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, const String &p_description);
 	GroupID _add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description);
 
-	template <class C, class M, class U>
+	template <typename C, typename M, typename U>
 	struct TaskUserData : public BaseTemplateUserdata {
 		C *instance;
 		M method;
@@ -167,7 +167,7 @@ private:
 		}
 	};
 
-	template <class C, class M, class U>
+	template <typename C, typename M, typename U>
 	struct GroupUserData : public BaseTemplateUserdata {
 		C *instance;
 		M method;
@@ -181,7 +181,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	template <class C, class M, class U>
+	template <typename C, typename M, typename U>
 	TaskID add_template_task(C *p_instance, M p_method, U p_userdata, bool p_high_priority = false, const String &p_description = String()) {
 		typedef TaskUserData<C, M, U> TUD;
 		TUD *ud = memnew(TUD);
@@ -196,7 +196,7 @@ public:
 	bool is_task_completed(TaskID p_task_id) const;
 	Error wait_for_task_completion(TaskID p_task_id);
 
-	template <class C, class M, class U>
+	template <typename C, typename M, typename U>
 	GroupID add_template_group_task(C *p_instance, M p_method, U p_userdata, int p_elements, int p_tasks = -1, bool p_high_priority = false, const String &p_description = String()) {
 		typedef GroupUserData<C, M, U> GroupUD;
 		GroupUD *ud = memnew(GroupUD);

--- a/core/os/condition_variable.h
+++ b/core/os/condition_variable.h
@@ -54,7 +54,7 @@ class ConditionVariable {
 	mutable THREADING_NAMESPACE::condition_variable condition;
 
 public:
-	template <class BinaryMutexT>
+	template <typename BinaryMutexT>
 	_ALWAYS_INLINE_ void wait(const MutexLock<BinaryMutexT> &p_lock) const {
 		condition.wait(const_cast<THREADING_NAMESPACE::unique_lock<THREADING_NAMESPACE::mutex> &>(p_lock.lock));
 	}
@@ -72,7 +72,7 @@ public:
 
 class ConditionVariable {
 public:
-	template <class BinaryMutexT>
+	template <typename BinaryMutexT>
 	void wait(const MutexLock<BinaryMutexT> &p_lock) const {}
 	void notify_one() const {}
 	void notify_all() const {}

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -92,7 +92,7 @@ void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_d
 
 _ALWAYS_INLINE_ void postinitialize_handler(void *) {}
 
-template <class T>
+template <typename T>
 _ALWAYS_INLINE_ T *_post_initialize(T *p_obj) {
 	postinitialize_handler(p_obj);
 	return p_obj;
@@ -107,7 +107,7 @@ _ALWAYS_INLINE_ bool predelete_handler(void *) {
 	return true;
 }
 
-template <class T>
+template <typename T>
 void memdelete(T *p_class) {
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
@@ -119,7 +119,7 @@ void memdelete(T *p_class) {
 	Memory::free_static(p_class, false);
 }
 
-template <class T, class A>
+template <typename T, typename A>
 void memdelete_allocator(T *p_class) {
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
@@ -213,10 +213,10 @@ struct _GlobalNilClass {
 	static _GlobalNil _nil;
 };
 
-template <class T>
+template <typename T>
 class DefaultTypedAllocator {
 public:
-	template <class... Args>
+	template <typename... Args>
 	_FORCE_INLINE_ T *new_allocation(const Args &&...p_args) { return memnew(T(p_args...)); }
 	_FORCE_INLINE_ void delete_allocation(T *p_allocation) { memdelete(p_allocation); }
 };

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -45,10 +45,10 @@
 
 #ifdef THREADS_ENABLED
 
-template <class MutexT>
+template <typename MutexT>
 class MutexLock;
 
-template <class StdMutexT>
+template <typename StdMutexT>
 class MutexImpl {
 	friend class MutexLock<MutexImpl<StdMutexT>>;
 
@@ -70,7 +70,7 @@ public:
 	}
 };
 
-template <class MutexT>
+template <typename MutexT>
 class MutexLock {
 	friend class ConditionVariable;
 
@@ -100,7 +100,7 @@ public:
 	bool try_lock() const { return true; }
 };
 
-template <class MutexT>
+template <typename MutexT>
 class MutexLock {
 public:
 	MutexLock(const MutexT &p_mutex) {}

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2459,7 +2459,7 @@ bool String::is_numeric() const {
 	return true; // TODO: Use the parser below for this instead
 }
 
-template <class C>
+template <typename C>
 static double built_in_strtod(
 		/* A decimal ASCII floating-point number,
 		 * optionally preceded by white space. Must

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -43,7 +43,7 @@
 /*  CharProxy                                                            */
 /*************************************************************************/
 
-template <class T>
+template <typename T>
 class CharProxy {
 	friend class Char16String;
 	friend class CharString;
@@ -602,13 +602,13 @@ _FORCE_INLINE_ void sarray_add_str(Vector<String> &arr, const String &p_str) {
 	arr.push_back(p_str);
 }
 
-template <class... P>
+template <typename... P>
 _FORCE_INLINE_ void sarray_add_str(Vector<String> &arr, const String &p_str, P... p_args) {
 	arr.push_back(p_str);
 	sarray_add_str(arr, p_args...);
 }
 
-template <class... P>
+template <typename... P>
 _FORCE_INLINE_ Vector<String> sarray(P... p_args) {
 	Vector<String> arr;
 	sarray_add_str(arr, p_args...);

--- a/core/templates/bin_sorted_array.h
+++ b/core/templates/bin_sorted_array.h
@@ -34,7 +34,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/paged_array.h"
 
-template <class T>
+template <typename T>
 class BinSortedArray {
 	PagedArray<T> array;
 	LocalVector<uint64_t> bin_limits;

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -207,41 +207,41 @@
 
 #define ARG(N) p##N
 #define PARAM(N) P##N p##N
-#define TYPE_PARAM(N) class P##N
+#define TYPE_PARAM(N) typename P##N
 #define PARAM_DECL(N) typename GetSimpleTypeT<P##N>::type_t p##N
 
-#define DECL_CMD(N)                                                    \
-	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)> \
-	struct Command##N : public CommandBase {                           \
-		T *instance;                                                   \
-		M method;                                                      \
-		SEMIC_SEP_LIST(PARAM_DECL, N);                                 \
-		virtual void call() override {                                 \
-			(instance->*method)(COMMA_SEP_LIST(ARG, N));               \
-		}                                                              \
+#define DECL_CMD(N)                                                          \
+	template <typename T, typename M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)> \
+	struct Command##N : public CommandBase {                                 \
+		T *instance;                                                         \
+		M method;                                                            \
+		SEMIC_SEP_LIST(PARAM_DECL, N);                                       \
+		virtual void call() override {                                       \
+			(instance->*method)(COMMA_SEP_LIST(ARG, N));                     \
+		}                                                                    \
 	};
 
-#define DECL_CMD_RET(N)                                                         \
-	template <class T, class M, COMMA_SEP_LIST(TYPE_PARAM, N) COMMA(N) class R> \
-	struct CommandRet##N : public SyncCommand {                                 \
-		R *ret;                                                                 \
-		T *instance;                                                            \
-		M method;                                                               \
-		SEMIC_SEP_LIST(PARAM_DECL, N);                                          \
-		virtual void call() override {                                          \
-			*ret = (instance->*method)(COMMA_SEP_LIST(ARG, N));                 \
-		}                                                                       \
+#define DECL_CMD_RET(N)                                                                  \
+	template <typename T, typename M, COMMA_SEP_LIST(TYPE_PARAM, N) COMMA(N) typename R> \
+	struct CommandRet##N : public SyncCommand {                                          \
+		R *ret;                                                                          \
+		T *instance;                                                                     \
+		M method;                                                                        \
+		SEMIC_SEP_LIST(PARAM_DECL, N);                                                   \
+		virtual void call() override {                                                   \
+			*ret = (instance->*method)(COMMA_SEP_LIST(ARG, N));                          \
+		}                                                                                \
 	};
 
-#define DECL_CMD_SYNC(N)                                               \
-	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)> \
-	struct CommandSync##N : public SyncCommand {                       \
-		T *instance;                                                   \
-		M method;                                                      \
-		SEMIC_SEP_LIST(PARAM_DECL, N);                                 \
-		virtual void call() override {                                 \
-			(instance->*method)(COMMA_SEP_LIST(ARG, N));               \
-		}                                                              \
+#define DECL_CMD_SYNC(N)                                                     \
+	template <typename T, typename M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)> \
+	struct CommandSync##N : public SyncCommand {                             \
+		T *instance;                                                         \
+		M method;                                                            \
+		SEMIC_SEP_LIST(PARAM_DECL, N);                                       \
+		virtual void call() override {                                       \
+			(instance->*method)(COMMA_SEP_LIST(ARG, N));                     \
+		}                                                                    \
 	};
 
 #define TYPE_ARG(N) P##N
@@ -249,7 +249,7 @@
 #define CMD_ASSIGN_PARAM(N) cmd->p##N = p##N
 
 #define DECL_PUSH(N)                                                         \
-	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>       \
+	template <typename T, typename M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)> \
 	void push(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) { \
 		CMD_TYPE(N) *cmd = allocate_and_lock<CMD_TYPE(N)>();                 \
 		cmd->instance = p_instance;                                          \
@@ -263,7 +263,7 @@
 #define CMD_RET_TYPE(N) CommandRet##N<T, M, COMMA_SEP_LIST(TYPE_ARG, N) COMMA(N) R>
 
 #define DECL_PUSH_AND_RET(N)                                                                   \
-	template <class T, class M, COMMA_SEP_LIST(TYPE_PARAM, N) COMMA(N) class R>                \
+	template <typename T, typename M, COMMA_SEP_LIST(TYPE_PARAM, N) COMMA(N) typename R>       \
 	void push_and_ret(T *p_instance, M p_method, COMMA_SEP_LIST(PARAM, N) COMMA(N) R *r_ret) { \
 		SyncSemaphore *ss = _alloc_sync_sem();                                                 \
 		CMD_RET_TYPE(N) *cmd = allocate_and_lock<CMD_RET_TYPE(N)>();                           \
@@ -282,7 +282,7 @@
 #define CMD_SYNC_TYPE(N) CommandSync##N<T, M COMMA(N) COMMA_SEP_LIST(TYPE_ARG, N)>
 
 #define DECL_PUSH_AND_SYNC(N)                                                         \
-	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>                \
+	template <typename T, typename M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>          \
 	void push_and_sync(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) { \
 		SyncSemaphore *ss = _alloc_sync_sem();                                        \
 		CMD_SYNC_TYPE(N) *cmd = allocate_and_lock<CMD_SYNC_TYPE(N)>();                \
@@ -343,7 +343,7 @@ class CommandQueueMT {
 	Semaphore *sync = nullptr;
 	uint64_t flush_read_ptr = 0;
 
-	template <class T>
+	template <typename T>
 	T *allocate() {
 		// alloc size is size+T+safeguard
 		uint32_t alloc_size = ((sizeof(T) + 8 - 1) & ~(8 - 1));
@@ -354,7 +354,7 @@ class CommandQueueMT {
 		return cmd;
 	}
 
-	template <class T>
+	template <typename T>
 	T *allocate_and_lock() {
 		lock();
 		T *ret = allocate<T>();

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -38,12 +38,12 @@
 #include <string.h>
 #include <type_traits>
 
-template <class T>
+template <typename T>
 class Vector;
 class String;
 class Char16String;
 class CharString;
-template <class T, class V>
+template <typename T, typename V>
 class VMap;
 
 static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
@@ -54,14 +54,14 @@ static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
 #pragma GCC diagnostic ignored "-Wplacement-new"
 #endif
 
-template <class T>
+template <typename T>
 class CowData {
-	template <class TV>
+	template <typename TV>
 	friend class Vector;
 	friend class String;
 	friend class Char16String;
 	friend class CharString;
-	template <class TV, class VV>
+	template <typename TV, typename VV>
 	friend class VMap;
 
 public:
@@ -241,7 +241,7 @@ public:
 	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); };
 };
 
-template <class T>
+template <typename T>
 void CowData<T>::_unref(void *p_data) {
 	if (!p_data) {
 		return;
@@ -268,7 +268,7 @@ void CowData<T>::_unref(void *p_data) {
 	Memory::free_static(((uint8_t *)p_data) - DATA_OFFSET, false);
 }
 
-template <class T>
+template <typename T>
 typename CowData<T>::USize CowData<T>::_copy_on_write() {
 	if (!_ptr) {
 		return 0;
@@ -308,7 +308,7 @@ typename CowData<T>::USize CowData<T>::_copy_on_write() {
 	return rc;
 }
 
-template <class T>
+template <typename T>
 template <bool p_ensure_zero>
 Error CowData<T>::resize(Size p_size) {
 	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
@@ -401,7 +401,7 @@ Error CowData<T>::resize(Size p_size) {
 	return OK;
 }
 
-template <class T>
+template <typename T>
 typename CowData<T>::Size CowData<T>::find(const T &p_val, Size p_from) const {
 	Size ret = -1;
 
@@ -419,7 +419,7 @@ typename CowData<T>::Size CowData<T>::find(const T &p_val, Size p_from) const {
 	return ret;
 }
 
-template <class T>
+template <typename T>
 typename CowData<T>::Size CowData<T>::rfind(const T &p_val, Size p_from) const {
 	const Size s = size();
 
@@ -438,7 +438,7 @@ typename CowData<T>::Size CowData<T>::rfind(const T &p_val, Size p_from) const {
 	return -1;
 }
 
-template <class T>
+template <typename T>
 typename CowData<T>::Size CowData<T>::count(const T &p_val) const {
 	Size amount = 0;
 	for (Size i = 0; i < size(); i++) {
@@ -449,12 +449,12 @@ typename CowData<T>::Size CowData<T>::count(const T &p_val) const {
 	return amount;
 }
 
-template <class T>
+template <typename T>
 void CowData<T>::_ref(const CowData *p_from) {
 	_ref(*p_from);
 }
 
-template <class T>
+template <typename T>
 void CowData<T>::_ref(const CowData &p_from) {
 	if (_ptr == p_from._ptr) {
 		return; // self assign, do nothing.
@@ -472,7 +472,7 @@ void CowData<T>::_ref(const CowData &p_from) {
 	}
 }
 
-template <class T>
+template <typename T>
 CowData<T>::~CowData() {
 	_unref(_ptr);
 }

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -51,7 +51,7 @@
  * The assignment operator copy the pairs from one map to the other.
  */
 
-template <class TKey, class TValue>
+template <typename TKey, typename TValue>
 struct HashMapElement {
 	HashMapElement *next = nullptr;
 	HashMapElement *prev = nullptr;
@@ -61,10 +61,10 @@ struct HashMapElement {
 			data(p_key, p_value) {}
 };
 
-template <class TKey, class TValue,
-		class Hasher = HashMapHasherDefault,
-		class Comparator = HashMapComparatorDefault<TKey>,
-		class Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
+template <typename TKey, typename TValue,
+		typename Hasher = HashMapHasherDefault,
+		typename Comparator = HashMapComparatorDefault<TKey>,
+		typename Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
 class HashMap {
 public:
 	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -46,9 +46,9 @@
  *
  */
 
-template <class TKey,
-		class Hasher = HashMapHasherDefault,
-		class Comparator = HashMapComparatorDefault<TKey>>
+template <typename TKey,
+		typename Hasher = HashMapHasherDefault,
+		typename Comparator = HashMapComparatorDefault<TKey>>
 class HashSet {
 public:
 	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -248,7 +248,7 @@ static _FORCE_INLINE_ uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev 
 	return ((p_prev << 5) + p_prev) + hash_one_uint64(u.i);
 }
 
-template <class T>
+template <typename T>
 static _FORCE_INLINE_ uint32_t hash_make_uint32_t(T p_in) {
 	union {
 		T t;
@@ -281,7 +281,7 @@ static _FORCE_INLINE_ uint64_t hash_djb2_one_64(uint64_t p_in, uint64_t p_prev =
 	return ((p_prev << 5) + p_prev) ^ p_in;
 }
 
-template <class T>
+template <typename T>
 static _FORCE_INLINE_ uint64_t hash_make_uint64_t(T p_in) {
 	union {
 		T t;
@@ -293,15 +293,15 @@ static _FORCE_INLINE_ uint64_t hash_make_uint64_t(T p_in) {
 	return _u._u64;
 }
 
-template <class T>
+template <typename T>
 class Ref;
 
 struct HashMapHasherDefault {
 	// Generic hash function for any type.
-	template <class T>
+	template <typename T>
 	static _FORCE_INLINE_ uint32_t hash(const T *p_pointer) { return hash_one_uint64((uint64_t)p_pointer); }
 
-	template <class T>
+	template <typename T>
 	static _FORCE_INLINE_ uint32_t hash(const Ref<T> &p_ref) { return hash_one_uint64((uint64_t)p_ref.operator->()); }
 
 	static _FORCE_INLINE_ uint32_t hash(const String &p_string) { return p_string.hash(); }
@@ -387,7 +387,7 @@ struct HashMapHasherDefault {
 };
 
 // TODO: Fold this into HashMapHasherDefault once C++20 concepts are allowed
-template <class T>
+template <typename T>
 struct HashableHasher {
 	static _FORCE_INLINE_ uint32_t hash(const T &hashable) { return hashable.hash(); }
 };

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -43,7 +43,7 @@
  * from the iterator.
  */
 
-template <class T, class A = DefaultAllocator>
+template <typename T, typename A = DefaultAllocator>
 class List {
 	struct _Data;
 
@@ -410,7 +410,7 @@ public:
 	/**
 	 * find an element in the list,
 	 */
-	template <class T_v>
+	template <typename T_v>
 	Element *find(const T_v &p_val) {
 		Element *it = front();
 		while (it) {
@@ -646,7 +646,7 @@ public:
 		sort_custom<Comparator<T>>();
 	}
 
-	template <class C>
+	template <typename C>
 	void sort_custom_inplace() {
 		if (size() < 2) {
 			return;
@@ -693,7 +693,7 @@ public:
 		_data->last = to;
 	}
 
-	template <class C>
+	template <typename C>
 	struct AuxiliaryComparator {
 		C compare;
 		_FORCE_INLINE_ bool operator()(const Element *a, const Element *b) const {
@@ -701,7 +701,7 @@ public:
 		}
 	};
 
-	template <class C>
+	template <typename C>
 	void sort_custom() {
 		//this version uses auxiliary memory for speed.
 		//if you don't want to use auxiliary memory, use the in_place version
@@ -764,7 +764,7 @@ public:
 	}
 };
 
-template <class T, class A>
+template <typename T, typename A>
 void List<T, A>::Element::transfer_to_back(List<T, A> *p_dst_list) {
 	// Detach from current.
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -41,7 +41,7 @@
 
 // If tight, it grows strictly as much as needed.
 // Otherwise, it grows exponentially (the default and what you want in most cases).
-template <class T, class U = uint32_t, bool force_trivial = false, bool tight = false>
+template <typename T, typename U = uint32_t, bool force_trivial = false, bool tight = false>
 class LocalVector {
 private:
 	U count = 0;
@@ -248,7 +248,7 @@ public:
 		return -1;
 	}
 
-	template <class C>
+	template <typename C>
 	void sort_custom() {
 		U len = count;
 		if (len == 0) {
@@ -322,7 +322,7 @@ public:
 	}
 };
 
-template <class T, class U = uint32_t, bool force_trivial = false>
+template <typename T, typename U = uint32_t, bool force_trivial = false>
 using TightLocalVector = LocalVector<T, U, force_trivial, true>;
 
 #endif // LOCAL_VECTOR_H

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -35,7 +35,7 @@
 #include "hash_map.h"
 #include "list.h"
 
-template <class TKey, class TData, class Hasher = HashMapHasherDefault, class Comparator = HashMapComparatorDefault<TKey>>
+template <typename TKey, typename TData, typename Hasher = HashMapHasherDefault, typename Comparator = HashMapComparatorDefault<TKey>>
 class LRUCache {
 private:
 	struct Pair {

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -50,9 +50,9 @@
  *
  * The assignment operator copy the pairs from one map to the other.
  */
-template <class TKey, class TValue,
-		class Hasher = HashMapHasherDefault,
-		class Comparator = HashMapComparatorDefault<TKey>>
+template <typename TKey, typename TValue,
+		typename Hasher = HashMapHasherDefault,
+		typename Comparator = HashMapComparatorDefault<TKey>>
 class OAHashMap {
 private:
 	TValue *values = nullptr;

--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -40,7 +40,7 @@
 #include <type_traits>
 #include <typeinfo>
 
-template <class T, bool thread_safe = false, uint32_t DEFAULT_PAGE_SIZE = 4096>
+template <typename T, bool thread_safe = false, uint32_t DEFAULT_PAGE_SIZE = 4096>
 class PagedAllocator {
 	T **page_pool = nullptr;
 	T ***available_pool = nullptr;
@@ -53,7 +53,7 @@ class PagedAllocator {
 	SpinLock spin_lock;
 
 public:
-	template <class... Args>
+	template <typename... Args>
 	T *alloc(Args &&...p_args) {
 		if (thread_safe) {
 			spin_lock.lock();
@@ -95,7 +95,7 @@ public:
 		}
 	}
 
-	template <class... Args>
+	template <typename... Args>
 	T *new_allocation(Args &&...p_args) { return alloc(p_args...); }
 	void delete_allocation(T *p_mem) { free(p_mem); }
 

--- a/core/templates/paged_array.h
+++ b/core/templates/paged_array.h
@@ -41,7 +41,7 @@
 
 // PageArrayPool manages central page allocation in a thread safe matter
 
-template <class T>
+template <typename T>
 class PagedArrayPool {
 	T **page_pool = nullptr;
 	uint32_t pages_allocated = 0;
@@ -134,7 +134,7 @@ public:
 // It does so by allocating pages from a PagedArrayPool.
 // It is safe to use multiple PagedArrays from different threads, sharing a single PagedArrayPool
 
-template <class T>
+template <typename T>
 class PagedArray {
 	PagedArrayPool<T> *page_pool = nullptr;
 

--- a/core/templates/pair.h
+++ b/core/templates/pair.h
@@ -33,7 +33,7 @@
 
 #include "core/templates/hashfuncs.h"
 #include "core/typedefs.h"
-template <class F, class S>
+template <typename F, typename S>
 struct Pair {
 	F first;
 	S second;
@@ -49,17 +49,17 @@ struct Pair {
 	}
 };
 
-template <class F, class S>
+template <typename F, typename S>
 bool operator==(const Pair<F, S> &pair, const Pair<F, S> &other) {
 	return (pair.first == other.first) && (pair.second == other.second);
 }
 
-template <class F, class S>
+template <typename F, typename S>
 bool operator!=(const Pair<F, S> &pair, const Pair<F, S> &other) {
 	return (pair.first != other.first) || (pair.second != other.second);
 }
 
-template <class F, class S>
+template <typename F, typename S>
 struct PairSort {
 	bool operator()(const Pair<F, S> &A, const Pair<F, S> &B) const {
 		if (A.first != B.first) {
@@ -69,7 +69,7 @@ struct PairSort {
 	}
 };
 
-template <class F, class S>
+template <typename F, typename S>
 struct PairHash {
 	static uint32_t hash(const Pair<F, S> &P) {
 		uint64_t h1 = HashMapHasherDefault::hash(P.first);
@@ -78,7 +78,7 @@ struct PairHash {
 	}
 };
 
-template <class K, class V>
+template <typename K, typename V>
 struct KeyValue {
 	const K key;
 	V value;
@@ -94,17 +94,17 @@ struct KeyValue {
 	}
 };
 
-template <class K, class V>
+template <typename K, typename V>
 bool operator==(const KeyValue<K, V> &pair, const KeyValue<K, V> &other) {
 	return (pair.key == other.key) && (pair.value == other.value);
 }
 
-template <class K, class V>
+template <typename K, typename V>
 bool operator!=(const KeyValue<K, V> &pair, const KeyValue<K, V> &other) {
 	return (pair.key != other.key) || (pair.value != other.value);
 }
 
-template <class K, class V>
+template <typename K, typename V>
 struct KeyValueSort {
 	bool operator()(const KeyValue<K, V> &A, const KeyValue<K, V> &B) const {
 		return A.key < B.key;

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -55,7 +55,7 @@
 
 #include "core/templates/local_vector.h"
 
-template <class T, class U = uint32_t, bool force_trivial = false, bool zero_on_first_request = false>
+template <typename T, typename U = uint32_t, bool force_trivial = false, bool zero_on_first_request = false>
 class PooledList {
 	LocalVector<T, U, force_trivial> list;
 	LocalVector<U, U, true> freelist;
@@ -128,7 +128,7 @@ public:
 };
 
 // a pooled list which automatically keeps a list of the active members
-template <class T, class U = uint32_t, bool force_trivial = false, bool zero_on_first_request = false>
+template <typename T, typename U = uint32_t, bool force_trivial = false, bool zero_on_first_request = false>
 class TrackedPooledList {
 public:
 	U pool_used_size() const { return _pool.used_size(); }

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -38,7 +38,7 @@
 // based on the very nice implementation of rb-trees by:
 // https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
 
-template <class K, class V, class C = Comparator<K>, class A = DefaultAllocator>
+template <typename K, typename V, typename C = Comparator<K>, typename A = DefaultAllocator>
 class RBMap {
 	enum Color {
 		RED,

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -37,7 +37,7 @@
 // based on the very nice implementation of rb-trees by:
 // https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
 
-template <class T, class C = Comparator<T>, class A = DefaultAllocator>
+template <typename T, typename C = Comparator<T>, typename A = DefaultAllocator>
 class RBSet {
 	enum Color {
 		RED,

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -67,7 +67,7 @@ public:
 	virtual ~RID_AllocBase() {}
 };
 
-template <class T, bool THREAD_SAFE = false>
+template <typename T, bool THREAD_SAFE = false>
 class RID_Alloc : public RID_AllocBase {
 	T **chunks = nullptr;
 	uint32_t **free_list_chunks = nullptr;
@@ -364,7 +364,7 @@ public:
 	}
 };
 
-template <class T, bool THREAD_SAFE = false>
+template <typename T, bool THREAD_SAFE = false>
 class RID_PtrOwner {
 	RID_Alloc<T *, THREAD_SAFE> alloc;
 
@@ -423,7 +423,7 @@ public:
 			alloc(p_target_chunk_byte_size) {}
 };
 
-template <class T, bool THREAD_SAFE = false>
+template <typename T, bool THREAD_SAFE = false>
 class RID_Owner {
 	RID_Alloc<T, THREAD_SAFE> alloc;
 

--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -48,7 +48,7 @@
 
 // This is used in very specific areas of the engine where it's critical that these guarantees are held.
 
-template <class T, class A = DefaultAllocator>
+template <typename T, typename A = DefaultAllocator>
 class SafeList {
 	struct SafeListNode {
 		std::atomic<SafeListNode *> next = nullptr;

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -59,7 +59,7 @@
 	static_assert(sizeof(SafeFlag) == sizeof(bool)); \
 	static_assert(alignof(SafeFlag) == alignof(bool));
 
-template <class T>
+template <typename T>
 class SafeNumeric {
 	std::atomic<T> value;
 

--- a/core/templates/search_array.h
+++ b/core/templates/search_array.h
@@ -33,7 +33,7 @@
 
 #include <core/templates/sort_array.h>
 
-template <class T, class Comparator = _DefaultComparator<T>>
+template <typename T, typename Comparator = _DefaultComparator<T>>
 class SearchArray {
 public:
 	Comparator compare;

--- a/core/templates/self_list.h
+++ b/core/templates/self_list.h
@@ -34,7 +34,7 @@
 #include "core/error/error_macros.h"
 #include "core/typedefs.h"
 
-template <class T>
+template <typename T>
 class SelfList {
 public:
 	class List {
@@ -109,7 +109,7 @@ public:
 			sort_custom<Comparator<T>>();
 		}
 
-		template <class C>
+		template <typename C>
 		void sort_custom() {
 			if (_first == _last) {
 				return;

--- a/core/templates/simple_type.h
+++ b/core/templates/simple_type.h
@@ -33,22 +33,22 @@
 
 /* Batch of specializations to obtain the actual simple type */
 
-template <class T>
+template <typename T>
 struct GetSimpleTypeT {
 	typedef T type_t;
 };
 
-template <class T>
+template <typename T>
 struct GetSimpleTypeT<T &> {
 	typedef T type_t;
 };
 
-template <class T>
+template <typename T>
 struct GetSimpleTypeT<T const> {
 	typedef T type_t;
 };
 
-template <class T>
+template <typename T>
 struct GetSimpleTypeT<T const &> {
 	typedef T type_t;
 };

--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -40,7 +40,7 @@
 		break;                                                        \
 	}
 
-template <class T>
+template <typename T>
 struct _DefaultComparator {
 	_FORCE_INLINE_ bool operator()(const T &a, const T &b) const { return (a < b); }
 };
@@ -51,7 +51,7 @@ struct _DefaultComparator {
 #define SORT_ARRAY_VALIDATE_ENABLED false
 #endif
 
-template <class T, class Comparator = _DefaultComparator<T>, bool Validate = SORT_ARRAY_VALIDATE_ENABLED>
+template <typename T, typename Comparator = _DefaultComparator<T>, bool Validate = SORT_ARRAY_VALIDATE_ENABLED>
 class SortArray {
 	enum {
 		INTROSORT_THRESHOLD = 16

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -45,7 +45,7 @@
 #include <climits>
 #include <initializer_list>
 
-template <class T>
+template <typename T>
 class VectorWriteProxy {
 public:
 	_FORCE_INLINE_ T &operator[](typename CowData<T>::Size p_index) {
@@ -55,7 +55,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class Vector {
 	friend class VectorWriteProxy<T>;
 
@@ -108,7 +108,7 @@ public:
 		sort_custom<_DefaultComparator<T>>();
 	}
 
-	template <class Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, class... Args>
+	template <typename Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, typename... Args>
 	void sort_custom(Args &&...args) {
 		Size len = _cowdata.size();
 		if (len == 0) {
@@ -124,7 +124,7 @@ public:
 		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
 	}
 
-	template <class Comparator, class Value, class... Args>
+	template <typename Comparator, typename Value, typename... Args>
 	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
 		SearchArray<T, Comparator> search{ args... };
 		return search.bisect(ptrw(), size(), p_value, p_before);
@@ -291,7 +291,7 @@ public:
 	_FORCE_INLINE_ ~Vector() {}
 };
 
-template <class T>
+template <typename T>
 void Vector<T>::reverse() {
 	for (Size i = 0; i < size() / 2; i++) {
 		T *p = ptrw();
@@ -299,7 +299,7 @@ void Vector<T>::reverse() {
 	}
 }
 
-template <class T>
+template <typename T>
 void Vector<T>::append_array(const Vector<T> &p_other) {
 	const Size ds = p_other.size();
 	if (ds == 0) {
@@ -312,7 +312,7 @@ void Vector<T>::append_array(const Vector<T> &p_other) {
 	}
 }
 
-template <class T>
+template <typename T>
 bool Vector<T>::push_back(T p_elem) {
 	Error err = resize(size() + 1);
 	ERR_FAIL_COND_V(err, true);
@@ -321,7 +321,7 @@ bool Vector<T>::push_back(T p_elem) {
 	return false;
 }
 
-template <class T>
+template <typename T>
 void Vector<T>::fill(T p_elem) {
 	T *p = ptrw();
 	for (Size i = 0; i < size(); i++) {

--- a/core/templates/vmap.h
+++ b/core/templates/vmap.h
@@ -34,7 +34,7 @@
 #include "core/templates/cowdata.h"
 #include "core/typedefs.h"
 
-template <class T, class V>
+template <typename T, typename V>
 class VMap {
 public:
 	struct Pair {

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -34,7 +34,7 @@
 #include "core/templates/vector.h"
 #include "core/typedefs.h"
 
-template <class T>
+template <typename T>
 class VSet {
 	Vector<T> _data;
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -132,7 +132,7 @@ constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
 // Generic swap template.
 #ifndef SWAP
 #define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))
-template <class T>
+template <typename T>
 inline void __swap_tmpl(T &x, T &y) {
 	T aux = x;
 	x = y;
@@ -186,7 +186,7 @@ static inline int get_shift_from_power_of_2(unsigned int p_bits) {
 	return -1;
 }
 
-template <class T>
+template <typename T>
 static _FORCE_INLINE_ T nearest_power_of_2_templated(T x) {
 	--x;
 
@@ -256,7 +256,7 @@ static inline uint64_t BSWAP64(uint64_t x) {
 #endif
 
 // Generic comparator used in Map, List, etc.
-template <class T>
+template <typename T>
 struct Comparator {
 	_ALWAYS_INLINE_ bool operator()(const T &p_a, const T &p_b) const { return (p_a < p_b); }
 };

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -47,7 +47,7 @@
 // Variant cannot define an implicit cast operator for every Object subclass, so the
 // casting is done here, to allow binding methods with parameters more specific than Object *
 
-template <class T>
+template <typename T>
 struct VariantCaster {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
@@ -59,7 +59,7 @@ struct VariantCaster {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantCaster<T &> {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
@@ -71,7 +71,7 @@ struct VariantCaster<T &> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantCaster<const T &> {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
 		using TStripped = std::remove_pointer_t<T>;
@@ -249,7 +249,7 @@ struct VariantObjectClassChecker<const Ref<T> &> {
 
 #ifdef DEBUG_METHODS_ENABLED
 
-template <class T>
+template <typename T>
 struct VariantCasterAndValidate {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, Callable::CallError &r_error) {
 		Variant::Type argtype = GetTypeInfo<T>::VARIANT_TYPE;
@@ -264,7 +264,7 @@ struct VariantCasterAndValidate {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantCasterAndValidate<T &> {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, Callable::CallError &r_error) {
 		Variant::Type argtype = GetTypeInfo<T>::VARIANT_TYPE;
@@ -279,7 +279,7 @@ struct VariantCasterAndValidate<T &> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantCasterAndValidate<const T &> {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, Callable::CallError &r_error) {
 		Variant::Type argtype = GetTypeInfo<T>::VARIANT_TYPE;
@@ -296,7 +296,7 @@ struct VariantCasterAndValidate<const T &> {
 
 #endif // DEBUG_METHODS_ENABLED
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_variant_args_helper(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -308,7 +308,7 @@ void call_with_variant_args_helper(T *p_instance, void (T::*p_method)(P...), con
 	(void)(p_args); //avoid warning
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_variant_argsc_helper(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -320,87 +320,87 @@ void call_with_variant_argsc_helper(T *p_instance, void (T::*p_method)(P...) con
 	(void)(p_args); //avoid warning
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_ptr_args_helper(T *p_instance, void (T::*p_method)(P...), const void **p_args, IndexSequence<Is...>) {
 	(p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...);
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_ptr_argsc_helper(T *p_instance, void (T::*p_method)(P...) const, const void **p_args, IndexSequence<Is...>) {
 	(p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...);
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_ptr_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const void **p_args, void *r_ret, IndexSequence<Is...>) {
 	PtrToArg<R>::encode((p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...), r_ret);
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_ptr_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const void **p_args, void *r_ret, IndexSequence<Is...>) {
 	PtrToArg<R>::encode((p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...), r_ret);
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_ptr_args_static_helper(T *p_instance, void (*p_method)(T *, P...), const void **p_args, IndexSequence<Is...>) {
 	p_method(p_instance, PtrToArg<P>::convert(p_args[Is])...);
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_ptr_args_static_retc_helper(T *p_instance, R (*p_method)(T *, P...), const void **p_args, void *r_ret, IndexSequence<Is...>) {
 	PtrToArg<R>::encode(p_method(p_instance, PtrToArg<P>::convert(p_args[Is])...), r_ret);
 }
 
-template <class R, class... P, size_t... Is>
+template <typename R, typename... P, size_t... Is>
 void call_with_ptr_args_static_method_ret_helper(R (*p_method)(P...), const void **p_args, void *r_ret, IndexSequence<Is...>) {
 	PtrToArg<R>::encode(p_method(PtrToArg<P>::convert(p_args[Is])...), r_ret);
 }
 
-template <class... P, size_t... Is>
+template <typename... P, size_t... Is>
 void call_with_ptr_args_static_method_helper(void (*p_method)(P...), const void **p_args, IndexSequence<Is...>) {
 	p_method(PtrToArg<P>::convert(p_args[Is])...);
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_validated_variant_args_helper(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, IndexSequence<Is...>) {
 	(p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...);
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_validated_variant_argsc_helper(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, IndexSequence<Is...>) {
 	(p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...);
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_validated_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
 	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, (p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_validated_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
 	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, (p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_validated_variant_args_static_retc_helper(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
 	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, p_method(p_instance, (VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_validated_variant_args_static_helper(T *p_instance, void (*p_method)(T *, P...), const Variant **p_args, IndexSequence<Is...>) {
 	p_method(p_instance, (VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...);
 }
 
-template <class R, class... P, size_t... Is>
+template <typename R, typename... P, size_t... Is>
 void call_with_validated_variant_args_static_method_ret_helper(R (*p_method)(P...), const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
 	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, p_method((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
 }
 
-template <class... P, size_t... Is>
+template <typename... P, size_t... Is>
 void call_with_validated_variant_args_static_method_helper(void (*p_method)(P...), const Variant **p_args, IndexSequence<Is...>) {
 	p_method((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 #ifdef DEBUG_METHODS_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -418,7 +418,7 @@ void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Vari
 	call_with_variant_args_helper<T, P...>(p_instance, p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -451,7 +451,7 @@ void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const V
 	call_with_variant_args_helper(p_instance, p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_variant_argsc(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 #ifdef DEBUG_METHODS_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -469,7 +469,7 @@ void call_with_variant_argsc(T *p_instance, void (T::*p_method)(P...) const, con
 	call_with_variant_args_helper<T, P...>(p_instance, p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -502,7 +502,7 @@ void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, 
 	call_with_variant_argsc_helper(p_instance, p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -535,7 +535,7 @@ void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const 
 	call_with_variant_args_ret_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -568,111 +568,111 @@ void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const,
 	call_with_variant_args_retc_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_ptr_args(T *p_instance, void (T::*p_method)(P...), const void **p_args) {
 	call_with_ptr_args_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_ptr_argsc(T *p_instance, void (T::*p_method)(P...) const, const void **p_args) {
 	call_with_ptr_argsc_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_ptr_args_ret(T *p_instance, R (T::*p_method)(P...), const void **p_args, void *r_ret) {
 	call_with_ptr_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_ptr_args_retc(T *p_instance, R (T::*p_method)(P...) const, const void **p_args, void *r_ret) {
 	call_with_ptr_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_ptr_args_static(T *p_instance, void (*p_method)(T *, P...), const void **p_args) {
 	call_with_ptr_args_static_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_ptr_args_static_retc(T *p_instance, R (*p_method)(T *, P...), const void **p_args, void *r_ret) {
 	call_with_ptr_args_static_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 void call_with_ptr_args_static_method_ret(R (*p_method)(P...), const void **p_args, void *r_ret) {
 	call_with_ptr_args_static_method_ret_helper<R, P...>(p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 void call_with_ptr_args_static_method(void (*p_method)(P...), const void **p_args) {
 	call_with_ptr_args_static_method_helper<P...>(p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
 // Validated
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_validated_variant_args(Variant *base, void (T::*p_method)(P...), const Variant **p_args) {
 	call_with_validated_variant_args_helper<T, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_validated_variant_args_ret(Variant *base, R (T::*p_method)(P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_ret_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_validated_variant_args_retc(Variant *base, R (T::*p_method)(P...) const, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_retc_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_validated_variant_args_static(Variant *base, void (*p_method)(T *, P...), const Variant **p_args) {
 	call_with_validated_variant_args_static_helper<T, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_validated_variant_args_static_retc(Variant *base, R (*p_method)(T *, P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static_retc_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 void call_with_validated_variant_args_static_method(void (*p_method)(P...), const Variant **p_args) {
 	call_with_validated_variant_args_static_method_helper<P...>(p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 void call_with_validated_variant_args_static_method_ret(R (*p_method)(P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static_method_ret_helper<R, P...>(p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
 // Validated Object
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_validated_object_instance_args(T *base, void (T::*p_method)(P...), const Variant **p_args) {
 	call_with_validated_variant_args_helper<T, P...>(base, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_validated_object_instance_argsc(T *base, void (T::*p_method)(P...) const, const Variant **p_args) {
 	call_with_validated_variant_argsc_helper<T, P...>(base, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_validated_object_instance_args_ret(T *base, R (T::*p_method)(P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_ret_helper<T, R, P...>(base, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_validated_object_instance_args_retc(T *base, R (T::*p_method)(P...) const, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_retc_helper<T, R, P...>(base, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_validated_object_instance_args_static(T *base, void (*p_method)(T *, P...), const Variant **p_args) {
 	call_with_validated_variant_args_static_helper<T, P...>(base, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_validated_object_instance_args_static_retc(T *base, R (*p_method)(T *, P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static_retc_helper<T, R, P...>(base, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -684,7 +684,7 @@ void call_with_validated_object_instance_args_static_retc(T *base, R (*p_method)
 #pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
 #endif
 
-template <class Q>
+template <typename Q>
 void call_get_argument_type_helper(int p_arg, int &index, Variant::Type &type) {
 	if (p_arg == index) {
 		type = GetTypeInfo<Q>::VARIANT_TYPE;
@@ -692,7 +692,7 @@ void call_get_argument_type_helper(int p_arg, int &index, Variant::Type &type) {
 	index++;
 }
 
-template <class... P>
+template <typename... P>
 Variant::Type call_get_argument_type(int p_arg) {
 	Variant::Type type = Variant::NIL;
 	int index = 0;
@@ -704,7 +704,7 @@ Variant::Type call_get_argument_type(int p_arg) {
 	return type;
 }
 
-template <class Q>
+template <typename Q>
 void call_get_argument_type_info_helper(int p_arg, int &index, PropertyInfo &info) {
 	if (p_arg == index) {
 		info = GetTypeInfo<Q>::get_class_info();
@@ -712,7 +712,7 @@ void call_get_argument_type_info_helper(int p_arg, int &index, PropertyInfo &inf
 	index++;
 }
 
-template <class... P>
+template <typename... P>
 void call_get_argument_type_info(int p_arg, PropertyInfo &info) {
 	int index = 0;
 	// I think rocket science is simpler than modern C++.
@@ -723,7 +723,7 @@ void call_get_argument_type_info(int p_arg, PropertyInfo &info) {
 }
 
 #ifdef DEBUG_METHODS_ENABLED
-template <class Q>
+template <typename Q>
 void call_get_argument_metadata_helper(int p_arg, int &index, GodotTypeInfo::Metadata &md) {
 	if (p_arg == index) {
 		md = GetTypeInfo<Q>::METADATA;
@@ -731,7 +731,7 @@ void call_get_argument_metadata_helper(int p_arg, int &index, GodotTypeInfo::Met
 	index++;
 }
 
-template <class... P>
+template <typename... P>
 GodotTypeInfo::Metadata call_get_argument_metadata(int p_arg) {
 	GodotTypeInfo::Metadata md = GodotTypeInfo::METADATA_NONE;
 
@@ -748,7 +748,7 @@ GodotTypeInfo::Metadata call_get_argument_metadata(int p_arg) {
 
 //////////////////////
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -759,7 +759,7 @@ void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), co
 #endif
 }
 
-template <class R, class... P, size_t... Is>
+template <typename R, typename... P, size_t... Is>
 void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -770,7 +770,7 @@ void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_ar
 #endif
 }
 
-template <class... P, size_t... Is>
+template <typename... P, size_t... Is>
 void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -781,7 +781,7 @@ void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_arg
 #endif
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_variant_args_ret(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_METHODS_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -799,7 +799,7 @@ void call_with_variant_args_ret(T *p_instance, R (T::*p_method)(P...), const Var
 	call_with_variant_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -811,7 +811,7 @@ void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) co
 	(void)p_args;
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_METHODS_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -829,7 +829,7 @@ void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_ar
 	call_with_variant_args_static_ret<R, P...>(p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 void call_with_variant_args_static_ret(void (*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_METHODS_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -847,7 +847,7 @@ void call_with_variant_args_static_ret(void (*p_method)(P...), const Variant **p
 	call_with_variant_args_static<P...>(p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_METHODS_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -865,7 +865,7 @@ void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, co
 	call_with_variant_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class R, class... P, size_t... Is>
+template <typename T, typename R, typename... P, size_t... Is>
 void call_with_variant_args_retc_static_helper(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -878,7 +878,7 @@ void call_with_variant_args_retc_static_helper(T *p_instance, R (*p_method)(T *,
 	(void)p_args;
 }
 
-template <class T, class R, class... P>
+template <typename T, typename R, typename... P>
 void call_with_variant_args_retc_static_helper_dv(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &default_values, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -911,7 +911,7 @@ void call_with_variant_args_retc_static_helper_dv(T *p_instance, R (*p_method)(T
 	call_with_variant_args_retc_static_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class T, class... P, size_t... Is>
+template <typename T, typename... P, size_t... Is>
 void call_with_variant_args_static_helper(T *p_instance, void (*p_method)(T *, P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -924,7 +924,7 @@ void call_with_variant_args_static_helper(T *p_instance, void (*p_method)(T *, P
 	(void)p_args;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 void call_with_variant_args_static_helper_dv(T *p_instance, void (*p_method)(T *, P...), const Variant **p_args, int p_argcount, const Vector<Variant> &default_values, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -957,7 +957,7 @@ void call_with_variant_args_static_helper_dv(T *p_instance, void (*p_method)(T *
 	call_with_variant_args_static_helper(p_instance, p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
@@ -990,7 +990,7 @@ void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const Variant **p
 	call_with_variant_args_static_ret(p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 void call_with_variant_args_static_dv(void (*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -35,7 +35,7 @@
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 
-template <class T>
+template <typename T>
 struct PtrToArg {};
 
 #define MAKE_PTRARG(m_type)                                              \
@@ -156,7 +156,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 
 // This is for Object.
 
-template <class T>
+template <typename T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
 		if (p_ptr == nullptr) {
@@ -170,7 +170,7 @@ struct PtrToArg<T *> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
 		if (p_ptr == nullptr) {

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -35,7 +35,7 @@
 #include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
 
-template <class T>
+template <typename T>
 struct GDExtensionConstPtr {
 	const T *data = nullptr;
 	GDExtensionConstPtr(const T *p_assign) { data = p_assign; }
@@ -44,7 +44,7 @@ struct GDExtensionConstPtr {
 	operator Variant() const { return uint64_t(data); }
 };
 
-template <class T>
+template <typename T>
 struct GDExtensionPtr {
 	T *data = nullptr;
 	GDExtensionPtr(T *p_assign) { data = p_assign; }
@@ -95,7 +95,7 @@ struct GDExtensionPtr {
 		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) { *VariantInternal::get_int(v) = uint64_t(p_value.data); }                                               \
 	};
 
-template <class T>
+template <typename T>
 struct GetTypeInfo<GDExtensionConstPtr<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
@@ -104,7 +104,7 @@ struct GetTypeInfo<GDExtensionConstPtr<T>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct GetTypeInfo<GDExtensionPtr<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
@@ -113,7 +113,7 @@ struct GetTypeInfo<GDExtensionPtr<T>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct PtrToArg<GDExtensionConstPtr<T>> {
 	_FORCE_INLINE_ static GDExtensionConstPtr<T> convert(const void *p_ptr) {
 		return GDExtensionConstPtr<T>(reinterpret_cast<const T *>(p_ptr));
@@ -123,7 +123,7 @@ struct PtrToArg<GDExtensionConstPtr<T>> {
 		*((const T **)p_ptr) = p_val.data;
 	}
 };
-template <class T>
+template <typename T>
 struct PtrToArg<GDExtensionPtr<T>> {
 	_FORCE_INLINE_ static GDExtensionPtr<T> convert(const void *p_ptr) {
 		return GDExtensionPtr<T>(reinterpret_cast<const T *>(p_ptr));

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -80,7 +80,7 @@ enum Metadata {
 // If 'T' is a class that inherits 'Object', make sure it can see the actual class declaration
 // instead of a forward declaration. You can always forward declare 'T' in a header file, and then
 // include the actual declaration of 'T' in the source file where 'GetTypeInfo<T>' is instantiated.
-template <class T, typename = void>
+template <typename T, typename = void>
 struct GetTypeInfo;
 
 #define MAKE_TYPE_INFO(m_type, m_var_type)                                            \
@@ -278,7 +278,7 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 	return GetTypeInfo<T>::get_class_info().class_name;
 }
 
-template <class T>
+template <typename T>
 class BitField {
 	int64_t value = 0;
 

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -38,7 +38,7 @@
 #include "core/variant/type_info.h"
 #include "core/variant/variant.h"
 
-template <class T>
+template <typename T>
 class TypedArray : public Array {
 public:
 	_FORCE_INLINE_ void operator=(const Array &p_array) {
@@ -56,12 +56,12 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantInternalAccessor<TypedArray<T>> {
 	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
 	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
 };
-template <class T>
+template <typename T>
 struct VariantInternalAccessor<const TypedArray<T> &> {
 	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
 	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
@@ -136,7 +136,7 @@ MAKE_TYPED_ARRAY(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
 MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
 MAKE_TYPED_ARRAY(IPAddress, Variant::STRING)
 
-template <class T>
+template <typename T>
 struct PtrToArg<TypedArray<T>> {
 	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
 		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
@@ -147,7 +147,7 @@ struct PtrToArg<TypedArray<T>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct PtrToArg<const TypedArray<T> &> {
 	typedef Array EncodeT;
 	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
@@ -155,7 +155,7 @@ struct PtrToArg<const TypedArray<T> &> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct GetTypeInfo<TypedArray<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
@@ -164,7 +164,7 @@ struct GetTypeInfo<TypedArray<T>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct GetTypeInfo<const TypedArray<T> &> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1697,7 +1697,7 @@ String stringify_variant_clean(const Variant &p_variant, int recursion_count) {
 	return s;
 }
 
-template <class T>
+template <typename T>
 String stringify_vector(const T &vec, int recursion_count) {
 	String str("[");
 	for (int i = 0; i < vec.size(); i++) {
@@ -2188,7 +2188,7 @@ Variant::operator Signal() const {
 	}
 }
 
-template <class DA, class SA>
+template <typename DA, typename SA>
 inline DA _convert_array(const SA &p_array) {
 	DA da;
 	da.resize(p_array.size());
@@ -2200,7 +2200,7 @@ inline DA _convert_array(const SA &p_array) {
 	return da;
 }
 
-template <class DA>
+template <typename DA>
 inline DA _convert_array_from_variant(const Variant &p_variant) {
 	switch (p_variant.get_type()) {
 		case Variant::ARRAY: {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -204,7 +204,7 @@ private:
 		_FORCE_INLINE_ virtual ~PackedArrayRefBase() {} //needs virtual destructor, but make inline
 	};
 
-	template <class T>
+	template <typename T>
 	struct PackedArrayRef : public PackedArrayRefBase {
 		Vector<T> array;
 		static _FORCE_INLINE_ PackedArrayRef<T> *create() {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -43,329 +43,329 @@
 typedef void (*VariantFunc)(Variant &r_ret, Variant &p_self, const Variant **p_args);
 typedef void (*VariantConstructFunc)(Variant &r_ret, const Variant **p_args);
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ void vc_static_method_call(R (*method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_static_ret_dv(method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ void vc_static_method_call(void (*method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_static_dv(method, p_args, p_argcount, r_error, p_defvals);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(R (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_ret_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_retc_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(void (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	VariantInternal::clear(&r_ret);
 	call_with_variant_args_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_error, p_defvals);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	VariantInternal::clear(&r_ret);
 	call_with_variant_argsc_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_error, p_defvals);
 }
 
-template <class From, class R, class T, class... P>
+template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(R (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_variant_args_ret_dv(&converted, method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
-template <class From, class R, class T, class... P>
+template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_variant_args_retc_dv(&converted, method, p_args, p_argcount, r_ret, r_error, p_defvals);
 }
 
-template <class From, class T, class... P>
+template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(void (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_variant_args_dv(&converted, method, p_args, p_argcount, r_error, p_defvals);
 }
 
-template <class From, class T, class... P>
+template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_method_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_variant_argsc_dv(&converted, method, p_args, p_argcount, r_error, p_defvals);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call_static(R (*method)(T *, P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_retc_static_helper_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, p_defvals, r_error);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_method_call_static(void (*method)(T *, P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_static_helper_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, p_defvals, r_error);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_validated_call(R (T::*method)(P...), Variant *base, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_ret(base, method, p_args, r_ret);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_validated_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_retc(base, method, p_args, r_ret);
 }
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_validated_call(void (T::*method)(P...), Variant *base, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args(base, method, p_args);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_validated_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_argsc(base, method, p_args);
 }
 
-template <class From, class R, class T, class... P>
+template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(R (T::*method)(P...), Variant *base, const Variant **p_args, Variant *r_ret) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_validated_variant_args_ret_helper<T, R, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class From, class R, class T, class... P>
+template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(R (T::*method)(P...) const, Variant *base, const Variant **p_args, Variant *r_ret) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_validated_variant_args_retc_helper<T, R, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
-template <class From, class T, class... P>
+template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(void (T::*method)(P...), Variant *base, const Variant **p_args, Variant *r_ret) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_validated_variant_args_helper<T, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class From, class T, class... P>
+template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_validated_call(void (T::*method)(P...) const, Variant *base, const Variant **p_args, Variant *r_ret) {
 	T converted(static_cast<T>(*VariantGetInternalPtr<From>::get_ptr(base)));
 	call_with_validated_variant_argsc_helper<T, P...>(&converted, method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_validated_call_static(R (*method)(T *, P...), Variant *base, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static_retc(base, method, p_args, r_ret);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_validated_call_static(void (*method)(T *, P...), Variant *base, const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static(base, method, p_args);
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ void vc_validated_static_call(R (*method)(P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static_method_ret(method, p_args, r_ret);
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ void vc_validated_static_call(void (*method)(P...), const Variant **p_args, Variant *r_ret) {
 	call_with_validated_variant_args_static_method(method, p_args);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_ptrcall(R (T::*method)(P...), void *p_base, const void **p_args, void *r_ret) {
 	call_with_ptr_args_ret(reinterpret_cast<T *>(p_base), method, p_args, r_ret);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_ptrcall(R (T::*method)(P...) const, void *p_base, const void **p_args, void *r_ret) {
 	call_with_ptr_args_retc(reinterpret_cast<T *>(p_base), method, p_args, r_ret);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_ptrcall(void (T::*method)(P...), void *p_base, const void **p_args, void *r_ret) {
 	call_with_ptr_args(reinterpret_cast<T *>(p_base), method, p_args);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_ptrcall(void (T::*method)(P...) const, void *p_base, const void **p_args, void *r_ret) {
 	call_with_ptr_argsc(reinterpret_cast<T *>(p_base), method, p_args);
 }
 
-template <class From, class R, class T, class... P>
+template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_ptrcall(R (T::*method)(P...), void *p_base, const void **p_args, void *r_ret) {
 	T converted(*reinterpret_cast<From *>(p_base));
 	call_with_ptr_args_ret(&converted, method, p_args, r_ret);
 }
 
-template <class From, class R, class T, class... P>
+template <typename From, typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_ptrcall(R (T::*method)(P...) const, void *p_base, const void **p_args, void *r_ret) {
 	T converted(*reinterpret_cast<From *>(p_base));
 	call_with_ptr_args_retc(&converted, method, p_args, r_ret);
 }
 
-template <class From, class T, class... P>
+template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_ptrcall(void (T::*method)(P...), void *p_base, const void **p_args, void *r_ret) {
 	T converted(*reinterpret_cast<From *>(p_base));
 	call_with_ptr_args(&converted, method, p_args);
 }
 
-template <class From, class T, class... P>
+template <typename From, typename T, typename... P>
 static _FORCE_INLINE_ void vc_convert_ptrcall(void (T::*method)(P...) const, void *p_base, const void **p_args, void *r_ret) {
 	T converted(*reinterpret_cast<From *>(p_base));
 	call_with_ptr_argsc(&converted, method, p_args);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ int vc_get_argument_count(R (T::*method)(P...)) {
 	return sizeof...(P);
 }
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ int vc_get_argument_count(R (T::*method)(P...) const) {
 	return sizeof...(P);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ int vc_get_argument_count(void (T::*method)(P...)) {
 	return sizeof...(P);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ int vc_get_argument_count(void (T::*method)(P...) const) {
 	return sizeof...(P);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ int vc_get_argument_count(R (*method)(T *, P...)) {
 	return sizeof...(P);
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ int vc_get_argument_count_static(R (*method)(P...)) {
 	return sizeof...(P);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_argument_type(R (T::*method)(P...), int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_argument_type(R (T::*method)(P...) const, int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_argument_type(void (T::*method)(P...), int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_argument_type(void (T::*method)(P...) const, int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_argument_type(R (*method)(T *, P...), int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_argument_type_static(R (*method)(P...), int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(R (T::*method)(P...)) {
 	return GetTypeInfo<R>::VARIANT_TYPE;
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(R (T::*method)(P...) const) {
 	return GetTypeInfo<R>::VARIANT_TYPE;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(void (T::*method)(P...)) {
 	return Variant::NIL;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(void (T::*method)(P...) const) {
 	return Variant::NIL;
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(R (*method)(P...)) {
 	return GetTypeInfo<R>::VARIANT_TYPE;
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(void (*method)(P...)) {
 	return Variant::NIL;
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ bool vc_has_return_type(R (T::*method)(P...)) {
 	return true;
 }
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ bool vc_has_return_type(R (T::*method)(P...) const) {
 	return true;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ bool vc_has_return_type(void (T::*method)(P...)) {
 	return false;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ bool vc_has_return_type(void (T::*method)(P...) const) {
 	return false;
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ bool vc_has_return_type_static(void (*method)(P...)) {
 	return false;
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ bool vc_has_return_type_static(R (*method)(P...)) {
 	return true;
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ bool vc_is_const(R (T::*method)(P...)) {
 	return false;
 }
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ bool vc_is_const(R (T::*method)(P...) const) {
 	return true;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ bool vc_is_const(void (T::*method)(P...)) {
 	return false;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ bool vc_is_const(void (T::*method)(P...) const) {
 	return true;
 }
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_base_type(R (T::*method)(P...)) {
 	return GetTypeInfo<T>::VARIANT_TYPE;
 }
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_base_type(R (T::*method)(P...) const) {
 	return GetTypeInfo<T>::VARIANT_TYPE;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...)) {
 	return GetTypeInfo<T>::VARIANT_TYPE;
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) const) {
 	return GetTypeInfo<T>::VARIANT_TYPE;
 }
@@ -450,12 +450,12 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 		}                                                                                                                                                         \
 	};
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ void vc_static_ptrcall(R (*method)(P...), const void **p_args, void *r_ret) {
 	call_with_ptr_args_static_method_ret<R, P...>(method, p_args, r_ret);
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ void vc_static_ptrcall(void (*method)(P...), const void **p_args, void *r_ret) {
 	call_with_ptr_args_static_method<P...>(method, p_args);
 }
@@ -500,12 +500,12 @@ static _FORCE_INLINE_ void vc_static_ptrcall(void (*method)(P...), const void **
 		}                                                                                                                                                         \
 	};
 
-template <class R, class T, class... P>
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ void vc_ptrcall(R (*method)(T *, P...), void *p_base, const void **p_args, void *r_ret) {
 	call_with_ptr_args_static_retc<T, R, P...>(reinterpret_cast<T *>(p_base), method, p_args, r_ret);
 }
 
-template <class T, class... P>
+template <typename T, typename... P>
 static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, const void **p_args, void *r_ret) {
 	call_with_ptr_args_static<T, P...>(reinterpret_cast<T *>(p_base), method, p_args);
 }
@@ -1160,7 +1160,7 @@ typedef OAHashMap<StringName, VariantBuiltInMethodInfo> BuiltinMethodMap;
 static BuiltinMethodMap *builtin_method_info;
 static List<StringName> *builtin_method_names;
 
-template <class T>
+template <typename T>
 static void register_builtin_method(const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
 	StringName name = T::get_name();
 

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -41,7 +41,7 @@ struct VariantConstructData {
 
 static LocalVector<VariantConstructData> construct_data[Variant::VARIANT_MAX];
 
-template <class T>
+template <typename T>
 static void add_constructor(const Vector<String> &arg_names) {
 	ERR_FAIL_COND_MSG(arg_names.size() != T::get_argument_count(), "Argument names size mismatch for " + Variant::get_type_name(T::get_base_type()) + ".");
 

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -42,7 +42,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
 
-template <class T>
+template <typename T>
 struct PtrConstruct {};
 
 #define MAKE_PTRCONSTRUCT(m_type)                                                  \
@@ -99,7 +99,7 @@ MAKE_PTRCONSTRUCT(PackedVector3Array);
 MAKE_PTRCONSTRUCT(PackedColorArray);
 MAKE_PTRCONSTRUCT(Variant);
 
-template <class T, class... P>
+template <typename T, typename... P>
 class VariantConstructor {
 	template <size_t... Is>
 	static _FORCE_INLINE_ void construct_helper(T &base, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
@@ -222,7 +222,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class VariantConstructorFromString {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
@@ -470,7 +470,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class VariantConstructorToArray {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
@@ -529,7 +529,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class VariantConstructorFromArray {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
@@ -622,7 +622,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class VariantConstructNoArgs {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {

--- a/core/variant/variant_destruct.cpp
+++ b/core/variant/variant_destruct.cpp
@@ -34,7 +34,7 @@
 
 static Variant::PTRDestructor destruct_pointers[Variant::VARIANT_MAX] = { nullptr };
 
-template <class T>
+template <typename T>
 static void add_destructor() {
 	destruct_pointers[T::get_base_type()] = T::ptr_destruct;
 }

--- a/core/variant/variant_destruct.h
+++ b/core/variant/variant_destruct.h
@@ -35,7 +35,7 @@
 
 #include "core/object/class_db.h"
 
-template <class T>
+template <typename T>
 struct VariantDestruct {};
 
 #define MAKE_PTRDESTRUCT(m_type)                               \

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -211,7 +211,7 @@ public:
 
 	_FORCE_INLINE_ static const ObjectID get_object_id(const Variant *v) { return v->_get_obj().id; }
 
-	template <class T>
+	template <typename T>
 	_FORCE_INLINE_ static void init_generic(Variant *v) {
 		v->type = GetTypeInfo<T>::VARIANT_TYPE;
 	}
@@ -510,7 +510,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantGetInternalPtr {
 };
 
@@ -797,7 +797,7 @@ struct VariantGetInternalPtr<PackedColorArray> {
 	static const PackedColorArray *get_ptr(const Variant *v) { return VariantInternal::get_color_array(v); }
 };
 
-template <class T>
+template <typename T>
 struct VariantInternalAccessor {
 };
 
@@ -830,13 +830,13 @@ struct VariantInternalAccessor<ObjectID> {
 	static _FORCE_INLINE_ void set(Variant *v, ObjectID p_value) { *VariantInternal::get_int(v) = p_value; }
 };
 
-template <class T>
+template <typename T>
 struct VariantInternalAccessor<T *> {
 	static _FORCE_INLINE_ T *get(const Variant *v) { return const_cast<T *>(static_cast<const T *>(*VariantInternal::get_object(v))); }
 	static _FORCE_INLINE_ void set(Variant *v, const T *p_value) { VariantInternal::object_assign(v, p_value); }
 };
 
-template <class T>
+template <typename T>
 struct VariantInternalAccessor<const T *> {
 	static _FORCE_INLINE_ const T *get(const Variant *v) { return static_cast<const T *>(*VariantInternal::get_object(v)); }
 	static _FORCE_INLINE_ void set(Variant *v, const T *p_value) { VariantInternal::object_assign(v, p_value); }
@@ -1091,7 +1091,7 @@ struct VariantInternalAccessor<Vector<Variant>> {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantInitializer {
 };
 
@@ -1301,7 +1301,7 @@ struct VariantInitializer<Object *> {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_object(v); }
 };
 
-template <class T>
+template <typename T>
 struct VariantDefaultInitializer {
 };
 
@@ -1490,7 +1490,7 @@ struct VariantDefaultInitializer<PackedColorArray> {
 	static _FORCE_INLINE_ void init(Variant *v) { *VariantInternal::get_color_array(v) = PackedColorArray(); }
 };
 
-template <class T>
+template <typename T>
 struct VariantTypeChanger {
 	static _FORCE_INLINE_ void change(Variant *v) {
 		if (v->get_type() != GetTypeInfo<T>::VARIANT_TYPE || GetTypeInfo<T>::VARIANT_TYPE >= Variant::PACKED_BYTE_ARRAY) { //second condition removed by optimizer
@@ -1508,7 +1508,7 @@ struct VariantTypeChanger {
 	}
 };
 
-template <class T>
+template <typename T>
 struct VariantTypeAdjust {
 	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
 		VariantTypeChanger<typename GetSimpleTypeT<T>::type_t>::change(r_ret);
@@ -1532,7 +1532,7 @@ struct VariantTypeAdjust<Object *> {
 
 // GDExtension helpers.
 
-template <class T>
+template <typename T>
 struct VariantTypeConstructor {
 	_FORCE_INLINE_ static void variant_from_type(void *r_variant, void *p_value) {
 		// r_variant is provided by caller as uninitialized memory

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -37,7 +37,7 @@ static VariantEvaluatorFunction operator_evaluator_table[Variant::OP_MAX][Varian
 static Variant::ValidatedOperatorEvaluator validated_operator_evaluator_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];
 static Variant::PTROperatorEvaluator ptr_operator_evaluator_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];
 
-template <class T>
+template <typename T>
 void register_op(Variant::Operator p_op, Variant::Type p_type_a, Variant::Type p_type_b) {
 	operator_return_type_table[p_op][p_type_a][p_type_b] = T::get_return_type();
 	operator_evaluator_table[p_op][p_type_a][p_type_b] = T::evaluate;

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -37,7 +37,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/object/class_db.h"
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorAdd {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -55,7 +55,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorSub {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -73,7 +73,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorMul {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -91,7 +91,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorPow {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -109,7 +109,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorXForm {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -127,7 +127,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorXFormInv {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -145,7 +145,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorDiv {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -163,7 +163,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorDivNZ {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -258,7 +258,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorMod {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -276,7 +276,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorModNZ {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -371,7 +371,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
 };
 
-template <class R, class A>
+template <typename R, typename A>
 class OperatorEvaluatorNeg {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -388,7 +388,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A>
+template <typename R, typename A>
 class OperatorEvaluatorPos {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -405,7 +405,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorShiftLeft {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -431,7 +431,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorShiftRight {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -457,7 +457,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorBitOr {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -475,7 +475,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorBitAnd {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -493,7 +493,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A, class B>
+template <typename R, typename A, typename B>
 class OperatorEvaluatorBitXor {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -511,7 +511,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class R, class A>
+template <typename R, typename A>
 class OperatorEvaluatorBitNeg {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -528,7 +528,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -599,7 +599,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorNotEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -670,7 +670,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorLess {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -688,7 +688,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorLessEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -706,7 +706,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorGreater {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -724,7 +724,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorGreaterEqual {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -742,7 +742,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorAnd {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -760,7 +760,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorOr {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -779,7 +779,7 @@ public:
 };
 
 #define XOR_OP(m_a, m_b) (((m_a) || (m_b)) && !((m_a) && (m_b)))
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorXor {
 public:
 	_FORCE_INLINE_ static bool xor_op(const A &a, const B &b) {
@@ -800,7 +800,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A>
+template <typename A>
 class OperatorEvaluatorNot {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -857,7 +857,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::ARRAY; }
 };
 
-template <class T>
+template <typename T>
 class OperatorEvaluatorAppendArray {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -880,7 +880,7 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector<T>>::VARIANT_TYPE; }
 };
 
-template <class Left, class Right>
+template <typename Left, typename Right>
 class OperatorEvaluatorStringConcat {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -902,10 +902,10 @@ public:
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
-template <class S, class T>
+template <typename S, typename T>
 class OperatorEvaluatorStringFormat;
 
-template <class S>
+template <typename S>
 class OperatorEvaluatorStringFormat<S, void> {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, bool *r_valid) {
@@ -933,7 +933,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
-template <class S>
+template <typename S>
 class OperatorEvaluatorStringFormat<S, Array> {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, const Array &p_values, bool *r_valid) {
@@ -958,7 +958,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
-template <class S>
+template <typename S>
 class OperatorEvaluatorStringFormat<S, Object> {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, const Object *p_object, bool *r_valid) {
@@ -986,7 +986,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
-template <class S, class T>
+template <typename S, typename T>
 class OperatorEvaluatorStringFormat {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, const T &p_value, bool *r_valid) {
@@ -1317,10 +1317,10 @@ public:
 
 ////
 
-template <class Left, class Right>
+template <typename Left, typename Right>
 class OperatorEvaluatorInStringFind;
 
-template <class Left>
+template <typename Left>
 class OperatorEvaluatorInStringFind<Left, String> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -1341,7 +1341,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class Left>
+template <typename Left>
 class OperatorEvaluatorInStringFind<Left, StringName> {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -1362,7 +1362,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A, class B>
+template <typename A, typename B>
 class OperatorEvaluatorInArrayFind {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -1417,7 +1417,7 @@ public:
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
-template <class A>
+template <typename A>
 class OperatorEvaluatorInDictionaryHas {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -546,7 +546,7 @@ Error VariantParser::_parse_enginecfg(Stream *p_stream, Vector<String> &strings,
 	}
 }
 
-template <class T>
+template <typename T>
 Error VariantParser::_parse_construct(Stream *p_stream, Vector<T> &r_construct, int &line, String &r_err_str) {
 	Token token;
 	get_token(p_stream, token, line, r_err_str);

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -139,7 +139,7 @@ public:
 private:
 	static const char *tk_name[TK_MAX];
 
-	template <class T>
+	template <typename T>
 	static Error _parse_construct(Stream *p_stream, Vector<T> &r_construct, int &line, String &r_err_str);
 	static Error _parse_enginecfg(Stream *p_stream, Vector<String> &strings, int &line, String &r_err_str);
 	static Error _parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -45,7 +45,7 @@ struct VariantSetterGetterInfo {
 static LocalVector<VariantSetterGetterInfo> variant_setters_getters[Variant::VARIANT_MAX];
 static LocalVector<StringName> variant_setters_getters_names[Variant::VARIANT_MAX]; //one next to another to make it cache friendly
 
-template <class T>
+template <typename T>
 static void register_member(Variant::Type p_type, const StringName &p_member) {
 	VariantSetterGetterInfo sgi;
 	sgi.setter = T::set;
@@ -873,7 +873,7 @@ struct VariantIndexedSetterGetterInfo {
 
 static VariantIndexedSetterGetterInfo variant_indexed_setters_getters[Variant::VARIANT_MAX];
 
-template <class T>
+template <typename T>
 static void register_indexed_member(Variant::Type p_type) {
 	VariantIndexedSetterGetterInfo &sgi = variant_indexed_setters_getters[p_type];
 
@@ -1094,7 +1094,7 @@ struct VariantKeyedSetterGetterInfo {
 
 static VariantKeyedSetterGetterInfo variant_keyed_setters_getters[Variant::VARIANT_MAX];
 
-template <class T>
+template <typename T>
 static void register_keyed_member(Variant::Type p_type) {
 	VariantKeyedSetterGetterInfo &sgi = variant_keyed_setters_getters[p_type];
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1235,7 +1235,7 @@ bool VariantUtilityFunctions::is_same(const Variant &p_a, const Variant &p_b) {
 #define VCALL p_func(VariantCaster<P>::cast(*p_args[Is])...)
 #endif
 
-template <class R, class... P, size_t... Is>
+template <typename R, typename... P, size_t... Is>
 static _FORCE_INLINE_ void call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 	VCALLR;
@@ -1243,51 +1243,51 @@ static _FORCE_INLINE_ void call_helperpr(R (*p_func)(P...), Variant *ret, const 
 	(void)r_error;
 }
 
-template <class R, class... P, size_t... Is>
+template <typename R, typename... P, size_t... Is>
 static _FORCE_INLINE_ void validated_call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, IndexSequence<Is...>) {
 	*ret = p_func(VariantCaster<P>::cast(*p_args[Is])...);
 	(void)p_args;
 }
 
-template <class R, class... P, size_t... Is>
+template <typename R, typename... P, size_t... Is>
 static _FORCE_INLINE_ void ptr_call_helperpr(R (*p_func)(P...), void *ret, const void **p_args, IndexSequence<Is...>) {
 	PtrToArg<R>::encode(p_func(PtrToArg<P>::convert(p_args[Is])...), ret);
 	(void)p_args;
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error) {
 	call_helperpr(p_func, ret, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ void validated_call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args) {
 	validated_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ void ptr_call_helperr(R (*p_func)(P...), void *ret, const void **p_args) {
 	ptr_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ int get_arg_count_helperr(R (*p_func)(P...)) {
 	return sizeof...(P);
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ Variant::Type get_arg_type_helperr(R (*p_func)(P...), int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class R, class... P>
+template <typename R, typename... P>
 static _FORCE_INLINE_ Variant::Type get_ret_type_helperr(R (*p_func)(P...)) {
 	return GetTypeInfo<R>::VARIANT_TYPE;
 }
 
 // WITHOUT RET
 
-template <class... P, size_t... Is>
+template <typename... P, size_t... Is>
 static _FORCE_INLINE_ void call_helperp(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 	VCALL;
@@ -1295,44 +1295,44 @@ static _FORCE_INLINE_ void call_helperp(void (*p_func)(P...), const Variant **p_
 	(void)r_error;
 }
 
-template <class... P, size_t... Is>
+template <typename... P, size_t... Is>
 static _FORCE_INLINE_ void validated_call_helperp(void (*p_func)(P...), const Variant **p_args, IndexSequence<Is...>) {
 	p_func(VariantCaster<P>::cast(*p_args[Is])...);
 	(void)p_args;
 }
 
-template <class... P, size_t... Is>
+template <typename... P, size_t... Is>
 static _FORCE_INLINE_ void ptr_call_helperp(void (*p_func)(P...), const void **p_args, IndexSequence<Is...>) {
 	p_func(PtrToArg<P>::convert(p_args[Is])...);
 	(void)p_args;
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error) {
 	call_helperp(p_func, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ void validated_call_helper(void (*p_func)(P...), const Variant **p_args) {
 	validated_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ void ptr_call_helper(void (*p_func)(P...), const void **p_args) {
 	ptr_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ int get_arg_count_helper(void (*p_func)(P...)) {
 	return sizeof...(P);
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ Variant::Type get_arg_type_helper(void (*p_func)(P...), int p_arg) {
 	return call_get_argument_type<P...>(p_arg);
 }
 
-template <class... P>
+template <typename... P>
 static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	return Variant::NIL;
 }
@@ -1645,7 +1645,7 @@ struct VariantUtilityFunctionInfo {
 static OAHashMap<StringName, VariantUtilityFunctionInfo> utility_function_table;
 static List<StringName> utility_function_name_table;
 
-template <class T>
+template <typename T>
 static void register_utility_function(const String &p_name, const Vector<String> &argnames) {
 	String name = p_name;
 	if (name.begins_with("_")) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -144,7 +144,7 @@ private:
 	RS::ViewportDebugDraw debug_draw = RS::VIEWPORT_DEBUG_DRAW_DISABLED;
 	uint64_t scene_pass = 0;
 
-	template <class T>
+	template <typename T>
 	struct InstanceSort {
 		float depth;
 		T *instance = nullptr;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -300,7 +300,7 @@ public:
 	void remove_node(Node *p_node);
 	bool is_selected(Node *p_node) const;
 
-	template <class T>
+	template <typename T>
 	T *get_node_editor_data(Node *p_node) {
 		if (!selection.has(p_node)) {
 			return nullptr;

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -117,7 +117,7 @@ class EditorHelpSearch::Runner : public RefCounted {
 	};
 	int phase = 0;
 
-	template <class T>
+	template <typename T>
 	struct MemberMatch {
 		T *doc = nullptr;
 		bool name = false;

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -264,7 +264,7 @@ class EditorPlugins {
 	static EditorPluginCreateFunc creation_funcs[MAX_CREATE_FUNCS];
 	static int creation_func_count;
 
-	template <class T>
+	template <typename T>
 	static EditorPlugin *creator() {
 		return memnew(T);
 	}
@@ -276,7 +276,7 @@ public:
 		return creation_funcs[p_idx]();
 	}
 
-	template <class T>
+	template <typename T>
 	static void add_by_type() {
 		add_create_func(creator<T>);
 	}

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -303,10 +303,10 @@ public:
 	ResourceImporterScene(bool p_animation_import = false, bool p_singleton = false);
 	~ResourceImporterScene();
 
-	template <class M>
+	template <typename M>
 	static Vector<Ref<Shape3D>> get_collision_shapes(const Ref<ImporterMesh> &p_mesh, const M &p_options, float p_applied_root_scale);
 
-	template <class M>
+	template <typename M>
 	static Transform3D get_collision_shapes_transform(const M &p_options);
 };
 
@@ -319,7 +319,7 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 
-template <class M>
+template <typename M>
 Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<ImporterMesh> &p_mesh, const M &p_options, float p_applied_root_scale) {
 	ERR_FAIL_COND_V(p_mesh.is_null(), Vector<Ref<Shape3D>>());
 	ShapeType generate_shape_type = SHAPE_TYPE_DECOMPOSE_CONVEX;
@@ -476,7 +476,7 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Impor
 	return Vector<Ref<Shape3D>>();
 }
 
-template <class M>
+template <typename M>
 Transform3D ResourceImporterScene::get_collision_shapes_transform(const M &p_options) {
 	Transform3D transform;
 

--- a/main/main.h
+++ b/main/main.h
@@ -35,7 +35,7 @@
 #include "core/os/thread.h"
 #include "core/typedefs.h"
 
-template <class T>
+template <typename T>
 class Vector;
 
 class Main {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -799,7 +799,7 @@ void GDScriptParser::parse_extends() {
 	}
 }
 
-template <class T>
+template <typename T>
 void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)(bool), AnnotationInfo::TargetKind p_target, const String &p_member_kind, bool p_is_static) {
 	advance();
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -777,7 +777,7 @@ public:
 		bool has_function(const StringName &p_name) const {
 			return has_member(p_name) && members[members_indices[p_name]].type == Member::FUNCTION;
 		}
-		template <class T>
+		template <typename T>
 		void add_member(T *p_member_node) {
 			members_indices[p_member_node->identifier->name] = members.size();
 			members.push_back(Member(p_member_node));
@@ -1167,7 +1167,7 @@ public:
 
 		bool has_local(const StringName &p_name) const;
 		const Local &get_local(const StringName &p_name) const;
-		template <class T>
+		template <typename T>
 		void add_local(T *p_local, FunctionNode *p_source_function) {
 			locals_indices[p_local->identifier->name] = locals.size();
 			locals.push_back(Local(p_local, p_source_function));
@@ -1418,7 +1418,7 @@ private:
 	void reset_extents(Node *p_node, GDScriptTokenizer::Token p_token);
 	void reset_extents(Node *p_node, Node *p_from);
 
-	template <class T>
+	template <typename T>
 	T *alloc_node() {
 		T *node = memnew(T);
 
@@ -1464,7 +1464,7 @@ private:
 	void parse_class_name();
 	void parse_extends();
 	void parse_class_body(bool p_is_multiline);
-	template <class T>
+	template <typename T>
 	void parse_class_member(T *(GDScriptParser::*p_parse_function)(bool), AnnotationInfo::TargetKind p_target, const String &p_member_kind, bool p_is_static = false);
 	SignalNode *parse_signal(bool p_is_static);
 	EnumNode *parse_enum(bool p_is_static);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5483,7 +5483,7 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> p_state, const GL
 	}
 }
 
-template <class T>
+template <typename T>
 struct SceneFormatImporterGLTFInterpolate {
 	T lerp(const T &a, const T &b, float c) const {
 		return a + (b - a) * c;
@@ -5533,7 +5533,7 @@ struct SceneFormatImporterGLTFInterpolate<Quaternion> {
 	}
 };
 
-template <class T>
+template <typename T>
 T GLTFDocument::_interpolate_track(const Vector<real_t> &p_times, const Vector<T> &p_values, const float p_time, const GLTFAnimation::Interpolation p_interp) {
 	ERR_FAIL_COND_V(p_values.is_empty(), T());
 	if (p_times.size() != (p_values.size() / (p_interp == GLTFAnimation::INTERP_CUBIC_SPLINE ? 3 : 1))) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -216,7 +216,7 @@ private:
 	Light3D *_generate_light(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
 	Node3D *_generate_spatial(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
 	void _assign_node_names(Ref<GLTFState> p_state);
-	template <class T>
+	template <typename T>
 	T _interpolate_track(const Vector<real_t> &p_times, const Vector<T> &p_values,
 			const float p_time,
 			const GLTFAnimation::Interpolation p_interp);

--- a/modules/gltf/gltf_template_convert.h
+++ b/modules/gltf/gltf_template_convert.h
@@ -37,7 +37,7 @@
 #include "core/variant/typed_array.h"
 
 namespace GLTFTemplateConvert {
-template <class T>
+template <typename T>
 static Array to_array(const Vector<T> &p_inp) {
 	Array ret;
 	for (int i = 0; i < p_inp.size(); i++) {
@@ -46,7 +46,7 @@ static Array to_array(const Vector<T> &p_inp) {
 	return ret;
 }
 
-template <class T>
+template <typename T>
 static TypedArray<T> to_array(const HashSet<T> &p_inp) {
 	TypedArray<T> ret;
 	typename HashSet<T>::Iterator elem = p_inp.begin();
@@ -57,7 +57,7 @@ static TypedArray<T> to_array(const HashSet<T> &p_inp) {
 	return ret;
 }
 
-template <class T>
+template <typename T>
 static void set_from_array(Vector<T> &r_out, const Array &p_inp) {
 	r_out.clear();
 	for (int i = 0; i < p_inp.size(); i++) {
@@ -65,7 +65,7 @@ static void set_from_array(Vector<T> &r_out, const Array &p_inp) {
 	}
 }
 
-template <class T>
+template <typename T>
 static void set_from_array(HashSet<T> &r_out, const TypedArray<T> &p_inp) {
 	r_out.clear();
 	for (int i = 0; i < p_inp.size(); i++) {
@@ -73,7 +73,7 @@ static void set_from_array(HashSet<T> &r_out, const TypedArray<T> &p_inp) {
 	}
 }
 
-template <class K, class V>
+template <typename K, typename V>
 static Dictionary to_dictionary(const HashMap<K, V> &p_inp) {
 	Dictionary ret;
 	for (const KeyValue<K, V> &E : p_inp) {
@@ -82,7 +82,7 @@ static Dictionary to_dictionary(const HashMap<K, V> &p_inp) {
 	return ret;
 }
 
-template <class K, class V>
+template <typename K, typename V>
 static void set_from_dictionary(HashMap<K, V> &r_out, const Dictionary &p_inp) {
 	r_out.clear();
 	Array keys = p_inp.keys();

--- a/modules/gltf/structures/gltf_animation.h
+++ b/modules/gltf/structures/gltf_animation.h
@@ -47,7 +47,7 @@ public:
 		INTERP_CUBIC_SPLINE,
 	};
 
-	template <class T>
+	template <typename T>
 	struct Channel {
 		Interpolation interpolation = INTERP_LINEAR;
 		Vector<real_t> times;

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -112,7 +112,7 @@ private:
 	Error _update_spawn_visibility(int p_peer, const ObjectID &p_oid);
 	void _free_remotes(const PeerInfo &p_info);
 
-	template <class T>
+	template <typename T>
 	static T *get_id_as(const ObjectID &p_id) {
 		return p_id.is_valid() ? Object::cast_to<T>(ObjectDB::get_instance(p_id)) : nullptr;
 	}

--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -33,7 +33,7 @@
 
 #include "core/templates/ring_buffer.h"
 
-template <class T>
+template <typename T>
 class PacketBuffer {
 private:
 	typedef struct {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -69,7 +69,7 @@
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x4
 #endif
 
-template <class T>
+template <typename T>
 class ComAutoreleaseRef {
 public:
 	T *reference = nullptr;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -57,7 +57,7 @@ protected:
 		MTFlag() :
 				mt{} {}
 	};
-	template <class T>
+	template <typename T>
 	union MTNumeric {
 		SafeNumeric<T> mt;
 		T st;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1041,7 +1041,7 @@ bool Animation::track_get_interpolation_loop_wrap(int p_track) const {
 	return tracks[p_track]->loop_wrap;
 }
 
-template <class T, class V>
+template <typename T, typename V>
 int Animation::_insert(double p_time, T &p_keys, const V &p_value) {
 	int idx = p_keys.size();
 
@@ -1065,7 +1065,7 @@ int Animation::_insert(double p_time, T &p_keys, const V &p_value) {
 	return -1;
 }
 
-template <class T>
+template <typename T>
 void Animation::_clear(T &p_keys) {
 	p_keys.clear();
 }
@@ -2331,7 +2331,7 @@ void Animation::track_set_key_transition(int p_track, int p_key_idx, real_t p_tr
 	emit_changed();
 }
 
-template <class K>
+template <typename K>
 int Animation::_find(const Vector<K> &p_keys, double p_time, bool p_backward, bool p_limit) const {
 	int len = p_keys.size();
 	if (len == 0) {
@@ -2451,7 +2451,7 @@ Variant Animation::_cubic_interpolate_angle_in_time(const Variant &p_pre_a, cons
 	return _cubic_interpolate_in_time(p_pre_a, p_a, p_b, p_post_b, p_c, p_pre_a_t, p_b_t, p_post_b_t);
 }
 
-template <class T>
+template <typename T>
 T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward) const {
 	int len = _find(p_keys, length) + 1; // try to find last key (there may be more past the end)
 
@@ -2693,7 +2693,7 @@ Animation::UpdateMode Animation::value_track_get_update_mode(int p_track) const 
 	return vt->update_mode;
 }
 
-template <class T>
+template <typename T>
 void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const {
 	int len = p_array.size();
 	if (len == 0) {

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -120,7 +120,7 @@ private:
 	};
 
 	// Transform key holds either Vector3 or Quaternion.
-	template <class T>
+	template <typename T>
 	struct TKey : public Key {
 		T value;
 	};
@@ -235,13 +235,13 @@ private:
 
 	Vector<Track *> tracks;
 
-	template <class T>
+	template <typename T>
 	void _clear(T &p_keys);
 
-	template <class T, class V>
+	template <typename T, typename V>
 	int _insert(double p_time, T &p_keys, const V &p_value);
 
-	template <class K>
+	template <typename K>
 
 	inline int _find(const Vector<K> &p_keys, double p_time, bool p_backward = false, bool p_limit = false) const;
 
@@ -257,10 +257,10 @@ private:
 	_FORCE_INLINE_ real_t _cubic_interpolate_in_time(const real_t &p_pre_a, const real_t &p_a, const real_t &p_b, const real_t &p_post_b, real_t p_c, real_t p_pre_a_t, real_t p_b_t, real_t p_post_b_t) const;
 	_FORCE_INLINE_ Variant _cubic_interpolate_angle_in_time(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, real_t p_c, real_t p_pre_a_t, real_t p_b_t, real_t p_post_b_t) const;
 
-	template <class T>
+	template <typename T>
 	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward = false) const;
 
-	template <class T>
+	template <typename T>
 	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const;
 
 	double length = 1.0;

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -86,7 +86,7 @@ void AudioStreamPlaybackWAV::seek(double p_time) {
 	offset = uint64_t(p_time * base->mix_rate) << MIX_FRAC_BITS;
 }
 
-template <class Depth, bool is_stereo, bool is_ima_adpcm>
+template <typename Depth, bool is_stereo, bool is_ima_adpcm>
 void AudioStreamPlaybackWAV::do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &p_offset, int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm) {
 	// this function will be compiled branchless by any decent compiler
 

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -60,7 +60,7 @@ class AudioStreamPlaybackWAV : public AudioStreamPlayback {
 	friend class AudioStreamWAV;
 	Ref<AudioStreamWAV> base;
 
-	template <class Depth, bool is_stereo, bool is_ima_adpcm>
+	template <typename Depth, bool is_stereo, bool is_ima_adpcm>
 	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &p_offset, int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm);
 
 public:

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -71,7 +71,7 @@ protected:
 
 	static void _bind_methods();
 
-	template <class T>
+	template <typename T>
 	static CameraServer *_create_builtin() {
 		return memnew(T);
 	}
@@ -79,7 +79,7 @@ protected:
 public:
 	static CameraServer *get_singleton();
 
-	template <class T>
+	template <typename T>
 	static void make_default() {
 		create_func = _create_builtin<T>;
 	}

--- a/servers/physics_2d/godot_broad_phase_2d_bvh.h
+++ b/servers/physics_2d/godot_broad_phase_2d_bvh.h
@@ -38,7 +38,7 @@
 #include "core/math/vector2.h"
 
 class GodotBroadPhase2DBVH : public GodotBroadPhase2D {
-	template <class T>
+	template <typename T>
 	class UserPairTestFunction {
 	public:
 		static bool user_pair_check(const T *p_a, const T *p_b) {
@@ -47,7 +47,7 @@ class GodotBroadPhase2DBVH : public GodotBroadPhase2D {
 		}
 	};
 
-	template <class T>
+	template <typename T>
 	class UserCullTestFunction {
 	public:
 		static bool user_cull_check(const T *p_a, const T *p_b) {

--- a/servers/physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d_sat.cpp
@@ -171,7 +171,7 @@ static void _generate_contacts_from_supports(const Vector2 *p_points_A, int p_po
 	contacts_func(points_A, pointcount_A, points_B, pointcount_B, p_collector);
 }
 
-template <class ShapeA, class ShapeB, bool castA = false, bool castB = false, bool withMargin = false>
+template <typename ShapeA, typename ShapeB, bool castA = false, bool castB = false, bool withMargin = false>
 class SeparatorAxisTest2D {
 	const ShapeA *shape_A = nullptr;
 	const ShapeB *shape_B = nullptr;

--- a/servers/physics_3d/godot_broad_phase_3d_bvh.h
+++ b/servers/physics_3d/godot_broad_phase_3d_bvh.h
@@ -36,7 +36,7 @@
 #include "core/math/bvh.h"
 
 class GodotBroadPhase3DBVH : public GodotBroadPhase3D {
-	template <class T>
+	template <typename T>
 	class UserPairTestFunction {
 	public:
 		static bool user_pair_check(const T *p_a, const T *p_b) {
@@ -45,7 +45,7 @@ class GodotBroadPhase3DBVH : public GodotBroadPhase3D {
 		}
 	};
 
-	template <class T>
+	template <typename T>
 	class UserCullTestFunction {
 	public:
 		static bool user_cull_check(const T *p_a, const T *p_b) {

--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -612,7 +612,7 @@ static void _generate_contacts_from_supports(const Vector3 *p_points_A, int p_po
 	contacts_func(points_A, pointcount_A, points_B, pointcount_B, p_callback);
 }
 
-template <class ShapeA, class ShapeB, bool withMargin = false>
+template <typename ShapeA, typename ShapeB, bool withMargin = false>
 class SeparatorAxisTest {
 	const ShapeA *shape_A = nullptr;
 	const ShapeB *shape_B = nullptr;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -2162,7 +2162,7 @@ bool RendererCanvasCull::free(RID p_rid) {
 	return true;
 }
 
-template <class T>
+template <typename T>
 void RendererCanvasCull::_free_rids(T &p_owner, const char *p_type) {
 	List<RID> owned;
 	p_owner.get_owned_list(&owned);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -170,7 +170,7 @@ public:
 	RID_Owner<Item, true> canvas_item_owner;
 	RID_Owner<RendererCanvasRender::Light, true> canvas_light_owner;
 
-	template <class T>
+	template <typename T>
 	void _free_rids(T &p_owner, const char *p_type);
 
 	bool disable_scale;

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -366,7 +366,7 @@ public:
 		mutable double debug_redraw_time = 0;
 #endif
 
-		template <class T>
+		template <typename T>
 		T *alloc_command() {
 			T *command = nullptr;
 			if (commands == nullptr) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -5182,7 +5182,7 @@ void RenderingDevice::_save_pipeline_cache(void *p_data) {
 	}
 }
 
-template <class T>
+template <typename T>
 void RenderingDevice::_free_rids(T &p_owner, const char *p_type) {
 	List<RID> owned;
 	p_owner.get_owned_list(&owned);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1294,7 +1294,7 @@ private:
 	void _stall_for_previous_frames();
 	void _flush_and_stall_for_all_frames();
 
-	template <class T>
+	template <typename T>
 	void _free_rids(T &p_owner, const char *p_type);
 
 #ifdef DEV_ENABLED

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -56,7 +56,7 @@
 
 // This may one day be used in Godot for interoperability between C arrays, Vector and LocalVector.
 // (See https://github.com/godotengine/godot-proposals/issues/5144.)
-template <class T>
+template <typename T>
 class VectorView {
 	const T *_ptr = nullptr;
 	const uint32_t _size = 0;
@@ -97,20 +97,20 @@ public:
 #define ENUM_MEMBERS_EQUAL(m_a, m_b) ((int64_t)m_a == (int64_t)m_b)
 
 // This helps using a single paged allocator for many resource types.
-template <class... RESOURCE_TYPES>
+template <typename... RESOURCE_TYPES>
 struct VersatileResourceTemplate {
 	static constexpr size_t RESOURCE_SIZES[] = { sizeof(RESOURCE_TYPES)... };
 	static constexpr size_t MAX_RESOURCE_SIZE = std::max_element(RESOURCE_SIZES, RESOURCE_SIZES + sizeof...(RESOURCE_TYPES))[0];
 	uint8_t data[MAX_RESOURCE_SIZE];
 
-	template <class T>
+	template <typename T>
 	static T *allocate(PagedAllocator<VersatileResourceTemplate> &p_allocator) {
 		T *obj = (T *)p_allocator.alloc();
 		memnew_placement(obj, T);
 		return obj;
 	}
 
-	template <class T>
+	template <typename T>
 	static void free(PagedAllocator<VersatileResourceTemplate> &p_allocator, T *p_object) {
 		p_object->~T();
 		p_allocator.free((VersatileResourceTemplate *)p_object);

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -383,7 +383,7 @@ public:
 		virtual ~Node() {}
 	};
 
-	template <class T>
+	template <typename T>
 	T *alloc_node() {
 		T *node = memnew(T);
 		node->next = nodes;

--- a/servers/rendering/storage/variant_converters.h
+++ b/servers/rendering/storage/variant_converters.h
@@ -242,10 +242,10 @@ inline bool is_convertible_array(Variant::Type type) {
 			type == Variant::PACKED_COLOR_ARRAY;
 }
 
-template <class, class = void>
+template <typename, typename = void>
 inline constexpr bool is_vector_type_v = false;
 
-template <class T>
+template <typename T>
 inline constexpr bool is_vector_type_v<T, std::void_t<decltype(T::AXIS_COUNT)>> = true;
 
 template <typename T, typename P>


### PR DESCRIPTION
Cleanup commit meant to standardize template `class` vs `typename` naming conventions, opting for the latter. Nothing functionally changes as a result of this, beyond uniformity across all templates.