### PR TITLE
Add checks for scene type reimports

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1058,9 +1058,9 @@ void EditorNode::_resources_reimported(const Vector<String> &p_resources) {
 	// They are removed in reload_instances_with_path_in_edited_scenes
 	// so now we fix the scene tree
 	if (!scenes.is_empty()) {
-		Node *current = editor_data.get_edited_scene_root();
-		if (current) {
-			set_edited_scene(current);
+		Node *current_edited_root = editor_data.get_edited_scene_root();
+		if (current_edited_root) {
+			set_edited_scene(current_edited_root);
 		}
 	}
 }

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -196,7 +196,8 @@ void SceneTreeEditor::_toggle_visible(Node *p_node) {
 }
 
 void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
-	if (!p_node) {
+	// If the node is null or outside of the tree, don't do this stuff?
+	if (!p_node || !p_node->is_inside_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
-Removes duplicate scene that is added during reimport when it is safe to do so.
-Added some safeties to the set_edited_scene() function of the EditorNode script (doesn't check if the signal exists when disconnecting it, and same issue as the next point)
-Adds a safety to the _add_nodes() function of the SceneTreeEditor script (would print an error if the node had its parent changed from the viewport/null, which can happen in plugin scripts)

Could be improved by properly selecting the node directly to restore the node tree, instead of using set_edited_scene() on line 1063 of editor_node.cpp (possible slight efficiency gain)

Fixes #87451