### PR TITLE
[Editor] Remove redundant code from `EditorSpinSlider`

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -238,28 +238,28 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 void EditorSpinSlider::_value_input_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !is_read_only()) {
-		double step = get_step();
-		if (step < 1) {
-			double divisor = 1.0 / get_step();
-
-			if (trunc(divisor) == divisor) {
-				step = 1.0;
-			}
-		}
-
-		if (k->is_command_or_control_pressed()) {
-			step *= 100.0;
-		} else if (k->is_shift_pressed()) {
-			step *= 10.0;
-		} else if (k->is_alt_pressed()) {
-			step *= 0.1;
-		}
-
 		Key code = k->get_keycode();
 
 		switch (code) {
 			case Key::UP:
 			case Key::DOWN: {
+				double step = get_step();
+				if (step < 1) {
+					double divisor = 1.0 / step;
+
+					if (trunc(divisor) == divisor) {
+						step = 1.0;
+					}
+				}
+
+				if (k->is_command_or_control_pressed()) {
+					step *= 100.0;
+				} else if (k->is_shift_pressed()) {
+					step *= 10.0;
+				} else if (k->is_alt_pressed()) {
+					step *= 0.1;
+				}
+
 				_evaluate_input_text();
 
 				double last_value = get_value();
@@ -267,12 +267,6 @@ void EditorSpinSlider::_value_input_gui_input(const Ref<InputEvent> &p_event) {
 					step *= -1;
 				}
 				set_value(last_value + step);
-				double new_value = get_value();
-
-				double clamp_value = CLAMP(new_value, get_min(), get_max());
-				if (new_value != clamp_value) {
-					set_value(clamp_value);
-				}
 
 				value_input_dirty = true;
 				set_process_internal(true);


### PR DESCRIPTION
While working on some other code I ran into some issues with the range when using up/down with the inspector, the underlying range already does clamping, which is configurable with greater/less, so all this code does is ignore those flags, otherwise the code is redundant

This makes the behavior of the spin up/down consistent with the key input (which is especially relevant for `float` exports as they don't show the up/down)

Also moved some of the code into the cases where it's used, and cleaned up some minor details

Tested and confirmed the code without clamping works correctly, not reintroducing the issues described in:
* https://github.com/godotengine/godot/issues/81272

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
