### PR TITLE
Fix AnimationPlayer pin behavior

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -73,6 +73,8 @@ void AnimationPlayerEditor::_node_removed(Node *p_node) {
 		_update_player();
 
 		_ensure_dummy_player();
+
+		pin->set_pressed(false);
 	}
 }
 


### PR DESCRIPTION
Fixes issues described by #85285 .  Also fixes situation described by @KoBeWi where if you remove the pinned `AnimationPlayer` from the scene - the `AnimationPlayerEditor`  becomes stuck.

*Bugsquad edit:*
- Fixes #85285