### PR TITLE
Tighter shadow culling - apply distance fade to shadow culling

### DIFF
--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -348,6 +348,18 @@ public:
 		return light->shadow;
 	}
 
+	// Return -1 if distance fade not active..
+	virtual float light_get_shadow_camera_distance_max(RID p_light) const override {
+		const Light *light = light_owner.get_or_null(p_light);
+		ERR_FAIL_NULL_V(light, -1.0f);
+
+		if (!light->shadow || !light->distance_fade) {
+			return -1.0f;
+		}
+
+		return light->distance_fade_shadow + light->distance_fade_length;
+	}
+
 	virtual bool light_has_projector(RID p_light) const override {
 		const Light *light = light_owner.get_or_null(p_light);
 		ERR_FAIL_NULL_V(light, RS::LIGHT_DIRECTIONAL);

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -71,6 +71,8 @@ public:
 	virtual RS::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) override { return RS::LIGHT_OMNI_SHADOW_DUAL_PARABOLOID; }
 
 	virtual bool light_has_shadow(RID p_light) const override { return false; }
+	// Return -1 if distance fade not active..
+	virtual float light_get_shadow_camera_distance_max(RID p_light) const override { return -1.0f; }
 	virtual bool light_has_projector(RID p_light) const override { return false; }
 
 	virtual RS::LightType light_get_type(RID p_light) const override { return RS::LIGHT_OMNI; }

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -544,6 +544,18 @@ public:
 		return light->shadow;
 	}
 
+	// Return -1 if distance fade not active..
+	virtual float light_get_shadow_camera_distance_max(RID p_light) const override {
+		const Light *light = light_owner.get_or_null(p_light);
+		ERR_FAIL_NULL_V(light, -1.0f);
+
+		if (!light->shadow || !light->distance_fade) {
+			return -1.0f;
+		}
+
+		return light->distance_fade_shadow + light->distance_fade_length;
+	}
+
 	virtual bool light_has_projector(RID p_light) const override {
 		const Light *light = light_owner.get_or_null(p_light);
 		ERR_FAIL_NULL_V(light, RS::LIGHT_DIRECTIONAL);

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -427,15 +427,19 @@ bool RenderingLightCuller::_add_light_camera_planes(LightCullPlanes &r_cull_plan
 	uint8_t *entry = &data.LUT_entries[lookup][0];
 	int n_edges = data.LUT_entry_sizes[lookup] - 1;
 
+	const Vector3 &pt2 = p_light_source.pos;
+
 	for (int e = 0; e < n_edges; e++) {
 		int i0 = entry[e];
 		int i1 = entry[e + 1];
 		const Vector3 &pt0 = data.frustum_points[i0];
 		const Vector3 &pt1 = data.frustum_points[i1];
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, p_light_source.pos);
-		r_cull_planes.add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			r_cull_planes.add_cull_plane(p);
+		}
 	}
 
 	// Last to 0 edge.
@@ -446,9 +450,11 @@ bool RenderingLightCuller::_add_light_camera_planes(LightCullPlanes &r_cull_plan
 		const Vector3 &pt0 = data.frustum_points[i0];
 		const Vector3 &pt1 = data.frustum_points[i1];
 
-		// Create plane from 3 points.
-		Plane p(pt0, pt1, p_light_source.pos);
-		r_cull_planes.add_cull_plane(p);
+		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+			// Create plane from 3 points.
+			Plane p(pt0, pt1, pt2);
+			r_cull_planes.add_cull_plane(p);
+		}
 	}
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING

--- a/servers/rendering/rendering_light_culler.h
+++ b/servers/rendering/rendering_light_culler.h
@@ -44,7 +44,7 @@ struct Transform3D;
 // Uncomment LIGHT_CULLER_DEBUG_LOGGING to get periodic print of the number of casters culled before / after.
 // Uncomment LIGHT_CULLER_DEBUG_DIRECTIONAL_LIGHT to get periodic print of the number of casters culled for the directional light..
 
-//  #define LIGHT_CULLER_DEBUG_LOGGING
+// #define LIGHT_CULLER_DEBUG_LOGGING
 // #define LIGHT_CULLER_DEBUG_DIRECTIONAL_LIGHT
 // #define LIGHT_CULLER_DEBUG_REGULAR_LIGHT
 // #define LIGHT_CULLER_DEBUG_FLASH
@@ -208,6 +208,13 @@ private:
 
 	// Do we want to log some debug output?
 	bool is_logging() const { return data.debug_count == 0; }
+
+	struct DistanceFadeData {
+		Vector3 camera_pos;
+		float cutoff_distance_from_camera = 0;
+		float cutoff_distance_from_camera_squared = 0;
+		bool distance_fade_enabled = false;
+	} distance_fade_data;
 
 	struct Data {
 		// Camera frustum planes (world space) - order ePlane.

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -74,6 +74,7 @@ public:
 	virtual RS::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) = 0;
 
 	virtual bool light_has_shadow(RID p_light) const = 0;
+	virtual float light_get_shadow_camera_distance_max(RID p_light) const = 0;
 
 	virtual bool light_has_projector(RID p_light) const = 0;
 


### PR DESCRIPTION
Prevent shadows being rendered for instances further than required by light distance fade.

Note that this works by culling individual instances _within_ the shadow map, rather than culling the entire shadow map (which #89729 does).

Fixes #88085

Built on top of #89714 . Can be rebased after that is merged.

## Discussion and Gotchas
This is based on the assumption that shadows can be culled _before_ the lights themselves. If that is not the case (or we don't want to support that in future), then #89729 should cover all the cases, in which case this PR wouldn't be needed.

## Notes
* Bandits the existing framework for tighter shadow culling, which also deals with shadow map caching.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
