### PR TITLE
Add priority setting to reflection probes

### DIFF
--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -51,6 +51,9 @@
 		<member name="origin_offset" type="Vector3" setter="set_origin_offset" getter="get_origin_offset" default="Vector3(0, 0, 0)">
 			Sets the origin offset to be used when this [ReflectionProbe] is in [member box_projection] mode. This can be set to a non-zero value to ensure a reflection fits a rectangle-shaped room, while reducing the number of objects that "get in the way" of the reflection.
 		</member>
+		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="0">
+			Sets the priority of this probe. Only probes with the highest priority that touches a fragment is used. If more than one probe matches they are blended.
+		</member>
 		<member name="reflection_mask" type="int" setter="set_reflection_mask" getter="get_reflection_mask" default="1048575">
 			Sets the reflection mask which determines what objects have reflections applied from this probe. Every [VisualInstance3D] with a layer included in this reflection mask will have reflections applied from this probe. See also [member cull_mask], which can be used to exclude objects from appearing in the reflection while still making them affected by the [ReflectionProbe].
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3026,6 +3026,14 @@
 				Sets the origin offset to be used when this reflection probe is in box project mode. Equivalent to [member ReflectionProbe.origin_offset].
 			</description>
 		</method>
+		<method name="reflection_probe_set_priority">
+			<return type="void" />
+			<param index="0" name="probe" type="RID" />
+			<param index="1" name="priority" type="int" />
+			<description>
+				Sets the priority of this probe. Equivalent to [member ReflectionProbe.priority].
+			</description>
+		</method>
 		<method name="reflection_probe_set_reflection_mask">
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -474,6 +474,9 @@ void LightStorage::reflection_probe_set_reflection_mask(RID p_probe, uint32_t p_
 void LightStorage::reflection_probe_set_resolution(RID p_probe, int p_resolution) {
 }
 
+void LightStorage::reflection_probe_set_priority(RID p_probe, int p_priority) {
+}
+
 AABB LightStorage::reflection_probe_get_aabb(RID p_probe) const {
 	return AABB();
 }

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -579,6 +579,7 @@ public:
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) override;
 	virtual void reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_ratio) override;
 	virtual float reflection_probe_get_mesh_lod_threshold(RID p_probe) const override;
+	virtual void reflection_probe_set_priority(RID p_probe, int p_priority) override;
 
 	virtual AABB reflection_probe_get_aabb(RID p_probe) const override;
 	virtual RS::ReflectionProbeUpdateMode reflection_probe_get_update_mode(RID p_probe) const override;

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -183,6 +183,17 @@ ReflectionProbe::UpdateMode ReflectionProbe::get_update_mode() const {
 	return update_mode;
 }
 
+void ReflectionProbe::set_priority(int p_priority) {
+	ERR_FAIL_INDEX_MSG(p_priority, 101, "Probe priority should be a value between 0 and 100"); // should be between 0 - 100
+	priority = p_priority;
+
+	RS::get_singleton()->reflection_probe_set_priority(probe, p_priority);
+}
+
+int ReflectionProbe::get_priority() const {
+	return priority;
+}
+
 AABB ReflectionProbe::get_aabb() const {
 	AABB aabb;
 	aabb.position = -origin_offset;
@@ -252,6 +263,9 @@ void ReflectionProbe::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_update_mode", "mode"), &ReflectionProbe::set_update_mode);
 	ClassDB::bind_method(D_METHOD("get_update_mode"), &ReflectionProbe::get_update_mode);
 
+	ClassDB::bind_method(D_METHOD("set_priority", "priority"), &ReflectionProbe::set_priority);
+	ClassDB::bind_method(D_METHOD("get_priority"), &ReflectionProbe::get_priority);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Once (Fast),Always (Slow)"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "intensity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_intensity", "get_intensity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "0,16384,0.1,or_greater,exp,suffix:m"), "set_max_distance", "get_max_distance");
@@ -263,6 +277,7 @@ void ReflectionProbe::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_cull_mask", "get_cull_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "reflection_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_reflection_mask", "get_reflection_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mesh_lod_threshold", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_mesh_lod_threshold", "get_mesh_lod_threshold");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,100,1"), "set_priority", "get_priority");
 
 	ADD_GROUP("Ambient", "ambient_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ambient_mode", PROPERTY_HINT_ENUM, "Disabled,Environment,Constant Color"), "set_ambient_mode", "get_ambient_mode");

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -61,6 +61,7 @@ private:
 	Color ambient_color = Color(0, 0, 0);
 	float ambient_color_energy = 1.0;
 	float mesh_lod_threshold = 1.0;
+	int priority = 0;
 
 	uint32_t cull_mask = (1 << 20) - 1;
 	uint32_t reflection_mask = (1 << 20) - 1;
@@ -119,6 +120,9 @@ public:
 
 	void set_update_mode(UpdateMode p_mode);
 	UpdateMode get_update_mode() const;
+
+	void set_priority(int p_priority);
+	int get_priority() const;
 
 	virtual AABB get_aabb() const override;
 

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -113,6 +113,7 @@ public:
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) override {}
 	virtual void reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_ratio) override {}
 	virtual float reflection_probe_get_mesh_lod_threshold(RID p_probe) const override { return 0.0; }
+	virtual void reflection_probe_set_priority(RID p_probe, int p_priority) override {}
 
 	virtual AABB reflection_probe_get_aabb(RID p_probe) const override { return AABB(); }
 	virtual RS::ReflectionProbeUpdateMode reflection_probe_get_update_mode(RID p_probe) const override { return RenderingServer::REFLECTION_PROBE_UPDATE_ONCE; }

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1614,6 +1614,7 @@ void fragment_shader(in SceneData scene_data) {
 
 		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
 		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		uint priority = 0;
 
 		uint cluster_reflection_offset = cluster_offset + implementation_data.cluster_type_size * 3;
 
@@ -1664,7 +1665,7 @@ void fragment_shader(in SceneData scene_data) {
 					continue; //not masked
 				}
 
-				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
+				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum, priority);
 			}
 		}
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1214,6 +1214,7 @@ void main() {
 	if (!sc_disable_reflection_probes) { //Reflection probes
 		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
 		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		uint priority = 0;
 
 		uint reflection_indices = instances.data[draw_call.instance_index].reflection_probes.x;
 
@@ -1241,7 +1242,7 @@ void main() {
 				break;
 			}
 
-			reflection_process(reflection_index, vertex, ref_vec, bent_normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
+			reflection_process(reflection_index, vertex, ref_vec, bent_normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum, priority);
 		}
 
 		if (reflection_accum.a > 0.0) {

--- a/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
@@ -48,6 +48,10 @@ struct ReflectionData {
 	//0-8 is intensity,8-9 is ambient, mode
 	highp mat4 local_matrix; // up to here for spot and omni, rest is for directional
 	// notes: for ambientblend, use distance to edge to blend between already existing global environment
+	uint priority;
+	float res1;
+	float res2;
+	float res3;
 };
 
 struct DirectionalLightData {

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -898,12 +898,22 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			diffuse_light, specular_light);
 }
 
-void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) {
+void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum, inout uint curr_importance) {
 	vec3 box_extents = reflections.data[ref_index].box_extents;
 	vec3 local_pos = (reflections.data[ref_index].local_matrix * vec4(vertex, 1.0)).xyz;
 
 	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
 		return;
+	}
+
+	if (reflections.data[ref_index].priority < curr_importance) { // Less important than our current entry?
+		return; // skip!
+	} else if (reflections.data[ref_index].priority > curr_importance) { // More important than our current entry?
+		// reset!
+		reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+
+		curr_importance = reflections.data[ref_index].priority;
 	}
 
 	vec3 inner_pos = abs(local_pos / box_extents);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1144,6 +1144,15 @@ void LightStorage::reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_
 	reflection_probe->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_REFLECTION_PROBE);
 }
 
+void LightStorage::reflection_probe_set_priority(RID p_probe, int p_priority) {
+	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
+	ERR_FAIL_NULL(reflection_probe);
+
+	ERR_FAIL_INDEX_MSG(p_priority, 101, "Probe priority should be a value between 0 and 100"); // should be between 0 - 100
+
+	reflection_probe->priority = p_priority;
+}
+
 void LightStorage::reflection_probe_set_baked_exposure(RID p_probe, float p_exposure) {
 	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
 	ERR_FAIL_NULL(reflection_probe);
@@ -1749,6 +1758,8 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 		Transform3D transform = rpi->transform;
 		Transform3D proj = (p_camera_inverse_transform * transform).inverse();
 		MaterialStorage::store_transform(proj, reflection_ubo.local_matrix);
+
+		reflection_ubo.priority = probe->priority;
 
 		// hook for subclass to do further processing.
 		RendererSceneRenderRD::get_singleton()->setup_added_reflection_probe(transform, extents);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -235,6 +235,7 @@ private:
 		uint32_t reflection_mask = (1 << 20) - 1;
 		float mesh_lod_threshold = 0.01;
 		float baked_exposure = 1.0;
+		int priority = 0;
 
 		Dependency dependency;
 	};
@@ -307,6 +308,10 @@ private:
 		uint32_t ambient_mode;
 		float exposure_normalization;
 		float local_matrix[16]; // up to here for spot and omni, rest is for directional
+		uint32_t priority;
+		float res1;
+		float res2;
+		float res3;
 	};
 
 	struct ReflectionProbeInstanceSort {
@@ -800,6 +805,7 @@ public:
 	virtual void reflection_probe_set_reflection_mask(RID p_probe, uint32_t p_layers) override;
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) override;
 	virtual void reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_ratio) override;
+	virtual void reflection_probe_set_priority(RID p_probe, int p_priority) override;
 
 	void reflection_probe_set_baked_exposure(RID p_probe, float p_exposure);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -410,6 +410,7 @@ public:
 	FUNC2(reflection_probe_set_reflection_mask, RID, uint32_t)
 	FUNC2(reflection_probe_set_resolution, RID, int)
 	FUNC2(reflection_probe_set_mesh_lod_threshold, RID, float)
+	FUNC2(reflection_probe_set_priority, RID, int)
 
 	/* LIGHTMAP */
 

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -120,6 +120,7 @@ public:
 	virtual void reflection_probe_set_cull_mask(RID p_probe, uint32_t p_layers) = 0;
 	virtual void reflection_probe_set_reflection_mask(RID p_probe, uint32_t p_layers) = 0;
 	virtual void reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_ratio) = 0;
+	virtual void reflection_probe_set_priority(RID p_probe, int p_priority) = 0;
 
 	virtual AABB reflection_probe_get_aabb(RID p_probe) const = 0;
 	virtual RS::ReflectionProbeUpdateMode reflection_probe_get_update_mode(RID p_probe) const = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2559,6 +2559,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_reflection_mask", "probe", "layers"), &RenderingServer::reflection_probe_set_reflection_mask);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_resolution", "probe", "resolution"), &RenderingServer::reflection_probe_set_resolution);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_mesh_lod_threshold", "probe", "pixels"), &RenderingServer::reflection_probe_set_mesh_lod_threshold);
+	ClassDB::bind_method(D_METHOD("reflection_probe_set_priority", "probe", "priority"), &RenderingServer::reflection_probe_set_priority);
 
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ONCE);
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ALWAYS);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -586,6 +586,7 @@ public:
 	virtual void reflection_probe_set_reflection_mask(RID p_probe, uint32_t p_layers) = 0;
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) = 0;
 	virtual void reflection_probe_set_mesh_lod_threshold(RID p_probe, float p_pixels) = 0;
+	virtual void reflection_probe_set_priority(RID p_probe, int p_priority) = 0;
 
 	/* DECAL API */
 


### PR DESCRIPTION
This PR adds a priority setting to reflection probes.

This is to solve the scenario where probes overlap but where we do not want to apply blending but choose the most appropriate probe.

In this screenshot we have setup the Sponza demo with a reflection probe spanning the entire center so we get a reflection on the floor, and a probe centered on the sphere to get a nice reflection on the sphere:
![image](https://github.com/godotengine/godot/assets/1945449/f2d9a291-5659-4377-bdc1-74838b4c12e2)

As the two reflection probes overlap for the sphere, we see them blended resulting in an ugly reflection. Now this simple scenario can be solved with setting masks however in more complex scenarios that is not an option.

With this PR we can increase the priority of the reflection probe for the sphere so that it is used for anything inside of its AABB:
![image](https://github.com/godotengine/godot/assets/1945449/106e9c62-0182-4739-a258-4cb1ba2ef7eb)

This works on fragment level. The probe with the highest priority is used. If multiple probes match the highest priority, they are blended as before.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8167.*