### PR TITLE
Core: Implement autogenerator for `!=` operators

### DIFF
--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -64,21 +64,7 @@ public:
 		}
 		return true;
 	}
-
-	bool operator!=(const IPAddress &p_ip) const {
-		if (p_ip.valid != valid) {
-			return true;
-		}
-		if (!valid) {
-			return true;
-		}
-		for (int i = 0; i < 4; i++) {
-			if (field32[i] != p_ip.field32[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
+	INEQUALITY_OPERATOR(const IPAddress &);
 
 	void clear();
 	bool is_wildcard() const { return wildcard; }

--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -41,10 +41,6 @@ bool AABB::operator==(const AABB &p_rval) const {
 	return ((position == p_rval.position) && (size == p_rval.size));
 }
 
-bool AABB::operator!=(const AABB &p_rval) const {
-	return ((position != p_rval.position) || (size != p_rval.size));
-}
-
 void AABB::merge_with(const AABB &p_aabb) {
 #ifdef MATH_CHECKS
 	if (unlikely(size.x < 0 || size.y < 0 || size.z < 0 || p_aabb.size.x < 0 || p_aabb.size.y < 0 || p_aabb.size.z < 0)) {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -60,7 +60,7 @@ struct _NO_DISCARD_ AABB {
 	void set_size(const Vector3 &p_size) { size = p_size; }
 
 	bool operator==(const AABB &p_rval) const;
-	bool operator!=(const AABB &p_rval) const;
+	INEQUALITY_OPERATOR(const AABB &);
 
 	bool is_equal_approx(const AABB &p_aabb) const;
 	bool is_finite() const;

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -710,10 +710,6 @@ bool Basis::operator==(const Basis &p_matrix) const {
 	return true;
 }
 
-bool Basis::operator!=(const Basis &p_matrix) const {
-	return (!(*this == p_matrix));
-}
-
 Basis::operator String() const {
 	return "[X: " + get_column(0).operator String() +
 			", Y: " + get_column(1).operator String() +

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -124,7 +124,7 @@ struct _NO_DISCARD_ Basis {
 	bool is_finite() const;
 
 	bool operator==(const Basis &p_matrix) const;
-	bool operator!=(const Basis &p_matrix) const;
+	INEQUALITY_OPERATOR(const Basis &);
 
 	_FORCE_INLINE_ Vector3 xform(const Vector3 &p_vector) const;
 	_FORCE_INLINE_ Vector3 xform_inv(const Vector3 &p_vector) const;

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -58,7 +58,7 @@ struct BVH_ABB {
 	POINT neg_max;
 
 	bool operator==(const BVH_ABB &o) const { return (min == o.min) && (neg_max == o.neg_max); }
-	bool operator!=(const BVH_ABB &o) const { return (*this == o) == false; }
+	INEQUALITY_OPERATOR(const BVH_ABB &);
 
 	void set(const POINT &_min, const POINT &_max) {
 		min = _min;

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -102,7 +102,7 @@ struct BVHHandle {
 	void set_id(uint32_t p_id) { _data = p_id; }
 
 	bool operator==(const BVHHandle &p_h) const { return _data == p_h._data; }
-	bool operator!=(const BVHHandle &p_h) const { return (*this == p_h) == false; }
+	INEQUALITY_OPERATOR(const BVHHandle &);
 };
 
 // helper class to make iterative versions of recursive functions

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -72,9 +72,7 @@ struct _NO_DISCARD_ Color {
 	bool operator==(const Color &p_color) const {
 		return (r == p_color.r && g == p_color.g && b == p_color.b && a == p_color.a);
 	}
-	bool operator!=(const Color &p_color) const {
-		return (r != p_color.r || g != p_color.g || b != p_color.b || a != p_color.a);
-	}
+	INEQUALITY_OPERATOR(const Color &);
 
 	Color operator+(const Color &p_color) const;
 	void operator+=(const Color &p_color);

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -40,6 +40,7 @@
  * - adapted to Godot's code style
  * - replaced Bullet's types (e.g. vectors) with Godot's
  * - replaced custom Pool implementation with PagedAllocator
+ * - replaced Point32's inequality operator with wrapper
  */
 
 /*
@@ -137,9 +138,7 @@ public:
 			return (x == b.x) && (y == b.y) && (z == b.z);
 		}
 
-		bool operator!=(const Point32 &b) const {
-			return (x != b.x) || (y != b.y) || (z != b.z);
-		}
+		INEQUALITY_OPERATOR(const Point32 &);
 
 		bool is_zero() {
 			return (x == 0) && (y == 0) && (z == 0);

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -77,7 +77,7 @@ struct _NO_DISCARD_ Plane {
 	bool is_finite() const;
 
 	_FORCE_INLINE_ bool operator==(const Plane &p_plane) const;
-	_FORCE_INLINE_ bool operator!=(const Plane &p_plane) const;
+	INEQUALITY_OPERATOR(const Plane &);
 	operator String() const;
 
 	_FORCE_INLINE_ Plane() {}
@@ -127,10 +127,6 @@ Plane::Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_
 
 bool Plane::operator==(const Plane &p_plane) const {
 	return normal == p_plane.normal && d == p_plane.d;
-}
-
-bool Plane::operator!=(const Plane &p_plane) const {
-	return normal != p_plane.normal || d != p_plane.d;
 }
 
 #endif // PLANE_H

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -143,10 +143,7 @@ struct _NO_DISCARD_ Projection {
 		}
 		return true;
 	}
-
-	bool operator!=(const Projection &p_cam) const {
-		return !(*this == p_cam);
-	}
+	INEQUALITY_OPERATOR(const Projection &);
 
 	float get_lod_multiplier() const;
 

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -111,7 +111,7 @@ struct _NO_DISCARD_ Quaternion {
 	_FORCE_INLINE_ Quaternion operator/(real_t p_s) const;
 
 	_FORCE_INLINE_ bool operator==(const Quaternion &p_quaternion) const;
-	_FORCE_INLINE_ bool operator!=(const Quaternion &p_quaternion) const;
+	INEQUALITY_OPERATOR(const Quaternion &);
 
 	operator String() const;
 
@@ -219,10 +219,6 @@ Quaternion Quaternion::operator/(real_t p_s) const {
 
 bool Quaternion::operator==(const Quaternion &p_quaternion) const {
 	return x == p_quaternion.x && y == p_quaternion.y && z == p_quaternion.z && w == p_quaternion.w;
-}
-
-bool Quaternion::operator!=(const Quaternion &p_quaternion) const {
-	return x != p_quaternion.x || y != p_quaternion.y || z != p_quaternion.z || w != p_quaternion.w;
 }
 
 _FORCE_INLINE_ Quaternion operator*(real_t p_real, const Quaternion &p_quaternion) {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -210,7 +210,7 @@ struct _NO_DISCARD_ Rect2 {
 	bool is_finite() const;
 
 	bool operator==(const Rect2 &p_rect) const { return position == p_rect.position && size == p_rect.size; }
-	bool operator!=(const Rect2 &p_rect) const { return position != p_rect.position || size != p_rect.size; }
+	INEQUALITY_OPERATOR(const Rect2 &);
 
 	inline Rect2 grow(real_t p_amount) const {
 		Rect2 g = *this;

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -149,7 +149,7 @@ struct _NO_DISCARD_ Rect2i {
 	}
 
 	bool operator==(const Rect2i &p_rect) const { return position == p_rect.position && size == p_rect.size; }
-	bool operator!=(const Rect2i &p_rect) const { return position != p_rect.position || size != p_rect.size; }
+	INEQUALITY_OPERATOR(const Rect2i &);
 
 	Rect2i grow(int p_amount) const {
 		Rect2i g = *this;

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -201,16 +201,6 @@ bool Transform2D::operator==(const Transform2D &p_transform) const {
 	return true;
 }
 
-bool Transform2D::operator!=(const Transform2D &p_transform) const {
-	for (int i = 0; i < 3; i++) {
-		if (columns[i] != p_transform.columns[i]) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 void Transform2D::operator*=(const Transform2D &p_transform) {
 	columns[2] = xform(p_transform.columns[2]);
 

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -103,7 +103,7 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D looking_at(const Vector2 &p_target) const;
 
 	bool operator==(const Transform2D &p_transform) const;
-	bool operator!=(const Transform2D &p_transform) const;
+	INEQUALITY_OPERATOR(const Transform2D &);
 
 	void operator*=(const Transform2D &p_transform);
 	Transform2D operator*(const Transform2D &p_transform) const;

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -182,10 +182,6 @@ bool Transform3D::operator==(const Transform3D &p_transform) const {
 	return (basis == p_transform.basis && origin == p_transform.origin);
 }
 
-bool Transform3D::operator!=(const Transform3D &p_transform) const {
-	return (basis != p_transform.basis || origin != p_transform.origin);
-}
-
 void Transform3D::operator*=(const Transform3D &p_transform) {
 	origin = xform(p_transform.origin);
 	basis *= p_transform.basis;

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -78,7 +78,7 @@ struct _NO_DISCARD_ Transform3D {
 	bool is_finite() const;
 
 	bool operator==(const Transform3D &p_transform) const;
-	bool operator!=(const Transform3D &p_transform) const;
+	INEQUALITY_OPERATOR(const Transform3D &);
 
 	_FORCE_INLINE_ Vector3 xform(const Vector3 &p_vector) const;
 	_FORCE_INLINE_ AABB xform(const AABB &p_aabb) const;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -144,7 +144,7 @@ struct _NO_DISCARD_ Vector2 {
 	Vector2 operator-() const;
 
 	bool operator==(const Vector2 &p_vec2) const;
-	bool operator!=(const Vector2 &p_vec2) const;
+	INEQUALITY_OPERATOR(const Vector2 &);
 
 	bool operator<(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y < p_vec2.y) : (x < p_vec2.x); }
 	bool operator>(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y > p_vec2.y) : (x > p_vec2.x); }
@@ -235,10 +235,6 @@ _FORCE_INLINE_ Vector2 Vector2::operator-() const {
 
 _FORCE_INLINE_ bool Vector2::operator==(const Vector2 &p_vec2) const {
 	return x == p_vec2.x && y == p_vec2.y;
-}
-
-_FORCE_INLINE_ bool Vector2::operator!=(const Vector2 &p_vec2) const {
-	return x != p_vec2.x || y != p_vec2.y;
 }
 
 Vector2 Vector2::lerp(const Vector2 &p_to, real_t p_weight) const {

--- a/core/math/vector2i.cpp
+++ b/core/math/vector2i.cpp
@@ -118,10 +118,6 @@ bool Vector2i::operator==(const Vector2i &p_vec2) const {
 	return x == p_vec2.x && y == p_vec2.y;
 }
 
-bool Vector2i::operator!=(const Vector2i &p_vec2) const {
-	return x != p_vec2.x || y != p_vec2.y;
-}
-
 Vector2i::operator String() const {
 	return "(" + itos(x) + ", " + itos(y) + ")";
 }

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -118,7 +118,7 @@ struct _NO_DISCARD_ Vector2i {
 	bool operator>=(const Vector2i &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
 
 	bool operator==(const Vector2i &p_vec2) const;
-	bool operator!=(const Vector2i &p_vec2) const;
+	INEQUALITY_OPERATOR(const Vector2i &);
 
 	int64_t length_squared() const;
 	double length() const;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -166,7 +166,7 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ Vector3 operator-() const;
 
 	_FORCE_INLINE_ bool operator==(const Vector3 &p_v) const;
-	_FORCE_INLINE_ bool operator!=(const Vector3 &p_v) const;
+	INEQUALITY_OPERATOR(const Vector3 &);
 	_FORCE_INLINE_ bool operator<(const Vector3 &p_v) const;
 	_FORCE_INLINE_ bool operator<=(const Vector3 &p_v) const;
 	_FORCE_INLINE_ bool operator>(const Vector3 &p_v) const;
@@ -408,10 +408,6 @@ Vector3 Vector3::operator-() const {
 
 bool Vector3::operator==(const Vector3 &p_v) const {
 	return x == p_v.x && y == p_v.y && z == p_v.z;
-}
-
-bool Vector3::operator!=(const Vector3 &p_v) const {
-	return x != p_v.x || y != p_v.y || z != p_v.z;
 }
 
 bool Vector3::operator<(const Vector3 &p_v) const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -113,7 +113,7 @@ struct _NO_DISCARD_ Vector3i {
 	_FORCE_INLINE_ Vector3i operator-() const;
 
 	_FORCE_INLINE_ bool operator==(const Vector3i &p_v) const;
-	_FORCE_INLINE_ bool operator!=(const Vector3i &p_v) const;
+	INEQUALITY_OPERATOR(const Vector3i &);
 	_FORCE_INLINE_ bool operator<(const Vector3i &p_v) const;
 	_FORCE_INLINE_ bool operator<=(const Vector3i &p_v) const;
 	_FORCE_INLINE_ bool operator>(const Vector3i &p_v) const;
@@ -268,10 +268,6 @@ Vector3i Vector3i::operator-() const {
 
 bool Vector3i::operator==(const Vector3i &p_v) const {
 	return (x == p_v.x && y == p_v.y && z == p_v.z);
-}
-
-bool Vector3i::operator!=(const Vector3i &p_v) const {
-	return (x != p_v.x || y != p_v.y || z != p_v.z);
 }
 
 bool Vector3i::operator<(const Vector3i &p_v) const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -122,7 +122,7 @@ struct _NO_DISCARD_ Vector4 {
 	_FORCE_INLINE_ Vector4 operator/(real_t p_s) const;
 
 	_FORCE_INLINE_ bool operator==(const Vector4 &p_vec4) const;
-	_FORCE_INLINE_ bool operator!=(const Vector4 &p_vec4) const;
+	INEQUALITY_OPERATOR(const Vector4 &);
 	_FORCE_INLINE_ bool operator>(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ bool operator<(const Vector4 &p_vec4) const;
 	_FORCE_INLINE_ bool operator>=(const Vector4 &p_vec4) const;
@@ -230,10 +230,6 @@ Vector4 Vector4::operator/(real_t p_s) const {
 
 bool Vector4::operator==(const Vector4 &p_vec4) const {
 	return x == p_vec4.x && y == p_vec4.y && z == p_vec4.z && w == p_vec4.w;
-}
-
-bool Vector4::operator!=(const Vector4 &p_vec4) const {
-	return x != p_vec4.x || y != p_vec4.y || z != p_vec4.z || w != p_vec4.w;
 }
 
 bool Vector4::operator<(const Vector4 &p_v) const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -115,7 +115,7 @@ struct _NO_DISCARD_ Vector4i {
 	_FORCE_INLINE_ Vector4i operator-() const;
 
 	_FORCE_INLINE_ bool operator==(const Vector4i &p_v) const;
-	_FORCE_INLINE_ bool operator!=(const Vector4i &p_v) const;
+	INEQUALITY_OPERATOR(const Vector4i &);
 	_FORCE_INLINE_ bool operator<(const Vector4i &p_v) const;
 	_FORCE_INLINE_ bool operator<=(const Vector4i &p_v) const;
 	_FORCE_INLINE_ bool operator>(const Vector4i &p_v) const;
@@ -280,10 +280,6 @@ Vector4i Vector4i::operator-() const {
 
 bool Vector4i::operator==(const Vector4i &p_v) const {
 	return (x == p_v.x && y == p_v.y && z == p_v.z && w == p_v.w);
-}
-
-bool Vector4i::operator!=(const Vector4i &p_v) const {
-	return (x != p_v.x || y != p_v.y || z != p_v.z || w != p_v.w);
 }
 
 bool Vector4i::operator<(const Vector4i &p_v) const {

--- a/core/object/object_id.h
+++ b/core/object/object_id.h
@@ -49,7 +49,7 @@ public:
 	_ALWAYS_INLINE_ operator int64_t() const { return id; }
 
 	_ALWAYS_INLINE_ bool operator==(const ObjectID &p_id) const { return id == p_id.id; }
-	_ALWAYS_INLINE_ bool operator!=(const ObjectID &p_id) const { return id != p_id.id; }
+	INEQUALITY_OPERATOR(const ObjectID &);
 	_ALWAYS_INLINE_ bool operator<(const ObjectID &p_id) const { return id < p_id.id; }
 
 	_ALWAYS_INLINE_ void operator=(int64_t p_int64) { id = p_int64; }

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -83,9 +83,7 @@ public:
 	_FORCE_INLINE_ bool operator==(const T *p_ptr) const {
 		return reference == p_ptr;
 	}
-	_FORCE_INLINE_ bool operator!=(const T *p_ptr) const {
-		return reference != p_ptr;
-	}
+	INEQUALITY_OPERATOR(const T *);
 
 	_FORCE_INLINE_ bool operator<(const Ref<T> &p_r) const {
 		return reference < p_r.reference;
@@ -93,9 +91,7 @@ public:
 	_FORCE_INLINE_ bool operator==(const Ref<T> &p_r) const {
 		return reference == p_r.reference;
 	}
-	_FORCE_INLINE_ bool operator!=(const Ref<T> &p_r) const {
-		return reference != p_r.reference;
-	}
+	INEQUALITY_OPERATOR(const Ref<T> &);
 
 	_FORCE_INLINE_ T *operator*() const {
 		return reference;

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -153,10 +153,6 @@ bool NodePath::operator==(const NodePath &p_path) const {
 	return true;
 }
 
-bool NodePath::operator!=(const NodePath &p_path) const {
-	return (!(*this == p_path));
-}
-
 void NodePath::operator=(const NodePath &p_path) {
 	if (this == &p_path) {
 		return;

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -83,7 +83,7 @@ public:
 	bool is_empty() const;
 
 	bool operator==(const NodePath &p_path) const;
-	bool operator!=(const NodePath &p_path) const;
+	INEQUALITY_OPERATOR(const NodePath &);
 	void operator=(const NodePath &p_path);
 
 	void simplify();

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -163,20 +163,6 @@ bool StringName::operator==(const char *p_name) const {
 	return (_data->get_name() == p_name);
 }
 
-bool StringName::operator!=(const String &p_name) const {
-	return !(operator==(p_name));
-}
-
-bool StringName::operator!=(const char *p_name) const {
-	return !(operator==(p_name));
-}
-
-bool StringName::operator!=(const StringName &p_name) const {
-	// the real magic of all this mess happens here.
-	// this is why path comparisons are very fast
-	return _data != p_name._data;
-}
-
 void StringName::operator=(const StringName &p_name) {
 	if (this == &p_name) {
 		return;
@@ -486,13 +472,7 @@ StringName StringName::search(const String &p_name) {
 bool operator==(const String &p_name, const StringName &p_string_name) {
 	return p_name == p_string_name.operator String();
 }
-bool operator!=(const String &p_name, const StringName &p_string_name) {
-	return p_name != p_string_name.operator String();
-}
 
 bool operator==(const char *p_name, const StringName &p_string_name) {
 	return p_name == p_string_name.operator String();
-}
-bool operator!=(const char *p_name, const StringName &p_string_name) {
-	return p_name != p_string_name.operator String();
 }

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -96,8 +96,8 @@ public:
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
-	bool operator!=(const String &p_name) const;
-	bool operator!=(const char *p_name) const;
+	INEQUALITY_OPERATOR(const String &);
+	INEQUALITY_OPERATOR(const char *);
 
 	_FORCE_INLINE_ bool is_node_unique_name() const {
 		if (!_data) {
@@ -136,7 +136,7 @@ public:
 	_FORCE_INLINE_ const void *data_unique_pointer() const {
 		return (void *)_data;
 	}
-	bool operator!=(const StringName &p_name) const;
+	INEQUALITY_OPERATOR(const StringName &);
 
 	_FORCE_INLINE_ operator String() const {
 		if (_data) {
@@ -195,9 +195,9 @@ public:
 };
 
 bool operator==(const String &p_name, const StringName &p_string_name);
-bool operator!=(const String &p_name, const StringName &p_string_name);
 bool operator==(const char *p_name, const StringName &p_string_name);
-bool operator!=(const char *p_name, const StringName &p_string_name);
+INEQUALITY_OPERATOR_GLOBAL(const String &, const StringName &);
+INEQUALITY_OPERATOR_GLOBAL(const char *, const StringName &);
 
 StringName _scs_create(const char *p_chr, bool p_static = false);
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -738,36 +738,6 @@ bool operator==(const wchar_t *p_chr, const String &p_str) {
 #endif
 }
 
-bool operator!=(const char *p_chr, const String &p_str) {
-	return !(p_str == p_chr);
-}
-
-bool operator!=(const wchar_t *p_chr, const String &p_str) {
-#ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit
-	return !(p_str == String::utf16((const char16_t *)p_chr));
-#else
-	// wchar_t is 32-bi
-	return !(p_str == String((const char32_t *)p_chr));
-#endif
-}
-
-bool String::operator!=(const char *p_str) const {
-	return (!(*this == p_str));
-}
-
-bool String::operator!=(const wchar_t *p_str) const {
-	return (!(*this == p_str));
-}
-
-bool String::operator!=(const char32_t *p_str) const {
-	return (!(*this == p_str));
-}
-
-bool String::operator!=(const String &p_str) const {
-	return !((*this == p_str));
-}
-
 bool String::operator<=(const String &p_str) const {
 	return !(p_str < *this);
 }

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -227,7 +227,7 @@ public:
 	_FORCE_INLINE_ CharProxy<char32_t> operator[](int p_index) { return CharProxy<char32_t>(p_index, _cowdata); }
 
 	bool operator==(const String &p_str) const;
-	bool operator!=(const String &p_str) const;
+	INEQUALITY_OPERATOR(const String &);
 	String operator+(const String &p_str) const;
 	String operator+(char32_t p_char) const;
 
@@ -248,9 +248,9 @@ public:
 	bool operator==(const char32_t *p_str) const;
 	bool operator==(const StrRange &p_str_range) const;
 
-	bool operator!=(const char *p_str) const;
-	bool operator!=(const wchar_t *p_str) const;
-	bool operator!=(const char32_t *p_str) const;
+	INEQUALITY_OPERATOR(const char *);
+	INEQUALITY_OPERATOR(const wchar_t *);
+	INEQUALITY_OPERATOR(const char32_t *);
 
 	bool operator<(const char32_t *p_str) const;
 	bool operator<(const char *p_str) const;
@@ -475,8 +475,8 @@ public:
 
 bool operator==(const char *p_chr, const String &p_str);
 bool operator==(const wchar_t *p_chr, const String &p_str);
-bool operator!=(const char *p_chr, const String &p_str);
-bool operator!=(const wchar_t *p_chr, const String &p_str);
+INEQUALITY_OPERATOR_GLOBAL(const char *, const String &);
+INEQUALITY_OPERATOR_GLOBAL(const wchar_t *, const String &);
 
 String operator+(const char *p_chr, const String &p_str);
 String operator+(const wchar_t *p_chr, const String &p_str);

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -429,7 +429,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
+		INEQUALITY_OPERATOR(const ConstIterator &);
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return E != nullptr;
@@ -465,7 +465,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
+		INEQUALITY_OPERATOR(const Iterator &);
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return E != nullptr;

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -345,7 +345,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return keys == b.keys && index == b.index; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return keys != b.keys || index != b.index; }
+		INEQUALITY_OPERATOR(const Iterator &);
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return keys != nullptr;

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -154,7 +154,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
+		INEQUALITY_OPERATOR(const Iterator &);
 
 		Iterator(Element *p_E) { E = p_E; }
 		Iterator() {}
@@ -179,7 +179,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
+		INEQUALITY_OPERATOR(const ConstIterator &);
 
 		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ ConstIterator() {}

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -177,7 +177,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
+		INEQUALITY_OPERATOR(const Iterator &);
 
 		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
 		Iterator() {}
@@ -202,7 +202,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
+		INEQUALITY_OPERATOR(const ConstIterator &);
 
 		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
 		ConstIterator() {}

--- a/core/templates/pair.h
+++ b/core/templates/pair.h
@@ -47,17 +47,12 @@ struct Pair {
 			first(p_first),
 			second(p_second) {
 	}
+
+	bool operator==(const Pair &p_other) const {
+		return (first == p_other.first) && (second == p_other.second);
+	}
+	INEQUALITY_OPERATOR(const Pair &);
 };
-
-template <typename F, typename S>
-bool operator==(const Pair<F, S> &pair, const Pair<F, S> &other) {
-	return (pair.first == other.first) && (pair.second == other.second);
-}
-
-template <typename F, typename S>
-bool operator!=(const Pair<F, S> &pair, const Pair<F, S> &other) {
-	return (pair.first != other.first) || (pair.second != other.second);
-}
 
 template <typename F, typename S>
 struct PairSort {
@@ -92,17 +87,12 @@ struct KeyValue {
 			key(p_key),
 			value(p_value) {
 	}
+
+	bool operator==(const KeyValue &p_other) const {
+		return (key == p_other.key) && (value == p_other.value);
+	}
+	INEQUALITY_OPERATOR(const KeyValue &);
 };
-
-template <typename K, typename V>
-bool operator==(const KeyValue<K, V> &pair, const KeyValue<K, V> &other) {
-	return (pair.key == other.key) && (pair.value == other.value);
-}
-
-template <typename K, typename V>
-bool operator!=(const KeyValue<K, V> &pair, const KeyValue<K, V> &other) {
-	return (pair.key != other.key) || (pair.value != other.value);
-}
 
 template <typename K, typename V>
 struct KeyValueSort {

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -112,7 +112,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &p_it) const { return E == p_it.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &p_it) const { return E != p_it.E; }
+		INEQUALITY_OPERATOR(const Iterator &);
 		explicit operator bool() const {
 			return E != nullptr;
 		}
@@ -144,7 +144,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_it) const { return E == p_it.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_it) const { return E != p_it.E; }
+		INEQUALITY_OPERATOR(const ConstIterator &);
 		explicit operator bool() const {
 			return E != nullptr;
 		}

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -97,7 +97,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
+		INEQUALITY_OPERATOR(const Iterator &);
 
 		explicit operator bool() const { return E != nullptr; }
 		Iterator(Element *p_E) { E = p_E; }
@@ -123,7 +123,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
+		INEQUALITY_OPERATOR(const ConstIterator &);
 
 		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ ConstIterator() {}

--- a/core/templates/rid.h
+++ b/core/templates/rid.h
@@ -55,9 +55,7 @@ public:
 	_ALWAYS_INLINE_ bool operator>=(const RID &p_rid) const {
 		return _id >= p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator!=(const RID &p_rid) const {
-		return _id != p_rid._id;
-	}
+	INEQUALITY_OPERATOR(const RID &);
 	_ALWAYS_INLINE_ bool is_valid() const { return _id != 0; }
 	_ALWAYS_INLINE_ bool is_null() const { return _id == 0; }
 

--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -105,19 +105,13 @@ public:
 		bool operator==(const void *p_other) const {
 			return cursor == p_other;
 		}
-
-		bool operator!=(const void *p_other) const {
-			return cursor != p_other;
-		}
+		INEQUALITY_OPERATOR(const void *);
 
 		// These two allow easy range-based for loops.
 		bool operator==(const Iterator &p_other) const {
 			return cursor == p_other.cursor;
 		}
-
-		bool operator!=(const Iterator &p_other) const {
-			return cursor != p_other.cursor;
-		}
+		INEQUALITY_OPERATOR(const Iterator &);
 	};
 
 public:

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -198,19 +198,7 @@ public:
 		}
 		return true;
 	}
-
-	bool operator!=(const Vector<T> &p_arr) const {
-		Size s = size();
-		if (s != p_arr.size()) {
-			return true;
-		}
-		for (Size i = 0; i < s; i++) {
-			if (operator[](i) != p_arr[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
+	INEQUALITY_OPERATOR(const Vector<T> &);
 
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {
@@ -227,7 +215,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
+		INEQUALITY_OPERATOR(const Iterator &);
 
 		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
 		Iterator() {}
@@ -252,7 +240,7 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
+		INEQUALITY_OPERATOR(const ConstIterator &);
 
 		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
 		ConstIterator() {}

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -317,4 +317,15 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 #define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
 #define GD_IS_DEFINED(x) ___gd_is_defined(x)
 
+// Wrappers for inequality operators, will be omitted entirely from C++20 builds.
+#ifndef CPP20_ENABLED
+#define INEQUALITY_OPERATOR(m_type) \
+	_ALWAYS_INLINE_ bool operator!=(m_type p_other) const { return !(*this == p_other); }
+#define INEQUALITY_OPERATOR_GLOBAL(m_type1, m_type2) \
+	_ALWAYS_INLINE_ bool operator!=(m_type1 p_left, m_type2 p_right) { return !(p_left == p_right); }
+#else
+#define INEQUALITY_OPERATOR(m_type)
+#define INEQUALITY_OPERATOR_GLOBAL(m_type1, m_type2)
+#endif
+
 #endif // TYPEDEFS_H

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -114,10 +114,6 @@ bool Array::operator==(const Array &p_array) const {
 	return recursive_equal(p_array, 0);
 }
 
-bool Array::operator!=(const Array &p_array) const {
-	return !recursive_equal(p_array, 0);
-}
-
 bool Array::recursive_equal(const Array &p_array, int recursion_count) const {
 	// Cheap checks
 	if (_p == p_array._p) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -59,7 +59,7 @@ public:
 	void clear();
 
 	bool operator==(const Array &p_array) const;
-	bool operator!=(const Array &p_array) const;
+	INEQUALITY_OPERATOR(const Array &);
 	bool recursive_equal(const Array &p_array, int recursion_count) const;
 
 	uint32_t hash() const;

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -280,10 +280,6 @@ bool Callable::operator==(const Callable &p_callable) const {
 	}
 }
 
-bool Callable::operator!=(const Callable &p_callable) const {
-	return !(*this == p_callable);
-}
-
 bool Callable::operator<(const Callable &p_callable) const {
 	bool custom_a = is_custom();
 	bool custom_b = p_callable.is_custom();
@@ -486,10 +482,6 @@ StringName Signal::get_name() const {
 
 bool Signal::operator==(const Signal &p_signal) const {
 	return object == p_signal.object && name == p_signal.name;
-}
-
-bool Signal::operator!=(const Signal &p_signal) const {
-	return object != p_signal.object || name != p_signal.name;
 }
 
 bool Signal::operator<(const Signal &p_signal) const {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -119,7 +119,7 @@ public:
 	const Callable *get_base_comparator() const; //used for bind/unbind to do less precise comparisons (ignoring binds) in signal connect/disconnect
 
 	bool operator==(const Callable &p_callable) const;
-	bool operator!=(const Callable &p_callable) const;
+	INEQUALITY_OPERATOR(const Callable &);
 	bool operator<(const Callable &p_callable) const;
 
 	void operator=(const Callable &p_callable);
@@ -183,7 +183,7 @@ public:
 	StringName get_name() const;
 
 	bool operator==(const Signal &p_signal) const;
-	bool operator!=(const Signal &p_signal) const;
+	INEQUALITY_OPERATOR(const Signal &);
 	bool operator<(const Signal &p_signal) const;
 
 	operator String() const;

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -69,9 +69,7 @@ struct ContainerTypeValidate {
 	_FORCE_INLINE_ bool operator==(const ContainerTypeValidate &p_type) const {
 		return type == p_type.type && class_name == p_type.class_name && script == p_type.script;
 	}
-	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
-		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
-	}
+	INEQUALITY_OPERATOR(const ContainerTypeValidate &);
 
 	// Coerces String and StringName into each other and int into float when needed.
 	_FORCE_INLINE_ bool validate(Variant &inout_variant, const char *p_operation = "use") const {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -198,10 +198,6 @@ bool Dictionary::operator==(const Dictionary &p_dictionary) const {
 	return recursive_equal(p_dictionary, 0);
 }
 
-bool Dictionary::operator!=(const Dictionary &p_dictionary) const {
-	return !recursive_equal(p_dictionary, 0);
-}
-
 bool Dictionary::recursive_equal(const Dictionary &p_dictionary, int recursion_count) const {
 	// Cheap checks
 	if (_p == p_dictionary._p) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -73,7 +73,7 @@ public:
 	bool erase(const Variant &p_key);
 
 	bool operator==(const Dictionary &p_dictionary) const;
-	bool operator!=(const Dictionary &p_dictionary) const;
+	INEQUALITY_OPERATOR(const Dictionary &);
 	bool recursive_equal(const Dictionary &p_dictionary, int recursion_count) const;
 
 	uint32_t hash() const;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -835,17 +835,6 @@ bool Variant::operator==(const Variant &p_variant) const {
 	return hash_compare(p_variant);
 }
 
-bool Variant::operator!=(const Variant &p_variant) const {
-	// Don't use `!hash_compare(p_variant)` given it makes use of OP_EQUAL
-	if (type != p_variant.type) { //evaluation of operator== needs to be more strict
-		return true;
-	}
-	bool v;
-	Variant r;
-	evaluate(OP_NOT_EQUAL, *this, p_variant, r, v);
-	return r;
-}
-
 bool Variant::operator<(const Variant &p_variant) const {
 	if (type != p_variant.type) { //if types differ, then order by type first
 		return type < p_variant.type;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -763,7 +763,7 @@ public:
 	//argsVariant call()
 
 	bool operator==(const Variant &p_variant) const;
-	bool operator!=(const Variant &p_variant) const;
+	INEQUALITY_OPERATOR(const Variant &);
 	bool operator<(const Variant &p_variant) const;
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -46,10 +46,6 @@ bool AbstractPolygon2DEditor::Vertex::operator==(const AbstractPolygon2DEditor::
 	return polygon == p_vertex.polygon && vertex == p_vertex.vertex;
 }
 
-bool AbstractPolygon2DEditor::Vertex::operator!=(const AbstractPolygon2DEditor::Vertex &p_vertex) const {
-	return !(*this == p_vertex);
-}
-
 bool AbstractPolygon2DEditor::Vertex::valid() const {
 	return vertex >= 0;
 }

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -55,7 +55,7 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 				vertex(p_vertex) {}
 
 		bool operator==(const Vertex &p_vertex) const;
-		bool operator!=(const Vertex &p_vertex) const;
+		INEQUALITY_OPERATOR(const Vertex &);
 
 		bool valid() const;
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -221,10 +221,7 @@ public:
 
 			return false;
 		}
-
-		bool operator!=(const DataType &p_other) const {
-			return !(*this == p_other);
-		}
+		INEQUALITY_OPERATOR(const DataType &);
 
 		void operator=(const DataType &p_other) {
 			kind = p_other.kind;

--- a/modules/mono/editor/semver.h
+++ b/modules/mono/editor/semver.h
@@ -60,10 +60,7 @@ public:
 	bool operator==(const SemVer &b) const {
 		return cmp(*this, b) == 0;
 	}
-
-	bool operator!=(const SemVer &b) const {
-		return !operator==(b);
-	}
+	INEQUALITY_OPERATOR(const SemVer &);
 
 	bool operator<(const SemVer &b) const {
 		return cmp(*this, b) < 0;

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -46,8 +46,8 @@ extern "C" {
 struct GCHandleIntPtr {
 	void *value;
 
-	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) { return value == p_other.value; }
-	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) { return value != p_other.value; }
+	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) const { return value == p_other.value; }
+	INEQUALITY_OPERATOR(const GCHandleIntPtr &);
 
 	GCHandleIntPtr() = delete;
 };

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -140,10 +140,7 @@ struct NavigationPoly {
 	bool operator==(const NavigationPoly &other) const {
 		return poly == other.poly;
 	}
-
-	bool operator!=(const NavigationPoly &other) const {
-		return !operator==(other);
-	}
+	INEQUALITY_OPERATOR(const NavigationPoly &);
 };
 
 struct ClosestPointQueryResult {

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -103,12 +103,10 @@ union TileMapCell {
 		}
 	}
 
-	bool operator!=(const TileMapCell &p_other) const {
-		return !(source_id == p_other.source_id && coord_x == p_other.coord_x && coord_y == p_other.coord_y && alternative_tile == p_other.alternative_tile);
-	}
 	bool operator==(const TileMapCell &p_other) const {
 		return source_id == p_other.source_id && coord_x == p_other.coord_x && coord_y == p_other.coord_y && alternative_tile == p_other.alternative_tile;
 	}
+	INEQUALITY_OPERATOR(const TileMapCell &);
 };
 
 class TileMapPattern : public Resource {
@@ -276,9 +274,7 @@ public:
 
 		bool operator<(const TerrainsPattern &p_terrains_pattern) const;
 		bool operator==(const TerrainsPattern &p_terrains_pattern) const;
-		bool operator!=(const TerrainsPattern &p_terrains_pattern) const {
-			return !operator==(p_terrains_pattern);
-		};
+		INEQUALITY_OPERATOR(const TerrainsPattern &);
 
 		void set_terrain(int p_terrain);
 		int get_terrain() const;

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -886,9 +886,10 @@ public:
 		BitField<ShaderStage> stages;
 		uint32_t length = 0; // Size of arrays (in total elements), or ubos (in bytes * total elements).
 
-		bool operator!=(const ShaderUniform &p_other) const {
-			return binding != p_other.binding || type != p_other.type || writable != p_other.writable || stages != p_other.stages || length != p_other.length;
+		bool operator==(const ShaderUniform &p_other) const {
+			return binding == p_other.binding && type == p_other.type && writable == p_other.writable && stages == p_other.stages && length == p_other.length;
 		}
+		INEQUALITY_OPERATOR(const ShaderUniform &);
 
 		bool operator<(const ShaderUniform &p_other) const {
 			if (binding != p_other.binding) {

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -135,7 +135,7 @@ public:
 		}                                                                                             \
 		_ALWAYS_INLINE_ bool operator<(const m_name##ID &p_other) const { return id < p_other.id; }   \
 		_ALWAYS_INLINE_ bool operator==(const m_name##ID &p_other) const { return id == p_other.id; } \
-		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const { return id != p_other.id; } \
+		INEQUALITY_OPERATOR(const m_name##ID &);                                                      \
 		_ALWAYS_INLINE_ m_name##ID(const m_name##ID &p_other) : ID(p_other.id) {}                     \
 		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {}                            \
 		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((size_t)p_ptr) {}                       \

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -153,10 +153,6 @@ bool Glyph::operator==(const Glyph &p_a) const {
 	return (p_a.index == index) && (p_a.font_rid == font_rid) && (p_a.font_size == font_size) && (p_a.start == start);
 }
 
-bool Glyph::operator!=(const Glyph &p_a) const {
-	return (p_a.index != index) || (p_a.font_rid != font_rid) || (p_a.font_size != font_size) || (p_a.start != start);
-}
-
 bool Glyph::operator<(const Glyph &p_a) const {
 	if (p_a.start == start) {
 		if (p_a.count == count) {

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -574,7 +574,7 @@ struct Glyph {
 	int32_t index = 0; // Glyph index (font specific) or UTF-32 codepoint (for the invalid glyphs).
 
 	bool operator==(const Glyph &p_a) const;
-	bool operator!=(const Glyph &p_a) const;
+	INEQUALITY_OPERATOR(const Glyph &);
 
 	bool operator<(const Glyph &p_a) const;
 	bool operator>(const Glyph &p_a) const;


### PR DESCRIPTION
Inspired by C++20 making `!=` operators implicit, I was looking for a way to prepare the repo for that conversion without compromising functionality nor readability. Initially this was achieved by wrapping all existing inequality operators in a c++20 define, though that made things incredibly cluttered. Instead, this PR adds an autogenerating define that replaces the old implementations entirely. This not only cleans up the codebase by consolidating logic, but it will allow for seamlessly excluding these operators when c++20 is officially supported.