### PR TITLE
[Core] `Array` and `Dictionary` `set` improvements

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -512,6 +512,16 @@ void Array::set(int p_idx, const Variant &p_value) {
 	_p->array.write[p_idx] = std::move(value);
 }
 
+Error Array::set_safe(int p_idx, const Variant &p_value) {
+	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Array is in read-only state.");
+	Variant value = p_value;
+	ERR_FAIL_COND_V(!_p->typed.validate(value, "set"), ERR_INVALID_PARAMETER);
+
+	ERR_FAIL_INDEX_V(p_idx, size(), ERR_PARAMETER_RANGE_ERROR);
+	_p->array.write[p_idx] = std::move(value);
+	return OK;
+}
+
 const Variant &Array::get(int p_idx) const {
 	return operator[](p_idx);
 }

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -115,6 +115,7 @@ public:
 	const Variant &operator[](int p_idx) const;
 
 	void set(int p_idx, const Variant &p_value);
+	Error set_safe(int p_idx, const Variant &p_value);
 	const Variant &get(int p_idx) const;
 
 	int size() const;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -208,6 +208,16 @@ bool Dictionary::set(const Variant &p_key, const Variant &p_value) {
 	return true;
 }
 
+Error Dictionary::set_safe(const Variant &p_key, const Variant &p_value) {
+	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Dictionary is in read-only state.");
+	Variant key = p_key;
+	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "set_safe"), ERR_INVALID_PARAMETER);
+	Variant value = p_value;
+	ERR_FAIL_COND_V(!_p->typed_value.validate(value, "set_safe"), ERR_INVALID_PARAMETER);
+	_p->variant_map[key] = value;
+	return OK;
+}
+
 int Dictionary::size() const {
 	return _p->variant_map.size();
 }

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -189,6 +189,7 @@ Variant Dictionary::get_or_add(const Variant &p_key, const Variant &p_default) {
 	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "get"), p_default);
 	const Variant *result = getptr(key);
 	if (!result) {
+		ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Dictionary is in read-only state.");
 		Variant value = p_default;
 		ERR_FAIL_COND_V(!_p->typed_value.validate(value, "add"), value);
 		operator[](key) = value;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -70,6 +70,7 @@ public:
 	Variant get(const Variant &p_key, const Variant &p_default) const;
 	Variant get_or_add(const Variant &p_key, const Variant &p_default);
 	bool set(const Variant &p_key, const Variant &p_value);
+	Error set_safe(const Variant &p_key, const Variant &p_value);
 
 	int size() const;
 	bool is_empty() const;

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -72,6 +72,11 @@ TEST_CASE("[Dictionary] Assignment using bracket notation ([])") {
 	map.make_read_only();
 	CHECK(int(map["This key does not exist"].get_type()) == Variant::NIL);
 	CHECK(map.size() == length);
+
+	ERR_PRINT_OFF;
+	CHECK(int(map.get_or_add("This key does not exist", String()).get_type()) == Variant::NIL);
+	CHECK(map.size() == length);
+	ERR_PRINT_ON;
 }
 
 TEST_CASE("[Dictionary] List init") {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -76,6 +76,13 @@ TEST_CASE("[Dictionary] Assignment using bracket notation ([])") {
 	ERR_PRINT_OFF;
 	CHECK(int(map.get_or_add("This key does not exist", String()).get_type()) == Variant::NIL);
 	CHECK(map.size() == length);
+
+	map.set("This key does not exist", String());
+	CHECK_FALSE(map.has("This key does not exist"));
+	CHECK(map.size() == length);
+
+	CHECK(map.set_safe("This key does not exist", String()) == ERR_LOCKED);
+	CHECK(map.size() == length);
 	ERR_PRINT_ON;
 }
 


### PR DESCRIPTION
* Make `Dictionary.get_or_add` check for read-only
* Add `Dictionary.set` for read-only enforcing assignments
* Add `set_safe` method to `Array` and `Dictionary`
* Add a range check to `Array.set` for safe usage and to match `Vector`

A number of different changes, largely related, can split them up if desired (the range check for `Array.set` could be cherry-picked if desired), and the `set_safe` isn't necessarily needed but added it just to see about the demand for it

Will look at adding some unit tests for read-only arrays to complement the dictionary ones
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
