### PR TITLE
Fix description of touch input position

### DIFF
--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -17,7 +17,7 @@
 			Returns [code]true[/code] when using the eraser end of a stylus pen.
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			The drag position.
+			The drag position in the viewport the node is in, using the coordinate system of this viewport.
 		</member>
 		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0">
 			Represents the pressure the user puts on the pen. Ranges from [code]0.0[/code] to [code]1.0[/code].

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -20,7 +20,7 @@
 			The touch index in the case of a multi-touch event. One index = one finger.
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			The touch position, in screen (global) coordinates.
+			The touch position in the viewport the node is in, using the coordinate system of this viewport.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the touch's state is pressed. If [code]false[/code], the touch's state is released.


### PR DESCRIPTION
`InputEventScreen{Touch,Drag}.position` is in viewport coordinates.

Related engine codes are all using `get_global_transform_with_canvas()` to transform `position` to local coordinates.