### PR TITLE
Add `String.number_format()` method for more readable large numbers

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4360,6 +4360,35 @@ String String::pad_zeros(int p_digits) const {
 	}
 }
 
+String String::format_number(const String &p_delimiter_separator, const String &p_decimal_separator, int p_delimiter_interval) const {
+	ERR_FAIL_COND_V_MSG(p_delimiter_interval <= 0, *this, vformat("Delimiter interval for number formatting must be positive (%d specified).", p_delimiter_interval));
+
+	const String s = *this;
+	const bool is_negative = s.begins_with("-");
+	const String s_trimmed = s.trim_prefix("-");
+	const bool is_hexadecimal = s_trimmed.begins_with("0x");
+	PackedStringArray split = s_trimmed.trim_prefix("0x").split(".");
+
+	const String integer = split[0];
+	const String fractional = split.size() >= 2 ? split[1] : "";
+
+	String new_string;
+	int count = p_delimiter_interval - 1;
+	for (int i = integer.size() - 1; i >= 0; i--) {
+		new_string = integer[i] + new_string;
+		count++;
+		if (i != 0 && i != (integer.size() - 1) && count % p_delimiter_interval == 0) {
+			new_string = p_delimiter_separator + new_string;
+		}
+	}
+
+	if (!fractional.is_empty()) {
+		new_string += p_decimal_separator + fractional;
+	}
+
+	return String(is_negative ? "-" : "") + String(is_hexadecimal ? "0x" : "") + new_string;
+}
+
 String String::trim_prefix(const String &p_prefix) const {
 	String s = *this;
 	if (s.begins_with(p_prefix)) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -310,6 +310,7 @@ public:
 	String erase(int p_pos, int p_chars = 1) const;
 	String pad_decimals(int p_digits) const;
 	String pad_zeros(int p_digits) const;
+	String format_number(const String &p_thousands_separator = ",", const String &p_decimal_separator = ".", int p_delimiter_interval = 3) const;
 	String trim_prefix(const String &p_prefix) const;
 	String trim_suffix(const String &p_suffix) const;
 	String lpad(int min_length, const String &character = " ") const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1735,6 +1735,7 @@ static void _register_variant_builtin_methods() {
 	bind_string_method(rpad, sarray("min_length", "character"), varray(" "));
 	bind_string_method(pad_decimals, sarray("digits"), varray());
 	bind_string_method(pad_zeros, sarray("digits"), varray());
+	bind_string_method(format_number, sarray("delimiter_separator", "decimal_separator", "delimiter_interval"), varray(",", ".", 3));
 	bind_string_method(trim_prefix, sarray("prefix"), varray());
 	bind_string_method(trim_suffix, sarray("suffix"), varray());
 

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -242,6 +242,25 @@
 				[b]Note:[/b] In C#, it's recommended to [url=https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated]interpolate strings with "$"[/url], instead.
 			</description>
 		</method>
+		<method name="format_number" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="delimiter_separator" type="String" />
+			<param index="1" name="decimal_separator" type="String" default="&quot;,&quot;" />
+			<param index="2" name="delimiter_interval" type="int" default="&quot;.&quot;" />
+			<description>
+				Formats the string representing a number to make its integral part contain separators at regular intervals (thousands by default). This improves readability of large numbers. The decimal separator can also optionally be replaced from its default comma character. Negative and hexadecimal numbers are also supported ([code]-[/code] and [code]0x[/code] prefixes are ignored by the delimiter interval). See also [method pad_decimals], [method pad_zeros] and [method humanize_size].
+				[codeblock]
+				print(str(12345.6).format_number())  # Prints 12,345.678
+
+				print(str(12345.6).format_number(" ", ","))  # Prints 12 345,678
+				print(str(12345.6).pad_decimals(4).format_number())  # Prints 12,345.6000
+				print("0x00060d07".format_number(" ", ".", 4))  # Prints 0x0006 0d07
+
+				[/codeblock]
+				[b]Note:[/b] When using internationalization, consider [method TextServer.format_number] (which internally uses this method with most languages) instead of using this method directly. This allows for better internationalization support, as the thousands and decimal separators will automatically be selected according to the current language (or language override passed as a parameter).
+				[b]Tip:[/b] [method format_number] can be used together with [method pad_decimals] and/or [method pad_zeros] by chaining them. The correct order to use is [code]str(...).pad_zeros(...).format_number()[/code] or [code]str(...).pad_decimals(...).format_number()[/code]. Otherwise, leading zeros will not contain the delimiter separator and they won't be taken into account for formatting the rest of the number.
+			</description>
+		</method>
 		<method name="get_base_dir" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -360,7 +379,7 @@
 			<return type="String" />
 			<param index="0" name="size" type="int" />
 			<description>
-				Converts [param size] which represents a number of bytes into a human-readable form.
+				Converts [param size] which represents a number of bytes into a human-readable form. See also [method format_number].
 				The result is in [url=https://en.wikipedia.org/wiki/Binary_prefix#IEC_prefixes]IEC prefix format[/url], which may end in either [code]"B"[/code], [code]"KiB"[/code], [code]"MiB"[/code], [code]"GiB"[/code], [code]"TiB"[/code], [code]"PiB"[/code], or [code]"EiB"[/code].
 			</description>
 		</method>
@@ -680,14 +699,14 @@
 			<return type="String" />
 			<param index="0" name="digits" type="int" />
 			<description>
-				Formats the string representing a number to have an exact number of [param digits] [i]after[/i] the decimal point.
+				Formats the string representing a number to have an exact number of [param digits] [i]after[/i] the decimal point. See also [method pad_zeros] and [method format_number].
 			</description>
 		</method>
 		<method name="pad_zeros" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="digits" type="int" />
 			<description>
-				Formats the string representing a number to have an exact number of [param digits] [i]before[/i] the decimal point.
+				Formats the string representing a number to have an exact number of [param digits] [i]before[/i] the decimal point. See also [method pad_decimals] and [method format_number].
 			</description>
 		</method>
 		<method name="path_join" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -226,6 +226,14 @@
 				[b]Note:[/b] In C#, it's recommended to [url=https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated]interpolate strings with "$"[/url], instead.
 			</description>
 		</method>
+		<method name="format_number" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="delimiter_separator" type="String" />
+			<param index="1" name="decimal_separator" type="String" default="&quot;,&quot;" />
+			<param index="2" name="delimiter_interval" type="int" default="&quot;.&quot;" />
+			<description>
+			</description>
+		</method>
 		<method name="get_base_dir" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -999,7 +999,7 @@
 			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" default="&quot;&quot;" />
 			<description>
-				Converts a number from the Western Arabic (0..9) to the numeral systems used in [param language].
+				Converts a number from the Western Arabic (0..9) to the numeral systems used in [param language]. If no numeral system conversion is required, separators for thousands are added to improve readability of large numbers, and the decimal separator is replaced to match the specified [param language]. See also [method String.format_number].
 				If [param language] is omitted, the active locale will be used.
 			</description>
 		</method>

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2878,9 +2878,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 			if (show_info) {
 				const String viewport_size = vformat(U"%d × %d", viewport->get_size().x, viewport->get_size().y);
 				String text;
-				text += vformat(TTR("X: %s\n"), rtos(current_camera->get_position().x).pad_decimals(1));
-				text += vformat(TTR("Y: %s\n"), rtos(current_camera->get_position().y).pad_decimals(1));
-				text += vformat(TTR("Z: %s\n"), rtos(current_camera->get_position().z).pad_decimals(1));
+				text += vformat(TTR("X: %s\n"), TS->format_number(rtos(current_camera->get_position().x).pad_decimals(1)));
+				text += vformat(TTR("Y: %s\n"), TS->format_number(rtos(current_camera->get_position().y).pad_decimals(1)));
+				text += vformat(TTR("Z: %s\n"), TS->format_number(rtos(current_camera->get_position().z).pad_decimals(1)));
 				text += "\n";
 				text += vformat(
 						TTR("Size: %s (%.1fMP)\n"),
@@ -2888,9 +2888,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 						viewport->get_size().x * viewport->get_size().y * 0.000001);
 
 				text += "\n";
-				text += vformat(TTR("Objects: %d\n"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_OBJECTS_IN_FRAME));
-				text += vformat(TTR("Primitives: %d\n"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_PRIMITIVES_IN_FRAME));
-				text += vformat(TTR("Draw Calls: %d"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_DRAW_CALLS_IN_FRAME));
+				text += vformat(TTR("Objects: %s\n"), TS->format_number(itos(viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_OBJECTS_IN_FRAME))));
+				text += vformat(TTR("Primitives: %s\n"), TS->format_number(itos(viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_PRIMITIVES_IN_FRAME))));
+				text += vformat(TTR("Draw Calls: %s"), TS->format_number(itos(viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_DRAW_CALLS_IN_FRAME))));
 
 				info_label->set_text(text);
 			}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -6704,6 +6704,9 @@ String TextServerAdvanced::_format_number(const String &p_string, const String &
 				}
 			}
 			break;
+		} else {
+			// Use fallback formatter for thousands separators and decimal character replacement.
+			return TextServer::format_number(p_string, p_language);
 		}
 	}
 	return res;

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -1435,7 +1435,8 @@ String TextServerExtension::format_number(const String &p_string, const String &
 	if (GDVIRTUAL_CALL(_format_number, p_string, p_language, ret)) {
 		return ret;
 	}
-	return p_string;
+
+	return TextServer::format_number(p_string, p_language);
 }
 
 String TextServerExtension::parse_number(const String &p_string, const String &p_language) const {

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "servers/text_server.h"
+#include "core/string/translation.h"
 #include "core/variant/typed_array.h"
 #include "servers/rendering_server.h"
 
@@ -2129,6 +2130,30 @@ bool TextServer::is_valid_identifier(const String &p_string) const {
 		}
 	}
 	return true;
+}
+
+String TextServer::format_number(const String &p_string, const String &p_language) const {
+	const String lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+
+	String thousands_separator = ",";
+	String decimal_separator = ".";
+
+	// Format number for common languages.
+	// https://en.wikipedia.org/wiki/Decimal_separator#Examples_of_use
+	if (!lang.begins_with("en")) {
+		if (lang.begins_with("de")) {
+			thousands_separator = ".";
+			decimal_separator = ",";
+		} else {
+			// Most English-speaking countries use a comma and period.
+			// In contrast, most other languages use SI style.
+			// Thin non-breaking space.
+			thousands_separator = U" ";
+			decimal_separator = ",";
+		}
+	}
+
+	return p_string.format_number(thousands_separator, decimal_separator);
 }
 
 TextServer::TextServer() {

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -517,12 +517,12 @@ public:
 	virtual int64_t shaped_text_prev_character_pos(const RID &p_shaped, int64_t p_pos) const;
 	virtual int64_t shaped_text_closest_character_pos(const RID &p_shaped, int64_t p_pos) const;
 
-	// The pen position is always placed on the baseline and moveing left to right.
+	// The pen position is always placed on the baseline and moving left to right.
 	virtual void shaped_text_draw(const RID &p_shaped, const RID &p_canvas, const Vector2 &p_pos, double p_clip_l = -1.0, double p_clip_r = -1.0, const Color &p_color = Color(1, 1, 1)) const;
 	virtual void shaped_text_draw_outline(const RID &p_shaped, const RID &p_canvas, const Vector2 &p_pos, double p_clip_l = -1.0, double p_clip_r = -1.0, int64_t p_outline_size = 1, const Color &p_color = Color(1, 1, 1)) const;
 
 	// Number conversion.
-	virtual String format_number(const String &p_string, const String &p_language = "") const = 0;
+	virtual String format_number(const String &p_string, const String &p_language = "") const;
 	virtual String parse_number(const String &p_string, const String &p_language = "") const = 0;
 	virtual String percent_sign(const String &p_language = "") const = 0;
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1190,6 +1190,76 @@ TEST_CASE("[String] pad") {
 	CHECK(s.pad_zeros(1) == U"10.10");
 }
 
+TEST_CASE("[String] format_number") {
+	// Examples with a space below use a thin space character, as opposed to a
+	// regular space character to follow SI conventions.
+	String s = String("");
+	CHECK(s.format_number() == "");
+	CHECK(s.format_number(U" ", ",") == U"");
+
+	s = String("0");
+	CHECK(s.format_number() == "0");
+	CHECK(s.format_number(U" ", ",") == U"0");
+
+	s = String("10.10");
+	CHECK(s.format_number() == "10.10");
+	CHECK(s.format_number(U" ", ",") == U"10,10");
+
+	s = String("1234");
+	CHECK(s.format_number() == "1,234");
+	CHECK(s.format_number(U" ", ",") == U"1 234");
+
+	s = String("-1234");
+	CHECK(s.format_number() == "-1,234");
+	CHECK(s.format_number(U" ", ",") == U"-1 234");
+
+	s = String("12345");
+	CHECK(s.format_number() == "12,345");
+	CHECK(s.format_number(U" ", ",") == U"12 345");
+
+	s = String("-12345");
+	CHECK(s.format_number() == "-12,345");
+	CHECK(s.format_number(U" ", ",") == U"-12 345");
+
+	s = String("123456789");
+	CHECK(s.format_number() == "123,456,789");
+	CHECK(s.format_number(U" ", ",") == U"123 456 789");
+
+	s = String("-123456789");
+	CHECK(s.format_number() == "-123,456,789");
+	CHECK(s.format_number(U" ", ",") == U"-123 456 789");
+
+	s = String("123456789.01");
+	CHECK(s.format_number() == "123,456,789.01");
+	CHECK(s.format_number(U" ", ",") == U"123 456 789,01");
+
+	s = String("-123456789.01");
+	CHECK(s.format_number() == "-123,456,789.01");
+	CHECK(s.format_number(U" ", ",") == U"-123 456 789,01");
+
+	s = String("123456789.01234567");
+	CHECK(s.format_number() == "123,456,789.01234567");
+	CHECK(s.format_number(U" ", ",") == U"123 456 789,01234567");
+
+	s = String("-123456789.01234567");
+	CHECK(s.format_number() == "-123,456,789.01234567");
+	CHECK(s.format_number(U" ", ",") == U"-123 456 789,01234567");
+
+	// Hexadecimal formatting with custom interval.
+	s = String("0x00060d07");
+	CHECK(s.format_number(" ", ".", 4) == "0x0006 0d07");
+
+	s = String("-0x00060d07");
+	CHECK(s.format_number(" ", ".", 4) == "-0x0006 0d07");
+
+	// Zero and negative intervals are invalid, but should not crash and return the string as-is.
+	s = String("123456");
+	ERR_PRINT_OFF;
+	CHECK(s.format_number(" ", ".", 0) == "123456");
+	CHECK(s.format_number(" ", ".", -5) == "123456");
+	ERR_PRINT_ON;
+}
+
 TEST_CASE("[String] is_subsequence_of") {
 	String a = "is subsequence of";
 	CHECK(String("sub").is_subsequence_of(a));

--- a/tests/servers/test_text_server.h
+++ b/tests/servers/test_text_server.h
@@ -660,6 +660,27 @@ TEST_SUITE("[TextServer]") {
 			}
 		}
 
+		SUBCASE("[TextServer] Number formatting") {
+			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
+				Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(i);
+				CHECK_FALSE_MESSAGE(ts.is_null(), "Invalid TS interface.");
+
+				CHECK(ts->format_number("") == "");
+				CHECK(ts->format_number("0") == "0");
+				CHECK(ts->format_number("10.10") == "10.10");
+				CHECK(ts->format_number("1234") == "1,234");
+				CHECK(ts->format_number("-1234") == "-1,234");
+				CHECK(ts->format_number("12345") == "12,345");
+				CHECK(ts->format_number("-12345") == "-12,345");
+				CHECK(ts->format_number("123456789") == "123,456,789");
+				CHECK(ts->format_number("-123456789") == "-123,456,789");
+				CHECK(ts->format_number("123456789.01") == "123,456,789.01");
+				CHECK(ts->format_number("-123456789.01") == "-123,456,789.01");
+				CHECK(ts->format_number("123456789.01234567") == "123,456,789.01234567");
+				CHECK(ts->format_number("-123456789.01234567") == "-123,456,789.01234567");
+			}
+		}
+
 		SUBCASE("[TextServer] Word break") {
 			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 				Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(i);


### PR DESCRIPTION
This is used in the editor to display large numbers such as in the View Information panel.

`TextServer.format_number()` automatically uses this method with the current language (if no language is specified), which benefits many locations in the editor such as the inspector, performance monitors and the 3D editor View Information panel.

Unit tests have been added for both `String.number_format()` and `TextServer.number_format()`.

- This closes https://github.com/godotengine/godot-proposals/issues/9289.

## Preview

### English

![Screenshot_20240311_224042](https://github.com/godotengine/godot/assets/180032/964f1bc5-2604-4510-8c39-5a5e74ea7026) | ![Screenshot_20240311_235852](https://github.com/godotengine/godot/assets/180032/e2e49a06-992b-4d05-93f3-8076e1d73e7d) | ![Screenshot_20240311_235917](https://github.com/godotengine/godot/assets/180032/25b023d9-6437-4603-8609-cbbac5510b67)
-|-|-

### French

| ![Screenshot_20240312_000354](https://github.com/godotengine/godot/assets/180032/e2aa2c56-6ba0-4928-90a6-4fb319dd3a2c) |
|-|