### PR TITLE
Editor: Add ability to rename theme types

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -462,6 +462,15 @@
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
 		</method>
+		<method name="rename_type">
+			<return type="void" />
+			<param index="0" name="old_theme_type" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" />
+			<description>
+				Renames the theme type [param old_theme_type] to [param theme_type], if the old type exists and the new one doesn't exist.
+				[b]Note:[/b] Renaming a theme type to an empty name or a variation to a type associated with a built-in class removes type variation connections in a way that cannot be undone by reversing the rename alone.
+			</description>
+		</method>
 		<method name="set_color">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -42,6 +42,7 @@ class CheckButton;
 class EditorFileDialog;
 class ItemList;
 class Label;
+class LineEdit;
 class OptionButton;
 class PanelContainer;
 class TabBar;
@@ -253,13 +254,14 @@ class ThemeItemEditorDialog : public AcceptDialog {
 	void _dialog_about_to_show();
 	void _update_edit_types();
 	void _edited_type_selected();
+	void _edited_type_edited();
 	void _edited_type_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _update_edit_item_tree(String p_item_type);
 	void _item_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
-	void _add_theme_type(const String &p_new_text);
-	void _add_theme_item(Theme::DataType p_data_type, String p_item_name, String p_item_type);
+	void _add_theme_type();
+	void _add_theme_item(Theme::DataType p_data_type, const String &p_item_name, const String &p_item_type);
 	void _remove_theme_type(const String &p_theme_type);
 	void _remove_data_type_items(Theme::DataType p_data_type, String p_item_type);
 	void _remove_class_items();
@@ -344,6 +346,10 @@ class ThemeTypeEditor : public MarginContainer {
 
 	OptionButton *theme_type_list = nullptr;
 	Button *add_type_button = nullptr;
+	Button *rename_type_button = nullptr;
+	ConfirmationDialog *theme_type_rename_dialog = nullptr;
+	LineEdit *theme_type_rename_line_edit = nullptr;
+	Button *remove_type_button = nullptr;
 
 	CheckButton *show_default_items_button = nullptr;
 
@@ -380,6 +386,9 @@ class ThemeTypeEditor : public MarginContainer {
 
 	void _list_type_selected(int p_index);
 	void _add_type_button_cbk();
+	void _rename_type_button_cbk();
+	void _theme_type_rename_dialog_confirmed();
+	void _remove_type_button_cbk();
 	void _add_default_type_items();
 
 	void _update_add_button(const String &p_text, LineEdit *p_for_edit);

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -361,6 +361,17 @@ void Theme::remove_icon_type(const StringName &p_theme_type) {
 	_unfreeze_and_propagate_changes();
 }
 
+void Theme::rename_icon_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!icon_map.has(p_old_theme_type) || icon_map.has(p_theme_type)) {
+		return;
+	}
+
+	icon_map[p_theme_type] = icon_map[p_old_theme_type];
+	icon_map.erase(p_old_theme_type);
+}
+
 void Theme::get_icon_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -469,6 +480,17 @@ void Theme::remove_stylebox_type(const StringName &p_theme_type) {
 	style_map.erase(p_theme_type);
 
 	_unfreeze_and_propagate_changes();
+}
+
+void Theme::rename_stylebox_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!style_map.has(p_old_theme_type) || style_map.has(p_theme_type)) {
+		return;
+	}
+
+	style_map[p_theme_type] = style_map[p_old_theme_type];
+	style_map.erase(p_old_theme_type);
 }
 
 void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
@@ -587,6 +609,17 @@ void Theme::remove_font_type(const StringName &p_theme_type) {
 	_unfreeze_and_propagate_changes();
 }
 
+void Theme::rename_font_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!font_map.has(p_old_theme_type) || font_map.has(p_theme_type)) {
+		return;
+	}
+
+	font_map[p_theme_type] = font_map[p_old_theme_type];
+	font_map.erase(p_old_theme_type);
+}
+
 void Theme::get_font_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -679,6 +712,17 @@ void Theme::remove_font_size_type(const StringName &p_theme_type) {
 	font_size_map.erase(p_theme_type);
 }
 
+void Theme::rename_font_size_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!font_size_map.has(p_old_theme_type) || font_size_map.has(p_theme_type)) {
+		return;
+	}
+
+	font_size_map[p_theme_type] = font_size_map[p_old_theme_type];
+	font_size_map.erase(p_old_theme_type);
+}
+
 void Theme::get_font_size_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -765,6 +809,17 @@ void Theme::remove_color_type(const StringName &p_theme_type) {
 	color_map.erase(p_theme_type);
 }
 
+void Theme::rename_color_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!color_map.has(p_old_theme_type) || color_map.has(p_theme_type)) {
+		return;
+	}
+
+	color_map[p_theme_type] = color_map[p_old_theme_type];
+	color_map.erase(p_old_theme_type);
+}
+
 void Theme::get_color_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
@@ -849,6 +904,17 @@ void Theme::remove_constant_type(const StringName &p_theme_type) {
 	}
 
 	constant_map.erase(p_theme_type);
+}
+
+void Theme::rename_constant_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!constant_map.has(p_old_theme_type) || constant_map.has(p_theme_type)) {
+		return;
+	}
+
+	constant_map[p_theme_type] = constant_map[p_old_theme_type];
+	constant_map.erase(p_old_theme_type);
 }
 
 void Theme::get_constant_type_list(List<StringName> *p_list) const {
@@ -1099,6 +1165,31 @@ void Theme::remove_theme_item_type(DataType p_data_type, const StringName &p_the
 	}
 }
 
+void Theme::rename_theme_item_type(DataType p_data_type, const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	switch (p_data_type) {
+		case DATA_TYPE_COLOR:
+			rename_color_type(p_old_theme_type, p_theme_type);
+			break;
+		case DATA_TYPE_CONSTANT:
+			rename_constant_type(p_old_theme_type, p_theme_type);
+			break;
+		case DATA_TYPE_FONT:
+			rename_font_type(p_old_theme_type, p_theme_type);
+			break;
+		case DATA_TYPE_FONT_SIZE:
+			rename_font_size_type(p_old_theme_type, p_theme_type);
+			break;
+		case DATA_TYPE_ICON:
+			rename_icon_type(p_old_theme_type, p_theme_type);
+			break;
+		case DATA_TYPE_STYLEBOX:
+			rename_stylebox_type(p_old_theme_type, p_theme_type);
+			break;
+		case DATA_TYPE_MAX:
+			break; // Can't happen, but silences warning.
+	}
+}
+
 void Theme::get_theme_item_type_list(DataType p_data_type, List<StringName> *p_list) const {
 	switch (p_data_type) {
 		case DATA_TYPE_COLOR:
@@ -1212,6 +1303,35 @@ void Theme::remove_type(const StringName &p_theme_type) {
 	get_type_variation_list(p_theme_type, &names);
 	for (const StringName &E : names) {
 		clear_type_variation(E);
+	}
+
+	_emit_theme_changed(true);
+}
+
+void Theme::rename_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	// Gracefully rename the record in every data type map.
+	for (int i = 0; i < Theme::DATA_TYPE_MAX; i++) {
+		Theme::DataType dt = (Theme::DataType)i;
+		rename_theme_item_type(dt, p_old_theme_type, p_theme_type);
+	}
+
+	// If type is a variation, replace that connection.
+	const StringName base_type = get_type_variation_base(p_old_theme_type);
+	if (base_type != StringName()) {
+		clear_type_variation(p_old_theme_type);
+		if (p_theme_type != StringName() && !ClassDB::class_exists(p_theme_type)) {
+			set_type_variation(p_theme_type, base_type);
+		}
+	}
+
+	// If type is a variation base, replace all those connections.
+	List<StringName> names;
+	get_type_variation_list(p_old_theme_type, &names);
+	for (const StringName &E : names) {
+		clear_type_variation(E);
+		if (p_theme_type != StringName()) {
+			set_type_variation(E, p_theme_type);
+		}
 	}
 
 	_emit_theme_changed(true);
@@ -1769,6 +1889,7 @@ void Theme::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_type", "theme_type"), &Theme::add_type);
 	ClassDB::bind_method(D_METHOD("remove_type", "theme_type"), &Theme::remove_type);
+	ClassDB::bind_method(D_METHOD("rename_type", "old_theme_type", "theme_type"), &Theme::rename_type);
 	ClassDB::bind_method(D_METHOD("get_type_list"), &Theme::_get_type_list);
 
 	ClassDB::bind_method(D_METHOD("merge_with", "other"), &Theme::merge_with);

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -138,6 +138,7 @@ public:
 	void get_icon_list(const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_icon_type(const StringName &p_theme_type);
 	void remove_icon_type(const StringName &p_theme_type);
+	void rename_icon_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_icon_type_list(List<StringName> *p_list) const;
 
 	void set_stylebox(const StringName &p_name, const StringName &p_theme_type, const Ref<StyleBox> &p_style);
@@ -149,6 +150,7 @@ public:
 	void get_stylebox_list(const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_stylebox_type(const StringName &p_theme_type);
 	void remove_stylebox_type(const StringName &p_theme_type);
+	void rename_stylebox_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_stylebox_type_list(List<StringName> *p_list) const;
 
 	void set_font(const StringName &p_name, const StringName &p_theme_type, const Ref<Font> &p_font);
@@ -161,6 +163,7 @@ public:
 	void get_font_list(const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_font_type(const StringName &p_theme_type);
 	void remove_font_type(const StringName &p_theme_type);
+	void rename_font_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_font_type_list(List<StringName> *p_list) const;
 
 	void set_font_size(const StringName &p_name, const StringName &p_theme_type, int p_font_size);
@@ -173,6 +176,7 @@ public:
 	void get_font_size_list(const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_font_size_type(const StringName &p_theme_type);
 	void remove_font_size_type(const StringName &p_theme_type);
+	void rename_font_size_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_font_size_type_list(List<StringName> *p_list) const;
 
 	void set_color(const StringName &p_name, const StringName &p_theme_type, const Color &p_color);
@@ -184,6 +188,7 @@ public:
 	void get_color_list(const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_color_type(const StringName &p_theme_type);
 	void remove_color_type(const StringName &p_theme_type);
+	void rename_color_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_color_type_list(List<StringName> *p_list) const;
 
 	void set_constant(const StringName &p_name, const StringName &p_theme_type, int p_constant);
@@ -195,6 +200,7 @@ public:
 	void get_constant_list(const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_constant_type(const StringName &p_theme_type);
 	void remove_constant_type(const StringName &p_theme_type);
+	void rename_constant_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_constant_type_list(List<StringName> *p_list) const;
 
 	void set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type, const Variant &p_value);
@@ -206,6 +212,7 @@ public:
 	void get_theme_item_list(DataType p_data_type, const StringName &p_theme_type, List<StringName> *p_list) const;
 	void add_theme_item_type(DataType p_data_type, const StringName &p_theme_type);
 	void remove_theme_item_type(DataType p_data_type, const StringName &p_theme_type);
+	void rename_theme_item_type(DataType p_data_type, const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_theme_item_type_list(DataType p_data_type, List<StringName> *p_list) const;
 
 	void set_type_variation(const StringName &p_theme_type, const StringName &p_base_type);
@@ -216,6 +223,7 @@ public:
 
 	void add_type(const StringName &p_theme_type);
 	void remove_type(const StringName &p_theme_type);
+	void rename_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_type_list(List<StringName> *p_list) const;
 	void get_type_dependencies(const StringName &p_base_type, const StringName &p_type_variant, Vector<StringName> &r_result);
 


### PR DESCRIPTION
* Closes #86898.
* Closes https://github.com/godotengine/godot-proposals/issues/10038.

![](https://github.com/godotengine/godot/assets/47700418/ce862867-cc25-4873-86c7-c36c8fafc21b)
![](https://github.com/godotengine/godot/assets/47700418/c63f3cc2-08e6-410f-bcdb-60d1e6a0c12a)

Also adds type/item name validation, since themes don't allow arbitrary names:

https://github.com/godotengine/godot/blob/68ad520da4365c866ceea42e0238b2ea24647289/scene/resources/theme.cpp#L179-L198

Fixes the error `Error calling UndoRedo method operation '_update_edit_item_tree': 'ThemeTypeEditor::_update_edit_item_tree': Instance is null`.