### PR TITLE
[3.x] Physics Interpolation 2D - fix light and light occluder resetting

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -319,7 +319,12 @@ void Light2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (is_visible_in_tree() && is_physics_interpolated()) {
-				VisualServer::get_singleton()->canvas_light_reset_physics_interpolation(canvas_light);
+				// Explicitly make sure the transform is up to date in VisualServer before
+				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
+				// is normally deferred, and a client change to transform will not always be sent
+				// before the reset, so we need to guarantee this.
+				VS::get_singleton()->canvas_light_set_transform(canvas_light, get_global_transform());
+				VS::get_singleton()->canvas_light_reset_physics_interpolation(canvas_light);
 			}
 		} break;
 	}

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -202,7 +202,12 @@ void LightOccluder2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (is_visible_in_tree() && is_physics_interpolated()) {
-				VisualServer::get_singleton()->canvas_light_occluder_reset_physics_interpolation(occluder);
+				// Explicitly make sure the transform is up to date in VisualServer before
+				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
+				// is normally deferred, and a client change to transform will not always be sent
+				// before the reset, so we need to guarantee this.
+				VS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
+				VS::get_singleton()->canvas_light_occluder_reset_physics_interpolation(occluder);
 			}
 		} break;
 	}


### PR DESCRIPTION
It turns out `NOTIFICATION_TRANSFORM_CHANGED` is deferred for these nodes, which can mean the transform is not set in the `VisualServer` until after the reset has been sent, even if the transform is set before the reset in script. This prevented the reset from acting correctly.

Here we explicitly set the transform prior to each reset, to ensure the `VisualServer` is up to date.

Fixes bug mentioned here:
https://github.com/godotengine/godot/pull/88424#issuecomment-1986918150

## Notes
* I hadn't noticed this during development of 2D interpolation. There are already similar techniques in place for canvas items and `CPUParticles` to deal with this deferred notification.
* This is probably the simplest way to fix this.
* It would be possible to do more complex (bug prone) code to ensure the transform was only sent once (after this PR it will be sent twice on a reset tick, once during the reset, and once redundantly during the `NOTIFICATION_TRANSFORM_CHANGED`), but resetting should be a rare occurrence and this will have minimum impact.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
