### PR TITLE
[iOS] Disable PCRE2 JIT.

### DIFF
--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -52,6 +52,7 @@ def get_flags():
         ("target", "template_debug"),
         ("use_volk", False),
         ("supported", ["mono"]),
+        ("builtin_pcre2_with_jit", False),
     ]
 
 


### PR DESCRIPTION
Fixes iOS build issue caused by https://github.com/godotengine/godot/pull/89371