### PR TITLE
Documentation: Fix RST generation for `[codeblock lang=text]`

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1975,7 +1975,7 @@ def format_text_block(
                     )
 
                     if "lang=text" in tag_state.arguments.split(" "):
-                        tag_text = "\n.. code::\n"
+                        tag_text = "\n.. code:: text\n"
                     else:
                         tag_text = "\n::\n"
 


### PR DESCRIPTION
![](https://github.com/godotengine/godot/assets/47700418/be94ed3c-76dd-43ea-a1dd-4817d5a19bc1)

**Before**
![](https://github.com/godotengine/godot/assets/47700418/f0998284-791a-4ce6-8a48-bca00b7c9e15)

**After**
![](https://github.com/godotengine/godot/assets/47700418/2059a418-b8fd-43b0-9ed2-ae7f122e643a)