### PR TITLE
Wayland: Setup next cursor frame callback only if animated

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1231,8 +1231,6 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 	// Pointer handling.
 	if (capabilities & WL_SEAT_CAPABILITY_POINTER) {
 		ss->cursor_surface = wl_compositor_create_surface(ss->registry->wl_compositor);
-		ss->cursor_frame_callback = wl_surface_frame(ss->cursor_surface);
-		wl_callback_add_listener(ss->cursor_frame_callback, &cursor_frame_callback_listener, ss);
 		wl_surface_commit(ss->cursor_surface);
 
 		ss->wl_pointer = wl_seat_get_pointer(wl_seat);
@@ -1313,11 +1311,9 @@ void WaylandThread::_cursor_frame_callback_on_done(void *data, struct wl_callbac
 	SeatState *ss = (SeatState *)data;
 	ERR_FAIL_NULL(ss);
 
-	ss->cursor_time_ms = time_ms;
+	ss->cursor_frame_callback = nullptr;
 
-	ss->cursor_frame_callback = wl_surface_frame(ss->cursor_surface);
-	wl_callback_add_listener(ss->cursor_frame_callback, &cursor_frame_callback_listener, ss);
-	wl_surface_commit(ss->cursor_surface);
+	ss->cursor_time_ms = time_ms;
 
 	seat_state_update_cursor(ss);
 }
@@ -2899,7 +2895,18 @@ void WaylandThread::seat_state_update_cursor(SeatState *p_ss) {
 			// compositor do it for us (badly).
 			scale = 1;
 		} else if (wl_cursor) {
-			int frame_idx = wl_cursor_frame(wl_cursor, p_ss->cursor_time_ms);
+			int frame_idx = 0;
+
+			if (wl_cursor->image_count > 1) {
+				// The cursor is animated.
+				frame_idx = wl_cursor_frame(wl_cursor, p_ss->cursor_time_ms);
+
+				if (!p_ss->cursor_frame_callback) {
+					// Since it's animated, we'll re-update it the next frame.
+					p_ss->cursor_frame_callback = wl_surface_frame(p_ss->cursor_surface);
+					wl_callback_add_listener(p_ss->cursor_frame_callback, &cursor_frame_callback_listener, p_ss);
+				}
+			}
 
 			struct wl_cursor_image *wl_cursor_image = wl_cursor->images[frame_idx];
 


### PR DESCRIPTION
Before, the cursor kept updating for no good reason really.

It's also a bit neater and it ever-so-slightly makes `WAYLAND_DEBUG` logs easier to read, although they're still spammed by the window's frame logic (which is needed).