### PR TITLE
Fix MoltenVK detection

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -242,10 +242,17 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-framework", "Metal", "-framework", "IOSurface"])
         if not env["use_volk"]:
             env.Append(LINKFLAGS=["-lMoltenVK"])
-            mvk_path = detect_mvk(env, "macos-arm64_x86_64")
+
+            mvk_path = ""
+            arch_variants = ["macos-arm64_x86_64", "macos-" + env["arch"]]
+            for arch in arch_variants:
+                mvk_path = detect_mvk(env, arch)
+                if mvk_path != "":
+                    mvk_path = os.path.join(mvk_path, arch)
+                    break
 
             if mvk_path != "":
-                env.Append(LINKFLAGS=["-L" + os.path.join(mvk_path, "macos-arm64_x86_64")])
+                env.Append(LINKFLAGS=["-L" + mvk_path])
             else:
                 print(
                     "MoltenVK SDK installation directory not found, use 'vulkan_sdk_path' SCons parameter to specify SDK path."


### PR DESCRIPTION
There have recently been changes to the logic detecting Vulkan SDK on MacOS.
I have MoltenVK installed using homebrew and the `macos-arm64_x86_64` is not available on my system.

Hence I have added code to detect multiple _arch_ variants.

Following is info about my MoltenVK installation:
```bash
$ brew info molten-vk                                                                                                                                                                                                                                   
==> molten-vk: stable 1.2.7 (bottled), HEAD
Implementation of the Vulkan graphics and compute API on top of Metal
https://github.com/KhronosGroup/MoltenVK
/opt/homebrew/Cellar/molten-vk/1.2.7 (145 files, 89.6MB) *
  Poured from bottle using the formulae.brew.sh API on 2024-02-02 at 14:16:49
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/m/molten-vk.rb
License: Apache-2.0
==> Dependencies
Build: cmake ✔
==> Requirements
Build: Xcode >= 11.7 (on macOS) ✔
Required: macOS >= 10.12 (or Linux) ✔, macOS ✔
==> Options
--HEAD
        Install HEAD version
==> Analytics
install: 1,133 (30 days), 4,053 (90 days), 15,190 (365 days)
install-on-request: 580 (30 days), 2,120 (90 days), 7,696 (365 days)
build-error: 102 (30 days)

$ brew ls molten-vk                                                                                                                                                                                                                                     
/opt/homebrew/Cellar/molten-vk/1.2.7/bin/MoltenVKShaderConverter
/opt/homebrew/Cellar/molten-vk/1.2.7/Frameworks/MoltenVK.xcframework/ (2 files)
/opt/homebrew/Cellar/molten-vk/1.2.7/Frameworks/MoltenVKShaderConverter.xcframework/ (2 files)
/opt/homebrew/Cellar/molten-vk/1.2.7/include/MoltenVK/ (6 files)
/opt/homebrew/Cellar/molten-vk/1.2.7/include/MoltenVKShaderConverter/ (4 files)
/opt/homebrew/Cellar/molten-vk/1.2.7/lib/libMoltenVK.dylib
/opt/homebrew/Cellar/molten-vk/1.2.7/lib/libMoltenVK.a
/opt/homebrew/Cellar/molten-vk/1.2.7/libexec/include/ (120 files)
/opt/homebrew/Cellar/molten-vk/1.2.7/libexec/lib/ (3 files)
/opt/homebrew/Cellar/molten-vk/1.2.7/share/vulkan/icd.d/MoltenVK_icd.json

$ ls /opt/homebrew/Frameworks/MoltenVK.xcframework/                                                                                                                                                                                                     
Info.plist  macos-arm64
```
