### PR TITLE
[iOS] Restore backward compatibility with old export templates.

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -416,6 +416,10 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$pbx_launch_screen_build_reference") != -1) {
 			String value = "90DD2D9E24B36E8000717FE1 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 90DD2D9D24B36E8000717FE1 /* Launch Screen.storyboard */; };";
 			strnew += lines[i].replace("$pbx_launch_screen_build_reference", value) + "\n";
+#ifndef DISABLE_DEPRECATED
+		} else if (lines[i].find("$pbx_launch_image_usage_setting") != -1) {
+			strnew += lines[i].replace("$pbx_launch_image_usage_setting", "") + "\n";
+#endif
 		} else if (lines[i].find("$launch_screen_image_mode") != -1) {
 			int image_scale_mode = p_preset->get("storyboard/image_scale_mode");
 			String value;


### PR DESCRIPTION
A little followup, for https://github.com/godotengine/godot/pull/86312, allows using custom export templates with old `pbxproj` (created before launch images removal).

Should prevent "corrupted project" errors, if you have updated libraries but not the project file in the custom export template.

