### PR TITLE
Fix packed scene translation parser missing strings.

### DIFF
--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -58,6 +58,15 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 		String node_type = state->get_node_type(i);
 		String parent_path = state->get_node_path(i, true);
 
+		// Handle instanced scenes.
+		if (node_type.is_empty()) {
+			Ref<PackedScene> instance = state->get_node_instance(i);
+			if (instance.is_valid()) {
+				Ref<SceneState> _state = instance->get_state();
+				node_type = _state->get_node_type(0);
+			}
+		}
+
 		// Find the `auto_translate_mode` property.
 		bool auto_translating = true;
 		bool auto_translate_mode_found = false;
@@ -118,7 +127,8 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 
 		for (int j = 0; j < state->get_node_property_count(i); j++) {
 			String property_name = state->get_node_property_name(i, j);
-			if (!lookup_properties.has(property_name) || (exception_list.has(node_type) && exception_list[node_type].has(property_name))) {
+
+			if (!match_property(property_name, node_type)) {
 				continue;
 			}
 
@@ -133,15 +143,6 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 					EditorTranslationParser::get_singleton()->get_parser(extension)->parse_file(s->get_path(), &temp, &ids_context_plural);
 					parsed_strings.append_array(temp);
 					r_ids_ctx_plural->append_array(ids_context_plural);
-				}
-			} else if ((node_type == "MenuButton" || node_type == "OptionButton") && property_name == "items") {
-				Vector<String> str_values = property_value;
-				int incr_value = node_type == "MenuButton" ? PopupMenu::ITEM_PROPERTY_SIZE : OptionButton::ITEM_PROPERTY_SIZE;
-				for (int k = 0; k < str_values.size(); k += incr_value) {
-					String desc = str_values[k].get_slice(";", 1).strip_edges();
-					if (!desc.is_empty()) {
-						parsed_strings.push_back(desc);
-					}
 				}
 			} else if (node_type == "FileDialog" && property_name == "filters") {
 				// Extract FileDialog's filters property with values in format "*.png ; PNG Images","*.gd ; GDScript Files".
@@ -167,14 +168,32 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 	return OK;
 }
 
+bool PackedSceneEditorTranslationParserPlugin::match_property(const String &p_property_name, const String &p_node_type) {
+	for (const KeyValue<String, Vector<String>> &exception : exception_list) {
+		const String &exception_node_type = exception.key;
+		if (ClassDB::is_parent_class(p_node_type, exception_node_type)) {
+			const Vector<String> &exception_properties = exception.value;
+			for (const String &exception_property : exception_properties) {
+				if (p_property_name.match(exception_property)) {
+					return false;
+				}
+			}
+		}
+	}
+	for (const String &lookup_property : lookup_properties) {
+		if (p_property_name.match(lookup_property)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlugin() {
 	// Scene Node's properties containing strings that will be fetched for translation.
 	lookup_properties.insert("text");
-	lookup_properties.insert("tooltip_text");
-	lookup_properties.insert("placeholder_text");
-	lookup_properties.insert("items");
+	lookup_properties.insert("*_text");
+	lookup_properties.insert("popup/*/text");
 	lookup_properties.insert("title");
-	lookup_properties.insert("dialog_text");
 	lookup_properties.insert("filters");
 	lookup_properties.insert("script");
 

--- a/editor/plugins/packed_scene_translation_parser_plugin.h
+++ b/editor/plugins/packed_scene_translation_parser_plugin.h
@@ -43,6 +43,7 @@ class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserP
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;
+	bool match_property(const String &p_property_name, const String &p_node_type);
 	virtual void get_recognized_extensions(List<String> *r_extensions) const override;
 
 	PackedSceneEditorTranslationParserPlugin();


### PR DESCRIPTION
This is my attempt to fix the POT generator missing strings. 

- Made a special case for when the node type is empty, it will open the scene and get the type from there. It might even make sense to parse the whole instanced scene too, but it's possible to work around by just adding it to the files list.
(fixes #74194, probably fixes #79144)
- Removed the `MenuButton` and `OptionButton` case, as it's attempting to parse the old 3.x scene format.
- Added a function that will tell if the property of the node should be included. It will now match the property name against all properties in the lookup list, which allows wildcard for `popup/item_0/text` property of the nodes with popup menus.
(fixes #88017)

I'm planning to add the lookup and exclude properties in the project settings, but i don't know how to do that yet.
This is my first time really working with c++ so **i have no idea really what im doing.**
It might be that the variable names im using are wrong.
I ported this code from a custom translation parser i made in gdscript.