### PR TITLE
Make the "Clear Output" shortcut not require panel focus

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -435,8 +435,7 @@ EditorLog::EditorLog() {
 	clear_button = memnew(Button);
 	clear_button->set_theme_type_variation("FlatButton");
 	clear_button->set_focus_mode(FOCUS_NONE);
-	clear_button->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::K));
-	clear_button->set_shortcut_context(this);
+	clear_button->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::K));
 	clear_button->connect("pressed", callable_mp(this, &EditorLog::_clear_request));
 	hb_tools->add_child(clear_button);
 


### PR DESCRIPTION
Removes the shortcut context (if you have to click the output panel first it's faster to click on the button itself) and changes the binding to `Ctrl+Alt+K` to avoid conflict with "Delete Line" in the script editor