### PR TITLE
Remove unnecessary `ring_buffer` template-id

### DIFF
--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -211,10 +211,10 @@ public:
 		size_mask = mask;
 	}
 
-	RingBuffer<T>(int p_power = 0) {
+	RingBuffer(int p_power = 0) {
 		resize(p_power);
 	}
-	~RingBuffer<T>() {}
+	~RingBuffer() {}
 };
 
 #endif // RING_BUFFER_H


### PR DESCRIPTION
A minor tweak for C++20 compatability that doesn't really fit into any other category: on GCC, the redundant template-id in `ring_buffer` got treated as an error.