### PR TITLE
Fix enum autocompletion for core classes

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -651,6 +651,21 @@ static int _get_enum_constant_location(const StringName &p_class, const StringNa
 	return depth | ScriptLanguage::LOCATION_PARENT_MASK;
 }
 
+static int _get_enum_location(const StringName &p_class, const StringName &p_enum) {
+	if (!ClassDB::has_enum(p_class, p_enum)) {
+		return ScriptLanguage::LOCATION_OTHER;
+	}
+
+	int depth = 0;
+	StringName class_test = p_class;
+	while (class_test && !ClassDB::has_enum(class_test, p_enum, true)) {
+		class_test = ClassDB::get_parent_class(class_test);
+		depth++;
+	}
+
+	return depth | ScriptLanguage::LOCATION_PARENT_MASK;
+}
+
 // END LOCATION METHODS
 
 static String _trim_parent_class(const String &p_class, const String &p_base_class) {
@@ -1198,13 +1213,15 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 					return;
 				}
 
+				List<StringName> enums;
+				ClassDB::get_enum_list(type, &enums);
+				for (const StringName &E : enums) {
+					int location = p_recursion_depth + _get_enum_location(type, E);
+					ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_ENUM, location);
+					r_result.insert(option.display, option);
+				}
+
 				if (p_types_only) {
-					List<StringName> enums;
-					ClassDB::get_enum_list(type, &enums);
-					for (const StringName &E : enums) {
-						ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_ENUM);
-						r_result.insert(option.display, option);
-					}
 					return;
 				}
 
@@ -1264,7 +1281,20 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 				}
 				return;
 			} break;
-			case GDScriptParser::DataType::ENUM:
+			case GDScriptParser::DataType::ENUM: {
+				String type_str = base_type.native_type;
+				StringName type = type_str.get_slicec('.', 0);
+				StringName type_enum = base_type.enum_type;
+
+				List<StringName> enum_values;
+				ClassDB::get_enum_constants(type, type_enum, &enum_values);
+				for (const StringName &E : enum_values) {
+					int location = p_recursion_depth + _get_enum_constant_location(type, E);
+					ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+					r_result.insert(option.display, option);
+				}
+			}
+				[[fallthrough]];
 			case GDScriptParser::DataType::BUILTIN: {
 				if (p_types_only) {
 					return;

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_autocomplete.cfg
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_autocomplete.cfg
@@ -1,0 +1,9 @@
+[output]
+include=[
+    {"display": "DrawMode",
+     "location": 256},
+    {"display": "Anchor",
+     "location": 257},
+    {"display": "TextureRepeat",
+     "location": 258},
+]

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_autocomplete.gd
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_autocomplete.gd
@@ -1,0 +1,4 @@
+extends Control
+
+func _ready():
+    var t = BaseButton.➡

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_values_autocompletion.cfg
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_values_autocompletion.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    {"display": "HEURISTIC_MAX"},
+    {"display": "HEURISTIC_OCTILE"},
+]

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_values_autocompletion.gd
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_values_autocompletion.gd
@@ -1,0 +1,4 @@
+extends Control
+
+func _ready():
+    AStarGrid2D.Heuristic.➡


### PR DESCRIPTION
While writing a gdscript, autocompletion wouldn't suggest Enum names for core classes and also wouldn't suggest Enum Values even after the Enum name had been typed. This has now been fixed.

Now, while finding identifiers in a class, enumeration names are also fetched and enumeration constants are now suggested as well.

Fixes #88858.