### PR TITLE
Add keywords to `PhysicsBody{2D,3D}.test_move()` for easier discoverability

### DIFF
--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -50,7 +50,7 @@
 				Removes a body from the list of bodies that this body can't collide with.
 			</description>
 		</method>
-		<method name="test_move">
+		<method name="test_move" keywords="check, collision, sweep">
 			<return type="bool" />
 			<param index="0" name="from" type="Transform2D" />
 			<param index="1" name="motion" type="Vector2" />

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -68,7 +68,7 @@
 				Locks or unlocks the specified linear or rotational [param axis] depending on the value of [param lock].
 			</description>
 		</method>
-		<method name="test_move">
+		<method name="test_move" keywords="check, collision, sweep">
 			<return type="bool" />
 			<param index="0" name="from" type="Transform3D" />
 			<param index="1" name="motion" type="Vector3" />


### PR DESCRIPTION
`sweep` is the term used in Unity for collision checks without moving anything.

- See https://github.com/godotengine/godot-proposals/issues/9259.
