### PR TITLE
Avoid passing zoom scale for ParallaxLayer mirror

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -71,8 +71,8 @@ void ParallaxLayer::_update_mirroring() {
 	if (pb) {
 		RID c = pb->get_canvas();
 		RID ci = get_canvas_item();
-		Point2 mirrorScale = mirroring * get_scale();
-		RenderingServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirrorScale);
+		Point2 mirror_scale = mirroring * orig_scale;
+		RenderingServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirror_scale);
 		RenderingServer::get_singleton()->canvas_item_set_interpolated(ci, false);
 	}
 }


### PR DESCRIPTION
`ParallaxBackground` doesn't support zoom, so instead it scales all the `ParallaxLayer`s up(!). The old rendering method required that calculation done up front when deciding repeat size, but the new one doesn't. This just uses the `ParallaxLayer`'s original scale to mirror instead.

Before:
![68747470733a2f2f692e6779617a6f2e636f6d2f30326364616462626464653565383332643933613765366232356337346561392e676966](https://github.com/godotengine/godot/assets/21325943/3a93c038-8d2c-4c63-9fe1-f6aa646e2f2c)

After:

https://github.com/godotengine/godot/assets/21325943/499ba4fe-4c20-4f3a-92e0-90bdebab965b


Fixes #89563

I'd like to have some further testing to avoid more regressions. My original PR didn't have any changes to `ParallaxBackground` or `ParallaxLayer` so I want to be cautious with this fix. I'll comment when I have tried a few more scenarios.