### PR TITLE
Fix call queue problems when loading TileSet

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -4981,7 +4981,7 @@ void TileSetAtlasSource::create_tile(const Vector2i p_atlas_coords, const Vector
 	_create_coords_mapping_cache(p_atlas_coords);
 	_queue_update_padded_texture();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
@@ -5002,7 +5002,7 @@ void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
 
 	_queue_update_padded_texture();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 bool TileSetAtlasSource::has_tile(Vector2i p_atlas_coords) const {
@@ -5032,7 +5032,7 @@ void TileSetAtlasSource::set_tile_animation_columns(const Vector2i p_atlas_coord
 	_create_coords_mapping_cache(p_atlas_coords);
 	_queue_update_padded_texture();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 int TileSetAtlasSource::get_tile_animation_columns(const Vector2i p_atlas_coords) const {
@@ -5055,7 +5055,7 @@ void TileSetAtlasSource::set_tile_animation_separation(const Vector2i p_atlas_co
 	_create_coords_mapping_cache(p_atlas_coords);
 	_queue_update_padded_texture();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 Vector2i TileSetAtlasSource::get_tile_animation_separation(const Vector2i p_atlas_coords) const {
@@ -5069,7 +5069,7 @@ void TileSetAtlasSource::set_tile_animation_speed(const Vector2i p_atlas_coords,
 
 	tiles[p_atlas_coords].animation_speed = p_speed;
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 real_t TileSetAtlasSource::get_tile_animation_speed(const Vector2i p_atlas_coords) const {
@@ -5082,7 +5082,7 @@ void TileSetAtlasSource::set_tile_animation_mode(const Vector2i p_atlas_coords, 
 
 	tiles[p_atlas_coords].animation_mode = p_mode;
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 TileSetAtlasSource::TileAnimationMode TileSetAtlasSource::get_tile_animation_mode(const Vector2i p_atlas_coords) const {
@@ -5116,7 +5116,7 @@ void TileSetAtlasSource::set_tile_animation_frames_count(const Vector2i p_atlas_
 
 	notify_property_list_changed();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 int TileSetAtlasSource::get_tile_animation_frames_count(const Vector2i p_atlas_coords) const {
@@ -5131,7 +5131,7 @@ void TileSetAtlasSource::set_tile_animation_frame_duration(const Vector2i p_atla
 
 	tiles[p_atlas_coords].animation_frames_durations[p_frame_index] = p_duration;
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 real_t TileSetAtlasSource::get_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index) const {
@@ -5341,7 +5341,7 @@ void TileSetAtlasSource::move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_
 	_create_coords_mapping_cache(new_atlas_coords);
 	_queue_update_padded_texture();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 int TileSetAtlasSource::create_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_id_override) {
@@ -5359,7 +5359,7 @@ int TileSetAtlasSource::create_alternative_tile(const Vector2i p_atlas_coords, i
 	tiles[p_atlas_coords].alternatives_ids.sort();
 	_compute_next_alternative_id(p_atlas_coords);
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 
 	return new_alternative_id;
 }
@@ -5375,7 +5375,7 @@ void TileSetAtlasSource::remove_alternative_tile(const Vector2i p_atlas_coords, 
 	tiles[p_atlas_coords].alternatives_ids.erase(p_alternative_tile);
 	tiles[p_atlas_coords].alternatives_ids.sort();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 void TileSetAtlasSource::set_alternative_tile_id(const Vector2i p_atlas_coords, int p_alternative_tile, int p_new_id) {
@@ -5393,7 +5393,7 @@ void TileSetAtlasSource::set_alternative_tile_id(const Vector2i p_atlas_coords, 
 	tiles[p_atlas_coords].alternatives_ids.erase(p_alternative_tile);
 	tiles[p_atlas_coords].alternatives_ids.sort();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 bool TileSetAtlasSource::has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const {
@@ -5425,6 +5425,12 @@ TileData *TileSetAtlasSource::get_tile_data(const Vector2i p_atlas_coords, int p
 	ERR_FAIL_COND_V_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), nullptr, vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
 
 	return tiles[p_atlas_coords].alternatives[p_alternative_tile];
+}
+
+void TileSetAtlasSource::_notification(int p_notification) {
+	if (p_notification == NOTIFICATION_POSTINITIALIZE) {
+		initializing = false;
+	}
 }
 
 void TileSetAtlasSource::_bind_methods() {
@@ -5569,6 +5575,9 @@ void TileSetAtlasSource::_create_coords_mapping_cache(Vector2i p_atlas_coords) {
 }
 
 void TileSetAtlasSource::_queue_update_padded_texture() {
+	if (padded_texture_needs_update) {
+		return;
+	}
 	padded_texture_needs_update = true;
 	callable_mp(this, &TileSetAtlasSource::_update_padded_texture).call_deferred();
 }
@@ -5677,12 +5686,24 @@ void TileSetAtlasSource::_update_padded_texture() {
 	emit_changed();
 }
 
+void TileSetAtlasSource::_try_emit_changed() {
+	if (!initializing) {
+		emit_changed();
+	}
+}
+
 /////////////////////////////// TileSetScenesCollectionSource //////////////////////////////////////
 
 void TileSetScenesCollectionSource::_compute_next_alternative_id() {
 	while (scenes.has(next_scene_id)) {
 		next_scene_id = (next_scene_id % 1073741823) + 1; // 2 ** 30
 	};
+}
+
+void TileSetScenesCollectionSource::_try_emit_changed() {
+	if (!initializing) {
+		emit_changed();
+	}
 }
 
 int TileSetScenesCollectionSource::get_tiles_count() const {
@@ -5725,7 +5746,7 @@ int TileSetScenesCollectionSource::create_scene_tile(Ref<PackedScene> p_packed_s
 	set_scene_tile_scene(new_scene_id, p_packed_scene);
 	_compute_next_alternative_id();
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 
 	return new_scene_id;
 }
@@ -5745,7 +5766,7 @@ void TileSetScenesCollectionSource::set_scene_tile_id(int p_id, int p_new_id) {
 	scenes.erase(p_id);
 	scenes_ids.erase(p_id);
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 void TileSetScenesCollectionSource::set_scene_tile_scene(int p_id, Ref<PackedScene> p_packed_scene) {
@@ -5769,7 +5790,7 @@ void TileSetScenesCollectionSource::set_scene_tile_scene(int p_id, Ref<PackedSce
 	} else {
 		scenes[p_id].scene = Ref<PackedScene>();
 	}
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 Ref<PackedScene> TileSetScenesCollectionSource::get_scene_tile_scene(int p_id) const {
@@ -5782,7 +5803,7 @@ void TileSetScenesCollectionSource::set_scene_tile_display_placeholder(int p_id,
 
 	scenes[p_id].display_placeholder = p_display_placeholder;
 
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 bool TileSetScenesCollectionSource::get_scene_tile_display_placeholder(int p_id) const {
@@ -5795,7 +5816,7 @@ void TileSetScenesCollectionSource::remove_scene_tile(int p_id) {
 
 	scenes.erase(p_id);
 	scenes_ids.erase(p_id);
-	emit_signal(SNAME("changed"));
+	_try_emit_changed();
 }
 
 int TileSetScenesCollectionSource::get_next_scene_tile_id() const {
@@ -5851,6 +5872,12 @@ void TileSetScenesCollectionSource::_get_property_list(List<PropertyInfo> *p_lis
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		p_list->push_back(property_info);
+	}
+}
+
+void TileSetScenesCollectionSource::_notification(int p_notification) {
+	if (p_notification == NOTIFICATION_POSTINITIALIZE) {
+		initializing = false;
 	}
 }
 

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -637,6 +637,8 @@ private:
 		int next_alternative_id = 1;
 	};
 
+	bool initializing = true;
+
 	Ref<Texture2D> texture;
 	Vector2i margins;
 	Vector2i separation;
@@ -660,12 +662,14 @@ private:
 	void _queue_update_padded_texture();
 	Ref<ImageTexture> _create_padded_image_texture(const Ref<Texture2D> &p_source);
 	void _update_padded_texture();
+	void _try_emit_changed();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	void _notification(int p_notification);
 	static void _bind_methods();
 
 public:
@@ -779,13 +783,17 @@ private:
 	HashMap<int, SceneData> scenes;
 	int next_scene_id = 1;
 
+	bool initializing = true;
+
 	void _compute_next_alternative_id();
+	void _try_emit_changed();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	void _notification(int p_notification);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
When TileSet is being loaded, it will load every TileSetAtlasSource and it will emit `changed` signal for every tile and tile property. The signal is connected to `_queue_update_padded_texture()`, which doesn't have any safeguard against multiple calls, which means that it did a deferred call every time. So for my tileset with 40+ sources, 50+ tiles each that's like... 2000 deferred calls.

The fix in this PR is twofold:
- it adds a safeguard in `_queue_update_padded_texture()` to prevent multiple deferred calls
- it prevents redundant `changed` emissions while the TileSet is being loaded

Fixes the memory problem in #87593, effectively resolving the issue, as the project can load (albeit it's still extremely slow). The problem was that the deferred calls would build up and never get flushed, because many scenes were loaded one after another and the TileSet was repeatedly freed and loaded again (which is also why it takes so long). I have ~500 scenes that use this TileSet, so if you do the maths, it's obvious why the queue couldn't hold it.

Unfortunately it still results in some deferred calls that will very slowly clog up message queue, but since this makes like 100x less of them, it's much less likely to run out of memory. Not sure how to prevent it completely; we could maybe remove deferred call from queue manually by the TileSetAtlasSource if it's being deleted, but MessageQueue has no method for that AFAIK.