### PR TITLE
Bind `Node::force_parent_owned()` as `make_owned_by_parent()` and bind `Node::is_owned_by_parent()` as `is_managed_by_parent()`.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -606,6 +606,12 @@
 				Returns [code]true[/code] if this node is currently inside a [SceneTree]. See also [method get_tree].
 			</description>
 		</method>
+		<method name="is_managed_by_parent" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the node is managed by its parent (see [method mark_managed_by_parent]).
+			</description>
+		</method>
 		<method name="is_multiplayer_authority" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -665,6 +671,13 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the node is processing unhandled key input (see [method set_process_unhandled_key_input]).
+			</description>
+		</method>
+		<method name="mark_managed_by_parent">
+			<return type="void" />
+			<description>
+				Marks this node as being managed by its parent. Parent managed nodes are not duplicated or copied when calling [method duplicate] or [method replace_by].
+				[b]Note:[/b] Reparenting this node resets the managed status.
 			</description>
 		</method>
 		<method name="move_child">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3529,6 +3529,9 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_unique_name_in_owner", "enable"), &Node::set_unique_name_in_owner);
 	ClassDB::bind_method(D_METHOD("is_unique_name_in_owner"), &Node::is_unique_name_in_owner);
 
+	ClassDB::bind_method(D_METHOD("mark_managed_by_parent"), &Node::force_parent_owned);
+	ClassDB::bind_method(D_METHOD("is_managed_by_parent"), &Node::is_owned_by_parent);
+
 	ClassDB::bind_method(D_METHOD("atr", "message", "context"), &Node::atr, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("atr_n", "message", "plural_message", "n", "context"), &Node::atr_n, DEFVAL(""));
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Close [proposal #9282](https://github.com/godotengine/godot-proposals/issues/9282).