### PR TITLE
Fix missing gutter icon for inner class method overrides

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1164,9 +1164,20 @@ void ScriptTextEditor::_update_connected_methods() {
 	// Add override icons to methods.
 	methods_found.clear();
 	for (int i = 0; i < functions.size(); i++) {
-		StringName name = StringName(functions[i].get_slice(":", 0));
+		String raw_name = functions[i].get_slice(":", 0);
+		StringName name = StringName(raw_name);
 		if (methods_found.has(name)) {
 			continue;
+		}
+
+		// Account for inner classes
+		if (raw_name.contains(".")) {
+			// Strip inner class name from the method, and start from the right since
+			// our inner class might be inside another inner class
+			int pos = raw_name.rfind(".");
+			if (pos != -1) {
+				name = raw_name.substr(pos + 1);
+			}
 		}
 
 		String found_base_class;
@@ -1217,7 +1228,7 @@ void ScriptTextEditor::_update_connected_methods() {
 				text_edit->set_line_gutter_icon(line, connection_gutter, get_parent_control()->get_editor_theme_icon(SNAME("MethodOverrideAndSlot")));
 			}
 
-			methods_found.insert(name);
+			methods_found.insert(StringName(raw_name));
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/69023

Also handles inner, inner classes! And inner, inner, inner classes... and so on.
<img width="499" alt="Cap" src="https://github.com/godotengine/godot/assets/30541183/5e85a3bd-543a-42c5-8ea4-3b59722c0137">


