### PR TITLE
Fix `empty_clicked` signal in Tree when using `hide_root`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3868,6 +3868,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				if (!root || (!root->get_first_child() && hide_root)) {
+					emit_signal(SNAME("empty_clicked"), get_local_mouse_position(), mb->get_button_index());
 					break;
 				}
 


### PR DESCRIPTION
Fixes #83928

This PR fixes the `empty_clicked` function of the node `Tree`. Right clicking did not work when hide_root was active. Added an extra if statement with a command emitting the signal.