### PR TITLE
Wayland: Stop unreachable warning

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -585,9 +585,9 @@ void DisplayServerWayland::screen_set_keep_on(bool p_enable) {
 bool DisplayServerWayland::screen_is_kept_on() const {
 #ifdef DBUS_ENABLED
 	return wayland_thread.window_get_idle_inhibition(MAIN_WINDOW_ID) || screensaver_inhibited;
-#endif
-
+#else
 	return wayland_thread.window_get_idle_inhibition(MAIN_WINDOW_ID);
+#endif
 }
 
 Vector<DisplayServer::WindowID> DisplayServerWayland::get_window_list() const {


### PR DESCRIPTION
```
*** CID 415586:  Control flow issues  (UNREACHABLE) /platform/linuxbsd/wayland/display_server_wayland.cpp: 590 in DisplayServerWayland::screen_is_kept_on() const() 584
585     bool DisplayServerWayland::screen_is_kept_on() const {
586     #ifdef DBUS_ENABLED
587     	return wayland_thread.window_get_idle_inhibition(MAIN_WINDOW_ID) || screensaver_inhibited;
588     #endif
589
>>>     CID 415586:  Control flow issues  (UNREACHABLE)
>>>     This code cannot be reached: "return this->wayland_thread...".
590     	return wayland_thread.window_get_idle_inhibition(MAIN_WINDOW_ID);
591     }
592
593     Vector<DisplayServer::WindowID> DisplayServerWayland::get_window_list() const {
594     	MutexLock mutex_lock(wayland_thread.mutex);
595
```

