### PR TITLE
[3.x] Bullet - slight optimization to `mark_object_overlaps_inside()`

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -170,7 +170,12 @@ void AreaBullet::mark_all_overlaps_dirty() {
 
 void AreaBullet::mark_object_overlaps_inside(CollisionObjectBullet *p_other_object) {
 	OverlappingShapeData *overlapping_shapes_w = overlapping_shapes.ptrw();
-	for (int i = 0; i < overlapping_shapes.size(); i++) {
+
+	// This routine can be a bottleneck, and loading the count into register can be
+	// 3x faster than calling size() each iteration.
+	int count = overlapping_shapes.size();
+
+	for (int i = 0; i < count; i++) {
 		if (overlapping_shapes_w[i].other_object == p_other_object && overlapping_shapes_w[i].state == OVERLAP_STATE_DIRTY) {
 			overlapping_shapes_w[i].state = OVERLAP_STATE_INSIDE;
 		}


### PR DESCRIPTION
Makes potential bottleneck routine ~3x faster.

Super small change, but getting loop counters into a register can help in these tight loops.

## Notes
* Just looking at a few low hanging fruits from profiling TPS demo
* Probably won't make a massive difference real world (TPS demo is GPU limited) but helps CPU a little according to profile, so why not... :grin: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
