### PR TITLE
Partial fix XMLParser conformity to XML specification

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -243,6 +243,25 @@ Error XMLParser::_parse_opening_xml_element() {
 	// find name
 	const char *startName = P;
 
+	// check if there is a closing tag
+	auto P_copy = P;
+	int i = length;
+	bool found = false;
+	while(i>0 && *P_copy){
+		if(*P_copy == '>'){
+			found = true;
+			break;
+		}
+		if(*P_copy == '<'){
+			ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Malformatted XML, missing closing tag.");
+		}
+		i--;
+		P_copy++;
+	}
+	if(!found){
+		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Malformatted XML, missing closing tag.");
+	}
+
 	// find end of element
 	while (*P && *P != '>' && !_is_white_space(*P)) {
 		next_char();

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -86,23 +86,21 @@ Error XMLParser::_parse_closing_xml_element() {
 	node_name = String::utf8(pBeginClose, (int)(P - pBeginClose));
 
 	// remove possible white spaces at the beginning
-	while(true) {
-		if(node_name.begins_with(" ")) {
-			node_name = node_name.replace_first(" ","");
-		}
-		else {
+	while (true) {
+		if (node_name.begins_with(" ")) {
+			node_name = node_name.replace_first(" ", "");
+		} else {
 			break;
 		}
 	}
 
 	// remove possible white spaces at the end
-	while(true) {
-		if(node_name.ends_with(" ")) {
+	while (true) {
+		if (node_name.ends_with(" ")) {
 			node_name = node_name.reverse();
-			node_name = node_name.replace_first(" ","");
+			node_name = node_name.replace_first(" ", "");
 			node_name = node_name.reverse();
-		}
-		else {
+		} else {
 			break;
 		}
 	}
@@ -247,19 +245,19 @@ Error XMLParser::_parse_opening_xml_element() {
 	auto P_copy = P;
 	int i = length;
 	bool found = false;
-	while(i>0 && *P_copy){
-		if(*P_copy == '>'){
+	while (i > 0 && *P_copy) {
+		if (*P_copy == '>') {
 			found = true;
 			break;
 		}
-		if(*P_copy == '<'){
-			ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Malformatted XML, missing closing tag.");
+		if (*P_copy == '<') {
+			ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid element, missing closing tag.");
 		}
 		i--;
 		P_copy++;
 	}
-	if(!found){
-		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Malformatted XML, missing closing tag.");
+	if (!found) {
+		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid element, missing closing tag.");
 	}
 
 	// find end of element
@@ -328,7 +326,7 @@ Error XMLParser::_parse_opening_xml_element() {
 				// tag is closed directly
 				next_char();
 				// check if the ending char is a closing tag
-				if(*P != '>') {
+				if (*P != '>') {
 					ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid tag name, a tag cannot contain any character after '/' except for '>'.");
 				}
 				node_empty = true;

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -41,7 +41,7 @@ static inline bool _is_white_space(char c) {
 }
 
 static inline bool _is_punctuation(char c) {
-	return ((c == ',') || (c == '’') || (c == '\'') || (c == '"') || (c == '?') || (c == '!') || (c == '–') || (c == '—') || (c == '(') || (c == '[') || (c == '{') || (c == '.') || (c == ':') || (c == ';'));
+	return ((c == ',') || (c == "’") || (c == '\'') || (c == '"') || (c == '?') || (c == '!') || (c == "-") || (c == "—") || (c == '(') || (c == '[') || (c == '{') || (c == '.') || (c == ':') || (c == ';'));
 }
 
 //! sets the state that text was found. Returns true if set should be set

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -85,25 +85,7 @@ Error XMLParser::_parse_closing_xml_element() {
 
 	node_name = String::utf8(pBeginClose, (int)(P - pBeginClose));
 
-	// remove possible white spaces at the beginning
-	while (true) {
-		if (node_name.begins_with(" ")) {
-			node_name = node_name.replace_first(" ", "");
-		} else {
-			break;
-		}
-	}
-
-	// remove possible white spaces at the end
-	while (true) {
-		if (node_name.ends_with(" ")) {
-			node_name = node_name.reverse();
-			node_name = node_name.replace_first(" ", "");
-			node_name = node_name.reverse();
-		} else {
-			break;
-		}
-	}
+	node_name = node_name.strip_edges(true, true);
 
 #ifdef DEBUG_XML
 	print_line("XML CLOSE: " + node_name);
@@ -225,14 +207,10 @@ void XMLParser::_parse_comment() {
 
 Error XMLParser::_parse_opening_xml_element() {
 	// check if the first character is a digit
-	if (isdigit(*P)) {
-		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid tag name, a tag cannot begin with a number.");
-	}
+	ERR_FAIL_COND_V_MSG(isdigit(*P), ERR_INVALID_DATA, "Invalid tag name, a tag cannot begin with a number.");
 
 	// check if the first character is a punctuation
-	if (_is_punctuation(*P)) {
-		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid tag name, a tag cannot begin with a punctuation character.");
-	}
+	ERR_FAIL_COND_V_MSG(_is_punctuation(*P), ERR_INVALID_DATA, "Invalid tag name, a tag cannot begin with a punctuation character.");
 
 	node_type = NODE_ELEMENT;
 	node_empty = false;

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -83,9 +83,7 @@ Error XMLParser::_parse_closing_xml_element() {
 		next_char();
 	}
 
-	node_name = String::utf8(pBeginClose, (int)(P - pBeginClose));
-
-	node_name = node_name.strip_edges(true, true);
+	node_name = String::utf8(pBeginClose, (int)(P - pBeginClose)).strip_edges();
 
 #ifdef DEBUG_XML
 	print_line("XML CLOSE: " + node_name);
@@ -234,9 +232,8 @@ Error XMLParser::_parse_opening_xml_element() {
 		i--;
 		P_copy++;
 	}
-	if (!found) {
-		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Invalid element, missing closing tag.");
-	}
+
+	ERR_FAIL_COND_V_MSG(!found, ERR_INVALID_DATA, "Invalid element, missing closing tag.");
 
 	// find end of element
 	while (*P && *P != '>' && !_is_white_space(*P)) {

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -41,7 +41,7 @@ static inline bool _is_white_space(char c) {
 }
 
 static inline bool _is_punctuation(char c) {
-	return ((c == ',') || (c == "’") || (c == '\'') || (c == '"') || (c == '?') || (c == '!') || (c == "-") || (c == "—") || (c == '(') || (c == '[') || (c == '{') || (c == '.') || (c == ':') || (c == ';'));
+	return !((int(c) >= 65 && int(c) <= 90) || (int(c) >= 97 && int(c) <= 122));
 }
 
 //! sets the state that text was found. Returns true if set should be set

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -83,12 +83,12 @@ private:
 	Vector<Attribute> attributes;
 
 	bool _set_text(const char *start, const char *end);
-	void _parse_closing_xml_element();
+	Error _parse_closing_xml_element();
 	void _ignore_definition();
 	bool _parse_cdata();
 	void _parse_comment();
-	void _parse_opening_xml_element();
-	void _parse_current_node();
+	Error _parse_opening_xml_element();
+	Error _parse_current_node();
 
 	_FORCE_INLINE_ void next_char() {
 		if (*P == '\n') {

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -230,6 +230,28 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
 	CHECK_EQ(parser.get_node_name(), "a");
 }
+
+TEST_CASE("[XMLParser] Tag starting character(s)") {
+
+	SUBCASE("First character is a number") {
+		XMLParser parser;
+		const String input = "<1first></first>";
+		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
+	}
+	SUBCASE("First character is a punctuation") {
+		XMLParser parser;
+		const String input = "<.first></first>";
+		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
+	}
+	SUBCASE("First characters are 'xml") {
+		XMLParser parser;
+		const String input = "<xmlfirst></first>";
+		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
+	}
+}
 } // namespace TestXMLParser
 
 #endif // TEST_XML_PARSER_H

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -246,7 +246,7 @@ TEST_CASE("[XMLParser] Tag starting character(s)") {
 	}
 	SUBCASE("First characters are 'xml") {
 		XMLParser parser;
-		const String input = "<xmlfirst></first>";
+		const String input = "<xmlfirst></xmlfirst>";
 		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
 		REQUIRE_EQ(parser.read(), ERR_INVALID_DATA);
 	}

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -232,7 +232,6 @@ TEST_CASE("[XMLParser] CDATA") {
 }
 
 TEST_CASE("[XMLParser] Tag starting character(s)") {
-
 	SUBCASE("First character is a number") {
 		XMLParser parser;
 		const String input = "<1first></first>";


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Partial fix to issues in [89668](https://github.com/godotengine/godot/issues/89668) . Now XMLparser throws an exception if a tag starts with a number, a punctuation character or the letters "xml".

- *Bugsquad: Fixes #89668*