### PR TITLE
[macOS Sandbox] Use custom URI schema to pass command line arguments when using OS:create_instance.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -448,6 +448,10 @@ bool OS::is_sandboxed() const {
 	return ::OS::get_singleton()->is_sandboxed();
 }
 
+void OS::sandbox_use_url_for_instance_argumments(const String &p_schema) {
+	::OS::get_singleton()->sandbox_use_url_for_instance_argumments(p_schema);
+}
+
 uint64_t OS::get_static_memory_usage() const {
 	return ::OS::get_singleton()->get_static_memory_usage();
 }
@@ -647,6 +651,7 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &OS::has_feature);
 	ClassDB::bind_method(D_METHOD("is_sandboxed"), &OS::is_sandboxed);
+	ClassDB::bind_method(D_METHOD("sandbox_use_url_for_instance_argumments", "schema"), &OS::sandbox_use_url_for_instance_argumments);
 
 	ClassDB::bind_method(D_METHOD("request_permission", "name"), &OS::request_permission);
 	ClassDB::bind_method(D_METHOD("request_permissions"), &OS::request_permissions);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -238,6 +238,7 @@ public:
 
 	bool has_feature(const String &p_feature) const;
 	bool is_sandboxed() const;
+	void sandbox_use_url_for_instance_argumments(const String &p_schema);
 
 	bool request_permission(const String &p_name);
 	bool request_permissions();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -296,6 +296,7 @@ public:
 	bool has_feature(const String &p_feature);
 
 	virtual bool is_sandboxed() const;
+	virtual void sandbox_use_url_for_instance_argumments(const String &p_schema) {}
 
 	void set_has_server_feature_callback(HasServerFeatureCallback p_callback);
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -669,6 +669,13 @@
 				On macOS (sandboxed applications only), this function clears list of user selected folders accessible to the application.
 			</description>
 		</method>
+		<method name="sandbox_use_url_for_instance_argumments">
+			<return type="void" />
+			<param index="0" name="schema" type="String" />
+			<description>
+				On macOS (sandboxed applications only), sets URI schema name to use for passing command line arguments when using [method create_instance].
+			</description>
+		</method>
 		<method name="set_environment" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="variable" type="String" />

--- a/misc/dist/macos/editor_info_plist.template
+++ b/misc/dist/macos/editor_info_plist.template
@@ -47,6 +47,19 @@
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>godoteditorargs</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>org.godotengine.godoteditorargs</string>
+		</dict>
+	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -59,5 +59,6 @@ $usage_descriptions
 	<key>NSHighResolutionCapable</key>
 $highres
 $additional_plist_content
+$url_schema
 </dict>
 </plist>

--- a/misc/dist/macos_tools.app/Contents/Info.plist
+++ b/misc/dist/macos_tools.app/Contents/Info.plist
@@ -47,6 +47,19 @@
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>godoteditorargs</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>org.godotengine.godoteditorargs</string>
+		</dict>
+	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -118,6 +118,9 @@
 		<member name="codesign/entitlements/app_sandbox/network_server" type="bool" setter="" getter="">
 			Enable to allow app to listen for incoming network connections. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_network_server]com.apple.security.network.server[/url].
 		</member>
+		<member name="codesign/entitlements/app_sandbox/url_schema" type="String" setter="" getter="">
+			Sets URI schema name to use for passing command line arguments when using [method OS.create_instance].
+		</member>
 		<member name="codesign/entitlements/apple_events" type="bool" setter="" getter="">
 			Enable to allow app to send Apple events to other apps. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_automation_apple-events]com.apple.security.automation.apple-events[/url].
 		</member>

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -430,6 +430,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/entitlements/apple_events"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/entitlements/debugging"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/entitlements/app_sandbox/enabled"), false, true, true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements/app_sandbox/url_schema"), "godotargs"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/entitlements/app_sandbox/network_server"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/entitlements/app_sandbox/network_client"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/entitlements/app_sandbox/device_usb"), false));
@@ -679,6 +680,26 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 			strnew += lines[i].replace("$xcodever", p_preset->get("xcode/xcode_version")) + "\n";
 		} else if (lines[i].find("$xcodebuild") != -1) {
 			strnew += lines[i].replace("$xcodebuild", p_preset->get("xcode/xcode_build")) + "\n";
+		} else if (lines[i].find("$url_schema") != -1) {
+			if ((bool)p_preset->get("codesign/entitlements/app_sandbox/enabled")) {
+				String url_schema;
+				url_schema += "<key>CFBundleURLTypes</key>\n";
+				url_schema += "<array>\n";
+				url_schema += "\t<dict>\n";
+				url_schema += "\t\t<key>CFBundleTypeRole</key>\n";
+				url_schema += "\t\t<string>Editor</string>\n";
+				url_schema += "\t\t<key>CFBundleURLSchemes</key>\n";
+				url_schema += "\t\t<array>\n";
+				url_schema += "\t\t\t<string>" + p_preset->get("codesign/entitlements/app_sandbox/url_schema").operator String() + "</string>\n";
+				url_schema += "\t\t</array>\n";
+				url_schema += "\t\t<key>CFBundleURLName</key>\n";
+				url_schema += "\t\t<string>" + p_preset->get("application/bundle_identifier").operator String() + "." + p_preset->get("codesign/entitlements/app_sandbox/url_schema").operator String() + "</string>\n";
+				url_schema += "\t</dict>\n";
+				url_schema += "\t</array>\n";
+				strnew += lines[i].replace("$url_schema", url_schema) + "\n";
+			} else {
+				strnew += lines[i].replace("$url_schema", "") + "\n";
+			}
 		} else if (lines[i].find("$usage_descriptions") != -1) {
 			String descriptions;
 			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -57,10 +57,17 @@ class OS_MacOS : public OS_Unix {
 	MainLoop *main_loop = nullptr;
 
 	List<String> launch_service_args;
+#ifdef TOOLS_ENABLED
+	String url_schema = "godoteditorargs";
+#else
+	String url_schema = "godotargs";
+#endif
 
 	CGFloat _weight_to_ct(int p_weight) const;
 	CGFloat _stretch_to_ct(int p_stretch) const;
 	String _get_default_fontname(const String &p_font_name) const;
+
+	Error _create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false, bool p_instance = false);
 
 	static _FORCE_INLINE_ String get_framework_executable(const String &p_path);
 	static void pre_wait_observer_cb(CFRunLoopObserverRef p_observer, CFRunLoopActivity p_activiy, void *p_context);
@@ -114,6 +121,9 @@ public:
 	virtual String get_processor_name() const override;
 
 	virtual bool is_sandboxed() const override;
+	virtual void sandbox_use_url_for_instance_argumments(const String &p_schema) override;
+	String sandbox_get_url_schema() const { return url_schema; }
+
 	virtual Vector<String> get_granted_permissions() const override;
 	virtual void revoke_granted_permissions() override;
 


### PR DESCRIPTION
Allows sandboxed Godot editor (or similar apps) to pass arguments (not directly supported in the sandbox) when creating instances with `OS:create_instance` via custom URI schema.