### PR TITLE
Allow LSP to process multiple messages per poll

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -105,7 +105,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 
 Error GDScriptLanguageProtocol::LSPeer::send_data() {
 	int sent = 0;
-	if (!res_queue.is_empty()) {
+	while (!res_queue.is_empty()) {
 		CharString c_res = res_queue[0];
 		if (res_sent < c_res.size()) {
 			Error err = connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent);
@@ -229,7 +229,9 @@ void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
 	notify_client("gdscript/capabilities", capabilities.to_json());
 }
 
-void GDScriptLanguageProtocol::poll() {
+void GDScriptLanguageProtocol::poll(int p_limit_usec) {
+	uint64_t target_ticks = OS::get_singleton()->get_ticks_usec() + p_limit_usec;
+
 	if (server->is_connection_available()) {
 		on_client_connected();
 	}
@@ -244,16 +246,22 @@ void GDScriptLanguageProtocol::poll() {
 			E = clients.begin();
 			continue;
 		} else {
-			if (peer->connection->get_available_bytes() > 0) {
+			Error err = OK;
+			while (peer->connection->get_available_bytes() > 0) {
 				latest_client_id = E->key;
-				Error err = peer->handle_data();
-				if (err != OK && err != ERR_BUSY) {
-					on_client_disconnected(E->key);
-					E = clients.begin();
-					continue;
+				err = peer->handle_data();
+				if (err != OK || OS::get_singleton()->get_ticks_usec() >= target_ticks) {
+					break;
 				}
 			}
-			Error err = peer->send_data();
+
+			if (err != OK && err != ERR_BUSY) {
+				on_client_disconnected(E->key);
+				E = clients.begin();
+				continue;
+			}
+
+			err = peer->send_data();
 			if (err != OK && err != ERR_BUSY) {
 				on_client_disconnected(E->key);
 				E = clients.begin();

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -105,7 +105,7 @@ public:
 	_FORCE_INLINE_ Ref<GDScriptTextDocument> get_text_document() { return text_document; }
 	_FORCE_INLINE_ bool is_initialized() const { return _initialized; }
 
-	void poll();
+	void poll(int p_limit_usec);
 	Error start(int p_port, const IPAddress &p_bind_ip);
 	void stop();
 

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -44,6 +44,7 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
 	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
 	_EDITOR_DEF("network/language_server/use_thread", use_thread);
+	_EDITOR_DEF("network/language_server/poll_limit_usec", poll_limit_usec);
 }
 
 void GDScriptLanguageServer::_notification(int p_what) {
@@ -58,7 +59,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (started && !use_thread) {
-				protocol.poll();
+				protocol.poll(poll_limit_usec);
 			}
 		} break;
 
@@ -70,7 +71,8 @@ void GDScriptLanguageServer::_notification(int p_what) {
 			String remote_host = String(_EDITOR_GET("network/language_server/remote_host"));
 			int remote_port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 			bool remote_use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
-			if (remote_host != host || remote_port != port || remote_use_thread != use_thread) {
+			int remote_poll_limit = (int)_EDITOR_GET("network/language_server/poll_limit_usec");
+			if (remote_host != host || remote_port != port || remote_use_thread != use_thread || remote_poll_limit != poll_limit_usec) {
 				stop();
 				start();
 			}
@@ -83,7 +85,7 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 	GDScriptLanguageServer *self = static_cast<GDScriptLanguageServer *>(p_userdata);
 	while (self->thread_running) {
 		// Poll 20 times per second
-		self->protocol.poll();
+		self->protocol.poll(self->poll_limit_usec);
 		OS::get_singleton()->delay_usec(50000);
 	}
 }
@@ -92,6 +94,7 @@ void GDScriptLanguageServer::start() {
 	host = String(_EDITOR_GET("network/language_server/remote_host"));
 	port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
+	poll_limit_usec = (int)_EDITOR_GET("network/language_server/poll_limit_usec");
 	if (protocol.start(port, IPAddress(host)) == OK) {
 		EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
 		if (use_thread) {

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -47,6 +47,7 @@ class GDScriptLanguageServer : public EditorPlugin {
 	bool use_thread = false;
 	String host = "127.0.0.1";
 	int port = 6005;
+	int poll_limit_usec = 100000;
 	static void thread_main(void *p_userdata);
 
 private:


### PR DESCRIPTION
When using GDScript from an external editor that makes use of Godot's LSP server you can currently encounter an issue where things like code completion and error squigglies lag behind quite a bit, which looks something like this:

https://github.com/godotengine/godot/assets/4884246/79382b29-aed5-4ae5-82ef-71f0eabe653d

The problem seem to be linked to Godot's low-processing mode, as workarounds consist of either enabling `interface/editor/update_continuously` or lowering `interface/editor/unfocused_low_processor_mode_sleep_usec`. When using the [VS Code extension](https://github.com/godotengine/godot-vscode-plugin) you can also work around this by setting its `godotTools.lsp.headless` setting to `true`, which launches a completely separate instance of Godot for the sole purpose of acting as a headless LSP.

The reason for this seems to fall on the Godot side of things, namely that the LSP implementation is currently set to only ever process a single message per poll. This meant that if you in your text editor typed faster than the 100 ms that `unfocused_low_processor_mode_sleep_usec` is set to by default you would start stacking up messages that would only ever get popped once every 100 ms, thereby building up more and more latency.

This PR resolves this by changing both `GDScriptLanguageProtocol::LSPeer::handle_data` and `GDScriptLanguageProtocol::LSPeer::send_data` to be done within a `while` instead of within an `if`, thereby allowing multiple messages to be processed per poll.