### PR TITLE
Fix possible crash when converting a node to other in visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -482,6 +482,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 	if (p_just_update) {
 		Link &link = links[p_id];
 
+		link.visual_node = vsnode.ptr();
 		link.graph_element = node;
 		link.preview_box = nullptr;
 		link.preview_pos = -1;


### PR DESCRIPTION
I've detected that sometimes the editor crashing when the user use this option in visual shaders:

![изображение](https://github.com/godotengine/godot/assets/3036176/ab483b97-a38e-4e99-bca9-ae2673fb42a5)

Visual shader node pointer become a null and crash:

![изображение](https://github.com/godotengine/godot/assets/3036176/65b5a09c-be0c-4147-80e1-2e7396a111f7)

After this fix, it will not.