### PR TITLE
Pre-commit: Fix `copyright_headers.py` to run on all relevant files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,10 @@ repos:
         entry: python3 misc/scripts/copyright_headers.py
         exclude: |
           (?x)^(
-            tests/python_build.*|
             .*thirdparty.*|
-            .*platform/android/java/lib/src/com.*|
             .*-so_wrap.*|
+            core/math/bvh_.*\.inc$|
+            platform/android/java/lib/src/com.*|
             platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView.*|
             platform/android/java/lib/src/org/godotengine/godot/gl/EGLLogWrapper.*|
             platform/android/java/lib/src/org/godotengine/godot/utils/ProcessPhoenix.*

--- a/misc/scripts/copyright_headers.py
+++ b/misc/scripts/copyright_headers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import sys
 
 header = """\
@@ -35,58 +36,61 @@ header = """\
 /**************************************************************************/
 """
 
-fname = sys.argv[1]
+if len(sys.argv) < 2:
+    print("Invalid usage of copyright_headers.py, it should be called with a path to one or multiple files.")
+    sys.exit(1)
 
-# Handle replacing $filename with actual filename and keep alignment
-fsingle = fname.strip()
-if fsingle.find("/") != -1:
-    fsingle = fsingle[fsingle.rfind("/") + 1 :]
-rep_fl = "$filename"
-rep_fi = fsingle
-len_fl = len(rep_fl)
-len_fi = len(rep_fi)
-# Pad with spaces to keep alignment
-if len_fi < len_fl:
-    for x in range(len_fl - len_fi):
-        rep_fi += " "
-elif len_fl < len_fi:
-    for x in range(len_fi - len_fl):
-        rep_fl += " "
-if header.find(rep_fl) != -1:
-    text = header.replace(rep_fl, rep_fi)
-else:
-    text = header.replace("$filename", fsingle)
-text += "\n"
+for f in sys.argv[1:]:
+    fname = f
 
-# We now have the proper header, so we want to ignore the one in the original file
-# and potentially empty lines and badly formatted lines, while keeping comments that
-# come after the header, and then keep everything non-header unchanged.
-# To do so, we skip empty lines that may be at the top in a first pass.
-# In a second pass, we skip all consecutive comment lines starting with "/*",
-# then we can append the rest (step 2).
+    # Handle replacing $filename with actual filename and keep alignment
+    fsingle = os.path.basename(fname.strip())
+    rep_fl = "$filename"
+    rep_fi = fsingle
+    len_fl = len(rep_fl)
+    len_fi = len(rep_fi)
+    # Pad with spaces to keep alignment
+    if len_fi < len_fl:
+        for x in range(len_fl - len_fi):
+            rep_fi += " "
+    elif len_fl < len_fi:
+        for x in range(len_fi - len_fl):
+            rep_fl += " "
+    if header.find(rep_fl) != -1:
+        text = header.replace(rep_fl, rep_fi)
+    else:
+        text = header.replace("$filename", fsingle)
+    text += "\n"
 
-with open(fname.strip(), "r") as fileread:
-    line = fileread.readline()
-    header_done = False
+    # We now have the proper header, so we want to ignore the one in the original file
+    # and potentially empty lines and badly formatted lines, while keeping comments that
+    # come after the header, and then keep everything non-header unchanged.
+    # To do so, we skip empty lines that may be at the top in a first pass.
+    # In a second pass, we skip all consecutive comment lines starting with "/*",
+    # then we can append the rest (step 2).
 
-    while line.strip() == "":  # Skip empty lines at the top
+    with open(fname.strip(), "r") as fileread:
         line = fileread.readline()
+        header_done = False
 
-    if line.find("/**********") == -1:  # Godot header starts this way
-        # Maybe starting with a non-Godot comment, abort header magic
-        header_done = True
+        while line.strip() == "":  # Skip empty lines at the top
+            line = fileread.readline()
 
-    while not header_done:  # Handle header now
-        if line.find("/*") != 0:  # No more starting with a comment
+        if line.find("/**********") == -1:  # Godot header starts this way
+            # Maybe starting with a non-Godot comment, abort header magic
             header_done = True
-            if line.strip() != "":
-                text += line
-        line = fileread.readline()
 
-    while line != "":  # Dump everything until EOF
-        text += line
-        line = fileread.readline()
+        while not header_done:  # Handle header now
+            if line.find("/*") != 0:  # No more starting with a comment
+                header_done = True
+                if line.strip() != "":
+                    text += line
+            line = fileread.readline()
 
-# Write
-with open(fname.strip(), "w", encoding="utf-8", newline="\n") as filewrite:
-    filewrite.write(text)
+        while line != "":  # Dump everything until EOF
+            text += line
+            line = fileread.readline()
+
+    # Write
+    with open(fname.strip(), "w", encoding="utf-8", newline="\n") as filewrite:
+        filewrite.write(text)


### PR DESCRIPTION
It was only running on the first file passed by pre-commit, instead of all. Fixes compatibility with Windows paths to get the basename.

CC @KoBeWi @EIREXE I believe this should fix both issues you raised today.