### PR TITLE
Fix use after free in `GDScriptLanguage::debug_get_globals`

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -402,7 +402,9 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 		}
 
 		const Variant &var = gl_array[E.value];
-		if (Object *obj = var) {
+		bool freed = false;
+		const Object *obj = var.get_validated_object_with_check(freed);
+		if (obj && !freed) {
 			if (Object::cast_to<GDScriptNativeClass>(obj)) {
 				continue;
 			}


### PR DESCRIPTION
The `Object*` cast operator of `Variant` does not validate that the object still exists. This means that in the case you eg `queue_free` an autoload class this will crash on the next script error due to trying to `dynamic_cast` a freed pointer.

Not sure `get_validated_object_with_check` is needed or if `get_validated_object` would have been enough. But I think better safe than sorry in this case.

There would also be the option of printing a warning/error here since I don't think you should really free autoloads intentionally.

* _Bugsquad edit:_ Fixes #92607.