### PR TITLE
Fix mouse events when `physics_object_picking_first_only` enabled

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -856,9 +856,10 @@ void Viewport::_process_picking() {
 
 							if (send_event) {
 								co->_input_event_call(this, ev, res[i].shape);
-								if (physics_object_picking_first_only) {
-									break;
-								}
+							}
+
+							if (physics_object_picking_first_only) {
+								break;
 							}
 						}
 					}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/89641
See issue for test project and reasoning. In my testing this change makes all the CollisionObject2D events (input, mouse_enter, mouse_exit, mouse_shape_enter, mouse_shape_exit) fire as expected.

The enter/exit events still fire continuously when sorting is OFF+first_only is ON, but this is expected and unavoidable (it's as if we're flipping rapidly and randomly between the stacked areas).