### PR TITLE
Add property `UsingGodotNETSdk` to Godot.NET.Sdk

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -2,6 +2,8 @@
   <Import Project="$(MSBuildThisFileDirectory)\SdkPackageVersions.props" />
 
   <PropertyGroup>
+    <UsingGodotNETSdk>true</UsingGodotNETSdk>
+
     <!-- Determines if we should import Microsoft.NET.Sdk, if it wasn't already imported. -->
     <GodotSdkImportsMicrosoftNetSdk Condition=" '$(UsingMicrosoftNETSdk)' != 'true' ">true</GodotSdkImportsMicrosoftNetSdk>
   </PropertyGroup>


### PR DESCRIPTION
The Godot.NET.Sdk (for C# use) should define the property `UsingGodotNETSdk` in its [SDK.props](https://github.com/godotengine/godot/blob/a07dd0d6a520723c4838fb4b65461a16b7a50f90/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props).  

## Why
Defining this property allows shared build configuration (e.g. Directory.Build.targets or other imported msbuild files) to detect deterministically when they are operating within the scope of a project controlled by Godot.NET.Sdk.  This enables shared build configuration that may span many different projects within a folder to have Godot.NET.Sdk-specific configuration that only applies to Godot projects.

## Why named UsingGodotNETSdk
This naming scheme is common practice in Microsoft Dotnet SDKs.  For example, the property `UsingMicrosoftNETSdk` is defined by the default SDK, `UsingMicrosoftTraversalSdk` is defined by [Microsoft.Build.Traversal](https://github.com/microsoft/MSBuildSdks/blob/363532de5b406c9afc6e6ff0f276431c27b11347/src/Traversal/Sdk/Sdk.props#L10), `UsingMicrosoftNoTargetsSdk` by [Microsoft.Build.NoTargets](https://github.com/microsoft/MSBuildSdks/blob/363532de5b406c9afc6e6ff0f276431c27b11347/src/NoTargets/Sdk/Sdk.props#L10), and so on.  The property `UsingMicrosoftNETSdk` is even used in the implementation of Godot.NET.Sdk for conditional logic of the type predicted here.

Note that these "Using*" properties are _additive_ in the sense that more than one can be defined for a given project (as SDKs can effectively be built upon other SDKs, using them as components).  So, it is normal and appropriate for both `UsingMicrosoftNETSdk` and `UsingGodotNETSdk` to be simultaneously defined within the same project.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
