### PR TITLE
[3.x] Fix building with `disable_3d`

### DIFF
--- a/scene/resources/world.cpp
+++ b/scene/resources/world.cpp
@@ -331,9 +331,11 @@ void World::get_camera_list(List<Camera *> *r_cameras) {
 }
 
 void World::notify_saving(bool p_active) {
+#ifndef _3D_DISABLED
 	if (lod_manager) {
 		lod_manager->notify_saving(p_active);
 	}
+#endif
 }
 
 void World::_bind_methods() {


### PR DESCRIPTION
~We might want to look at adding a minimal template build to 3.x like we have for 4.x, if desired, the building there is relatively minimal at the moment but might be something to look into~

Edit: Realized one exists already:
* https://github.com/godotengine/godot/pull/53489

---

* Fixes: https://github.com/godotengine/godot/issues/89550
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
