### PR TITLE
Fix error when CPUParticles3D has `scale` set to `(0, 0, 0)`

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1307,7 +1307,11 @@ void CPUParticles3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			inv_emission_transform = get_global_transform().affine_inverse();
+			Transform3D global_transform = get_global_transform();
+			if (unlikely(global_transform.basis.determinant() == 0)) {
+				return;
+			}
+			inv_emission_transform = global_transform.affine_inverse();
 
 			if (!local_coords) {
 				int pc = particles.size();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/63011 (also look at the comments)