### PR TITLE
Add option to import skeleton rest as RESET animation

### DIFF
--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -21,6 +21,9 @@
 		<member name="animation/import" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], import animations from the 3D scene.
 		</member>
+		<member name="animation/import_rest_as_RESET" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], adds an [Animation] named [code]RESET[/code], containing the [method Skeleton3D.get_bone_rest] from [Skeleton3D] nodes. This can be useful to extract an animation in the reference pose.
+		</member>
 		<member name="animation/remove_immutable_tracks" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], remove animation tracks that only contain default values. This can reduce output file size and memory usage with certain 3D scenes, depending on the contents of their animation tracks.
 		</member>

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -282,6 +282,7 @@ public:
 	// Import scenes *after* everything else (such as textures).
 	virtual int get_import_order() const override { return ResourceImporter::IMPORT_ORDER_SCENE; }
 
+	void _pre_fix_global(Node *p_scene, const HashMap<StringName, Variant> &p_options) const;
 	Node *_pre_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &r_collision_map, Pair<PackedVector3Array, PackedInt32Array> *r_occluder_arrays, List<Pair<NodePath, Node *>> &r_node_renames);
 	Node *_pre_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps);
 	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps, float p_applied_root_scale);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -433,13 +433,20 @@ void SceneImportSettingsDialog::_update_view_gizmos() {
 		return;
 	}
 	const HashMap<StringName, Variant> &main_settings = scene_import_settings_data->current;
+	bool reshow_settings = false;
 	if (main_settings.has("nodes/import_as_skeleton_bones")) {
 		bool new_import_as_skeleton = main_settings["nodes/import_as_skeleton_bones"];
-		if (new_import_as_skeleton != previous_import_as_skeleton) {
-			previous_import_as_skeleton = new_import_as_skeleton;
-			_re_import();
-			open_settings(base_path);
-		}
+		reshow_settings = reshow_settings || (new_import_as_skeleton != previous_import_as_skeleton);
+		previous_import_as_skeleton = new_import_as_skeleton;
+	}
+	if (main_settings.has("animation/import_rest_as_RESET")) {
+		bool new_rest_as_reset = main_settings["animation/import_rest_as_RESET"];
+		reshow_settings = reshow_settings || (new_rest_as_reset != previous_rest_as_reset);
+		previous_rest_as_reset = new_rest_as_reset;
+	}
+	if (reshow_settings) {
+		_re_import();
+		open_settings(base_path);
 		return;
 	}
 	for (const KeyValue<String, NodeData> &e : node_map) {
@@ -687,6 +694,9 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, bool p_for_a
 	const HashMap<StringName, Variant> &main_settings = scene_import_settings_data->current;
 	if (main_settings.has("nodes/import_as_skeleton_bones")) {
 		previous_import_as_skeleton = main_settings["nodes/import_as_skeleton_bones"];
+	}
+	if (main_settings.has("animation/import_rest_as_RESET")) {
+		previous_rest_as_reset = main_settings["animation/import_rest_as_RESET"];
 	}
 	popup_centered_ratio();
 	_update_view_gizmos();

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -97,6 +97,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	Animation::LoopMode animation_loop_mode = Animation::LOOP_NONE;
 	bool animation_pingpong = false;
 	bool previous_import_as_skeleton = false;
+	bool previous_rest_as_reset = false;
 
 	Ref<StandardMaterial3D> collider_mat;
 


### PR DESCRIPTION
Add option "Import Rest as RESET" to generate a RESET animation for a skeleton bone rest pose.

Also creates an AnimationPlayer if one does not exist.
Designed to be used in conjunction with PR #88824, loading rest pose in another importer

When used in conjunction with #88824 , will resolve- #65656 and #89244