### PR TITLE
[StatusIndicator] Add method to get indicator icon screen rect.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1167,12 +1167,21 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, macOS, Windows, and Linux (X11/Wayland).
 			</description>
 		</method>
+		<method name="status_indicator_get_rect" qualifiers="const">
+			<return type="Rect2" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the rectangle for the given status indicator [param id] in screen coordinates. If the status indicator is not visible, returns an empty [Rect2].
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
 		<method name="status_indicator_set_callback">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
 				Sets the application status indicator activation callback.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
 		<method name="status_indicator_set_icon">
@@ -1181,6 +1190,7 @@
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
 				Sets the application status indicator icon.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
 		<method name="status_indicator_set_menu">
@@ -1200,6 +1210,7 @@
 			<param index="1" name="tooltip" type="String" />
 			<description>
 				Sets the application status indicator tooltip.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
 		<method name="tablet_get_current_driver" qualifiers="const">

--- a/doc/classes/StatusIndicator.xml
+++ b/doc/classes/StatusIndicator.xml
@@ -8,6 +8,14 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_rect" qualifiers="const">
+			<return type="Rect2" />
+			<description>
+				Returns the status indicator rectangle in screen coordinates. If this status indicator is not visible, returns an empty [Rect2].
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="icon" type="Texture2D" setter="set_icon" getter="get_icon">
 			Status indicator icon.

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -436,6 +436,7 @@ public:
 	virtual void status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) override;
 	virtual void status_indicator_set_menu(IndicatorID p_id, const RID &p_menu_rid) override;
 	virtual void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) override;
+	virtual Rect2 status_indicator_get_rect(IndicatorID p_id) const override;
 	virtual void delete_status_indicator(IndicatorID p_id) override;
 
 	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3283,6 +3283,30 @@ void DisplayServerMacOS::status_indicator_set_callback(IndicatorID p_id, const C
 	[indicators[p_id].delegate setCallback:p_callback];
 }
 
+Rect2 DisplayServerMacOS::status_indicator_get_rect(IndicatorID p_id) const {
+	ERR_FAIL_COND_V(!indicators.has(p_id), Rect2());
+
+	NSStatusItem *item = indicators[p_id].item;
+	NSView *v = item.button;
+	const NSRect contentRect = [v frame];
+	const NSRect nsrect = [v.window convertRectToScreen:contentRect];
+	Rect2 rect;
+
+	// Return the position of the top-left corner, for macOS the y starts at the bottom.
+	const float scale = screen_get_max_scale();
+	rect.size.x = nsrect.size.width;
+	rect.size.y = nsrect.size.height;
+	rect.size *= scale;
+	rect.position.x = nsrect.origin.x;
+	rect.position.y = (nsrect.origin.y + nsrect.size.height);
+	rect.position *= scale;
+	rect.position -= _get_screens_origin();
+	// macOS native y-coordinate relative to _get_screens_origin() is negative,
+	// Godot expects a positive value.
+	rect.position.y *= -1;
+	return rect;
+}
+
 void DisplayServerMacOS::delete_status_indicator(IndicatorID p_id) {
 	ERR_FAIL_COND(!indicators.has(p_id));
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3325,6 +3325,30 @@ void DisplayServerWindows::status_indicator_set_callback(IndicatorID p_id, const
 	indicators[p_id].callback = p_callback;
 }
 
+Rect2 DisplayServerWindows::status_indicator_get_rect(IndicatorID p_id) const {
+	ERR_FAIL_COND_V(!indicators.has(p_id), Rect2());
+
+	NOTIFYICONIDENTIFIER nid;
+	ZeroMemory(&nid, sizeof(NOTIFYICONIDENTIFIER));
+	nid.cbSize = sizeof(NOTIFYICONIDENTIFIER);
+	nid.hWnd = windows[MAIN_WINDOW_ID].hWnd;
+	nid.uID = p_id;
+	nid.guidItem = GUID_NULL;
+
+	RECT rect;
+	if (Shell_NotifyIconGetRect(&nid, &rect) != S_OK) {
+		return Rect2();
+	}
+	Rect2 ind_rect = Rect2(Point2(rect.left, rect.top) - _get_screens_origin(), Size2(rect.right - rect.left, rect.bottom - rect.top));
+	for (int i = 0; i < get_screen_count(); i++) {
+		Rect2 screen_rect = Rect2(screen_get_position(i), screen_get_size(i));
+		if (screen_rect.encloses(ind_rect)) {
+			return ind_rect;
+		}
+	}
+	return Rect2();
+}
+
 void DisplayServerWindows::delete_status_indicator(IndicatorID p_id) {
 	ERR_FAIL_COND(!indicators.has(p_id));
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -690,6 +690,7 @@ public:
 	virtual void status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) override;
 	virtual void status_indicator_set_menu(IndicatorID p_id, const RID &p_rid) override;
 	virtual void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) override;
+	virtual Rect2 status_indicator_get_rect(IndicatorID p_id) const override;
 	virtual void delete_status_indicator(IndicatorID p_id) override;
 
 	virtual void set_context(Context p_context) override;

--- a/scene/main/status_indicator.cpp
+++ b/scene/main/status_indicator.cpp
@@ -80,6 +80,7 @@ void StatusIndicator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_visible"), &StatusIndicator::is_visible);
 	ClassDB::bind_method(D_METHOD("set_menu", "menu"), &StatusIndicator::set_menu);
 	ClassDB::bind_method(D_METHOD("get_menu"), &StatusIndicator::get_menu);
+	ClassDB::bind_method(D_METHOD("get_rect"), &StatusIndicator::get_rect);
 
 	ADD_SIGNAL(MethodInfo("pressed", PropertyInfo(Variant::INT, "mouse_button"), PropertyInfo(Variant::VECTOR2I, "mouse_position")));
 
@@ -181,4 +182,11 @@ void StatusIndicator::set_visible(bool p_visible) {
 
 bool StatusIndicator::is_visible() const {
 	return visible;
+}
+
+Rect2 StatusIndicator::get_rect() const {
+	if (iid == DisplayServer::INVALID_INDICATOR_ID) {
+		return Rect2();
+	}
+	return DisplayServer::get_singleton()->status_indicator_get_rect(iid);
 }

--- a/scene/main/status_indicator.h
+++ b/scene/main/status_indicator.h
@@ -61,6 +61,8 @@ public:
 
 	void set_visible(bool p_visible);
 	bool is_visible() const;
+
+	Rect2 get_rect() const;
 };
 
 #endif // STATUS_INDICATOR_H

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -730,6 +730,11 @@ void DisplayServer::status_indicator_set_callback(IndicatorID p_id, const Callab
 	WARN_PRINT("Status indicator not supported by this display server.");
 }
 
+Rect2 DisplayServer::status_indicator_get_rect(IndicatorID p_id) const {
+	WARN_PRINT("Status indicator not supported by this display server.");
+	return Rect2();
+}
+
 void DisplayServer::delete_status_indicator(IndicatorID p_id) {
 	WARN_PRINT("Status indicator not supported by this display server.");
 }
@@ -983,6 +988,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("status_indicator_set_tooltip", "id", "tooltip"), &DisplayServer::status_indicator_set_tooltip);
 	ClassDB::bind_method(D_METHOD("status_indicator_set_menu", "id", "menu_rid"), &DisplayServer::status_indicator_set_menu);
 	ClassDB::bind_method(D_METHOD("status_indicator_set_callback", "id", "callback"), &DisplayServer::status_indicator_set_callback);
+	ClassDB::bind_method(D_METHOD("status_indicator_get_rect", "id"), &DisplayServer::status_indicator_get_rect);
 	ClassDB::bind_method(D_METHOD("delete_status_indicator", "id"), &DisplayServer::delete_status_indicator);
 
 	ClassDB::bind_method(D_METHOD("tablet_get_driver_count"), &DisplayServer::tablet_get_driver_count);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -569,6 +569,7 @@ public:
 	virtual void status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip);
 	virtual void status_indicator_set_menu(IndicatorID p_id, const RID &p_menu_rid);
 	virtual void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback);
+	virtual Rect2 status_indicator_get_rect(IndicatorID p_id) const;
 	virtual void delete_status_indicator(IndicatorID p_id);
 
 	enum Context {


### PR DESCRIPTION
Add `status_indicator_get_rect` method to get indicator rectangle in the screen coordinates. Usefully of positioning popups (existing methods only include mouse click coordinates).