### PR TITLE
iOS: Fix AirPods routing when Play and Record category is used.

### DIFF
--- a/platform/ios/app_delegate.mm
+++ b/platform/ios/app_delegate.mm
@@ -116,6 +116,8 @@ static ViewController *mainViewController = nil;
 	} else if (sessionCategorySetting == SESSION_CATEGORY_PLAY_AND_RECORD) {
 		category = AVAudioSessionCategoryPlayAndRecord;
 		options |= AVAudioSessionCategoryOptionDefaultToSpeaker;
+		options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+		options |= AVAudioSessionCategoryOptionAllowAirPlay;
 	} else if (sessionCategorySetting == SESSION_CATEGORY_PLAYBACK) {
 		category = AVAudioSessionCategoryPlayback;
 	} else if (sessionCategorySetting == SESSION_CATEGORY_RECORD) {


### PR DESCRIPTION
So after the changes merged on https://github.com/godotengine/godot/pull/89006, the Play and Record audio session category is almost perfect on iOS (this means normal volume both on speakers and headphones!). However, I decided to try it out with my AirPods and, surprisingly, Godot didn't change the route to them. :(

This pull request does what [SDL does](https://github.com/libsdl-org/SDL/blob/e03746b25f485fdf8637cbcb3126dc2c52bd32a7/src/audio/coreaudio/SDL_coreaudio.m#L433), it adds two extra options when Play and Record is used to fix the issue:
**AVAudioSessionCategoryOptionAllowBluetoothA2DP**
**AVAudioSessionCategoryOptionAllowAirPlay**