### PR TITLE
Add optional param `cancel_sliding` to `move_and_collide`

### DIFF
--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -35,12 +35,14 @@
 			<param index="1" name="test_only" type="bool" default="false" />
 			<param index="2" name="safe_margin" type="float" default="0.08" />
 			<param index="3" name="recovery_as_collision" type="bool" default="false" />
+			<param index="4" name="cancel_sliding" type="bool" default="true" />
 			<description>
 				Moves the body along the vector [param motion]. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [param motion] should be computed using [code]delta[/code].
 				Returns a [KinematicCollision2D], which contains information about the collision when stopped, or when touching another body along the motion.
 				If [param test_only] is [code]true[/code], the body does not move but the would-be collision information is given.
 				[param safe_margin] is the extra margin used for collision recovery (see [member CharacterBody2D.safe_margin] for more details).
 				If [param recovery_as_collision] is [code]true[/code], any depenetration from the recovery phase is also reported as a collision; this is used e.g. by [CharacterBody2D] for improving floor detection during floor snapping.
+				If [param cancel_sliding] is [code]true[/code], the direction of motion will be restored to be along original motion, in order to avoid sliding due to recovery.
 			</description>
 		</method>
 		<method name="remove_collision_exception_with">

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -44,6 +44,7 @@
 			<param index="2" name="safe_margin" type="float" default="0.001" />
 			<param index="3" name="recovery_as_collision" type="bool" default="false" />
 			<param index="4" name="max_collisions" type="int" default="1" />
+			<param index="5" name="cancel_sliding" type="bool" default="true" />
 			<description>
 				Moves the body along the vector [param motion]. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [param motion] should be computed using [code]delta[/code].
 				The body will stop if it collides. Returns a [KinematicCollision3D], which contains information about the collision when stopped, or when touching another body along the motion.
@@ -51,6 +52,7 @@
 				[param safe_margin] is the extra margin used for collision recovery (see [member CharacterBody3D.safe_margin] for more details).
 				If [param recovery_as_collision] is [code]true[/code], any depenetration from the recovery phase is also reported as a collision; this is used e.g. by [CharacterBody3D] for improving floor detection during floor snapping.
 				[param max_collisions] allows to retrieve more than one collision result.
+				If [param cancel_sliding] is [code]true[/code], the direction of motion will be restored to be along original motion, in order to avoid sliding due to recovery.
 			</description>
 		</method>
 		<method name="remove_collision_exception_with">

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -33,7 +33,7 @@
 #include "scene/scene_string_names.h"
 
 void PhysicsBody2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::_move, DEFVAL(false), DEFVAL(0.08), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision", "cancel_sliding"), &PhysicsBody2D::_move, DEFVAL(false), DEFVAL(0.08), DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "motion", "collision", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::test_move, DEFVAL(Variant()), DEFVAL(0.08), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_gravity"), &PhysicsBody2D::get_gravity);
 
@@ -54,13 +54,13 @@ PhysicsBody2D::~PhysicsBody2D() {
 	}
 }
 
-Ref<KinematicCollision2D> PhysicsBody2D::_move(const Vector2 &p_motion, bool p_test_only, real_t p_margin, bool p_recovery_as_collision) {
+Ref<KinematicCollision2D> PhysicsBody2D::_move(const Vector2 &p_motion, bool p_test_only, real_t p_margin, bool p_recovery_as_collision, bool p_cancel_sliding) {
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), p_motion, p_margin);
 	parameters.recovery_as_collision = p_recovery_as_collision;
 
 	PhysicsServer2D::MotionResult result;
 
-	if (move_and_collide(parameters, result, p_test_only)) {
+	if (move_and_collide(parameters, result, p_test_only, p_cancel_sliding)) {
 		// Create a new instance when the cached reference is invalid or still in use in script.
 		if (motion_cache.is_null() || motion_cache->get_reference_count() > 1) {
 			motion_cache.instantiate();

--- a/scene/2d/physics/physics_body_2d.h
+++ b/scene/2d/physics/physics_body_2d.h
@@ -46,7 +46,7 @@ protected:
 
 	Ref<KinematicCollision2D> motion_cache;
 
-	Ref<KinematicCollision2D> _move(const Vector2 &p_motion, bool p_test_only = false, real_t p_margin = 0.08, bool p_recovery_as_collision = false);
+	Ref<KinematicCollision2D> _move(const Vector2 &p_motion, bool p_test_only = false, real_t p_margin = 0.08, bool p_recovery_as_collision = false, bool p_cancel_sliding = true);
 
 public:
 	bool move_and_collide(const PhysicsServer2D::MotionParameters &p_parameters, PhysicsServer2D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -33,7 +33,7 @@
 #include "scene/scene_string_names.h"
 
 void PhysicsBody3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::_move, DEFVAL(false), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision", "max_collisions", "cancel_sliding"), &PhysicsBody3D::_move, DEFVAL(false), DEFVAL(0.001), DEFVAL(false), DEFVAL(1), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "motion", "collision", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::test_move, DEFVAL(Variant()), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("get_gravity"), &PhysicsBody3D::get_gravity);
 
@@ -91,14 +91,14 @@ void PhysicsBody3D::remove_collision_exception_with(Node *p_node) {
 	PhysicsServer3D::get_singleton()->body_remove_collision_exception(get_rid(), collision_object->get_rid());
 }
 
-Ref<KinematicCollision3D> PhysicsBody3D::_move(const Vector3 &p_motion, bool p_test_only, real_t p_margin, bool p_recovery_as_collision, int p_max_collisions) {
+Ref<KinematicCollision3D> PhysicsBody3D::_move(const Vector3 &p_motion, bool p_test_only, real_t p_margin, bool p_recovery_as_collision, int p_max_collisions, bool p_cancel_sliding) {
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), p_motion, p_margin);
 	parameters.max_collisions = p_max_collisions;
 	parameters.recovery_as_collision = p_recovery_as_collision;
 
 	PhysicsServer3D::MotionResult result;
 
-	if (move_and_collide(parameters, result, p_test_only)) {
+	if (move_and_collide(parameters, result, p_test_only, p_cancel_sliding)) {
 		// Create a new instance when the cached reference is invalid or still in use in script.
 		if (motion_cache.is_null() || motion_cache->get_reference_count() > 1) {
 			motion_cache.instantiate();

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -48,7 +48,7 @@ protected:
 
 	uint16_t locked_axis = 0;
 
-	Ref<KinematicCollision3D> _move(const Vector3 &p_motion, bool p_test_only = false, real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1);
+	Ref<KinematicCollision3D> _move(const Vector3 &p_motion, bool p_test_only = false, real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1, bool p_cancel_sliding = true);
 
 public:
 	bool move_and_collide(const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);


### PR DESCRIPTION
This PR exposes the `p_cancel_sliding` as a parameter to `move_and_collide` in `ClassDB` (which GDScript uses). This makes it possible to specify either to cancel sliding or not.

As @smix8 [said in the proposal](https://github.com/godotengine/godot-proposals/issues/9253#issuecomment-1983773398):
> The problem here is more the method binding, e.g. GDScript users think they are calling `move_and_collide()` but what they are really calling is a `_move()` wrapper function that omits parameters.


## ~~Open questions~~
~~Currently, there's a discrepancy between 2D and 3D in the `cancel_sliding` default values. The original C++ `move_and_collide` `p_cancel_sliding` parameters change between versions (being `true` on 2D, and `false` on 3D).~~

~~I chose to keep that default behavior for the exposed `ClassDB` `move_and_collide`, but maybe it should be better to expose the same default for end-users.~~

(update: it was me that caused that discrepancy but didn't realized it. Thank you @AThousandShips!)

## MRP
[cancel-sliding.zip](https://github.com/godotengine/godot/files/14540275/cancel-sliding.zip)

## Fixes
Fixes godotengine/godot-proposals#9253