### PR TITLE
Make input_ray_pickable CollisionObjects sensitive to collision layers

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2275,6 +2275,12 @@
 			Controls the maximum number of physics steps that can be simulated each rendered frame. The default value is tuned to avoid "spiral of death" situations where expensive physics simulations trigger more expensive simulations indefinitely. However, the game will appear to slow down if the rendering FPS is less than [code]1 / max_physics_steps_per_frame[/code] of [member physics/common/physics_ticks_per_second]. This occurs even if [code]delta[/code] is consistently used in physics calculations. To avoid this, increase [member physics/common/max_physics_steps_per_frame] if you have increased [member physics/common/physics_ticks_per_second] significantly above its default value.
 			[b]Note:[/b] This property is only read when the project starts. To change the maximum number of simulated physics steps per frame at runtime, set [member Engine.max_physics_steps_per_frame] instead.
 		</member>
+		<member name="physics/common/object_picking_2d_mask" type="int" setter="" getter="" default="4294967295">
+			Sets the default value for [member Viewport.input_cull_mask_2d] on the root viewport.
+		</member>
+		<member name="physics/common/object_picking_3d_mask" type="int" setter="" getter="" default="4294967295">
+			Sets the default value for [member Viewport.input_cull_mask_3d] on the root viewport.
+		</member>
 		<member name="physics/common/physics_interpolation" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the renderer will interpolate the transforms of physics objects between the last two transforms, so that smooth motion is seen even when physics ticks do not coincide with rendered frames. See also [member Node.physics_interpolation_mode] and [method Node.reset_physics_interpolation].
 			[b]Note:[/b] If [code]true[/code], the physics jitter fix should be disabled by setting [member physics/common/physics_jitter_fix] to [code]0.0[/code].

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -65,6 +65,20 @@
 				Returns the transform from the viewport's coordinate system to the embedder's coordinate system.
 			</description>
 		</method>
+		<method name="get_input_cull_mask_2d_bit" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns an individual bit on the 2d input culling layer mask.
+			</description>
+		</method>
+		<method name="get_input_cull_mask_3d_bit" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns an individual bit on the 3d input culling layer mask.
+			</description>
+		</method>
 		<method name="get_mouse_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -218,6 +232,22 @@
 				[b]Note:[/b] This does not affect the methods in [Input], only the way events are propagated.
 			</description>
 		</method>
+		<method name="set_input_cull_mask_2d_bit">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Set/clear individual bits on the 2D input culling layer mask. This simplifies editing this [Viewport]'s 2D input culling layers.
+			</description>
+		</method>
+		<method name="set_input_cull_mask_3d_bit">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Set/clear individual bits on the 3D input culling layer mask. This simplifies editing this [Viewport]'s 3D input culling layers.
+			</description>
+		</method>
 		<method name="set_positional_shadow_atlas_quadrant_subdiv">
 			<return type="void" />
 			<param index="0" name="quadrant" type="int" />
@@ -286,6 +316,12 @@
 			If [code]true[/code], this viewport will mark incoming input events as handled by itself. If [code]false[/code], this is instead done by the first parent viewport that is set to handle input locally.
 			A [SubViewportContainer] will automatically set this property to [code]false[/code] for the [Viewport] contained inside of it.
 			See also [method set_input_as_handled] and [method is_input_handled].
+		</member>
+		<member name="input_cull_mask_2d" type="int" setter="set_input_cull_mask_2d" getter="get_input_cull_mask_2d" default="4294967295">
+			The collision layers in which 2D physics objects can receive input events if [member physics_object_picking] is [code]true[/code].
+		</member>
+		<member name="input_cull_mask_3d" type="int" setter="set_input_cull_mask_3d" getter="get_input_cull_mask_3d" default="4294967295">
+			The collision layers in which 3D physics objects can receive input events if [member physics_object_picking] is [code]true[/code].
 		</member>
 		<member name="mesh_lod_threshold" type="float" setter="set_mesh_lod_threshold" getter="get_mesh_lod_threshold" default="1.0">
 			The automatic LOD bias to use for meshes rendered within the [Viewport] (this is analogous to [member ReflectionProbe.mesh_lod_threshold]). Higher values will use less detailed versions of meshes that have LOD variations generated. If set to [code]0.0[/code], automatic LOD is disabled. Increase [member mesh_lod_threshold] to improve performance at the cost of geometry detail.

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1890,6 +1890,9 @@ SceneTree::SceneTree() {
 
 	root->set_physics_object_picking(GLOBAL_DEF("physics/common/enable_object_picking", true));
 
+	root->set_input_cull_mask_2d(GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/common/object_picking_2d_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), 0xffffffff));
+	root->set_input_cull_mask_3d(GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/common/object_picking_3d_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), 0xffffffff));
+
 	root->connect("close_requested", callable_mp(this, &SceneTree::_main_window_close));
 	root->connect("go_back_requested", callable_mp(this, &SceneTree::_main_window_go_back));
 	root->connect("focus_entered", callable_mp(this, &SceneTree::_main_window_focus_in));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -804,6 +804,7 @@ void Viewport::_process_picking() {
 				point_params.canvas_instance_id = canvas_layer_id;
 				point_params.collide_with_areas = true;
 				point_params.pick_point = true;
+				point_params.collision_mask = input_cull_mask_2d;
 
 				int rc = ss2d->intersect_point(point_params, res, 64);
 				if (physics_object_picking_sort) {
@@ -905,6 +906,7 @@ void Viewport::_process_picking() {
 					ray_params.to = from + dir * depth_far;
 					ray_params.collide_with_areas = true;
 					ray_params.pick_ray = true;
+					ray_params.collision_mask = input_cull_mask_3d;
 
 					bool col = space->intersect_ray(ray_params, result);
 					ObjectID new_collider;
@@ -3621,6 +3623,58 @@ bool Viewport::is_handling_input_locally() const {
 	return handle_input_locally;
 }
 
+void Viewport::set_input_cull_mask_2d(uint32_t p_mask) {
+	input_cull_mask_2d = p_mask;
+}
+
+uint32_t Viewport::get_input_cull_mask_2d() const {
+	return input_cull_mask_2d;
+}
+
+void Viewport::set_input_cull_mask_2d_bit(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Input cull layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Input cull layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_input_cull_mask_2d();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_input_cull_mask_2d(mask);
+}
+
+bool Viewport::get_input_cull_mask_2d_bit(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Input cull layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Input cull layer number must be between 1 and 32 inclusive.");
+	return get_input_cull_mask_2d() & (1 << (p_layer_number - 1));
+}
+
+void Viewport::set_input_cull_mask_3d(uint32_t p_mask) {
+	input_cull_mask_3d = p_mask;
+}
+
+uint32_t Viewport::get_input_cull_mask_3d() const {
+	return input_cull_mask_3d;
+}
+
+void Viewport::set_input_cull_mask_3d_bit(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Input cull layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Input cull layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_input_cull_mask_3d();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_input_cull_mask_3d(mask);
+}
+
+bool Viewport::get_input_cull_mask_3d_bit(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Input cull layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Input cull layer number must be between 1 and 32 inclusive.");
+	return get_input_cull_mask_3d() & (1 << (p_layer_number - 1));
+}
+
 void Viewport::set_default_canvas_item_texture_filter(DefaultCanvasItemTextureFilter p_filter) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_INDEX(p_filter, DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_MAX);
@@ -4631,6 +4685,16 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_object_picking_first_only", "enable"), &Viewport::set_physics_object_picking_first_only);
 	ClassDB::bind_method(D_METHOD("get_physics_object_picking_first_only"), &Viewport::get_physics_object_picking_first_only);
 
+	ClassDB::bind_method(D_METHOD("set_input_cull_mask_2d", "input_cull_mask_2d"), &Viewport::set_input_cull_mask_2d);
+	ClassDB::bind_method(D_METHOD("get_input_cull_mask_2d"), &Viewport::get_input_cull_mask_2d);
+	ClassDB::bind_method(D_METHOD("set_input_cull_mask_2d_bit", "layer_number", "value"), &Viewport::set_input_cull_mask_2d_bit);
+	ClassDB::bind_method(D_METHOD("get_input_cull_mask_2d_bit", "layer_number"), &Viewport::get_input_cull_mask_2d_bit);
+
+	ClassDB::bind_method(D_METHOD("set_input_cull_mask_3d", "input_cull_mask_3d"), &Viewport::set_input_cull_mask_3d);
+	ClassDB::bind_method(D_METHOD("get_input_cull_mask_3d"), &Viewport::get_input_cull_mask_3d);
+	ClassDB::bind_method(D_METHOD("set_input_cull_mask_3d_bit", "layer_number", "value"), &Viewport::set_input_cull_mask_3d_bit);
+	ClassDB::bind_method(D_METHOD("get_input_cull_mask_3d_bit", "layer_number"), &Viewport::get_input_cull_mask_3d_bit);
+
 	ClassDB::bind_method(D_METHOD("get_viewport_rid"), &Viewport::get_viewport_rid);
 	ClassDB::bind_method(D_METHOD("push_text_input", "text"), &Viewport::push_text_input);
 	ClassDB::bind_method(D_METHOD("push_input", "event", "in_local_coords"), &Viewport::push_input, DEFVAL(false));
@@ -4789,6 +4853,8 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking"), "set_physics_object_picking", "get_physics_object_picking");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking_sort"), "set_physics_object_picking_sort", "get_physics_object_picking_sort");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_object_picking_first_only"), "set_physics_object_picking_first_only", "get_physics_object_picking_first_only");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_cull_mask_2d", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_input_cull_mask_2d", "get_input_cull_mask_2d");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_cull_mask_3d", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_input_cull_mask_3d", "get_input_cull_mask_3d");
 	ADD_GROUP("GUI", "gui_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_disable_input"), "set_disable_input", "is_input_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -260,6 +260,9 @@ private:
 	Transform3D physics_last_camera_transform;
 	ObjectID physics_last_id;
 
+	uint32_t input_cull_mask_2d = 0xffffffff; // By default, all collision layers are pickable
+	uint32_t input_cull_mask_3d = 0xffffffff;
+
 	bool handle_input_locally = true;
 	bool local_input_handled = false;
 
@@ -582,6 +585,16 @@ public:
 	bool get_physics_object_picking_sort();
 	void set_physics_object_picking_first_only(bool p_enable);
 	bool get_physics_object_picking_first_only();
+
+	void set_input_cull_mask_2d(uint32_t p_mask);
+	uint32_t get_input_cull_mask_2d() const;
+	void set_input_cull_mask_2d_bit(int p_layer_number, bool p_value);
+	bool get_input_cull_mask_2d_bit(int p_layer_number) const;
+
+	void set_input_cull_mask_3d(uint32_t p_mask);
+	uint32_t get_input_cull_mask_3d() const;
+	void set_input_cull_mask_3d_bit(int p_layer_number, bool p_value);
+	bool get_input_cull_mask_3d_bit(int p_layer_number) const;
 
 	Variant gui_get_drag_data() const;
 


### PR DESCRIPTION
Implements and thus closes godotengine/godot-proposals#9135

This was doable by simply exposing collision layer settings to Viewport, and forwarding these to the ray-picking method. The entire physics were already implemented and simply fed a full ``0xffffffff`` collision mask.

Because the default value for the Viewport is also ``0xffffffff``, existing projects are entirely unaffected.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
