### PR TITLE
Enforce `\n` eol for Python writes

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -36,7 +36,7 @@ if "SCRIPT_AES256_ENCRYPTION_KEY" in os.environ:
         Exit(255)
 
 # NOTE: It is safe to generate this file here, since this is still executed serially
-with open("script_encryption_key.gen.cpp", "w") as f:
+with open("script_encryption_key.gen.cpp", "w", encoding="utf-8", newline="\n") as f:
     f.write('#include "core/config/project_settings.h"\nuint8_t script_encryption_key[32]={' + txt + "};\n")
 
 

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -32,7 +32,7 @@ def make_certs_header(target, source, env):
     src = source[0]
     dst = target[0]
     f = open(src, "rb")
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
     buf = f.read()
     decomp_size = len(buf)
 
@@ -79,7 +79,7 @@ def make_authors_header(target, source, env):
     src = source[0]
     dst = target[0]
     f = open(src, "r", encoding="utf-8")
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef AUTHORS_GEN_H\n")
@@ -141,7 +141,7 @@ def make_donors_header(target, source, env):
     src = source[0]
     dst = target[0]
     f = open(src, "r", encoding="utf-8")
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef DONORS_GEN_H\n")
@@ -239,7 +239,7 @@ def make_license_header(target, source, env):
             part["copyright_index"] = len(data_list)
             data_list += part["Copyright"]
 
-    with open(dst, "w", encoding="utf-8") as f:
+    with open(dst, "w", encoding="utf-8", newline="\n") as f:
         f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         f.write("#ifndef LICENSE_GEN_H\n")
         f.write("#define LICENSE_GEN_H\n")

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -5,7 +5,7 @@ def run(target, source, env):
     src = source[0]
     dst = target[0]
     f = open(src, "rb")
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     buf = f.read()
     decomp_size = len(buf)

--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -142,7 +142,7 @@ def run(target, source, env):
 
     txt += "\n#endif\n"
 
-    with open(target[0], "w") as f:
+    with open(target[0], "w", encoding="utf-8", newline="\n") as f:
         f.write(txt)
 
 

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 
 def make_default_controller_mappings(target, source, env):
     dst = target[0]
-    g = open(dst, "w")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write('#include "core/typedefs.h"\n')

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -201,7 +201,7 @@ def run(target, source, env):
 
     txt += "#endif // GDVIRTUAL_GEN_H\n"
 
-    with open(target[0], "w") as f:
+    with open(target[0], "w", encoding="utf-8", newline="\n") as f:
         f.write(txt)
 
 

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -891,9 +891,9 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
     class_name = class_def.name
 
     if dry_run:
-        f = open(os.devnull, "w", encoding="utf-8")
+        f = open(os.devnull, "w", encoding="utf-8", newline="\n")
     else:
-        f = open(os.path.join(output_dir, f"class_{class_name.lower()}.rst"), "w", encoding="utf-8")
+        f = open(os.path.join(output_dir, f"class_{class_name.lower()}.rst"), "w", encoding="utf-8", newline="\n")
 
     # Remove the "Edit on Github" button from the online docs page.
     f.write(":github_url: hide\n\n")
@@ -1691,9 +1691,9 @@ def make_link(url: str, title: str) -> str:
 
 def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_dir: str) -> None:
     if dry_run:
-        f = open(os.devnull, "w", encoding="utf-8")
+        f = open(os.devnull, "w", encoding="utf-8", newline="\n")
     else:
-        f = open(os.path.join(output_dir, "index.rst"), "w", encoding="utf-8")
+        f = open(os.path.join(output_dir, "index.rst"), "w", encoding="utf-8", newline="\n")
 
     # Remove the "Edit on Github" button from the online docs page, and disallow user-contributed notes
     # on the index page. User-contributed notes are allowed on individual class pages.

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -11,7 +11,7 @@ import editor_builders
 
 def _make_doc_data_class_path(to_path):
     # NOTE: It is safe to generate this file here, since this is still executed serially
-    g = open(os.path.join(to_path, "doc_data_class_path.gen.h"), "w", encoding="utf-8")
+    g = open(os.path.join(to_path, "doc_data_class_path.gen.h"), "w", encoding="utf-8", newline="\n")
     g.write("static const int _doc_data_class_path_count = " + str(len(env.doc_class_path)) + ";\n")
     g.write("struct _DocDataClassPath { const char* name; const char* path; };\n")
 
@@ -41,7 +41,7 @@ if env.editor_build:
     reg_exporters += "}\n"
 
     # NOTE: It is safe to generate this file here, since this is still executed serially
-    with open("register_exporters.gen.cpp", "w", encoding="utf-8") as f:
+    with open("register_exporters.gen.cpp", "w", encoding="utf-8", newline="\n") as f:
         f.write(reg_exporters_inc)
         f.write(reg_exporters)
 

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -16,7 +16,7 @@ from platform_methods import subprocess_main
 
 def make_doc_header(target, source, env):
     dst = target[0]
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
     buf = ""
     docbegin = ""
     docend = ""
@@ -53,7 +53,7 @@ def make_doc_header(target, source, env):
 def make_translations_header(target, source, env, category):
     dst = target[0]
 
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _{}_TRANSLATIONS_H\n".format(category.upper()))

--- a/editor/icons/editor_icons_builders.py
+++ b/editor/icons/editor_icons_builders.py
@@ -85,7 +85,7 @@ def make_editor_icons_action(target, source, env):
 
     s.write("#endif\n")
 
-    with open(dst, "w") as f:
+    with open(dst, "w", encoding="utf-8", newline="\n") as f:
         f.write(s.getvalue())
 
     s.close()

--- a/editor/template_builders.py
+++ b/editor/template_builders.py
@@ -85,7 +85,7 @@ def make_templates(target, source, env):
 
     s.write("\n#endif\n")
 
-    with open(dst, "w") as f:
+    with open(dst, "w", encoding="utf-8", newline="\n") as f:
         f.write(s.getvalue())
 
     s.close()

--- a/editor/themes/editor_theme_builders.py
+++ b/editor/themes/editor_theme_builders.py
@@ -12,7 +12,7 @@ from platform_methods import subprocess_main
 def make_fonts_header(target, source, env):
     dst = target[0]
 
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_FONTS_H\n")

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -211,7 +211,7 @@ def build_gles3_header(
     else:
         out_file = optional_output_filename
 
-    fd = open(out_file, "w")
+    fd = open(out_file, "w", encoding="utf-8", newline="\n")
     defspec = 0
     defvariant = ""
 

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -165,7 +165,7 @@ public:
 #endif
 """
 
-    with open(out_file, "w") as fd:
+    with open(out_file, "w", encoding="utf-8", newline="\n") as fd:
         fd.write(shader_template)
 
 
@@ -224,7 +224,7 @@ static const char {out_file_base}[] = {{
 #endif
 """
 
-    with open(out_file, "w") as f:
+    with open(out_file, "w", encoding="utf-8", newline="\n") as f:
         f.write(shader_template)
 
 

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -14,7 +14,7 @@ def make_splash(target, source, env):
     with open(src, "rb") as f:
         buf = f.read()
 
-    with open(dst, "w") as g:
+    with open(dst, "w", encoding="utf-8", newline="\n") as g:
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef BOOT_SPLASH_H\n")
         g.write("#define BOOT_SPLASH_H\n")
@@ -34,7 +34,7 @@ def make_splash_editor(target, source, env):
     with open(src, "rb") as f:
         buf = f.read()
 
-    with open(dst, "w") as g:
+    with open(dst, "w", encoding="utf-8", newline="\n") as g:
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef BOOT_SPLASH_EDITOR_H\n")
         g.write("#define BOOT_SPLASH_EDITOR_H\n")
@@ -55,7 +55,7 @@ def make_app_icon(target, source, env):
     with open(src, "rb") as f:
         buf = f.read()
 
-    with open(dst, "w") as g:
+    with open(dst, "w", encoding="utf-8", newline="\n") as g:
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef APP_ICON_H\n")
         g.write("#define APP_ICON_H\n")

--- a/methods.py
+++ b/methods.py
@@ -230,7 +230,7 @@ def generate_version_header(module_version_string=""):
 
     # NOTE: It is safe to generate these files here, since this is still executed serially.
 
-    f = open("core/version_generated.gen.h", "w")
+    f = open("core/version_generated.gen.h", "w", encoding="utf-8", newline="\n")
     f.write(
         """/* THIS FILE IS GENERATED DO NOT EDIT */
 #ifndef VERSION_GENERATED_GEN_H
@@ -253,7 +253,7 @@ def generate_version_header(module_version_string=""):
     )
     f.close()
 
-    fhash = open("core/version_hash.gen.cpp", "w")
+    fhash = open("core/version_hash.gen.cpp", "w", encoding="utf-8", newline="\n")
     fhash.write(
         """/* THIS FILE IS GENERATED DO NOT EDIT */
 #include "core/version.h"
@@ -384,7 +384,7 @@ def is_module(path):
 
 
 def write_disabled_classes(class_list):
-    f = open("core/disabled_classes.gen.h", "w")
+    f = open("core/disabled_classes.gen.h", "w", encoding="utf-8", newline="\n")
     f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     f.write("#ifndef DISABLED_CLASSES_GEN_H\n")
     f.write("#define DISABLED_CLASSES_GEN_H\n\n")
@@ -435,7 +435,7 @@ void uninitialize_modules(ModuleInitializationLevel p_level) {
     )
 
     # NOTE: It is safe to generate this file here, since this is still executed serially
-    with open("modules/register_module_types.gen.cpp", "w") as f:
+    with open("modules/register_module_types.gen.cpp", "w", encoding="utf-8", newline="\n") as f:
         f.write(modules_cpp)
 
 
@@ -757,7 +757,7 @@ def generate_cpp_hint_file(filename):
         pass
     else:
         try:
-            with open(filename, "w") as fd:
+            with open(filename, "w", encoding="utf-8", newline="\n") as fd:
                 fd.write("#define GDCLASS(m_class, m_inherits)\n")
         except OSError:
             print("Could not write cpp.hint file.")
@@ -1062,7 +1062,7 @@ def show_progress(env):
     def progress_finish(target, source, env):
         nonlocal node_count, progressor
         try:
-            with open(node_count_fname, "w") as f:
+            with open(node_count_fname, "w", encoding="utf-8", newline="\n") as f:
                 f.write("%d\n" % node_count)
             progressor.delete(progressor.file_list())
         except Exception:
@@ -1092,7 +1092,7 @@ def dump(env):
     def non_serializable(obj):
         return "<<non-serializable: %s>>" % (type(obj).__qualname__)
 
-    with open(".scons_env.json", "w") as f:
+    with open(".scons_env.json", "w", encoding="utf-8", newline="\n") as f:
         dump(env.Dictionary(), f, indent=4, default=non_serializable)
 
 
@@ -1294,7 +1294,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
 
         filters_template = filters_template.replace("%%HASH%%", md5)
 
-        with open(f"{project_name}.vcxproj.filters", "w") as f:
+        with open(f"{project_name}.vcxproj.filters", "w", encoding="utf-8", newline="\n") as f:
             f.write(filters_template)
 
     envsources = []
@@ -1469,7 +1469,9 @@ def generate_vs_project(env, original_args, project_name="godot"):
         cmd = " ^&amp; ".join(common_build_prefix + [" ".join([commands] + cmd_clean)])
         props_template = props_template.replace("%%CLEAN%%", cmd)
 
-        with open(f"{project_name}.{platform}.{target}.{arch}.generated.props", "w") as f:
+        with open(
+            f"{project_name}.{platform}.{target}.{arch}.generated.props", "w", encoding="utf-8", newline="\n"
+        ) as f:
             f.write(props_template)
 
     proj_uuid = str(uuid.uuid4())
@@ -1572,7 +1574,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
         proj_template = proj_template.replace("%%DEFAULT_ITEMS%%", "\n    ".join(all_items))
         proj_template = proj_template.replace("%%PROPERTIES%%", "\n  ".join(properties))
 
-        with open(f"{project_name}.vcxproj", "w") as f:
+        with open(f"{project_name}.vcxproj", "w", encoding="utf-8", newline="\n") as f:
             f.write(proj_template)
 
     if not get_bool(original_args, "vsproj_props_only", False):
@@ -1583,7 +1585,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
         sln_template = sln_template.replace("%%SECTION1%%", "\n    ".join(section1))
         sln_template = sln_template.replace("%%SECTION2%%", "\n    ".join(section2))
 
-        with open(f"{project_name}.sln", "w") as f:
+        with open(f"{project_name}.sln", "w", encoding="utf-8", newline="\n") as f:
             f.write(sln_template)
 
     if get_bool(original_args, "vsproj_gen_only", True):

--- a/misc/scripts/copyright_headers.py
+++ b/misc/scripts/copyright_headers.py
@@ -90,6 +90,6 @@ while line != "":  # Dump everything until EOF
 fileread.close()
 
 # Write
-filewrite = open(fname.strip(), "w")
+filewrite = open(fname.strip(), "w", encoding="utf-8", newline="\n")
 filewrite.write(text)
 filewrite.close()

--- a/misc/scripts/dotnet_format.py
+++ b/misc/scripts/dotnet_format.py
@@ -10,7 +10,7 @@ for path in [
     "modules/mono/SdkPackageVersions.props",
 ]:
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
         f.write("<Project />")
 
 # Avoid importing GeneratedIncludes.props.

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -7,7 +7,7 @@ from platform_methods import subprocess_main
 
 
 def generate_modules_enabled(target, source, env):
-    with open(target[0].path, "w") as f:
+    with open(target[0].path, "w", encoding="utf-8", newline="\n") as f:
         for module in env.module_list:
             f.write("#define %s\n" % ("MODULE_" + module.upper() + "_ENABLED"))
 
@@ -15,7 +15,7 @@ def generate_modules_enabled(target, source, env):
 def generate_modules_tests(target, source, env):
     import os
 
-    with open(target[0].path, "w") as f:
+    with open(target[0].path, "w", encoding="utf-8", newline="\n") as f:
         for header in source:
             f.write('#include "%s"\n' % (os.path.normpath(header.path)))
 

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -312,7 +312,7 @@ def generate_sdk_package_versions():
     )
 
     # We write in ../SdkPackageVersions.props.
-    with open(os.path.join(dirname(script_path), "SdkPackageVersions.props"), "w", encoding="utf-8") as f:
+    with open(os.path.join(dirname(script_path), "SdkPackageVersions.props"), "w", encoding="utf-8", newline="\n") as f:
         f.write(props)
         f.close()
 
@@ -340,7 +340,7 @@ def generate_sdk_package_versions():
     )
     os.makedirs(generators_dir, exist_ok=True)
 
-    with open(os.path.join(generators_dir, "Common.Constants.cs"), "w", newline="\n", encoding="utf-8") as f:
+    with open(os.path.join(generators_dir, "Common.Constants.cs"), "w", encoding="utf-8", newline="\n") as f:
         f.write(constants)
         f.close()
 

--- a/modules/raycast/godot_update_embree.py
+++ b/modules/raycast/godot_update_embree.py
@@ -96,7 +96,7 @@ for f in all_files:
         os.makedirs(d)
     shutil.copy2(f, d)
 
-with open(os.path.join(dest_dir, "kernels/hash.h"), "w") as hash_file:
+with open(os.path.join(dest_dir, "kernels/hash.h"), "w", encoding="utf-8", newline="\n") as hash_file:
     hash_file.write(
         f"""// Copyright 2009-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
@@ -105,7 +105,7 @@ with open(os.path.join(dest_dir, "kernels/hash.h"), "w") as hash_file:
 """
     )
 
-with open(os.path.join(dest_dir, "kernels/config.h"), "w") as config_file:
+with open(os.path.join(dest_dir, "kernels/config.h"), "w", encoding="utf-8", newline="\n") as config_file:
     config_file.write(
         """// Copyright 2009-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
@@ -193,7 +193,9 @@ with open("CMakeLists.txt", "r") as cmake_file:
     minor_version = int(re.compile(r"EMBREE_VERSION_MINOR\s(\d+)").findall(cmake_content)[0])
     patch_version = int(re.compile(r"EMBREE_VERSION_PATCH\s(\d+)").findall(cmake_content)[0])
 
-with open(os.path.join(dest_dir, "include/embree3/rtcore_config.h"), "w") as config_file:
+with open(
+    os.path.join(dest_dir, "include/embree3/rtcore_config.h"), "w", encoding="utf-8", newline="\n"
+) as config_file:
     config_file.write(
         f"""// Copyright 2009-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -9,7 +9,7 @@ env_text_server_adv = env_modules.Clone()
 def make_icu_data(target, source, env):
     dst = target[0].srcnode().abspath
 
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("/* (C) 2016 and later: Unicode, Inc. and others. */\n")

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -83,7 +83,7 @@ def disable_warnings(self):
 
 def make_icu_data(target, source, env):
     dst = target[0].srcnode().abspath
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("/* (C) 2016 and later: Unicode, Inc. and others. */\n")
@@ -108,7 +108,7 @@ def make_icu_data(target, source, env):
 
 def write_macos_plist(target, binary_name, identifier, name):
     os.makedirs(f"{target}/Resource/", exist_ok=True)
-    f = open(f"{target}/Resource/Info.plist", "w")
+    f = open(f"{target}/Resource/Info.plist", "w", encoding="utf-8", newline="\n")
 
     f.write(f'<?xml version="1.0" encoding="UTF-8"?>\n')
     f.write(f'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n')

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -83,7 +83,7 @@ def disable_warnings(self):
 
 def make_icu_data(target, source, env):
     dst = target[0].srcnode().abspath
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("/* (C) 2016 and later: Unicode, Inc. and others. */\n")
@@ -108,7 +108,7 @@ def make_icu_data(target, source, env):
 
 def write_macos_plist(target, binary_name, identifier, name):
     os.makedirs(f"{target}/Resource/", exist_ok=True)
-    f = open(f"{target}/Resource/Info.plist", "w")
+    f = open(f"{target}/Resource/Info.plist", "w", encoding="utf-8", newline="\n")
 
     f.write(f'<?xml version="1.0" encoding="UTF-8"?>\n')
     f.write(f'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n')

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -19,7 +19,7 @@ reg_apis += "}\n\n"
 unreg_apis += "}\n"
 
 # NOTE: It is safe to generate this file here, since this is still execute serially
-with open("register_platform_apis.gen.cpp", "w", encoding="utf-8") as f:
+with open("register_platform_apis.gen.cpp", "w", encoding="utf-8", newline="\n") as f:
     f.write(reg_apis_inc)
     f.write(reg_apis)
     f.write(unreg_apis)

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -36,7 +36,7 @@ def generate_bundle(target, source, env):
         version = get_build_version(False)
         short_version = get_build_version(True)
         with open(Dir("#misc/dist/macos").abspath + "/editor_info_plist.template", "rt") as fin:
-            with open(app_dir + "/Contents/Info.plist", "wt") as fout:
+            with open(app_dir + "/Contents/Info.plist", "wt", encoding="utf-8", newline="\n") as fout:
                 for line in fin:
                     line = line.replace("$version", version)
                     line = line.replace("$short_version", short_version)

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -40,7 +40,7 @@ def run_in_subprocess(builder_function):
         args = (target, source, filtered_env)
         data = dict(fn=function_name, args=args)
         json_path = os.path.join(os.environ["TMP"], uuid.uuid4().hex + ".json")
-        with open(json_path, "wt") as json_file:
+        with open(json_path, "wt", encoding="utf-8", newline="\n") as json_file:
             json.dump(data, json_file, indent=2)
         json_file_size = os.stat(json_path).st_size
 
@@ -138,7 +138,7 @@ def generate_export_icons(platform_path, platform_name):
 
         # NOTE: It is safe to generate this file here, since this is still executed serially.
         wf = export_path + "/" + name + "_svg.gen.h"
-        with open(wf, "w") as svgw:
+        with open(wf, "w", encoding="utf-8", newline="\n") as svgw:
             svgw.write(svg_str)
 
 

--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -13,7 +13,7 @@ from platform_methods import subprocess_main
 def make_fonts_header(target, source, env):
     dst = target[0]
 
-    g = open(dst, "w", encoding="utf-8")
+    g = open(dst, "w", encoding="utf-8", newline="\n")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _DEFAULT_FONTS_H\n")

--- a/scene/theme/icons/default_theme_icons_builders.py
+++ b/scene/theme/icons/default_theme_icons_builders.py
@@ -65,7 +65,7 @@ def make_default_theme_icons_action(target, source, env):
 
     s.write("#endif\n")
 
-    with open(dst, "w") as f:
+    with open(dst, "w", encoding="utf-8", newline="\n") as f:
         f.write(s.getvalue())
 
     s.close()

--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -38,7 +38,7 @@ def main():
     if os.path.isfile(file_path):
         print(f'ERROR: The file "{file_path}" already exists.')
         sys.exit(1)
-    with open(file_path, "w") as file:
+    with open(file_path, "w", encoding="utf-8", newline="\n") as file:
         file.write(
             """/**************************************************************************/
 /*  test_{name_snake_case}.h {padding} */
@@ -108,7 +108,7 @@ TEST_CASE("[{name_pascal_case}] Example test case") {{
         if match:
             new_string = contents[: match.start()] + f'#include "tests/{file_path}"\n' + contents[match.start() :]
 
-            with open("test_main.cpp", "w") as file:
+            with open("test_main.cpp", "w", encoding="utf-8", newline="\n") as file:
                 file.write(new_string)
                 print("Done.")
             # Use clang format to sort include directives afster insertion.


### PR DESCRIPTION
Primarily created with the intent of fixing a pre-commit hook bug causing eol to change to `CRLF` on Windows machines, which was fixed by enforcing `\n` eol on-write in `copyright_headers.py`. However, realizing that this eol specification isn't really used elsewhere in the repo, in constrast to `.gitattributes` expecting it at all times, this branched out to applying that specification to **all** relevant file writes across every Python script. Additionally, while largly superfluous, this also enforces `utf-8` encoding for file writes if previously unspecified.