### PR TITLE
SCons: Convert remaining `run_in_subprocess` to `env.Run`

### DIFF
--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -4,13 +4,12 @@ Import("env")
 
 import make_wrappers
 import make_interface_dumper
-from platform_methods import run_in_subprocess
 
-env.CommandNoCache(["ext_wrappers.gen.inc"], "make_wrappers.py", run_in_subprocess(make_wrappers.run))
+env.CommandNoCache(["ext_wrappers.gen.inc"], "make_wrappers.py", env.Run(make_wrappers.run))
 env.CommandNoCache(
     "gdextension_interface_dump.gen.h",
     ["gdextension_interface.h", "make_interface_dumper.py"],
-    run_in_subprocess(make_interface_dumper.run),
+    env.Run(make_interface_dumper.run),
 )
 
 env_extension = env.Clone()

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -3,9 +3,8 @@
 Import("env")
 
 import make_virtuals
-from platform_methods import run_in_subprocess
 
-env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", run_in_subprocess(make_virtuals.run))
+env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", env.Run(make_virtuals.run))
 
 env_object = env.Clone()
 

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -3,7 +3,7 @@
 Import("env")
 
 import os, json
-from platform_methods import run_in_subprocess, architectures, lipo, get_build_version, detect_mvk
+from platform_methods import architectures, lipo, get_build_version, detect_mvk
 import subprocess
 import shutil
 

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -2,7 +2,6 @@
 
 Import("env")
 
-from platform_methods import run_in_subprocess
 import platform_linuxbsd_builders
 
 common_linuxbsd = [
@@ -42,4 +41,4 @@ if env["dbus"]:
 prog = env.add_program("#bin/godot", ["godot_linuxbsd.cpp"] + common_linuxbsd)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
-    env.AddPostAction(prog, run_in_subprocess(platform_linuxbsd_builders.make_debug_linuxbsd))
+    env.AddPostAction(prog, env.Run(platform_linuxbsd_builders.make_debug_linuxbsd))

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -3,7 +3,7 @@
 Import("env")
 
 import os, json
-from platform_methods import run_in_subprocess, architectures, lipo, get_build_version
+from platform_methods import architectures, lipo, get_build_version
 import platform_macos_builders
 import subprocess
 import shutil
@@ -125,7 +125,7 @@ files = [
 prog = env.add_program("#bin/godot", files)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
-    env.AddPostAction(prog, run_in_subprocess(platform_macos_builders.make_debug_macos))
+    env.AddPostAction(prog, env.Run(platform_macos_builders.make_debug_macos))
 
 if env["generate_bundle"]:
     generate_bundle_command = env.Command("generate_bundle", [], generate_bundle)

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -4,7 +4,6 @@ Import("env")
 
 import os
 from pathlib import Path
-from platform_methods import run_in_subprocess
 import platform_windows_builders
 
 sources = []
@@ -135,8 +134,8 @@ if env["d3d12"]:
 
 if not os.getenv("VCINSTALLDIR"):
     if env["debug_symbols"]:
-        env.AddPostAction(prog, run_in_subprocess(platform_windows_builders.make_debug_mingw))
+        env.AddPostAction(prog, env.Run(platform_windows_builders.make_debug_mingw))
         if env["windows_subsystem"] == "gui":
-            env.AddPostAction(prog_wrap, run_in_subprocess(platform_windows_builders.make_debug_mingw))
+            env.AddPostAction(prog_wrap, env.Run(platform_windows_builders.make_debug_mingw))
 
 env.platform_sources += sources

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -2,7 +2,6 @@
 
 Import("env")
 
-from platform_methods import run_in_subprocess
 import default_theme_builders
 
 
@@ -14,5 +13,5 @@ env.Depends("#scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiB
 env.CommandNoCache(
     "#scene/theme/default_font.gen.h",
     "#thirdparty/fonts/OpenSans_SemiBold.woff2",
-    run_in_subprocess(default_theme_builders.make_fonts_header),
+    env.Run(default_theme_builders.make_fonts_header),
 )


### PR DESCRIPTION
A handful stragglers making direct calls to `run_in_subprocess` were still in the repo. Replaced them with calls to `env.Run`, like everything else. I *believe* this means that every single log output is now accounted for, so `verbose=no` will be a sea of uninterrupted blue.