### PR TITLE
Vector2, Vector3 `project` edge case robustness

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -126,7 +126,12 @@ Vector2 Vector2::posmodv(const Vector2 &p_modv) const {
 }
 
 Vector2 Vector2::project(const Vector2 &p_to) const {
-	return p_to * (dot(p_to) / p_to.length_squared());
+	real_t length_squared = p_to.length_squared();
+	if (length_squared == 0) {
+		return Vector2();
+	}
+
+	return p_to * (dot(p_to) / length_squared);
 }
 
 Vector2 Vector2::clamp(const Vector2 &p_min, const Vector2 &p_max) const {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -295,7 +295,12 @@ Vector3 Vector3::posmodv(const Vector3 &p_modv) const {
 }
 
 Vector3 Vector3::project(const Vector3 &p_to) const {
-	return p_to * (dot(p_to) / p_to.length_squared());
+	real_t length_squared = p_to.length_squared();
+	if (length_squared == 0) {
+		return Vector3();
+	}
+
+	return p_to * (dot(p_to) / length_squared);
 }
 
 real_t Vector3::angle_to(const Vector3 &p_to) const {

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -354,6 +354,13 @@ TEST_CASE("[Vector2] Plane methods") {
 	const Vector2 vector_y = Vector2(0, 1);
 	const Vector2 vector_normal = Vector2(0.95879811270838721622267, 0.2840883296913739899919);
 	const Vector2 vector_non_normal = Vector2(5.4, 1.6);
+	const Vector2 vector_zero = Vector2(0.0, 0.0);
+#ifdef REAL_T_IS_DOUBLE
+	const Vector2 vector_tiny = Vector2(0.0, 2.22507385850720138309e-308);
+#else
+	const Vector2 vector_tiny = Vector2(0.0, 1.17549435e-38);
+#endif // REAL_T_IS_DOUBLE
+
 	CHECK_MESSAGE(
 			vector.bounce(vector_y) == Vector2(1.2, -3.4),
 			"Vector2 bounce on a plane with normal of the Y axis should.");
@@ -366,12 +373,20 @@ TEST_CASE("[Vector2] Plane methods") {
 	CHECK_MESSAGE(
 			vector.reflect(vector_normal).is_equal_approx(Vector2(2.85851197982345523329, -2.197477931904161412358)),
 			"Vector2 reflect with normal should return expected value.");
+
 	CHECK_MESSAGE(
 			vector.project(vector_y) == Vector2(0, 3.4),
 			"Vector2 projected on the Y axis should only give the Y component.");
 	CHECK_MESSAGE(
 			vector.project(vector_normal).is_equal_approx(Vector2(2.0292559899117276166, 0.60126103404791929382)),
 			"Vector2 projected on a normal should return expected value.");
+	CHECK_MESSAGE(
+			vector.project(vector_zero) == Vector2(),
+			"Vector2 projected on zero should return finite.");
+	CHECK_MESSAGE(
+			vector.project(vector_tiny) == Vector2(),
+			"Vector2 projected on a very small normal should return finite.");
+
 	CHECK_MESSAGE(
 			vector.slide(vector_y) == Vector2(1.2, 0),
 			"Vector2 slide on a plane with normal of the Y axis should set the Y to zero.");

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -369,6 +369,13 @@ TEST_CASE("[Vector3] Plane methods") {
 	const Vector3 vector_y = Vector3(0, 1, 0);
 	const Vector3 vector_normal = Vector3(0.88763458893247992491, 0.26300284116517923701, 0.37806658417494515320);
 	const Vector3 vector_non_normal = Vector3(5.4, 1.6, 2.3);
+	const Vector3 vector_zero = Vector3(0.0, 0.0, 0.0);
+#ifdef REAL_T_IS_DOUBLE
+	const Vector3 vector_tiny = Vector3(0.0, 0.0, 2.22507385850720138309e-308);
+#else
+	const Vector3 vector_tiny = Vector3(0.0, 0.0, 1.17549435e-38);
+#endif // REAL_T_IS_DOUBLE
+
 	CHECK_MESSAGE(
 			vector.bounce(vector_y) == Vector3(1.2, -3.4, 5.6),
 			"Vector3 bounce on a plane with normal of the Y axis should.");
@@ -381,12 +388,20 @@ TEST_CASE("[Vector3] Plane methods") {
 	CHECK_MESSAGE(
 			vector.reflect(vector_normal).is_equal_approx(Vector3(6.0369629829775736287, -1.25571467171034855444, -2.517589840583626047)),
 			"Vector3 reflect with normal should return expected value.");
+
 	CHECK_MESSAGE(
 			vector.project(vector_y) == Vector3(0, 3.4, 0),
 			"Vector3 projected on the Y axis should only give the Y component.");
 	CHECK_MESSAGE(
 			vector.project(vector_normal).is_equal_approx(Vector3(3.61848149148878681437, 1.0721426641448257227776, 1.54120507970818697649)),
 			"Vector3 projected on a normal should return expected value.");
+	CHECK_MESSAGE(
+			vector.project(vector_zero) == Vector3(),
+			"Vector3 projected onto zero should return finite.");
+	CHECK_MESSAGE(
+			vector.project(vector_tiny) == Vector3(),
+			"Vector3 projected onto a very small normal should return finite.");
+
 	CHECK_MESSAGE(
 			vector.slide(vector_y) == Vector3(1.2, 0, 5.6),
 			"Vector3 slide on a plane with normal of the Y axis should set the Y to zero.");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Before this change, `project` would return a vector full of `NaN`s given a zero vector, or assorted non-finite elements given a very small (but nonzero) vector.

```gdscript
var vec := Vector3(5, -2, 9)
var zero := Vector3(0, 0, 0)
var small := Vector3(0, 1e-25, -1e-28)

var up := Vector3(0, 1, 0)

print("(point)\t", point)
print("Up\t", point.project(up))
print("Small\t", point.project(small))
print("Zero\t", point.project(zero))
```

```
(point)	(5, -2, 9)
Up	(0, -2, 0)
Small	(nan, -inf, inf)
Zero	(nan, nan, nan)
```

After this change, the methods will instead return zero vectors.
```
(point)	(5, -2, 9)
Up	(0, -2, 0)
Small	(0, 0, 0)	
Zero	(0, 0, 0)
```

This matches the behavior of `normalize`, which also results in a zero vector when given a zero vector.