### PR TITLE
Allow for 32 max collisions in `test_body_motion`

### DIFF
--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -655,7 +655,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 	//this took about a week to get right..
 	//but is it right? who knows at this point..
 
-	ERR_FAIL_INDEX_V(p_parameters.max_collisions, PhysicsServer3D::MotionResult::MAX_COLLISIONS, false);
+	ERR_FAIL_COND_V(p_parameters.max_collisions < 0 || p_parameters.max_collisions > PhysicsServer3D::MotionResult::MAX_COLLISIONS, false);
 
 	if (r_result) {
 		*r_result = PhysicsServer3D::MotionResult();


### PR DESCRIPTION
The `max_collisions` parameter in `PhysicsServer3D.body_test_motion`, and by proxy `PhysicsBody3D.test_move` and `PhysicsBody3D.move_and_collide`, is meant to be capped by the size of the fixed-size `collisions` array in `PhysicsServer3D::MotionResult` that's set to the size of `PhysicsServer3D::MotionResult::MAX_COLLISIONS`, which is currently 32.

This is currently being bounds-checked with the `ERR_FAIL_INDEX_V` macro when using Godot Physics, which incorrectly leads to an error when passing a `max_collisions` of 32, as the `max_collisions` parameter is treated as an index rather than a count.

This PR addresses this by switching to `ERR_FAIL_COND_V` instead.