### PR TITLE
Add support for accessing the Android-specific `assets` directory

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -68,7 +68,7 @@ String DirAccessJAndroid::get_next() {
 	if (_dir_next) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, "");
-		jstring str = (jstring)env->CallObjectMethod(dir_access_handler, _dir_next, get_access_type(), id);
+		jstring str = (jstring)env->CallObjectMethod(dir_access_handler, _dir_next, id);
 		if (!str) {
 			return "";
 		}
@@ -85,7 +85,7 @@ bool DirAccessJAndroid::current_is_dir() const {
 	if (_dir_is_dir) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, false);
-		return env->CallBooleanMethod(dir_access_handler, _dir_is_dir, get_access_type(), id);
+		return env->CallBooleanMethod(dir_access_handler, _dir_is_dir, id);
 	} else {
 		return false;
 	}
@@ -95,7 +95,7 @@ bool DirAccessJAndroid::current_is_hidden() const {
 	if (_current_is_hidden) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, false);
-		return env->CallBooleanMethod(dir_access_handler, _current_is_hidden, get_access_type(), id);
+		return env->CallBooleanMethod(dir_access_handler, _current_is_hidden, id);
 	}
 	return false;
 }
@@ -307,9 +307,9 @@ void DirAccessJAndroid::setup(jobject p_dir_access_handler) {
 	cls = (jclass)env->NewGlobalRef(c);
 
 	_dir_open = env->GetMethodID(cls, "dirOpen", "(ILjava/lang/String;)I");
-	_dir_next = env->GetMethodID(cls, "dirNext", "(II)Ljava/lang/String;");
-	_dir_close = env->GetMethodID(cls, "dirClose", "(II)V");
-	_dir_is_dir = env->GetMethodID(cls, "dirIsDir", "(II)Z");
+	_dir_next = env->GetMethodID(cls, "dirNext", "(I)Ljava/lang/String;");
+	_dir_close = env->GetMethodID(cls, "dirClose", "(I)V");
+	_dir_is_dir = env->GetMethodID(cls, "dirIsDir", "(I)Z");
 	_dir_exists = env->GetMethodID(cls, "dirExists", "(ILjava/lang/String;)Z");
 	_file_exists = env->GetMethodID(cls, "fileExists", "(ILjava/lang/String;)Z");
 	_get_drive_count = env->GetMethodID(cls, "getDriveCount", "(I)I");
@@ -318,7 +318,7 @@ void DirAccessJAndroid::setup(jobject p_dir_access_handler) {
 	_get_space_left = env->GetMethodID(cls, "getSpaceLeft", "(I)J");
 	_rename = env->GetMethodID(cls, "rename", "(ILjava/lang/String;Ljava/lang/String;)Z");
 	_remove = env->GetMethodID(cls, "remove", "(ILjava/lang/String;)Z");
-	_current_is_hidden = env->GetMethodID(cls, "isCurrentHidden", "(II)Z");
+	_current_is_hidden = env->GetMethodID(cls, "isCurrentHidden", "(I)Z");
 }
 
 void DirAccessJAndroid::terminate() {
@@ -355,6 +355,6 @@ void DirAccessJAndroid::dir_close(int p_id) {
 	if (_dir_close) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL(env);
-		env->CallVoidMethod(dir_access_handler, _dir_close, get_access_type(), p_id);
+		env->CallVoidMethod(dir_access_handler, _dir_close, p_id);
 	}
 }

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -85,6 +85,9 @@ Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mo
 
 				case -2:
 					return ERR_FILE_NOT_FOUND;
+
+				case -5:
+					return ERR_UNAVAILABLE;
 			}
 		}
 
@@ -334,6 +337,8 @@ Error FileAccessFilesystemJAndroid::resize(int64_t p_length) {
 		switch (res) {
 			case 0:
 				return OK;
+			case -5:
+				return ERR_UNAVAILABLE;
 			case -4:
 				return ERR_INVALID_PARAMETER;
 			case -3:

--- a/platform/android/java/lib/src/org/godotengine/godot/io/StorageScope.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/StorageScope.kt
@@ -40,6 +40,11 @@ import java.io.File
  */
 internal enum class StorageScope {
 	/**
+	 * Covers the 'assets' directory
+	 */
+	ASSETS,
+
+	/**
 	 * Covers internal and external directories accessible to the app without restrictions.
 	 */
 	APP,
@@ -56,6 +61,10 @@ internal enum class StorageScope {
 
 	class Identifier(context: Context) {
 
+		companion object {
+			internal const val ASSETS_PREFIX = "assets://"
+		}
+
 		private val internalAppDir: String? = context.filesDir.canonicalPath
 		private val internalCacheDir: String? = context.cacheDir.canonicalPath
 		private val externalAppDir: String? = context.getExternalFilesDir(null)?.canonicalPath
@@ -69,6 +78,10 @@ internal enum class StorageScope {
 		fun identifyStorageScope(path: String?): StorageScope {
 			if (path == null) {
 				return UNKNOWN
+			}
+
+			if (path.startsWith(ASSETS_PREFIX)) {
+				return ASSETS
 			}
 
 			val pathFile = File(path)

--- a/platform/android/java/lib/src/org/godotengine/godot/io/directory/FilesystemDirectoryAccess.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/directory/FilesystemDirectoryAccess.kt
@@ -45,7 +45,7 @@ import java.io.File
 /**
  * Handles directories access with the internal and external filesystem.
  */
-internal class FilesystemDirectoryAccess(private val context: Context):
+internal class FilesystemDirectoryAccess(private val context: Context, private val storageScopeIdentifier: StorageScope.Identifier):
 	DirectoryAccessHandler.DirectoryAccess {
 
 	companion object {
@@ -54,7 +54,6 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 
 	private data class DirData(val dirFile: File, val files: Array<File>, var current: Int = 0)
 
-	private val storageScopeIdentifier = StorageScope.Identifier(context)
 	private val storageManager = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
 	private var lastDirId = STARTING_DIR_ID
 	private val dirs = SparseArray<DirData>()
@@ -63,7 +62,8 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 		// Directory access is available for shared storage on Android 11+
 		// On Android 10, access is also available as long as the `requestLegacyExternalStorage`
 		// tag is available.
-		return storageScopeIdentifier.identifyStorageScope(path) != StorageScope.UNKNOWN
+		val storageScope = storageScopeIdentifier.identifyStorageScope(path)
+		return storageScope != StorageScope.UNKNOWN && storageScope != StorageScope.ASSETS
 	}
 
 	override fun hasDirId(dirId: Int) = dirs.indexOfKey(dirId) >= 0

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/AssetData.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/AssetData.kt
@@ -1,0 +1,150 @@
+/**************************************************************************/
+/*  AssetData.kt                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.godot.io.file
+
+import android.content.Context
+import android.content.res.AssetManager
+import android.util.Log
+import org.godotengine.godot.io.directory.AssetsDirectoryAccess
+import java.io.IOException
+import java.io.InputStream
+import java.lang.UnsupportedOperationException
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.ReadableByteChannel
+
+/**
+ * Implementation of the [DataAccess] which handles access and interaction with files in the
+ * 'assets' directory
+ */
+internal class AssetData(context: Context, private val filePath: String, accessFlag: FileAccessFlags) : DataAccess() {
+
+	companion object {
+		private val TAG = AssetData::class.java.simpleName
+
+		fun fileExists(context: Context, path: String): Boolean {
+			val assetsPath = AssetsDirectoryAccess.getAssetsPath(path)
+			try {
+				val files = context.assets.list(assetsPath) ?: return false
+				// Empty directories don't get added to the 'assets' directory, so
+				// if files.length > 0 ==> path is directory
+				// if files.length == 0 ==> path is file
+				return files.isEmpty()
+			} catch (e: IOException) {
+				Log.e(TAG, "Exception on fileExists", e)
+				return false
+			}
+		}
+
+		fun fileLastModified(path: String) = 0L
+
+		fun delete(path: String) = false
+
+		fun rename(from: String, to: String) = false
+	}
+
+	private val inputStream: InputStream
+	private val readChannel: ReadableByteChannel
+
+	private var position = 0L
+	private val length: Long
+
+	init {
+		if (accessFlag == FileAccessFlags.WRITE) {
+			throw UnsupportedOperationException("Writing to the 'assets' directory is not supported")
+		}
+
+		val assetsPath = AssetsDirectoryAccess.getAssetsPath(filePath)
+		inputStream = context.assets.open(assetsPath, AssetManager.ACCESS_BUFFER)
+		readChannel = Channels.newChannel(inputStream)
+
+		length = inputStream.available().toLong()
+	}
+
+	override fun close() {
+		try {
+			inputStream.close()
+		} catch (e: IOException) {
+			Log.w(TAG, "Exception when closing file $filePath.", e)
+		}
+	}
+
+	override fun flush() {
+		Log.w(TAG, "flush() is not supported.")
+	}
+
+	override fun seek(position: Long) {
+		try {
+			inputStream.skip(position)
+
+			this.position = position
+			if (this.position > length) {
+				this.position = length
+				endOfFile = true
+			} else {
+				endOfFile = false
+			}
+
+		} catch(e: IOException) {
+			Log.w(TAG, "Exception when seeking file $filePath.", e)
+		}
+	}
+
+	override fun resize(length: Long): Int {
+		Log.w(TAG, "resize() is not supported.")
+		return FileErrors.UNSUPPORTED_OPERATION.nativeValue
+	}
+
+	override fun position() = position
+
+	override fun size() = length
+
+	override fun read(buffer: ByteBuffer): Int {
+		return try {
+			val readBytes = readChannel.read(buffer)
+			if (readBytes == -1) {
+				endOfFile = true
+				0
+			} else {
+				position += readBytes
+				endOfFile = position() >= size()
+				readBytes
+			}
+		} catch (e: IOException) {
+			Log.w(TAG, "Exception while reading from $filePath.", e)
+			0
+		}
+	}
+
+	override fun write(buffer: ByteBuffer) {
+		Log.w(TAG, "write() is not supported.")
+	}
+}

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
@@ -34,11 +34,13 @@ import android.content.Context
 import android.os.Build
 import android.util.Log
 import org.godotengine.godot.io.StorageScope
+import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels.ClosedChannelException
 import java.nio.channels.FileChannel
 import java.nio.channels.NonWritableChannelException
+import kotlin.jvm.Throws
 import kotlin.math.max
 
 /**
@@ -47,11 +49,12 @@ import kotlin.math.max
  * Its derived instances provide concrete implementations to handle regular file access, as well
  * as file access through the media store API on versions of Android were scoped storage is enabled.
  */
-internal abstract class DataAccess(private val filePath: String) {
+internal abstract class DataAccess {
 
 	companion object {
 		private val TAG = DataAccess::class.java.simpleName
 
+		@Throws(java.lang.Exception::class, FileNotFoundException::class)
 		fun generateDataAccess(
 			storageScope: StorageScope,
 			context: Context,
@@ -60,6 +63,8 @@ internal abstract class DataAccess(private val filePath: String) {
 		): DataAccess? {
 			return when (storageScope) {
 				StorageScope.APP -> FileData(filePath, accessFlag)
+
+				StorageScope.ASSETS -> AssetData(context, filePath, accessFlag)
 
 				StorageScope.SHARED -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 					MediaStoreData(context, filePath, accessFlag)
@@ -74,7 +79,13 @@ internal abstract class DataAccess(private val filePath: String) {
 		fun fileExists(storageScope: StorageScope, context: Context, path: String): Boolean {
 			return when(storageScope) {
 				StorageScope.APP -> FileData.fileExists(path)
-				StorageScope.SHARED -> MediaStoreData.fileExists(context, path)
+				StorageScope.ASSETS -> AssetData.fileExists(context, path)
+				StorageScope.SHARED -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+					MediaStoreData.fileExists(context, path)
+				} else {
+					false
+				}
+
 				StorageScope.UNKNOWN -> false
 			}
 		}
@@ -82,7 +93,13 @@ internal abstract class DataAccess(private val filePath: String) {
 		fun fileLastModified(storageScope: StorageScope, context: Context, path: String): Long {
 			return when(storageScope) {
 				StorageScope.APP -> FileData.fileLastModified(path)
-				StorageScope.SHARED -> MediaStoreData.fileLastModified(context, path)
+				StorageScope.ASSETS -> AssetData.fileLastModified(path)
+				StorageScope.SHARED -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+					MediaStoreData.fileLastModified(context, path)
+				} else {
+					0L
+				}
+
 				StorageScope.UNKNOWN -> 0L
 			}
 		}
@@ -90,7 +107,13 @@ internal abstract class DataAccess(private val filePath: String) {
 		fun removeFile(storageScope: StorageScope, context: Context, path: String): Boolean {
 			return when(storageScope) {
 				StorageScope.APP -> FileData.delete(path)
-				StorageScope.SHARED -> MediaStoreData.delete(context, path)
+				StorageScope.ASSETS -> AssetData.delete(path)
+				StorageScope.SHARED -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+					MediaStoreData.delete(context, path)
+				} else {
+					false
+				}
+
 				StorageScope.UNKNOWN -> false
 			}
 		}
@@ -98,103 +121,120 @@ internal abstract class DataAccess(private val filePath: String) {
 		fun renameFile(storageScope: StorageScope, context: Context, from: String, to: String): Boolean {
 			return when(storageScope) {
 				StorageScope.APP -> FileData.rename(from, to)
-				StorageScope.SHARED -> MediaStoreData.rename(context, from, to)
+				StorageScope.ASSETS -> AssetData.rename(from, to)
+				StorageScope.SHARED -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+					MediaStoreData.rename(context, from, to)
+				} else {
+					false
+				}
+
 				StorageScope.UNKNOWN -> false
 			}
 		}
 	}
 
-	protected abstract val fileChannel: FileChannel
 	internal var endOfFile = false
-
-	fun close() {
-		try {
-			fileChannel.close()
-		} catch (e: IOException) {
-			Log.w(TAG, "Exception when closing file $filePath.", e)
-		}
-	}
-
-	fun flush() {
-		try {
-			fileChannel.force(false)
-		} catch (e: IOException) {
-			Log.w(TAG, "Exception when flushing file $filePath.", e)
-		}
-	}
-
-	fun seek(position: Long) {
-		try {
-			fileChannel.position(position)
-			endOfFile = position >= fileChannel.size()
-		} catch (e: Exception) {
-			Log.w(TAG, "Exception when seeking file $filePath.", e)
-		}
-	}
+	abstract fun close()
+	abstract fun flush()
+	abstract fun seek(position: Long)
+	abstract fun resize(length: Long): Int
+	abstract fun position(): Long
+	abstract fun size(): Long
+	abstract fun read(buffer: ByteBuffer): Int
+	abstract fun write(buffer: ByteBuffer)
 
 	fun seekFromEnd(positionFromEnd: Long) {
 		val positionFromBeginning = max(0, size() - positionFromEnd)
 		seek(positionFromBeginning)
 	}
 
-	fun resize(length: Long): Int {
-		return try {
-			fileChannel.truncate(length)
-			FileErrors.OK.nativeValue
-		} catch (e: NonWritableChannelException) {
-			FileErrors.FILE_CANT_OPEN.nativeValue
-		} catch (e: ClosedChannelException) {
-			FileErrors.FILE_CANT_OPEN.nativeValue
-		} catch (e: IllegalArgumentException) {
-			FileErrors.INVALID_PARAMETER.nativeValue
-		} catch (e: IOException) {
-			FileErrors.FAILED.nativeValue
-		}
-	}
+	abstract class FileChannelDataAccess(private val filePath: String) : DataAccess() {
+		protected abstract val fileChannel: FileChannel
 
-	fun position(): Long {
-		return try {
-			fileChannel.position()
+		override fun close() {
+			try {
+				fileChannel.close()
+			} catch (e: IOException) {
+				Log.w(TAG, "Exception when closing file $filePath.", e)
+			}
+		}
+
+		override fun flush() {
+			try {
+				fileChannel.force(false)
+			} catch (e: IOException) {
+				Log.w(TAG, "Exception when flushing file $filePath.", e)
+			}
+		}
+
+		override fun seek(position: Long) {
+			try {
+				fileChannel.position(position)
+				endOfFile = position >= fileChannel.size()
+			} catch (e: Exception) {
+				Log.w(TAG, "Exception when seeking file $filePath.", e)
+			}
+		}
+
+		override fun resize(length: Long): Int {
+			return try {
+				fileChannel.truncate(length)
+				FileErrors.OK.nativeValue
+			} catch (e: NonWritableChannelException) {
+				FileErrors.FILE_CANT_OPEN.nativeValue
+			} catch (e: ClosedChannelException) {
+				FileErrors.FILE_CANT_OPEN.nativeValue
+			} catch (e: IllegalArgumentException) {
+				FileErrors.INVALID_PARAMETER.nativeValue
+			} catch (e: IOException) {
+				FileErrors.FAILED.nativeValue
+			}
+		}
+
+		override fun position(): Long {
+			return try {
+				fileChannel.position()
+			} catch (e: IOException) {
+				Log.w(
+					TAG,
+					"Exception when retrieving position for file $filePath.",
+					e
+				)
+				0L
+			}
+		}
+
+		override fun size() = try {
+			fileChannel.size()
 		} catch (e: IOException) {
-			Log.w(
-				TAG,
-				"Exception when retrieving position for file $filePath.",
-				e
-			)
+			Log.w(TAG, "Exception when retrieving size for file $filePath.", e)
 			0L
 		}
-	}
 
-	fun size() = try {
-		fileChannel.size()
-	} catch (e: IOException) {
-		Log.w(TAG, "Exception when retrieving size for file $filePath.", e)
-		0L
-	}
-
-	fun read(buffer: ByteBuffer): Int {
-		return try {
-			val readBytes = fileChannel.read(buffer)
-			endOfFile = readBytes == -1 || (fileChannel.position() >= fileChannel.size())
-			if (readBytes == -1) {
+		override fun read(buffer: ByteBuffer): Int {
+			return try {
+				val readBytes = fileChannel.read(buffer)
+				endOfFile = readBytes == -1 || (fileChannel.position() >= fileChannel.size())
+				if (readBytes == -1) {
+					0
+				} else {
+					readBytes
+				}
+			} catch (e: IOException) {
+				Log.w(TAG, "Exception while reading from file $filePath.", e)
 				0
-			} else {
-				readBytes
 			}
-		} catch (e: IOException) {
-			Log.w(TAG, "Exception while reading from file $filePath.", e)
-			0
 		}
-	}
 
-	fun write(buffer: ByteBuffer) {
-		try {
-			val writtenBytes = fileChannel.write(buffer)
-			if (writtenBytes > 0) {
-				endOfFile = false
+		override fun write(buffer: ByteBuffer) {
+			try {
+				val writtenBytes = fileChannel.write(buffer)
+				if (writtenBytes > 0) {
+					endOfFile = false
+				}
+			} catch (e: IOException) {
+				Log.w(TAG, "Exception while writing to file $filePath.", e)
 			}
-		} catch (e: IOException) {
-			Log.w(TAG, "Exception while writing to file $filePath.", e)
 		}
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessFlags.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessFlags.kt
@@ -76,7 +76,7 @@ internal enum class FileAccessFlags(val nativeValue: Int) {
 
     companion object {
         fun fromNativeModeFlags(modeFlag: Int): FileAccessFlags? {
-            for (flag in values()) {
+            for (flag in entries) {
                 if (flag.nativeValue == modeFlag) {
                     return flag
                 }

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
@@ -35,6 +35,7 @@ import android.util.Log
 import android.util.SparseArray
 import org.godotengine.godot.io.StorageScope
 import java.io.FileNotFoundException
+import java.lang.UnsupportedOperationException
 import java.nio.ByteBuffer
 
 /**
@@ -118,6 +119,8 @@ class FileAccessHandler(val context: Context) {
 			} ?: INVALID_FILE_ID
 		} catch (e: FileNotFoundException) {
 			FileErrors.FILE_NOT_FOUND.nativeValue
+		} catch (e: UnsupportedOperationException) {
+			FileErrors.UNSUPPORTED_OPERATION.nativeValue
 		} catch (e: Exception) {
 			Log.w(TAG, "Error while opening $path", e)
 			INVALID_FILE_ID

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileData.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileData.kt
@@ -38,7 +38,7 @@ import java.nio.channels.FileChannel
 /**
  * Implementation of [DataAccess] which handles regular (not scoped) file access and interactions.
  */
-internal class FileData(filePath: String, accessFlag: FileAccessFlags) : DataAccess(filePath) {
+internal class FileData(filePath: String, accessFlag: FileAccessFlags) : DataAccess.FileChannelDataAccess(filePath) {
 
 	companion object {
 		private val TAG = FileData::class.java.simpleName
@@ -80,10 +80,10 @@ internal class FileData(filePath: String, accessFlag: FileAccessFlags) : DataAcc
 	override val fileChannel: FileChannel
 
 	init {
-		if (accessFlag == FileAccessFlags.WRITE) {
-			fileChannel = FileOutputStream(filePath, !accessFlag.shouldTruncate()).channel
+		fileChannel = if (accessFlag == FileAccessFlags.WRITE) {
+			FileOutputStream(filePath, !accessFlag.shouldTruncate()).channel
 		} else {
-			fileChannel = RandomAccessFile(filePath, accessFlag.getMode()).channel
+			RandomAccessFile(filePath, accessFlag.getMode()).channel
 		}
 
 		if (accessFlag.shouldTruncate()) {

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileErrors.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileErrors.kt
@@ -38,7 +38,8 @@ internal enum class FileErrors(val nativeValue: Int) {
 	FAILED(-1),
 	FILE_NOT_FOUND(-2),
 	FILE_CANT_OPEN(-3),
-	INVALID_PARAMETER(-4);
+	INVALID_PARAMETER(-4),
+	UNSUPPORTED_OPERATION(-5);
 
 	companion object {
 		fun fromNativeError(error: Int): FileErrors? {

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/MediaStoreData.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/MediaStoreData.kt
@@ -52,7 +52,7 @@ import java.nio.channels.FileChannel
  */
 @RequiresApi(Build.VERSION_CODES.Q)
 internal class MediaStoreData(context: Context, filePath: String, accessFlag: FileAccessFlags) :
-	DataAccess(filePath) {
+	DataAccess.FileChannelDataAccess(filePath) {
 
 	private data class DataItem(
 		val id: Long,


### PR DESCRIPTION
Android binaries contain a read-only `assets` directory which can be used to [access stored original files and directories](https://developer.android.com/guide/topics/resources/providing-resources#OriginalFiles).

This is the location used by the engine to store project files and metadata and on `template` (non-editor) builds of the engine, this location is mapped to the `RESOURCES` (`res://`) access type.

On `editor` builds of the engine, though it's included in the binary, this location can't be accessed given that on those builds, the `RESOURCES` access type maps to the opened project's directory. This prevents Android `editor` builds from accessing any files / contents stored in their `assets` directory.

This PR resolves the described issue by adding support for an Android-specific `assets://` _root_ which maps to the `assets` directory. 
On `template` builds, the `assets://` root has the same behavior as the `res://` root.
On `editor` builds, the `assets://` root maps to the Android editor build's `assets` directory, while the `res://` root maps to the selected / opened project's directory. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
