### PR TITLE
Editor: Fix same-name (sub)groups interfering in Inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2806,6 +2806,9 @@ void EditorInspector::update_tree() {
 			subgroup_base = "";
 			section_depth = 0;
 
+			vbox_per_path.clear();
+			editor_inspector_array_per_prefix.clear();
+
 			if (!show_categories) {
 				continue;
 			}


### PR DESCRIPTION
* Closes #71616.
* Fixes #83336.
* Fixes #83662.
* Fixes #89620.

Clear (sub)group hashmaps when changing category.

**Before**
![](https://github.com/godotengine/godot/assets/47700418/848b0724-14bd-4096-bc73-db6a78ebac21)

**After**
![](https://github.com/godotengine/godot/assets/47700418/05bdf50f-df5f-4de7-80fb-36907858ae79)