### PR TITLE
Fix `compiledb` SCons tool availability

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -956,25 +956,25 @@ if selected_platform in platform_list:
         env.vs_incs = []
         env.vs_srcs = []
 
-    if env["compiledb"]:
+    # CompileDB
+    from SCons import __version__ as scons_raw_version
+
+    scons_ver = env._get_major_minor_revision(scons_raw_version)
+    if env["compiledb"] and scons_ver < (4, 0, 0):
         # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
-        from SCons import __version__ as scons_raw_version
-
-        scons_ver = env._get_major_minor_revision(scons_raw_version)
-
-        if scons_ver < (4, 0, 0):
-            print("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
-            Exit(255)
-
+        print("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
+        Exit(255)
+    if scons_ver >= (4, 0, 0):
         env.Tool("compilation_db")
         env.Alias("compiledb", env.CompilationDatabase())
 
+    # Threads
     if env["threads"]:
         env.Append(CPPDEFINES=["THREADS_ENABLED"])
 
+    # Build subdirs, the build order is dependent on link order.
     Export("env")
 
-    # Build subdirs, the build order is dependent on link order.
     SConscript("core/SCsub")
     SConscript("servers/SCsub")
     SConscript("scene/SCsub")


### PR DESCRIPTION
Currently, `scons compiledb compiledb=no` fails to run, as the `compiledb` alias isn't set if the `compiledb` variable isn't `True`.

```
X@X godot $ scons -Q compiledb
Automatically detected platform: linuxbsd
Auto-detected 8 CPU cores available for build parallelism. Using 7 cores by default. You can override it with the -j argument.
Note: Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.
Building for platform "linuxbsd", architecture "x86_64", target "editor".
[Initial build] scons: *** Do not know how to make File target `compiledb' (/home/X/srg/godot/compiledb).  Stop.
[Time elapsed: 00:00:03.429]
```

This PR makes the `compiledb` tool available for being summoned directly.

The variable is only used to indicate that we want to run the `compiledb` tool on the main build.