### PR TITLE
Fix TextEdit selection end of line drawing for wrapped lines and gaps

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1113,7 +1113,7 @@ void TextEdit::_notification(int p_what) {
 							Vector<Vector2> sel = TS->shaped_text_get_selection(rid, sel_from, sel_to);
 
 							// Show selection at the end of line.
-							if (line < get_selection_to_line(c)) {
+							if (line_wrap_index == line_wrap_amount && line < get_selection_to_line(c)) {
 								if (rtl) {
 									sel.push_back(Vector2(-char_w, 0));
 								} else {
@@ -1123,7 +1123,7 @@ void TextEdit::_notification(int p_what) {
 							}
 
 							for (int j = 0; j < sel.size(); j++) {
-								Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, Math::ceil(sel[j].y - sel[j].x), row_height);
+								Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, Math::ceil(sel[j].y) - sel[j].x, row_height);
 								if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
 									continue;
 								}


### PR DESCRIPTION
- related https://github.com/godotengine/godot/pull/72341

There were a couple of issues with the end of line drawing.
Fixes it being applied to all lines of wrapped text when the selection extended past it, instead of only the last one:

![godot te wrapped line end](https://github.com/godotengine/godot/assets/10054226/00b9eeb9-7b99-486d-840f-8345c6d454e4)

Fixes occasional gaps or overlaps. 
I can reproduce it only on certain lines of text and it changes based on zoom factor. It also depends on where the top of the selection is, usually at the start of a word:

![image](https://github.com/godotengine/godot/assets/10054226/ba4447f4-4157-45b4-ac78-9ce6d1d5ce24)

Fixes very small 1px selection end moving when the selection start is moved sometimes:

![godot te select end jitter](https://github.com/godotengine/godot/assets/10054226/d9651810-4ea3-4fd2-95e3-1a573722b08c)


Edit: Made sure it works with rtl text at the end of the line.
