### PR TITLE
Remove unused warnings for bones and skeleton modifications and change some cache reload warning to error in case of failure

### DIFF
--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -448,7 +448,6 @@ void Bone2D::calculate_length_and_rotation() {
 		}
 	}
 
-	WARN_PRINT("No Bone2D children of node " + get_name() + ". Cannot calculate bone length or angle reliably.\nUsing transform rotation for bone angle.");
 	bone_angle = get_transform().get_rotation();
 }
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -113,9 +113,11 @@ void SkeletonModification2DPhysicalBones::_execute(float p_delta) {
 	for (int i = 0; i < physical_bone_chain.size(); i++) {
 		PhysicalBone_Data2D bone_data = physical_bone_chain[i];
 		if (bone_data.physical_bone_node_cache.is_null()) {
-			WARN_PRINT_ONCE("PhysicalBone2D cache " + itos(i) + " is out of date. Attempting to update...");
 			_physical_bone_update_cache(i);
-			continue;
+			if (bone_data.physical_bone_node_cache.is_null()) {
+				ERR_PRINT_ONCE("PhysicalBone2D cache " + itos(i) + " is out of date. Failed to update...");
+				continue;
+			}
 		}
 
 		PhysicalBone2D *physical_bone = Object::cast_to<PhysicalBone2D>(ObjectDB::get_instance(bone_data.physical_bone_node_cache));
@@ -263,7 +265,9 @@ void SkeletonModification2DPhysicalBones::_update_simulation_state() {
 void SkeletonModification2DPhysicalBones::set_physical_bone_node(int p_joint_idx, const NodePath &p_nodepath) {
 	ERR_FAIL_INDEX_MSG(p_joint_idx, physical_bone_chain.size(), "Joint index out of range!");
 	physical_bone_chain.write[p_joint_idx].physical_bone_node = p_nodepath;
-	_physical_bone_update_cache(p_joint_idx);
+	if (is_setup) {
+		_physical_bone_update_cache(p_joint_idx);
+	}
 }
 
 NodePath SkeletonModification2DPhysicalBones::get_physical_bone_node(int p_joint_idx) const {

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -327,7 +327,9 @@ void SkeletonModification2DTwoBoneIK::update_joint_two_bone2d_cache() {
 
 void SkeletonModification2DTwoBoneIK::set_target_node(const NodePath &p_target_node) {
 	target_node = p_target_node;
-	update_target_cache();
+	if (is_setup) {
+		update_target_cache();
+	}
 }
 
 NodePath SkeletonModification2DTwoBoneIK::get_target_node() const {
@@ -336,7 +338,9 @@ NodePath SkeletonModification2DTwoBoneIK::get_target_node() const {
 
 void SkeletonModification2DTwoBoneIK::set_joint_one_bone2d_node(const NodePath &p_target_node) {
 	joint_one_bone2d_node = p_target_node;
-	update_joint_one_bone2d_cache();
+	if (is_setup) {
+		update_joint_one_bone2d_cache();
+	}
 	notify_property_list_changed();
 }
 
@@ -378,7 +382,9 @@ NodePath SkeletonModification2DTwoBoneIK::get_joint_one_bone2d_node() const {
 
 void SkeletonModification2DTwoBoneIK::set_joint_two_bone2d_node(const NodePath &p_target_node) {
 	joint_two_bone2d_node = p_target_node;
-	update_joint_two_bone2d_cache();
+	if (is_setup) {
+		update_joint_two_bone2d_cache();
+	}
 	notify_property_list_changed();
 }
 
@@ -389,20 +395,12 @@ NodePath SkeletonModification2DTwoBoneIK::get_joint_two_bone2d_node() const {
 void SkeletonModification2DTwoBoneIK::set_joint_one_bone_idx(int p_bone_idx) {
 	ERR_FAIL_COND_MSG(p_bone_idx < 0, "Bone index is out of range: The index is too low!");
 
-	if (is_setup) {
-		if (stack->skeleton) {
-			ERR_FAIL_INDEX_MSG(p_bone_idx, stack->skeleton->get_bone_count(), "Passed-in Bone index is out of range!");
-			joint_one_bone_idx = p_bone_idx;
-			joint_one_bone2d_node_cache = stack->skeleton->get_bone(p_bone_idx)->get_instance_id();
-			joint_one_bone2d_node = stack->skeleton->get_path_to(stack->skeleton->get_bone(p_bone_idx));
-		} else {
-			WARN_PRINT("TwoBoneIK: Cannot verify the joint bone index for joint one...");
-			joint_one_bone_idx = p_bone_idx;
-		}
-	} else {
-		WARN_PRINT("TwoBoneIK: Cannot verify the joint bone index for joint one...");
-		joint_one_bone_idx = p_bone_idx;
+	if (is_setup && stack->skeleton) {
+		ERR_FAIL_INDEX_MSG(p_bone_idx, stack->skeleton->get_bone_count(), "Passed-in Bone index is out of range!");
+		joint_one_bone2d_node_cache = stack->skeleton->get_bone(p_bone_idx)->get_instance_id();
+		joint_one_bone2d_node = stack->skeleton->get_path_to(stack->skeleton->get_bone(p_bone_idx));
 	}
+	joint_one_bone_idx = p_bone_idx;
 
 	notify_property_list_changed();
 }
@@ -414,20 +412,12 @@ int SkeletonModification2DTwoBoneIK::get_joint_one_bone_idx() const {
 void SkeletonModification2DTwoBoneIK::set_joint_two_bone_idx(int p_bone_idx) {
 	ERR_FAIL_COND_MSG(p_bone_idx < 0, "Bone index is out of range: The index is too low!");
 
-	if (is_setup) {
-		if (stack->skeleton) {
-			ERR_FAIL_INDEX_MSG(p_bone_idx, stack->skeleton->get_bone_count(), "Passed-in Bone index is out of range!");
-			joint_two_bone_idx = p_bone_idx;
-			joint_two_bone2d_node_cache = stack->skeleton->get_bone(p_bone_idx)->get_instance_id();
-			joint_two_bone2d_node = stack->skeleton->get_path_to(stack->skeleton->get_bone(p_bone_idx));
-		} else {
-			WARN_PRINT("TwoBoneIK: Cannot verify the joint bone index for joint two...");
-			joint_two_bone_idx = p_bone_idx;
-		}
-	} else {
-		WARN_PRINT("TwoBoneIK: Cannot verify the joint bone index for joint two...");
-		joint_two_bone_idx = p_bone_idx;
+	if (is_setup && stack->skeleton) {
+		ERR_FAIL_INDEX_MSG(p_bone_idx, stack->skeleton->get_bone_count(), "Passed-in Bone index is out of range!");
+		joint_two_bone2d_node_cache = stack->skeleton->get_bone(p_bone_idx)->get_instance_id();
+		joint_two_bone2d_node = stack->skeleton->get_path_to(stack->skeleton->get_bone(p_bone_idx));
 	}
+	joint_two_bone_idx = p_bone_idx;
 
 	notify_property_list_changed();
 }


### PR DESCRIPTION
Based on: https://github.com/godotengine/godot/issues/73247#issuecomment-1988322815

My findings are on that page, but will put them here also:

The warning doesn't need to be a warning as the bone_cache will be updated anyway during the setup call.
Also some warnings don't need to be warnings at all as they are not actually warnings, but just the value is set initially(eg. bone index) and the cache not computed.