### PR TITLE
meshoptimizer: State used version explicitly

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -540,7 +540,7 @@ File extracted from upstream release tarball:
 ## meshoptimizer
 
 - Upstream: https://github.com/zeux/meshoptimizer
-- Version: git (c21d3be6ddf627f8ca852ba4b6db9903b0557858, 2023)
+- Version: 0.20 (c21d3be6ddf627f8ca852ba4b6db9903b0557858, 2023)
 - License: MIT
 
 Files extracted from upstream repository:


### PR DESCRIPTION
Given that `meshoptimizer` uses a stable release (v0.20) of https://github.com/zeux/meshoptimizer, I think it's better to have it written explicitly in the `README.md` file as opposed to the ambiguous "git".
