### PR TITLE
Ensure specialization constants come sorted from reflection

### DIFF
--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -912,6 +912,8 @@ public:
 
 	struct ShaderSpecializationConstant : public PipelineSpecializationConstant {
 		BitField<ShaderStage> stages;
+
+		bool operator<(const ShaderSpecializationConstant &p_other) const { return constant_id < p_other.constant_id; }
 	};
 
 	struct ShaderDescription {

--- a/servers/rendering/rendering_device_driver.cpp
+++ b/servers/rendering/rendering_device_driver.cpp
@@ -265,6 +265,8 @@ Error RenderingDeviceDriver::_reflect_spirv(VectorView<ShaderStageSPIRVData> p_s
 							r_reflection.specialization_constants.push_back(sconst);
 						}
 					}
+
+					r_reflection.specialization_constants.sort();
 				}
 			}
 


### PR DESCRIPTION
Although it's not the end of the world, spec constants can come not sorted by `constant_id`. Ensuring they are sorted makes things easier for third-party code (extensions, etc.) that parses them.

If at some point `spirv_reflect` includes support for spec constants upstream, we may no longer need this patch, provided their code already sorts them. In the meantime, it's much easier for us to sort in Godot-land, where we have `sort()` than trying to extend the patch to include a sorting algo in the C code of `spirv_reflect`.