### PR TITLE
Refactor how file cache entries are stored

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1333,24 +1333,28 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 	p_file->store_line("::" + p_dir->get_path() + "::" + String::num(p_dir->modified_time));
 
 	for (int i = 0; i < p_dir->files.size(); i++) {
-		if (!p_dir->files[i]->import_group_file.is_empty()) {
-			group_file_cache.insert(p_dir->files[i]->import_group_file);
+		const EditorFileSystemDirectory::FileInfo *file_info = p_dir->files[i];
+		if (!file_info->import_group_file.is_empty()) {
+			group_file_cache.insert(file_info->import_group_file);
 		}
 
-		String type = p_dir->files[i]->type;
-		if (p_dir->files[i]->resource_script_class) {
-			type += "/" + String(p_dir->files[i]->resource_script_class);
-		}
-		String s = p_dir->files[i]->file + "::" + type + "::" + itos(p_dir->files[i]->uid) + "::" + itos(p_dir->files[i]->modified_time) + "::" + itos(p_dir->files[i]->import_modified_time) + "::" + itos(p_dir->files[i]->import_valid) + "::" + p_dir->files[i]->import_group_file + "::" + p_dir->files[i]->script_class_name + "<>" + p_dir->files[i]->script_class_extends + "<>" + p_dir->files[i]->script_class_icon_path;
-		s += "::";
-		for (int j = 0; j < p_dir->files[i]->deps.size(); j++) {
-			if (j > 0) {
-				s += "<>";
-			}
-			s += p_dir->files[i]->deps[j];
+		String type = file_info->type;
+		if (file_info->resource_script_class) {
+			type += "/" + String(file_info->resource_script_class);
 		}
 
-		p_file->store_line(s);
+		PackedStringArray cache_string;
+		cache_string.append(file_info->file);
+		cache_string.append(type);
+		cache_string.append(itos(file_info->uid));
+		cache_string.append(itos(file_info->modified_time));
+		cache_string.append(itos(file_info->import_modified_time));
+		cache_string.append(itos(file_info->import_valid));
+		cache_string.append(file_info->import_group_file);
+		cache_string.append(String("<>").join({ file_info->script_class_name, file_info->script_class_extends, file_info->script_class_icon_path }));
+		cache_string.append(String("<>").join(file_info->deps));
+
+		p_file->store_line(String("::").join(cache_string));
 	}
 
 	for (int i = 0; i < p_dir->subdirs.size(); i++) {


### PR DESCRIPTION
Currently the code for writing FileSystem cache is basically a one unreadable line of string additions, followed by a loop of string additions. This PR changes it to be much more readable, without affecting the file's content. It might also make the code faster.