### PR TITLE
Fix some build errors with `disable_3d=yes`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -697,7 +697,9 @@ Error Main::test_setup() {
 
 	/** INITIALIZE SERVERS **/
 	register_server_types();
+#ifndef _3D_DISABLED
 	XRServer::set_xr_mode(XRServer::XRMODE_OFF); // Skip in tests.
+#endif // _3D_DISABLED
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -100,7 +100,6 @@
 #include "tests/core/variant/test_variant.h"
 #include "tests/core/variant/test_variant_utility.h"
 #include "tests/scene/test_animation.h"
-#include "tests/scene/test_arraymesh.h"
 #include "tests/scene/test_audio_stream_wav.h"
 #include "tests/scene/test_bit_map.h"
 #include "tests/scene/test_camera_2d.h"
@@ -127,6 +126,7 @@
 #include "tests/test_validate_testing.h"
 
 #ifndef _3D_DISABLED
+#include "tests/scene/test_arraymesh.h"
 #include "tests/scene/test_camera_3d.h"
 #include "tests/scene/test_navigation_agent_2d.h"
 #include "tests/scene/test_navigation_agent_3d.h"


### PR DESCRIPTION
Some new issues with 3D disabled popped up after recent changes, it now once again works correctly (and tests run properly)

These are all test related and won't be caught by the CI, as it doesn't build minimal debug builds, and 3D can't be disabled in the editor
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
