### PR TITLE
Fix main editor button margins while using a custom theme

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -517,9 +517,8 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 
 		scene_root_parent->add_theme_style_override("panel", theme->get_stylebox(SNAME("Content"), EditorStringName(EditorStyles)));
 		bottom_panel->add_theme_style_override("panel", theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles)));
-		main_menu->add_theme_style_override("pressed", theme->get_stylebox(SNAME("MenuTransparent"), EditorStringName(EditorStyles)));
 		distraction_free->set_icon(theme->get_icon(SNAME("DistractionFree"), EditorStringName(EditorIcons)));
-		distraction_free->add_theme_style_override("pressed", theme->get_stylebox(SNAME("MenuTransparent"), EditorStringName(EditorStyles)));
+		distraction_free->add_theme_style_override("pressed", theme->get_stylebox("normal", "FlatMenuButton"));
 
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_SEARCH), theme->get_icon(SNAME("HelpSearch"), EditorStringName(EditorIcons)));
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_COPY_SYSTEM_INFO), theme->get_icon(SNAME("ActionCopy"), EditorStringName(EditorIcons)));
@@ -6638,7 +6637,7 @@ EditorNode::EditorNode() {
 
 	main_menu = memnew(MenuBar);
 	title_bar->add_child(main_menu);
-	main_menu->set_theme_type_variation("FlatMenuButton");
+	main_menu->set_theme_type_variation("MainMenuBar");
 	main_menu->set_start_index(0); // Main menu, add to the start of global menu.
 	main_menu->set_prefer_global_menu(global_menu);
 	main_menu->set_switch_on_hover(true);

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -50,10 +50,6 @@ void EditorBottomPanel::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			expand_button->set_icon(get_editor_theme_icon(SNAME("ExpandBottomDock")));
-			for (int i = 0; i < items.size(); i++) {
-				items.write[i].button->add_theme_style_override("pressed", get_theme_stylebox(SNAME("MenuTransparent"), EditorStringName(EditorStyles)));
-				items.write[i].button->add_theme_style_override("hover_pressed", get_theme_stylebox(SNAME("MenuHover"), EditorStringName(EditorStyles)));
-			}
 		} break;
 	}
 }
@@ -160,7 +156,7 @@ void EditorBottomPanel::load_layout_from_config(Ref<ConfigFile> p_config_file, c
 
 Button *EditorBottomPanel::add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut, bool p_at_front) {
 	Button *tb = memnew(Button);
-	tb->set_theme_type_variation("FlatMenuButton");
+	tb->set_theme_type_variation("BottomPanelButton");
 	tb->connect("toggled", callable_mp(this, &EditorBottomPanel::_switch_by_control).bind(p_item));
 	tb->set_drag_forwarding(Callable(), callable_mp(this, &EditorBottomPanel::_button_drag_hover).bind(tb, p_item), Callable());
 	tb->set_text(p_text);

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1742,29 +1742,40 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_stylebox("ScriptEditorPanelFloating", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
 		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
 
-		// Bottom panel.
-		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
-		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
-		p_theme->set_stylebox("BottomPanel", EditorStringName(EditorStyles), style_bottom_panel);
-
 		// Main menu.
 		Ref<StyleBoxFlat> menu_transparent_style = p_config.button_style->duplicate();
 		menu_transparent_style->set_bg_color(Color(1, 1, 1, 0));
 		menu_transparent_style->set_border_width_all(0);
-		Ref<StyleBoxFlat> main_screen_button_transparent = menu_transparent_style->duplicate();
+		Ref<StyleBoxFlat> main_screen_button_hover = p_config.button_style_hover->duplicate();
 		for (int i = 0; i < 4; i++) {
-			menu_transparent_style->set_content_margin((Side)i, p_config.button_style->get_margin((Side)i) + p_config.button_style->get_border_width((Side)i));
+			menu_transparent_style->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+			main_screen_button_hover->set_content_margin((Side)i, p_config.button_style_hover->get_content_margin((Side)i));
 		}
-		p_theme->set_stylebox("MenuTransparent", EditorStringName(EditorStyles), menu_transparent_style);
-		p_theme->set_stylebox("MenuHover", EditorStringName(EditorStyles), p_config.button_style_hover);
-		p_theme->set_stylebox("normal", "MainScreenButton", main_screen_button_transparent);
-		p_theme->set_stylebox("pressed", "MainScreenButton", main_screen_button_transparent);
-		p_theme->set_stylebox("hover_pressed", "MainScreenButton", p_config.button_style_hover);
+		p_theme->set_stylebox("normal", "MainScreenButton", menu_transparent_style);
+		p_theme->set_stylebox("pressed", "MainScreenButton", menu_transparent_style);
+		p_theme->set_stylebox("hover", "MainScreenButton", main_screen_button_hover);
+		p_theme->set_stylebox("hover_pressed", "MainScreenButton", main_screen_button_hover);
+
+		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
+		p_theme->set_stylebox("normal", "MainMenuBar", menu_transparent_style);
+		p_theme->set_stylebox("pressed", "MainMenuBar", main_screen_button_hover);
+		p_theme->set_stylebox("hover", "MainMenuBar", main_screen_button_hover);
+		p_theme->set_stylebox("hover_pressed", "MainMenuBar", main_screen_button_hover);
 
 		// Run bar.
 		p_theme->set_type_variation("RunBarButton", "FlatMenuButton");
 		p_theme->set_stylebox("disabled", "RunBarButton", menu_transparent_style);
 		p_theme->set_stylebox("pressed", "RunBarButton", menu_transparent_style);
+
+		// Bottom panel.
+		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
+		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("BottomPanel", EditorStringName(EditorStyles), style_bottom_panel);
+		p_theme->set_type_variation("BottomPanelButton", "FlatMenuButton");
+		p_theme->set_stylebox("normal", "BottomPanelButton", menu_transparent_style);
+		p_theme->set_stylebox("pressed", "BottomPanelButton", menu_transparent_style);
+		p_theme->set_stylebox("hover_pressed", "BottomPanelButton", main_screen_button_hover);
+		p_theme->set_stylebox("hover", "BottomPanelButton", main_screen_button_hover);
 	}
 
 	// Editor GUI widgets.
@@ -1821,9 +1832,9 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 			Ref<StyleBoxFlat> style_flat_button_pressed = p_config.button_style_pressed->duplicate();
 
 			for (int i = 0; i < 4; i++) {
-				style_flat_button->set_content_margin((Side)i, p_config.button_style->get_margin((Side)i) + p_config.button_style->get_border_width((Side)i));
-				style_flat_button_hover->set_content_margin((Side)i, p_config.button_style->get_margin((Side)i) + p_config.button_style->get_border_width((Side)i));
-				style_flat_button_pressed->set_content_margin((Side)i, p_config.button_style->get_margin((Side)i) + p_config.button_style->get_border_width((Side)i));
+				style_flat_button->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+				style_flat_button_hover->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+				style_flat_button_pressed->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
 			}
 			Color flat_pressed_color = p_config.dark_color_1.lightened(0.24).lerp(p_config.accent_color, 0.2) * Color(0.8, 0.8, 0.8, 0.85);
 			if (p_config.dark_theme) {


### PR DESCRIPTION
Fixes #89122 

Should also address @Calinou 's comment made here regarding the bottom panel: https://github.com/godotengine/godot/pull/88652#issuecomment-1969682222

Previously I was able to apply a fix for the margins of the "main editor buttons" when the Draw Extra Borders option was enabled (in #88652 ), but it was discovered that @passivestar 's theme reintroduces these margin errors in #89122 . Thanks to suggestions from @Rindbee I was able to simplify the margin copying steps and learn that defining the styleboxes for some of the theme variations more explicitly works around an issue with custom themes where otherwise they would fall back to incorrect styles. So to address the issues, I explicitly set styleboxes for the `MainScreenButton` theme and created new theme variations for the bottom panel bar and top left menu bar. The `MenuTransparent` and `MenuHover` styles were no longer necessary at that point. As far as I can tell this should now fix all of the margin issues I've come across at the cost of a few extra lines in the theme manager.

Since the theme combinations are getting a little complicated I will demonstrate each case in a short video. Each video is recorded using the build with this PR's commit after rebasing it on master today:

**Default theme, default & compact spacing with draw extra borders**

https://github.com/godotengine/godot/assets/11141862/488444f3-b036-45fa-90d7-bdb412e3c136

^This was working previously so this is a good baseline to ensure it's still working.

**Default theme, compact, corner radius and additional spacing 0**

https://github.com/godotengine/godot/assets/11141862/6ae216d7-97f9-4dd8-ae87-b8083a8de819

**Passivestar's theme, compact spacing, draw extra borders on and off**

https://github.com/godotengine/godot/assets/11141862/edbfde26-adc3-438c-874a-8a9eabffd73f

^Base margin set to 0 while a custom theme was active was previously an issue as I posted in https://github.com/godotengine/godot/issues/89122#issuecomment-1977838376

**Passivestar's theme, compact spacing, editor scale to 75%**

https://github.com/godotengine/godot/assets/11141862/d6ea28b8-ad37-4284-9b60-90ce25fc9a4b

^This should be the exact reproduction step reported in #89122 

As always let me know if I've missed anything or if you'd like me to address anything else in this PR. I'm pretty confident that this should at least tackle the reported issues so feel free to test out the build and let me know how it works for you! Thanks!