### PR TITLE
Remove redundant code in `Node3D`

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -155,11 +155,7 @@ void Node3D::_notification(int p_what) {
 
 			if (data.top_level && !Engine::get_singleton()->is_editor_hint()) {
 				if (data.parent) {
-					if (!data.top_level) {
-						data.local_transform = data.parent->get_global_transform() * get_transform();
-					} else {
-						data.local_transform = get_transform();
-					}
+					data.local_transform = get_transform();
 					_replace_dirty_mask(DIRTY_EULER_ROTATION_AND_SCALE); // As local transform was updated, rot/scale should be dirty.
 				}
 			}


### PR DESCRIPTION
I don't know this code well enough to know if the entire block isn't redundant, I'm not sure what the need for assigning `local_transform` is here if we're just taking the existing transform, as we'll update the dirty transform later anyway, but keeping the change small for the moment

Followup to:
* https://github.com/godotengine/godot/pull/84643
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
