### PR TITLE
Clear debug session's tab when multiple running instance's count is changed

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -269,6 +269,16 @@ Error EditorDebuggerNode::start(const String &p_uri) {
 	stop(true);
 	current_uri = p_uri;
 
+	// Update tab count bases on running instance.
+	TypedArray<Dictionary> stored_data = TypedArray<Dictionary>(EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_instances_config", TypedArray<Dictionary>()));
+	int instance_count = stored_data.size();
+	int tab_count = tabs->get_tab_count();
+	if (instance_count != tab_count) {
+		for (int x = tab_count - 1; x != 0; x--) {
+			tabs->remove_child(tabs->get_tab_control(x));
+		}
+	}
+
 	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.substr(0, p_uri.find("://") + 3)));
 	const Error err = server->start(p_uri);
 	if (err != OK) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/89527

Is there a better way to clear the tabContainer?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
