### PR TITLE
Improve warning when XR shaders are not enabled

### DIFF
--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -626,7 +626,7 @@ PackedStringArray XROrigin3D::get_configuration_warnings() const {
 
 	bool xr_enabled = GLOBAL_GET("xr/shaders/enabled");
 	if (!xr_enabled) {
-		warnings.push_back(RTR("XR is not enabled in rendering project settings. Stereoscopic output is not supported unless this is enabled."));
+		warnings.push_back(RTR("XR shaders are not enabled in project settings. Stereoscopic output is not supported unless they are enabled. Please enable `xr/shaders/enabled` to use stereoscopic output."));
 	}
 
 	return warnings;


### PR DESCRIPTION
I ran into this warning when trying to repro an XR issue. The warning points you to the "rendering project settings" but the project setting is not in the rendering section, nor is the specific setting mentioned. 
