### PR TITLE
Always look for unique node names in owner if not found in owned nodes

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1679,23 +1679,14 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 			}
 
 		} else if (name.is_node_unique_name()) {
-			if (current->data.owned_unique_nodes.size()) {
-				// Has unique nodes in ownership
-				Node **unique = current->data.owned_unique_nodes.getptr(name);
-				if (!unique) {
-					return nullptr;
-				}
-				next = *unique;
-			} else if (current->data.owner) {
-				Node **unique = current->data.owner->data.owned_unique_nodes.getptr(name);
-				if (!unique) {
-					return nullptr;
-				}
-				next = *unique;
-			} else {
+			Node **unique = current->data.owned_unique_nodes.getptr(name);
+			if (!unique && current->data.owner) {
+				unique = current->data.owner->data.owned_unique_nodes.getptr(name);
+			}
+			if (!unique) {
 				return nullptr;
 			}
-
+			next = *unique;
 		} else {
 			next = nullptr;
 			const Node *const *node = current->data.children.getptr(name);


### PR DESCRIPTION
Makes unique node names work consistently for subscene root nodes.

Resolves #66536.


If this will be approved I'll follow up with with docs (in manual) update etc. later.