### PR TITLE
[Core] Prevent further infinite recursion when printing errors

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -183,7 +183,7 @@ Error CallQueue::push_notification(ObjectID p_id, int p_notification) {
 
 	if ((page_bytes[pages_used - 1] + room_needed) > uint32_t(PAGE_SIZE_BYTES)) {
 		if (pages_used == max_pages) {
-			fprintf(stderr, "Failed notification: %s target ID: %s. Message queue out of memory. %s\n", itos(p_notification).utf8().get_data(), itos(p_id).utf8().get_data(), error_text.utf8().get_data());
+			fprintf(stderr, "Failed notification: %d target ID: %s. Message queue out of memory. %s\n", p_notification, itos(p_id).utf8().get_data(), error_text.utf8().get_data());
 			statistics();
 			UNLOCK_MUTEX;
 			return ERR_OUT_OF_MEMORY;
@@ -256,7 +256,7 @@ Error CallQueue::_transfer_messages_to_main_queue() {
 	// Any other possibly existing source page needs to be added.
 
 	if (mq->pages_used + (pages_used - src_page) > mq->max_pages) {
-		ERR_PRINT("Failed appending thread queue. Message queue out of memory. " + mq->error_text);
+		fprintf(stderr, "Failed appending thread queue. Message queue out of memory. %s\n", mq->error_text.utf8().get_data());
 		mq->statistics();
 		mq->mutex.unlock();
 		return ERR_OUT_OF_MEMORY;
@@ -462,8 +462,8 @@ void CallQueue::statistics() {
 				} break;
 			}
 			if (null_target) {
-				//object was deleted
-				print_line("Object was deleted while awaiting a callback");
+				// Object was deleted.
+				fprintf(stdout, "Object was deleted while awaiting a callback.\n");
 
 				null_count++;
 			}
@@ -481,19 +481,19 @@ void CallQueue::statistics() {
 		}
 	}
 
-	print_line("TOTAL PAGES: " + itos(pages_used) + " (" + itos(pages_used * PAGE_SIZE_BYTES) + " bytes).");
-	print_line("NULL count: " + itos(null_count));
+	fprintf(stdout, "TOTAL PAGES: %d (%d bytes).\n", pages_used, pages_used * PAGE_SIZE_BYTES);
+	fprintf(stdout, "NULL count: %d.\n", null_count);
 
 	for (const KeyValue<StringName, int> &E : set_count) {
-		print_line("SET " + E.key + ": " + itos(E.value));
+		fprintf(stdout, "SET %s: %d.\n", String(E.key).utf8().get_data(), E.value);
 	}
 
 	for (const KeyValue<Callable, int> &E : call_count) {
-		print_line("CALL " + E.key + ": " + itos(E.value));
+		fprintf(stdout, "CALL %s: %d.\n", String(E.key).utf8().get_data(), E.value);
 	}
 
 	for (const KeyValue<int, int> &E : notify_count) {
-		print_line("NOTIFY " + itos(E.key) + ": " + itos(E.value));
+		fprintf(stdout, "NOTIFY %d: %d.\n", E.key, E.value);
 	}
 
 	UNLOCK_MUTEX;


### PR DESCRIPTION
Similar to:
* https://github.com/godotengine/godot/pull/85397

The `statistics` method is only called when the queue runs out of memory anyway so it would *always* break things, while you can call it from elsewhere it's only called from within the queue at the moment, there's also a possible interlock issue as the mutex isn't unlocked until *after* the `statistics` method is called.

We could add some form of check to print differently if you call it manually, but I think it's fine this way, only unsure if it should be `stdout` or `stderr`

* Fixes crash in: https://github.com/godotengine/godot/issues/87593

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
