### PR TITLE
Disable all 3D nodes, physics, and resources when compiling without 3D

### DIFF
--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -37,8 +37,11 @@
 #include "servers/audio_server.h"
 #include "servers/navigation_server_3d.h"
 #include "servers/physics_server_2d.h"
-#include "servers/physics_server_3d.h"
 #include "servers/rendering_server.h"
+
+#ifndef _3D_DISABLED
+#include "servers/physics_server_3d.h"
+#endif // _3D_DISABLED
 
 Performance *Performance::singleton = nullptr;
 
@@ -71,9 +74,11 @@ void Performance::_bind_methods() {
 	BIND_ENUM_CONSTANT(PHYSICS_2D_ACTIVE_OBJECTS);
 	BIND_ENUM_CONSTANT(PHYSICS_2D_COLLISION_PAIRS);
 	BIND_ENUM_CONSTANT(PHYSICS_2D_ISLAND_COUNT);
+#ifndef _3D_DISABLED
 	BIND_ENUM_CONSTANT(PHYSICS_3D_ACTIVE_OBJECTS);
 	BIND_ENUM_CONSTANT(PHYSICS_3D_COLLISION_PAIRS);
 	BIND_ENUM_CONSTANT(PHYSICS_3D_ISLAND_COUNT);
+#endif // _3D_DISABLED
 	BIND_ENUM_CONSTANT(AUDIO_OUTPUT_LATENCY);
 	BIND_ENUM_CONSTANT(NAVIGATION_ACTIVE_MAPS);
 	BIND_ENUM_CONSTANT(NAVIGATION_REGION_COUNT);
@@ -119,9 +124,11 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 		"physics_2d/active_objects",
 		"physics_2d/collision_pairs",
 		"physics_2d/islands",
+#ifndef _3D_DISABLED
 		"physics_3d/active_objects",
 		"physics_3d/collision_pairs",
 		"physics_3d/islands",
+#endif // _3D_DISABLED
 		"audio/driver/output_latency",
 		"navigation/active_maps",
 		"navigation/regions",
@@ -248,9 +255,11 @@ Performance::MonitorType Performance::get_monitor_type(Monitor p_monitor) const 
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
+#ifndef _3D_DISABLED
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
+#endif // _3D_DISABLED
 		MONITOR_TYPE_TIME,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,

--- a/modules/navigation/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation/3d/godot_navigation_server_3d.cpp
@@ -30,11 +30,12 @@
 
 #include "godot_navigation_server_3d.h"
 
+#include "core/os/mutex.h"
+#include "scene/main/node.h"
+
 #ifndef _3D_DISABLED
 #include "nav_mesh_generator_3d.h"
 #endif // _3D_DISABLED
-
-#include "core/os/mutex.h"
 
 using namespace NavigationUtilities;
 

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -33,13 +33,16 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/node_3d.h"
-#include "scene/3d/skeleton_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/resources/animation.h"
 #include "scene/scene_string_names.h"
 #include "servers/audio/audio_stream.h"
+
+#ifndef _3D_DISABLED
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/node_3d.h"
+#include "scene/3d/skeleton_3d.h"
+#endif // _3D_DISABLED
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -30,7 +30,7 @@
 
 #include "shader_globals_override.h"
 
-#include "scene/3d/node_3d.h"
+#include "scene/main/node.h"
 #include "scene/scene_string_names.h"
 
 StringName *ShaderGlobalsOverride::_remap(const StringName &p_name) const {
@@ -247,12 +247,12 @@ void ShaderGlobalsOverride::_activate() {
 
 void ShaderGlobalsOverride::_notification(int p_what) {
 	switch (p_what) {
-		case Node3D::NOTIFICATION_ENTER_TREE: {
+		case Node::NOTIFICATION_ENTER_TREE: {
 			add_to_group(SceneStringNames::get_singleton()->shader_overrides_group);
 			_activate();
 		} break;
 
-		case Node3D::NOTIFICATION_EXIT_TREE: {
+		case Node::NOTIFICATION_EXIT_TREE: {
 			if (active) {
 				//remove overrides
 				for (const KeyValue<StringName, Override> &E : overrides) {

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -39,15 +39,11 @@
 #include "servers/navigation_server_3d.h"
 
 void World3D::_register_camera(Camera3D *p_camera) {
-#ifndef _3D_DISABLED
 	cameras.insert(p_camera);
-#endif
 }
 
 void World3D::_remove_camera(Camera3D *p_camera) {
-#ifndef _3D_DISABLED
 	cameras.erase(p_camera);
-#endif
 }
 
 RID World3D::get_space() const {

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -24,4 +24,5 @@ env.scene_sources += scene_obj
 env.Depends(scene_obj, thirdparty_obj)
 
 SConscript("2d/SCsub")
-SConscript("3d/SCsub")
+if not env["disable_3d"]:
+    SConscript("3d/SCsub")

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -34,8 +34,10 @@
 #include "core/templates/pair.h"
 #include "scene/resources/surface_tool.h"
 
+#ifndef _3D_DISABLED
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
+#endif // _3D_DISABLED
 
 void MeshConvexDecompositionSettings::set_max_concavity(real_t p_max_concavity) {
 	max_concavity = CLAMP(p_max_concavity, 0.001, 1.0);
@@ -519,6 +521,7 @@ Vector<Face3> Mesh::get_surface_faces(int p_surface) const {
 	return Vector<Face3>();
 }
 
+#ifndef _3D_DISABLED
 Ref<ConvexPolygonShape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplify) const {
 	if (p_simplify) {
 		Ref<MeshConvexDecompositionSettings> settings = Ref<MeshConvexDecompositionSettings>();
@@ -578,6 +581,7 @@ Ref<ConcavePolygonShape3D> Mesh::create_trimesh_shape() const {
 	shape->set_faces(face_points);
 	return shape;
 }
+#endif // _3D_DISABLED
 
 Ref<Mesh> Mesh::create_outline(float p_margin) const {
 	Array arrays;
@@ -896,6 +900,7 @@ void Mesh::clear_cache() const {
 	debug_lines.clear();
 }
 
+#ifndef _3D_DISABLED
 Vector<Ref<Shape3D>> Mesh::convex_decompose(const Ref<MeshConvexDecompositionSettings> &p_settings) const {
 	ERR_FAIL_NULL_V(convex_decomposition_function, Vector<Ref<Shape3D>>());
 
@@ -932,6 +937,7 @@ Vector<Ref<Shape3D>> Mesh::convex_decompose(const Ref<MeshConvexDecompositionSet
 
 	return ret;
 }
+#endif // _3D_DISABLED
 
 int Mesh::get_builtin_bind_pose_count() const {
 	return 0;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -34,7 +34,9 @@
 #include "core/io/resource.h"
 #include "core/math/face3.h"
 #include "core/math/triangle_mesh.h"
+#ifndef _3D_DISABLED
 #include "scene/resources/3d/shape_3d.h"
+#endif // _3D_DISABLED
 #include "scene/resources/material.h"
 #include "servers/rendering_server.h"
 
@@ -194,9 +196,11 @@ public:
 
 	static ConvexDecompositionFunc convex_decomposition_function;
 
+#ifndef _3D_DISABLED
 	Vector<Ref<Shape3D>> convex_decompose(const Ref<MeshConvexDecompositionSettings> &p_settings) const;
 	Ref<ConvexPolygonShape3D> create_convex_shape(bool p_clean = true, bool p_simplify = false) const;
 	Ref<ConcavePolygonShape3D> create_trimesh_shape() const;
+#endif // _3D_DISABLED
 
 	virtual int get_builtin_bind_pose_count() const;
 	virtual Transform3D get_builtin_bind_pose(int p_index) const;

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.h
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.h
@@ -31,7 +31,7 @@
 #ifndef NAVIGATION_MESH_SOURCE_GEOMETRY_DATA_3D_H
 #define NAVIGATION_MESH_SOURCE_GEOMETRY_DATA_3D_H
 
-#include "scene/3d/visual_instance_3d.h"
+#include "scene/resources/mesh.h"
 
 class NavigationMeshSourceGeometryData3D : public Resource {
 	GDCLASS(NavigationMeshSourceGeometryData3D, Resource);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -37,7 +37,9 @@
 #include "core/io/resource_loader.h"
 #include "core/templates/local_vector.h"
 #include "scene/2d/node_2d.h"
+#ifndef _3D_DISABLED
 #include "scene/3d/node_3d.h"
+#endif // _3D_DISABLED
 #include "scene/gui/control.h"
 #include "scene/main/instance_placeholder.h"
 #include "scene/main/missing_node.h"

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -3,11 +3,26 @@
 Import("env")
 
 env.servers_sources = []
-env.add_source_files(env.servers_sources, "*.cpp")
+
+env.add_source_files(env.servers_sources, "audio_server.cpp")
+env.add_source_files(env.servers_sources, "camera_server.cpp")
+env.add_source_files(env.servers_sources, "display_server.cpp")
+env.add_source_files(env.servers_sources, "native_menu.cpp")
+env.add_source_files(env.servers_sources, "navigation_server_2d.cpp")
+env.add_source_files(env.servers_sources, "navigation_server_3d.cpp")
+env.add_source_files(env.servers_sources, "physics_server_2d.cpp")
+env.add_source_files(env.servers_sources, "physics_server_2d_wrap_mt.cpp")
+env.add_source_files(env.servers_sources, "register_server_types.cpp")
+env.add_source_files(env.servers_sources, "rendering_server.cpp")
+env.add_source_files(env.servers_sources, "text_server.cpp")
+env.add_source_files(env.servers_sources, "xr_server.cpp")
 
 SConscript("xr/SCsub")
 SConscript("camera/SCsub")
-SConscript("physics_3d/SCsub")
+if not env["disable_3d"]:
+    SConscript("physics_3d/SCsub")
+    env.add_source_files(env.servers_sources, "physics_server_3d.cpp")
+    env.add_source_files(env.servers_sources, "physics_server_3d_wrap_mt.cpp")
 SConscript("physics_2d/SCsub")
 SConscript("rendering/SCsub")
 SConscript("audio/SCsub")

--- a/servers/extensions/SCsub
+++ b/servers/extensions/SCsub
@@ -4,4 +4,7 @@ Import("env")
 
 env_object = env.Clone()
 
-env_object.add_source_files(env.servers_sources, "*.cpp")
+env_object.add_source_files(env.servers_sources, "physics_server_2d_extension.cpp")
+
+if not env["disable_3d"]:
+    env_object.add_source_files(env.servers_sources, "physics_server_3d_extension.cpp")

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -29,7 +29,9 @@
 /**************************************************************************/
 
 #include "navigation_server_3d.h"
+
 #include "core/config/project_settings.h"
+#include "scene/main/node.h"
 
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifndef _3D_DISABLED
+
 #include "physics_server_3d.h"
 
 #include "core/config/project_settings.h"
@@ -1213,3 +1215,5 @@ PhysicsServer3DManager::PhysicsServer3DManager() {
 PhysicsServer3DManager::~PhysicsServer3DManager() {
 	singleton = nullptr;
 }
+
+#endif // _3D_DISABLED

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -31,6 +31,8 @@
 #ifndef PHYSICS_SERVER_3D_H
 #define PHYSICS_SERVER_3D_H
 
+#ifndef _3D_DISABLED
+
 #include "core/io/resource.h"
 #include "core/object/class_db.h"
 #include "core/object/gdvirtual.gen.inc"
@@ -1054,5 +1056,7 @@ VARIANT_ENUM_CAST(PhysicsServer3D::G6DOFJointAxisParam);
 VARIANT_ENUM_CAST(PhysicsServer3D::G6DOFJointAxisFlag);
 VARIANT_ENUM_CAST(PhysicsServer3D::AreaBodyStatus);
 VARIANT_ENUM_CAST(PhysicsServer3D::ProcessInfo);
+
+#endif // _3D_DISABLED
 
 #endif // PHYSICS_SERVER_3D_H

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -33,7 +33,6 @@
 #include "core/math/plane.h"
 #include "core/math/projection.h"
 #include "rendering_server_globals.h"
-#include "scene/3d/camera_3d.h"
 
 #ifdef RENDERING_LIGHT_CULLER_DEBUG_STRINGS
 const char *RenderingLightCuller::Data::string_planes[] = {


### PR DESCRIPTION
This PR disables all 3D nodes and resources, and ensures that some key files like World3D are not included anywhere, when compiling with 3D disabled. A summary of some of the changes:

* World3D is now not included at all when 3D is disabled, so I removed the 3D disabled checks from that file.
* PhysicsServer3D is not compiled when 3D is disabled.
* PackedScene no longer includes Node3D when 3D is disabled.
* Mesh no longer includes 3D physics shape generation methods when 3D is disabled.
* NavigationMeshSourceGeometryData3D was including VisualInstance3D, but it only needed Mesh. I changed this to including only Mesh.
* The above point broke NavigationServer3D and GodotNavigationServer3D since those need Node (but not Node3D), so I added a Node include for each of those.
* ShaderGlobalsOverride included Node3D, but it only needs the tree notifications, so I switched it to Node.
* RenderingLightCuller included Camera3D, but it does not need it, it only needs the core/math files.

Overall these changes are surprisingly clean, the last 4 bullets are just good fixes for including what you use. The big messy change is in the servers folder, with all the `env.add_source_files` lines in the SCsub file. I am of the opinion that we should move the server files into the server folders (like move PhysicsServer3D into the `servers/physics_3d` folder). But that should likely be a separate PR (maybe as a prerequisite to this one? or we can merge this first).