### PR TITLE
Fix some AcceptDialog argument types

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -44,14 +44,14 @@
 		</method>
 		<method name="register_text_enter">
 			<return type="void" />
-			<param index="0" name="line_edit" type="Control" />
+			<param index="0" name="line_edit" type="LineEdit" />
 			<description>
 				Registers a [LineEdit] in the dialog. When the enter key is pressed, the dialog will be accepted.
 			</description>
 		</method>
 		<method name="remove_button">
 			<return type="void" />
-			<param index="0" name="button" type="Control" />
+			<param index="0" name="button" type="Button" />
 			<description>
 				Removes the [param button] from the dialog. Does NOT free the [param button]. The [param button] must be a [Button] added with [method add_button] or [method add_cancel_button] method. After removal, pressing the [param button] will no longer emit this dialog's [signal custom_action] or [signal canceled] signals.
 			</description>

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -240,3 +240,11 @@ Validate extension JSON: Error: Field 'classes/EditorPlugin/methods/add_control_
 
 Added optional argument to add_control_to_bottom_panel and add_control_to_dock to specify a shortcut that toggles the bottom panel/dock's visibility.
 Compatibility method registered.
+
+
+GH-89419
+--------
+Validate extension JSON: Error: Field 'classes/AcceptDialog/methods/register_text_enter/arguments/0': type changed value in new API, from "Control" to "LineEdit".
+Validate extension JSON: Error: Field 'classes/AcceptDialog/methods/remove_button/arguments/0': type changed value in new API, from "Control" to "Button".
+
+Changed argument type to the more specific one actually expected by the method. Compatibility method registered.

--- a/scene/gui/dialogs.compat.inc
+++ b/scene/gui/dialogs.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  dialogs.compat.inc                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void AcceptDialog::_register_text_enter_bind_compat_89419(Control *p_line_edit) {
+	register_text_enter(Object::cast_to<LineEdit>(p_line_edit));
+}
+
+void AcceptDialog::_remove_button_bind_compat_89419(Control *p_button) {
+	remove_button(Object::cast_to<Button>(p_button));
+}
+
+void AcceptDialog::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("register_text_enter"), &AcceptDialog::_register_text_enter_bind_compat_89419);
+	ClassDB::bind_compatibility_method(D_METHOD("remove_button", "quadrant_size"), &AcceptDialog::_remove_button_bind_compat_89419);
+}
+
+#endif

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "dialogs.h"
+#include "dialogs.compat.inc"
 
 #include "core/os/keyboard.h"
 #include "core/string/print_string.h"
@@ -195,12 +196,9 @@ String AcceptDialog::get_ok_button_text() const {
 	return ok_button->get_text();
 }
 
-void AcceptDialog::register_text_enter(Control *p_line_edit) {
+void AcceptDialog::register_text_enter(LineEdit *p_line_edit) {
 	ERR_FAIL_NULL(p_line_edit);
-	LineEdit *line_edit = Object::cast_to<LineEdit>(p_line_edit);
-	if (line_edit) {
-		line_edit->connect("text_submitted", callable_mp(this, &AcceptDialog::_text_submitted));
-	}
+	p_line_edit->connect("text_submitted", callable_mp(this, &AcceptDialog::_text_submitted));
 }
 
 void AcceptDialog::_update_child_rects() {
@@ -329,31 +327,30 @@ Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 	return b;
 }
 
-void AcceptDialog::remove_button(Control *p_button) {
-	Button *button = Object::cast_to<Button>(p_button);
-	ERR_FAIL_NULL(button);
-	ERR_FAIL_COND_MSG(button->get_parent() != buttons_hbox, vformat("Cannot remove button %s as it does not belong to this dialog.", button->get_name()));
-	ERR_FAIL_COND_MSG(button == ok_button, "Cannot remove dialog's OK button.");
+void AcceptDialog::remove_button(Button *p_button) {
+	ERR_FAIL_NULL(p_button);
+	ERR_FAIL_COND_MSG(p_button->get_parent() != buttons_hbox, vformat("Cannot remove button %s as it does not belong to this dialog.", p_button->get_name()));
+	ERR_FAIL_COND_MSG(p_button == ok_button, "Cannot remove dialog's OK button.");
 
-	Control *right_spacer = Object::cast_to<Control>(button->get_meta("__right_spacer"));
+	Control *right_spacer = Object::cast_to<Control>(p_button->get_meta("__right_spacer"));
 	if (right_spacer) {
-		ERR_FAIL_COND_MSG(right_spacer->get_parent() != buttons_hbox, vformat("Cannot remove button %s as its associated spacer does not belong to this dialog.", button->get_name()));
+		ERR_FAIL_COND_MSG(right_spacer->get_parent() != buttons_hbox, vformat("Cannot remove button %s as its associated spacer does not belong to this dialog.", p_button->get_name()));
 	}
 
-	button->disconnect("visibility_changed", callable_mp(this, &AcceptDialog::_custom_button_visibility_changed));
-	if (button->is_connected("pressed", callable_mp(this, &AcceptDialog::_custom_action))) {
-		button->disconnect("pressed", callable_mp(this, &AcceptDialog::_custom_action));
+	p_button->disconnect("visibility_changed", callable_mp(this, &AcceptDialog::_custom_button_visibility_changed));
+	if (p_button->is_connected("pressed", callable_mp(this, &AcceptDialog::_custom_action))) {
+		p_button->disconnect("pressed", callable_mp(this, &AcceptDialog::_custom_action));
 	}
-	if (button->is_connected("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed))) {
-		button->disconnect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
+	if (p_button->is_connected("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed))) {
+		p_button->disconnect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
 	}
 
 	if (right_spacer) {
 		buttons_hbox->remove_child(right_spacer);
-		button->remove_meta("__right_spacer");
+		p_button->remove_meta("__right_spacer");
 		right_spacer->queue_free();
 	}
-	buttons_hbox->remove_child(button);
+	buttons_hbox->remove_child(p_button);
 
 	child_controls_changed();
 	if (is_visible()) {

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -83,16 +83,23 @@ protected:
 	void _ok_pressed();
 	void _cancel_pressed();
 
+#ifndef DISABLE_DEPRECATED
+	void _register_text_enter_bind_compat_89419(Control *p_line_edit);
+	void _remove_button_bind_compat_89419(Control *p_button);
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	Label *get_label() { return message_label; }
 	static void set_swap_cancel_ok(bool p_swap);
 
-	void register_text_enter(Control *p_line_edit);
+	void register_text_enter(LineEdit *p_line_edit);
 
 	Button *get_ok_button() { return ok_button; }
 	Button *add_button(const String &p_text, bool p_right = false, const String &p_action = "");
 	Button *add_cancel_button(const String &p_cancel = "");
-	void remove_button(Control *p_button);
+	void remove_button(Button *p_button);
 
 	void set_hide_on_ok(bool p_hide);
 	bool get_hide_on_ok() const;


### PR DESCRIPTION
Some AcceptDialog expect specific node types, but they use Control as argument. Probably a legacy thing, which this PR fixes.

I added compatibility methods, but this breaks compatibility for GDScript if you used these methods incorrectly (e.g. `register_text_enter()` called with non-LineEdit will now print error instead of doing nothing).