### PR TITLE
Introduce `Window` option to contain multiple `Viewports` with a focused `Control`

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -691,6 +691,10 @@
 			[b]Note:[/b] On Windows, the portion of a window that lies outside the region is not drawn, while on Linux (X11) and macOS it is.
 			[b]Note:[/b] This property is implemented on Linux (X11), macOS and Windows.
 		</member>
+		<member name="multi_viewport_focus" type="bool" setter="set_multi_viewport_focus" getter="is_multi_viewport_focus_enabled" default="false">
+			If [code]false[/code], only a single focused [Control] is allowed in [Viewport] nodes within this window. If [code]true[/code], every [Viewport] in this window keeps an independent state of their own focused [Control] node.
+			This setting affects only the window itself and child [SubViewport] nodes. Child [Window] nodes and their child nodes aren't affected by this setting. This is useful for splitscreen input handling.
+		</member>
 		<member name="popup_window" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] will be considered a popup. Popups are sub-windows that don't show as separate windows in system's window manager's window list and will send close request when anything is clicked outside of them (unless [member exclusive] is enabled).
 		</member>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2651,11 +2651,34 @@ bool Viewport::_gui_control_has_focus(const Control *p_control) {
 }
 
 void Viewport::_gui_control_grab_focus(Control *p_control) {
-	if (gui.key_focus && gui.key_focus == p_control) {
-		// No need for change.
-		return;
+	Window *base_window = get_base_window();
+	if (base_window->is_multi_viewport_focus_enabled()) {
+		// Release previous focus.
+		if (gui.key_focus && gui.key_focus != p_control) {
+			gui_release_focus();
+		}
+
+		// Ensure chain of SubViewportContainer focus in parent Viewport. Needs to happen, even if control has focus in this Viewport.
+		Viewport *vp = this;
+		if (Object::cast_to<SubViewport>(vp)) {
+			SubViewportContainer *svc = Object::cast_to<SubViewportContainer>(get_parent());
+			if (svc) {
+				svc->grab_focus();
+			}
+		}
+		if (gui.key_focus == p_control) {
+			// No need for change.
+			return;
+		}
+	} else {
+		if (gui.key_focus && gui.key_focus == p_control) {
+			// No need for change.
+			return;
+		}
+		get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", base_window);
 	}
-	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", get_base_window());
+
+	// Perform necessary adjustments for focuschange.
 	if (p_control->is_inside_tree() && p_control->get_viewport() == this) {
 		gui.key_focus = p_control;
 		emit_signal(SNAME("gui_focus_changed"), p_control);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3087,6 +3087,16 @@ void Window::_mouse_leave_viewport() {
 	}
 }
 
+void Window::set_multi_viewport_focus(bool p_enable) {
+	ERR_MAIN_THREAD_GUARD;
+	multi_viewport_focus = p_enable;
+}
+
+bool Window::is_multi_viewport_focus_enabled() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return multi_viewport_focus;
+}
+
 void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &Window::set_title);
 	ClassDB::bind_method(D_METHOD("get_title"), &Window::get_title);
@@ -3248,6 +3258,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_layout_direction"), &Window::get_layout_direction);
 	ClassDB::bind_method(D_METHOD("is_layout_rtl"), &Window::is_layout_rtl);
 
+	ClassDB::bind_method(D_METHOD("set_multi_viewport_focus", "enable"), &Window::set_multi_viewport_focus);
+	ClassDB::bind_method(D_METHOD("is_multi_viewport_focus_enabled"), &Window::is_multi_viewport_focus_enabled);
+
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_auto_translate", "enable"), &Window::set_auto_translate);
 	ClassDB::bind_method(D_METHOD("is_auto_translating"), &Window::is_auto_translating);
@@ -3313,6 +3326,8 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "content_scale_aspect", PROPERTY_HINT_ENUM, "Ignore,Keep,Keep Width,Keep Height,Expand"), "set_content_scale_aspect", "get_content_scale_aspect");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "content_scale_stretch", PROPERTY_HINT_ENUM, "Fractional,Integer"), "set_content_scale_stretch", "get_content_scale_stretch");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "content_scale_factor", PROPERTY_HINT_RANGE, "0.5,8.0,0.01"), "set_content_scale_factor", "get_content_scale_factor");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "multi_viewport_focus"), "set_multi_viewport_focus", "is_multi_viewport_focus_enabled");
 
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_auto_translate", "is_auto_translating");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -144,6 +144,8 @@ private:
 	bool unparent_when_invisible = false;
 	bool keep_title_visible = false;
 
+	bool multi_viewport_focus = false;
+
 	LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
 	void _update_child_controls();
@@ -511,6 +513,9 @@ public:
 	virtual Transform2D get_popup_base_transform() const override;
 	virtual Viewport *get_section_root_viewport() const override;
 	virtual bool is_attached_in_viewport() const override;
+
+	void set_multi_viewport_focus(bool p_enable);
+	bool is_multi_viewport_focus_enabled() const;
 
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;


### PR DESCRIPTION
Introduce `Window` option to contain multiple `Viewports` with a focused `Control`

This PR introduces an option `Window.multi_viewport_focus` to allow all contained `Viewports` to keep their focused `Control` independently from other Viewports in the same `Window`.

Alternative to #62421
Supersedes alternative #79480 and doesn't change existing behavior
Implements parts of https://github.com/godotengine/godot-proposals/issues/385
Implements parts of https://github.com/godotengine/godot-proposals/issues/4295

MRP for testing: [MultiFocusPerWindow.zip](https://github.com/godotengine/godot/files/14733415/MultiFocusPerWindow.zip)

Updated 2024-03-23: I have discarded my first approach, because of the added complexity caused by multiple edge cases.
Updated 2025-06-11: Fix simple merge conflict with #97378 and tested, that the above MRP still works.