### PR TITLE
Make `ShaderDescription` and related types public

### DIFF
--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -878,6 +878,7 @@ protected:
 
 	static const char *SHADER_STAGE_NAMES[SHADER_STAGE_MAX];
 
+public:
 	struct ShaderUniform {
 		UniformType type = UniformType::UNIFORM_TYPE_MAX;
 		bool writable = false;
@@ -925,6 +926,7 @@ protected:
 		Vector<ShaderStage> stages;
 	};
 
+protected:
 	struct ShaderReflection : public ShaderDescription {
 		BitField<ShaderStage> stages;
 		BitField<ShaderStage> push_constant_stages;


### PR DESCRIPTION
`ShaderDescription` is used as a return parameter in one of the public functions of `RenderingDeviceDriver`, so it makes little sense that such structs were protected, hidden from the same scope that can call the mentioned function if directly dealing with the driver.