### PR TITLE
Add `animation_looped` signal to AnimationMixer

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -309,7 +309,7 @@
 			<param index="0" name="anim_name" type="StringName" />
 			<description>
 				Notifies when an animation finished playing.
-				[b]Note:[/b] This signal is not emitted if an animation is looping.
+				[b]Note:[/b] This signal is not emitted if an animation is looping. For looping animations, use [signal animation_looped] instead.
 			</description>
 		</signal>
 		<signal name="animation_libraries_updated">
@@ -320,6 +320,14 @@
 		<signal name="animation_list_changed">
 			<description>
 				Notifies when an animation list is changed.
+			</description>
+		</signal>
+		<signal name="animation_looped">
+			<param index="0" name="anim_name" type="StringName" />
+			<param index="1" name="backwards" type="bool" />
+			<description>
+				Notifies when a looping animation finished playing. [param backwards] is [code]true[/code] if the looping "barrier" has been crossed backwards when playing the animation, [code]false[/code] otherwise. In practice, [param backwards] is [code]true[/code] every time when the animation is played backwards, or every 2 signals emitted when ping-pong looping is used.
+				[b]Note:[/b] This signal is not emitted if an animation is not looping. For non-looping animations, use [signal animation_finished] instead.
 			</description>
 		</signal>
 		<signal name="animation_started">

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -147,6 +147,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 			if (!Math::is_zero_approx(cur_len)) {
 				if (prev_time <= cur_len && cur_time > cur_len) {
 					is_just_looped = true; // Don't break with negative timescale since remain will not be 0.
+					process_state->tree->call_deferred(SNAME("emit_signal"), SceneStringNames::get_singleton()->animation_looped, animation, node_backward);
 				}
 				cur_time = Math::fposmod(cur_time, cur_len);
 			}
@@ -155,9 +156,11 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 			if (!Math::is_zero_approx(cur_len)) {
 				if (prev_time >= 0 && cur_time < 0) {
 					backward = !backward;
+					process_state->tree->call_deferred(SNAME("emit_signal"), SceneStringNames::get_singleton()->animation_looped, animation, !node_backward);
 				} else if (prev_time <= cur_len && cur_time > cur_len) {
 					backward = !backward;
 					is_just_looped = true; // Don't break with negative timescale since remain will not be 0.
+					process_state->tree->call_deferred(SNAME("emit_signal"), SceneStringNames::get_singleton()->animation_looped, animation, node_backward);
 				}
 				cur_time = Math::pingpong(cur_time, cur_len);
 			}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2276,6 +2276,7 @@ void AnimationMixer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo(SNAME("animation_list_changed")));
 	ADD_SIGNAL(MethodInfo(SNAME("animation_libraries_updated")));
 	ADD_SIGNAL(MethodInfo(SNAME("animation_finished"), PropertyInfo(Variant::STRING_NAME, "anim_name")));
+	ADD_SIGNAL(MethodInfo(SNAME("animation_looped"), PropertyInfo(Variant::STRING_NAME, "anim_name"), PropertyInfo(Variant::BOOL, "backwards")));
 	ADD_SIGNAL(MethodInfo(SNAME("animation_started"), PropertyInfo(Variant::STRING_NAME, "anim_name")));
 	ADD_SIGNAL(MethodInfo(SNAME("caches_cleared")));
 	ADD_SIGNAL(MethodInfo(SNAME("mixer_applied")));

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -181,9 +181,11 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 		case Animation::LOOP_LINEAR: {
 			if (next_pos < 0 && cd.pos >= 0) {
 				looped_flag = Animation::LOOPED_FLAG_START;
+				emit_signal(SceneStringNames::get_singleton()->animation_looped, playback.assigned, !backwards);
 			}
 			if (next_pos > len && cd.pos <= len) {
 				looped_flag = Animation::LOOPED_FLAG_END;
+				emit_signal(SceneStringNames::get_singleton()->animation_looped, playback.assigned, backwards);
 			}
 			next_pos = Math::fposmod(next_pos, (double)len);
 		} break;
@@ -192,10 +194,12 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 			if (next_pos < 0 && cd.pos >= 0) {
 				cd.speed_scale *= -1.0;
 				looped_flag = Animation::LOOPED_FLAG_START;
+				emit_signal(SceneStringNames::get_singleton()->animation_looped, playback.assigned, !backwards);
 			}
 			if (next_pos > len && cd.pos <= len) {
 				cd.speed_scale *= -1.0;
 				looped_flag = Animation::LOOPED_FLAG_END;
+				emit_signal(SceneStringNames::get_singleton()->animation_looped, playback.assigned, backwards);
 			}
 			next_pos = Math::pingpong(next_pos, (double)len);
 		} break;

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -58,6 +58,7 @@ SceneStringNames::SceneStringNames() {
 
 	finished = StaticCString::create("finished");
 	animation_finished = StaticCString::create("animation_finished");
+	animation_looped = StaticCString::create("animation_looped");
 	animation_changed = StaticCString::create("animation_changed");
 	animation_started = StaticCString::create("animation_started");
 	RESET = StaticCString::create("RESET");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -94,6 +94,7 @@ public:
 
 	StringName finished;
 	StringName animation_finished;
+	StringName animation_looped;
 	StringName animation_changed;
 	StringName animation_started;
 	StringName RESET;


### PR DESCRIPTION
The signal has two parameters: the animation name, and a boolean that is `true` if the looping barrier was crossed backwards (which occurs when playing backwards or with ping-pong looping), `false` otherwise.

This is available in both AnimationPlayer and AnimationTree. In AnimationTree, this is implemented in AnimationNodeAnimation.

For reference, AnimatedSprite2D/3D have similar signals available, although they don't have an `anim_name` and `backwards` parameters.

**Testing project:** [test_animation_looped_signal.zip](https://github.com/godotengine/godot/files/14618244/test_animation_looped_signal.zip)

- This closes https://github.com/godotengine/godot/issues/76159. See also https://github.com/godotengine/godot/pull/71088.