### PR TITLE
Remove dead code in animation mixer's `_blend_process`

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1634,7 +1634,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							default:
 								break;
 						}
-						if (player2->is_playing() || seeked) {
+						if (player2->is_playing()) {
 							player2->seek(at_anim_pos);
 							player2->play(anim_name);
 							t->playing = true;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/89768

cc @TokageItLab , is this fix correct or we should move the code down in the else branch

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
