### PR TITLE
Fix XRBodyModifier3D hip driving for avatars no Root bone

### DIFF
--- a/scene/3d/xr_body_modifier_3d.cpp
+++ b/scene/3d/xr_body_modifier_3d.cpp
@@ -252,11 +252,6 @@ void XRBodyModifier3D::_get_joint_data() {
 		}
 	}
 
-	// If the root bone is not found then use the skeleton root bone.
-	if (bones[XRBodyTracker::JOINT_ROOT] == -1) {
-		bones[XRBodyTracker::JOINT_ROOT] = 0;
-	}
-
 	// Assemble the joint relationship to the available skeleton bones.
 	for (int i = 0; i < XRBodyTracker::JOINT_MAX; i++) {
 		// Get the skeleton bone (skip if not found).


### PR DESCRIPTION
The XRBodyModifier3D node fails to correctly drive avatars which have no Root bone. This occurs on common avatars such as ReadyPlayerMe, Mixamo, and AvaturnMe where the root bone of the skeleton is the hips. The importers Skeleton Retarget doesn't add a Root but instead leaves the Hips as the root bone but with the corrected name.

The XRBodyModifier3D code assumes their must always be a bone associated with the Root tracking joint, and picks bone 0 (the first bone) if it didn't find it by the correct bone name. Unfortunately if it does this with an avatar where bone 0 is the hips then it associates the hips with the root and locks the hips in place.

This PR removes the offending code:
https://github.com/godotengine/godot/blob/89f70e98d209563abb4dbc1f8cd5d76c81eb7940/scene/3d/xr_body_modifier_3d.cpp#L255-L258

With this removed the behavior is as follows:
- The XRBodyModifier3D is still positioned at the trackers "root" location
- The Hips bone is correctly positioned relative to the trackers "root" location

The following video demonstrates four different avatars moving correctly:
1. An AvaturnMe avatar with no Root bone (bone 0 = Hips)
2. A Mixamo avatar with no Root bone (bone 0 = Hips)
3. A ReadyPlayerMe avatar with no Root bone (bone 0 = Hips)
4. A VRM avatar with bone 0 = Root

https://github.com/godotengine/godot/assets/1863707/9f1d90b8-fccc-4769-8bc1-ee7cad062ae9
