### PR TITLE
Fix error on undoing the creation of a node that you are currently renaming

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -610,11 +610,6 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 		tree_dirty = false;
 		return;
 	}
-
-	if (tree->is_editing()) {
-		return;
-	}
-
 	updating_tree = true;
 	tree->clear();
 	if (get_scene_node()) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -113,6 +113,7 @@ void TreeItem::_change_tree(Tree *p_tree) {
 			tree->popup_edited_item = nullptr;
 			tree->popup_pressing_edited_item = nullptr;
 			tree->pressing_for_editor = false;
+			tree->popup_editor->hide();
 		}
 
 		if (tree->cache.hover_item == this) {
@@ -4082,10 +4083,6 @@ bool Tree::edit_selected(bool p_force_edit) {
 	}
 
 	return false;
-}
-
-bool Tree::is_editing() {
-	return popup_editor->is_visible();
 }
 
 void Tree::set_editor_selection(int p_from_line, int p_to_line, int p_from_column, int p_to_column, int p_caret) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -758,7 +758,6 @@ public:
 	int get_item_offset(TreeItem *p_item) const;
 	Rect2 get_item_rect(TreeItem *p_item, int p_column = -1, int p_button = -1) const;
 	bool edit_selected(bool p_force_edit = false);
-	bool is_editing();
 	void set_editor_selection(int p_from_line, int p_to_line, int p_from_column = -1, int p_to_column = -1, int p_caret = 0);
 
 	// First item that starts with the text, from the current focused item down and wraps around.


### PR DESCRIPTION
Fixes #87406

I'm not 100% sure why it was checking if the tree was editing an item and prevented update in this case but it does not seems to be causing any issue to remove it and it fixes the issue. I would really like to have the opinion of the person who first added this check.
It was added here #44831 to fix #44163. I tested and can't reproduce the bug with my PR. But since the bug stated that it was not happening every time I would really like if people could test it a bit more.

