### PR TITLE
thorvg: Update to 0.12.9

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -860,7 +860,7 @@ instead of `miniz.h` as an external dependency.
 ## thorvg
 
 - Upstream: https://github.com/thorvg/thorvg
-- Version: 0.12.7 (cddae9966cbb48c431ea17c262d6f48393206fd7, 2024)
+- Version: 0.12.9 (afa6d8499bd49141d99d5e40a4620bd9f6bc0467, 2024)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -10,5 +10,5 @@
 // For internal debugging:
 //#define THORVG_LOG_ENABLED
 
-#define THORVG_VERSION_STRING "0.12.7"
+#define THORVG_VERSION_STRING "0.12.9"
 #endif

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgPath.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgPath.cpp
@@ -122,9 +122,6 @@ void _pathAppendArcTo(Array<PathCommand>* cmds, Array<Point>* pts, Point* cur, P
     sx = cur->x;
     sy = cur->y;
 
-    //If start and end points are identical, then no arc is drawn
-    if ((fabsf(x - sx) < (1.0f / 256.0f)) && (fabsf(y - sy) < (1.0f / 256.0f))) return;
-
     //Correction of out-of-range radii, see F6.6.1 (step 2)
     rx = fabsf(rx);
     ry = fabsf(ry);

--- a/thirdparty/thorvg/src/renderer/tvgScene.h
+++ b/thirdparty/thorvg/src/renderer/tvgScene.h
@@ -133,7 +133,6 @@ struct Scene::Impl
         if (needComp) {
             cmp = renderer->target(bounds(renderer), renderer->colorSpace());
             renderer->beginComposite(cmp, CompositeMethod::None, opacity);
-            needComp = false;
         }
 
         for (auto paint : paints) {

--- a/thirdparty/thorvg/src/renderer/tvgShape.h
+++ b/thirdparty/thorvg/src/renderer/tvgShape.h
@@ -56,7 +56,6 @@ struct Shape::Impl
         if (needComp) {
             cmp = renderer->target(bounds(renderer), renderer->colorSpace());
             renderer->beginComposite(cmp, CompositeMethod::None, opacity);
-            needComp = false;
         }
         ret = renderer->renderShape(rd);
         if (cmp) renderer->endComposite(cmp);

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION=0.12.7
+VERSION=0.12.9
 
 cd thirdparty/thorvg/ || true
 rm -rf AUTHORS LICENSE inc/ src/ *.zip *.tar.gz tmp/


### PR DESCRIPTION
https://github.com/thorvg/thorvg/releases/tag/v0.12.8

This update doesn't change anything regarding Godot, but we might as well bump the version.

---

**Update**: Also includes version 0.12.9:

- https://github.com/thorvg/thorvg/releases/tag/v0.12.9
