### PR TITLE
Fix lightmap captures not applied in one octant

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2053,7 +2053,7 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 
 		Vector3 inner_pos = ((lm_pos - bounds.position) / bounds.size) * 2.0 - Vector3(1.0, 1.0, 1.0);
 
-		real_t blend = MAX(inner_pos.x, MAX(inner_pos.y, inner_pos.z));
+		real_t blend = MAX(ABS(inner_pos.x), MAX(ABS(inner_pos.y), ABS(inner_pos.z)));
 		//make blend more rounded
 		blend = Math::lerp(inner_pos.length(), blend, blend);
 		blend *= blend;


### PR DESCRIPTION
GI from probe captures was not applied to dynamic objects in the (-,-,-) octant of the lightmap. If the object had traveled from a different part of the lightmap, it would simply not update anymore and kept whatever ambient light it had from before. If the object on the other hand came from outside of the lightmap into this octant, it would receive no ambient light at all.

The same bug also caused incorrect blending when the object is inside several overlapping lightmaps.

The bug lies in a blending factor for overlapping lightmaps. This factor is mostly cancelled out when there is only a single lightmap, except that the captured light is not applied at all if the blend is not greater than zero. The calculation of `blend` did not account for `inner_pos` being in the [-1, 1] interval, which would cause `blend` to become negative.