### PR TITLE
Fix get_node_deferred_nodepath_properties Index Out Of Bounds

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1721,6 +1721,10 @@ StringName SceneState::get_node_property_name(int p_idx, int p_prop) const {
 }
 
 Vector<String> SceneState::get_node_deferred_nodepath_properties(int p_idx) const {
+	if (p_idx >= nodes.size() && base_scene_node_remap.has(p_idx)) {
+		return get_base_scene_state()->get_node_deferred_nodepath_properties(base_scene_node_remap[p_idx]);
+	}
+
 	Vector<String> ret;
 	ERR_FAIL_INDEX_V(p_idx, nodes.size(), ret);
 	for (int i = 0; i < nodes[p_idx].properties.size(); i++) {


### PR DESCRIPTION
This fixes the issue described here: https://github.com/godotengine/godot/issues/88517

The error occurs when there is a scene that has at least once child and multiple levels of inheritance.

Example scene setup:

```
Node
|
|__ Child
```

Lets refer to this scene as ``base_scene``.  And then create a few levels of inheritence so that it looks like:

``base_scene -> inherited_scene1 -> inherited_scene2 -> inherited_scene3``

Then open ``inherited_scene_3`` and select ``Child`` in the ``Scene`` panel.  You will see an error such as:

```
ERROR: Index p_idx = 1 is out of bounds (nodes.size() = 1)
```

Then we can see that the error occurs within lines 76 and 77 of property_utils.cpp:

https://github.com/godotengine/godot/blob/ffc41fb76df5922321cdd98cce12715a039629b0/scene/property_utils.cpp#L76C1-L77C105

```cpp
Variant value_in_ancestor = ia.state->get_property_value(ia.node, p_property, found);
const Vector<String> &deferred_properties = ia.state->get_node_deferred_nodepath_properties(ia.node);
```

The first line makes a call to ``get_property_value`` to see if it can find it.  If we take a look at this method, we will see something interesting:

https://github.com/godotengine/godot/blob/ffc41fb76df5922321cdd98cce12715a039629b0/scene/resources/packed_scene.cpp#L1334C1-L1336C3

```cpp

if (base_scene_node_remap.has(p_node)) {
	return get_base_scene_state()->get_property_value(base_scene_node_remap[p_node], p_property, found);
}
```

Here it allows for situations with the ``base_scene_node_remap`` if it doesn't find it in the instance node (I think that's the right terminology?  Was picking up from the comments.).

Then if we take a look at the ``get_node_deferred_nodepath_properties`` method, we will see that it is not taking into account ``base_scene_node_remap``:

https://github.com/godotengine/godot/blob/ffc41fb76df5922321cdd98cce12715a039629b0/scene/resources/packed_scene.cpp#L1723

```cpp
Vector<String> SceneState::get_node_deferred_nodepath_properties(int p_idx) const {
	Vector<String> ret;
	ERR_FAIL_INDEX_V(p_idx, nodes.size(), ret);
	for (int i = 0; i < nodes[p_idx].properties.size(); i++) {
		uint32_t idx = nodes[p_idx].properties[i].name;
		if (idx & FLAG_PATH_PROPERTY_IS_NODE) {
			ret.push_back(names[idx & FLAG_PROP_NAME_MASK]);
		}
	}
	return ret;
}
```

Hence it will error in instances where the previous check passed because the previous check made used of ``base_scene_node_remap``.

The good news is this method is only used in 2 places from what I can tell.  So changing it should have limited side effects if any.  The 1st place being the 1 that this PR is fixing.  And the second place being:

https://github.com/godotengine/godot/blob/ffc41fb76df5922321cdd98cce12715a039629b0/scene/resources/resource_format_text.cpp#L2248

The 2nd place above doesn't jump out to me as problematic.  In fact, I expect this will fix a bug that exists there (idk what resource_format_text.cpp is used for).  But if we don't want to take the ``base_scene_node_remap`` into account for resource_format_text.cpp for some reason, we can simply add a boolean or alternate method to indicate whether or not to use ``base_scene_node_remap``.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/88517*