### PR TITLE
Windows: Avoid `scale_with_dpi` constexpr compiler error.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2573,7 +2573,7 @@ struct Win32InputTextDialogInit {
 	const Callable &callback;
 };
 
-static constexpr int scale_with_dpi(int p_pos, int p_dpi) {
+static int scale_with_dpi(int p_pos, int p_dpi) {
 	return IsProcessDPIAware() ? (p_pos * p_dpi / 96) : p_pos;
 }
 


### PR DESCRIPTION
`IsProcessDPIAware()` is not a const expression causing compiles to fail.

~~I'll try to get full bug report soon.~~ I can't find the recreation steps. I think it's like using mingw on a mac.