### PR TITLE
[3.x] Physics Interpolation 2D - change transform API to use const ref

### DIFF
--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1592,7 +1592,7 @@ void VisualServerCanvas::canvas_item_set_skeleton_relative_xform(RID p_item, Tra
 }
 
 // Useful especially for origin shifting.
-void VisualServerCanvas::canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform) {
+void VisualServerCanvas::canvas_item_transform_physics_interpolation(RID p_item, const Transform2D &p_transform) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 	canvas_item->xform_prev = p_transform * canvas_item->xform_prev;
@@ -1623,7 +1623,7 @@ void VisualServerCanvas::canvas_light_reset_physics_interpolation(RID p_light) {
 	clight->xform_prev = clight->xform_curr;
 }
 
-void VisualServerCanvas::canvas_light_transform_physics_interpolation(RID p_light, Transform2D p_transform) {
+void VisualServerCanvas::canvas_light_transform_physics_interpolation(RID p_light, const Transform2D &p_transform) {
 	RasterizerCanvas::Light *clight = canvas_light_owner.get(p_light);
 	ERR_FAIL_COND(!clight);
 	clight->xform_prev = p_transform * clight->xform_prev;
@@ -1642,7 +1642,7 @@ void VisualServerCanvas::canvas_light_occluder_reset_physics_interpolation(RID p
 	occluder->xform_prev = occluder->xform_curr;
 }
 
-void VisualServerCanvas::canvas_light_occluder_transform_physics_interpolation(RID p_occluder, Transform2D p_transform) {
+void VisualServerCanvas::canvas_light_occluder_transform_physics_interpolation(RID p_occluder, const Transform2D &p_transform) {
 	RasterizerCanvas::LightOccluderInstance *occluder = canvas_light_occluder_owner.get(p_occluder);
 	ERR_FAIL_COND(!occluder);
 	occluder->xform_prev = p_transform * occluder->xform_prev;

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -265,7 +265,7 @@ public:
 
 	void canvas_item_set_interpolated(RID p_item, bool p_interpolated);
 	void canvas_item_reset_physics_interpolation(RID p_item);
-	void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform);
+	void canvas_item_transform_physics_interpolation(RID p_item, const Transform2D &p_transform);
 
 	void _canvas_item_invalidate_local_bound(RID p_item);
 	void _canvas_item_remove_references(RID p_item, RID p_rid);
@@ -294,7 +294,7 @@ public:
 
 	void canvas_light_set_interpolated(RID p_light, bool p_interpolated);
 	void canvas_light_reset_physics_interpolation(RID p_light);
-	void canvas_light_transform_physics_interpolation(RID p_light, Transform2D p_transform);
+	void canvas_light_transform_physics_interpolation(RID p_light, const Transform2D &p_transform);
 
 	RID canvas_light_occluder_create();
 	void canvas_light_occluder_attach_to_canvas(RID p_occluder, RID p_canvas);
@@ -305,7 +305,7 @@ public:
 
 	void canvas_light_occluder_set_interpolated(RID p_occluder, bool p_interpolated);
 	void canvas_light_occluder_reset_physics_interpolation(RID p_occluder);
-	void canvas_light_occluder_transform_physics_interpolation(RID p_occluder, Transform2D p_transform);
+	void canvas_light_occluder_transform_physics_interpolation(RID p_occluder, const Transform2D &p_transform);
 
 	RID canvas_occluder_polygon_create();
 	void canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const PoolVector<Vector2> &p_shape, bool p_closed);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -722,7 +722,7 @@ public:
 
 	BIND2(canvas_item_set_interpolated, RID, bool)
 	BIND1(canvas_item_reset_physics_interpolation, RID)
-	BIND2(canvas_item_transform_physics_interpolation, RID, Transform2D)
+	BIND2(canvas_item_transform_physics_interpolation, RID, const Transform2D &)
 
 	BIND0R(RID, canvas_light_create)
 	BIND2(canvas_light_attach_to_canvas, RID, RID)
@@ -750,7 +750,7 @@ public:
 
 	BIND2(canvas_light_set_interpolated, RID, bool)
 	BIND1(canvas_light_reset_physics_interpolation, RID)
-	BIND2(canvas_light_transform_physics_interpolation, RID, Transform2D)
+	BIND2(canvas_light_transform_physics_interpolation, RID, const Transform2D &)
 
 	BIND0R(RID, canvas_light_occluder_create)
 	BIND2(canvas_light_occluder_attach_to_canvas, RID, RID)
@@ -761,7 +761,7 @@ public:
 
 	BIND2(canvas_light_occluder_set_interpolated, RID, bool)
 	BIND1(canvas_light_occluder_reset_physics_interpolation, RID)
-	BIND2(canvas_light_occluder_transform_physics_interpolation, RID, Transform2D)
+	BIND2(canvas_light_occluder_transform_physics_interpolation, RID, const Transform2D &)
 
 	BIND0R(RID, canvas_occluder_polygon_create)
 	BIND3(canvas_occluder_polygon_set_shape, RID, const PoolVector<Vector2> &, bool)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -626,7 +626,7 @@ public:
 
 	FUNC2(canvas_item_set_interpolated, RID, bool)
 	FUNC1(canvas_item_reset_physics_interpolation, RID)
-	FUNC2(canvas_item_transform_physics_interpolation, RID, Transform2D)
+	FUNC2(canvas_item_transform_physics_interpolation, RID, const Transform2D &)
 
 	FUNC0R(RID, canvas_light_create)
 	FUNC2(canvas_light_attach_to_canvas, RID, RID)
@@ -654,7 +654,7 @@ public:
 
 	FUNC2(canvas_light_set_interpolated, RID, bool)
 	FUNC1(canvas_light_reset_physics_interpolation, RID)
-	FUNC2(canvas_light_transform_physics_interpolation, RID, Transform2D)
+	FUNC2(canvas_light_transform_physics_interpolation, RID, const Transform2D &)
 
 	FUNCRID(canvas_light_occluder)
 	FUNC2(canvas_light_occluder_attach_to_canvas, RID, RID)
@@ -665,7 +665,7 @@ public:
 
 	FUNC2(canvas_light_occluder_set_interpolated, RID, bool)
 	FUNC1(canvas_light_occluder_reset_physics_interpolation, RID)
-	FUNC2(canvas_light_occluder_transform_physics_interpolation, RID, Transform2D)
+	FUNC2(canvas_light_occluder_transform_physics_interpolation, RID, const Transform2D &)
 
 	FUNCRID(canvas_occluder_polygon)
 	FUNC3(canvas_occluder_polygon_set_shape, RID, const PoolVector<Vector2> &, bool)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1076,7 +1076,7 @@ public:
 
 	virtual void canvas_item_set_interpolated(RID p_item, bool p_interpolated) = 0;
 	virtual void canvas_item_reset_physics_interpolation(RID p_item) = 0;
-	virtual void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform) = 0;
+	virtual void canvas_item_transform_physics_interpolation(RID p_item, const Transform2D &p_transform) = 0;
 
 	virtual RID canvas_light_create() = 0;
 	virtual void canvas_light_attach_to_canvas(RID p_light, RID p_canvas) = 0;
@@ -1095,7 +1095,7 @@ public:
 
 	virtual void canvas_light_set_interpolated(RID p_light, bool p_interpolated) = 0;
 	virtual void canvas_light_reset_physics_interpolation(RID p_light) = 0;
-	virtual void canvas_light_transform_physics_interpolation(RID p_light, Transform2D p_transform) = 0;
+	virtual void canvas_light_transform_physics_interpolation(RID p_light, const Transform2D &p_transform) = 0;
 
 	enum CanvasLightMode {
 		CANVAS_LIGHT_MODE_ADD,
@@ -1131,7 +1131,7 @@ public:
 
 	virtual void canvas_light_occluder_set_interpolated(RID p_occluder, bool p_interpolated) = 0;
 	virtual void canvas_light_occluder_reset_physics_interpolation(RID p_occluder) = 0;
-	virtual void canvas_light_occluder_transform_physics_interpolation(RID p_occluder, Transform2D p_transform) = 0;
+	virtual void canvas_light_occluder_transform_physics_interpolation(RID p_occluder, const Transform2D &p_transform) = 0;
 
 	virtual RID canvas_occluder_polygon_create() = 0;
 	virtual void canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const PoolVector<Vector2> &p_shape, bool p_closed) = 0;


### PR DESCRIPTION
## Notes
* I must have missed this on the original PR, const ref should be slightly better.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
