### PR TITLE
Fix import and saving related crashes

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -152,12 +152,10 @@ void ResourceLoader::_bind_methods() {
 ////// ResourceSaver //////
 
 Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, BitField<SaverFlags> p_flags) {
-	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + p_path + "'.");
 	return ::ResourceSaver::save(p_resource, p_path, p_flags);
 }
 
 Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
-	ERR_FAIL_COND_V_MSG(p_resource.is_null(), Vector<String>(), "It's not a reference to a valid Resource object.");
 	List<String> exts;
 	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
 	Vector<String> ret;

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -98,6 +98,7 @@ void ResourceFormatSaver::_bind_methods() {
 }
 
 Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + p_path + "'.");
 	String path = p_path;
 	if (path.is_empty()) {
 		path = p_resource->get_path();
@@ -174,6 +175,7 @@ void ResourceSaver::set_save_callback(ResourceSavedCallback p_callback) {
 }
 
 void ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) {
+	ERR_FAIL_COND_MSG(p_resource.is_null(), "It's not a reference to a valid Resource object.");
 	for (int i = 0; i < saver_count; i++) {
 		saver[i]->get_recognized_extensions(p_resource, p_extensions);
 	}

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -497,7 +497,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 		}
 	}
 
-	if (p_single_mesh) {
+	if (p_single_mesh && mesh->get_surface_count() > 0) {
 		r_meshes.push_back(mesh);
 	}
 


### PR DESCRIPTION
* Don't add empty mesh to result when importing obj files
* Check for null resources in `ResourceSaver`

This adds the check from `core_bind` to `ResourceSaver` directly, ~could remove the one in `ResourceSaver.save` in `core_bind` as it's now redundant, but just added it for now~, it helps catch broken cases when doing things from c++

The obj side avoids doing any of the remaining code, makes things a bit clearer, and matches the code here:
https://github.com/godotengine/godot/blob/fe01776f05b1787b28b4a270d53037a3c25f4ca2/editor/import/3d/resource_importer_obj.cpp#L441-L445

For this specific case we might want to look at adding support for lines in obj files as they support it, or a more clear error message or warning when using unsupported features, but that's outside the scope of this

---

* Fixes: https://github.com/godotengine/godot/issues/89776

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
