### PR TITLE
Remove stray item icon from tabs menu

### DIFF
--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -167,7 +167,7 @@ void EditorSceneTabs::_update_context_menu() {
 
 	if (tab_id >= 0) {
 		scene_tabs_context_menu->add_separator();
-		scene_tabs_context_menu->add_icon_item(get_editor_theme_icon(SNAME("ShowInFileSystem")), TTR("Show in FileSystem"), EditorNode::FILE_SHOW_IN_FILESYSTEM);
+		scene_tabs_context_menu->add_item(TTR("Show in FileSystem"), EditorNode::FILE_SHOW_IN_FILESYSTEM);
 		_disable_menu_option_if(EditorNode::FILE_SHOW_IN_FILESYSTEM, !ResourceLoader::exists(EditorNode::get_editor_data().get_scene_path(tab_id)));
 		scene_tabs_context_menu->add_item(TTR("Play This Scene"), EditorNode::FILE_RUN_SCENE);
 		_disable_menu_option_if(EditorNode::FILE_RUN_SCENE, no_root_node);


### PR DESCRIPTION
Context: https://github.com/godotengine/godot/pull/84882/files#r1434449440

"Show in FileSystem" option in scene tabs menu is the only one with an icon, which looks out of place.

Before:
![image](https://github.com/godotengine/godot/assets/2223172/183c6132-8031-41b5-8c30-e03d1819d21f)

After:
![image](https://github.com/godotengine/godot/assets/2223172/e344be57-452b-4ce2-aae7-a044be3e96f3)
