### PR TITLE
Fix compiler warning when highlighting codeblocks in editor help

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2618,20 +2618,25 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 			p_rt->set_cell_padding(Rect2(10 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE));
 			p_rt->push_color(code_dark_color);
 
-			if (lang.is_empty() || lang == "gdscript") {
+			bool codeblock_printed = false;
+
 #ifdef MODULE_GDSCRIPT_ENABLED
+			if (!codeblock_printed && (lang.is_empty() || lang == "gdscript")) {
 				EditorHelpHighlighter::get_singleton()->highlight(p_rt, EditorHelpHighlighter::LANGUAGE_GDSCRIPT, codeblock_text, is_native);
-#else
-				p_rt->add_text(codeblock_text);
+				codeblock_printed = true;
+			}
 #endif
-			} else if (lang == "csharp") {
+
 #ifdef MODULE_MONO_ENABLED
+			if (!codeblock_printed && lang == "csharp") {
 				EditorHelpHighlighter::get_singleton()->highlight(p_rt, EditorHelpHighlighter::LANGUAGE_CSHARP, codeblock_text, is_native);
-#else
-				p_rt->add_text(codeblock_text);
+				codeblock_printed = true;
+			}
 #endif
-			} else {
+
+			if (!codeblock_printed) {
 				p_rt->add_text(codeblock_text);
+				codeblock_printed = true;
 			}
 
 			p_rt->pop(); // color


### PR DESCRIPTION
It's more verbose but it should do the trick.

---

For context, it fixes the following error:

```
In file included from editor/scu/scu_editor.gen.cpp:24:
./editor/editor_help.cpp: In function 'void _add_text_to_rt(const String&, RichTextLabel*, Control*, const String&)':
./editor/editor_help.cpp:2627:32: error: this condition has identical branches [-Werror=duplicated-branches]
 2627 |                         } else if (lang == "csharp") {
      |                                ^~
cc1plus: all warnings being treated as errors
scons: *** [editor/scu/scu_editor.gen.linuxbsd.editor.dev.x86_64.o] Error 1
scons: building terminated because of errors.
```

(the fact that it's a SCU build doesn't matter AFAIA)

It happens because, without mono, the following:

```cpp
			if (lang.is_empty() || lang == "gdscript") {
#ifdef MODULE_GDSCRIPT_ENABLED
				EditorHelpHighlighter::get_singleton()->highlight(p_rt, EditorHelpHighlighter::LANGUAGE_GDSCRIPT, codeblock_text, is_native);
#else
				p_rt->add_text(codeblock_text);
#endif
			} else if (lang == "csharp") {
#ifdef MODULE_MONO_ENABLED
				EditorHelpHighlighter::get_singleton()->highlight(p_rt, EditorHelpHighlighter::LANGUAGE_CSHARP, codeblock_text, is_native);
#else
				p_rt->add_text(codeblock_text);
#endif
			} else {
				p_rt->add_text(codeblock_text);
			}
```

gets preprocessed into this:

```cpp
			if (lang.is_empty() || lang == "gdscript") {
				EditorHelpHighlighter::get_singleton()->highlight(p_rt, EditorHelpHighlighter::LANGUAGE_GDSCRIPT, codeblock_text, is_native);
			} else if (lang == "csharp") {
				p_rt->add_text(codeblock_text);
			} else {
				p_rt->add_text(codeblock_text);
			}
```

(this would also happen when disabling gdscript or both really)