### PR TITLE
Consistently use `USE_MULTIVIEW` as the define in shaders

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -107,8 +107,8 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		copy_modes.push_back("\n#define MODE_PANORAMA_TO_DP\n"); // COPY_TO_FB_COPY_PANORAMA_TO_DP
 		copy_modes.push_back("\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_COPY2
 		copy_modes.push_back("\n#define MODE_SET_COLOR\n"); // COPY_TO_FB_SET_COLOR
-		copy_modes.push_back("\n#define MULTIVIEW\n"); // COPY_TO_FB_MULTIVIEW
-		copy_modes.push_back("\n#define MULTIVIEW\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_MULTIVIEW_WITH_DEPTH
+		copy_modes.push_back("\n#define USE_MULTIVIEW\n"); // COPY_TO_FB_MULTIVIEW
+		copy_modes.push_back("\n#define USE_MULTIVIEW\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_MULTIVIEW_WITH_DEPTH
 
 		copy_to_fb.shader.initialize(copy_modes);
 

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -47,12 +47,12 @@ ToneMapper::ToneMapper() {
 		tonemap_modes.push_back("\n#define SUBPASS\n#define USE_1D_LUT\n");
 
 		// multiview versions of our shaders
-		tonemap_modes.push_back("\n#define MULTIVIEW\n");
-		tonemap_modes.push_back("\n#define MULTIVIEW\n#define USE_GLOW_FILTER_BICUBIC\n");
-		tonemap_modes.push_back("\n#define MULTIVIEW\n#define USE_1D_LUT\n");
-		tonemap_modes.push_back("\n#define MULTIVIEW\n#define USE_GLOW_FILTER_BICUBIC\n#define USE_1D_LUT\n");
-		tonemap_modes.push_back("\n#define MULTIVIEW\n#define SUBPASS\n");
-		tonemap_modes.push_back("\n#define MULTIVIEW\n#define SUBPASS\n#define USE_1D_LUT\n");
+		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n");
+		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define USE_GLOW_FILTER_BICUBIC\n");
+		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define USE_1D_LUT\n");
+		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define USE_GLOW_FILTER_BICUBIC\n#define USE_1D_LUT\n");
+		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define SUBPASS\n");
+		tonemap_modes.push_back("\n#define USE_MULTIVIEW\n#define SUBPASS\n#define USE_1D_LUT\n");
 
 		tonemap.shader.initialize(tonemap_modes);
 
@@ -130,7 +130,7 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	tonemap.push_constant.flags |= p_settings.convert_to_srgb ? TONEMAP_FLAG_CONVERT_TO_SRGB : 0;
 
 	if (p_settings.view_count > 1) {
-		// Use MULTIVIEW versions
+		// Use USE_MULTIVIEW versions
 		mode += 6;
 	}
 
@@ -196,7 +196,7 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 
 	int mode = p_settings.use_1d_color_correction ? TONEMAP_MODE_SUBPASS_1D_LUT : TONEMAP_MODE_SUBPASS;
 	if (p_settings.view_count > 1) {
-		// Use MULTIVIEW versions
+		// Use USE_MULTIVIEW versions
 		mode += 6;
 	}
 

--- a/servers/rendering/renderer_rd/effects/vrs.cpp
+++ b/servers/rendering/renderer_rd/effects/vrs.cpp
@@ -40,7 +40,7 @@ VRS::VRS() {
 	{
 		Vector<String> vrs_modes;
 		vrs_modes.push_back("\n"); // VRS_DEFAULT
-		vrs_modes.push_back("\n#define MULTIVIEW\n"); // VRS_MULTIVIEW
+		vrs_modes.push_back("\n#define USE_MULTIVIEW\n"); // VRS_MULTIVIEW
 
 		vrs_shader.shader.initialize(vrs_modes);
 

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -4,14 +4,14 @@
 
 #VERSION_DEFINES
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 #ifdef has_VK_KHR_multiview
 #extension GL_EXT_multiview : enable
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
 #define ViewIndex 0
 #endif // has_VK_KHR_multiview
-#endif //MULTIVIEW
+#endif //USE_MULTIVIEW
 
 #define FLAG_FLIP_Y (1 << 0)
 #define FLAG_USE_SECTION (1 << 1)
@@ -22,7 +22,7 @@
 #define FLAG_LINEAR (1 << 6)
 #define FLAG_NORMAL (1 << 7)
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 layout(location = 0) out vec3 uv_interp;
 #else
 layout(location = 0) out vec2 uv_interp;
@@ -41,7 +41,7 @@ params;
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
 	uv_interp.xy = base_arr[gl_VertexIndex];
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 	uv_interp.z = ViewIndex;
 #endif
 	vec2 vpos = uv_interp.xy;
@@ -62,14 +62,14 @@ void main() {
 
 #VERSION_DEFINES
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 #ifdef has_VK_KHR_multiview
 #extension GL_EXT_multiview : enable
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
 #define ViewIndex 0
 #endif // has_VK_KHR_multiview
-#endif //MULTIVIEW
+#endif //USE_MULTIVIEW
 
 #define FLAG_FLIP_Y (1 << 0)
 #define FLAG_USE_SECTION (1 << 1)
@@ -91,24 +91,24 @@ layout(push_constant, std430) uniform Params {
 params;
 
 #ifndef MODE_SET_COLOR
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 layout(location = 0) in vec3 uv_interp;
 #else
 layout(location = 0) in vec2 uv_interp;
 #endif
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 layout(set = 0, binding = 0) uniform sampler2DArray source_color;
 #ifdef MODE_TWO_SOURCES
 layout(set = 1, binding = 0) uniform sampler2DArray source_depth;
 layout(location = 1) out float depth;
 #endif /* MODE_TWO_SOURCES */
-#else /* MULTIVIEW */
+#else /* USE_MULTIVIEW */
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 #ifdef MODE_TWO_SOURCES
 layout(set = 1, binding = 0) uniform sampler2D source_color2;
 #endif /* MODE_TWO_SOURCES */
-#endif /* MULTIVIEW */
+#endif /* USE_MULTIVIEW */
 #endif /* !SET_COLOR */
 
 layout(location = 0) out vec4 frag_color;
@@ -129,7 +129,7 @@ void main() {
 	frag_color = params.color;
 #else
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 	vec3 uv = uv_interp;
 #else
 	vec2 uv = uv_interp;
@@ -165,19 +165,19 @@ void main() {
 	}
 #endif /* MODE_PANORAMA_TO_DP */
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 	vec4 color = textureLod(source_color, uv, 0.0);
 #ifdef MODE_TWO_SOURCES
 	// In multiview our 2nd input will be our depth map
 	depth = textureLod(source_depth, uv, 0.0).r;
 #endif /* MODE_TWO_SOURCES */
 
-#else /* MULTIVIEW */
+#else /* USE_MULTIVIEW */
 	vec4 color = textureLod(source_color, uv, 0.0);
 #ifdef MODE_TWO_SOURCES
 	color += textureLod(source_color2, uv, 0.0);
 #endif /* MODE_TWO_SOURCES */
-#endif /* MULTIVIEW */
+#endif /* USE_MULTIVIEW */
 
 	if (bool(params.flags & FLAG_FORCE_LUMINANCE)) {
 		color.rgb = vec3(max(max(color.r, color.g), color.b));

--- a/servers/rendering/renderer_rd/shaders/effects/vrs.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/vrs.glsl
@@ -4,16 +4,16 @@
 
 #VERSION_DEFINES
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 #ifdef has_VK_KHR_multiview
 #extension GL_EXT_multiview : enable
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
 #define ViewIndex 0
 #endif // has_VK_KHR_multiview
-#endif //MULTIVIEW
+#endif //USE_MULTIVIEW
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 layout(location = 0) out vec3 uv_interp;
 #else
 layout(location = 0) out vec2 uv_interp;
@@ -23,7 +23,7 @@ void main() {
 	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
 	gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
 	uv_interp.xy = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 	uv_interp.z = ViewIndex;
 #endif
 }
@@ -34,36 +34,36 @@ void main() {
 
 #VERSION_DEFINES
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 #ifdef has_VK_KHR_multiview
 #extension GL_EXT_multiview : enable
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
 #define ViewIndex 0
 #endif // has_VK_KHR_multiview
-#endif //MULTIVIEW
+#endif //USE_MULTIVIEW
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 layout(location = 0) in vec3 uv_interp;
 layout(set = 0, binding = 0) uniform sampler2DArray source_color;
-#else /* MULTIVIEW */
+#else /* USE_MULTIVIEW */
 layout(location = 0) in vec2 uv_interp;
 layout(set = 0, binding = 0) uniform sampler2D source_color;
-#endif /* MULTIVIEW */
+#endif /* USE_MULTIVIEW */
 
 layout(location = 0) out uint frag_color;
 
 void main() {
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 	vec3 uv = uv_interp;
 #else
 	vec2 uv = uv_interp;
 #endif
 
-#ifdef MULTIVIEW
+#ifdef USE_MULTIVIEW
 	vec4 color = textureLod(source_color, uv, 0.0);
 	frag_color = uint(color.r * 255.0);
-#else /* MULTIVIEW */
+#else /* USE_MULTIVIEW */
 	vec4 color = textureLod(source_color, uv, 0.0);
 
 	// for user supplied VRS map we do a color mapping
@@ -75,5 +75,5 @@ void main() {
 
 	// note 1x4, 4x1, 1x8, 8x1, 2x8 and 8x2 are not supported
 	// 4x8, 8x4 and 8x8 are only available on some GPUs
-#endif /* MULTIVIEW */
+#endif /* USE_MULTIVIEW */
 }


### PR DESCRIPTION
Just some clean up, we had a number of shaders where our define was set to `MULTIVIEW` and others where we were using `USE_MULTIVIEW`. This PR makes the usage consistent to `USE_MULTIVIEW`.