### PR TITLE
Add disable_scripting build option

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -214,6 +214,9 @@ opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))
 opts.Add("vsproj_name", "Name of the Visual Studio solution", "godot")
 opts.Add("import_env_vars", "A comma-separated list of environment variables to copy from the outer environment.", "")
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
+opts.Add(
+    BoolVariable("disable_scripting", "Disable scripting for a smaller executable for GDExtension projects", False)
+)
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
 opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
@@ -387,6 +390,9 @@ for name, path in modules_detected.items():
         except AttributeError:
             pass
     else:
+        enabled = False
+
+    if env_base["disable_scripting"] and name == "gdscript":
         enabled = False
 
     opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
@@ -904,6 +910,9 @@ if selected_platform in platform_list:
 
     env["OBJPREFIX"] = env["object_prefix"]
     env["SHOBJPREFIX"] = env["object_prefix"]
+
+    if env["disable_scripting"]:
+        env.Append(CPPDEFINES=["DISABLE_SCRIPTING"])
 
     if env["disable_3d"]:
         if env.editor_build:

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -227,6 +227,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 	_edited = true;
 #endif
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		if (script_instance->set(p_name, p_value)) {
 			if (r_valid) {
@@ -235,6 +236,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 			return;
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 	if (_extension && _extension->set) {
 // C style pointer casts should never trigger a compiler warning because the risk is assumed by the user, so GCC should keep quiet about it.
@@ -286,6 +288,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 	}
 
 #ifdef TOOLS_ENABLED
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		bool valid;
 		script_instance->property_set_fallback(p_name, p_value, &valid);
@@ -296,6 +299,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 			return;
 		}
 	}
+#endif // DISABLE_SCRIPTING
 #endif
 
 	// Something inside the object... :|
@@ -315,6 +319,7 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 Variant Object::get(const StringName &p_name, bool *r_valid) const {
 	Variant ret;
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		if (script_instance->get(p_name, ret)) {
 			if (r_valid) {
@@ -323,6 +328,8 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 			return ret;
 		}
 	}
+#endif // DISABLE_SCRIPTING
+
 	if (_extension && _extension->get) {
 // C style pointer casts should never trigger a compiler warning because the risk is assumed by the user, so GCC should keep quiet about it.
 #if defined(__GNUC__) && !defined(__clang__)
@@ -370,6 +377,7 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 
 	} else {
 #ifdef TOOLS_ENABLED
+#ifndef DISABLE_SCRIPTING
 		if (script_instance) {
 			bool valid;
 			ret = script_instance->property_get_fallback(p_name, &valid);
@@ -380,6 +388,7 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 				return ret;
 			}
 		}
+#endif // DISABLE_SCRIPTING
 #endif
 		// Something inside the object... :|
 		bool success = _getv(p_name, ret);
@@ -481,9 +490,11 @@ Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) co
 }
 
 void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) const {
+#ifndef DISABLE_SCRIPTING
 	if (script_instance && p_reversed) {
 		script_instance->get_property_list(p_list);
 	}
+#endif // DISABLE_SCRIPTING
 
 	if (_extension) {
 		const ObjectGDExtension *current_extension = _extension;
@@ -517,13 +528,17 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 
 	_get_property_listv(p_list, p_reversed);
 
+#ifndef DISABLE_SCRIPTING
 	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NEVER_DUPLICATE));
 	}
+#endif // DISABLE_SCRIPTING
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance && !p_reversed) {
 		script_instance->get_property_list(p_list);
 	}
+#endif // DISABLE_SCRIPTING
 
 	for (const KeyValue<StringName, Variant> &K : metadata) {
 		PropertyInfo pi = PropertyInfo(K.value.get_type(), "metadata/" + K.key.operator String());
@@ -559,17 +574,21 @@ void Object::validate_property(PropertyInfo &p_property) const {
 		};
 	}
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) { // Call it last to allow user altering already validated properties.
 		script_instance->validate_property(p_property);
 	}
+#endif // DISABLE_SCRIPTING
 }
 
 bool Object::property_can_revert(const StringName &p_name) const {
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		if (script_instance->property_can_revert(p_name)) {
 			return true;
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 // C style pointer casts should never trigger a compiler warning because the risk is assumed by the user, so GCC should keep quiet about it.
 #if defined(__GNUC__) && !defined(__clang__)
@@ -591,11 +610,13 @@ bool Object::property_can_revert(const StringName &p_name) const {
 Variant Object::property_get_revert(const StringName &p_name) const {
 	Variant ret;
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		if (script_instance->property_get_revert(p_name, ret)) {
 			return ret;
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 // C style pointer casts should never trigger a compiler warning because the risk is assumed by the user, so GCC should keep quiet about it.
 #if defined(__GNUC__) && !defined(__clang__)
@@ -619,9 +640,11 @@ Variant Object::property_get_revert(const StringName &p_name) const {
 
 void Object::get_method_list(List<MethodInfo> *p_list) const {
 	ClassDB::get_method_list(get_class_name(), p_list);
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		script_instance->get_method_list(p_list);
 	}
+#endif // DISABLE_SCRIPTING
 }
 
 Variant Object::_call_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -671,9 +694,11 @@ bool Object::has_method(const StringName &p_method) const {
 		return true;
 	}
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance && script_instance->has_method(p_method)) {
 		return true;
 	}
+#endif // DISABLE_SCRIPTING
 
 	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
 	if (method != nullptr) {
@@ -758,6 +783,7 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 	Variant ret;
 	OBJ_DEBUG_LOCK
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		ret = script_instance->callp(p_method, p_args, p_argcount, r_error);
 		//force jumptable
@@ -775,6 +801,7 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 			}
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 	//extension does not need this, because all methods are registered in MethodBind
 
@@ -801,6 +828,7 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 	Variant ret;
 	OBJ_DEBUG_LOCK
 
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		ret = script_instance->call_const(p_method, p_args, p_argcount, r_error);
 		//force jumptable
@@ -819,6 +847,7 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 			}
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 	//extension does not need this, because all methods are registered in MethodBind
 
@@ -839,9 +868,11 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 
 void Object::notification(int p_notification, bool p_reversed) {
 	if (p_reversed) {
+#ifndef DISABLE_SCRIPTING
 		if (script_instance) {
 			script_instance->notification(p_notification, p_reversed);
 		}
+#endif // DISABLE_SCRIPTING
 	} else {
 		_notificationv(p_notification, p_reversed);
 	}
@@ -859,13 +890,16 @@ void Object::notification(int p_notification, bool p_reversed) {
 	if (p_reversed) {
 		_notificationv(p_notification, p_reversed);
 	} else {
+#ifndef DISABLE_SCRIPTING
 		if (script_instance) {
 			script_instance->notification(p_notification, p_reversed);
 		}
+#endif // DISABLE_SCRIPTING
 	}
 }
 
 String Object::to_string() {
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		bool valid;
 		String ret = script_instance->to_string(&valid);
@@ -873,6 +907,7 @@ String Object::to_string() {
 			return ret;
 		}
 	}
+#endif // DISABLE_SCRIPTING
 	if (_extension && _extension->to_string) {
 		String ret;
 		GDExtensionBool is_valid;
@@ -883,6 +918,7 @@ String Object::to_string() {
 }
 
 void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
+#ifndef DISABLE_SCRIPTING
 	//this function is not meant to be used in any of these ways
 	ERR_FAIL_COND(p_script.is_null());
 	ERR_FAIL_NULL(p_instance);
@@ -890,9 +926,13 @@ void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_
 
 	script = p_script;
 	script_instance = p_instance;
+#else
+	ERR_FAIL();
+#endif // DISABLE_SCRIPTING
 }
 
 void Object::set_script(const Variant &p_script) {
+#ifndef DISABLE_SCRIPTING
 	if (script == p_script) {
 		return;
 	}
@@ -922,9 +962,14 @@ void Object::set_script(const Variant &p_script) {
 
 	notify_property_list_changed(); //scripts may add variables, so refresh is desired
 	emit_signal(CoreStringNames::get_singleton()->script_changed);
+#else
+	ERR_FAIL_COND(!p_script.is_null());
+#endif // DISABLE_SCRIPTING
 }
 
 void Object::set_script_instance(ScriptInstance *p_instance) {
+#ifndef DISABLE_SCRIPTING
+
 	if (script_instance == p_instance) {
 		return;
 	}
@@ -940,10 +985,17 @@ void Object::set_script_instance(ScriptInstance *p_instance) {
 	} else {
 		script = Variant();
 	}
+#else
+	ERR_FAIL();
+#endif // DISABLE_SCRIPTING
 }
 
 Variant Object::get_script() const {
+#ifndef DISABLE_SCRIPTING
 	return script;
+#else
+	return Variant();
+#endif // DISABLE_SCRIPTING
 }
 
 bool Object::has_meta(const StringName &p_name) const {
@@ -1090,7 +1142,9 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 #ifdef DEBUG_ENABLED
 		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_name);
 		//check in script
+#ifndef DISABLE_SCRIPTING
 		ERR_FAIL_COND_V_MSG(!signal_is_valid && !script.is_null() && !Ref<Script>(script)->has_script_signal(p_name), ERR_UNAVAILABLE, "Can't emit non-existing signal " + String("\"") + p_name + "\".");
+#endif // DISABLE_SCRIPTING
 #endif
 		//not connected? just return
 		return ERR_UNAVAILABLE;
@@ -1138,7 +1192,11 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 
 			if (ce.error != Callable::CallError::CALL_OK) {
 #ifdef DEBUG_ENABLED
-				if (c.flags & CONNECT_PERSIST && Engine::get_singleton()->is_editor_hint() && (script.is_null() || !Ref<Script>(script)->is_tool())) {
+				if (c.flags & CONNECT_PERSIST && Engine::get_singleton()->is_editor_hint()
+#ifndef DISABLE_SCRIPTING
+						&& (script.is_null() || !Ref<Script>(script)->is_tool())
+#endif // DISABLE_SCRIPTING
+				) {
 					continue;
 				}
 #endif
@@ -1240,12 +1298,14 @@ TypedArray<Dictionary> Object::_get_incoming_connections() const {
 }
 
 bool Object::has_signal(const StringName &p_name) const {
+#ifndef DISABLE_SCRIPTING
 	if (!script.is_null()) {
 		Ref<Script> scr = script;
 		if (scr.is_valid() && scr->has_script_signal(p_name)) {
 			return true;
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 	if (ClassDB::has_signal(get_class_name(), p_name)) {
 		return true;
@@ -1259,12 +1319,14 @@ bool Object::has_signal(const StringName &p_name) const {
 }
 
 void Object::get_signal_list(List<MethodInfo> *p_signals) const {
+#ifndef DISABLE_SCRIPTING
 	if (!script.is_null()) {
 		Ref<Script> scr = script;
 		if (scr.is_valid()) {
 			scr->get_script_signal_list(p_signals);
 		}
 	}
+#endif // DISABLE_SCRIPTING
 
 	ClassDB::get_signal_list(get_class_name(), p_signals);
 	//find maybe usersignals?
@@ -1335,6 +1397,8 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
 		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal);
+
+#ifndef DISABLE_SCRIPTING
 		//check in script
 		if (!signal_is_valid && !script.is_null()) {
 			if (Ref<Script>(script)->has_script_signal(p_signal)) {
@@ -1349,6 +1413,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 			}
 #endif
 		}
+#endif // DISABLE_SCRIPTING
 
 		ERR_FAIL_COND_V_MSG(!signal_is_valid, ERR_INVALID_PARAMETER, "In Object of type '" + String(get_class()) + "': Attempt to connect nonexistent signal '" + p_signal + "' to callable '" + p_callable + "'.");
 
@@ -1397,9 +1462,11 @@ bool Object::is_connected(const StringName &p_signal, const Callable &p_callable
 			return false;
 		}
 
+#ifndef DISABLE_SCRIPTING
 		if (!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal)) {
 			return false;
 		}
+#endif // DISABLE_SCRIPTING
 
 		ERR_FAIL_V_MSG(false, "Nonexistent signal: " + p_signal + ".");
 	}
@@ -1416,8 +1483,11 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
-		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal) ||
-				(!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal));
+		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal)
+#ifndef DISABLE_SCRIPTING
+				|| (!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal))
+#endif // DISABLE_SCRIPTING
+				;
 		ERR_FAIL_COND_V_MSG(signal_is_valid, false, "Attempt to disconnect a nonexistent connection from '" + to_string() + "'. Signal: '" + p_signal + "', callable: '" + p_callable + "'.");
 	}
 	ERR_FAIL_NULL_V_MSG(s, false, vformat("Disconnecting nonexistent signal '%s' in %s.", p_signal, to_string()));
@@ -1602,8 +1672,10 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("to_string"), &Object::to_string);
 	ClassDB::bind_method(D_METHOD("get_instance_id"), &Object::get_instance_id);
 
+#ifndef DISABLE_SCRIPTING
 	ClassDB::bind_method(D_METHOD("set_script", "script"), &Object::set_script);
 	ClassDB::bind_method(D_METHOD("get_script"), &Object::get_script);
+#endif // DISABLE_SCRIPTING
 
 	ClassDB::bind_method(D_METHOD("set_meta", "name", "value"), &Object::set_meta);
 	ClassDB::bind_method(D_METHOD("remove_meta", "name"), &Object::remove_meta);
@@ -2004,10 +2076,12 @@ void Object::detach_from_objectdb() {
 }
 
 Object::~Object() {
+#ifndef DISABLE_SCRIPTING
 	if (script_instance) {
 		memdelete(script_instance);
 	}
 	script_instance = nullptr;
+#endif // DISABLE_SCRIPTING
 
 	if (_extension) {
 #ifdef TOOLS_ENABLED

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -638,8 +638,12 @@ private:
 	uint32_t _edited_version = 0;
 	HashSet<String> editor_section_folding;
 #endif
+
+#ifndef DISABLE_SCRIPTING
 	ScriptInstance *script_instance = nullptr;
 	Variant script; // Reference does not exist yet, store it in a Variant.
+#endif // DISABLE_SCRIPTING
+
 	HashMap<StringName, Variant> metadata;
 	HashMap<StringName, Variant *> metadata_properties;
 	mutable const StringName *_class_name_ptr = nullptr;
@@ -914,7 +918,13 @@ public:
 #endif
 
 	void set_script_instance(ScriptInstance *p_instance);
-	_FORCE_INLINE_ ScriptInstance *get_script_instance() const { return script_instance; }
+	_FORCE_INLINE_ ScriptInstance *get_script_instance() const {
+#ifndef DISABLE_SCRIPTING
+		return script_instance;
+#else
+		return nullptr;
+#endif // DISABLE_SCRIPTING
+	}
 
 	// Some script languages can't control instance creation, so this function eases the process.
 	void set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance);

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -163,9 +163,13 @@ bool ScriptServer::is_scripting_enabled() {
 }
 
 ScriptLanguage *ScriptServer::get_language(int p_idx) {
+#ifndef DISABLE_SCRIPTING
 	MutexLock lock(languages_mutex);
 	ERR_FAIL_INDEX_V(p_idx, _language_count, nullptr);
 	return _languages[p_idx];
+#else
+	return nullptr;
+#endif // DISABLE_SCRIPTING
 }
 
 ScriptLanguage *ScriptServer::get_language_for_extension(const String &p_extension) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -47,7 +47,11 @@ typedef void (*ScriptEditRequestFunction)(const String &p_path);
 
 class ScriptServer {
 	enum {
+#ifndef DISABLE_SCRIPTING
 		MAX_LANGUAGES = 16
+#else
+		MAX_LANGUAGES = 1
+#endif // DISABLE_SCRIPTING
 	};
 
 	static ScriptLanguage *_languages[MAX_LANGUAGES];

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3284,21 +3284,24 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 		resource_picker = nullptr;
 	}
 
+#ifndef DISABLE_SCRIPTING
 	if (p_path == "script" && p_base_type == "Script" && Object::cast_to<Node>(p_object)) {
 		EditorScriptPicker *script_picker = memnew(EditorScriptPicker);
 		script_picker->set_script_owner(Object::cast_to<Node>(p_object));
 		resource_picker = script_picker;
-	} else if (p_path == "shader" && p_base_type == "Shader" && Object::cast_to<ShaderMaterial>(p_object)) {
-		EditorShaderPicker *shader_picker = memnew(EditorShaderPicker);
-		shader_picker->set_edited_material(Object::cast_to<ShaderMaterial>(p_object));
-		resource_picker = shader_picker;
-		connect(SNAME("ready"), callable_mp(this, &EditorPropertyResource::_update_preferred_shader));
-	} else if (p_base_type == "AudioStream") {
-		EditorAudioStreamPicker *astream_picker = memnew(EditorAudioStreamPicker);
-		resource_picker = astream_picker;
-	} else {
-		resource_picker = memnew(EditorResourcePicker);
-	}
+	} else
+#endif // DISABLE_SCRIPTING
+		if (p_path == "shader" && p_base_type == "Shader" && Object::cast_to<ShaderMaterial>(p_object)) {
+			EditorShaderPicker *shader_picker = memnew(EditorShaderPicker);
+			shader_picker->set_edited_material(Object::cast_to<ShaderMaterial>(p_object));
+			resource_picker = shader_picker;
+			connect(SNAME("ready"), callable_mp(this, &EditorPropertyResource::_update_preferred_shader));
+		} else if (p_base_type == "AudioStream") {
+			EditorAudioStreamPicker *astream_picker = memnew(EditorAudioStreamPicker);
+			resource_picker = astream_picker;
+		} else {
+			resource_picker = memnew(EditorResourcePicker);
+		}
 
 	resource_picker->set_base_type(p_base_type);
 	resource_picker->set_editable(true);

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -60,7 +60,11 @@ void PluginConfigDialog::_on_confirmed() {
 	}
 
 	int lang_idx = script_option_edit->get_selected();
-	String ext = ScriptServer::get_language(lang_idx)->get_extension();
+	ScriptLanguage *language = ScriptServer::get_language(lang_idx);
+	if (language == nullptr) {
+		return;
+	}
+	String ext = language->get_extension();
 	String script_name = script_edit->get_text().is_empty() ? _get_subfolder() : script_edit->get_text();
 	if (script_name.get_extension() != ext) {
 		script_name += "." + ext;
@@ -79,11 +83,11 @@ void PluginConfigDialog::_on_confirmed() {
 	if (!_edit_mode) {
 		String class_name = script_name.get_basename();
 		String template_content = "";
-		Vector<ScriptLanguage::ScriptTemplate> templates = ScriptServer::get_language(lang_idx)->get_built_in_templates("EditorPlugin");
+		Vector<ScriptLanguage::ScriptTemplate> templates = language->get_built_in_templates("EditorPlugin");
 		if (!templates.is_empty()) {
 			template_content = templates[0].content;
 		}
-		Ref<Script> scr = ScriptServer::get_language(lang_idx)->make_template(template_content, class_name, "EditorPlugin");
+		Ref<Script> scr = language->make_template(template_content, class_name, "EditorPlugin");
 		scr->set_path(script_path, true);
 		ResourceSaver::save(scr);
 
@@ -101,6 +105,9 @@ void PluginConfigDialog::_on_canceled() {
 void PluginConfigDialog::_on_required_text_changed() {
 	int lang_idx = script_option_edit->get_selected();
 	ScriptLanguage *language = ScriptServer::get_language(lang_idx);
+	if (language == nullptr) {
+		return;
+	}
 	String ext = language->get_extension();
 
 	if (name_edit->get_text().is_empty()) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -587,7 +587,14 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "Script"; }
+	virtual String get_name() const override {
+		return
+#ifndef DISABLE_SCRIPTING
+				"Script";
+#else
+				"TextFile";
+#endif // DISABLE_SCRIPTING
+	}
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1778,7 +1778,9 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 		if (p_pattern.is_empty() || cptr[i]->data.name.operator String().match(p_pattern)) {
 			if (p_type.is_empty() || cptr[i]->is_class(p_type)) {
 				ret.append(cptr[i]);
-			} else if (cptr[i]->get_script_instance()) {
+			}
+#ifndef DISABLE_SCRIPTING
+			else if (cptr[i]->get_script_instance()) {
 				Ref<Script> scr = cptr[i]->get_script_instance()->get_script();
 				while (scr.is_valid()) {
 					if ((ScriptServer::is_global_class(p_type) && ScriptServer::get_global_class_path(p_type) == scr->get_path()) || p_type == scr->get_path()) {
@@ -1789,6 +1791,7 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 					scr = scr->get_base_script();
 				}
 			}
+#endif // DISABLE_SCRIPTING
 		}
 
 		if (p_recursive) {


### PR DESCRIPTION
Added build option disable_scripting which disables the GDScript module and removes the script property and make the get always return a nullptr also fixes a bug where having no scripts languages in an editor build would not even load a project this is for GDExtension projects