### PR TITLE
Fix audio crackling issues due to incorrect WASAPI buffer size

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -737,12 +737,17 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 		ad->start_counting_ticks();
 
 		if (avail_frames > 0 && ad->audio_output.audio_client) {
+			UINT32 buffer_size;
 			UINT32 cur_frames;
 			bool invalidated = false;
-			HRESULT hr = ad->audio_output.audio_client->GetCurrentPadding(&cur_frames);
+			HRESULT hr = ad->audio_output.audio_client->GetBufferSize(&buffer_size);
+			if (hr != S_OK) {
+				ERR_PRINT("WASAPI: GetBufferSize error");
+			}
+			hr = ad->audio_output.audio_client->GetCurrentPadding(&cur_frames);
 			if (hr == S_OK) {
 				// Check how much frames are available on the WASAPI buffer
-				UINT32 write_frames = MIN(ad->buffer_frames - cur_frames, avail_frames);
+				UINT32 write_frames = MIN(buffer_size - cur_frames, avail_frames);
 				if (write_frames > 0) {
 					BYTE *buffer = nullptr;
 					hr = ad->audio_output.render_client->GetBuffer(write_frames, &buffer);


### PR DESCRIPTION
Hopefully, finally fixes https://github.com/godotengine/godot/issues/75109.

This is an extremely straightforward fix to an issue that has been plaguing Godot users as well as players for months. Obtaining the current max buffer size and subtracting the current padding size is the recommended standard practice when calculating the max amount of frames to request to `GetBuffer()`. However, Godot was previously using the `period_frames` value instead, which is significantly smaller and would cause issues such as crackling and slowdowns during audio playback.

I have done extensive testing and I am fairly confident in this fix, but this still requires a lot of testing by as many users with as many different audio devices and drivers as possible.