### PR TITLE
Core: Improve enum class & `BitField` functionality across repo

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -385,11 +385,11 @@ bool InputEventKey::is_echo() const {
 }
 
 Key InputEventKey::get_keycode_with_modifiers() const {
-	return keycode | (int64_t)get_modifiers_mask();
+	return keycode | get_modifiers_mask();
 }
 
 Key InputEventKey::get_physical_keycode_with_modifiers() const {
-	return physical_keycode | (int64_t)get_modifiers_mask();
+	return physical_keycode | get_modifiers_mask();
 }
 
 Key InputEventKey::get_key_label_with_modifiers() const {

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -289,19 +289,6 @@ constexpr Key operator-(Key a, Key b) {
 	return (Key)((int)a - (int)b);
 }
 
-constexpr Key operator&(Key a, Key b) {
-	return (Key)((int)a & (int)b);
-}
-
-constexpr Key operator|(Key a, Key b) {
-	return (Key)((int)a | (int)b);
-}
-
-constexpr Key &operator|=(Key &a, Key b) {
-	a = static_cast<Key>(static_cast<int>(a) | static_cast<int>(b));
-	return a;
-}
-
 constexpr Key &operator|=(Key &a, KeyModifierMask b) {
 	a = static_cast<Key>(static_cast<int>(a) | static_cast<int>(b));
 	return a;
@@ -330,10 +317,6 @@ constexpr Key operator|(KeyModifierMask a, Key b) {
 
 constexpr KeyModifierMask operator+(KeyModifierMask a, KeyModifierMask b) {
 	return (KeyModifierMask)((int)a + (int)b);
-}
-
-constexpr KeyModifierMask operator|(KeyModifierMask a, KeyModifierMask b) {
-	return (KeyModifierMask)((int)a | (int)b);
 }
 
 String keycode_get_string(Key p_code);

--- a/core/templates/bit_field.h
+++ b/core/templates/bit_field.h
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  bit_field.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef BIT_FIELD_H
+#define BIT_FIELD_H
+
+#include "core/typedefs.h"
+
+#include <type_traits>
+
+template <typename T, typename = void>
+class BitField {};
+
+// Legacy enums
+
+template <typename T>
+class BitField<T, std::enable_if_t<std::is_enum_v<T> && std::is_convertible_v<T, std::underlying_type_t<T>>>> {
+	using enum_t = std::underlying_type_t<T>;
+	enum_t value = 0;
+
+public:
+	constexpr void set_flag(T p_flag) { value |= static_cast<enum_t>(p_flag); }
+	constexpr bool has_flag(T p_flag) const { return value & static_cast<enum_t>(p_flag); }
+	constexpr bool is_empty() const { return value == 0; }
+	constexpr void clear_flag(T p_flag) { value &= ~static_cast<enum_t>(p_flag); }
+	constexpr void clear() { value = 0; }
+
+	constexpr BitField() = default;
+	constexpr BitField(T p_value) { value = static_cast<enum_t>(p_value); }
+	constexpr explicit operator T() const { return static_cast<T>(value); }
+
+	constexpr BitField(int64_t p_value) { value = static_cast<enum_t>(p_value); }
+	constexpr operator int64_t() const { return static_cast<int64_t>(value); }
+};
+
+// Enum classes
+
+template <typename T>
+class BitField<T, std::enable_if_t<std::is_enum_v<T> && !std::is_convertible_v<T, std::underlying_type_t<T>>>> {
+	using enum_t = std::underlying_type_t<T>;
+	enum_t value = 0;
+
+public:
+	constexpr void set_flag(T p_flag) { value |= static_cast<enum_t>(p_flag); }
+	constexpr bool has_flag(T p_flag) const { return value & static_cast<enum_t>(p_flag); }
+	constexpr bool is_empty() const { return value == 0; }
+	constexpr void clear_flag(T p_flag) { value &= ~static_cast<enum_t>(p_flag); }
+	constexpr void clear() { value = 0; }
+
+	constexpr BitField() = default;
+	constexpr BitField(T p_value) { value = static_cast<enum_t>(p_value); }
+	constexpr operator T() const { return static_cast<T>(value); }
+
+	template <typename V, std::enable_if_t<std::is_arithmetic_v<V>, int> = 0>
+	constexpr explicit BitField(V p_value) { value = static_cast<enum_t>(p_value); }
+	template <typename V, std::enable_if_t<std::is_arithmetic_v<V>, int> = 0>
+	constexpr explicit operator V() const { return static_cast<V>(value); }
+};
+
+#endif // BIT_FIELD_H

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -246,27 +246,6 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 	return GetTypeInfo<T>::get_class_info().class_name;
 }
 
-template <typename T>
-class BitField {
-	int64_t value = 0;
-
-public:
-	_FORCE_INLINE_ BitField<T> &set_flag(T p_flag) {
-		value |= (int64_t)p_flag;
-		return *this;
-	}
-	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & (int64_t)p_flag; }
-	_FORCE_INLINE_ bool is_empty() const { return value == 0; }
-	_FORCE_INLINE_ void clear_flag(T p_flag) { value &= ~(int64_t)p_flag; }
-	_FORCE_INLINE_ void clear() { value = 0; }
-	_FORCE_INLINE_ constexpr BitField() = default;
-	_FORCE_INLINE_ constexpr BitField(int64_t p_value) { value = p_value; }
-	_FORCE_INLINE_ constexpr BitField(T p_value) { value = (int64_t)p_value; }
-	_FORCE_INLINE_ operator int64_t() const { return value; }
-	_FORCE_INLINE_ operator Variant() const { return value; }
-	_FORCE_INLINE_ BitField<T> operator^(const BitField<T> &p_b) const { return BitField<T>(value ^ p_b.value); }
-};
-
 #define TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, m_impl)                                                                                            \
 	template <>                                                                                                                                  \
 	struct GetTypeInfo<m_impl> {                                                                                                                 \

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2400,14 +2400,6 @@ Variant::operator Vector<StringName>() const {
 	return to;
 }
 
-Variant::operator Side() const {
-	return (Side) operator int();
-}
-
-Variant::operator Orientation() const {
-	return (Orientation) operator int();
-}
-
 Variant::operator IPAddress() const {
 	if (type == PACKED_FLOAT32_ARRAY || type == PACKED_INT32_ARRAY || type == PACKED_FLOAT64_ARRAY || type == PACKED_INT64_ARRAY || type == PACKED_BYTE_ARRAY) {
 		Vector<int> addr = operator Vector<int>();

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -73,7 +73,7 @@ JoypadLinux::Joypad::~Joypad() {
 }
 
 void JoypadLinux::Joypad::reset() {
-	dpad = 0;
+	dpad.clear();
 	fd = -1;
 	for (int i = 0; i < MAX_ABS; i++) {
 		abs_map[i] = -1;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -509,7 +509,7 @@ BitField<MouseButtonMask> DisplayServerX11::mouse_get_button_state() const {
 		int root_x, root_y, win_x, win_y;
 		unsigned int mask;
 		if (XQueryPointer(x11_display, XRootWindow(x11_display, i), &root, &child, &root_x, &root_y, &win_x, &win_y, &mask)) {
-			BitField<MouseButtonMask> last_button_state = 0;
+			BitField<MouseButtonMask> last_button_state = MouseButtonMask::NONE;
 
 			if (mask & Button1Mask) {
 				last_button_state.set_flag(MouseButtonMask::LEFT);
@@ -530,7 +530,7 @@ BitField<MouseButtonMask> DisplayServerX11::mouse_get_button_state() const {
 			return last_button_state;
 		}
 	}
-	return 0;
+	return MouseButtonMask::NONE;
 }
 
 void DisplayServerX11::clipboard_set(const String &p_text) {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1406,7 +1406,7 @@ Point2i DisplayServerMacOS::mouse_get_position() const {
 }
 
 BitField<MouseButtonMask> DisplayServerMacOS::mouse_get_button_state() const {
-	BitField<MouseButtonMask> last_button_state = 0;
+	BitField<MouseButtonMask> last_button_state = MouseButtonMask::NONE;
 
 	NSUInteger buttons = [NSEvent pressedMouseButtons];
 	if (buttons & (1 << 0)) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -661,7 +661,7 @@ Point2i DisplayServerWindows::mouse_get_position() const {
 }
 
 BitField<MouseButtonMask> DisplayServerWindows::mouse_get_button_state() const {
-	BitField<MouseButtonMask> last_button_state = 0;
+	BitField<MouseButtonMask> last_button_state = MouseButtonMask::NONE;
 
 	if (GetKeyState(VK_LBUTTON) & (1 << 15)) {
 		last_button_state.set_flag(MouseButtonMask::LEFT);
@@ -4254,7 +4254,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			mb.instantiate();
 			mb->set_window_id(window_id);
 
-			BitField<MouseButtonMask> last_button_state = 0;
+			BitField<MouseButtonMask> last_button_state = MouseButtonMask::NONE;
 			if (IS_POINTER_FIRSTBUTTON_WPARAM(wParam)) {
 				last_button_state.set_flag(MouseButtonMask::LEFT);
 				mb->set_button_index(MouseButton::LEFT);
@@ -4420,7 +4420,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			mm->set_alt_pressed(mods.has_flag(WinKeyModifierMask::ALT));
 			mm->set_meta_pressed(mods.has_flag(WinKeyModifierMask::META));
 
-			BitField<MouseButtonMask> last_button_state = 0;
+			BitField<MouseButtonMask> last_button_state = MouseButtonMask::NONE;
 			if (IS_POINTER_FIRSTBUTTON_WPARAM(wParam)) {
 				last_button_state.set_flag(MouseButtonMask::LEFT);
 			}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1065,7 +1065,7 @@ void PopupMenu::_notification(int p_what) {
 
 		case NOTIFICATION_POST_POPUP: {
 			initial_button_mask = Input::get_singleton()->get_mouse_button_mask();
-			during_grabbed_click = (bool)initial_button_mask;
+			during_grabbed_click = !initial_button_mask.is_empty();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -498,7 +498,7 @@ Point2i DisplayServer::mouse_get_position() const {
 }
 
 BitField<MouseButtonMask> DisplayServer::mouse_get_button_state() const {
-	ERR_FAIL_V_MSG(0, "Mouse is not supported by this display server.");
+	ERR_FAIL_V_MSG(MouseButtonMask::NONE, "Mouse is not supported by this display server.");
 }
 
 void DisplayServer::clipboard_set(const String &p_text) {

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -4119,10 +4119,10 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 			Point2 caret_pos = code_edit->get_caret_draw_pos();
 			caret_pos.y += code_edit->get_line_height();
-			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::WHEEL_DOWN, 0, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::WHEEL_DOWN, MouseButtonMask::NONE, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 1);
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::WHEEL_UP, 0, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
 			/* Single click selects. */
@@ -4492,7 +4492,7 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 
 		Point2 caret_pos = code_edit->get_caret_draw_pos();
 		caret_pos.x += 60;
-		SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::NONE, 0, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::NONE, MouseButtonMask::NONE, Key::NONE);
 		CHECK(code_edit->get_text_for_symbol_lookup() == "this is s" + String::chr(0xFFFF) + "ome text");
 
 		SIGNAL_WATCH(code_edit, "symbol_validate");

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -7579,28 +7579,28 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 
 	// Scroll.
 	int v_scroll = text_edit->get_v_scroll();
-	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButtonMask::NONE, Key::NONE);
 	CHECK(text_edit->get_v_scroll() > v_scroll);
-	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
 	// smooth scroll speed.
 	text_edit->set_smooth_scroll_enabled(true);
 
 	v_scroll = text_edit->get_v_scroll();
-	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButtonMask::NONE, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
-	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
 	v_scroll = text_edit->get_v_scroll();
 	text_edit->set_v_scroll_speed(10000);
-	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButtonMask::NONE, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
-	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -327,7 +327,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 				SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 				CHECK(node_a->has_focus());
 
-				SEND_GUI_MOUSE_BUTTON_EVENT(on_b, MouseButton::RIGHT, (int)MouseButtonMask::LEFT | (int)MouseButtonMask::RIGHT, Key::NONE);
+				SEND_GUI_MOUSE_BUTTON_EVENT(on_b, MouseButton::RIGHT, MouseButtonMask::LEFT | MouseButtonMask::RIGHT, Key::NONE);
 				CHECK(node_a->has_focus());
 
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_b, MouseButton::RIGHT, MouseButtonMask::LEFT, Key::NONE);
@@ -342,12 +342,12 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 				SEND_GUI_MOUSE_BUTTON_EVENT(on_background, MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
 				CHECK_FALSE(root->gui_get_focus_owner());
 
-				SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, (int)MouseButtonMask::LEFT | (int)MouseButtonMask::RIGHT, Key::NONE);
+				SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::LEFT | MouseButtonMask::RIGHT, Key::NONE);
 				CHECK(node_a->has_focus());
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::RIGHT, Key::NONE);
 				CHECK(node_a->has_focus());
 
-				SEND_GUI_MOUSE_BUTTON_EVENT(on_b, MouseButton::LEFT, (int)MouseButtonMask::LEFT | (int)MouseButtonMask::RIGHT, Key::NONE);
+				SEND_GUI_MOUSE_BUTTON_EVENT(on_b, MouseButton::LEFT, MouseButtonMask::LEFT | MouseButtonMask::RIGHT, Key::NONE);
 				CHECK(node_b->has_focus());
 
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_d, MouseButton::LEFT, MouseButtonMask::RIGHT, Key::NONE);

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -209,12 +209,12 @@ int register_test_command(String p_command, TestFunc p_function);
 		MessageQueue::get_singleton()->flush();                                         \
 	}
 
-#define SEND_GUI_DOUBLE_CLICK(m_screen_pos, m_modifers)                          \
-	{                                                                            \
-		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, MouseButton::LEFT, 0, m_modifers); \
-		event->set_double_click(true);                                           \
-		_SEND_DISPLAYSERVER_EVENT(event);                                        \
-		MessageQueue::get_singleton()->flush();                                  \
+#define SEND_GUI_DOUBLE_CLICK(m_screen_pos, m_modifers)                                              \
+	{                                                                                                \
+		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, MouseButton::LEFT, MouseButtonMask::NONE, m_modifers); \
+		event->set_double_click(true);                                                               \
+		_SEND_DISPLAYSERVER_EVENT(event);                                                            \
+		MessageQueue::get_singleton()->flush();                                                      \
 	}
 
 // We toggle _print_error_enabled to prevent display server not supported warnings.


### PR DESCRIPTION
This PR lays the groundwork for transitioning entirely from legacy enums to enum classes, if so desired. A lot of quirks that were specific to enum classes are now smoothed out, without compromising qualified name & explicit conversion benefits. This is *especially* applicable to `BitField`, which now handles itself differently depending on if it contains a legacy enum or enum class. Part of this process was detaching it from `type_info.h` entirely, now existing as a template header without any dependency on `Variant`.

There's now specialized defines for binding enum classes, which adds bitwise operators. These operators are *strictly* against the enum class itself, so there's still no implicit conversions at play. Instead, this streamlines certain comparisons/assignments in argument parameters, most obviously with the `|` operator not requiring any `(int)` wrappers. Similarly, enum classes no longer require jumping through hoops with `Variant`, instead being handled via a template conditional constructor that will **only** accept enum classes.

Beyond that, two other minor adjustments were made in `BitField` specifically. One is the removal of `set_flag` returning a reference to itself, which wasn't used anywhere in the repo and has been a design pattern the repo generally avoids. The second is making the internal `value` of the bitfield be based on the enum's underlying type instead of `int64_t`, as there's otherwise going to be discrepancies between that value & what enum it's actually representing. I'm entirely fine reverting either or both if it's deemed necessary, but the latter point especially should probably have some alternative enforcement otherwise (require `int64_t`/`uint64_t` builtin type for `BitField` enums?).