### PR TITLE
Android: Fix UnsupportedOperationException remove from non-ArrayList

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
@@ -293,15 +293,15 @@ public final class PermissionsUtil {
 	/**
 	 * Returns the permissions defined in the AndroidManifest.xml file.
 	 * @param context the caller context for this method.
-	 * @return manifest permissions list
+	 * @return mutable copy of manifest permissions list
 	 * @throws PackageManager.NameNotFoundException the exception is thrown when a given package, application, or component name cannot be found.
 	 */
-	public static List<String> getManifestPermissions(Context context) throws PackageManager.NameNotFoundException {
+	public static ArrayList<String> getManifestPermissions(Context context) throws PackageManager.NameNotFoundException {
 		PackageManager packageManager = context.getPackageManager();
 		PackageInfo packageInfo = packageManager.getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
 		if (packageInfo.requestedPermissions == null)
-			return Collections.emptyList();
-		return Arrays.asList(packageInfo.requestedPermissions);
+			return new ArrayList<String>();
+		return new ArrayList<>(Arrays.asList(packageInfo.requestedPermissions));
 	}
 
 	/**


### PR DESCRIPTION
`getManifestPermissions` on some versions of android seem to return some other implementation of List<> which does not implement `remove()`

I workaround this crash by converting the generic List<> to an ArrayList<> which is known to support `remove()`

Tested crash fix on `Pixel Tablet` Android 14:
Godot v4.3.dev - Android - Vulkan (Mobile) - integrated Mali-G710 -  (8 Threads)

Fixes #89696
