### PR TITLE
Fix `CPUParticles3D` using angle incorrectly when `ROTATE_Y` is set.

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1124,7 +1124,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			//turn particle by rotation in Y
 			if (particle_flags[PARTICLE_FLAG_ROTATE_Y]) {
 				Basis rot_y(Vector3(0, 1, 0), p.custom[0]);
-				p.transform.basis = p.transform.basis * rot_y;
+				p.transform.basis = rot_y;
 			}
 		}
 


### PR DESCRIPTION
Resolves #89559.