### PR TITLE
Make AnimationMixer consider Discrete for RESET track

### DIFF
--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -222,9 +222,14 @@ protected:
 		Variant init_value;
 		Variant value;
 		Vector<StringName> subpath;
+
+		// TODO: There are many boolean, can be packed into one integer.
+		bool init_use_continuous = false;
+		bool use_continuous = false;
 		bool use_discrete = false;
 		bool is_using_angle = false;
 		bool is_variant_interpolatable = true;
+
 		Variant element_size;
 
 		TrackCacheValue(const TrackCacheValue &p_other) :
@@ -232,6 +237,8 @@ protected:
 				init_value(p_other.init_value),
 				value(p_other.value),
 				subpath(p_other.subpath),
+				init_use_continuous(p_other.init_use_continuous),
+				use_continuous(p_other.use_continuous),
 				use_discrete(p_other.use_discrete),
 				is_using_angle(p_other.is_using_angle),
 				is_variant_interpolatable(p_other.is_variant_interpolatable),


### PR DESCRIPTION
- Fixes #89163

Deterministic sets the initial value if an animation are lacking some tracks from another animation, but this should not be done for Discrete tracks, so add some flagging when caching and initializing. It should behave as follows:

| Deterministic  | RESET Track | CallbackModeDiscrete | Is init value appeared in animation with lacking some tracks |
| -- | -- | -- | -- |
| true | Continuous | Dominant | Yes, init value is continuous clearly |
| true | Continuous | Recessive | Yes, init value is continuous clearly |
| true | Continuous | Force Continuous | Yes, init value is continuous clearly |
| true | Discrete| Dominant | No, init value is discrete clearly |
| true | Discrete| Recessive | No, init value is discrete clearly |
| true | Discrete | Force Continuous | No, init value is discrete clearly |
| true | None (but there is track in another animation)  | Dominant | No, init value may be discrete |
| true | None (but there is track in another animation)  | Recessive | No, init value may be discrete |
| true | None (but there is track in another animation)  | Force Continuous | Yes, init value is discrete clearly by Force Continuous |
| false | Continuous | Dominant | No, Un-Deterministic doesn't process init value |
| false | Continuous | Recessive | No, Un-Deterministic doesn't process init value |
| false | Continuous | Force Continuous | No, Un-Deterministic doesn't process init value |
| false | Discrete | Dominant | No, Un-Deterministic doesn't process init value |
| false | Discrete | Recessive | No, Un-Deterministic doesn't process init value |
| false | Discrete | Force Continuous |  No, Un-Deterministic doesn't process init value |
| false | None (but there is track in another animation)  | Dominant | No, Un-Deterministic doesn't process init value |
| false | None (but there is track in another animation)  | Recessive | No, Un-Deterministic doesn't process init value |
| false | None (but there is track in another animation)  | Force Continuous | No, Un-Deterministic doesn't process init value |