### PR TITLE
[Core] Fix `rand_weighted` not using the current state

### DIFF
--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -52,7 +52,7 @@ int64_t RandomPCG::rand_weighted(const Vector<float> &p_weights) {
 		weights_sum += weights[i];
 	}
 
-	float remaining_distance = Math::randf() * weights_sum;
+	float remaining_distance = randf() * weights_sum;
 	for (int64_t i = 0; i < weights_size; ++i) {
 		remaining_distance -= weights[i];
 		if (remaining_distance < 0) {


### PR DESCRIPTION
The method incorrectly used `Math::randf` instead of `randf`

* Fixes: https://github.com/godotengine/godot/issues/89618

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
