### PR TITLE
Account for scale in scroll logic for `Parallax2D`

### DIFF
--- a/scene/2d/parallax_2d.cpp
+++ b/scene/2d/parallax_2d.cpp
@@ -102,14 +102,14 @@ void Parallax2D::_update_scroll() {
 	scroll_ofs *= scroll_scale;
 
 	if (repeat_size.x) {
-		real_t mod = Math::fposmod(scroll_ofs.x - scroll_offset.x - autoscroll_offset.x, repeat_size.x);
+		real_t mod = Math::fposmod(scroll_ofs.x - scroll_offset.x - autoscroll_offset.x, repeat_size.x * get_scale().x);
 		scroll_ofs.x = screen_offset.x - mod;
 	} else {
 		scroll_ofs.x = screen_offset.x + scroll_offset.x - scroll_ofs.x;
 	}
 
 	if (repeat_size.y) {
-		real_t mod = Math::fposmod(scroll_ofs.y - scroll_offset.y - autoscroll_offset.y, repeat_size.y);
+		real_t mod = Math::fposmod(scroll_ofs.y - scroll_offset.y - autoscroll_offset.y, repeat_size.y * get_scale().y);
 		scroll_ofs.y = screen_offset.y - mod;
 	} else {
 		scroll_ofs.y = screen_offset.y + scroll_offset.y - scroll_ofs.y;
@@ -127,8 +127,7 @@ void Parallax2D::_update_repeat() {
 		return;
 	}
 
-	Point2 repeat_scale = repeat_size * get_scale();
-	RenderingServer::get_singleton()->canvas_set_item_repeat(get_canvas_item(), repeat_scale, repeat_times);
+	RenderingServer::get_singleton()->canvas_set_item_repeat(get_canvas_item(), repeat_size, repeat_times);
 	RenderingServer::get_singleton()->canvas_item_set_interpolated(get_canvas_item(), false);
 }
 


### PR DESCRIPTION
Previously, it was misunderstood how the scaling should be considered when scrolling. I originally just kinda copied how `ParallaxLayer` handles it, and recently discovered that it handles it incorrectly. Scaled `ParallaxLayer`s currently wrap at incorrect points. This can be fixed in a separate PR.

This change is for `Parallax2D` to have its scale not taken into account when the repeat is spaced, but the point in which it wraps when scrolling is updated. It shouldn't come up very often as it's not a recommended workflow, but it's good to handle it either way. I also should add some notes to the docs in the future for "use at your own risk" scenarios like scaling or moving parents.