### PR TITLE
Core: Add `constexpr` wrappers, apply to error macros

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -31,6 +31,7 @@
 #include "error_macros.h"
 
 #include "core/io/logger.h"
+#include "core/object/object_id.h"
 #include "core/os/os.h"
 #include "core/string/ustring.h"
 

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -31,12 +31,12 @@
 #ifndef ERROR_MACROS_H
 #define ERROR_MACROS_H
 
-#include "core/object/object_id.h"
 #include "core/typedefs.h"
 
 #include <atomic> // We'd normally use safe_refcount.h, but that would cause circular includes.
 
 class String;
+class ObjectID;
 
 enum ErrorHandlerType {
 	ERR_HANDLER_ERROR,
@@ -104,7 +104,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Always try to return processable data, so the engine can keep running well.
  * Use the _MSG versions to print a meaningful message to help with debugging.
  *
- * The `((void)0)` no-op statement is used as a trick to force us to put a semicolon after
+ * The `FORCE_SEMICOLON` macro is used as a trick to force us to put a semicolon after
  * those macros, making them look like proper statements.
  * The if wrappers are used to ensure that the macro replacement does not trigger unexpected
  * issues when expanded e.g. after an `if (cond) ERR_FAIL();` without braces.
@@ -123,32 +123,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns.
  */
 #define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
+	MACRO_WRAPPER_BEGIN                                                                                         \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 		return;                                                                                                 \
-	} else                                                                                                      \
-		((void)0)
+	}                                                                                                           \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
+	MACRO_WRAPPER_BEGIN                                                                                                \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 		return;                                                                                                        \
-	} else                                                                                                             \
-		((void)0)
+	}                                                                                                                  \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
+	MACRO_WRAPPER_BEGIN                                                                                                      \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
 		return;                                                                                                              \
-	} else                                                                                                                   \
-		((void)0)
+	}                                                                                                                        \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_INDEX_V_MSG`.
@@ -158,32 +161,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
+	MACRO_WRAPPER_BEGIN                                                                                         \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 		return m_retval;                                                                                        \
-	} else                                                                                                      \
-		((void)0)
+	}                                                                                                           \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
+	MACRO_WRAPPER_BEGIN                                                                                                \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 		return m_retval;                                                                                               \
-	} else                                                                                                             \
-		((void)0)
+	}                                                                                                                  \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
+	MACRO_WRAPPER_BEGIN                                                                                                      \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
 		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
-		((void)0)
+	}                                                                                                                        \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
@@ -194,12 +200,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the application crashes.
  */
 #define CRASH_BAD_INDEX(m_index, m_size)                                                                                         \
+	MACRO_WRAPPER_BEGIN                                                                                                          \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                      \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
 		_err_flush_stdout();                                                                                                     \
 		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
-		((void)0)
+	}                                                                                                                            \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
@@ -209,12 +216,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the application crashes.
  */
 #define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                 \
+	MACRO_WRAPPER_BEGIN                                                                                                             \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                         \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
 		_err_flush_stdout();                                                                                                        \
 		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
-		((void)0)
+	}                                                                                                                               \
+	MACRO_WRAPPER_END
 
 // Unsigned integer index out of bounds error macros.
 
@@ -226,32 +234,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns.
  */
 #define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                \
+	MACRO_WRAPPER_BEGIN                                                                                         \
 	if (unlikely((m_index) >= (m_size))) {                                                                      \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 		return;                                                                                                 \
-	} else                                                                                                      \
-		((void)0)
+	}                                                                                                           \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                            \
+	MACRO_WRAPPER_BEGIN                                                                                                \
 	if (unlikely((m_index) >= (m_size))) {                                                                             \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 		return;                                                                                                        \
-	} else                                                                                                             \
-		((void)0)
+	}                                                                                                                  \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                \
+	MACRO_WRAPPER_BEGIN                                                                                                      \
 	if (unlikely((m_index) >= (m_size))) {                                                                                   \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
 		return;                                                                                                              \
-	} else                                                                                                                   \
-		((void)0)
+	}                                                                                                                        \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
@@ -261,32 +272,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns `m_retval`.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
+	MACRO_WRAPPER_BEGIN                                                                                         \
 	if (unlikely((m_index) >= (m_size))) {                                                                      \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
 		return m_retval;                                                                                        \
-	} else                                                                                                      \
-		((void)0)
+	}                                                                                                           \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                \
+	MACRO_WRAPPER_BEGIN                                                                                                \
 	if (unlikely((m_index) >= (m_size))) {                                                                             \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
 		return m_retval;                                                                                               \
-	} else                                                                                                             \
-		((void)0)
+	}                                                                                                                  \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_V_EDMSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
+	MACRO_WRAPPER_BEGIN                                                                                                      \
 	if (unlikely((m_index) >= (m_size))) {                                                                                   \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
 		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
-		((void)0)
+	}                                                                                                                        \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
@@ -297,12 +311,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the application crashes.
  */
 #define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                \
+	MACRO_WRAPPER_BEGIN                                                                                                          \
 	if (unlikely((m_index) >= (m_size))) {                                                                                       \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
 		_err_flush_stdout();                                                                                                     \
 		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
-		((void)0)
+	}                                                                                                                            \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
@@ -312,12 +327,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the application crashes.
  */
 #define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                        \
+	MACRO_WRAPPER_BEGIN                                                                                                             \
 	if (unlikely((m_index) >= (m_size))) {                                                                                          \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
 		_err_flush_stdout();                                                                                                        \
 		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
-		((void)0)
+	}                                                                                                                               \
+	MACRO_WRAPPER_END
 
 // Null reference error macros.
 
@@ -329,32 +345,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, the current function returns.
  */
 #define ERR_FAIL_NULL(m_param)                                                                          \
+	MACRO_WRAPPER_BEGIN                                                                                 \
 	if (unlikely(m_param == nullptr)) {                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
 		return;                                                                                         \
-	} else                                                                                              \
-		((void)0)
+	}                                                                                                   \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                      \
+	MACRO_WRAPPER_BEGIN                                                                                        \
 	if (unlikely(m_param == nullptr)) {                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
 		return;                                                                                                \
-	} else                                                                                                     \
-		((void)0)
+	}                                                                                                          \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_NULL_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_EDMSG(m_param, m_msg)                                                                          \
+	MACRO_WRAPPER_BEGIN                                                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                              \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
 		return;                                                                                                      \
-	} else                                                                                                           \
-		((void)0)
+	}                                                                                                                \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_NULL_V_MSG`.
@@ -364,32 +383,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, the current function returns `m_retval`.
  */
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                              \
+	MACRO_WRAPPER_BEGIN                                                                                 \
 	if (unlikely(m_param == nullptr)) {                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
 		return m_retval;                                                                                \
-	} else                                                                                              \
-		((void)0)
+	}                                                                                                   \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                          \
+	MACRO_WRAPPER_BEGIN                                                                                        \
 	if (unlikely(m_param == nullptr)) {                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
 		return m_retval;                                                                                       \
-	} else                                                                                                     \
-		((void)0)
+	}                                                                                                          \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_NULL_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg)                                                              \
+	MACRO_WRAPPER_BEGIN                                                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                              \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
 		return m_retval;                                                                                             \
-	} else                                                                                                           \
-		((void)0)
+	}                                                                                                                \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG`.
@@ -401,11 +423,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current function returns.
  */
 #define ERR_FAIL_COND(m_cond)                                                                          \
+	MACRO_WRAPPER_BEGIN                                                                                \
 	if (unlikely(m_cond)) {                                                                            \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
 		return;                                                                                        \
-	} else                                                                                             \
-		((void)0)
+	}                                                                                                  \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
@@ -415,21 +438,23 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
  */
 #define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                      \
+	MACRO_WRAPPER_BEGIN                                                                                       \
 	if (unlikely(m_cond)) {                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg); \
 		return;                                                                                               \
-	} else                                                                                                    \
-		((void)0)
+	}                                                                                                         \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_COND_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_COND_EDMSG(m_cond, m_msg)                                                                          \
+	MACRO_WRAPPER_BEGIN                                                                                             \
 	if (unlikely(m_cond)) {                                                                                         \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg, true); \
 		return;                                                                                                     \
-	} else                                                                                                          \
-		((void)0)
+	}                                                                                                               \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_V_MSG`.
@@ -441,11 +466,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current function returns `m_retval`.
  */
 #define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                         \
+	MACRO_WRAPPER_BEGIN                                                                                                           \
 	if (unlikely(m_cond)) {                                                                                                       \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
 		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
-		((void)0)
+	}                                                                                                                             \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
@@ -455,21 +481,23 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
  */
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                     \
+	MACRO_WRAPPER_BEGIN                                                                                                                  \
 	if (unlikely(m_cond)) {                                                                                                              \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
 		return m_retval;                                                                                                                 \
-	} else                                                                                                                               \
-		((void)0)
+	}                                                                                                                                    \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_COND_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg)                                                                                         \
+	MACRO_WRAPPER_BEGIN                                                                                                                        \
 	if (unlikely(m_cond)) {                                                                                                                    \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg, true); \
 		return m_retval;                                                                                                                       \
-	} else                                                                                                                                     \
-		((void)0)
+	}                                                                                                                                          \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_CONTINUE_MSG`.
@@ -479,32 +507,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current loop continues.
  */
 #define ERR_CONTINUE(m_cond)                                                                                       \
+	MACRO_WRAPPER_BEGIN                                                                                            \
 	if (unlikely(m_cond)) {                                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
 		continue;                                                                                                  \
-	} else                                                                                                         \
-		((void)0)
+	}                                                                                                              \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop continues.
  */
 #define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                   \
+	MACRO_WRAPPER_BEGIN                                                                                                   \
 	if (unlikely(m_cond)) {                                                                                               \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg); \
 		continue;                                                                                                         \
-	} else                                                                                                                \
-		((void)0)
+	}                                                                                                                     \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_CONTINUE_MSG` but also notifies the editor.
  */
 #define ERR_CONTINUE_EDMSG(m_cond, m_msg)                                                                                       \
+	MACRO_WRAPPER_BEGIN                                                                                                         \
 	if (unlikely(m_cond)) {                                                                                                     \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg, true); \
 		continue;                                                                                                               \
-	} else                                                                                                                      \
-		((void)0)
+	}                                                                                                                           \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_BREAK_MSG`.
@@ -514,32 +545,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current loop breaks.
  */
 #define ERR_BREAK(m_cond)                                                                                        \
+	MACRO_WRAPPER_BEGIN                                                                                          \
 	if (unlikely(m_cond)) {                                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
 		break;                                                                                                   \
-	} else                                                                                                       \
-		((void)0)
+	}                                                                                                            \
+	MACRO_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop breaks.
  */
 #define ERR_BREAK_MSG(m_cond, m_msg)                                                                                    \
+	MACRO_WRAPPER_BEGIN                                                                                                 \
 	if (unlikely(m_cond)) {                                                                                             \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg); \
 		break;                                                                                                          \
-	} else                                                                                                              \
-		((void)0)
+	}                                                                                                                   \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_BREAK_MSG` but also notifies the editor.
  */
 #define ERR_BREAK_EDMSG(m_cond, m_msg)                                                                                        \
+	MACRO_WRAPPER_BEGIN                                                                                                       \
 	if (unlikely(m_cond)) {                                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg, true); \
 		break;                                                                                                                \
-	} else                                                                                                                    \
-		((void)0)
+	}                                                                                                                         \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_COND_V_MSG`.
@@ -550,12 +584,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the application crashes.
  */
 #define CRASH_COND(m_cond)                                                                                    \
+	MACRO_WRAPPER_BEGIN                                                                                       \
 	if (unlikely(m_cond)) {                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
 		_err_flush_stdout();                                                                                  \
 		GENERATE_TRAP();                                                                                      \
-	} else                                                                                                    \
-		((void)0)
+	}                                                                                                         \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_COND_V_MSG`.
@@ -565,12 +600,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, prints `m_msg` and the application crashes.
  */
 #define CRASH_COND_MSG(m_cond, m_msg)                                                                                \
+	MACRO_WRAPPER_BEGIN                                                                                              \
 	if (unlikely(m_cond)) {                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
 		_err_flush_stdout();                                                                                         \
 		GENERATE_TRAP();                                                                                             \
-	} else                                                                                                           \
-		((void)0)
+	}                                                                                                                \
+	MACRO_WRAPPER_END
 
 // Generic error macros.
 
@@ -581,12 +617,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * The current function returns.
  */
-#define ERR_FAIL()                                                                     \
-	if (true) {                                                                        \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
-		return;                                                                        \
-	} else                                                                             \
-		((void)0)
+#define ERR_FAIL()                                                                 \
+	MACRO_WRAPPER_BEGIN                                                            \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
+	return;                                                                        \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG`.
@@ -594,22 +629,20 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * Prints `m_msg`, and the current function returns.
  */
-#define ERR_FAIL_MSG(m_msg)                                                                   \
-	if (true) {                                                                               \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg); \
-		return;                                                                               \
-	} else                                                                                    \
-		((void)0)
+#define ERR_FAIL_MSG(m_msg)                                                               \
+	MACRO_WRAPPER_BEGIN                                                                   \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg); \
+	return;                                                                               \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_EDMSG(m_msg)                                                                       \
-	if (true) {                                                                                     \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg, true); \
-		return;                                                                                     \
-	} else                                                                                          \
-		((void)0)
+#define ERR_FAIL_EDMSG(m_msg)                                                                   \
+	MACRO_WRAPPER_BEGIN                                                                         \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg, true); \
+	return;                                                                                     \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_V_MSG` or `ERR_FAIL_V_MSG`.
@@ -618,12 +651,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * The current function returns `m_retval`.
  */
-#define ERR_FAIL_V(m_retval)                                                                                      \
-	if (true) {                                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                          \
-	} else                                                                                                        \
-		((void)0)
+#define ERR_FAIL_V(m_retval)                                                                                  \
+	MACRO_WRAPPER_BEGIN                                                                                       \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
+	return m_retval;                                                                                          \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_V_MSG`.
@@ -631,22 +663,20 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * Prints `m_msg`, and the current function returns `m_retval`.
  */
-#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                  \
-	if (true) {                                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
-		return m_retval;                                                                                                 \
-	} else                                                                                                               \
-		((void)0)
+#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                              \
+	MACRO_WRAPPER_BEGIN                                                                                              \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
+	return m_retval;                                                                                                 \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_V_EDMSG(m_retval, m_msg)                                                                                      \
-	if (true) {                                                                                                                \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
-		return m_retval;                                                                                                       \
-	} else                                                                                                                     \
-		((void)0)
+#define ERR_FAIL_V_EDMSG(m_retval, m_msg)                                                                                  \
+	MACRO_WRAPPER_BEGIN                                                                                                    \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
+	return m_retval;                                                                                                       \
+	MACRO_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG`, `ERR_FAIL_COND_V_MSG`, `ERR_CONTINUE_MSG` or `ERR_BREAK_MSG`.
@@ -667,28 +697,26 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 /**
  * Prints `m_msg` once during the application lifetime.
  */
-#define ERR_PRINT_ONCE(m_msg)                                          \
-	if (true) {                                                        \
-		static bool first_print = true;                                \
-		if (first_print) {                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
-			first_print = false;                                       \
-		}                                                              \
-	} else                                                             \
-		((void)0)
+#define ERR_PRINT_ONCE(m_msg)                                      \
+	MACRO_WRAPPER_BEGIN                                            \
+	static bool first_print = true;                                \
+	if (first_print) {                                             \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
+		first_print = false;                                       \
+	}                                                              \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `ERR_PRINT_ONCE` but also notifies the editor.
  */
-#define ERR_PRINT_ONCE_ED(m_msg)                                             \
-	if (true) {                                                              \
-		static bool first_print = true;                                      \
-		if (first_print) {                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
-			first_print = false;                                             \
-		}                                                                    \
-	} else                                                                   \
-		((void)0)
+#define ERR_PRINT_ONCE_ED(m_msg)                                         \
+	MACRO_WRAPPER_BEGIN                                                  \
+	static bool first_print = true;                                      \
+	if (first_print) {                                                   \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
+		first_print = false;                                             \
+	}                                                                    \
+	MACRO_WRAPPER_END
 
 // Print warning message macros.
 
@@ -711,66 +739,62 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
-#define WARN_PRINT_ONCE(m_msg)                                                                     \
-	if (true) {                                                                                    \
-		static bool first_print = true;                                                            \
-		if (first_print) {                                                                         \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING); \
-			first_print = false;                                                                   \
-		}                                                                                          \
-	} else                                                                                         \
-		((void)0)
+#define WARN_PRINT_ONCE(m_msg)                                                                 \
+	MACRO_WRAPPER_BEGIN                                                                        \
+	static bool first_print = true;                                                            \
+	if (first_print) {                                                                         \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING); \
+		first_print = false;                                                                   \
+	}                                                                                          \
+	MACRO_WRAPPER_END
 
 /**
  * Same as `WARN_PRINT_ONCE` but also notifies the editor.
  */
-#define WARN_PRINT_ONCE_ED(m_msg)                                                                 \
-	if (true) {                                                                                   \
-		static bool first_print = true;                                                           \
-		if (first_print) {                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING); \
-			first_print = false;                                                                  \
-		}                                                                                         \
-	} else                                                                                        \
-		((void)0)
+#define WARN_PRINT_ONCE_ED(m_msg)                                                             \
+	MACRO_WRAPPER_BEGIN                                                                       \
+	static bool first_print = true;                                                           \
+	if (first_print) {                                                                        \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING); \
+		first_print = false;                                                                  \
+	}                                                                                         \
+	MACRO_WRAPPER_END
 
 /**
  * Warns about `m_msg` only when verbose mode is enabled.
  */
-#define WARN_VERBOSE(m_msg)               \
-	{                                     \
-		if (is_print_verbose_enabled()) { \
-			WARN_PRINT(m_msg);            \
-		}                                 \
-	}
+#define WARN_VERBOSE(m_msg)           \
+	MACRO_WRAPPER_BEGIN               \
+	if (is_print_verbose_enabled()) { \
+		WARN_PRINT(m_msg);            \
+	}                                 \
+	MACRO_WRAPPER_END
 
 // Print deprecated warning message macros.
 
 /**
  * Warns that the current function is deprecated.
  */
-#define WARN_DEPRECATED                                                                                                                                           \
-	if (true) {                                                                                                                                                   \
-		static std::atomic<bool> warning_shown;                                                                                                                   \
-		if (!warning_shown.load()) {                                                                                                                              \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, ERR_HANDLER_WARNING); \
-			warning_shown.store(true);                                                                                                                            \
-		}                                                                                                                                                         \
-	} else                                                                                                                                                        \
-		((void)0)
+#define WARN_DEPRECATED                                                                                                                                       \
+	MACRO_WRAPPER_BEGIN                                                                                                                                       \
+	static std::atomic<bool> warning_shown;                                                                                                                   \
+	if (!warning_shown.load()) {                                                                                                                              \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, ERR_HANDLER_WARNING); \
+		warning_shown.store(true);                                                                                                                            \
+	}                                                                                                                                                         \
+	MACRO_WRAPPER_END
 
 /**
  * Warns that the current function is deprecated and prints `m_msg`.
  */
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                       \
-	if (true) {                                                                                                                                                          \
-		static std::atomic<bool> warning_shown;                                                                                                                          \
-		if (!warning_shown.load()) {                                                                                                                                     \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, ERR_HANDLER_WARNING); \
-			warning_shown.store(true);                                                                                                                                   \
-		}                                                                                                                                                                \
-	} else                                                                                                                                                               \
-		((void)0)
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                   \
+	MACRO_WRAPPER_BEGIN                                                                                                                                              \
+	static std::atomic<bool> warning_shown;                                                                                                                          \
+	if (!warning_shown.load()) {                                                                                                                                     \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, ERR_HANDLER_WARNING); \
+		warning_shown.store(true);                                                                                                                                   \
+	}                                                                                                                                                                \
+	MACRO_WRAPPER_END
 
 /**
  * Do not use.
@@ -778,26 +802,24 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * The application crashes.
  */
-#define CRASH_NOW()                                                                           \
-	if (true) {                                                                               \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
-		_err_flush_stdout();                                                                  \
-		GENERATE_TRAP();                                                                      \
-	} else                                                                                    \
-		((void)0)
+#define CRASH_NOW()                                                                       \
+	MACRO_WRAPPER_BEGIN                                                                   \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
+	_err_flush_stdout();                                                                  \
+	GENERATE_TRAP();                                                                      \
+	MACRO_WRAPPER_END
 
 /**
  * Only use if the application should never reach this point.
  *
  * Prints `m_msg`, and then the application crashes.
  */
-#define CRASH_NOW_MSG(m_msg)                                                                         \
-	if (true) {                                                                                      \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
-		_err_flush_stdout();                                                                         \
-		GENERATE_TRAP();                                                                             \
-	} else                                                                                           \
-		((void)0)
+#define CRASH_NOW_MSG(m_msg)                                                                     \
+	MACRO_WRAPPER_BEGIN                                                                          \
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
+	_err_flush_stdout();                                                                         \
+	GENERATE_TRAP();                                                                             \
+	MACRO_WRAPPER_END
 
 /**
  * Note: IN MOST CASES YOU SHOULD NOT USE THIS MACRO.
@@ -816,24 +838,26 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #ifdef DEV_ENABLED
 #define DEV_ASSERT(m_cond)                                                                                              \
+	MACRO_WRAPPER_BEGIN                                                                                                 \
 	if (unlikely(!(m_cond))) {                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
 		_err_flush_stdout();                                                                                            \
 		GENERATE_TRAP();                                                                                                \
-	} else                                                                                                              \
-		((void)0)
+	}                                                                                                                   \
+	MACRO_WRAPPER_END
 #else
-#define DEV_ASSERT(m_cond)
+#define DEV_ASSERT(m_cond) FORCE_SEMICOLON
 #endif
 
 #ifdef DEV_ENABLED
 #define DEV_CHECK_ONCE(m_cond)                                                   \
+	MACRO_WRAPPER_BEGIN                                                          \
 	if (unlikely(!(m_cond))) {                                                   \
 		ERR_PRINT_ONCE("DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
-	} else                                                                       \
-		((void)0)
+	}                                                                            \
+	MACRO_WRAPPER_END
 #else
-#define DEV_CHECK_ONCE(m_cond)
+#define DEV_CHECK_ONCE(m_cond) FORCE_SEMICOLON
 #endif
 
 /**

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -647,7 +647,6 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			ERR_FAIL_V_MSG(Vector3(), "Invalid parameter for get_euler(order)");
 		}
 	}
-	return Vector3();
 }
 
 void Basis::set_euler(const Vector3 &p_euler, EulerOrder p_order) {

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -80,6 +80,21 @@ static_assert(__cplusplus >= 201703L);
 #define _ALLOW_DISCARD_ (void)
 #endif
 
+// Some of our macros require a trailing semicolon; appending this to the end of a macro
+// enforces that behavior without increasing build size or compilation time whatsoever.
+#ifndef FORCE_SEMICOLON
+#define FORCE_SEMICOLON static_assert(true)
+#endif
+
+// Ensure that macro replacement does not trigger unexpected issues when expanded by
+// constraining them to "if" wrappers. e.g. `if (cond) SOME_MACRO();` without braces.
+/* clang-format off */
+#ifndef MACRO_WRAPPER_BEGIN
+#define MACRO_WRAPPER_BEGIN if constexpr (true) {
+#define MACRO_WRAPPER_END } else FORCE_SEMICOLON
+#endif
+/* clang-format on */
+
 // Windows badly defines a lot of stuff we'll never use. Undefine it.
 #ifdef _WIN32
 #undef min // override standard definition

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -217,7 +217,7 @@ Error WSLPeer::_do_server_handshake() {
 	if (use_tls) {
 		Ref<StreamPeerTLS> tls = static_cast<Ref<StreamPeerTLS>>(connection);
 		if (tls.is_null()) {
-			ERR_FAIL_V_MSG(ERR_BUG, "Couldn't get StreamPeerTLS for WebSocket handshake.");
+			ERR_PRINT("Couldn't get StreamPeerTLS for WebSocket handshake.");
 			close(-1);
 			return FAILED;
 		}


### PR DESCRIPTION
By converting `if (true)` to `if constexpr (true)` in error macros, the binary size shrinks a fair amount (release template: ~8KiB, dev editor: ~27KiB) & additional compile-time checks are enabled (if extra warnings are enabled) by detecting if a returning macro causes inaccessible code.