### PR TITLE
Improve the editor native shader source visualizer

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1032,7 +1032,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_v_scroll_speed(EDITOR_GET("text_editor/behavior/navigation/v_scroll_speed"));
 	text_editor->set_drag_and_drop_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/drag_and_drop_selection"));
 
-	// Behavior: indent
+	// Behavior: Indent
 	set_indent_using_spaces(EDITOR_GET("text_editor/behavior/indent/type"));
 	text_editor->set_indent_size(EDITOR_GET("text_editor/behavior/indent/size"));
 	text_editor->set_auto_indent_enabled(EDITOR_GET("text_editor/behavior/indent/auto_indent"));

--- a/editor/editor_native_shader_source_visualizer.cpp
+++ b/editor/editor_native_shader_source_visualizer.cpp
@@ -30,7 +30,43 @@
 
 #include "editor_native_shader_source_visualizer.h"
 
+#include "editor/code_editor.h"
+#include "editor/editor_settings.h"
+#include "editor/themes/editor_scale.h"
 #include "scene/gui/text_edit.h"
+#include "servers/rendering/shader_language.h"
+
+void EditorNativeShaderSourceVisualizer::_load_theme_settings() {
+	syntax_highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+	syntax_highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	syntax_highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/function_color"));
+	syntax_highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/member_variable_color"));
+
+	syntax_highlighter->clear_keyword_colors();
+
+	List<String> keywords;
+	ShaderLanguage::get_keyword_list(&keywords);
+	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+
+	for (const String &keyword : keywords) {
+		if (ShaderLanguage::is_control_flow_keyword(keyword)) {
+			syntax_highlighter->add_keyword_color(keyword, control_flow_keyword_color);
+		} else {
+			syntax_highlighter->add_keyword_color(keyword, keyword_color);
+		}
+	}
+
+	// Colorize comments.
+	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	syntax_highlighter->clear_color_regions();
+	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
+	syntax_highlighter->add_color_region("//", "", comment_color, true);
+
+	// Colorize preprocessor statements.
+	const Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	syntax_highlighter->add_color_region("#", "", user_type_color, true);
+}
 
 void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 	if (versions) {
@@ -39,6 +75,8 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 	}
 
 	RS::ShaderNativeSourceCode nsc = RS::get_singleton()->shader_get_native_source_code(p_shader);
+
+	_load_theme_settings();
 
 	versions = memnew(TabContainer);
 	versions->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
@@ -52,13 +90,55 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 		vtab->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		versions->add_child(vtab);
 		for (int j = 0; j < nsc.versions[i].stages.size(); j++) {
-			TextEdit *vtext = memnew(TextEdit);
-			vtext->set_editable(false);
-			vtext->set_name(nsc.versions[i].stages[j].name);
-			vtext->set_text(nsc.versions[i].stages[j].code);
-			vtext->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-			vtext->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			vtab->add_child(vtext);
+			CodeEdit *code_edit = memnew(CodeEdit);
+			code_edit->set_editable(false);
+			code_edit->set_syntax_highlighter(syntax_highlighter);
+			code_edit->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
+			code_edit->add_theme_font_size_override("font_size", get_theme_font_size("source_size", "EditorFonts"));
+			code_edit->add_theme_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 6));
+
+			// Appearance: Caret
+			code_edit->set_caret_type((TextEdit::CaretType)EDITOR_GET("text_editor/appearance/caret/type").operator int());
+			code_edit->set_caret_blink_enabled(EDITOR_GET("text_editor/appearance/caret/caret_blink"));
+			code_edit->set_caret_blink_interval(EDITOR_GET("text_editor/appearance/caret/caret_blink_interval"));
+			code_edit->set_highlight_current_line(EDITOR_GET("text_editor/appearance/caret/highlight_current_line"));
+			code_edit->set_highlight_all_occurrences(EDITOR_GET("text_editor/appearance/caret/highlight_all_occurrences"));
+
+			// Appearance: Gutters
+			code_edit->set_draw_line_numbers(EDITOR_GET("text_editor/appearance/gutters/show_line_numbers"));
+			code_edit->set_line_numbers_zero_padded(EDITOR_GET("text_editor/appearance/gutters/line_numbers_zero_padded"));
+
+			// Appearance: Minimap
+			code_edit->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));
+			code_edit->set_minimap_width((int)EDITOR_GET("text_editor/appearance/minimap/minimap_width") * EDSCALE);
+
+			// Appearance: Lines
+			code_edit->set_line_folding_enabled(EDITOR_GET("text_editor/appearance/lines/code_folding"));
+			code_edit->set_draw_fold_gutter(EDITOR_GET("text_editor/appearance/lines/code_folding"));
+			code_edit->set_line_wrapping_mode((TextEdit::LineWrappingMode)EDITOR_GET("text_editor/appearance/lines/word_wrap").operator int());
+			code_edit->set_autowrap_mode((TextServer::AutowrapMode)EDITOR_GET("text_editor/appearance/lines/autowrap_mode").operator int());
+
+			// Appearance: Whitespace
+			code_edit->set_draw_tabs(EDITOR_GET("text_editor/appearance/whitespace/draw_tabs"));
+			code_edit->set_draw_spaces(EDITOR_GET("text_editor/appearance/whitespace/draw_spaces"));
+			code_edit->add_theme_constant_override("line_spacing", EDITOR_GET("text_editor/appearance/whitespace/line_spacing"));
+
+			// Behavior: Navigation
+			code_edit->set_scroll_past_end_of_file_enabled(EDITOR_GET("text_editor/behavior/navigation/scroll_past_end_of_file"));
+			code_edit->set_smooth_scroll_enabled(EDITOR_GET("text_editor/behavior/navigation/smooth_scrolling"));
+			code_edit->set_v_scroll_speed(EDITOR_GET("text_editor/behavior/navigation/v_scroll_speed"));
+			code_edit->set_drag_and_drop_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/drag_and_drop_selection"));
+
+			// Behavior: Indent
+			code_edit->set_indent_size(EDITOR_GET("text_editor/behavior/indent/size"));
+			code_edit->set_auto_indent_enabled(EDITOR_GET("text_editor/behavior/indent/auto_indent"));
+			code_edit->set_indent_wrapped_lines(EDITOR_GET("text_editor/behavior/indent/indent_wrapped_lines"));
+
+			code_edit->set_name(nsc.versions[i].stages[j].name);
+			code_edit->set_text(nsc.versions[i].stages[j].code);
+			code_edit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			code_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			vtab->add_child(code_edit);
 		}
 	}
 	add_child(versions);
@@ -68,7 +148,10 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 void EditorNativeShaderSourceVisualizer::_bind_methods() {
 	ClassDB::bind_method("_inspect_shader", &EditorNativeShaderSourceVisualizer::_inspect_shader);
 }
+
 EditorNativeShaderSourceVisualizer::EditorNativeShaderSourceVisualizer() {
+	syntax_highlighter.instantiate();
+
 	add_to_group("_native_shader_source_visualizer");
 	set_title(TTR("Native Shader Source Inspector"));
 }

--- a/editor/editor_native_shader_source_visualizer.h
+++ b/editor/editor_native_shader_source_visualizer.h
@@ -33,11 +33,14 @@
 
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tab_container.h"
+#include "scene/resources/syntax_highlighter.h"
 
 class EditorNativeShaderSourceVisualizer : public AcceptDialog {
 	GDCLASS(EditorNativeShaderSourceVisualizer, AcceptDialog)
 	TabContainer *versions = nullptr;
+	Ref<CodeHighlighter> syntax_highlighter;
 
+	void _load_theme_settings();
 	void _inspect_shader(RID p_shader);
 
 protected:


### PR DESCRIPTION
- Use CodeEdit to enable features such as line numbers and minimap.
- Enable syntax highlighting.
- Use a fixed-width font.
- Use the script editor settings.

The native shader source visualizer is the option from this dropdown:

![inspector_option](https://github.com/godotengine/godot/assets/180032/9406d9e4-43f3-4bf8-b518-c86e516ce21a)

Performance (in terms of the time it takes for the dialog to open) is roughly the same as before.

## Preview

### Before

![Before](https://github.com/godotengine/godot/assets/180032/e5cc21a9-fef9-4816-ab6c-aad844260710)

### After

![After](https://github.com/godotengine/godot/assets/180032/5cb756d9-7505-419a-928b-9a7ead425dc5)