### PR TITLE
[Core] Fix property access on read-only `Dictionary`

### DIFF
--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -251,15 +251,21 @@ void Variant::set_named(const StringName &p_member, const Variant &p_value, bool
 			return;
 		}
 	} else if (type == Variant::DICTIONARY) {
-		Variant *v = VariantGetInternalPtr<Dictionary>::get_ptr(this)->getptr(p_member);
-		if (v) {
-			*v = p_value;
-			r_valid = true;
-		} else {
-			VariantGetInternalPtr<Dictionary>::get_ptr(this)->operator[](p_member) = p_value;
-			r_valid = true;
+		Dictionary &dict = *VariantGetInternalPtr<Dictionary>::get_ptr(this);
+
+		if (dict.is_read_only()) {
+			r_valid = false;
+			return;
 		}
 
+		Variant *v = dict.getptr(p_member);
+		if (v) {
+			*v = p_value;
+		} else {
+			dict[p_member] = p_value;
+		}
+
+		r_valid = true;
 	} else {
 		r_valid = false;
 	}

--- a/modules/gdscript/tests/scripts/runtime/errors/read_only_dictionary.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/read_only_dictionary.gd
@@ -1,0 +1,4 @@
+func test():
+	var dictionary := { "a": 0 }
+	dictionary.make_read_only()
+	dictionary.a = 1

--- a/modules/gdscript/tests/scripts/runtime/errors/read_only_dictionary.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/read_only_dictionary.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/read_only_dictionary.gd
+>> 4
+>> Invalid assignment of property or key 'a' with value of type 'int' on a base object of type 'Dictionary'.


### PR DESCRIPTION
Read-only dictionaries can be modified with property access, like so:
```gdscript
var my_dict := { "a": 0 }
my_dict.make_read_only()
my_dict.a = 1
```

This seems to be an oversight (and can't find any reports on it), but this makes it aligned with how it works for `const`
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
