### PR TITLE
[Windows] Fix exporting as ZIP when console wrapper and/or embedded PCK is enabled.

### DIFF
--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -285,15 +285,15 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 
 	if (p_preset->get("codesign/enable")) {
 		_code_sign(p_preset, pck_path);
-		String wrapper_path = p_path.get_basename() + ".console.exe";
+		String wrapper_path = path.get_basename() + ".console.exe";
 		if (FileAccess::exists(wrapper_path)) {
 			_code_sign(p_preset, wrapper_path);
 		}
 	}
 
 	if (embedded) {
-		Ref<DirAccess> tmp_dir = DirAccess::create_for_path(p_path.get_base_dir());
-		err = tmp_dir->rename(pck_path, p_path);
+		Ref<DirAccess> tmp_dir = DirAccess::create_for_path(path.get_base_dir());
+		err = tmp_dir->rename(pck_path, path);
 		if (err != OK) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("PCK Embedding"), vformat(TTR("Failed to rename temporary file \"%s\"."), pck_path));
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/89501