### PR TITLE
Fix Make Unique (Recursive) failing with `AnimationNode`s

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1193,15 +1193,21 @@ AnimationNodeOutput::AnimationNodeOutput() {
 
 ///////////////////////////////////////////////////////
 void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position) {
-	ERR_FAIL_COND(nodes.has(p_name));
+	ERR_FAIL_COND(nodes.has(p_name) && nodes[p_name].node == (p_node));
 	ERR_FAIL_COND(p_node.is_null());
 	ERR_FAIL_COND(p_name == SceneStringNames::get_singleton()->output);
 	ERR_FAIL_COND(String(p_name).contains("/"));
 
 	Node n;
 	n.node = p_node;
-	n.position = p_position;
-	n.connections.resize(n.node->get_input_count());
+	if (nodes.has(p_name) && nodes[p_name].node != (p_node)) { // This is for ensuring same position and connections when using Make Unique (Recursive).
+		n.position = nodes[p_name].position;
+		n.connections = nodes[p_name].connections;
+	} else {
+		n.position = p_position;
+		n.connections.resize(n.node->get_input_count());
+	}
+
 	nodes[p_name] = n;
 
 	emit_changed();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1266,13 +1266,17 @@ bool AnimationNodeStateMachine::is_parameter_read_only(const StringName &p_param
 }
 
 void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position) {
-	ERR_FAIL_COND(states.has(p_name));
+	ERR_FAIL_COND(states.has(p_name) && states[p_name].node == (p_node));
 	ERR_FAIL_COND(p_node.is_null());
 	ERR_FAIL_COND(String(p_name).contains("/"));
 
 	State state_new;
 	state_new.node = p_node;
-	state_new.position = p_position;
+	if (states.has(p_name) && states[p_name].node != (p_node)) { // This is for ensuring same position when using Make Unique (Recursive).
+		state_new.position = states[p_name].position;
+	} else {
+		state_new.position = p_position;
+	}
 
 	states[p_name] = state_new;
 


### PR DESCRIPTION
Fixes #87766 

Issue(regression from 93d180b) is caused by Make Unique (Recursive) eventually calling `AnimationNodeBlendTree::add_node()` and `AnimationNodeStateMachine::add_node()`, which will throw an error if the new node(`AnimationNode`) shares the name of any in-use node. On top of that, even if it doesn't err, it will reset the position(`BlendTree`, `StateMachine`) and connections(`BlendTree`) in the AnimationTree bottom panel. My naïve solution was to add if checks, to know when it's trying to replace a node with a duplicate.

There is probably a better solution by intercepting earlier, i.e. as seen in the below code snippet. However, I do not know enough, so I would only be fumbling if I tried it myself.

```cpp
void EditorResourcePicker::_duplicate_selected_resources() {
	[...]

	if (meta.size() == 1) { // Root.
		edited_resource = unique_resource;
		emit_signal(SNAME("resource_changed"), edited_resource);
		_update_resource();
	} else {
                ////////////////////////////////////////////////////////////
                /* Add check here to intercept eventual add_node() call with
                   an alternate assignment that works for AnimationNodes  */
                ////////////////////////////////////////////////////////////
		Array parent_meta = item->get_parent()->get_metadata(0);
		Ref<Resource> parent = parent_meta[0];
		parent->set(meta[1], unique_resource); //This leads to add_node()
	}

}
```

Note: The way it worked before the regression, it would do a deep duplication (`res->duplicate(true)`) of the root node and replace it(doesn't cause errors for some reason). Maybe that info helps in finding a better solution.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
