### PR TITLE
C#: Fix warnings in GodotSharp

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -125,6 +125,20 @@ const Vector<String> ignored_types = {};
 // Don't check against all C# reserved words, as many cases are GDScript-specific.
 const Vector<String> langword_check = { "true", "false", "null" };
 
+// The following properties currently need to be defined with `new` to avoid warnings. We treat
+// them as a special case instead of silencing the warnings altogether, to be warned if more
+// shadowing appears.
+const Vector<String> prop_allowed_inherited_member_hiding = {
+	"ArrayMesh.BlendShapeMode",
+	"Button.TextDirection",
+	"Label.TextDirection",
+	"LineEdit.TextDirection",
+	"LinkButton.TextDirection",
+	"MenuBar.TextDirection",
+	"RichTextLabel.TextDirection",
+	"TextEdit.TextDirection",
+};
+
 void BindingsGenerator::TypeInterface::postsetup_enum_type(BindingsGenerator::TypeInterface &r_enum_itype) {
 	// C interface for enums is the same as that of 'uint32_t'. Remember to apply
 	// any of the changes done here to the 'uint32_t' type interface as well.
@@ -2568,6 +2582,10 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 	}
 
 	p_output.append(MEMBER_BEGIN "public ");
+
+	if (prop_allowed_inherited_member_hiding.has(p_itype.proxy_name + "." + p_iprop.proxy_name)) {
+		p_output.append("new ");
+	}
 
 	if (p_itype.is_singleton) {
 		p_output.append("static ");

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -6,7 +6,10 @@ namespace Godot;
 
 #nullable enable
 
+// TODO: Disabled because it is a false positive, see https://github.com/dotnet/roslyn-analyzers/issues/6151
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
 public partial struct Variant : IDisposable
+#pragma warning restore CA1001
 {
     internal godot_variant.movable NativeVar;
     private object? _obj;


### PR DESCRIPTION
- Fix most CS0108 in generated glue
- Suppress CA1001 on `Variant`

---

As discussed on RC. Overall, regarding warnings: we're almost there 😅 I left the `CS0108` we currently have on `GltfAccessor.GetType()` because it is so stinky, we deserve to endure seeing it every time.

Here's the diff of the generated classes.

```
--- GodotSharp/Generated.old/GodotObjects/ArrayMesh.cs	2024-03-09 16:46:29.047422800 +0100
+++ GodotSharp/Generated/GodotObjects/ArrayMesh.cs	2024-03-09 16:48:42.112835900 +0100
@@ -61,7 +61,7 @@
     /// <summary>
     /// <para>Sets the blend shape mode to one of <see cref="Godot.Mesh.BlendShapeMode"/>.</para>
     /// </summary>
-    public Mesh.BlendShapeMode BlendShapeMode
+    public new Mesh.BlendShapeMode BlendShapeMode
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/Button.cs	2024-03-09 16:46:29.125389100 +0100
+++ GodotSharp/Generated/GodotObjects/Button.cs	2024-03-09 16:48:42.191835200 +0100
@@ -182,7 +182,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/Label.cs	2024-03-09 16:46:29.577388900 +0100
+++ GodotSharp/Generated/GodotObjects/Label.cs	2024-03-09 16:48:42.634867600 +0100
@@ -256,7 +256,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/LineEdit.cs	2024-03-09 16:46:29.608389400 +0100
+++ GodotSharp/Generated/GodotObjects/LineEdit.cs	2024-03-09 16:48:42.661835600 +0100
@@ -605,7 +605,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/LinkButton.cs	2024-03-09 16:46:29.609390700 +0100
+++ GodotSharp/Generated/GodotObjects/LinkButton.cs	2024-03-09 16:48:42.663834900 +0100
@@ -82,7 +82,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/MenuBar.cs	2024-03-09 16:46:29.617415700 +0100
+++ GodotSharp/Generated/GodotObjects/MenuBar.cs		2024-03-09 16:48:42.671836500 +0100
@@ -74,7 +74,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/RichTextLabel.cs	2024-03-09 16:46:30.229494900 +0100
+++ GodotSharp/Generated/GodotObjects/RichTextLabel.cs	2024-03-09 16:48:43.247380000 +0100
@@ -413,7 +413,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
--- GodotSharp/Generated.old/GodotObjects/TextEdit.cs	2024-03-09 16:46:30.389491200 +0100
+++ GodotSharp/Generated/GodotObjects/TextEdit.cs	2024-03-09 16:48:43.401418000 +0100
@@ -758,7 +758,7 @@
     /// <summary>
     /// <para>Base text writing direction.</para>
     /// </summary>
-    public Control.TextDirection TextDirection
+    public new Control.TextDirection TextDirection
     {
         get
         {
```