### PR TITLE
Add method to obtain camera viewport group

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -243,13 +243,10 @@ void Camera2D::_notification(int p_what) {
 			} else {
 				viewport = get_viewport();
 			}
-
 			canvas = get_canvas();
 
-			RID vp = viewport->get_viewport_rid();
-
-			group_name = "__cameras_" + itos(vp.get_id());
-			canvas_group_name = "__cameras_c" + itos(canvas.get_id());
+			group_name = get_camera_group_for_viewport(viewport->get_viewport_rid());
+			canvas_group_name = get_camera_group_for_canvas(canvas);
 			add_to_group(group_name);
 			add_to_group(canvas_group_name);
 
@@ -668,9 +665,8 @@ void Camera2D::set_custom_viewport(Node *p_viewport) {
 			viewport = get_viewport();
 		}
 
-		RID vp = viewport->get_viewport_rid();
-		group_name = "__cameras_" + itos(vp.get_id());
-		canvas_group_name = "__cameras_c" + itos(canvas.get_id());
+		group_name = get_camera_group_for_viewport(viewport->get_viewport_rid());
+		canvas_group_name = get_camera_group_for_canvas(canvas);
 		add_to_group(group_name);
 		add_to_group(canvas_group_name);
 	}
@@ -711,6 +707,14 @@ void Camera2D::set_margin_drawing_enabled(bool enable) {
 
 bool Camera2D::is_margin_drawing_enabled() const {
 	return margin_drawing_enabled;
+}
+
+StringName Camera2D::get_camera_group_for_viewport(const RID &p_viewport) {
+	return "__cameras_" + itos(p_viewport.get_id());
+}
+
+StringName Camera2D::get_camera_group_for_canvas(const RID &p_canvas) {
+	return "__cameras_c" + itos(p_canvas.get_id());
 }
 
 void Camera2D::_validate_property(PropertyInfo &p_property) const {

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -186,6 +186,9 @@ public:
 	void set_margin_drawing_enabled(bool enable);
 	bool is_margin_drawing_enabled() const;
 
+	static StringName get_camera_group_for_viewport(const RID &p_viewport);
+	static StringName get_camera_group_for_canvas(const RID &p_canvas);
+
 	Camera2D();
 };
 

--- a/scene/2d/parallax_2d.cpp
+++ b/scene/2d/parallax_2d.cpp
@@ -31,11 +31,12 @@
 #include "parallax_2d.h"
 
 #include "core/config/project_settings.h"
+#include "scene/2d/camera_2d.h"
 
 void Parallax2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			group_name = "__cameras_" + itos(get_viewport_rid().get_id());
+			group_name = Camera2D::get_camera_group_for_viewport(get_viewport_rid());
 			add_to_group(group_name);
 			_update_repeat();
 			_update_scroll();

--- a/scene/2d/parallax_2d.h
+++ b/scene/2d/parallax_2d.h
@@ -38,7 +38,7 @@ class Parallax2D : public Node2D {
 
 	static constexpr real_t DEFAULT_LIMIT = 10000000;
 
-	String group_name;
+	StringName group_name;
 	Size2 scroll_scale = Size2(1, 1);
 	Point2 scroll_offset;
 	Point2 screen_offset;

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -31,11 +31,12 @@
 #include "parallax_background.h"
 
 #include "parallax_layer.h"
+#include "scene/2d/camera_2d.h"
 
 void ParallaxBackground::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			group_name = "__cameras_" + itos(get_viewport().get_id());
+			group_name = Camera2D::get_camera_group_for_viewport(get_viewport());
 			add_to_group(group_name);
 		} break;
 


### PR DESCRIPTION
As noted in https://github.com/godotengine/godot/pull/87391/files#r1477424681, some nodes use hard-coded per-viewport camera groups and it's better to avoid that. The group name is now generated in unified way.