### PR TITLE
Partial fix XMLParser conformity to XML specification

### DIFF
--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -83,12 +83,12 @@ private:
 	Vector<Attribute> attributes;
 
 	bool _set_text(const char *start, const char *end);
-	void _parse_closing_xml_element();
+	Error _parse_closing_xml_element();
 	void _ignore_definition();
 	bool _parse_cdata();
 	void _parse_comment();
-	void _parse_opening_xml_element();
-	void _parse_current_node();
+	Error _parse_opening_xml_element();
+	Error _parse_current_node();
 
 	_FORCE_INLINE_ void next_char() {
 		if (*P == '\n') {

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -230,6 +230,28 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
 	CHECK_EQ(parser.get_node_name(), "a");
 }
+
+TEST_CASE("[XMLParser] Tag starting character(s)") {
+
+	SUBCASE("First character is a number") {
+		XMLParser parser;
+		const String input = "<1first></first>";
+		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
+	}
+	SUBCASE("First character is a punctuation") {
+		XMLParser parser;
+		const String input = "<.first></first>";
+		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
+	}
+	SUBCASE("First characters are 'xml") {
+		XMLParser parser;
+		const String input = "<xmlfirst></first>";
+		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
+	}
+}
 } // namespace TestXMLParser
 
 #endif // TEST_XML_PARSER_H

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -232,7 +232,6 @@ TEST_CASE("[XMLParser] CDATA") {
 }
 
 TEST_CASE("[XMLParser] Tag starting character(s)") {
-
 	SUBCASE("First character is a number") {
 		XMLParser parser;
 		const String input = "<1first></first>";


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Partial fix to issues in [89668](https://github.com/godotengine/godot/issues/89668) . Now XMLparser throws an exception if a tag starts with a number, a punctuation character or the letters "xml".