### PR TITLE
Fix backspace always unfolding previous line

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -737,7 +737,7 @@ void CodeEdit::_backspace_internal(int p_caret) {
 			continue;
 		}
 
-		if (to_line > 0 && _is_line_hidden(to_line - 1)) {
+		if (to_line > 0 && to_column == 0 && _is_line_hidden(to_line - 1)) {
 			unfold_line(to_line - 1);
 		}
 

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -4570,6 +4570,26 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		CHECK(code_edit->get_text() == "line 1\nline 2\nline 3");
 		CHECK(code_edit->get_caret_line() == 0);
 		CHECK(code_edit->get_caret_column() == 0);
+
+		// Unfold previous folded line on backspace if the caret is at the first column.
+		code_edit->set_line_folding_enabled(true);
+		code_edit->set_text("line 1\n\tline 2\nline 3");
+		code_edit->set_caret_line(2);
+		code_edit->set_caret_column(0);
+		code_edit->fold_line(0);
+		code_edit->backspace();
+		CHECK_FALSE(code_edit->is_line_folded(0));
+		code_edit->set_line_folding_enabled(false);
+
+		// Do not unfold previous line on backspace if the caret is not at the first column.
+		code_edit->set_line_folding_enabled(true);
+		code_edit->set_text("line 1\n\tline 2\nline 3");
+		code_edit->set_caret_line(2);
+		code_edit->set_caret_column(4);
+		code_edit->fold_line(0);
+		code_edit->backspace();
+		CHECK(code_edit->is_line_folded(0));
+		code_edit->set_line_folding_enabled(false);
 	}
 
 	SUBCASE("[TextEdit] cut") {


### PR DESCRIPTION
Add a condition to `CodeEdit::_backspace_internal` so the previous line is only unfolded when the caret is at the start of the current line.

Fixes #89522 
