### PR TITLE
Disable XR server when compiling without 3D

### DIFF
--- a/servers/SCsub
+++ b/servers/SCsub
@@ -15,22 +15,24 @@ env.add_source_files(env.servers_sources, "physics_server_2d_wrap_mt.cpp")
 env.add_source_files(env.servers_sources, "register_server_types.cpp")
 env.add_source_files(env.servers_sources, "rendering_server.cpp")
 env.add_source_files(env.servers_sources, "text_server.cpp")
-env.add_source_files(env.servers_sources, "xr_server.cpp")
 
-SConscript("xr/SCsub")
-SConscript("camera/SCsub")
-if not env["disable_3d"]:
-    SConscript("physics_3d/SCsub")
-    env.add_source_files(env.servers_sources, "physics_server_3d.cpp")
-    env.add_source_files(env.servers_sources, "physics_server_3d_wrap_mt.cpp")
-SConscript("physics_2d/SCsub")
-SConscript("rendering/SCsub")
 SConscript("audio/SCsub")
-SConscript("text/SCsub")
+SConscript("camera/SCsub")
 SConscript("debugger/SCsub")
 SConscript("extensions/SCsub")
 SConscript("movie_writer/SCsub")
 SConscript("navigation/SCsub")
+SConscript("rendering/SCsub")
+SConscript("text/SCsub")
+
+SConscript("physics_2d/SCsub")
+
+if not env["disable_3d"]:
+    SConscript("physics_3d/SCsub")
+    env.add_source_files(env.servers_sources, "physics_server_3d.cpp")
+    env.add_source_files(env.servers_sources, "physics_server_3d_wrap_mt.cpp")
+    SConscript("xr/SCsub")
+    env.add_source_files(env.servers_sources, "xr_server.cpp")
 
 lib = env.add_library("servers", env.servers_sources)
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -77,13 +77,6 @@
 #include "text/text_server_dummy.h"
 #include "text/text_server_extension.h"
 #include "text_server.h"
-#include "xr/xr_body_tracker.h"
-#include "xr/xr_face_tracker.h"
-#include "xr/xr_hand_tracker.h"
-#include "xr/xr_interface.h"
-#include "xr/xr_interface_extension.h"
-#include "xr/xr_positional_tracker.h"
-#include "xr_server.h"
 
 // 2D physics and navigation.
 #include "navigation_server_2d.h"
@@ -99,6 +92,13 @@
 #include "physics_server_3d.h"
 #include "physics_server_3d_wrap_mt.h"
 #include "servers/extensions/physics_server_3d_extension.h"
+#include "xr/xr_body_tracker.h"
+#include "xr/xr_face_tracker.h"
+#include "xr/xr_hand_tracker.h"
+#include "xr/xr_interface.h"
+#include "xr/xr_interface_extension.h"
+#include "xr/xr_positional_tracker.h"
+#include "xr_server.h"
 #endif // _3D_DISABLED
 
 ShaderTypes *shader_types = nullptr;
@@ -165,25 +165,9 @@ void register_server_types() {
 
 	GDREGISTER_CLASS(NativeMenu);
 
-	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
-	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
-	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
-	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
-	GDREGISTER_CLASS(NavigationPathQueryResult2D);
-	GDREGISTER_CLASS(NavigationPathQueryResult3D);
-
-	GDREGISTER_CLASS(XRServer);
 	GDREGISTER_CLASS(CameraServer);
 
 	GDREGISTER_ABSTRACT_CLASS(RenderingDevice);
-
-	GDREGISTER_CLASS(XRBodyTracker);
-	GDREGISTER_ABSTRACT_CLASS(XRInterface);
-	GDREGISTER_CLASS(XRHandTracker);
-	GDREGISTER_CLASS(XRInterfaceExtension); // can't register this as virtual because we need a creation function for our extensions.
-	GDREGISTER_CLASS(XRPose);
-	GDREGISTER_CLASS(XRPositionalTracker);
-	GDREGISTER_CLASS(XRFaceTracker);
 
 	GDREGISTER_CLASS(AudioStream);
 	GDREGISTER_CLASS(AudioStreamPlayback);
@@ -303,6 +287,10 @@ void register_server_types() {
 	PhysicsServer2DManager::get_singleton()->register_server("GodotPhysics2D", callable_mp_static(_createGodotPhysics2DCallback));
 	PhysicsServer2DManager::get_singleton()->set_default_server("GodotPhysics2D");
 
+	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
+	GDREGISTER_CLASS(NavigationPathQueryResult2D);
+
 #ifndef _3D_DISABLED
 	// Physics 3D
 	GDREGISTER_CLASS(PhysicsServer3DManager);
@@ -332,7 +320,20 @@ void register_server_types() {
 
 	PhysicsServer3DManager::get_singleton()->register_server("GodotPhysics3D", callable_mp_static(_createGodotPhysics3DCallback));
 	PhysicsServer3DManager::get_singleton()->set_default_server("GodotPhysics3D");
+
+	GDREGISTER_ABSTRACT_CLASS(XRInterface);
+	GDREGISTER_CLASS(XRBodyTracker);
+	GDREGISTER_CLASS(XRFaceTracker);
+	GDREGISTER_CLASS(XRHandTracker);
+	GDREGISTER_CLASS(XRInterfaceExtension); // can't register this as virtual because we need a creation function for our extensions.
+	GDREGISTER_CLASS(XRPose);
+	GDREGISTER_CLASS(XRPositionalTracker);
+	GDREGISTER_CLASS(XRServer);
 #endif // _3D_DISABLED
+
+	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
+	GDREGISTER_CLASS(NavigationPathQueryResult3D);
 
 	writer_mjpeg = memnew(MovieWriterMJPEG);
 	MovieWriter::add_writer(writer_mjpeg);
@@ -357,18 +358,19 @@ void unregister_server_types() {
 void register_server_singletons() {
 	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Singletons");
 
-	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServer", DisplayServer::get_singleton(), "DisplayServer"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
-#ifndef _3D_DISABLED
-	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));
-#endif // _3D_DISABLED
+	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServer", DisplayServer::get_singleton(), "DisplayServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NativeMenu", NativeMenu::get_singleton(), "NativeMenu"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton(), "NavigationServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton(), "NavigationServer3D"));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
+
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
+#ifndef _3D_DISABLED
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
+#endif // _3D_DISABLED
 
 	OS::get_singleton()->benchmark_end_measure("Servers", "Register Singletons");
 }

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -49,9 +49,11 @@ bool RendererCompositor::is_xr_enabled() const {
 RendererCompositor::RendererCompositor() {
 	singleton = this;
 
+#ifndef _3D_DISABLED
 	if (XRServer::get_xr_mode() == XRServer::XRMODE_DEFAULT) {
 		xr_enabled = GLOBAL_GET("xr/shaders/enabled");
 	} else {
 		xr_enabled = XRServer::get_xr_mode() == XRServer::XRMODE_ON;
 	}
+#endif // _3D_DISABLED
 }

--- a/servers/rendering/renderer_rd/effects/vrs.cpp
+++ b/servers/rendering/renderer_rd/effects/vrs.cpp
@@ -32,7 +32,10 @@
 #include "../renderer_compositor_rd.h"
 #include "../storage_rd/texture_storage.h"
 #include "../uniform_set_cache_rd.h"
+
+#ifndef _3D_DISABLED
 #include "servers/xr_server.h"
+#endif // _3D_DISABLED
 
 using namespace RendererRD;
 
@@ -124,6 +127,7 @@ void VRS::update_vrs_texture(RID p_vrs_fb, RID p_render_target) {
 					copy_vrs(rd_texture, p_vrs_fb, layers > 1);
 				}
 			}
+#ifndef _3D_DISABLED
 		} else if (vrs_mode == RS::VIEWPORT_VRS_XR) {
 			Ref<XRInterface> interface = XRServer::get_singleton()->get_primary_interface();
 			if (interface.is_valid()) {
@@ -138,6 +142,7 @@ void VRS::update_vrs_texture(RID p_vrs_fb, RID p_render_target) {
 					}
 				}
 			}
+#endif // _3D_DISABLED
 		}
 
 		RD::get_singleton()->draw_command_end_label();

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -44,7 +44,10 @@
 #include "servers/rendering/rendering_method.h"
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/rendering/storage/utilities.h"
+
+#ifndef _3D_DISABLED
 #include "servers/xr/xr_interface.h"
+#endif // _3D_DISABLED
 
 class RenderingLightCuller;
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -220,6 +220,7 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 }
 
 void RendererViewport::_draw_3d(Viewport *p_viewport) {
+#ifndef _3D_DISABLED
 	RENDER_TIMESTAMP("> Render 3D Scene");
 
 	Ref<XRInterface> xr_interface;
@@ -246,6 +247,7 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 	RSG::scene->render_camera(p_viewport->render_buffers, p_viewport->camera, p_viewport->scenario, p_viewport->self, p_viewport->internal_size, p_viewport->jitter_phase_count, screen_mesh_lod_threshold, p_viewport->shadow_atlas, xr_interface, &p_viewport->render_info);
 
 	RENDER_TIMESTAMP("< Render 3D Scene");
+#endif // _3D_DISABLED
 }
 
 void RendererViewport::_draw_viewport(Viewport *p_viewport) {
@@ -629,6 +631,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 void RendererViewport::draw_viewports(bool p_swap_buffers) {
 	timestamp_vp_map.clear();
 
+#ifndef _3D_DISABLED
 	// get our xr interface in case we need it
 	Ref<XRInterface> xr_interface;
 	XRServer *xr_server = XRServer::get_singleton();
@@ -639,6 +642,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 		// retrieve the interface responsible for rendering
 		xr_interface = xr_server->get_primary_interface();
 	}
+#endif // _3D_DISABLED
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		set_default_clear_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
@@ -671,6 +675,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 
 		bool visible = vp->viewport_to_screen_rect != Rect2();
 
+#ifndef _3D_DISABLED
 		if (vp->use_xr) {
 			if (xr_interface.is_valid()) {
 				// Ignore update mode we have to commit frames to our XR interface
@@ -684,7 +689,9 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 				visible = false;
 				vp->size = Size2();
 			}
-		} else {
+		} else
+#endif // _3D_DISABLED
+		{
 			if (vp->update_mode == RS::VIEWPORT_UPDATE_ALWAYS || vp->update_mode == RS::VIEWPORT_UPDATE_ONCE) {
 				visible = true;
 			}
@@ -722,6 +729,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 		RENDER_TIMESTAMP("> Render Viewport " + itos(i));
 
 		RSG::texture_storage->render_target_set_as_unused(vp->render_target);
+#ifndef _3D_DISABLED
 		if (vp->use_xr && xr_interface.is_valid()) {
 			// Inform XR interface we're about to render its viewport,
 			// if this returns false we don't render.
@@ -758,7 +766,9 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 					RSG::rasterizer->end_viewport(p_swap_buffers && blits.size() > 0);
 				}
 			}
-		} else {
+		} else
+#endif // _3D_DISABLED
+		{
 			RSG::texture_storage->render_target_set_override(vp->render_target, RID(), RID(), RID());
 
 			RSG::scene->set_debug_draw_mode(vp->debug_draw);

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -37,8 +37,11 @@
 #include "servers/rendering/renderer_scene_render.h"
 #include "servers/rendering/rendering_method.h"
 #include "servers/rendering_server.h"
-#include "servers/xr/xr_interface.h"
 #include "storage/render_scene_buffers.h"
+
+#ifndef _3D_DISABLED
+#include "servers/xr/xr_interface.h"
+#endif // _3D_DISABLED
 
 class RendererViewport {
 public:

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -33,7 +33,14 @@
 
 #include "servers/rendering/storage/render_scene_buffers.h"
 #include "servers/rendering_server.h"
+
+#ifdef _3D_DISABLED
+// RendererSceneCull::render_camera is empty when 3D is disabled, but
+// it and RenderingMethod::render_camera have a parameter for XRInterface.
+#define XRInterface RefCounted
+#else // 3D enabled
 #include "servers/xr/xr_interface.h"
+#endif // _3D_DISABLED
 
 class RenderingMethod {
 public:

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -93,11 +93,13 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 
 	RSG::rasterizer->end_frame(p_swap_buffers);
 
+#ifndef _3D_DISABLED
 	XRServer *xr_server = XRServer::get_singleton();
 	if (xr_server != nullptr) {
 		// let our XR server know we're done so we can get our frame timing
 		xr_server->end_frame();
 	}
+#endif // _3D_DISABLED
 
 	RSG::canvas->update_visibility_notifiers();
 	RSG::scene->update_visibility_notifiers();


### PR DESCRIPTION
This PR disables XRServer and all XR classes when compiling without 3D. Also, this PR organizes `servers/SCsub`'s `SConscript` lines by alphabetizing them (except with physics and XR at the bottom). The XR modules already disable themselves when compiling without 3D, but in master the classes are still compiled and referenced by the rendering code, from the `main.cpp` file, and exposed to scripting.

Note: There is a code order change in `register_server_singletons`'s `add_singleton` calls. I don't think this will change behavior but please look at this.