### PR TITLE
Add hand capsule data to `XRHandTracker`

### DIFF
--- a/doc/classes/XRHandTracker.xml
+++ b/doc/classes/XRHandTracker.xml
@@ -11,6 +11,40 @@
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_hand_capsule_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of capsules this hand tracker is storing.
+			</description>
+		</method>
+		<method name="get_hand_capsule_height" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="capsule_index" type="int" />
+			<description>
+				Returns the height of the capsule at the given index.
+			</description>
+		</method>
+		<method name="get_hand_capsule_joint">
+			<return type="int" enum="XRHandTracker.HandJoint" />
+			<param index="0" name="capsule_index" type="int" />
+			<description>
+				Returns the parent hand joint of the capsule at the given index.
+			</description>
+		</method>
+		<method name="get_hand_capsule_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="capsule_index" type="int" />
+			<description>
+				Returns the radius of the capsule at the given index.
+			</description>
+		</method>
+		<method name="get_hand_capsule_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<param index="0" name="capsule_index" type="int" />
+			<description>
+				Returns the transform of the capsule at the given index.
+			</description>
+		</method>
 		<method name="get_hand_joint_angular_velocity" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
@@ -44,6 +78,51 @@
 			<param index="0" name="joint" type="int" enum="XRHandTracker.HandJoint" />
 			<description>
 				Returns the transform for the given hand joint.
+			</description>
+		</method>
+		<method name="has_hand_capsule_data" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if this hand tracker is storing any capsule data.
+			</description>
+		</method>
+		<method name="set_hand_capsule_count">
+			<return type="void" />
+			<param index="0" name="capsule_count" type="int" />
+			<description>
+				Sets the number of capsules this hand tracker is storing.
+			</description>
+		</method>
+		<method name="set_hand_capsule_height">
+			<return type="void" />
+			<param index="0" name="capsule_index" type="int" />
+			<param index="1" name="height" type="float" />
+			<description>
+				Sets the height of the capsule at the given index.
+			</description>
+		</method>
+		<method name="set_hand_capsule_joint">
+			<return type="void" />
+			<param index="0" name="capsule_index" type="int" />
+			<param index="1" name="joint" type="int" enum="XRHandTracker.HandJoint" />
+			<description>
+				Sets the parent hant joint of the capsule at the given index.
+			</description>
+		</method>
+		<method name="set_hand_capsule_radius">
+			<return type="void" />
+			<param index="0" name="capsule_index" type="int" />
+			<param index="1" name="radius" type="float" />
+			<description>
+				Sets the radius of the capsule at the given index.
+			</description>
+		</method>
+		<method name="set_hand_capsule_transform">
+			<return type="void" />
+			<param index="0" name="capsule_index" type="int" />
+			<param index="1" name="transform" type="Transform3D" />
+			<description>
+				Sets the transform of the capsule at the given index.
 			</description>
 		</method>
 		<method name="set_hand_joint_angular_velocity">

--- a/servers/xr/xr_hand_tracker.cpp
+++ b/servers/xr/xr_hand_tracker.cpp
@@ -55,6 +55,23 @@ void XRHandTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hand_joint_angular_velocity", "joint", "angular_velocity"), &XRHandTracker::set_hand_joint_angular_velocity);
 	ClassDB::bind_method(D_METHOD("get_hand_joint_angular_velocity", "joint"), &XRHandTracker::get_hand_joint_angular_velocity);
 
+	ClassDB::bind_method(D_METHOD("set_hand_capsule_transform", "capsule_index", "transform"), &XRHandTracker::set_hand_capsule_transform);
+	ClassDB::bind_method(D_METHOD("get_hand_capsule_transform", "capsule_index"), &XRHandTracker::get_hand_capsule_transform);
+
+	ClassDB::bind_method(D_METHOD("set_hand_capsule_height", "capsule_index", "height"), &XRHandTracker::set_hand_capsule_height);
+	ClassDB::bind_method(D_METHOD("get_hand_capsule_height", "capsule_index"), &XRHandTracker::get_hand_capsule_height);
+
+	ClassDB::bind_method(D_METHOD("set_hand_capsule_radius", "capsule_index", "radius"), &XRHandTracker::set_hand_capsule_radius);
+	ClassDB::bind_method(D_METHOD("get_hand_capsule_radius", "capsule_index"), &XRHandTracker::get_hand_capsule_radius);
+
+	ClassDB::bind_method(D_METHOD("set_hand_capsule_joint", "capsule_index", "joint"), &XRHandTracker::set_hand_capsule_joint);
+	ClassDB::bind_method(D_METHOD("get_hand_capsule_joint", "capsule_index"), &XRHandTracker::get_hand_capsule_joint);
+
+	ClassDB::bind_method(D_METHOD("set_hand_capsule_count", "capsule_count"), &XRHandTracker::set_hand_capsule_count);
+	ClassDB::bind_method(D_METHOD("get_hand_capsule_count"), &XRHandTracker::get_hand_capsule_count);
+
+	ClassDB::bind_method(D_METHOD("has_hand_capsule_data"), &XRHandTracker::has_hand_capsule_data);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand", PROPERTY_HINT_ENUM, "Left,Right"), "set_hand", "get_hand");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_tracking_data", PROPERTY_HINT_NONE), "set_has_tracking_data", "get_has_tracking_data");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand_tracking_source", PROPERTY_HINT_ENUM, "Unknown,Unobstructed,Controller"), "set_hand_tracking_source", "get_hand_tracking_source");
@@ -176,4 +193,56 @@ void XRHandTracker::set_hand_joint_angular_velocity(XRHandTracker::HandJoint p_j
 Vector3 XRHandTracker::get_hand_joint_angular_velocity(XRHandTracker::HandJoint p_joint) const {
 	ERR_FAIL_INDEX_V(p_joint, HAND_JOINT_MAX, Vector3());
 	return hand_joint_angular_velocities[p_joint];
+}
+
+void XRHandTracker::set_hand_capsule_transform(int p_capsule_index, const Transform3D &p_transform) {
+	ERR_FAIL_INDEX_MSG(p_capsule_index, hand_capsules.size(), vformat("Invalid capsule index %d", p_capsule_index));
+	hand_capsules.write[p_capsule_index].transform = p_transform;
+}
+
+Transform3D XRHandTracker::get_hand_capsule_transform(int p_capsule_index) const {
+	ERR_FAIL_INDEX_V_MSG(p_capsule_index, hand_capsules.size(), Transform3D(), vformat("Invalid capsule index %d", p_capsule_index));
+	return hand_capsules[p_capsule_index].transform;
+}
+
+void XRHandTracker::set_hand_capsule_height(int p_capsule_index, float p_height) {
+	ERR_FAIL_INDEX_MSG(p_capsule_index, hand_capsules.size(), vformat("Invalid capsule index %d", p_capsule_index));
+	hand_capsules.write[p_capsule_index].height = p_height;
+}
+
+float XRHandTracker::get_hand_capsule_height(int p_capsule_index) const {
+	ERR_FAIL_INDEX_V_MSG(p_capsule_index, hand_capsules.size(), 0.0, vformat("Invalid capsule index %d", p_capsule_index));
+	return hand_capsules[p_capsule_index].height;
+}
+
+void XRHandTracker::set_hand_capsule_radius(int p_capsule_index, float p_radius) {
+	ERR_FAIL_INDEX_MSG(p_capsule_index, hand_capsules.size(), vformat("Invalid capsule index %d", p_capsule_index));
+	hand_capsules.write[p_capsule_index].radius = p_radius;
+}
+
+float XRHandTracker::get_hand_capsule_radius(int p_capsule_index) const {
+	ERR_FAIL_INDEX_V_MSG(p_capsule_index, hand_capsules.size(), 0.0, vformat("Invalid capsule index %d", p_capsule_index));
+	return hand_capsules[p_capsule_index].radius;
+}
+
+void XRHandTracker::set_hand_capsule_joint(int p_capsule_index, HandJoint p_joint) {
+	ERR_FAIL_INDEX_MSG(p_capsule_index, hand_capsules.size(), vformat("Invalid capsule index %d", p_capsule_index));
+	hand_capsules.write[p_capsule_index].joint = p_joint;
+}
+
+XRHandTracker::HandJoint XRHandTracker::get_hand_capsule_joint(int p_capsule_index) {
+	ERR_FAIL_INDEX_V_MSG(p_capsule_index, hand_capsules.size(), HandJoint(0), vformat("Invalid capsule index %d", p_capsule_index));
+	return hand_capsules[p_capsule_index].joint;
+}
+
+void XRHandTracker::set_hand_capsule_count(int p_capsule_count) {
+	hand_capsules.resize(p_capsule_count);
+}
+
+int XRHandTracker::get_hand_capsule_count() const {
+	return hand_capsules.size();
+}
+
+bool XRHandTracker::has_hand_capsule_data() const {
+	return hand_capsules.size() > 0;
 }

--- a/servers/xr/xr_hand_tracker.h
+++ b/servers/xr/xr_hand_tracker.h
@@ -90,6 +90,13 @@ public:
 		HAND_JOINT_FLAG_ANGULAR_VELOCITY_VALID = 32,
 	};
 
+	struct HandCapsule {
+		Transform3D transform;
+		float height;
+		float radius;
+		HandJoint joint;
+	};
+
 	void set_hand(Hand p_hand);
 	Hand get_hand() const;
 
@@ -114,6 +121,23 @@ public:
 	void set_hand_joint_angular_velocity(HandJoint p_joint, const Vector3 &p_velocity);
 	Vector3 get_hand_joint_angular_velocity(HandJoint p_joint) const;
 
+	void set_hand_capsule_transform(int p_capsule_index, const Transform3D &p_transform);
+	Transform3D get_hand_capsule_transform(int p_capsule_index) const;
+
+	void set_hand_capsule_height(int p_capsule_index, float p_height);
+	float get_hand_capsule_height(int p_capsule_index) const;
+
+	void set_hand_capsule_radius(int p_capsule_index, float p_radius);
+	float get_hand_capsule_radius(int p_capsule_index) const;
+
+	void set_hand_capsule_joint(int p_capsule_index, HandJoint p_joint);
+	HandJoint get_hand_capsule_joint(int p_capsule_index);
+
+	void set_hand_capsule_count(int p_capsule_count);
+	int get_hand_capsule_count() const;
+
+	bool has_hand_capsule_data() const;
+
 protected:
 	static void _bind_methods();
 
@@ -127,6 +151,8 @@ private:
 	float hand_joint_radii[HAND_JOINT_MAX] = {};
 	Vector3 hand_joint_linear_velocities[HAND_JOINT_MAX];
 	Vector3 hand_joint_angular_velocities[HAND_JOINT_MAX];
+
+	Vector<HandCapsule> hand_capsules;
 };
 
 VARIANT_ENUM_CAST(XRHandTracker::Hand)


### PR DESCRIPTION
This PR makes it possible to provide `XRHandTracker` with capsule data that could then be used to construct meshes or collision shapes.

Discussion has taken place that a vendor-neutral way of populating/consuming hand capsule data may be desirable in https://github.com/GodotVR/godot_openxr_vendors/pull/88. The conversation boils down to: OpenXR extension [XR_FB_hand_tracking_capsules](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_hand_tracking_capsules) provides capsule data, however similar capsule data could also be constructed via joint data from the vendor-neutral [XR_EXT_hand_tracking](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_EXT_hand_tracking). This is the main motivation for this PR.