### PR TITLE
Add minimum width/height to dialog buttons

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -100,6 +100,12 @@
 		</signal>
 	</signals>
 	<theme_items>
+		<theme_item name="buttons_min_height" data_type="constant" type="int" default="0">
+			The minimum height of each button in the bottom row (such as OK/Cancel) in pixels. This can be increased to make buttons with short texts easier to click/tap.
+		</theme_item>
+		<theme_item name="buttons_min_width" data_type="constant" type="int" default="0">
+			The minimum width of each button in the bottom row (such as OK/Cancel) in pixels. This can be increased to make buttons with short texts easier to click/tap.
+		</theme_item>
 		<theme_item name="buttons_separation" data_type="constant" type="int" default="10">
 			The size of the vertical space between the dialog's content and the button row.
 		</theme_item>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -356,20 +356,25 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 		if (config.spacing_preset != "Custom") {
 			int preset_base_spacing = 0;
 			int preset_extra_spacing = 0;
+			Size2 preset_dialogs_buttons_min_size;
 
 			if (config.spacing_preset == "Compact") {
 				preset_base_spacing = 0;
 				preset_extra_spacing = 4;
+				preset_dialogs_buttons_min_size = Size2(90, 26);
 			} else if (config.spacing_preset == "Spacious") {
 				preset_base_spacing = 6;
 				preset_extra_spacing = 2;
+				preset_dialogs_buttons_min_size = Size2(112, 36);
 			} else { // Default
 				preset_base_spacing = 4;
 				preset_extra_spacing = 0;
+				preset_dialogs_buttons_min_size = Size2(105, 34);
 			}
 
 			config.base_spacing = preset_base_spacing;
 			config.extra_spacing = preset_extra_spacing;
+			config.dialogs_buttons_min_size = preset_dialogs_buttons_min_size;
 
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/base_spacing", config.base_spacing);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/additional_spacing", config.extra_spacing);
@@ -1271,6 +1276,9 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		// AcceptDialog.
 		p_theme->set_stylebox("panel", "AcceptDialog", p_config.dialog_style);
 		p_theme->set_constant("buttons_separation", "AcceptDialog", 8 * EDSCALE);
+		// Make buttons with short texts such as "OK" easier to click/tap.
+		p_theme->set_constant("buttons_min_width", "AcceptDialog", p_config.dialogs_buttons_min_size.x * EDSCALE);
+		p_theme->set_constant("buttons_min_height", "AcceptDialog", p_config.dialogs_buttons_min_size.y * EDSCALE);
 
 		// FileDialog.
 		p_theme->set_icon("folder", "FileDialog", p_theme->get_icon(SNAME("Folder"), EditorStringName(EditorIcons)));

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -62,6 +62,7 @@ class EditorThemeManager {
 
 		int base_spacing = 4;
 		int extra_spacing = 0;
+		Size2 dialogs_buttons_min_size = Size2(105, 34);
 		int border_width = 0;
 		int corner_radius = 3;
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -210,6 +210,15 @@ void AcceptDialog::_update_child_rects() {
 	bg_panel->set_position(Point2());
 	bg_panel->set_size(dlg_size);
 
+	for (int i = 0; i < buttons_hbox->get_child_count(); i++) {
+		Button *b = Object::cast_to<Button>(buttons_hbox->get_child(i));
+		if (!b) {
+			continue;
+		}
+
+		b->set_custom_minimum_size(Size2(theme_cache.buttons_min_width, theme_cache.buttons_min_height));
+	}
+
 	// Place the buttons from the bottom edge to their minimum required size.
 	Size2 buttons_minsize = buttons_hbox->get_combined_minimum_size();
 	Size2 buttons_size = Size2(dlg_size.x - h_margins, buttons_minsize.y);
@@ -389,6 +398,8 @@ void AcceptDialog::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, AcceptDialog, panel_style, "panel");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_separation);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_min_width);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, AcceptDialog, buttons_min_height);
 }
 
 bool AcceptDialog::swap_cancel_ok = false;

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -57,6 +57,8 @@ class AcceptDialog : public Window {
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
 		int buttons_separation = 0;
+		int buttons_min_width = 0;
+		int buttons_min_height = 0;
 	} theme_cache;
 
 	void _custom_action(const String &p_action);


### PR DESCRIPTION
This makes buttons with short texts such as "OK" or "Close" easier to click, especially on a touchscreen.

This is exposed to projects via `buttons_min_width` and `buttons_min_height` theme items in AcceptDialog (and therefore ConfirmationDialog and FileDialog), with the default values being 0 to preserve compatibility with existing projects.

## Preview

### AcceptDialog

Before
|-|
![acceptdialog_before](https://github.com/godotengine/godot/assets/180032/d623883d-853c-45ff-8be5-72dc78247f0e)

Default | Compact | Spacious
-|-|-
![Default](https://github.com/godotengine/godot/assets/180032/ff8d5eaf-a80d-4360-8f4c-7899683b7c95) | ![Compact](https://github.com/godotengine/godot/assets/180032/924c4070-c517-4b0a-a42a-2cdfb2746f61) | ![Spacious](https://github.com/godotengine/godot/assets/180032/7989eba7-c069-4a6e-bb01-a1d57df1daa7)

### ConfirmationDialog

Before
|-|
![confirmationdialog_before](https://github.com/godotengine/godot/assets/180032/6de0593d-1470-455f-ac76-d80e463fd818)

Default | Compact | Spacious
-|-|-
![Default](https://github.com/godotengine/godot/assets/180032/3b10d70d-e86c-49a7-bef7-1caec318f9de) | ![Compact](https://github.com/godotengine/godot/assets/180032/191e920f-9b48-4013-a912-c635fe432716) | ![Spacious](https://github.com/godotengine/godot/assets/180032/91751755-ada3-4483-ad7c-9a576b331c37)
