### PR TITLE
Add null check in _validate_child_name function

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1301,6 +1301,7 @@ String Node::adjust_name_casing(const String &p_name) {
 }
 
 void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
+	ERR_FAIL_NULL(p_child);
 	/* Make sure the name is unique */
 
 	if (p_force_human_readable) {


### PR DESCRIPTION
Added a null check for the child node parameter in the _validate_child_name function to prevent potential issues.

I reproduced this by clicking on the reimport on this model https://sketchfab.com/3d-models/shibahu-2e9dffd948f747668609a5a477daad86

On https://github.com/godotengine/godot/commit/0ace0a129284ffc6646b199699c1607a316fcec0