### PR TITLE
GDScript: Improve DocGen for non-constant expressions

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.h
+++ b/modules/gdscript/editor/gdscript_docgen.h
@@ -45,6 +45,7 @@ class GDScriptDocGen {
 	static String _get_class_name(const GDP::ClassNode &p_class);
 	static void _doctype_from_gdtype(const GDType &p_gdtype, String &r_type, String &r_enum, bool p_is_return = false);
 	static String _docvalue_from_variant(const Variant &p_variant, int p_recursion_level = 1);
+	static String _docvalue_from_expression(const GDP::ExpressionNode *p_expression);
 	static void _generate_docs(GDScript *p_script, const GDP::ClassNode *p_class);
 
 public:


### PR DESCRIPTION
* See https://github.com/godotengine/godot/pull/88211#pullrequestreview-1874821095.

```gdscript
func test(a = [], b = a, c = {x = 0}):
    pass
```

**Before**
![](https://github.com/godotengine/godot/assets/47700418/c2185136-756d-43d2-9ac2-fc421a13f7d0)

**After**
![](https://github.com/godotengine/godot/assets/47700418/cca98aff-e3c8-4372-97c0-a5cbbb4b02bd)