### PR TITLE
Fix GCC build warning

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -353,7 +353,7 @@ static void _test_and_swap(T &p_elem, uint32_t p_a, uint32_t p_b) {
 }
 
 void AudioStreamInteractive::_inspector_array_swap_clip(uint32_t p_item_a, uint32_t p_item_b) {
-	ERR_FAIL_INDEX(p_item_a, (uint32_t)clip_count);
+	ERR_FAIL_UNSIGNED_INDEX(p_item_a, (uint32_t)clip_count);
 	ERR_FAIL_UNSIGNED_INDEX(p_item_b, (uint32_t)clip_count);
 
 	for (int i = 0; i < clip_count; i++) {


### PR DESCRIPTION
Fixes a GCC warning as error introduced with the merge of #64488.

`p_item_a` cannot be `< 0`, as it's a `uint32_t`.

```
In file included from ./core/object/object_id.h:34,
                 from ./core/object/message_queue.h:34,
                 from ./core/object/object.h:35,
                 from ./core/variant/binder_common.h:35,
                 from ./core/object/method_bind.h:34,
                 from ./core/object/class_db.h:34,
                 from ./core/object/ref_counted.h:34,
                 from ./core/io/resource_uid.h:34,
                 from ./core/io/resource.h:34,
                 from ./core/io/image.h:34,
                 from ./servers/audio/audio_stream.h:34,
                 from modules/interactive_music/audio_stream_interactive.h:34,
                 from modules/interactive_music/audio_stream_interactive.cpp:31:
modules/interactive_music/audio_stream_interactive.cpp: In member function 'void AudioStreamInteractive::_inspector_array_swap_clip(uint32_t, uint32_t)':
./core/error/error_macros.h:122:32: error: comparison of unsigned expression in '< 0' is always false [-Werror=type-limits]
  122 |         if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
      |                      ~~~~~~~~~~^~~
./core/typedefs.h:277:41: note: in definition of macro 'unlikely'
  277 | #define unlikely(x) __builtin_expect(!!(x), 0)
      |                                         ^
modules/interactive_music/audio_stream_interactive.cpp:356:9: note: in expansion of macro 'ERR_FAIL_INDEX'
  356 |         ERR_FAIL_INDEX(p_item_a, (uint32_t)clip_count);
      |         ^~~~~~~~~~~~~~
```