### PR TITLE
Core: Implement `real_t` literal `_R`

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -47,7 +47,7 @@ int64_t AStar3D::get_available_point_id() const {
 
 void AStar3D::add_point(int64_t p_id, const Vector3 &p_pos, real_t p_weight_scale) {
 	ERR_FAIL_COND_MSG(p_id < 0, vformat("Can't add a point with negative id: %d.", p_id));
-	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't add a point with weight scale less than 0.0: %f.", p_weight_scale));
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0_R, vformat("Can't add a point with weight scale less than 0.0: %f.", p_weight_scale));
 
 	Point *found_pt;
 	bool p_exists = points.lookup(p_id, found_pt);
@@ -96,7 +96,7 @@ void AStar3D::set_point_weight_scale(int64_t p_id, real_t p_weight_scale) {
 	Point *p = nullptr;
 	bool p_exists = points.lookup(p_id, p);
 	ERR_FAIL_COND_MSG(!p_exists, vformat("Can't set point's weight scale. Point with id: %d doesn't exist.", p_id));
-	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0_R, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
 
 	p->weight_scale = p_weight_scale;
 }
@@ -530,7 +530,7 @@ bool AStar3D::is_point_disabled(int64_t p_id) const {
 
 void AStar3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_available_point_id"), &AStar3D::get_available_point_id);
-	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar3D::add_point, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar3D::add_point, DEFVAL(1.0_R));
 	ClassDB::bind_method(D_METHOD("get_point_position", "id"), &AStar3D::get_point_position);
 	ClassDB::bind_method(D_METHOD("set_point_position", "id", "position"), &AStar3D::set_point_position);
 	ClassDB::bind_method(D_METHOD("get_point_weight_scale", "id"), &AStar3D::get_point_weight_scale);
@@ -849,7 +849,7 @@ bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point) {
 
 void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_available_point_id"), &AStar2D::get_available_point_id);
-	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar2D::add_point, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar2D::add_point, DEFVAL(1.0_R));
 	ClassDB::bind_method(D_METHOD("get_point_position", "id"), &AStar2D::get_point_position);
 	ClassDB::bind_method(D_METHOD("set_point_position", "id", "position"), &AStar2D::set_point_position);
 	ClassDB::bind_method(D_METHOD("get_point_weight_scale", "id"), &AStar2D::get_point_weight_scale);

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -214,7 +214,7 @@ bool AStarGrid2D::is_point_solid(const Vector2i &p_id) const {
 void AStarGrid2D::set_point_weight_scale(const Vector2i &p_id, real_t p_weight_scale) {
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_MSG(!is_in_boundsv(p_id), vformat("Can't set point's weight scale. Point %s out of bounds %s.", p_id, region));
-	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0_R, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
 	_get_point_unchecked(p_id)->weight_scale = p_weight_scale;
 }
 
@@ -240,7 +240,7 @@ void AStarGrid2D::fill_solid_region(const Rect2i &p_region, bool p_solid) {
 
 void AStarGrid2D::fill_weight_scale_region(const Rect2i &p_region, real_t p_weight_scale) {
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
-	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0_R, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
 
 	const Rect2i safe_region = p_region.intersection(region);
 	const int32_t end_x = safe_region.get_end().x;
@@ -478,7 +478,7 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point) {
 		_get_nbors(p, nbors);
 
 		for (Point *e : nbors) {
-			real_t weight_scale = 1.0;
+			real_t weight_scale = 1.0_R;
 
 			if (jumping_enabled) {
 				// TODO: Make it works with weight_scale.

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -80,7 +80,7 @@ private:
 
 		bool solid = false;
 		Vector2 pos;
-		real_t weight_scale = 1.0;
+		real_t weight_scale = 1.0_R;
 
 		// Used for pathfinding.
 		Point *prev_point = nullptr;

--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -190,7 +190,7 @@ bool AABB::intersects_segment(const Vector3 &p_from, const Vector3 &p_to, Vector
 			real_t length = seg_to - seg_from;
 			cmin = (seg_from < box_begin) ? ((box_begin - seg_from) / length) : 0;
 			cmax = (seg_to > box_end) ? ((box_end - seg_from) / length) : 1;
-			csign = -1.0;
+			csign = -1.0_R;
 
 		} else {
 			if (seg_to > box_end || seg_from < box_begin) {
@@ -199,7 +199,7 @@ bool AABB::intersects_segment(const Vector3 &p_from, const Vector3 &p_to, Vector
 			real_t length = seg_to - seg_from;
 			cmin = (seg_from > box_end) ? (box_end - seg_from) / length : 0;
 			cmax = (seg_to < box_begin) ? (box_begin - seg_from) / length : 1;
-			csign = 1.0;
+			csign = 1.0_R;
 		}
 
 		if (cmin > min) {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -47,11 +47,11 @@ struct _NO_DISCARD_ AABB {
 
 	real_t get_volume() const;
 	_FORCE_INLINE_ bool has_volume() const {
-		return size.x > 0.0f && size.y > 0.0f && size.z > 0.0f;
+		return size.x > 0.0_R && size.y > 0.0_R && size.z > 0.0_R;
 	}
 
 	_FORCE_INLINE_ bool has_surface() const {
-		return size.x > 0.0f || size.y > 0.0f || size.z > 0.0f;
+		return size.x > 0.0_R || size.y > 0.0_R || size.z > 0.0_R;
 	}
 
 	const Vector3 &get_position() const { return position; }
@@ -101,7 +101,7 @@ struct _NO_DISCARD_ AABB {
 	_FORCE_INLINE_ void expand_to(const Vector3 &p_vector); /** expand to contain a point if necessary */
 
 	_FORCE_INLINE_ AABB abs() const {
-		return AABB(Vector3(position.x + MIN(size.x, (real_t)0), position.y + MIN(size.y, (real_t)0), position.z + MIN(size.z, (real_t)0)), size.abs());
+		return AABB(Vector3(position.x + MIN(size.x, 0.0_R), position.y + MIN(size.y, 0.0_R), position.z + MIN(size.z, 0.0_R)), size.abs());
 	}
 
 	Variant intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const;
@@ -119,7 +119,7 @@ struct _NO_DISCARD_ AABB {
 	}
 
 	_FORCE_INLINE_ Vector3 get_center() const {
-		return position + (size * 0.5f);
+		return position + (size * 0.5_R);
 	}
 
 	operator String() const;
@@ -407,9 +407,9 @@ bool AABB::smits_intersect_ray(const Vector3 &p_from, const Vector3 &p_dir, real
 		ERR_PRINT("AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size.");
 	}
 #endif
-	real_t divx = 1.0f / p_dir.x;
-	real_t divy = 1.0f / p_dir.y;
-	real_t divz = 1.0f / p_dir.z;
+	real_t divx = 1.0_R / p_dir.x;
+	real_t divy = 1.0_R / p_dir.y;
+	real_t divz = 1.0_R / p_dir.z;
 
 	Vector3 upbound = position + size;
 	real_t tmin, tmax, tymin, tymax, tzmin, tzmax;

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -46,7 +46,7 @@ void Basis::invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t s = 1.0f / det;
+	real_t s = 1.0_R / det;
 
 	set(co[0] * s, cofac(0, 2, 2, 1) * s, cofac(0, 1, 1, 2) * s,
 			co[1] * s, cofac(0, 0, 2, 2) * s, cofac(0, 2, 1, 0) * s,
@@ -188,7 +188,7 @@ Basis Basis::diagonalize() {
 		if (Math::is_equal_approx(rows[j][j], rows[i][i])) {
 			angle = Math_PI / 4;
 		} else {
-			angle = 0.5f * Math::atan(2 * rows[i][j] / (rows[j][j] - rows[i][i]));
+			angle = 0.5_R * Math::atan(2 * rows[i][j] / (rows[j][j] - rows[i][i]));
 		}
 
 		// Compute the rotation matrix
@@ -279,7 +279,7 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 }
 
 float Basis::get_uniform_scale() const {
-	return (rows[0].length() + rows[1].length() + rows[2].length()) / 3.0f;
+	return (rows[0].length() + rows[1].length() + rows[2].length()) / 3.0_R;
 }
 
 Basis Basis::scaled_local(const Vector3 &p_scale) const {
@@ -418,7 +418,7 @@ void Basis::rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction) 
 	const Vector3 axis = p_start_direction.cross(p_end_direction).normalized();
 	if (axis.length_squared() != 0) {
 		real_t dot = p_start_direction.dot(p_end_direction);
-		dot = CLAMP(dot, -1.0f, 1.0f);
+		dot = CLAMP(dot, -1.0_R, 1.0_R);
 		const real_t angle_rads = Math::acos(dot);
 		*this = Basis(axis, angle_rads) * (*this);
 	}
@@ -466,8 +466,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sy = rows[0][2];
-			if (sy < (1.0f - (real_t)CMP_EPSILON)) {
-				if (sy > -(1.0f - (real_t)CMP_EPSILON)) {
+			if (sy < (1.0_R - (real_t)CMP_EPSILON)) {
+				if (sy > -(1.0_R - (real_t)CMP_EPSILON)) {
 					// is this a pure Y rotation?
 					if (rows[1][0] == 0 && rows[0][1] == 0 && rows[1][2] == 0 && rows[2][1] == 0 && rows[1][1] == 1) {
 						// return the simplest form (human friendlier in editor and scripts)
@@ -481,13 +481,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					}
 				} else {
 					euler.x = Math::atan2(rows[2][1], rows[1][1]);
-					euler.y = -Math_PI / 2.0f;
-					euler.z = 0.0f;
+					euler.y = -Math_PI / 2.0_R;
+					euler.z = 0.0_R;
 				}
 			} else {
 				euler.x = Math::atan2(rows[2][1], rows[1][1]);
-				euler.y = Math_PI / 2.0f;
-				euler.z = 0.0f;
+				euler.y = Math_PI / 2.0_R;
+				euler.z = 0.0_R;
 			}
 			return euler;
 		}
@@ -501,22 +501,22 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sz = rows[0][1];
-			if (sz < (1.0f - (real_t)CMP_EPSILON)) {
-				if (sz > -(1.0f - (real_t)CMP_EPSILON)) {
+			if (sz < (1.0_R - (real_t)CMP_EPSILON)) {
+				if (sz > -(1.0_R - (real_t)CMP_EPSILON)) {
 					euler.x = Math::atan2(rows[2][1], rows[1][1]);
 					euler.y = Math::atan2(rows[0][2], rows[0][0]);
 					euler.z = Math::asin(-sz);
 				} else {
 					// It's -1
 					euler.x = -Math::atan2(rows[1][2], rows[2][2]);
-					euler.y = 0.0f;
-					euler.z = Math_PI / 2.0f;
+					euler.y = 0.0_R;
+					euler.z = Math_PI / 2.0_R;
 				}
 			} else {
 				// It's 1
 				euler.x = -Math::atan2(rows[1][2], rows[2][2]);
-				euler.y = 0.0f;
-				euler.z = -Math_PI / 2.0f;
+				euler.y = 0.0_R;
+				euler.z = -Math_PI / 2.0_R;
 			}
 			return euler;
 		}
@@ -546,12 +546,12 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 						euler.z = atan2(rows[1][0], rows[1][1]);
 					}
 				} else { // m12 == -1
-					euler.x = Math_PI * 0.5f;
+					euler.x = Math_PI * 0.5_R;
 					euler.y = atan2(rows[0][1], rows[0][0]);
 					euler.z = 0;
 				}
 			} else { // m12 == 1
-				euler.x = -Math_PI * 0.5f;
+				euler.x = -Math_PI * 0.5_R;
 				euler.y = -atan2(rows[0][1], rows[0][0]);
 				euler.z = 0;
 			}
@@ -568,22 +568,22 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sz = rows[1][0];
-			if (sz < (1.0f - (real_t)CMP_EPSILON)) {
-				if (sz > -(1.0f - (real_t)CMP_EPSILON)) {
+			if (sz < (1.0_R - (real_t)CMP_EPSILON)) {
+				if (sz > -(1.0_R - (real_t)CMP_EPSILON)) {
 					euler.x = Math::atan2(-rows[1][2], rows[1][1]);
 					euler.y = Math::atan2(-rows[2][0], rows[0][0]);
 					euler.z = Math::asin(sz);
 				} else {
 					// It's -1
 					euler.x = Math::atan2(rows[2][1], rows[2][2]);
-					euler.y = 0.0f;
-					euler.z = -Math_PI / 2.0f;
+					euler.y = 0.0_R;
+					euler.z = -Math_PI / 2.0_R;
 				}
 			} else {
 				// It's 1
 				euler.x = Math::atan2(rows[2][1], rows[2][2]);
-				euler.y = 0.0f;
-				euler.z = Math_PI / 2.0f;
+				euler.y = 0.0_R;
+				euler.z = Math_PI / 2.0_R;
 			}
 			return euler;
 		} break;
@@ -596,20 +596,20 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			//        -cx*sy            sx                    cx*cy
 			Vector3 euler;
 			real_t sx = rows[2][1];
-			if (sx < (1.0f - (real_t)CMP_EPSILON)) {
-				if (sx > -(1.0f - (real_t)CMP_EPSILON)) {
+			if (sx < (1.0_R - (real_t)CMP_EPSILON)) {
+				if (sx > -(1.0_R - (real_t)CMP_EPSILON)) {
 					euler.x = Math::asin(sx);
 					euler.y = Math::atan2(-rows[2][0], rows[2][2]);
 					euler.z = Math::atan2(-rows[0][1], rows[1][1]);
 				} else {
 					// It's -1
-					euler.x = -Math_PI / 2.0f;
+					euler.x = -Math_PI / 2.0_R;
 					euler.y = Math::atan2(rows[0][2], rows[0][0]);
 					euler.z = 0;
 				}
 			} else {
 				// It's 1
-				euler.x = Math_PI / 2.0f;
+				euler.x = Math_PI / 2.0_R;
 				euler.y = Math::atan2(rows[0][2], rows[0][0]);
 				euler.z = 0;
 			}
@@ -624,21 +624,21 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			//        -sy               cy*sx                 cy*cx
 			Vector3 euler;
 			real_t sy = rows[2][0];
-			if (sy < (1.0f - (real_t)CMP_EPSILON)) {
-				if (sy > -(1.0f - (real_t)CMP_EPSILON)) {
+			if (sy < (1.0_R - (real_t)CMP_EPSILON)) {
+				if (sy > -(1.0_R - (real_t)CMP_EPSILON)) {
 					euler.x = Math::atan2(rows[2][1], rows[2][2]);
 					euler.y = Math::asin(-sy);
 					euler.z = Math::atan2(rows[1][0], rows[0][0]);
 				} else {
 					// It's -1
 					euler.x = 0;
-					euler.y = Math_PI / 2.0f;
+					euler.y = Math_PI / 2.0_R;
 					euler.z = -Math::atan2(rows[0][1], rows[1][1]);
 				}
 			} else {
 				// It's 1
 				euler.x = 0;
-				euler.y = -Math_PI / 2.0f;
+				euler.y = -Math_PI / 2.0_R;
 				euler.z = -Math::atan2(rows[0][1], rows[1][1]);
 			}
 			return euler;
@@ -729,10 +729,10 @@ Quaternion Basis::get_quaternion() const {
 	real_t trace = m.rows[0][0] + m.rows[1][1] + m.rows[2][2];
 	real_t temp[4];
 
-	if (trace > 0.0f) {
-		real_t s = Math::sqrt(trace + 1.0f);
-		temp[3] = (s * 0.5f);
-		s = 0.5f / s;
+	if (trace > 0.0_R) {
+		real_t s = Math::sqrt(trace + 1.0_R);
+		temp[3] = s * 0.5_R;
+		s = 0.5_R / s;
 
 		temp[0] = ((m.rows[2][1] - m.rows[1][2]) * s);
 		temp[1] = ((m.rows[0][2] - m.rows[2][0]) * s);
@@ -744,9 +744,9 @@ Quaternion Basis::get_quaternion() const {
 		int j = (i + 1) % 3;
 		int k = (i + 2) % 3;
 
-		real_t s = Math::sqrt(m.rows[i][i] - m.rows[j][j] - m.rows[k][k] + 1.0f);
-		temp[i] = s * 0.5f;
-		s = 0.5f / s;
+		real_t s = Math::sqrt(m.rows[i][i] - m.rows[j][j] - m.rows[k][k] + 1.0_R);
+		temp[i] = s * 0.5_R;
+		s = 0.5_R / s;
 
 		temp[3] = (m.rows[k][j] - m.rows[j][k]) * s;
 		temp[j] = (m.rows[j][i] + m.rows[i][j]) * s;
@@ -836,14 +836,14 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 
 void Basis::set_quaternion(const Quaternion &p_quaternion) {
 	real_t d = p_quaternion.length_squared();
-	real_t s = 2.0f / d;
+	real_t s = 2.0_R / d;
 	real_t xs = p_quaternion.x * s, ys = p_quaternion.y * s, zs = p_quaternion.z * s;
 	real_t wx = p_quaternion.w * xs, wy = p_quaternion.w * ys, wz = p_quaternion.w * zs;
 	real_t xx = p_quaternion.x * xs, xy = p_quaternion.x * ys, xz = p_quaternion.x * zs;
 	real_t yy = p_quaternion.y * ys, yz = p_quaternion.y * zs, zz = p_quaternion.z * zs;
-	set(1.0f - (yy + zz), xy - wz, xz + wy,
-			xy + wz, 1.0f - (xx + zz), yz - wx,
-			xz - wy, yz + wx, 1.0f - (xx + yy));
+	set(1.0_R - (yy + zz), xy - wz, xz + wy,
+			xy + wz, 1.0_R - (xx + zz), yz - wx,
+			xz - wy, yz + wx, 1.0_R - (xx + yy));
 }
 
 void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_angle) {
@@ -853,9 +853,9 @@ void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_angle) {
 #endif
 	Vector3 axis_sq(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
 	real_t cosine = Math::cos(p_angle);
-	rows[0][0] = axis_sq.x + cosine * (1.0f - axis_sq.x);
-	rows[1][1] = axis_sq.y + cosine * (1.0f - axis_sq.y);
-	rows[2][2] = axis_sq.z + cosine * (1.0f - axis_sq.z);
+	rows[0][0] = axis_sq.x + cosine * (1.0_R - axis_sq.x);
+	rows[1][1] = axis_sq.y + cosine * (1.0_R - axis_sq.y);
+	rows[2][2] = axis_sq.z + cosine * (1.0_R - axis_sq.z);
 
 	real_t sine = Math::sin(p_angle);
 	real_t t = 1 - cosine;
@@ -934,16 +934,16 @@ void Basis::rotate_sh(real_t *p_values) {
 	// http://filmicworlds.com/blog/simple-and-fast-spherical-harmonic-rotation/
 	// this code is Public Domain
 
-	const static real_t s_c3 = 0.94617469575; // (3*sqrt(5))/(4*sqrt(pi))
-	const static real_t s_c4 = -0.31539156525; // (-sqrt(5))/(4*sqrt(pi))
-	const static real_t s_c5 = 0.54627421529; // (sqrt(15))/(4*sqrt(pi))
+	const static real_t s_c3 = 0.94617469575_R; // (3*sqrt(5))/(4*sqrt(pi))
+	const static real_t s_c4 = -0.31539156525_R; // (-sqrt(5))/(4*sqrt(pi))
+	const static real_t s_c5 = 0.54627421529_R; // (sqrt(15))/(4*sqrt(pi))
 
-	const static real_t s_c_scale = 1.0 / 0.91529123286551084;
-	const static real_t s_c_scale_inv = 0.91529123286551084;
+	const static real_t s_c_scale = 1.0_R / 0.91529123286551084_R;
+	const static real_t s_c_scale_inv = 0.91529123286551084_R;
 
-	const static real_t s_rc2 = 1.5853309190550713 * s_c_scale;
+	const static real_t s_rc2 = 1.5853309190550713_R * s_c_scale;
 	const static real_t s_c4_div_c3 = s_c4 / s_c3;
-	const static real_t s_c4_div_c3_x2 = (s_c4 / s_c3) * 2.0;
+	const static real_t s_c4_div_c3_x2 = (s_c4 / s_c3) * 2.0_R;
 
 	const static real_t s_scale_dst2 = s_c3 * s_c_scale_inv;
 	const static real_t s_scale_dst4 = s_c5 * s_c_scale_inv;

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -75,7 +75,7 @@ public:
 	// see the variable declarations for more info.
 	void params_set_node_expansion(real_t p_value) {
 		BVH_LOCKED_FUNCTION
-		if (p_value >= 0.0) {
+		if (p_value >= 0.0_R) {
 			tree._node_expansion = p_value;
 			tree._auto_node_expansion = false;
 		} else {

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -93,7 +93,7 @@ struct BVH_ABB {
 
 	real_t get_proximity_to(const BVH_ABB &p_b) const {
 		const POINT d = (min - neg_max) - (p_b.min - p_b.neg_max);
-		real_t proximity = 0.0;
+		real_t proximity = 0.0_R;
 		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			proximity += Math::abs(d[axis]);
 		}

--- a/core/math/bvh_pair.inc
+++ b/core/math/bvh_pair.inc
@@ -64,9 +64,9 @@ struct ItemPairs {
 	// when the number of pairs is high, the density is high and a lower collision margin is better.
 	// when there are few local pairs, a larger margin is more optimal.
 	real_t scale_expansion_margin(real_t p_margin) const {
-		real_t x = real_t(num_pairs) * (1.0 / 9.0);
-		x = MIN(x, 1.0);
-		x = 1.0 - x;
+		real_t x = real_t(num_pairs) * (1.0_R / 9.0_R);
+		x = MIN(x, 1.0_R);
+		x = 1.0_R - x;
 		return p_margin * x;
 	}
 };

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -441,10 +441,10 @@ void update() {
 
 			// these magic numbers are determined by experiment
 			if (_auto_node_expansion) {
-				_node_expansion = size * 0.025;
+				_node_expansion = size * 0.025_R;
 			}
 			if (_auto_pairing_expansion) {
-				_pairing_expansion = size * 0.009;
+				_pairing_expansion = size * 0.009_R;
 			}
 		}
 	}
@@ -452,7 +452,7 @@ void update() {
 }
 
 void params_set_pairing_expansion(real_t p_value) {
-	if (p_value < 0.0) {
+	if (p_value < 0.0_R) {
 #ifdef BVH_ALLOW_AUTO_EXPANSION
 		_auto_pairing_expansion = true;
 #endif
@@ -465,8 +465,8 @@ void params_set_pairing_expansion(real_t p_value) {
 	_pairing_expansion = p_value;
 
 	// calculate shrinking threshold
-	const real_t fudge_factor = 1.1;
-	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2.0 * fudge_factor;
+	const real_t fudge_factor = 1.1_R;
+	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2.0_R * fudge_factor;
 }
 
 // This routine is not just an enclose check, it also checks for special case of shrinkage
@@ -481,8 +481,8 @@ bool expanded_aabb_encloses_not_shrink(const BOUNDS &p_expanded_aabb, const BOUN
 	const POINT &exp_size = p_expanded_aabb.size;
 	const POINT &new_size = p_aabb.size;
 
-	real_t exp_l = 0.0;
-	real_t new_l = 0.0;
+	real_t exp_l = 0.0_R;
+	real_t new_l = 0.0_R;
 
 	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
 		exp_l += exp_size[i];

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -195,13 +195,13 @@ uint32_t _root_node_id[NUM_TREES];
 // larger values give less re-insertion as items move...
 // but on the other hand over estimates the bounding box of nodes.
 // we can either use auto mode, where the expansion is based on the root node size, or specify manually
-real_t _node_expansion = 0.5;
+real_t _node_expansion = 0.5_R;
 bool _auto_node_expansion = true;
 
 // pairing expansion important for physics pairing
 // larger values gives more 'sticky' pairing, and is less likely to exhibit tunneling
 // we can either use auto mode, where the expansion is based on the root node size, or specify manually
-real_t _pairing_expansion = 0.1;
+real_t _pairing_expansion = 0.1_R;
 
 #ifdef BVH_ALLOW_AUTO_EXPANSION
 bool _auto_pairing_expansion = true;
@@ -212,4 +212,4 @@ bool _auto_pairing_expansion = true;
 // should override the optimization and create a new expanded bound.
 // This threshold is derived from the _pairing_expansion, and should be recalculated
 // if _pairing_expansion is changed.
-real_t _aabb_shrinkage_threshold = 0.0;
+real_t _aabb_shrinkage_threshold = 0.0_R;

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -191,7 +191,7 @@ public:
 		// In many cases you may want to change this default in the client code,
 		// or expose this value to the user.
 		// This default may make sense for a typically scaled 3d game, but maybe not for 2d on a pixel scale.
-		params_set_pairing_expansion(0.1);
+		params_set_pairing_expansion(0.1_R);
 	}
 
 private:
@@ -337,7 +337,7 @@ private:
 		// which are important in determining the bound. Any other aabb
 		// within this can be removed and not affect the overall bound.
 		BVHABB_CLASS node_bound = tnode.aabb;
-		node_bound.expand(-_node_expansion - 0.001f);
+		node_bound.expand(-_node_expansion - 0.001_R);
 		bool refit = true;
 
 		if (node_bound.is_other_within(old_aabb)) {

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2249,7 +2249,7 @@ Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3
 	}
 
 	ConvexHullComputer ch;
-	ch.compute(p_points.ptr(), p_points.size(), -1.0, -1.0);
+	ch.compute(p_points.ptr(), p_points.size(), -1.0_R, -1.0_R);
 
 	r_mesh.vertices = ch.vertices;
 

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -71,7 +71,7 @@ public:
 		Vector2 a = p_vertices[p_b] - p_vertices[p_a];
 		Vector2 b = p_vertices[p_c] - p_vertices[p_a];
 
-		Vector2 O = (b * a.length_squared() - a * b.length_squared()).orthogonal() / (a.cross(b) * 2.0f);
+		Vector2 O = (b * a.length_squared() - a * b.length_squared()).orthogonal() / (a.cross(b) * 2.0_R);
 
 		triangle.circum_radius_squared = O.length_squared();
 		triangle.circum_center = O + p_vertices[p_a];

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -199,10 +199,10 @@ class Delaunay3D {
 		cm.columns[2][2] = p_points[p_simplex.points[2]].z;
 		cm.columns[2][3] = p_points[p_simplex.points[3]].z;
 
-		cm.columns[3][0] = 1.0;
-		cm.columns[3][1] = 1.0;
-		cm.columns[3][2] = 1.0;
-		cm.columns[3][3] = 1.0;
+		cm.columns[3][0] = 1.0_R;
+		cm.columns[3][1] = 1.0_R;
+		cm.columns[3][2] = 1.0_R;
+		cm.columns[3][3] = 1.0_R;
 
 		return ABS(cm.determinant()) <= CMP_EPSILON;
 	}
@@ -234,7 +234,7 @@ public:
 			}
 
 			float delta_max = Math::sqrt(2.0) * 20.0;
-			Vector3 center = Vector3(0.5, 0.5, 0.5);
+			Vector3 center = Vector3(0.5_R, 0.5_R, 0.5_R);
 
 			// any simplex that contains everything is good
 			points[point_count + 0] = center + Vector3(0, 1, 0) * delta_max;

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -431,10 +431,10 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 
 	///what about division by zero? --> just set rayDirection[i] to INF/B3_LARGE_FLOAT
 	Vector3 inv_dir;
-	inv_dir[0] = ray_dir[0] == real_t(0.0) ? real_t(1e20) : real_t(1.0) / ray_dir[0];
-	inv_dir[1] = ray_dir[1] == real_t(0.0) ? real_t(1e20) : real_t(1.0) / ray_dir[1];
-	inv_dir[2] = ray_dir[2] == real_t(0.0) ? real_t(1e20) : real_t(1.0) / ray_dir[2];
-	unsigned int signs[3] = { inv_dir[0] < 0.0, inv_dir[1] < 0.0, inv_dir[2] < 0.0 };
+	inv_dir[0] = ray_dir[0] == 0.0_R ? 1e20_R : 1.0_R / ray_dir[0];
+	inv_dir[1] = ray_dir[1] == 0.0_R ? 1e20_R : 1.0_R / ray_dir[1];
+	inv_dir[2] = ray_dir[2] == 0.0_R ? 1e20_R : 1.0_R / ray_dir[2];
+	unsigned int signs[3] = { inv_dir[0] < 0.0_R, inv_dir[1] < 0.0_R, inv_dir[2] < 0.0_R };
 
 	real_t lambda_max = ray_dir.dot(p_to - p_from);
 
@@ -453,7 +453,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 		const Node *node = stack[depth];
 		bounds[0] = node->volume.min;
 		bounds[1] = node->volume.max;
-		real_t tmin = 1.f, lambda_min = 0.f;
+		real_t tmin = 1.0_R, lambda_min = 0.0_R;
 		unsigned int result1 = false;
 		result1 = _ray_aabb(p_from, inv_dir, signs, bounds, tmin, lambda_min, lambda_max);
 		if (result1) {

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -121,13 +121,13 @@ bool Face3::is_degenerate() const {
 }
 
 Vector3 Face3::get_random_point_inside() const {
-	real_t a = Math::random(0.0, 1.0);
-	real_t b = Math::random(0.0, 1.0);
+	real_t a = Math::random(0.0_R, 1.0_R);
+	real_t b = Math::random(0.0_R, 1.0_R);
 	if (a > b) {
 		SWAP(a, b);
 	}
 
-	return vertex[0] * a + vertex[1] * (b - a) + vertex[2] * (1.0f - b);
+	return vertex[0] * a + vertex[1] * (b - a) + vertex[2] * (1.0_R - b);
 }
 
 Plane Face3::get_plane(ClockDirection p_dir) const {
@@ -135,7 +135,7 @@ Plane Face3::get_plane(ClockDirection p_dir) const {
 }
 
 real_t Face3::get_area() const {
-	return vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]).length() * 0.5f;
+	return vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]).length() * 0.5_R;
 }
 
 bool Face3::intersects_aabb(const AABB &p_aabb) const {
@@ -183,7 +183,7 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 
 			Vector3 axis = vec3_cross(e1, e2);
 
-			if (axis.length_squared() < 0.0001f) {
+			if (axis.length_squared() < 0.0001_R) {
 				continue; // coplanar
 			}
 			axis.normalize();
@@ -312,7 +312,7 @@ Vector3 Face3::get_closest_point_to(const Vector3 &p_point) const {
 			s = CLAMP(-d / a, 0.f, 1.f);
 			t = 0.f;
 		} else {
-			real_t invDet = 1.f / det;
+			real_t invDet = 1.0_R / det;
 			s *= invDet;
 			t *= invDet;
 		}

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -90,7 +90,7 @@ struct _NO_DISCARD_ Face3 {
 bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 	Vector3 perp = (vertex[0] - vertex[2]).cross(vertex[0] - vertex[1]);
 
-	Vector3 half_extents = p_aabb.size * 0.5f;
+	Vector3 half_extents = p_aabb.size * 0.5_R;
 	Vector3 ofs = p_aabb.position + half_extents;
 
 	Vector3 sup = Vector3(
@@ -201,7 +201,7 @@ bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 
 			Vector3 axis = vec3_cross(e1, e2);
 
-			if (axis.length_squared() < 0.0001f) {
+			if (axis.length_squared() < 0.0001_R) {
 				continue; // coplanar
 			}
 			//axis.normalize();
@@ -217,7 +217,7 @@ bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 				SWAP(maxB, minB);
 			}
 
-			real_t minT = 1e20, maxT = -1e20;
+			real_t minT = 1e20_R, maxT = -1e20_R;
 			for (int k = 0; k < 3; k++) {
 				real_t vert_d = axis.dot(vertex[k]);
 

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -59,25 +59,25 @@ public:
 		}
 		if (a <= (real_t)CMP_EPSILON) {
 			// First segment degenerates into a point.
-			s = 0.0;
+			s = 0.0_R;
 			t = f / e; // s = 0 => t = (b*s + f) / e = f / e
-			t = CLAMP(t, 0.0f, 1.0f);
+			t = CLAMP(t, 0.0_R, 1.0_R);
 		} else {
 			real_t c = d1.dot(r);
 			if (e <= (real_t)CMP_EPSILON) {
 				// Second segment degenerates into a point.
-				t = 0.0;
-				s = CLAMP(-c / a, 0.0f, 1.0f); // t = 0 => s = (b*t - c) / a = -c / a
+				t = 0.0_R;
+				s = CLAMP(-c / a, 0.0_R, 1.0_R); // t = 0 => s = (b*t - c) / a = -c / a
 			} else {
 				// The general nondegenerate case starts here.
 				real_t b = d1.dot(d2);
 				real_t denom = a * e - b * b; // Always nonnegative.
 				// If segments not parallel, compute closest point on L1 to L2 and
 				// clamp to segment S1. Else pick arbitrary s (here 0).
-				if (denom != 0.0f) {
-					s = CLAMP((b * f - c * e) / denom, 0.0f, 1.0f);
+				if (denom != 0.0_R) {
+					s = CLAMP((b * f - c * e) / denom, 0.0_R, 1.0_R);
 				} else {
-					s = 0.0;
+					s = 0.0_R;
 				}
 				// Compute point on L2 closest to S1(s) using
 				// t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / e
@@ -86,12 +86,12 @@ public:
 				//If t in [0,1] done. Else clamp t, recompute s for the new value
 				// of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1)= (t*b - c) / a
 				// and clamp s to [0, 1].
-				if (t < 0.0f) {
-					t = 0.0;
-					s = CLAMP(-c / a, 0.0f, 1.0f);
-				} else if (t > 1.0f) {
-					t = 1.0;
-					s = CLAMP((b - c) / a, 0.0f, 1.0f);
+				if (t < 0.0_R) {
+					t = 0.0_R;
+					s = CLAMP(-c / a, 0.0_R, 1.0_R);
+				} else if (t > 1.0_R) {
+					t = 1.0_R;
+					s = CLAMP((b - c) / a, 0.0_R, 1.0_R);
 				}
 			}
 		}
@@ -110,9 +110,9 @@ public:
 
 		real_t d = n.dot(p) / l2;
 
-		if (d <= 0.0f) {
+		if (d <= 0.0_R) {
 			return p_segment[0]; // Before first point.
-		} else if (d >= 1.0f) {
+		} else if (d >= 1.0_R) {
 			return p_segment[1]; // After first point.
 		} else {
 			return p_segment[0] + n * d; // Inside.
@@ -363,7 +363,7 @@ public:
 			sum += (v2.x - v1.x) * (v2.y + v1.y);
 		}
 
-		return sum > 0.0f;
+		return sum > 0.0_R;
 	}
 
 	// Alternate implementation that should be faster.
@@ -373,8 +373,8 @@ public:
 			return false;
 		}
 		const Vector2 *p = p_polygon.ptr();
-		Vector2 further_away(-1e20, -1e20);
-		Vector2 further_away_opposite(1e20, 1e20);
+		Vector2 further_away(-1e20_R, -1e20_R);
+		Vector2 further_away_opposite(1e20_R, 1e20_R);
 
 		for (int i = 0; i < c; i++) {
 			further_away.x = MAX(p[i].x, further_away.x);
@@ -384,7 +384,7 @@ public:
 		}
 
 		// Make point outside that won't intersect with points in segment from p_point.
-		further_away += (further_away - further_away_opposite) * Vector2(1.221313, 1.512312);
+		further_away += (further_away - further_away_opposite) * Vector2(1.221313_R, 1.512312_R);
 
 		int intersections = 0;
 		for (int i = 0; i < c; i++) {

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -45,8 +45,8 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 	real_t d = p.dot(r);
 	real_t e = q.dot(r);
 
-	real_t s = 0.0f;
-	real_t t = 0.0f;
+	real_t s = 0.0_R;
+	real_t t = 0.0_R;
 
 	real_t det = a * c - b * b;
 	if (det > CMP_EPSILON) {
@@ -55,56 +55,56 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		real_t ctd = c * d;
 
 		if (bte <= ctd) {
-			// s <= 0.0f
-			if (e <= 0.0f) {
-				// t <= 0.0f
-				s = (-d >= a ? 1 : (-d > 0.0f ? -d / a : 0.0f));
-				t = 0.0f;
+			// s <= 0.0_R
+			if (e <= 0.0_R) {
+				// t <= 0.0_R
+				s = (-d >= a ? 1 : (-d > 0.0_R ? -d / a : 0.0_R));
+				t = 0.0_R;
 			} else if (e < c) {
-				// 0.0f < t < 1
-				s = 0.0f;
+				// 0.0_R < t < 1
+				s = 0.0_R;
 				t = e / c;
 			} else {
 				// t >= 1
-				s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
+				s = (b - d >= a ? 1 : (b - d > 0.0_R ? (b - d) / a : 0.0_R));
 				t = 1;
 			}
 		} else {
-			// s > 0.0f
+			// s > 0.0_R
 			s = bte - ctd;
 			if (s >= det) {
 				// s >= 1
-				if (b + e <= 0.0f) {
-					// t <= 0.0f
-					s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
-					t = 0.0f;
+				if (b + e <= 0.0_R) {
+					// t <= 0.0_R
+					s = (-d <= 0.0_R ? 0.0_R : (-d < a ? -d / a : 1));
+					t = 0.0_R;
 				} else if (b + e < c) {
-					// 0.0f < t < 1
+					// 0.0_R < t < 1
 					s = 1;
 					t = (b + e) / c;
 				} else {
 					// t >= 1
-					s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
+					s = (b - d <= 0.0_R ? 0.0_R : (b - d < a ? (b - d) / a : 1));
 					t = 1;
 				}
 			} else {
-				// 0.0f < s < 1
+				// 0.0_R < s < 1
 				real_t ate = a * e;
 				real_t btd = b * d;
 
 				if (ate <= btd) {
-					// t <= 0.0f
-					s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
-					t = 0.0f;
+					// t <= 0.0_R
+					s = (-d <= 0.0_R ? 0.0_R : (-d >= a ? 1 : -d / a));
+					t = 0.0_R;
 				} else {
-					// t > 0.0f
+					// t > 0.0_R
 					t = ate - btd;
 					if (t >= det) {
 						// t >= 1
-						s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+						s = (b - d <= 0.0_R ? 0.0_R : (b - d >= a ? 1 : (b - d) / a));
 						t = 1;
 					} else {
-						// 0.0f < t < 1
+						// 0.0_R < t < 1
 						s /= det;
 						t /= det;
 					}
@@ -113,14 +113,14 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		}
 	} else {
 		// Parallel segments
-		if (e <= 0.0f) {
-			s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
-			t = 0.0f;
+		if (e <= 0.0_R) {
+			s = (-d <= 0.0_R ? 0.0_R : (-d >= a ? 1 : -d / a));
+			t = 0.0_R;
 		} else if (e >= c) {
-			s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+			s = (b - d <= 0.0_R ? 0.0_R : (b - d >= a ? 1 : (b - d) / a));
 			t = 1;
 		} else {
-			s = 0.0f;
+			s = 0.0_R;
 			t = e / c;
 		}
 	}
@@ -589,14 +589,14 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 
 #define SUBPLANE_SIZE 1024.0
 
-	real_t subplane_size = 1024.0; // Should compute this from the actual plane.
+	real_t subplane_size = 1024.0_R; // Should compute this from the actual plane.
 	for (int i = 0; i < p_planes.size(); i++) {
 		Plane p = p_planes[i];
 
 		Vector3 ref = Vector3(0.0, 1.0, 0.0);
 
-		if (ABS(p.normal.dot(ref)) > 0.95f) {
-			ref = Vector3(0.0, 0.0, 1.0); // Change axis.
+		if (ABS(p.normal.dot(ref)) > 0.95_R) {
+			ref = Vector3(0.0_R, 0.0_R, 1.0_R); // Change axis.
 		}
 
 		Vector3 right = p.normal.cross(ref).normalized();
@@ -620,7 +620,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 			LocalVector<Vector3> new_vertices;
 			Plane clip = p_planes[j];
 
-			if (clip.normal.dot(p.normal) > 0.95f) {
+			if (clip.normal.dot(p.normal) > 0.95_R) {
 				continue;
 			}
 
@@ -673,7 +673,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 		for (const Vector3 &vertex : vertices) {
 			int idx = -1;
 			for (uint32_t k = 0; k < mesh.vertices.size(); k++) {
-				if (mesh.vertices[k].distance_to(vertex) < 0.001f) {
+				if (mesh.vertices[k].distance_to(vertex) < 0.001_R) {
 					idx = k;
 					break;
 				}
@@ -754,10 +754,10 @@ Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height
 	}
 
 	Vector3 axis;
-	axis[p_axis] = 1.0;
+	axis[p_axis] = 1.0_R;
 
-	planes.push_back(Plane(axis, p_height * 0.5f));
-	planes.push_back(Plane(-axis, p_height * 0.5f));
+	planes.push_back(Plane(axis, p_height * 0.5_R));
+	planes.push_back(Plane(-axis, p_height * 0.5_R));
 
 	return planes;
 }
@@ -768,12 +768,12 @@ Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p
 	Vector<Plane> planes;
 
 	Vector3 axis;
-	axis[p_axis] = 1.0;
+	axis[p_axis] = 1.0_R;
 
 	Vector3 axis_neg;
-	axis_neg[(p_axis + 1) % 3] = 1.0;
-	axis_neg[(p_axis + 2) % 3] = 1.0;
-	axis_neg[p_axis] = -1.0;
+	axis_neg[(p_axis + 1) % 3] = 1.0_R;
+	axis_neg[(p_axis + 2) % 3] = 1.0_R;
+	axis_neg[p_axis] = -1.0_R;
 
 	const double lon_step = Math_TAU / p_lons;
 	for (int i = 0; i < p_lons; i++) {
@@ -799,12 +799,12 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 	Vector<Plane> planes;
 
 	Vector3 axis;
-	axis[p_axis] = 1.0;
+	axis[p_axis] = 1.0_R;
 
 	Vector3 axis_neg;
-	axis_neg[(p_axis + 1) % 3] = 1.0;
-	axis_neg[(p_axis + 2) % 3] = 1.0;
-	axis_neg[p_axis] = -1.0;
+	axis_neg[(p_axis + 1) % 3] = 1.0_R;
+	axis_neg[(p_axis + 2) % 3] = 1.0_R;
+	axis_neg[p_axis] = -1.0_R;
 
 	const double sides_step = Math_TAU / p_sides;
 	for (int i = 0; i < p_sides; i++) {
@@ -816,7 +816,7 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 
 		for (int j = 1; j <= p_lats; j++) {
 			Vector3 plane_normal = normal.lerp(axis, j / (real_t)p_lats).normalized();
-			Vector3 position = axis * p_height * 0.5f + plane_normal * p_radius;
+			Vector3 position = axis * p_height * 0.5_R + plane_normal * p_radius;
 			planes.push_back(Plane(plane_normal, position));
 			planes.push_back(Plane(plane_normal * axis_neg, position * axis_neg));
 		}

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -51,12 +51,12 @@ public:
 			return false;
 		}
 
-		real_t f = 1.0f / a;
+		real_t f = 1.0_R / a;
 
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if ((u < 0.0f) || (u > 1.0f)) {
+		if ((u < 0.0_R) || (u > 1.0_R)) {
 			return false;
 		}
 
@@ -64,7 +64,7 @@ public:
 
 		real_t v = f * p_dir.dot(q);
 
-		if ((v < 0.0f) || (u + v > 1.0f)) {
+		if ((v < 0.0_R) || (u + v > 1.0_R)) {
 			return false;
 		}
 
@@ -72,7 +72,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > 0.00001f) { // ray intersection
+		if (t > 0.00001_R) { // ray intersection
 			if (r_res) {
 				*r_res = p_from + p_dir * t;
 			}
@@ -92,12 +92,12 @@ public:
 			return false;
 		}
 
-		real_t f = 1.0f / a;
+		real_t f = 1.0_R / a;
 
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if ((u < 0.0f) || (u > 1.0f)) {
+		if ((u < 0.0_R) || (u > 1.0_R)) {
 			return false;
 		}
 
@@ -105,7 +105,7 @@ public:
 
 		real_t v = f * rel.dot(q);
 
-		if ((v < 0.0f) || (u + v > 1.0f)) {
+		if ((v < 0.0_R) || (u + v > 1.0_R)) {
 			return false;
 		}
 
@@ -113,7 +113,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > (real_t)CMP_EPSILON && t <= 1.0f) { // Ray intersection.
+		if (t > (real_t)CMP_EPSILON && t <= 1.0_R) { // Ray intersection.
 			if (r_res) {
 				*r_res = p_from + rel * t;
 			}
@@ -174,7 +174,7 @@ public:
 		ERR_FAIL_COND_V(p_cylinder_axis < 0, false);
 		ERR_FAIL_COND_V(p_cylinder_axis > 2, false);
 		Vector3 cylinder_axis;
-		cylinder_axis[p_cylinder_axis] = 1.0f;
+		cylinder_axis[p_cylinder_axis] = 1.0_R;
 
 		// First check if they are parallel.
 		Vector3 normal = (rel / rel_l);
@@ -185,7 +185,7 @@ public:
 
 		if (crs_l < (real_t)CMP_EPSILON) {
 			Vector3 side_axis;
-			side_axis[(p_cylinder_axis + 1) % 3] = 1.0f; // Any side axis OK.
+			side_axis[(p_cylinder_axis + 1) % 3] = 1.0_R; // Any side axis OK.
 			axis_dir = side_axis;
 		} else {
 			axis_dir = crs / crs_l;
@@ -202,7 +202,7 @@ public:
 		if (w2 < (real_t)CMP_EPSILON) {
 			return false; // Avoid numerical error.
 		}
-		Size2 size(Math::sqrt(w2), p_height * 0.5f);
+		Size2 size(Math::sqrt(w2), p_height * 0.5_R);
 
 		Vector3 side_dir = axis_dir.cross(cylinder_axis).normalized();
 
@@ -275,7 +275,7 @@ public:
 	}
 
 	static bool segment_intersects_convex(const Vector3 &p_from, const Vector3 &p_to, const Plane *p_planes, int p_plane_count, Vector3 *p_res, Vector3 *p_norm) {
-		real_t min = -1e20, max = 1e20;
+		real_t min = -1e20_R, max = 1e20_R;
 
 		Vector3 rel = p_to - p_from;
 		real_t rel_l = rel.length();
@@ -337,9 +337,9 @@ public:
 
 		real_t d = n.dot(p) / l2;
 
-		if (d <= 0.0f) {
+		if (d <= 0.0_R) {
 			return p_segment[0]; // Before first point.
-		} else if (d >= 1.0f) {
+		} else if (d >= 1.0_R) {
 			return p_segment[1]; // After first point.
 		} else {
 			return p_segment[0] + n * d; // Inside.
@@ -350,7 +350,7 @@ public:
 		Vector3 p = p_point - p_segment[0];
 		Vector3 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20f) {
+		if (l2 < 1e-20_R) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
@@ -835,9 +835,9 @@ public:
 
 	_FORCE_INLINE_ static Vector3 octahedron_map_decode(const Vector2 &p_uv) {
 		// https://twitter.com/Stubbesaurus/status/937994790553227264
-		Vector2 f = p_uv * 2.0f - Vector2(1.0f, 1.0f);
-		Vector3 n = Vector3(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
-		float t = CLAMP(-n.z, 0.0f, 1.0f);
+		Vector2 f = p_uv * 2.0_R - Vector2(1.0_R, 1.0_R);
+		Vector3 n = Vector3(f.x, f.y, 1.0_R - Math::abs(f.x) - Math::abs(f.y));
+		float t = CLAMP(-n.z, 0.0_R, 1.0_R);
 		n.x += n.x >= 0 ? -t : t;
 		n.y += n.y >= 0 ? -t : t;
 		return n.normalized();

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -137,4 +137,10 @@ typedef double real_t;
 typedef float real_t;
 #endif
 
+/**
+ * Custom literal suffix for floating-point values to ensure they're cast
+ * as the expected "Real" type.
+ */
+constexpr real_t operator""_R(long double p_value) { return static_cast<real_t>(p_value); }
+
 #endif // MATH_DEFS_H

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -58,7 +58,7 @@ Vector3 Plane::get_any_perpendicular_normal() const {
 	static const Vector3 p2 = Vector3(0, 1, 0);
 	Vector3 p;
 
-	if (ABS(normal.dot(p1)) > 0.99f) { // if too similar to p1
+	if (ABS(normal.dot(p1)) > 0.99_R) { // if too similar to p1
 		p = p2; // use p2
 	} else {
 		p = p1; // use p1
@@ -125,7 +125,7 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 
 	real_t dist = (normal.dot(p_begin) - d) / den;
 
-	if (dist < (real_t)-CMP_EPSILON || dist > (1.0f + (real_t)CMP_EPSILON)) {
+	if (dist < (real_t)-CMP_EPSILON || dist > (1.0_R + (real_t)CMP_EPSILON)) {
 		return false;
 	}
 

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -85,7 +85,7 @@ struct _NO_DISCARD_ Plane {
 			normal(p_a, p_b, p_c),
 			d(p_d) {}
 
-	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_d = 0.0);
+	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_d = 0.0_R);
 	_FORCE_INLINE_ Plane(const Vector3 &p_normal, const Vector3 &p_point);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -251,11 +251,11 @@ Projection Projection ::jitter_offseted(const Vector2 &p_offset) const {
 
 void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov) {
 	if (p_flip_fov) {
-		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0_R / p_aspect);
 	}
 
 	real_t sine, cotangent, deltaZ;
-	real_t radians = Math::deg_to_rad(p_fovy_degrees / 2.0);
+	real_t radians = Math::deg_to_rad(p_fovy_degrees / 2.0_R);
 
 	deltaZ = p_z_far - p_z_near;
 	sine = Math::sin(radians);
@@ -277,30 +277,30 @@ void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t 
 
 void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist) {
 	if (p_flip_fov) {
-		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0_R / p_aspect);
 	}
 
 	real_t left, right, modeltranslation, ymax, xmax, frustumshift;
 
-	ymax = p_z_near * tan(Math::deg_to_rad(p_fovy_degrees / 2.0));
+	ymax = p_z_near * tan(Math::deg_to_rad(p_fovy_degrees / 2.0_R));
 	xmax = ymax * p_aspect;
-	frustumshift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
+	frustumshift = (p_intraocular_dist / 2.0_R) * p_z_near / p_convergence_dist;
 
 	switch (p_eye) {
 		case 1: { // left eye
 			left = -xmax + frustumshift;
 			right = xmax + frustumshift;
-			modeltranslation = p_intraocular_dist / 2.0;
+			modeltranslation = p_intraocular_dist / 2.0_R;
 		} break;
 		case 2: { // right eye
 			left = -xmax - frustumshift;
 			right = xmax - frustumshift;
-			modeltranslation = -p_intraocular_dist / 2.0;
+			modeltranslation = -p_intraocular_dist / 2.0_R;
 		} break;
 		default: { // mono, should give the same result as set_perspective(p_fovy_degrees,p_aspect,p_z_near,p_z_far,p_flip_fov)
 			left = -xmax;
 			right = xmax;
-			modeltranslation = 0.0;
+			modeltranslation = 0.0_R;
 		} break;
 	}
 
@@ -315,13 +315,13 @@ void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t 
 
 void Projection::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far) {
 	// we first calculate our base frustum on our values without taking our lens magnification into account.
-	real_t f1 = (p_intraocular_dist * 0.5) / p_display_to_lens;
-	real_t f2 = ((p_display_width - p_intraocular_dist) * 0.5) / p_display_to_lens;
-	real_t f3 = (p_display_width / 4.0) / p_display_to_lens;
+	real_t f1 = (p_intraocular_dist * 0.5_R) / p_display_to_lens;
+	real_t f2 = ((p_display_width - p_intraocular_dist) * 0.5_R) / p_display_to_lens;
+	real_t f3 = (p_display_width / 4.0_R) / p_display_to_lens;
 
 	// now we apply our oversample factor to increase our FOV. how much we oversample is always a balance we strike between performance and how much
 	// we're willing to sacrifice in FOV.
-	real_t add = ((f1 + f2) * (p_oversample - 1.0)) / 2.0;
+	real_t add = ((f1 + f2) * (p_oversample - 1.0_R)) / 2.0_R;
 	f1 += add;
 	f2 += add;
 	f3 *= p_oversample;
@@ -344,13 +344,13 @@ void Projection::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_di
 void Projection::set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
 	set_identity();
 
-	columns[0][0] = 2.0 / (p_right - p_left);
+	columns[0][0] = 2.0_R / (p_right - p_left);
 	columns[3][0] = -((p_right + p_left) / (p_right - p_left));
-	columns[1][1] = 2.0 / (p_top - p_bottom);
+	columns[1][1] = 2.0_R / (p_top - p_bottom);
 	columns[3][1] = -((p_top + p_bottom) / (p_top - p_bottom));
-	columns[2][2] = -2.0 / (p_zfar - p_znear);
+	columns[2][2] = -2.0_R / (p_zfar - p_znear);
 	columns[3][2] = -((p_zfar + p_znear) / (p_zfar - p_znear));
-	columns[3][3] = 1.0;
+	columns[3][3] = 1.0_R;
 }
 
 void Projection::set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov) {
@@ -600,7 +600,7 @@ void Projection::invert() {
 	int pvt_i[4], pvt_j[4]; /* Locations of pivot matrix */
 	real_t pvt_val; /* Value of current pivot element */
 	real_t hold; /* Temporary storage */
-	real_t determinant = 1.0f;
+	real_t determinant = 1.0_R;
 	for (k = 0; k < 4; k++) {
 		/** Locate k'th pivot element **/
 		pvt_val = columns[k][k]; /** Initialize for search **/
@@ -667,7 +667,7 @@ void Projection::invert() {
 		}
 
 		/** Replace pivot by reciprocal (at last we can touch it). **/
-		columns[k][k] = 1.0 / pvt_val;
+		columns[k][k] = 1.0_R / pvt_val;
 	}
 
 	/* That was most of the work, one final pass of row/column interchange */
@@ -723,63 +723,63 @@ void Projection::set_depth_correction(bool p_flip_y) {
 	real_t *m = &columns[0][0];
 
 	m[0] = 1;
-	m[1] = 0.0;
-	m[2] = 0.0;
-	m[3] = 0.0;
-	m[4] = 0.0;
+	m[1] = 0.0_R;
+	m[2] = 0.0_R;
+	m[3] = 0.0_R;
+	m[4] = 0.0_R;
 	m[5] = p_flip_y ? -1 : 1;
-	m[6] = 0.0;
-	m[7] = 0.0;
-	m[8] = 0.0;
-	m[9] = 0.0;
-	m[10] = 0.5;
-	m[11] = 0.0;
-	m[12] = 0.0;
-	m[13] = 0.0;
-	m[14] = 0.5;
-	m[15] = 1.0;
+	m[6] = 0.0_R;
+	m[7] = 0.0_R;
+	m[8] = 0.0_R;
+	m[9] = 0.0_R;
+	m[10] = 0.5_R;
+	m[11] = 0.0_R;
+	m[12] = 0.0_R;
+	m[13] = 0.0_R;
+	m[14] = 0.5_R;
+	m[15] = 1.0_R;
 }
 
 void Projection::set_light_bias() {
 	real_t *m = &columns[0][0];
 
-	m[0] = 0.5;
-	m[1] = 0.0;
-	m[2] = 0.0;
-	m[3] = 0.0;
-	m[4] = 0.0;
-	m[5] = 0.5;
-	m[6] = 0.0;
-	m[7] = 0.0;
-	m[8] = 0.0;
-	m[9] = 0.0;
-	m[10] = 0.5;
-	m[11] = 0.0;
-	m[12] = 0.5;
-	m[13] = 0.5;
-	m[14] = 0.5;
-	m[15] = 1.0;
+	m[0] = 0.5_R;
+	m[1] = 0.0_R;
+	m[2] = 0.0_R;
+	m[3] = 0.0_R;
+	m[4] = 0.0_R;
+	m[5] = 0.5_R;
+	m[6] = 0.0_R;
+	m[7] = 0.0_R;
+	m[8] = 0.0_R;
+	m[9] = 0.0_R;
+	m[10] = 0.5_R;
+	m[11] = 0.0_R;
+	m[12] = 0.5_R;
+	m[13] = 0.5_R;
+	m[14] = 0.5_R;
+	m[15] = 1.0_R;
 }
 
 void Projection::set_light_atlas_rect(const Rect2 &p_rect) {
 	real_t *m = &columns[0][0];
 
 	m[0] = p_rect.size.width;
-	m[1] = 0.0;
-	m[2] = 0.0;
-	m[3] = 0.0;
-	m[4] = 0.0;
+	m[1] = 0.0_R;
+	m[2] = 0.0_R;
+	m[3] = 0.0_R;
+	m[4] = 0.0_R;
 	m[5] = p_rect.size.height;
-	m[6] = 0.0;
-	m[7] = 0.0;
-	m[8] = 0.0;
-	m[9] = 0.0;
-	m[10] = 1.0;
-	m[11] = 0.0;
+	m[6] = 0.0_R;
+	m[7] = 0.0_R;
+	m[8] = 0.0_R;
+	m[9] = 0.0_R;
+	m[10] = 1.0_R;
+	m[11] = 0.0_R;
 	m[12] = p_rect.position.x;
 	m[13] = p_rect.position.y;
-	m[14] = 0.0;
-	m[15] = 1.0;
+	m[14] = 0.0_R;
+	m[15] = 1.0_R;
 }
 
 Projection::operator String() const {
@@ -801,11 +801,11 @@ real_t Projection::get_aspect() const {
 int Projection::get_pixels_per_meter(int p_for_pixel_width) const {
 	Vector3 result = xform(Vector3(1, 0, -1));
 
-	return int((result.x * 0.5 + 0.5) * p_for_pixel_width);
+	return int((result.x * 0.5_R + 0.5_R) * p_for_pixel_width);
 }
 
 bool Projection::is_orthogonal() const {
-	return columns[3][3] == 1.0;
+	return columns[3][3] == 1.0_R;
 }
 
 real_t Projection::get_fov() const {
@@ -818,7 +818,7 @@ real_t Projection::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return Math::rad_to_deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+		return Math::rad_to_deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0_R;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],
@@ -917,19 +917,19 @@ Projection::Projection(const Transform3D &p_transform) {
 	m[0] = tr.basis.rows[0][0];
 	m[1] = tr.basis.rows[1][0];
 	m[2] = tr.basis.rows[2][0];
-	m[3] = 0.0;
+	m[3] = 0.0_R;
 	m[4] = tr.basis.rows[0][1];
 	m[5] = tr.basis.rows[1][1];
 	m[6] = tr.basis.rows[2][1];
-	m[7] = 0.0;
+	m[7] = 0.0_R;
 	m[8] = tr.basis.rows[0][2];
 	m[9] = tr.basis.rows[1][2];
 	m[10] = tr.basis.rows[2][2];
-	m[11] = 0.0;
+	m[11] = 0.0_R;
 	m[12] = tr.origin.x;
 	m[13] = tr.origin.y;
 	m[14] = tr.origin.z;
-	m[15] = 1.0;
+	m[15] = 1.0_R;
 }
 
 Projection::~Projection() {

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -284,7 +284,7 @@ Vector3 Quaternion::get_axis() const {
 	if (Math::abs(w) > 1 - CMP_EPSILON) {
 		return Vector3(x, y, z);
 	}
-	real_t r = ((real_t)1) / Math::sqrt(1 - w * w);
+	real_t r = 1.0_R / Math::sqrt(1 - w * w);
 	return Vector3(x * r, y * r, z * r);
 }
 
@@ -303,8 +303,8 @@ Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 		z = 0;
 		w = 0;
 	} else {
-		real_t sin_angle = Math::sin(p_angle * 0.5f);
-		real_t cos_angle = Math::cos(p_angle * 0.5f);
+		real_t sin_angle = Math::sin(p_angle * 0.5_R);
+		real_t cos_angle = Math::cos(p_angle * 0.5_R);
 		real_t s = sin_angle / d;
 		x = p_axis.x * s;
 		y = p_axis.y * s;
@@ -318,9 +318,9 @@ Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 // and similar for other axes.
 // This implementation uses YXZ convention (Z is the first rotation).
 Quaternion Quaternion::from_euler(const Vector3 &p_euler) {
-	real_t half_a1 = p_euler.y * 0.5f;
-	real_t half_a2 = p_euler.x * 0.5f;
-	real_t half_a3 = p_euler.z * 0.5f;
+	real_t half_a1 = p_euler.y * 0.5_R;
+	real_t half_a2 = p_euler.x * 0.5_R;
+	real_t half_a3 = p_euler.z * 0.5_R;
 
 	// R = Y(a1).X(a2).Z(a3) convention for Euler angles.
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -43,7 +43,7 @@ struct _NO_DISCARD_ Quaternion {
 			real_t z;
 			real_t w;
 		};
-		real_t components[4] = { 0, 0, 0, 1.0 };
+		real_t components[4] = { 0, 0, 0, 1.0_R };
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_idx) {
@@ -78,7 +78,7 @@ struct _NO_DISCARD_ Quaternion {
 
 	_FORCE_INLINE_ void get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		r_angle = 2 * Math::acos(w);
-		real_t r = ((real_t)1) / Math::sqrt(1 - w * w);
+		real_t r = 1.0_R / Math::sqrt(1 - w * w);
 		r_axis.x = x * r;
 		r_axis.y = y * r;
 		r_axis.z = z * r;
@@ -93,7 +93,7 @@ struct _NO_DISCARD_ Quaternion {
 #endif
 		Vector3 u(x, y, z);
 		Vector3 uv = u.cross(p_v);
-		return p_v + ((uv * w) + u.cross(uv)) * ((real_t)2);
+		return p_v + ((uv * w) + u.cross(uv)) * 2.0_R;
 	}
 
 	_FORCE_INLINE_ Vector3 xform_inv(const Vector3 &p_v) const {
@@ -144,19 +144,19 @@ struct _NO_DISCARD_ Quaternion {
 		Vector3 c = p_v0.cross(p_v1);
 		real_t d = p_v0.dot(p_v1);
 
-		if (d < -1.0f + (real_t)CMP_EPSILON) {
+		if (d < -1.0_R + (real_t)CMP_EPSILON) {
 			x = 0;
 			y = 1;
 			z = 0;
 			w = 0;
 		} else {
-			real_t s = Math::sqrt((1.0f + d) * 2.0f);
-			real_t rs = 1.0f / s;
+			real_t s = Math::sqrt((1.0_R + d) * 2.0_R);
+			real_t rs = 1.0_R / s;
 
 			x = c.x * rs;
 			y = c.y * rs;
 			z = c.z * rs;
-			w = s * 0.5f;
+			w = s * 0.5_R;
 		}
 	}
 };
@@ -191,7 +191,7 @@ void Quaternion::operator*=(real_t p_s) {
 }
 
 void Quaternion::operator/=(real_t p_s) {
-	*this *= 1.0f / p_s;
+	*this *= 1.0_R / p_s;
 }
 
 Quaternion Quaternion::operator+(const Quaternion &p_q2) const {
@@ -214,7 +214,7 @@ Quaternion Quaternion::operator*(real_t p_s) const {
 }
 
 Quaternion Quaternion::operator/(real_t p_s) const {
-	return *this * (1.0f / p_s);
+	return *this * (1.0_R / p_s);
 }
 
 bool Quaternion::operator==(const Quaternion &p_quaternion) const {

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -55,7 +55,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 	HashSet<Vector3> valid_cache;
 
 	for (int i = 0; i < p_points.size(); i++) {
-		Vector3 sp = p_points[i].snapped(Vector3(0.0001, 0.0001, 0.0001));
+		Vector3 sp = p_points[i].snapped(Vector3(0.0001_R, 0.0001_R, 0.0001_R));
 		if (valid_cache.has(sp)) {
 			valid_points.write[i] = false;
 		} else {
@@ -139,7 +139,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 		center += p_points[simplex[i]];
 	}
 
-	center /= 4.0;
+	center /= 4.0_R;
 
 	//add faces
 

--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -39,7 +39,7 @@ void RandomNumberGenerator::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("randi"), &RandomNumberGenerator::randi);
 	ClassDB::bind_method(D_METHOD("randf"), &RandomNumberGenerator::randf);
-	ClassDB::bind_method(D_METHOD("randfn", "mean", "deviation"), &RandomNumberGenerator::randfn, DEFVAL(0.0), DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("randfn", "mean", "deviation"), &RandomNumberGenerator::randfn, DEFVAL(0.0_R), DEFVAL(1.0_R));
 	ClassDB::bind_method(D_METHOD("randf_range", "from", "to"), &RandomNumberGenerator::randf_range);
 	ClassDB::bind_method(D_METHOD("randi_range", "from", "to"), &RandomNumberGenerator::randi_range);
 	ClassDB::bind_method(D_METHOD("rand_weighted", "weights"), &RandomNumberGenerator::rand_weighted);

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -54,7 +54,7 @@ public:
 	_FORCE_INLINE_ uint32_t randi() { return randbase.rand(); }
 	_FORCE_INLINE_ real_t randf() { return randbase.randf(); }
 	_FORCE_INLINE_ real_t randf_range(real_t p_from, real_t p_to) { return randbase.random(p_from, p_to); }
-	_FORCE_INLINE_ real_t randfn(real_t p_mean = 0.0, real_t p_deviation = 1.0) { return randbase.randfn(p_mean, p_deviation); }
+	_FORCE_INLINE_ real_t randfn(real_t p_mean = 0.0_R, real_t p_deviation = 1.0_R) { return randbase.randfn(p_mean, p_deviation); }
 	_FORCE_INLINE_ int randi_range(int p_from, int p_to) { return randbase.random(p_from, p_to); }
 
 	_FORCE_INLINE_ int64_t rand_weighted(const Vector<float> &p_weights) { return randbase.rand_weighted(p_weights); }

--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -67,7 +67,7 @@ bool Rect2::intersects_segment(const Point2 &p_from, const Point2 &p_to, Point2 
 			real_t length = seg_to - seg_from;
 			cmin = (seg_from < box_begin) ? ((box_begin - seg_from) / length) : 0;
 			cmax = (seg_to > box_end) ? ((box_end - seg_from) / length) : 1;
-			csign = -1.0;
+			csign = -1.0_R;
 
 		} else {
 			if (seg_to > box_end || seg_from < box_begin) {
@@ -76,7 +76,7 @@ bool Rect2::intersects_segment(const Point2 &p_from, const Point2 &p_to, Point2 
 			real_t length = seg_to - seg_from;
 			cmin = (seg_from > box_end) ? (box_end - seg_from) / length : 0;
 			cmax = (seg_to < box_begin) ? (box_begin - seg_from) / length : 1;
-			csign = 1.0;
+			csign = 1.0_R;
 		}
 
 		if (cmin > min) {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -49,7 +49,7 @@ struct _NO_DISCARD_ Rect2 {
 
 	real_t get_area() const { return size.width * size.height; }
 
-	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5f); }
+	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5_R); }
 
 	inline bool intersects(const Rect2 &p_rect, bool p_include_borders = false) const {
 #ifdef MATH_CHECKS
@@ -94,7 +94,7 @@ struct _NO_DISCARD_ Rect2 {
 			ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");
 		}
 #endif
-		real_t dist = 0.0;
+		real_t dist = 0.0_R;
 		bool inside = true;
 
 		if (p_point.x < position.x) {
@@ -141,7 +141,7 @@ struct _NO_DISCARD_ Rect2 {
 	}
 
 	_FORCE_INLINE_ bool has_area() const {
-		return size.x > 0.0f && size.y > 0.0f;
+		return size.x > 0.0_R && size.y > 0.0_R;
 	}
 
 	// Returns the intersection between two Rect2s or an empty Rect2 if there is no intersection.
@@ -282,7 +282,7 @@ struct _NO_DISCARD_ Rect2 {
 	}
 
 	_FORCE_INLINE_ Rect2 abs() const {
-		return Rect2(Point2(position.x + MIN(size.x, (real_t)0), position.y + MIN(size.y, (real_t)0)), size.abs());
+		return Rect2(Point2(position.x + MIN(size.x, 0.0_R), position.y + MIN(size.y, 0.0_R)), size.abs());
 	}
 
 	_FORCE_INLINE_ Rect2 round() const {
@@ -290,7 +290,7 @@ struct _NO_DISCARD_ Rect2 {
 	}
 
 	Vector2 get_support(const Vector2 &p_normal) const {
-		Vector2 half_extents = size * 0.5f;
+		Vector2 half_extents = size * 0.5_R;
 		Vector2 ofs = position + half_extents;
 		return Vector2(
 					   (p_normal.x > 0) ? -half_extents.x : half_extents.x,
@@ -327,7 +327,7 @@ struct _NO_DISCARD_ Rect2 {
 
 			// Check ray box.
 			r /= l;
-			Vector2 ir(1.0f / r.x, 1.0f / r.y);
+			Vector2 ir(1.0_R / r.x, 1.0_R / r.y);
 
 			// lb is the corner of AABB with minimal coordinates - left bottom, rt is maximal corner
 			// r.org is origin of ray

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -50,7 +50,7 @@ void Transform2D::affine_invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t idet = 1.0f / det;
+	real_t idet = 1.0_R / det;
 
 	SWAP(columns[0][0], columns[1][1]);
 	columns[0] *= Vector2(idet, -idet);
@@ -71,12 +71,12 @@ void Transform2D::rotate(real_t p_angle) {
 
 real_t Transform2D::get_skew() const {
 	real_t det = determinant();
-	return Math::acos(columns[0].normalized().dot(SIGN(det) * columns[1].normalized())) - (real_t)Math_PI * 0.5f;
+	return Math::acos(columns[0].normalized().dot(SIGN(det) * columns[1].normalized())) - (real_t)Math_PI * 0.5_R;
 }
 
 void Transform2D::set_skew(real_t p_angle) {
 	real_t det = determinant();
-	columns[1] = SIGN(det) * columns[0].rotated(((real_t)Math_PI * 0.5f + p_angle)).normalized() * columns[1].length();
+	columns[1] = SIGN(det) * columns[0].rotated(((real_t)Math_PI * 0.5_R + p_angle)).normalized() * columns[1].length();
 }
 
 real_t Transform2D::get_rotation() const {

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -145,8 +145,8 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos);
 
 	Transform2D() {
-		columns[0][0] = 1.0;
-		columns[1][1] = 1.0;
+		columns[0][0] = 1.0_R;
+		columns[1][1] = 1.0_R;
 	}
 };
 

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -133,7 +133,7 @@ void TriangleMesh::create(const Vector<Vector3> &p_faces, const Vector<int32_t> 
 
 			for (int j = 0; j < 3; j++) {
 				int vidx = -1;
-				Vector3 vs = v[j].snapped(Vector3(0.0001, 0.0001, 0.0001));
+				Vector3 vs = v[j].snapped(Vector3(0.0001_R, 0.0001_R, 0.0001_R));
 				HashMap<Vector3, int>::Iterator E = db.find(vs);
 				if (E) {
 					vidx = E->value;

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -34,12 +34,12 @@ real_t Triangulate::get_area(const Vector<Vector2> &contour) {
 	int n = contour.size();
 	const Vector2 *c = &contour[0];
 
-	real_t A = 0.0;
+	real_t A = 0.0_R;
 
 	for (int p = n - 1, q = 0; q < n; p = q++) {
 		A += c[p].cross(c[q]);
 	}
-	return A * 0.5f;
+	return A * 0.5_R;
 }
 
 /* `is_inside_triangle` decides if a point P is inside the triangle
@@ -70,9 +70,9 @@ bool Triangulate::is_inside_triangle(real_t Ax, real_t Ay,
 	bCROSScp = bx * cpy - by * cpx;
 
 	if (include_edges) {
-		return ((aCROSSbp > 0.0f) && (bCROSScp > 0.0f) && (cCROSSap > 0.0f));
+		return ((aCROSSbp > 0.0_R) && (bCROSScp > 0.0_R) && (cCROSSap > 0.0_R));
 	} else {
-		return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f));
+		return ((aCROSSbp >= 0.0_R) && (bCROSScp >= 0.0_R) && (cCROSSap >= 0.0_R));
 	}
 }
 
@@ -128,7 +128,7 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 
 	/* we want a counter-clockwise polygon in V */
 
-	if (0.0f < get_area(contour)) {
+	if (0.0_R < get_area(contour)) {
 		for (int v = 0; v < n; v++) {
 			V.write[v] = v;
 		}

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -175,7 +175,7 @@ Vector2 Vector2::reflect(const Vector2 &p_normal) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector2(), "The normal Vector2 " + p_normal.operator String() + "must be normalized.");
 #endif
-	return 2.0f * p_normal * dot(p_normal) - *this;
+	return 2.0_R * p_normal * dot(p_normal) - *this;
 }
 
 bool Vector2::is_equal_approx(const Vector2 &p_v) const {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -83,7 +83,7 @@ struct _NO_DISCARD_ Vector2 {
 
 	real_t length() const;
 	real_t length_squared() const;
-	Vector2 limit_length(real_t p_len = 1.0) const;
+	Vector2 limit_length(real_t p_len = 1.0_R) const;
 
 	Vector2 min(const Vector2 &p_vector2) const {
 		return Vector2(MIN(x, p_vector2.x), MIN(y, p_vector2.y));
@@ -251,7 +251,7 @@ Vector2 Vector2::lerp(const Vector2 &p_to, real_t p_weight) const {
 Vector2 Vector2::slerp(const Vector2 &p_to, real_t p_weight) const {
 	real_t start_length_sq = length_squared();
 	real_t end_length_sq = p_to.length_squared();
-	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
+	if (unlikely(start_length_sq == 0.0_R || end_length_sq == 0.0_R)) {
 		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
 		return lerp(p_to, p_weight);
 	}

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -86,21 +86,21 @@ Vector2 Vector3::octahedron_encode() const {
 	Vector3 n = *this;
 	n /= Math::abs(n.x) + Math::abs(n.y) + Math::abs(n.z);
 	Vector2 o;
-	if (n.z >= 0.0f) {
+	if (n.z >= 0.0_R) {
 		o.x = n.x;
 		o.y = n.y;
 	} else {
-		o.x = (1.0f - Math::abs(n.y)) * (n.x >= 0.0f ? 1.0f : -1.0f);
-		o.y = (1.0f - Math::abs(n.x)) * (n.y >= 0.0f ? 1.0f : -1.0f);
+		o.x = (1.0_R - Math::abs(n.y)) * (n.x >= 0.0_R ? 1.0_R : -1.0_R);
+		o.y = (1.0_R - Math::abs(n.x)) * (n.y >= 0.0_R ? 1.0_R : -1.0_R);
 	}
-	o.x = o.x * 0.5f + 0.5f;
-	o.y = o.y * 0.5f + 0.5f;
+	o.x = o.x * 0.5_R + 0.5_R;
+	o.y = o.y * 0.5_R + 0.5_R;
 	return o;
 }
 
 Vector3 Vector3::octahedron_decode(const Vector2 &p_oct) {
-	Vector2 f(p_oct.x * 2.0f - 1.0f, p_oct.y * 2.0f - 1.0f);
-	Vector3 n(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
+	Vector2 f(p_oct.x * 2.0_R - 1.0_R, p_oct.y * 2.0_R - 1.0_R);
+	Vector3 n(f.x, f.y, 1.0_R - Math::abs(f.x) - Math::abs(f.y));
 	float t = CLAMP(-n.z, 0.0f, 1.0f);
 	n.x += n.x >= 0 ? -t : t;
 	n.y += n.y >= 0 ? -t : t;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -91,7 +91,7 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ Vector3 normalized() const;
 	_FORCE_INLINE_ bool is_normalized() const;
 	_FORCE_INLINE_ Vector3 inverse() const;
-	Vector3 limit_length(real_t p_len = 1.0) const;
+	Vector3 limit_length(real_t p_len = 1.0_R) const;
 
 	_FORCE_INLINE_ void zero();
 
@@ -229,13 +229,13 @@ Vector3 Vector3::slerp(const Vector3 &p_to, real_t p_weight) const {
 	// the internals of some methods for efficiency (mainly, checking length).
 	real_t start_length_sq = length_squared();
 	real_t end_length_sq = p_to.length_squared();
-	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
+	if (unlikely(start_length_sq == 0.0_R || end_length_sq == 0.0_R)) {
 		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
 		return lerp(p_to, p_weight);
 	}
 	Vector3 axis = cross(p_to);
 	real_t axis_length_sq = axis.length_squared();
-	if (unlikely(axis_length_sq == 0.0f)) {
+	if (unlikely(axis_length_sq == 0.0_R)) {
 		// Colinear vectors have no rotation axis or angle between them, so the best we can do is lerp.
 		return lerp(p_to, p_weight);
 	}
@@ -502,7 +502,7 @@ bool Vector3::is_normalized() const {
 }
 
 Vector3 Vector3::inverse() const {
-	return Vector3(1.0f / x, 1.0f / y, 1.0f / z);
+	return Vector3(1.0_R / x, 1.0_R / y, 1.0_R / z);
 }
 
 void Vector3::zero() {
@@ -525,7 +525,7 @@ Vector3 Vector3::reflect(const Vector3 &p_normal) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 " + p_normal.operator String() + " must be normalized.");
 #endif
-	return 2.0f * p_normal * dot(p_normal) - *this;
+	return 2.0_R * p_normal * dot(p_normal) - *this;
 }
 
 #endif // VECTOR3_H

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -92,7 +92,7 @@ Vector4 Vector4::normalized() const {
 }
 
 bool Vector4::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), (real_t)1, (real_t)UNIT_EPSILON);
+	return Math::is_equal_approx(length_squared(), 1.0_R, (real_t)UNIT_EPSILON);
 }
 
 real_t Vector4::distance_to(const Vector4 &p_to) const {
@@ -178,7 +178,7 @@ Vector4 Vector4::snapped(const Vector4 &p_step) const {
 }
 
 Vector4 Vector4::inverse() const {
-	return Vector4(1.0f / x, 1.0f / y, 1.0f / z, 1.0f / w);
+	return Vector4(1.0_R / x, 1.0_R / y, 1.0_R / z, 1.0_R / w);
 }
 
 Vector4 Vector4::clamp(const Vector4 &p_min, const Vector4 &p_max) const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -197,7 +197,7 @@ void Vector4::operator*=(real_t p_s) {
 }
 
 void Vector4::operator/=(real_t p_s) {
-	*this *= 1.0f / p_s;
+	*this *= 1.0_R / p_s;
 }
 
 Vector4 Vector4::operator+(const Vector4 &p_vec4) const {
@@ -225,7 +225,7 @@ Vector4 Vector4::operator*(real_t p_s) const {
 }
 
 Vector4 Vector4::operator/(real_t p_s) const {
-	return *this * (1.0f / p_s);
+	return *this * (1.0_R / p_s);
 }
 
 bool Vector4::operator==(const Vector4 &p_vec4) const {


### PR DESCRIPTION
It turns out that c++ supports user-defined literals for certain core types, one of which being floating-point values. This PR implements this functionality via `_R`, giving a convenient way to guarantee a floating-point literal will be represented as a `real_t` value. While most warning regarding implicit conversions & precision-loss are disabled, this should help open the door to conversions/operations being much more explicit across the repo & possibly remove the need to suppress those warnings in the first place. Limited implementation to `core/math` files as a proof of concept & only in values that either expect `real_t` but are using hardcoded float/double erroneously or could be trimmed down (ex: `(real_t)1`→`1.0_R`).