### PR TITLE
Add instantiate_as_child method to PackedScene

### DIFF
--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -95,6 +95,14 @@
 				Instantiates the scene's node hierarchy. Triggers child scene instantiation(s). Triggers a [constant Node.NOTIFICATION_SCENE_INSTANTIATED] notification on the root node.
 			</description>
 		</method>
+		<method name="instantiate_as_child" qualifiers="const" keywords="create, make, spawn, new">
+			<return type="Node" />
+			<param index="0" name="parent" type="Node" />
+			<param index="1" name="edit_state" type="int" enum="PackedScene.GenEditState" default="0" />
+			<description>
+				Same as [method instantiate], but also adds the instantiated node as a child to [param parent].
+			</description>
+		</method>
 		<method name="pack">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="Node" />

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2092,6 +2092,13 @@ Node *PackedScene::instantiate(GenEditState p_edit_state) const {
 	return s;
 }
 
+Node *PackedScene::instantiate_as_child(Node* p_parent, GenEditState p_edit_state) const {
+	ERR_FAIL_NULL_V_MSG(p_parent, nullptr, "Cannot instantiate scene under null parent.");
+	Node* p_node = instantiate(p_edit_state);
+	p_parent->add_child(p_node);
+	return p_node;
+}
+
 void PackedScene::replace_state(Ref<SceneState> p_by) {
 	state = p_by;
 	state->set_path(get_path());
@@ -2128,6 +2135,7 @@ void PackedScene::reset_state() {
 void PackedScene::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pack", "path"), &PackedScene::pack);
 	ClassDB::bind_method(D_METHOD("instantiate", "edit_state"), &PackedScene::instantiate, DEFVAL(GEN_EDIT_STATE_DISABLED));
+	ClassDB::bind_method(D_METHOD("instantiate_as_child", "parent", "edit_state"), &PackedScene::instantiate_as_child, DEFVAL(GEN_EDIT_STATE_DISABLED));
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &PackedScene::can_instantiate);
 	ClassDB::bind_method(D_METHOD("_set_bundled_scene", "scene"), &PackedScene::_set_bundled_scene);
 	ClassDB::bind_method(D_METHOD("_get_bundled_scene"), &PackedScene::_get_bundled_scene);

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -156,6 +156,7 @@ public:
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state) const;
+	Node *instantiate_as_child(Node* p_parent, GenEditState p_edit_state) const;
 
 	Array setup_resources_in_array(Array &array_to_scan, const SceneState::NodeData &n, HashMap<Ref<Resource>, Ref<Resource>> &resources_local_to_sub_scene, Node *node, const StringName sname, HashMap<Ref<Resource>, Ref<Resource>> &resources_local_to_scene, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Variant make_local_resource(Variant &value, const SceneState::NodeData &p_node_data, HashMap<Ref<Resource>, Ref<Resource>> &p_resources_local_to_sub_scene, Node *p_node, const StringName p_sname, HashMap<Ref<Resource>, Ref<Resource>> &p_resources_local_to_scene, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
@@ -255,7 +256,8 @@ public:
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
-
+	Node *instantiate_as_child(Node* parent, GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
+	
 	void recreate_state();
 	void replace_state(Ref<SceneState> p_by);
 


### PR DESCRIPTION
Figured this would be a nice quality of life addition since very often you would want to add an instantiated node to the tree right after instantiation. As of now you would have to add an extra line using add_child().

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9342*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
