### PR TITLE
[Editor] Fix handle ID being passed for 3D Gizmo plugins

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -431,12 +431,13 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 		colors.resize(p_handles.size());
 		Color *w = colors.ptrw();
 		for (int i = 0; i < p_handles.size(); i++) {
+			int id = p_ids.is_empty() ? i : p_ids[i];
+
 			Color col(1, 1, 1, 1);
-			if (is_handle_highlighted(i, p_secondary)) {
+			if (is_handle_highlighted(id, p_secondary)) {
 				col = Color(0, 0, 1, 0.9);
 			}
 
-			int id = p_ids.is_empty() ? i : p_ids[i];
 			if (!is_current_hover_gizmo || current_hover_handle != id || p_secondary != current_hover_handle_secondary) {
 				col.a = 0.8;
 			}


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/89581
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
