### PR TITLE
Core: Add enum class support to index error macros

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -34,6 +34,7 @@
 #include "core/typedefs.h"
 
 #include <atomic> // We'd normally use safe_refcount.h, but that would cause circular includes.
+#include <type_traits>
 
 class String;
 
@@ -109,6 +110,20 @@ void _err_flush_stdout();
 // Index out of bounds error macros.
 // These macros should be used instead of `ERR_FAIL_COND` for bounds checking.
 
+// Allow enum class values to be implicitly parsed by their underlying types
+template <typename T>
+constexpr auto _parse_enum_class(T p_value) {
+	if constexpr (std::is_enum_v<T>) {
+		if constexpr (!std::is_convertible_v<T, std::underlying_type_t<T>>) {
+			return static_cast<std::underlying_type_t<T>>(p_value);
+		} else {
+			return p_value;
+		}
+	} else {
+		return p_value;
+	}
+}
+
 // Integer index out of bounds error macros.
 
 /**
@@ -118,32 +133,32 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns.
  */
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+#define ERR_FAIL_INDEX(m_index, m_size)                                                                                                               \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                          \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size)); \
+		return;                                                                                                                                       \
+	} else                                                                                                                                            \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                        \
-	} else                                                                                                             \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                                           \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                                 \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg); \
+		return;                                                                                                                                              \
+	} else                                                                                                                                                   \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                              \
-	} else                                                                                                                   \
+#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                                                               \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                                       \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+		return;                                                                                                                                                    \
+	} else                                                                                                                                                         \
 		((void)0)
 
 /**
@@ -153,32 +168,32 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                                                   \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                          \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                                                              \
+	} else                                                                                                                                            \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                               \
-	} else                                                                                                             \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                                               \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                                 \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg); \
+		return m_retval;                                                                                                                                     \
+	} else                                                                                                                                                   \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
+#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                                                                   \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                                       \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+		return m_retval;                                                                                                                                           \
+	} else                                                                                                                                                         \
 		((void)0)
 
 /**
@@ -189,12 +204,12 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the application crashes.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                                                               \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                                           \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), "", false, true); \
+		_err_flush_stdout();                                                                                                                                           \
+		GENERATE_TRAP();                                                                                                                                               \
+	} else                                                                                                                                                             \
 		((void)0)
 
 /**
@@ -204,12 +219,12 @@ void _err_flush_stdout();
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                 \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                         \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                                                       \
+	if (unlikely(_parse_enum_class(m_index) < 0 || (m_index) >= (m_size))) {                                                                                              \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg, false, true); \
+		_err_flush_stdout();                                                                                                                                              \
+		GENERATE_TRAP();                                                                                                                                                  \
+	} else                                                                                                                                                                \
 		((void)0)
 
 // Unsigned integer index out of bounds error macros.
@@ -221,32 +236,32 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                                                      \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                            \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size)); \
+		return;                                                                                                                                       \
+	} else                                                                                                                                            \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                            \
-	if (unlikely((m_index) >= (m_size))) {                                                                             \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                        \
-	} else                                                                                                             \
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                                  \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                                   \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg); \
+		return;                                                                                                                                              \
+	} else                                                                                                                                                   \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                                   \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                              \
-	} else                                                                                                                   \
+#define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                                                      \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                                         \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+		return;                                                                                                                                                    \
+	} else                                                                                                                                                         \
 		((void)0)
 
 /**
@@ -256,32 +271,32 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                                                          \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                            \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                                                              \
+	} else                                                                                                                                            \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                             \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                               \
-	} else                                                                                                             \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                                      \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                                   \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg); \
+		return m_retval;                                                                                                                                     \
+	} else                                                                                                                                                   \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_V_EDMSG` but also notifies the editor.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
-	if (unlikely((m_index) >= (m_size))) {                                                                                   \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
+#define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                                                          \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                                         \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+		return m_retval;                                                                                                                                           \
+	} else                                                                                                                                                         \
 		((void)0)
 
 /**
@@ -292,12 +307,12 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                                                      \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                                             \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), "", false, true); \
+		_err_flush_stdout();                                                                                                                                           \
+		GENERATE_TRAP();                                                                                                                                               \
+	} else                                                                                                                                                             \
 		((void)0)
 
 /**
@@ -307,12 +322,12 @@ void _err_flush_stdout();
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                        \
-	if (unlikely((m_index) >= (m_size))) {                                                                                          \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                                              \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                                                \
+		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, _parse_enum_class(m_index), _parse_enum_class(m_size), _STR(m_index), _STR(m_size), m_msg, false, true); \
+		_err_flush_stdout();                                                                                                                                              \
+		GENERATE_TRAP();                                                                                                                                                  \
+	} else                                                                                                                                                                \
 		((void)0)
 
 // Null reference error macros.

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1083,7 +1083,7 @@ void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	_THREAD_SAFE_METHOD_;
 	Joypad &joy = joy_names[p_device];
-	ERR_FAIL_INDEX((int)p_button, (int)JoyButton::MAX);
+	ERR_FAIL_INDEX(p_button, JoyButton::MAX);
 
 	if (joy.last_buttons[(size_t)p_button] == p_pressed) {
 		return;
@@ -1110,7 +1110,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_THREAD_SAFE_METHOD_;
 
-	ERR_FAIL_INDEX((int)p_axis, (int)JoyAxis::MAX);
+	ERR_FAIL_INDEX(p_axis, JoyAxis::MAX);
 
 	Joypad &joy = joy_names[p_device];
 

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -173,7 +173,7 @@ bool AStarGrid2D::is_jumping_enabled() const {
 }
 
 void AStarGrid2D::set_diagonal_mode(DiagonalMode p_diagonal_mode) {
-	ERR_FAIL_INDEX((int)p_diagonal_mode, (int)DIAGONAL_MODE_MAX);
+	ERR_FAIL_INDEX(p_diagonal_mode, DIAGONAL_MODE_MAX);
 	diagonal_mode = p_diagonal_mode;
 }
 
@@ -182,7 +182,7 @@ AStarGrid2D::DiagonalMode AStarGrid2D::get_diagonal_mode() const {
 }
 
 void AStarGrid2D::set_default_compute_heuristic(Heuristic p_heuristic) {
-	ERR_FAIL_INDEX((int)p_heuristic, (int)HEURISTIC_MAX);
+	ERR_FAIL_INDEX(p_heuristic, HEURISTIC_MAX);
 	default_compute_heuristic = p_heuristic;
 }
 
@@ -191,7 +191,7 @@ AStarGrid2D::Heuristic AStarGrid2D::get_default_compute_heuristic() const {
 }
 
 void AStarGrid2D::set_default_estimate_heuristic(Heuristic p_heuristic) {
-	ERR_FAIL_INDEX((int)p_heuristic, (int)HEURISTIC_MAX);
+	ERR_FAIL_INDEX(p_heuristic, HEURISTIC_MAX);
 	default_estimate_heuristic = p_heuristic;
 }
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -954,7 +954,7 @@ String VariantUtilityFunctions::error_string(Error error) {
 }
 
 String VariantUtilityFunctions::type_string(Variant::Type p_type) {
-	ERR_FAIL_INDEX_V_MSG((int)p_type, (int)Variant::VARIANT_MAX, "<invalid type>", "Invalid type argument to type_string(), use the TYPE_* constants.");
+	ERR_FAIL_INDEX_V_MSG(p_type, Variant::VARIANT_MAX, "<invalid type>", "Invalid type argument to type_string(), use the TYPE_* constants.");
 	return Variant::get_type_name(p_type);
 }
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2405,7 +2405,7 @@ double TextServerAdvanced::_font_get_embolden(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		if (fdv->extra_spacing[p_spacing] != p_value) {
@@ -2423,7 +2423,7 @@ void TextServerAdvanced::_font_set_spacing(const RID &p_font_rid, SpacingType p_
 }
 
 int64_t TextServerAdvanced::_font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		return fdv->extra_spacing[p_spacing];
@@ -4213,7 +4213,7 @@ bool TextServerAdvanced::_shaped_text_get_preserve_control(const RID &p_shaped) 
 }
 
 void TextServerAdvanced::_shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL(sd);
 
@@ -4228,7 +4228,7 @@ void TextServerAdvanced::_shaped_text_set_spacing(const RID &p_shaped, SpacingTy
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 
 	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1396,7 +1396,7 @@ double TextServerFallback::_font_get_embolden(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		if (fdv->extra_spacing[p_spacing] != p_value) {
@@ -1415,7 +1415,7 @@ void TextServerFallback::_font_set_spacing(const RID &p_font_rid, SpacingType p_
 }
 
 int64_t TextServerFallback::_font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		return fdv->extra_spacing[p_spacing];
@@ -3061,7 +3061,7 @@ bool TextServerFallback::_shaped_text_get_preserve_control(const RID &p_shaped) 
 }
 
 void TextServerFallback::_shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL(sd);
 
@@ -3076,7 +3076,7 @@ void TextServerFallback::_shaped_text_set_spacing(const RID &p_shaped, SpacingTy
 }
 
 int64_t TextServerFallback::_shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 
 	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -560,7 +560,7 @@ Ref<Skin> GPUParticles3D::get_skin() const {
 }
 
 void GPUParticles3D::set_transform_align(TransformAlign p_align) {
-	ERR_FAIL_INDEX(uint32_t(p_align), 4);
+	ERR_FAIL_INDEX(int(p_align), 4);
 	transform_align = p_align;
 	RS::get_singleton()->particles_set_transform_align(particles, RS::ParticlesTransformAlign(transform_align));
 }

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2989,7 +2989,7 @@ Dictionary FontVariation::get_opentype_features() const {
 }
 
 void FontVariation::set_spacing(TextServer::SpacingType p_spacing, int p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, TextServer::SPACING_MAX);
+	ERR_FAIL_INDEX(p_spacing, TextServer::SPACING_MAX);
 	if (extra_spacing[p_spacing] != p_value) {
 		extra_spacing[p_spacing] = p_value;
 		_invalidate_rids();
@@ -2997,7 +2997,7 @@ void FontVariation::set_spacing(TextServer::SpacingType p_spacing, int p_value) 
 }
 
 int FontVariation::get_spacing(TextServer::SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, TextServer::SPACING_MAX, 0);
+	ERR_FAIL_INDEX_V(p_spacing, TextServer::SPACING_MAX, 0);
 	return extra_spacing[p_spacing];
 }
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -822,8 +822,8 @@ VisualShader::Type VisualShader::get_shader_type() const {
 
 void VisualShader::add_varying(const String &p_name, VaryingMode p_mode, VaryingType p_type) {
 	ERR_FAIL_COND(!p_name.is_valid_identifier());
-	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
-	ERR_FAIL_INDEX((int)p_type, (int)VARYING_TYPE_MAX);
+	ERR_FAIL_INDEX(p_mode, VARYING_MODE_MAX);
+	ERR_FAIL_INDEX(p_type, VARYING_TYPE_MAX);
 	ERR_FAIL_COND(varyings.has(p_name));
 	Varying var = Varying(p_name, p_mode, p_type);
 	varyings[p_name] = var;
@@ -857,7 +857,7 @@ const VisualShader::Varying *VisualShader::get_varying_by_index(int p_idx) const
 }
 
 void VisualShader::set_varying_mode(const String &p_name, VaryingMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
+	ERR_FAIL_INDEX(p_mode, VARYING_MODE_MAX);
 	ERR_FAIL_COND(!varyings.has(p_name));
 	if (varyings[p_name].mode == p_mode) {
 		return;
@@ -872,7 +872,7 @@ VisualShader::VaryingMode VisualShader::get_varying_mode(const String &p_name) {
 }
 
 void VisualShader::set_varying_type(const String &p_name, VaryingType p_type) {
-	ERR_FAIL_INDEX((int)p_type, (int)VARYING_TYPE_MAX);
+	ERR_FAIL_INDEX(p_type, VARYING_TYPE_MAX);
 	ERR_FAIL_COND(!varyings.has(p_name));
 	if (varyings[p_name].type == p_type) {
 		return;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3833,7 +3833,7 @@ String VisualShaderNodeDerivativeFunc::get_warning(Shader::Mode p_mode, VisualSh
 }
 
 void VisualShaderNodeDerivativeFunc::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4000,7 +4000,7 @@ String VisualShaderNodeClamp::generate_code(Shader::Mode p_mode, VisualShader::T
 }
 
 void VisualShaderNodeClamp::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -7584,7 +7584,7 @@ String VisualShaderNodeMultiplyAdd::generate_code(Shader::Mode p_mode, VisualSha
 }
 
 void VisualShaderNodeMultiplyAdd::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}


### PR DESCRIPTION
Currently, enum classes cannot be passed as arguments to any index-based error macro without prior conversion. While this makes complete sense if one of the arguments is a different type, it didn't make sense for two variables of the *same* enum class to fail. This addresses this issue, while retaining their implicit conversion guards, with the following changes:

- For **signed** index macros: Convert `m_index` to `int64_t` for the `< 0` check.
- For **all** index macros: Convert `m_index` and `m_size` to `int64_t` when passed as argument variables.

The reason these changes are safe is because there's still an explicit check between the two variables in the form of `(m_index) >= (m_size)` across all index macros. Meaning, passing an enum class `m_index` and an integer `m_size` will fail as expected, but making *both* arguments the same enum class will pass. The macros are otherwise functionally identical to their live counterparts. All relevant macro arguments were converted to this new format.