### PR TITLE
Use initializer list in Arrays

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -36,8 +36,7 @@
 #define CHECK_END(arr, expected, what) ERR_FAIL_COND_V_MSG((uint32_t)arr.size() > (uint32_t)expected, false, String("Malformed ") + what + " message from script debugger, message too long. Expected size: " + itos(expected) + ", actual size: " + itos(arr.size()))
 
 Array DebuggerMarshalls::ScriptStackDump::serialize() {
-	Array arr;
-	arr.push_back(frames.size() * 3);
+	Array arr = { frames.size() * 3 };
 	for (const ScriptLanguage::StackInfo &frame : frames) {
 		arr.push_back(frame.file);
 		arr.push_back(frame.line);
@@ -64,10 +63,7 @@ bool DebuggerMarshalls::ScriptStackDump::deserialize(const Array &p_arr) {
 }
 
 Array DebuggerMarshalls::ScriptStackVariable::serialize(int max_size) {
-	Array arr;
-	arr.push_back(name);
-	arr.push_back(type);
-	arr.push_back(value.get_type());
+	Array arr = { name, type, value.get_type() };
 
 	Variant var = value;
 	if (value.get_type() == Variant::OBJECT && value.get_validated_object() == nullptr) {
@@ -99,20 +95,20 @@ bool DebuggerMarshalls::ScriptStackVariable::deserialize(const Array &p_arr) {
 }
 
 Array DebuggerMarshalls::OutputError::serialize() {
-	Array arr;
-	arr.push_back(hr);
-	arr.push_back(min);
-	arr.push_back(sec);
-	arr.push_back(msec);
-	arr.push_back(source_file);
-	arr.push_back(source_func);
-	arr.push_back(source_line);
-	arr.push_back(error);
-	arr.push_back(error_descr);
-	arr.push_back(warning);
 	unsigned int size = callstack.size();
+	Array arr = {
+		hr,
+		min,
+		sec, msec,
+		source_file,
+		source_func,
+		source_line,
+		error,
+		error_descr,
+		warning,
+		size * 3
+	};
 	const ScriptLanguage::StackInfo *r = callstack.ptr();
-	arr.push_back(size * 3);
 	for (int i = 0; i < callstack.size(); i++) {
 		arr.push_back(r[i].file);
 		arr.push_back(r[i].func);

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -149,8 +149,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bo
 		singleton = memnew(RemoteDebugger(Ref<RemoteDebuggerPeer>(peer)));
 		script_debugger = memnew(ScriptDebugger);
 		// Notify editor of our pid (to allow focus stealing).
-		Array msg;
-		msg.push_back(OS::get_singleton()->get_process_id());
+		Array msg = { OS::get_singleton()->get_process_id() };
 		singleton->send_message("set_pid", msg);
 	}
 	if (!singleton) {

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -95,10 +95,7 @@ public:
 };
 
 Error RemoteDebugger::_put_msg(const String &p_message, const Array &p_data) {
-	Array msg;
-	msg.push_back(p_message);
-	msg.push_back(Thread::get_caller_id());
-	msg.push_back(p_data);
+	Array msg = { p_message, Thread::get_caller_id(), p_data };
 	Error err = peer->put_message(msg);
 	if (err != OK) {
 		n_messages_dropped++;
@@ -235,9 +232,7 @@ void RemoteDebugger::flush_output() {
 			types.push_back(MESSAGE_TYPE_LOG);
 		}
 
-		Array arr;
-		arr.push_back(strings);
-		arr.push_back(types);
+		Array arr = { strings, types };
 		_put_msg("output", arr);
 		output_strings.clear();
 	}
@@ -418,11 +413,12 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	const String error_str = script_lang ? script_lang->debug_get_error() : "";
 
 	if (can_break) {
-		Array msg;
-		msg.push_back(p_can_continue);
-		msg.push_back(error_str);
-		msg.push_back(script_lang->debug_get_stack_level_count() > 0);
-		msg.push_back(Thread::get_caller_id());
+		Array msg = {
+			p_can_continue,
+			error_str,
+			script_lang->debug_get_stack_level_count() > 0,
+			Thread::get_caller_id()
+		};
 		if (allow_focus_steal_fn) {
 			allow_focus_steal_fn();
 		}
@@ -514,8 +510,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				script_lang->debug_get_globals(&globals, &globals_vals);
 				ERR_FAIL_COND(globals.size() != globals_vals.size());
 
-				Array var_size;
-				var_size.push_back(local_vals.size() + member_vals.size() + globals_vals.size());
+				Array var_size = { local_vals.size() + member_vals.size() + globals_vals.size() };
 				send_message("stack_frame_vars", var_size);
 				_send_stack_vars(locals, local_vals, 0);
 				_send_stack_vars(members, member_vals, 1);

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -664,201 +664,96 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 
 		case Variant::VECTOR2: {
 			const Vector2 v = p_variant;
-
-			Array args;
-			args.push_back(v.x);
-			args.push_back(v.y);
-
+			Array args = { v.x, v.y };
 			RETURN_ARGS;
 		} break;
 		case Variant::VECTOR2I: {
 			const Vector2i v = p_variant;
-
-			Array args;
-			args.push_back(v.x);
-			args.push_back(v.y);
-
+			Array args = { v.x, v.y };
 			RETURN_ARGS;
 		} break;
 		case Variant::RECT2: {
 			const Rect2 r = p_variant;
-
-			Array args;
-			args.push_back(r.position.x);
-			args.push_back(r.position.y);
-			args.push_back(r.size.width);
-			args.push_back(r.size.height);
-
+			Array args = { r.position.x, r.position.y, r.size.width, r.size.height };
 			RETURN_ARGS;
 		} break;
 		case Variant::RECT2I: {
 			const Rect2i r = p_variant;
-
-			Array args;
-			args.push_back(r.position.x);
-			args.push_back(r.position.y);
-			args.push_back(r.size.width);
-			args.push_back(r.size.height);
-
+			Array args = { r.position.x, r.position.y, r.size.width, r.size.height };
 			RETURN_ARGS;
 		} break;
 		case Variant::VECTOR3: {
 			const Vector3 v = p_variant;
-
-			Array args;
-			args.push_back(v.x);
-			args.push_back(v.y);
-			args.push_back(v.z);
-
+			Array args = { v.x, v.y, v.z };
 			RETURN_ARGS;
 		} break;
 		case Variant::VECTOR3I: {
 			const Vector3i v = p_variant;
-
-			Array args;
-			args.push_back(v.x);
-			args.push_back(v.y);
-			args.push_back(v.z);
-
+			Array args = { v.x, v.y, v.z };
 			RETURN_ARGS;
 		} break;
 		case Variant::TRANSFORM2D: {
 			const Transform2D t = p_variant;
-
-			Array args;
-			args.push_back(t[0].x);
-			args.push_back(t[0].y);
-			args.push_back(t[1].x);
-			args.push_back(t[1].y);
-			args.push_back(t[2].x);
-			args.push_back(t[2].y);
-
+			Array args = { t[0].x, t[0].y, t[1].x, t[1].y, t[2].x, t[2].y };
 			RETURN_ARGS;
 		} break;
 		case Variant::VECTOR4: {
 			const Vector4 v = p_variant;
-
-			Array args;
-			args.push_back(v.x);
-			args.push_back(v.y);
-			args.push_back(v.z);
-			args.push_back(v.w);
-
+			Array args = { v.x, v.y, v.z, v.w };
 			RETURN_ARGS;
 		} break;
 		case Variant::VECTOR4I: {
 			const Vector4i v = p_variant;
-
-			Array args;
-			args.push_back(v.x);
-			args.push_back(v.y);
-			args.push_back(v.z);
-			args.push_back(v.w);
-
+			Array args = { v.x, v.y, v.z, v.w };
 			RETURN_ARGS;
 		} break;
 		case Variant::PLANE: {
 			const Plane p = p_variant;
-
-			Array args;
-			args.push_back(p.normal.x);
-			args.push_back(p.normal.y);
-			args.push_back(p.normal.z);
-			args.push_back(p.d);
-
+			Array args = { p.normal.x, p.normal.y, p.normal.z, p.d };
 			RETURN_ARGS;
 		} break;
 		case Variant::QUATERNION: {
 			const Quaternion q = p_variant;
-
-			Array args;
-			args.push_back(q.x);
-			args.push_back(q.y);
-			args.push_back(q.z);
-			args.push_back(q.w);
-
+			Array args = { q.x, q.y, q.z, q.w };
 			RETURN_ARGS;
 		} break;
 		case Variant::AABB: {
 			const AABB aabb = p_variant;
-
-			Array args;
-			args.push_back(aabb.position.x);
-			args.push_back(aabb.position.y);
-			args.push_back(aabb.position.z);
-			args.push_back(aabb.size.x);
-			args.push_back(aabb.size.y);
-			args.push_back(aabb.size.z);
-
+			Array args = { aabb.position.x, aabb.position.y, aabb.position.z, aabb.size.x, aabb.size.y, aabb.size.z };
 			RETURN_ARGS;
 		} break;
 		case Variant::BASIS: {
 			const Basis b = p_variant;
 
-			Array args;
-			args.push_back(b.get_column(0).x);
-			args.push_back(b.get_column(0).y);
-			args.push_back(b.get_column(0).z);
-			args.push_back(b.get_column(1).x);
-			args.push_back(b.get_column(1).y);
-			args.push_back(b.get_column(1).z);
-			args.push_back(b.get_column(2).x);
-			args.push_back(b.get_column(2).y);
-			args.push_back(b.get_column(2).z);
+			Array args = { b.get_column(0).x, b.get_column(0).y, b.get_column(0).z,
+				b.get_column(1).x, b.get_column(1).y, b.get_column(1).z,
+				b.get_column(2).x, b.get_column(2).y, b.get_column(2).z };
 
 			RETURN_ARGS;
 		} break;
 		case Variant::TRANSFORM3D: {
 			const Transform3D t = p_variant;
 
-			Array args;
-			args.push_back(t.basis.get_column(0).x);
-			args.push_back(t.basis.get_column(0).y);
-			args.push_back(t.basis.get_column(0).z);
-			args.push_back(t.basis.get_column(1).x);
-			args.push_back(t.basis.get_column(1).y);
-			args.push_back(t.basis.get_column(1).z);
-			args.push_back(t.basis.get_column(2).x);
-			args.push_back(t.basis.get_column(2).y);
-			args.push_back(t.basis.get_column(2).z);
-			args.push_back(t.origin.x);
-			args.push_back(t.origin.y);
-			args.push_back(t.origin.z);
+			Array args = { t.basis.get_column(0).x, t.basis.get_column(0).y, t.basis.get_column(0).z,
+				t.basis.get_column(1).x, t.basis.get_column(1).y, t.basis.get_column(1).z,
+				t.basis.get_column(2).x, t.basis.get_column(2).y, t.basis.get_column(2).z,
+				t.origin.x, t.origin.y, t.origin.z };
 
 			RETURN_ARGS;
 		} break;
 		case Variant::PROJECTION: {
 			const Projection p = p_variant;
 
-			Array args;
-			args.push_back(p[0].x);
-			args.push_back(p[0].y);
-			args.push_back(p[0].z);
-			args.push_back(p[0].w);
-			args.push_back(p[1].x);
-			args.push_back(p[1].y);
-			args.push_back(p[1].z);
-			args.push_back(p[1].w);
-			args.push_back(p[2].x);
-			args.push_back(p[2].y);
-			args.push_back(p[2].z);
-			args.push_back(p[2].w);
-			args.push_back(p[3].x);
-			args.push_back(p[3].y);
-			args.push_back(p[3].z);
-			args.push_back(p[3].w);
+			Array args = { p[0].x, p[0].y, p[0].z, p[0].w,
+				p[1].x, p[1].y, p[1].z, p[1].w,
+				p[2].x, p[2].y, p[2].z, p[2].w,
+				p[3].x, p[3].y, p[3].z, p[3].w };
 
 			RETURN_ARGS;
 		} break;
 		case Variant::COLOR: {
 			const Color c = p_variant;
-
-			Array args;
-			args.push_back(c.r);
-			args.push_back(c.g);
-			args.push_back(c.b);
-			args.push_back(c.a);
-
+			Array args = { c.r, c.g, c.b, c.a };
 			RETURN_ARGS;
 		} break;
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -45,6 +45,10 @@ struct ArrayPrivate {
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
 	ContainerTypeValidate typed;
+
+	ArrayPrivate() {}
+	ArrayPrivate(std::initializer_list<Variant> p_init) :
+			array(p_init) {}
 };
 
 void Array::_ref(const Array &p_from) const {

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -55,6 +55,8 @@ public:
 			assign(p_array);
 		}
 	}
+	_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :
+			TypedArray(Array(p_init)) {}
 	_FORCE_INLINE_ TypedArray() {
 		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
 	}

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -907,9 +907,7 @@ template <typename S>
 class OperatorEvaluatorStringFormat<S, void> {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, bool *r_valid) {
-		Array values;
-		values.push_back(Variant());
-
+		Array values = { Variant() };
 		String a = s.sprintf(values, r_valid);
 		if (r_valid) {
 			*r_valid = !*r_valid;
@@ -966,8 +964,7 @@ template <typename S>
 class OperatorEvaluatorStringFormat<S, Object> {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, const Object *p_object, bool *r_valid) {
-		Array values;
-		values.push_back(p_object);
+		Array values = { p_object };
 		String a = s.sprintf(values, r_valid);
 		if (r_valid) {
 			*r_valid = !*r_valid;
@@ -997,8 +994,7 @@ template <typename S, typename T>
 class OperatorEvaluatorStringFormat {
 public:
 	_FORCE_INLINE_ static String do_mod(const String &s, const T &p_value, bool *r_valid) {
-		Array values;
-		values.push_back(p_value);
+		Array values = { p_value };
 		String a = s.sprintf(values, r_valid);
 		if (r_valid) {
 			*r_valid = !*r_valid;

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1379,8 +1379,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 #endif
 			Callable::CallError ce;
 			ce.error = Callable::CallError::CALL_OK;
-			Array ref;
-			ref.push_back(r_iter);
+			Array ref = { r_iter };
 			Variant vref = ref;
 			const Variant *refp[] = { &vref };
 			Variant ret = _get_obj().obj->callp(CoreStringName(_iter_init), refp, 1, ce);
@@ -1614,8 +1613,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 #endif
 			Callable::CallError ce;
 			ce.error = Callable::CallError::CALL_OK;
-			Array ref;
-			ref.push_back(r_iter);
+			Array ref = { r_iter };
 			Variant vref = ref;
 			const Variant *refp[] = { &vref };
 			Variant ret = _get_obj().obj->callp(CoreStringName(_iter_next), refp, 1, ce);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1940,15 +1940,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->connect("caret_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
 	text_editor->connect(SceneStringName(text_changed), callable_mp(this, &CodeTextEditor::_text_changed));
 	text_editor->connect("code_completion_requested", callable_mp(this, &CodeTextEditor::_complete_request));
-	TypedArray<String> cs;
-	cs.push_back(".");
-	cs.push_back(",");
-	cs.push_back("(");
-	cs.push_back("=");
-	cs.push_back("$");
-	cs.push_back("@");
-	cs.push_back("\"");
-	cs.push_back("\'");
+	TypedArray<String> cs = { ".", ",", "(", "=", "$", "@", "\"", "\'" };
 	text_editor->set_code_completion_prefixes(cs);
 	idle->connect("timeout", callable_mp(this, &CodeTextEditor::_text_changed_idle_timeout));
 

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -301,12 +301,11 @@ Dictionary DebugAdapterParser::req_threads(const Dictionary &p_params) const {
 	Dictionary response = prepare_success_response(p_params), body;
 	response["body"] = body;
 
-	Array arr;
 	DAP::Thread thread;
 
 	thread.id = 1; // Hardcoded because Godot only supports debugging one thread at the moment
 	thread.name = "Main";
-	arr.push_back(thread.to_json());
+	Array arr = { thread.to_json() };
 	body["threads"] = arr;
 
 	return response;
@@ -383,13 +382,12 @@ Dictionary DebugAdapterParser::req_breakpointLocations(const Dictionary &p_param
 	response["body"] = body;
 	Dictionary args = p_params["arguments"];
 
-	Array locations;
 	DAP::BreakpointLocation location;
 	location.line = args["line"];
 	if (args.has("endLine")) {
 		location.endLine = args["endLine"];
 	}
-	locations.push_back(location.to_json());
+	Array locations = { location.to_json() };
 
 	body["breakpoints"] = locations;
 	return response;
@@ -595,8 +593,7 @@ Dictionary DebugAdapterParser::ev_stopped_breakpoint(const int &p_id) const {
 	body["reason"] = "breakpoint";
 	body["description"] = "Breakpoint";
 
-	Array breakpoints;
-	breakpoints.push_back(p_id);
+	Array breakpoints = { p_id };
 	body["hitBreakpointIds"] = breakpoints;
 
 	return event;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -205,9 +205,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			x.value = rtos(vec.x);
 			y.value = rtos(vec.y);
 
-			Array arr;
-			arr.push_back(x.to_json());
-			arr.push_back(y.to_json());
+			Array arr = { x.to_json(), y.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -230,11 +228,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			w.value = rtos(rect.size.x);
 			h.value = rtos(rect.size.y);
 
-			Array arr;
-			arr.push_back(x.to_json());
-			arr.push_back(y.to_json());
-			arr.push_back(w.to_json());
-			arr.push_back(h.to_json());
+			Array arr = { x.to_json(), y.to_json(), w.to_json(), h.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -254,10 +248,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			y.value = rtos(vec.y);
 			z.value = rtos(vec.z);
 
-			Array arr;
-			arr.push_back(x.to_json());
-			arr.push_back(y.to_json());
-			arr.push_back(z.to_json());
+			Array arr = { x.to_json(), y.to_json(), z.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -279,10 +270,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			y.variablesReference = parse_variant(transform.columns[1]);
 			origin.variablesReference = parse_variant(transform.columns[2]);
 
-			Array arr;
-			arr.push_back(x.to_json());
-			arr.push_back(y.to_json());
-			arr.push_back(origin.to_json());
+			Array arr = { x.to_json(), y.to_json(), origin.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -298,9 +286,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			normal.value = plane.normal;
 			normal.variablesReference = parse_variant(plane.normal);
 
-			Array arr;
-			arr.push_back(d.to_json());
-			arr.push_back(normal.to_json());
+			Array arr = { d.to_json(), normal.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -322,11 +308,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			z.value = rtos(quat.z);
 			w.value = rtos(quat.w);
 
-			Array arr;
-			arr.push_back(x.to_json());
-			arr.push_back(y.to_json());
-			arr.push_back(z.to_json());
-			arr.push_back(w.to_json());
+			Array arr = { x.to_json(), y.to_json(), z.to_json(), w.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -344,9 +326,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			position.variablesReference = parse_variant(aabb.position);
 			size.variablesReference = parse_variant(aabb.size);
 
-			Array arr;
-			arr.push_back(position.to_json());
-			arr.push_back(size.to_json());
+			Array arr = { position.to_json(), size.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -368,10 +348,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			y.variablesReference = parse_variant(basis.rows[1]);
 			z.variablesReference = parse_variant(basis.rows[2]);
 
-			Array arr;
-			arr.push_back(x.to_json());
-			arr.push_back(y.to_json());
-			arr.push_back(z.to_json());
+			Array arr = { x.to_json(), y.to_json(), z.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -388,9 +365,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			basis.variablesReference = parse_variant(transform.basis);
 			origin.variablesReference = parse_variant(transform.origin);
 
-			Array arr;
-			arr.push_back(basis.to_json());
-			arr.push_back(origin.to_json());
+			Array arr = { basis.to_json(), origin.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -412,11 +387,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			b.value = rtos(color.b);
 			a.value = rtos(color.a);
 
-			Array arr;
-			arr.push_back(r.to_json());
-			arr.push_back(g.to_json());
-			arr.push_back(b.to_json());
-			arr.push_back(a.to_json());
+			Array arr = { r.to_json(), g.to_json(), b.to_json(), a.to_json() };
 			variable_list.insert(id, arr);
 			return id;
 		}
@@ -428,8 +399,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -467,8 +437,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -488,8 +457,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -509,8 +477,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -530,8 +497,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -551,8 +517,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -572,8 +537,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -593,8 +557,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -615,8 +578,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -637,8 +599,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.type = Variant::get_type_name(Variant::INT);
 			size.value = itos(array.size());
 
-			Array arr;
-			arr.push_back(size.to_json());
+			Array arr = { size.to_json() };
 
 			for (int i = 0; i < array.size(); i++) {
 				DAP::Variable var;
@@ -880,8 +841,7 @@ bool DebugAdapterProtocol::process_message(const String &p_text) {
 	if (parser->has_method(command)) {
 		_current_request = params["command"];
 
-		Array args;
-		args.push_back(params);
+		Array args = { params };
 		Dictionary response = parser->callv(command, args);
 		if (!response.is_empty()) {
 			_current_peer->res_queue.push_front(response);

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -158,9 +158,7 @@ struct Capabilities {
 		dict["supportsTerminateRequest"] = supportsTerminateRequest;
 		dict["supportsBreakpointLocationsRequest"] = supportsBreakpointLocationsRequest;
 
-		Array arr;
-		arr.push_back(supportedChecksumAlgorithms[0]);
-		arr.push_back(supportedChecksumAlgorithms[1]);
+		Array arr = { supportedChecksumAlgorithms[0], supportedChecksumAlgorithms[1] };
 		dict["supportedChecksumAlgorithms"] = arr;
 
 		return dict;

--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -74,8 +74,7 @@ void EditorExpressionEvaluator::_clear() {
 }
 
 void EditorExpressionEvaluator::_remote_object_selected(ObjectID p_id) {
-	Array arr;
-	arr.append(p_id);
+	Array arr = { p_id };
 	editor_debugger->emit_signal(SNAME("remote_objects_requested"), arr);
 }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -73,10 +73,7 @@ using CameraOverride = EditorDebuggerNode::CameraOverride;
 void ScriptEditorDebugger::_put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id) {
 	ERR_FAIL_COND(p_thread_id == Thread::UNASSIGNED_ID);
 	if (is_session_active()) {
-		Array msg;
-		msg.push_back(p_message);
-		msg.push_back(p_thread_id);
-		msg.push_back(p_data);
+		Array msg = { p_message, p_thread_id, p_data };
 		Error err = peer->put_message(msg);
 		ERR_FAIL_COND_MSG(err != OK, vformat("Failed to send message %d", err));
 	}
@@ -98,8 +95,7 @@ void ScriptEditorDebugger::debug_skip_breakpoints() {
 		skip_breakpoints->set_button_icon(get_editor_theme_icon(SNAME("DebugSkipBreakpointsOff")));
 	}
 
-	Array msg;
-	msg.push_back(skip_breakpoints_value);
+	Array msg = { skip_breakpoints_value };
 	_put_msg("set_skip_breakpoints", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
 }
 
@@ -111,8 +107,7 @@ void ScriptEditorDebugger::debug_ignore_error_breaks() {
 		ignore_error_breaks->set_button_icon(get_theme_icon(SNAME("Notification"), SNAME("EditorIcons")));
 	}
 
-	Array msg;
-	msg.push_back(ignore_error_breaks_value);
+	Array msg = { ignore_error_breaks_value };
 	_put_msg("set_ignore_error_breaks", msg);
 }
 
@@ -170,9 +165,7 @@ void ScriptEditorDebugger::clear_style() {
 }
 
 void ScriptEditorDebugger::save_node(ObjectID p_id, const String &p_file) {
-	Array msg;
-	msg.push_back(p_id);
-	msg.push_back(p_file);
+	Array msg = { p_id, p_file };
 	_put_msg("scene:save_node", msg);
 }
 
@@ -265,17 +258,12 @@ const SceneDebuggerTree *ScriptEditorDebugger::get_remote_tree() {
 }
 
 void ScriptEditorDebugger::request_remote_evaluate(const String &p_expression, int p_stack_frame) {
-	Array msg;
-	msg.push_back(p_expression);
-	msg.push_back(p_stack_frame);
+	Array msg = { p_expression, p_stack_frame };
 	_put_msg("evaluate", msg);
 }
 
 void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value, const String &p_field) {
-	Array msg;
-	msg.push_back(p_obj_id);
-	msg.push_back(p_prop);
-	msg.push_back(p_value);
+	Array msg = { p_obj_id, p_prop, p_value };
 	if (p_field.is_empty()) {
 		_put_msg("scene:set_object_property", msg);
 	} else {
@@ -286,9 +274,7 @@ void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String 
 
 void ScriptEditorDebugger::request_remote_objects(const TypedArray<uint64_t> &p_obj_ids, bool p_update_selection) {
 	ERR_FAIL_COND(p_obj_ids.is_empty());
-	Array msg;
-	msg.push_back(p_obj_ids.duplicate());
-	msg.push_back(p_update_selection);
+	Array msg = { p_obj_ids.duplicate(), p_update_selection };
 	_put_msg("scene:inspect_objects", msg);
 }
 
@@ -300,8 +286,7 @@ void ScriptEditorDebugger::clear_inspector(bool p_send_msg) {
 }
 
 void ScriptEditorDebugger::_remote_object_selected(ObjectID p_id) {
-	Array arr;
-	arr.append(p_id);
+	Array arr = { p_id };
 	emit_signal(SNAME("remote_objects_requested"), arr);
 }
 
@@ -596,11 +581,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	ERR_FAIL_COND_MSG(oe.deserialize(p_data) == false, "Failed to deserialize error message");
 
 	// Format time.
-	Array time_vals;
-	time_vals.push_back(oe.hr);
-	time_vals.push_back(oe.min);
-	time_vals.push_back(oe.sec);
-	time_vals.push_back(oe.msec);
+	Array time_vals = { oe.hr, oe.min, oe.sec, oe.msec };
 	bool e;
 	String time = String("%d:%02d:%02d:%03d").sprintf(time_vals, &e);
 
@@ -608,9 +589,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	bool source_is_project_file = oe.source_file.begins_with("res://");
 
 	// Metadata to highlight error line in scripts.
-	Array source_meta;
-	source_meta.push_back(oe.source_file);
-	source_meta.push_back(oe.source_line);
+	Array source_meta = { oe.source_file, oe.source_line };
 
 	// Create error tree to display above error or warning details.
 	TreeItem *r = error_tree->get_root();
@@ -710,9 +689,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	for (unsigned int i = 0; i < (unsigned int)oe.callstack.size(); i++) {
 		TreeItem *stack_trace = error_tree->create_item(error);
 
-		Array meta;
-		meta.push_back(infos[i].file);
-		meta.push_back(infos[i].line);
+		Array meta = { infos[i].file, infos[i].line };
 		stack_trace->set_metadata(0, meta);
 
 		if (i == 0) {
@@ -1068,8 +1045,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						transform.scale_basis(Size2(zoom, zoom));
 						transform.columns[2] = -offset * zoom;
 
-						Array msg;
-						msg.push_back(transform);
+						Array msg = { transform };
 						_put_msg("scene:transform_camera_2d", msg);
 					}
 
@@ -1078,8 +1054,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						Node3DEditorViewport *viewport = Node3DEditor::get_singleton()->get_last_used_viewport();
 						const Camera3D *cam = viewport->get_camera_3d();
 
-						Array msg;
-						msg.push_back(cam->get_camera_transform());
+						Array msg = { cam->get_camera_transform() };
 						if (cam->get_projection() == Camera3D::PROJECTION_ORTHOGONAL) {
 							msg.push_back(false);
 							msg.push_back(cam->get_size());
@@ -1266,8 +1241,7 @@ void ScriptEditorDebugger::stop() {
 }
 
 void ScriptEditorDebugger::_profiler_activate(bool p_enable, int p_type) {
-	Array msg_data;
-	msg_data.push_back(p_enable);
+	Array msg_data = { p_enable };
 	switch (p_type) {
 		case PROFILER_VISUAL:
 			_put_msg("profiler:visual", msg_data);
@@ -1277,11 +1251,9 @@ void ScriptEditorDebugger::_profiler_activate(bool p_enable, int p_type) {
 				// Clear old script signatures. (should we move all this into the profiler?)
 				profiler_signature.clear();
 				// Add max funcs options to request.
-				Array opts;
 				int max_funcs = EDITOR_GET("debugger/profiler_frame_max_functions");
 				bool include_native = EDITOR_GET("debugger/profile_native_calls");
-				opts.push_back(CLAMP(max_funcs, 16, 512));
-				opts.push_back(include_native);
+				Array opts = { CLAMP(max_funcs, 16, 512), include_native };
 				msg_data.push_back(opts);
 			}
 			_put_msg("profiler:servers", msg_data);
@@ -1323,8 +1295,7 @@ String ScriptEditorDebugger::get_var_value(const String &p_var) const {
 }
 
 void ScriptEditorDebugger::_resources_reimported(const PackedStringArray &p_resources) {
-	Array msg;
-	msg.push_back(p_resources);
+	Array msg = { p_resources };
 	_put_msg("scene:reload_cached_files", msg);
 }
 
@@ -1337,9 +1308,7 @@ int ScriptEditorDebugger::_get_node_path_cache(const NodePath &p_path) {
 	last_path_id++;
 
 	node_path_cache[p_path] = last_path_id;
-	Array msg;
-	msg.push_back(p_path);
-	msg.push_back(last_path_id);
+	Array msg = { p_path, last_path_id };
 	_put_msg("scene:live_node_path", msg);
 
 	return last_path_id;
@@ -1355,9 +1324,7 @@ int ScriptEditorDebugger::_get_res_path_cache(const String &p_path) {
 	last_path_id++;
 
 	res_path_cache[p_path] = last_path_id;
-	Array msg;
-	msg.push_back(p_path);
-	msg.push_back(last_path_id);
+	Array msg = { p_path, last_path_id };
 	_put_msg("scene:live_res_path", msg);
 
 	return last_path_id;
@@ -1381,9 +1348,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 		NodePath path = EditorNode::get_singleton()->get_edited_scene()->get_path_to(node);
 		int pathid = _get_node_path_cache(path);
 
-		Array msg;
-		msg.push_back(pathid);
-		msg.push_back(p_name);
+		Array msg = { pathid, p_name };
 		for (int i = 0; i < p_argcount; i++) {
 			//no pointers, sorry
 			msg.push_back(*p_args[i]);
@@ -1399,9 +1364,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
-		Array msg;
-		msg.push_back(pathid);
-		msg.push_back(p_name);
+		Array msg = { pathid, p_name };
 		for (int i = 0; i < p_argcount; i++) {
 			//no pointers, sorry
 			msg.push_back(*p_args[i]);
@@ -1426,17 +1389,11 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res = p_value;
 			if (res.is_valid() && !res->get_path().is_empty()) {
-				Array msg;
-				msg.push_back(pathid);
-				msg.push_back(p_property);
-				msg.push_back(res->get_path());
+				Array msg = { pathid, p_property, res->get_path() };
 				_put_msg("scene:live_node_prop_res", msg);
 			}
 		} else {
-			Array msg;
-			msg.push_back(pathid);
-			msg.push_back(p_property);
-			msg.push_back(p_value);
+			Array msg = { pathid, p_property, p_value };
 			_put_msg("scene:live_node_prop", msg);
 		}
 
@@ -1452,17 +1409,11 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res2 = p_value;
 			if (res2.is_valid() && !res2->get_path().is_empty()) {
-				Array msg;
-				msg.push_back(pathid);
-				msg.push_back(p_property);
-				msg.push_back(res2->get_path());
+				Array msg = { pathid, p_property, res2->get_path() };
 				_put_msg("scene:live_res_prop_res", msg);
 			}
 		} else {
-			Array msg;
-			msg.push_back(pathid);
-			msg.push_back(p_property);
-			msg.push_back(p_value);
+			Array msg = { pathid, p_property, p_value };
 			_put_msg("scene:live_res_prop", msg);
 		}
 
@@ -1508,8 +1459,7 @@ int ScriptEditorDebugger::get_stack_script_frame() const {
 bool ScriptEditorDebugger::request_stack_dump(const int &p_frame) {
 	ERR_FAIL_COND_V(!is_session_active() || p_frame < 0, false);
 
-	Array msg;
-	msg.push_back(p_frame);
+	Array msg = { p_frame };
 	_put_msg("get_stack_frame_vars", msg, debugging_thread_id);
 	return true;
 }
@@ -1553,8 +1503,7 @@ void ScriptEditorDebugger::_live_edit_clear() {
 void ScriptEditorDebugger::update_live_edit_root() {
 	NodePath np = EditorNode::get_editor_data().get_edited_scene_live_edit_root();
 
-	Array msg;
-	msg.push_back(np);
+	Array msg = { np };
 	if (EditorNode::get_singleton()->get_edited_scene()) {
 		msg.push_back(EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path());
 	} else {
@@ -1566,67 +1515,49 @@ void ScriptEditorDebugger::update_live_edit_root() {
 
 void ScriptEditorDebugger::live_debug_create_node(const NodePath &p_parent, const String &p_type, const String &p_name) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_parent);
-		msg.push_back(p_type);
-		msg.push_back(p_name);
+		Array msg = { p_parent, p_type, p_name };
 		_put_msg("scene:live_create_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_instantiate_node(const NodePath &p_parent, const String &p_path, const String &p_name) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_parent);
-		msg.push_back(p_path);
-		msg.push_back(p_name);
+		Array msg = { p_parent, p_path, p_name };
 		_put_msg("scene:live_instantiate_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_remove_node(const NodePath &p_at) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_at);
+		Array msg = { p_at };
 		_put_msg("scene:live_remove_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_remove_and_keep_node(const NodePath &p_at, ObjectID p_keep_id) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_at);
-		msg.push_back(p_keep_id);
+		Array msg = { p_at, p_keep_id };
 		_put_msg("scene:live_remove_and_keep_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_restore_node(ObjectID p_id, const NodePath &p_at, int p_at_pos) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_id);
-		msg.push_back(p_at);
-		msg.push_back(p_at_pos);
+		Array msg = { p_id, p_at, p_at_pos };
 		_put_msg("scene:live_restore_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_duplicate_node(const NodePath &p_at, const String &p_new_name) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_at);
-		msg.push_back(p_new_name);
+		Array msg = { p_at, p_new_name };
 		_put_msg("scene:live_duplicate_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_reparent_node(const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos) {
 	if (live_debug) {
-		Array msg;
-		msg.push_back(p_at);
-		msg.push_back(p_new_place);
-		msg.push_back(p_new_name);
-		msg.push_back(p_at_pos);
+		Array msg = { p_at, p_new_place, p_new_name, p_at_pos };
 		_put_msg("scene:live_reparent_node", msg);
 	}
 }
@@ -1636,8 +1567,7 @@ bool ScriptEditorDebugger::get_debug_mute_audio() const {
 }
 
 void ScriptEditorDebugger::set_debug_mute_audio(bool p_mute) {
-	Array msg;
-	msg.push_back(p_mute);
+	Array msg = { p_mute };
 	_put_msg("scene:debug_mute_audio", msg);
 	debug_mute_audio = p_mute;
 }
@@ -1647,19 +1577,17 @@ CameraOverride ScriptEditorDebugger::get_camera_override() const {
 }
 
 void ScriptEditorDebugger::set_camera_override(CameraOverride p_override) {
-	Array msg;
-	msg.push_back(p_override != CameraOverride::OVERRIDE_NONE);
-	msg.push_back(p_override == CameraOverride::OVERRIDE_EDITORS);
+	Array msg = {
+		p_override != CameraOverride::OVERRIDE_NONE,
+		p_override == CameraOverride::OVERRIDE_EDITORS
+	};
 	_put_msg("scene:override_cameras", msg);
 
 	camera_override = p_override;
 }
 
 void ScriptEditorDebugger::set_breakpoint(const String &p_path, int p_line, bool p_enabled) {
-	Array msg;
-	msg.push_back(p_path);
-	msg.push_back(p_line);
-	msg.push_back(p_enabled);
+	Array msg = { p_path, p_line, p_enabled };
 	_put_msg("breakpoint", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
 
 	TreeItem *path_item = breakpoints_tree->search_item_text(p_path);
@@ -1992,9 +1920,7 @@ void ScriptEditorDebugger::send_message(const String &p_message, const Array &p_
 }
 
 void ScriptEditorDebugger::toggle_profiler(const String &p_profiler, bool p_enable, const Array &p_data) {
-	Array msg_data;
-	msg_data.push_back(p_enable);
-	msg_data.append_array(p_data);
+	Array msg_data = { p_enable, p_data };
 	_put_msg("profiler:" + p_profiler, msg_data);
 }
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -1031,8 +1031,7 @@ void EditorResourcePicker::_gather_resources_to_duplicate(const Ref<Resource> p_
 	p_item->set_icon(0, EditorNode::get_singleton()->get_object_icon(p_resource.ptr()));
 	p_item->set_editable(0, true);
 
-	Array meta;
-	meta.append(p_resource);
+	Array meta = { p_resource };
 	p_item->set_metadata(0, meta);
 
 	if (!p_property_name.is_empty()) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -321,9 +321,7 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 			if (main_scene == file_metadata) {
 				file_item->set_custom_color(0, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
 			}
-			Array udata;
-			udata.push_back(tree_update_id);
-			udata.push_back(file_item);
+			Array udata = { tree_update_id, file_item };
 			EditorResourcePreview::get_singleton()->queue_resource_preview(file_metadata, this, "_tree_thumbnail_done", udata);
 		}
 	} else {
@@ -437,9 +435,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 		ti->set_metadata(0, favorite);
 
 		if (!favorite.ends_with("/")) {
-			Array udata;
-			udata.push_back(tree_update_id);
-			udata.push_back(ti);
+			Array udata = { tree_update_id, ti };
 			EditorResourcePreview::get_singleton()->queue_resource_preview(favorite, this, "_tree_thumbnail_done", udata);
 		}
 	}

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -512,8 +512,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 
 		String msg_temp;
 		if (num_connections >= 1) {
-			Array arr;
-			arr.push_back(num_connections);
+			Array arr = { num_connections };
 			msg_temp += TTRN("Node has one connection.", "Node has {num} connections.", num_connections).format(arr, "{num}");
 			if (num_groups >= 1) {
 				msg_temp += "\n";

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -118,9 +118,7 @@ int EditorImportPlugin::get_format_version() const {
 }
 
 void EditorImportPlugin::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options, int p_preset) const {
-	Array needed;
-	needed.push_back("name");
-	needed.push_back("default_value");
+	Array needed = { "name", "default_value" };
 	TypedArray<Dictionary> options;
 	if (GDVIRTUAL_CALL(_get_import_options, p_path, p_preset, options)) {
 		for (int i = 0; i < options.size(); i++) {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -240,8 +240,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	}
 
 	if (color_amount > 0) {
-		Array arr;
-		arr.push_back(color_amount);
+		Array arr = { color_amount };
 		select_colors_label->set_text(TTRN("1 color", "{num} colors", color_amount).format(arr, "{num}"));
 		select_all_colors_button->set_visible(true);
 		select_full_colors_button->set_visible(true);
@@ -254,8 +253,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	}
 
 	if (constant_amount > 0) {
-		Array arr;
-		arr.push_back(constant_amount);
+		Array arr = { constant_amount };
 		select_constants_label->set_text(TTRN("1 constant", "{num} constants", constant_amount).format(arr, "{num}"));
 		select_all_constants_button->set_visible(true);
 		select_full_constants_button->set_visible(true);
@@ -268,8 +266,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	}
 
 	if (font_amount > 0) {
-		Array arr;
-		arr.push_back(font_amount);
+		Array arr = { font_amount };
 		select_fonts_label->set_text(TTRN("1 font", "{num} fonts", font_amount).format(arr, "{num}"));
 		select_all_fonts_button->set_visible(true);
 		select_full_fonts_button->set_visible(true);
@@ -282,8 +279,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	}
 
 	if (font_size_amount > 0) {
-		Array arr;
-		arr.push_back(font_size_amount);
+		Array arr = { font_size_amount };
 		select_font_sizes_label->set_text(TTRN("1 font size", "{num} font sizes", font_size_amount).format(arr, "{num}"));
 		select_all_font_sizes_button->set_visible(true);
 		select_full_font_sizes_button->set_visible(true);
@@ -296,8 +292,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	}
 
 	if (icon_amount > 0) {
-		Array arr;
-		arr.push_back(icon_amount);
+		Array arr = { icon_amount };
 		select_icons_label->set_text(TTRN("1 icon", "{num} icons", icon_amount).format(arr, "{num}"));
 		select_all_icons_button->set_visible(true);
 		select_full_icons_button->set_visible(true);
@@ -312,8 +307,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	}
 
 	if (stylebox_amount > 0) {
-		Array arr;
-		arr.push_back(stylebox_amount);
+		Array arr = { stylebox_amount };
 		select_styleboxes_label->set_text(TTRN("1 stylebox", "{num} styleboxes", stylebox_amount).format(arr, "{num}"));
 		select_all_styleboxes_button->set_visible(true);
 		select_full_styleboxes_button->set_visible(true);
@@ -460,8 +454,7 @@ void ThemeItemImportTree::_update_total_selected(Theme::DataType p_data_type) {
 	if (count == 0) {
 		total_selected_items_label->hide();
 	} else {
-		Array arr;
-		arr.push_back(count);
+		Array arr = { count };
 		total_selected_items_label->set_text(TTRN("{num} currently selected", "{num} currently selected", count).format(arr, "{num}"));
 		total_selected_items_label->show();
 	}
@@ -756,9 +749,7 @@ void ThemeItemImportTree::_import_selected() {
 		// Arbitrary number of items to skip from reporting.
 		// Reduces the number of UI updates that this causes when copying large themes.
 		if (idx % 10 == 0) {
-			Array arr;
-			arr.push_back(idx + 1);
-			arr.push_back(selected_items.size());
+			Array arr = { idx + 1, selected_items.size() };
 			ProgressDialog::get_singleton()->task_step("import_theme_items", TTR("Importing items {n}/{n}").format(arr, "{n}"), idx);
 		}
 

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -220,8 +220,7 @@ void GenericTilePolygonEditor::_base_control_draw() {
 			color = color.darkened(0.3);
 		}
 		color.a = 0.5;
-		Vector<Color> v_color;
-		v_color.push_back(color);
+		Vector<Color> v_color = { color };
 		base_control->draw_polygon(polygon, v_color);
 
 		color.a = 0.7;
@@ -1483,8 +1482,7 @@ void TileDataOcclusionShapeEditor::draw_over_tile(CanvasItem *p_canvas_item, Tra
 	}
 	color.a *= 0.5;
 
-	Vector<Color> debug_occlusion_color;
-	debug_occlusion_color.push_back(color);
+	Vector<Color> debug_occlusion_color = { color };
 
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(p_canvas_item->get_canvas_item(), p_transform);
 	for (int i = 0; i < tile_data->get_occluder_polygons_count(occlusion_layer); i++) {
@@ -2065,14 +2063,12 @@ void TileDataTerrainsEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas
 		}
 
 		Vector2 end = p_transform.affine_inverse().xform(p_canvas_item->get_local_mouse_position());
-		Vector<Point2> mouse_pos_rect_polygon;
-		mouse_pos_rect_polygon.push_back(drag_start_pos);
-		mouse_pos_rect_polygon.push_back(Vector2(end.x, drag_start_pos.y));
-		mouse_pos_rect_polygon.push_back(end);
-		mouse_pos_rect_polygon.push_back(Vector2(drag_start_pos.x, end.y));
+		Vector<Point2> mouse_pos_rect_polygon = {
+			drag_start_pos, Vector2(end.x, drag_start_pos.y),
+			end, Vector2(drag_start_pos.x, end.y)
+		};
 
-		Vector<Color> color;
-		color.push_back(Color(1.0, 1.0, 1.0, 0.5));
+		Vector<Color> color = { Color(1.0, 1.0, 1.0, 0.5) };
 
 		p_canvas_item->draw_set_transform_matrix(p_transform);
 
@@ -2132,8 +2128,7 @@ void TileDataTerrainsEditor::forward_draw_over_alternatives(TileAtlasView *p_til
 				Transform2D xform;
 				xform.set_origin(position);
 
-				Vector<Color> color;
-				color.push_back(Color(1.0, 1.0, 1.0, 0.5));
+				Vector<Color> color = { Color(1.0, 1.0, 1.0, 0.5) };
 
 				Vector<Vector2> polygon = tile_set->get_terrain_polygon(terrain_set);
 				if (Geometry2D::is_point_in_polygon(xform.affine_inverse().xform(mouse_pos), polygon)) {
@@ -2548,11 +2543,10 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 						}
 					}
 
-					Vector<Point2> mouse_pos_rect_polygon;
-					mouse_pos_rect_polygon.push_back(drag_start_pos);
-					mouse_pos_rect_polygon.push_back(Vector2(mb->get_position().x, drag_start_pos.y));
-					mouse_pos_rect_polygon.push_back(mb->get_position());
-					mouse_pos_rect_polygon.push_back(Vector2(drag_start_pos.x, mb->get_position().y));
+					Vector<Point2> mouse_pos_rect_polygon = {
+						drag_start_pos, Vector2(mb->get_position().x, drag_start_pos.y),
+						mb->get_position(), Vector2(drag_start_pos.x, mb->get_position().y)
+					};
 
 					undo_redo->create_action(TTR("Painting Terrain"));
 					for (const TileMapCell &E : edited) {
@@ -3031,8 +3025,7 @@ void TileDataNavigationEditor::draw_over_tile(CanvasItem *p_canvas_item, Transfo
 			Color random_variation_color;
 			random_variation_color.set_hsv(color.get_h() + rand.random(-1.0, 1.0) * 0.05, color.get_s(), color.get_v() + rand.random(-1.0, 1.0) * 0.1);
 			random_variation_color.a = color.a;
-			Vector<Color> colors;
-			colors.push_back(random_variation_color);
+			Vector<Color> colors = { random_variation_color };
 
 			RenderingServer::get_singleton()->canvas_item_add_polygon(p_canvas_item->get_canvas_item(), vertices, colors);
 		}

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -4285,10 +4285,7 @@ void TileMapLayerEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 
 			if (!source || !source->has_tile(tile_atlas_coords) || !source->has_alternative_tile(tile_atlas_coords, tile_alternative_tile)) {
 				// Generate a random color from the hashed identifier of the tiles.
-				Array to_hash;
-				to_hash.push_back(tile_source_id);
-				to_hash.push_back(tile_atlas_coords);
-				to_hash.push_back(tile_alternative_tile);
+				Array to_hash = { tile_source_id, tile_atlas_coords, tile_alternative_tile };
 				uint32_t hash = RandomPCG(to_hash.hash()).rand();
 
 				Color color;

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1473,9 +1473,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 				undo_redo->add_do_method(tile_set_atlas_source, "move_tile_in_atlas", drag_start_tile_shape.position, drag_current_tile, tile_set_atlas_source->get_tile_size_in_atlas(drag_current_tile));
 				undo_redo->add_do_method(this, "_set_selection_from_array", _get_selection_as_array());
 				undo_redo->add_undo_method(tile_set_atlas_source, "move_tile_in_atlas", drag_current_tile, drag_start_tile_shape.position, drag_start_tile_shape.size);
-				Array array;
-				array.push_back(drag_start_tile_shape.position);
-				array.push_back(0);
+				Array array = { drag_start_tile_shape.position, 0 };
 				undo_redo->add_undo_method(this, "_set_selection_from_array", array);
 				undo_redo->commit_action(false);
 			}
@@ -1573,9 +1571,7 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 				undo_redo->add_do_method(tile_set_atlas_source, "move_tile_in_atlas", drag_start_tile_shape.position, drag_current_tile, tile_set_atlas_source->get_tile_size_in_atlas(drag_current_tile));
 				undo_redo->add_do_method(this, "_set_selection_from_array", _get_selection_as_array());
 				undo_redo->add_undo_method(tile_set_atlas_source, "move_tile_in_atlas", drag_current_tile, drag_start_tile_shape.position, drag_start_tile_shape.size);
-				Array array;
-				array.push_back(drag_start_tile_shape.position);
-				array.push_back(0);
+				Array array = { drag_start_tile_shape.position, 0 };
 				undo_redo->add_undo_method(this, "_set_selection_from_array", array);
 				undo_redo->commit_action(false);
 			}
@@ -1664,9 +1660,7 @@ void TileSetAtlasSourceEditor::_menu_option(int p_option) {
 		case TILE_CREATE: {
 			undo_redo->create_action(TTR("Create a tile"));
 			undo_redo->add_do_method(tile_set_atlas_source, "create_tile", menu_option_coords);
-			Array array;
-			array.push_back(menu_option_coords);
-			array.push_back(0);
+			Array array = { menu_option_coords, 0 };
 			undo_redo->add_do_method(this, "_set_selection_from_array", array);
 			undo_redo->add_undo_method(tile_set_atlas_source, "remove_tile", menu_option_coords);
 			undo_redo->add_undo_method(this, "_set_selection_from_array", _get_selection_as_array());
@@ -2803,11 +2797,9 @@ void EditorPropertyTilePolygon::_polygons_changed() {
 		}
 	} else {
 		// Multiple array of vertices or OccluderPolygon2D.
-		Vector<String> changed_properties;
-		Array values;
+		Vector<String> changed_properties = { count_property };
 		int count = generic_tile_polygon_editor->get_polygon_count();
-		changed_properties.push_back(count_property);
-		values.push_back(count);
+		Array values = { count };
 		for (int i = 0; i < count; i++) {
 			changed_properties.push_back(vformat(element_pattern, i));
 			if (base_type.is_empty()) {
@@ -2941,8 +2933,7 @@ bool EditorInspectorPluginTileData::parse_property(Object *p_object, const Varia
 		if (components[1] == "polygons_count") {
 			EditorPropertyTilePolygon *ep = memnew(EditorPropertyTilePolygon);
 			ep->setup_multiple_mode(vformat("physics_layer_%d/polygons", layer_index), vformat("physics_layer_%d/polygons_count", layer_index), vformat("physics_layer_%d/polygon_%%d/points", layer_index), "");
-			Vector<String> properties;
-			properties.push_back(p_path);
+			Vector<String> properties = { p_path };
 			int count = p_object->get(vformat("physics_layer_%d/polygons_count", layer_index));
 			for (int i = 0; i < count; i++) {
 				properties.push_back(vformat(vformat("physics_layer_%d/polygon_%d/points", layer_index, i)));

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -210,13 +210,14 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	Ref<FontVariation> japanese_font_bold = make_bold_font(japanese_font, embolden_strength, &fallbacks_bold);
 
 	if (OS::get_singleton()->has_feature("system_fonts")) {
-		PackedStringArray emoji_font_names;
-		emoji_font_names.push_back("Apple Color Emoji");
-		emoji_font_names.push_back("Segoe UI Emoji");
-		emoji_font_names.push_back("Noto Color Emoji");
-		emoji_font_names.push_back("Twitter Color Emoji");
-		emoji_font_names.push_back("OpenMoji");
-		emoji_font_names.push_back("EmojiOne Color");
+		PackedStringArray emoji_font_names = {
+			"Apple Color Emoji",
+			"Segoe UI Emoji",
+			"Noto Color Emoji",
+			"Twitter Color Emoji",
+			"OpenMoji",
+			"EmojiOne Color"
+		};
 		Ref<SystemFont> emoji_font = load_system_font(emoji_font_names, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, false);
 		fallbacks.push_back(emoji_font);
 		fallbacks_bold.push_back(emoji_font);
@@ -238,8 +239,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font);
+			TypedArray<Font> fallback_custom = { default_font };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		default_fc->set_base_font(custom_font);
@@ -255,8 +255,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, font_allow_msdf);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font_msdf);
+			TypedArray<Font> fallback_custom = { default_font_msdf };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		default_fc_msdf->set_base_font(custom_font);
@@ -272,16 +271,14 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	if (custom_font_path_bold.length() > 0 && dir->file_exists(custom_font_path_bold)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path_bold, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font_bold);
+			TypedArray<Font> fallback_custom = { default_font_bold };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		bold_fc->set_base_font(custom_font);
 	} else if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font_bold);
+			TypedArray<Font> fallback_custom = { default_font_bold };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		bold_fc->set_base_font(custom_font);
@@ -298,16 +295,14 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	if (custom_font_path_bold.length() > 0 && dir->file_exists(custom_font_path_bold)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path_bold, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, font_allow_msdf);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font_bold_msdf);
+			TypedArray<Font> fallback_custom = { default_font_bold_msdf };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		bold_fc_msdf->set_base_font(custom_font);
 	} else if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, font_allow_msdf);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font_bold_msdf);
+			TypedArray<Font> fallback_custom = { default_font_bold_msdf };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		bold_fc_msdf->set_base_font(custom_font);
@@ -324,8 +319,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	if (custom_font_path_source.length() > 0 && dir->file_exists(custom_font_path_source)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path_source, font_mono_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
 		{
-			TypedArray<Font> fallback_custom;
-			fallback_custom.push_back(default_font_mono);
+			TypedArray<Font> fallback_custom = { default_font_mono };
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		mono_fc->set_base_font(custom_font);

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -320,14 +320,10 @@ Error ENetConnection::_create(ENetAddress *p_address, int p_max_peers, int p_max
 }
 
 Array ENetConnection::_service(int p_timeout) {
-	Array out;
 	Event event;
 	Ref<ENetPacketPeer> peer;
 	EventType ret = service(p_timeout, event);
-	out.push_back(ret);
-	out.push_back(event.peer);
-	out.push_back(event.data);
-	out.push_back(event.channel_id);
+	Array out = { ret, event.peer, event.data, event.channel_id };
 	if (event.packet && event.peer.is_valid()) {
 		event.peer->_queue_packet(event.packet);
 	}

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1656,8 +1656,7 @@ void FBXDocument::_generate_scene_node(Ref<FBXState> p_state, const GLTFNodeInde
 	// Add the node we generated and set the owner to the scene root.
 	p_scene_parent->add_child(current_node, true);
 	if (current_node != p_scene_root) {
-		Array args;
-		args.append(p_scene_root);
+		Array args = { p_scene_root };
 		current_node->propagate_call(StringName("set_owner"), args);
 	}
 	current_node->set_transform(fbx_node->transform);
@@ -1744,8 +1743,7 @@ void FBXDocument::_generate_skeleton_bone_node(Ref<FBXState> p_state, const GLTF
 		// Add the node we generated and set the owner to the scene root.
 		p_scene_parent->add_child(current_node, true);
 		if (current_node != p_scene_root) {
-			Array args;
-			args.append(p_scene_root);
+			Array args = { p_scene_root };
 			current_node->propagate_call(StringName("set_owner"), args);
 		}
 		// Do not set transform here. Transform is already applied to our bone.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2697,8 +2697,7 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload
 }
 
 void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {
-	Array scripts;
-	scripts.push_back(p_script);
+	Array scripts = { p_script };
 	reload_scripts(scripts, p_soft_reload);
 }
 

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -189,7 +189,7 @@ void GDScriptCache::remove_script(const String &p_path) {
 
 	if (HashMap<String, Vector<ObjectID>>::Iterator E = singleton->abandoned_parser_map.find(p_path)) {
 		for (ObjectID parser_ref_id : E->value) {
-			Ref<GDScriptParserRef> parser_ref{ ObjectDB::get_instance(parser_ref_id) };
+			Ref<GDScriptParserRef> parser_ref = { ObjectDB::get_instance(parser_ref_id) };
 			if (parser_ref.is_valid()) {
 				parser_ref->clear();
 			}
@@ -460,7 +460,7 @@ void GDScriptCache::clear() {
 
 	for (const KeyValue<String, Vector<ObjectID>> &KV : singleton->abandoned_parser_map) {
 		for (ObjectID parser_ref_id : KV.value) {
-			Ref<GDScriptParserRef> parser_ref{ ObjectDB::get_instance(parser_ref_id) };
+			Ref<GDScriptParserRef> parser_ref = { ObjectDB::get_instance(parser_ref_id) };
 			if (parser_ref.is_valid()) {
 				parser_ref->clear();
 			}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3284,9 +3284,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 				*counter = Variant();
-
-				Array ref;
-				ref.push_back(*counter);
+				Array ref = { *counter };
 				Variant vref;
 				VariantInternal::initialize(&vref, Variant::ARRAY);
 				*VariantInternal::get_array(&vref) = ref;
@@ -3619,8 +3617,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Object *obj = *VariantInternal::get_object(container);
 #endif
 
-				Array ref;
-				ref.push_back(*counter);
+				Array ref = { *counter };
 				Variant vref;
 				VariantInternal::initialize(&vref, Variant::ARRAY);
 				*VariantInternal::get_array(&vref) = ref;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4404,12 +4404,8 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 
 		Dictionary mr;
 		{
-			Array arr;
 			const Color c = base_material->get_albedo().srgb_to_linear();
-			arr.push_back(c.r);
-			arr.push_back(c.g);
-			arr.push_back(c.b);
-			arr.push_back(c.a);
+			Array arr = { c.r, c.g, c.b, c.a };
 			mr["baseColorFactor"] = arr;
 		}
 		if (_image_format != "None") {
@@ -4615,10 +4611,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 
 		if (base_material->get_feature(BaseMaterial3D::FEATURE_EMISSION)) {
 			const Color c = base_material->get_emission().linear_to_srgb();
-			Array arr;
-			arr.push_back(c.r);
-			arr.push_back(c.g);
-			arr.push_back(c.b);
+			Array arr = { c.r, c.g, c.b };
 			d["emissiveFactor"] = arr;
 		}
 

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -150,9 +150,7 @@ void MultiplayerDebugger::BandwidthProfiler::tick(double p_frame_time, double p_
 		int incoming_bandwidth = bandwidth_usage(bandwidth_in, bandwidth_in_ptr);
 		int outgoing_bandwidth = bandwidth_usage(bandwidth_out, bandwidth_out_ptr);
 
-		Array arr;
-		arr.push_back(incoming_bandwidth);
-		arr.push_back(outgoing_bandwidth);
+		Array arr = { incoming_bandwidth, outgoing_bandwidth };
 		EngineDebugger::get_singleton()->send_message("multiplayer:bandwidth", arr);
 	}
 }
@@ -160,8 +158,7 @@ void MultiplayerDebugger::BandwidthProfiler::tick(double p_frame_time, double p_
 // RPCProfiler
 
 Array MultiplayerDebugger::RPCFrame::serialize() {
-	Array arr;
-	arr.push_back(infos.size() * 6);
+	Array arr = { infos.size() * 6 };
 	for (int i = 0; i < infos.size(); ++i) {
 		arr.push_back(uint64_t(infos[i].node));
 		arr.push_back(infos[i].node_path);
@@ -270,8 +267,7 @@ bool MultiplayerDebugger::SyncInfo::read_from_array(const Array &p_arr, int p_of
 }
 
 Array MultiplayerDebugger::ReplicationFrame::serialize() {
-	Array arr;
-	arr.push_back(infos.size() * 7);
+	Array arr = { infos.size() * 7 };
 	for (const KeyValue<ObjectID, SyncInfo> &E : infos) {
 		E.value.write_to_array(arr);
 	}

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -40,10 +40,11 @@
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneMultiplayer::_profile_bandwidth(const String &p_what, int p_value) {
 	if (EngineDebugger::is_profiling("multiplayer:bandwidth")) {
-		Array values;
-		values.push_back(p_what);
-		values.push_back(OS::get_singleton()->get_ticks_msec());
-		values.push_back(p_value);
+		Array values = {
+			p_what,
+			OS::get_singleton()->get_ticks_msec(),
+			p_value
+		};
 		EngineDebugger::profiler_add_frame_data("multiplayer:bandwidth", values);
 	}
 }

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -43,10 +43,7 @@
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneReplicationInterface::_profile_node_data(const String &p_what, ObjectID p_id, int p_size) {
 	if (EngineDebugger::is_profiling("multiplayer:replication")) {
-		Array values;
-		values.push_back(p_what);
-		values.push_back(p_id);
-		values.push_back(p_size);
+		Array values = { p_what, p_id, p_size };
 		EngineDebugger::profiler_add_frame_data("multiplayer:replication", values);
 	}
 }

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -54,10 +54,7 @@
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneRPCInterface::_profile_node_data(const String &p_what, ObjectID p_id, int p_size) {
 	if (EngineDebugger::is_profiling("multiplayer:rpc")) {
-		Array values;
-		values.push_back(p_what);
-		values.push_back(p_id);
-		values.push_back(p_size);
+		Array values = { p_what, p_id, p_size };
 		EngineDebugger::profiler_add_frame_data("multiplayer:rpc", values);
 	}
 }

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -299,8 +299,7 @@ String OpenXRAPI::get_error_string(XrResult result) const {
 	}
 
 	if (instance == XR_NULL_HANDLE) {
-		Array args;
-		args.push_back(Variant(result));
+		Array args = { Variant(result) };
 		return String("Error code {0}").format(args);
 	}
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -236,10 +236,11 @@ Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_prese
 	replaces["___GODOT_ENSURE_CROSSORIGIN_ISOLATION_HEADERS___"] = ensure_crossorigin_isolation_headers ? "true" : "false";
 
 	// Files cached during worker install.
-	Array cache_files;
-	cache_files.push_back(name + ".html");
-	cache_files.push_back(name + ".js");
-	cache_files.push_back(name + ".offline.html");
+	Array cache_files = {
+		name + ".html",
+		name + ".js",
+		name + ".offline.html"
+	};
 	if (p_preset->get("html/export_icon")) {
 		cache_files.push_back(name + ".icon.png");
 		cache_files.push_back(name + ".apple-touch-icon.png");
@@ -250,9 +251,10 @@ Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_prese
 	replaces["___GODOT_CACHE___"] = Variant(cache_files).to_json_string();
 
 	// Heavy files that are cached on demand.
-	Array opt_cache_files;
-	opt_cache_files.push_back(name + ".wasm");
-	opt_cache_files.push_back(name + ".pck");
+	Array opt_cache_files = {
+		name + ".wasm",
+		name + ".pck"
+	};
 	if (extensions) {
 		opt_cache_files.push_back(name + ".side.wasm");
 		for (int i = 0; i < p_shared_objects.size(); i++) {

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -321,9 +321,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 					// Random animation offset.
 					real_t random_animation_offset = 0.0;
 					if (atlas_source->get_tile_animation_mode(cell_data.cell.get_atlas_coords()) != TileSetAtlasSource::TILE_ANIMATION_MODE_DEFAULT) {
-						Array to_hash;
-						to_hash.push_back(local_tile_pos);
-						to_hash.push_back(get_instance_id()); // Use instance id as a random hash
+						Array to_hash = { local_tile_pos, get_instance_id() }; // Use instance id as a random hash
 						random_animation_offset = RandomPCG(to_hash.hash()).randf();
 					}
 
@@ -652,10 +650,7 @@ void TileMapLayer::_rendering_draw_cell_debug(const RID &p_canvas_item, const Ve
 				Vector2i grid_size = atlas_source->get_atlas_grid_size();
 				if (atlas_source->get_runtime_texture().is_null() || c.get_atlas_coords().x >= grid_size.x || c.get_atlas_coords().y >= grid_size.y) {
 					// Generate a random color from the hashed values of the tiles.
-					Array to_hash;
-					to_hash.push_back(c.source_id);
-					to_hash.push_back(c.get_atlas_coords());
-					to_hash.push_back(c.alternative_tile);
+					Array to_hash = { c.source_id, c.get_atlas_coords(), c.alternative_tile };
 					uint32_t hash = RandomPCG(to_hash.hash()).rand();
 
 					Color color;
@@ -1513,9 +1508,7 @@ void TileMapLayer::_scenes_draw_cell_debug(const RID &p_canvas_item, const Vecto
 		if (scenes_collection_source) {
 			if (scenes_collection_source->get_scene_tile_scene(c.alternative_tile).is_null() || scenes_collection_source->get_scene_tile_display_placeholder(c.alternative_tile)) {
 				// Generate a random color from the hashed values of the tiles.
-				Array to_hash;
-				to_hash.push_back(c.source_id);
-				to_hash.push_back(c.alternative_tile);
+				Array to_hash = { c.source_id, c.alternative_tile };
 				uint32_t hash = RandomPCG(to_hash.hash()).rand();
 
 				Color color;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -293,8 +293,7 @@ Dictionary LightmapGIData::_get_probe_data() const {
 
 #ifndef DISABLE_DEPRECATED
 void LightmapGIData::set_light_texture(const Ref<TextureLayered> &p_light_texture) {
-	TypedArray<TextureLayered> arr;
-	arr.append(p_light_texture);
+	TypedArray<TextureLayered> arr = { p_light_texture };
 	set_lightmap_textures(arr);
 }
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -603,10 +603,7 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 
 		Ref<Resource> res = var;
 
-		Array prop;
-		prop.push_back(pi.name);
-		prop.push_back(pi.type);
-
+		Array prop = { pi.name, pi.type };
 		PropertyHint hint = pi.hint;
 		String hint_string = pi.hint_string;
 		if (res.is_valid() && !res->get_path().is_empty()) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -56,18 +56,10 @@ Dictionary Control::_edit_get_state() const {
 	s["scale"] = get_scale();
 	s["pivot"] = get_pivot_offset();
 
-	Array anchors;
-	anchors.push_back(get_anchor(SIDE_LEFT));
-	anchors.push_back(get_anchor(SIDE_TOP));
-	anchors.push_back(get_anchor(SIDE_RIGHT));
-	anchors.push_back(get_anchor(SIDE_BOTTOM));
+	Array anchors = { get_anchor(SIDE_LEFT), get_anchor(SIDE_TOP), get_anchor(SIDE_RIGHT), get_anchor(SIDE_BOTTOM) };
 	s["anchors"] = anchors;
 
-	Array offsets;
-	offsets.push_back(get_offset(SIDE_LEFT));
-	offsets.push_back(get_offset(SIDE_TOP));
-	offsets.push_back(get_offset(SIDE_RIGHT));
-	offsets.push_back(get_offset(SIDE_BOTTOM));
+	Array offsets = { get_offset(SIDE_LEFT), get_offset(SIDE_TOP), get_offset(SIDE_RIGHT), get_offset(SIDE_BOTTOM) };
 	s["offsets"] = offsets;
 
 	s["layout_mode"] = _get_layout_mode();

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -226,9 +226,7 @@ void ViewPanner::set_force_drag(bool p_force) {
 }
 
 ViewPanner::ViewPanner() {
-	Array inputs;
-	inputs.append(InputEventKey::create_reference(Key::SPACE));
-
+	Array inputs = { InputEventKey::create_reference(Key::SPACE) };
 	pan_view_shortcut.instantiate();
 	pan_view_shortcut->set_events(inputs);
 }

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -67,9 +67,7 @@ Array ResourcePreloader::_get_resources() const {
 		i++;
 	}
 
-	Array res;
-	res.push_back(names);
-	res.push_back(arr);
+	Array res = { names, arr };
 	return res;
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1827,9 +1827,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 #ifdef DEBUG_ENABLED
 			if (EngineDebugger::get_singleton()) {
-				Array arr;
-				arr.push_back(gui.mouse_focus->get_path());
-				arr.push_back(gui.mouse_focus->get_class());
+				Array arr = { gui.mouse_focus->get_path(), gui.mouse_focus->get_class() };
 				EngineDebugger::get_singleton()->send_message("scene:click_ctrl", arr);
 			}
 #endif

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -310,8 +310,7 @@ void Window::set_title(const String &p_title) {
 
 #ifdef DEBUG_ENABLED
 	if (EngineDebugger::get_singleton() && window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
-		Array arr;
-		arr.push_back(tr_title);
+		Array arr = { tr_title };
 		EngineDebugger::get_singleton()->send_message("window:title", arr);
 	}
 #endif

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -305,8 +305,7 @@ void TileSet::TerrainsPattern::from_array(Array p_terrains) {
 }
 
 Array TileSet::TerrainsPattern::as_array() const {
-	Array output;
-	output.push_back(get_terrain());
+	Array output = { get_terrain() };
 	for (int i = 0; i < TileSet::CELL_NEIGHBOR_MAX; i++) {
 		if (is_valid_bit[i]) {
 			output.push_back(bits[i]);
@@ -1177,42 +1176,26 @@ void TileSet::set_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_f
 	ERR_FAIL_COND(p_source_from == TileSet::INVALID_SOURCE || p_source_to == TileSet::INVALID_SOURCE);
 	ERR_FAIL_COND(p_coords_from == TileSetSource::INVALID_ATLAS_COORDS || p_coords_to == TileSetSource::INVALID_ATLAS_COORDS);
 
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-
-	Array to;
-	to.push_back(p_source_to);
-	to.push_back(p_coords_to);
-
+	Array from = { p_source_from, p_coords_from };
+	Array to = { p_source_to, p_coords_to };
 	coords_level_proxies[from] = to;
 
 	emit_changed();
 }
 
 Array TileSet::get_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from) {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-
+	Array from = { p_source_from, p_coords_from };
 	ERR_FAIL_COND_V(!coords_level_proxies.has(from), Array());
-
 	return coords_level_proxies[from];
 }
 
 bool TileSet::has_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from) {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-
+	Array from = { p_source_from, p_coords_from };
 	return coords_level_proxies.has(from);
 }
 
 void TileSet::remove_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from) {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-
+	Array from = { p_source_from, p_coords_from };
 	ERR_FAIL_COND(!coords_level_proxies.has(from));
 
 	coords_level_proxies.erase(from);
@@ -1224,47 +1207,27 @@ void TileSet::set_alternative_level_tile_proxy(int p_source_from, Vector2i p_coo
 	ERR_FAIL_COND(p_source_from == TileSet::INVALID_SOURCE || p_source_to == TileSet::INVALID_SOURCE);
 	ERR_FAIL_COND(p_coords_from == TileSetSource::INVALID_ATLAS_COORDS || p_coords_to == TileSetSource::INVALID_ATLAS_COORDS);
 
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-	from.push_back(p_alternative_from);
-
-	Array to;
-	to.push_back(p_source_to);
-	to.push_back(p_coords_to);
-	to.push_back(p_alternative_to);
-
+	Array from = { p_source_from, p_coords_from, p_alternative_from };
+	Array to = { p_source_to, p_coords_to, p_alternative_to };
 	alternative_level_proxies[from] = to;
 
 	emit_changed();
 }
 
 Array TileSet::get_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-	from.push_back(p_alternative_from);
-
+	Array from = { p_source_from, p_coords_from, p_alternative_from };
 	ERR_FAIL_COND_V(!alternative_level_proxies.has(from), Array());
 
 	return alternative_level_proxies[from];
 }
 
 bool TileSet::has_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-	from.push_back(p_alternative_from);
-
+	Array from = { p_source_from, p_coords_from, p_alternative_from };
 	return alternative_level_proxies.has(from);
 }
 
 void TileSet::remove_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-	from.push_back(p_alternative_from);
-
+	Array from = { p_source_from, p_coords_from, p_alternative_from };
 	ERR_FAIL_COND(!alternative_level_proxies.has(from));
 
 	alternative_level_proxies.erase(from);
@@ -1306,10 +1269,7 @@ Array TileSet::get_alternative_level_tile_proxies() const {
 }
 
 Array TileSet::map_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) const {
-	Array from;
-	from.push_back(p_source_from);
-	from.push_back(p_coords_from);
-	from.push_back(p_alternative_from);
+	Array from = { p_source_from, p_coords_from, p_alternative_from };
 
 	// Check if the tile is valid, and if so, don't map the tile and return the input.
 	if (has_source(p_source_from)) {
@@ -1334,17 +1294,11 @@ Array TileSet::map_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_a
 
 	// Source matches.
 	if (source_level_proxies.has(p_source_from)) {
-		Array output;
-		output.push_back(source_level_proxies[p_source_from]);
-		output.push_back(p_coords_from);
-		output.push_back(p_alternative_from);
+		Array output = { source_level_proxies[p_source_from], p_coords_from, p_alternative_from };
 		return output;
 	}
 
-	Array output;
-	output.push_back(p_source_from);
-	output.push_back(p_coords_from);
-	output.push_back(p_alternative_from);
+	Array output = { p_source_from, p_coords_from, p_alternative_from };
 	return output;
 }
 
@@ -3423,15 +3377,8 @@ void TileSet::_compatibility_conversion() {
 					}
 
 					// Add to the mapping.
-					Array key_array;
-					key_array.push_back(flip_h);
-					key_array.push_back(flip_v);
-					key_array.push_back(transpose);
-
-					Array value_array;
-					value_array.push_back(source_id);
-					value_array.push_back(coords);
-					value_array.push_back(alternative_tile);
+					Array key_array = { flip_h, flip_v, transpose };
+					Array value_array = { source_id, coords, alternative_tile };
 
 					if (!compatibility_tilemap_mapping.has(E.key)) {
 						compatibility_tilemap_mapping[E.key] = RBMap<Array, Array>();
@@ -3539,16 +3486,8 @@ void TileSet::_compatibility_conversion() {
 							}
 
 							// Add to the mapping.
-							Array key_array;
-							key_array.push_back(coords);
-							key_array.push_back(flip_h);
-							key_array.push_back(flip_v);
-							key_array.push_back(transpose);
-
-							Array value_array;
-							value_array.push_back(source_id);
-							value_array.push_back(coords);
-							value_array.push_back(alternative_tile);
+							Array key_array = { coords, flip_h, flip_v, transpose };
+							Array value_array = { source_id, coords, alternative_tile };
 
 							if (!compatibility_tilemap_mapping.has(E.key)) {
 								compatibility_tilemap_mapping[E.key] = RBMap<Array, Array>();
@@ -3673,10 +3612,11 @@ void TileSet::_compatibility_conversion() {
 }
 
 Array TileSet::compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool p_flip_h, bool p_flip_v, bool p_transpose) {
-	Array cannot_convert_array;
-	cannot_convert_array.push_back(TileSet::INVALID_SOURCE);
-	cannot_convert_array.push_back(TileSetAtlasSource::INVALID_ATLAS_COORDS);
-	cannot_convert_array.push_back(TileSetAtlasSource::INVALID_TILE_ALTERNATIVE);
+	Array cannot_convert_array = {
+		TileSet::INVALID_SOURCE,
+		TileSetAtlasSource::INVALID_ATLAS_COORDS,
+		TileSetAtlasSource::INVALID_TILE_ALTERNATIVE
+	};
 
 	if (!compatibility_tilemap_mapping.has(p_tile_id)) {
 		return cannot_convert_array;
@@ -3685,21 +3625,14 @@ Array TileSet::compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool 
 	int tile_mode = compatibility_tilemap_mapping_tile_modes[p_tile_id];
 	switch (tile_mode) {
 		case COMPATIBILITY_TILE_MODE_SINGLE_TILE: {
-			Array a;
-			a.push_back(p_flip_h);
-			a.push_back(p_flip_v);
-			a.push_back(p_transpose);
+			Array a = { p_flip_h, p_flip_v, p_transpose };
 			return compatibility_tilemap_mapping[p_tile_id][a];
 		}
 		case COMPATIBILITY_TILE_MODE_AUTO_TILE:
 			return cannot_convert_array;
 			break;
 		case COMPATIBILITY_TILE_MODE_ATLAS_TILE: {
-			Array a;
-			a.push_back(p_coords);
-			a.push_back(p_flip_h);
-			a.push_back(p_flip_v);
-			a.push_back(p_transpose);
+			Array a = { p_coords, p_flip_h, p_flip_v, p_transpose };
 			return compatibility_tilemap_mapping[p_tile_id][a];
 		}
 		default:

--- a/scene/resources/2d/world_boundary_shape_2d.cpp
+++ b/scene/resources/2d/world_boundary_shape_2d.cpp
@@ -49,9 +49,7 @@ bool WorldBoundaryShape2D::_edit_is_selected_on_click(const Point2 &p_point, dou
 }
 
 void WorldBoundaryShape2D::_update_shape() {
-	Array arr;
-	arr.push_back(normal);
-	arr.push_back(distance);
+	Array arr = { normal, distance };
 	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), arr);
 	emit_changed();
 }

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -42,8 +42,7 @@
 Array ServersDebugger::ResourceUsage::serialize() {
 	infos.sort();
 
-	Array arr;
-	arr.push_back(infos.size() * 4);
+	Array arr = { infos.size() * 4 };
 	for (const ResourceInfo &E : infos) {
 		arr.push_back(E.path);
 		arr.push_back(E.format);
@@ -73,9 +72,7 @@ bool ServersDebugger::ResourceUsage::deserialize(const Array &p_arr) {
 }
 
 Array ServersDebugger::ScriptFunctionSignature::serialize() {
-	Array arr;
-	arr.push_back(name);
-	arr.push_back(id);
+	Array arr = { name, id };
 	return arr;
 }
 
@@ -88,13 +85,7 @@ bool ServersDebugger::ScriptFunctionSignature::deserialize(const Array &p_arr) {
 }
 
 Array ServersDebugger::ServersProfilerFrame::serialize() {
-	Array arr;
-	arr.push_back(frame_number);
-	arr.push_back(frame_time);
-	arr.push_back(process_time);
-	arr.push_back(physics_time);
-	arr.push_back(physics_frame_time);
-	arr.push_back(script_time);
+	Array arr = { frame_number, frame_time, process_time, physics_time, physics_frame_time, script_time };
 
 	arr.push_back(servers.size());
 	for (const ServerInfo &s : servers) {
@@ -163,9 +154,7 @@ bool ServersDebugger::ServersProfilerFrame::deserialize(const Array &p_arr) {
 }
 
 Array ServersDebugger::VisualProfilerFrame::serialize() {
-	Array arr;
-	arr.push_back(frame_number);
-	arr.push_back(areas.size() * 3);
+	Array arr = { frame_number, areas.size() * 3 };
 	for (int i = 0; i < areas.size(); i++) {
 		arr.push_back(areas[i].name);
 		arr.push_back(areas[i].cpu_msec);
@@ -372,9 +361,10 @@ public:
 		RS::get_singleton()->set_frame_profiling_enabled(p_enable);
 
 		// Send hardware information from the remote device so that it's accurate for remote debugging.
-		Array hardware_info;
-		hardware_info.push_back(OS::get_singleton()->get_processor_name());
-		hardware_info.push_back(RenderingServer::get_singleton()->get_video_adapter_name());
+		Array hardware_info = {
+			OS::get_singleton()->get_processor_name(),
+			RenderingServer::get_singleton()->get_video_adapter_name()
+		};
 		EngineDebugger::get_singleton()->send_message("visual:hardware_info", hardware_info);
 	}
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -309,12 +309,8 @@ void RendererSceneRenderRD::_process_compositor_effects(RS::CompositorEffectCall
 	Vector<RID> re_rids = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type, true);
 
 	for (RID rid : re_rids) {
-		Array arr;
 		Callable callback = comp_storage->compositor_effect_get_callback(rid);
-
-		arr.push_back(p_callback_type);
-		arr.push_back(p_render_data);
-
+		Array arr = { p_callback_type, p_render_data };
 		callback.callv(arr);
 	}
 }

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -325,9 +325,7 @@ RID RenderSceneBuffersRD::create_texture_from_format(const StringName &p_context
 	named_texture.is_unique = p_unique;
 	named_texture.texture = RD::get_singleton()->texture_create(p_texture_format, p_view);
 
-	Array arr;
-	arr.push_back(p_context);
-	arr.push_back(p_texture_name);
+	Array arr = { p_context, p_texture_name };
 	RD::get_singleton()->set_resource_name(named_texture.texture, String("RenderBuffer {0}/{1}").format(arr));
 
 	update_sizes(named_texture);
@@ -366,9 +364,7 @@ RID RenderSceneBuffersRD::create_texture_view(const StringName &p_context, const
 
 	view_texture.texture = RD::get_singleton()->texture_create_shared(p_view, named_texture.texture);
 
-	Array arr;
-	arr.push_back(p_context);
-	arr.push_back(p_view_name);
+	Array arr = { p_context, p_view_name };
 	RD::get_singleton()->set_resource_name(view_texture.texture, String("RenderBuffer View {0}/{1}").format(arr));
 
 	update_sizes(named_texture);
@@ -446,18 +442,19 @@ RID RenderSceneBuffersRD::get_texture_slice_view(const StringName &p_context, co
 	RID &slice = named_texture.slices[slice_key];
 	slice = RD::get_singleton()->texture_create_shared_from_slice(p_view, named_texture.texture, p_layer, p_mipmap, p_mipmaps, p_layers > 1 ? RD::TEXTURE_SLICE_2D_ARRAY : RD::TEXTURE_SLICE_2D, p_layers);
 
-	Array arr;
-	arr.push_back(p_context);
-	arr.push_back(p_texture_name);
-	arr.push_back(itos(p_layer));
-	arr.push_back(itos(p_layers));
-	arr.push_back(itos(p_mipmap));
-	arr.push_back(itos(p_mipmaps));
-	arr.push_back(itos(p_view.format_override));
-	arr.push_back(itos(p_view.swizzle_r));
-	arr.push_back(itos(p_view.swizzle_g));
-	arr.push_back(itos(p_view.swizzle_b));
-	arr.push_back(itos(p_view.swizzle_a));
+	Array arr = {
+		p_context,
+		p_texture_name,
+		itos(p_layer),
+		itos(p_layers),
+		itos(p_mipmap),
+		itos(p_mipmaps),
+		itos(p_view.format_override),
+		itos(p_view.swizzle_r),
+		itos(p_view.swizzle_g),
+		itos(p_view.swizzle_b),
+		itos(p_view.swizzle_a)
+	};
 	RD::get_singleton()->set_resource_name(slice, String("RenderBuffer {0}/{1}, layer {2}/{3}, mipmap {4}/{5}, view {6}/{7}/{8}/{9}/{10}").format(arr));
 
 	// and return our slice

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -218,7 +218,6 @@ void XRInterface::trigger_haptic_pulse(const String &p_action_name, const String
 }
 
 Array XRInterface::get_supported_environment_blend_modes() {
-	Array default_blend_modes;
-	default_blend_modes.push_back(XR_ENV_BLEND_MODE_OPAQUE);
+	Array default_blend_modes = { XR_ENV_BLEND_MODE_OPAQUE };
 	return default_blend_modes;
 }

--- a/tests/core/input/test_input_event.h
+++ b/tests/core/input/test_input_event.h
@@ -43,10 +43,8 @@ TEST_CASE("[InputEvent] Signal is emitted when device is changed") {
 	input_event.instantiate();
 
 	SIGNAL_WATCH(*input_event, CoreStringName(changed));
-	Array args1;
-	Array empty_args;
-	empty_args.push_back(args1);
 
+	Array empty_args = { {} };
 	input_event->set_device(1);
 
 	SIGNAL_CHECK("changed", empty_args);

--- a/tests/core/input/test_shortcut.h
+++ b/tests/core/input/test_shortcut.h
@@ -60,10 +60,7 @@ TEST_CASE("[Shortcut] Setting and getting an event should result in the same eve
 	// Cast to InputEvent so the internal code recognizes the objects.
 	Ref<InputEvent> e1 = k1;
 	Ref<InputEvent> e2 = k2;
-
-	Array input_array;
-	input_array.append(e1);
-	input_array.append(e2);
+	Array input_array = { e1, e2 };
 
 	Shortcut s;
 	s.set_events(input_array);
@@ -131,8 +128,7 @@ TEST_CASE("[Shortcut] 'matches_event' should correctly match the same event") {
 	Ref<InputEvent> e_different = different;
 	Ref<InputEvent> e_copy = copy;
 
-	Array a;
-	a.append(e_original);
+	Array a = { e_original };
 	Shortcut s;
 	s.set_events(a);
 
@@ -154,9 +150,7 @@ TEST_CASE("[Shortcut] 'get_as_text' text representation should be correct") {
 	different->set_keycode(Key::ESCAPE);
 
 	Ref<InputEvent> key_event1 = same;
-
-	Array a;
-	a.append(key_event1);
+	Array a = { key_event1 };
 	Shortcut s;
 	s.set_events(a);
 
@@ -175,17 +169,14 @@ TEST_CASE("[Shortcut] Event validity should be correctly checked.") {
 	Ref<InputEvent> valid_event = valid;
 	Ref<InputEvent> invalid_event = invalid;
 
-	Array a;
-	a.append(invalid_event);
-	a.append(valid_event);
+	Array a = { invalid_event, valid_event };
 
 	Shortcut s;
 	s.set_events(a);
 
 	CHECK(s.has_valid_event() == true);
 
-	Array b;
-	b.append(invalid_event);
+	Array b = { invalid_event };
 
 	Shortcut shortcut_with_invalid_event;
 	shortcut_with_invalid_event.set_events(b);
@@ -213,13 +204,8 @@ TEST_CASE("[Shortcut] Equal arrays should be recognized as such.") {
 	Array same_as_same;
 	same_as_same.append(key_event1);
 
-	Array different1;
-	different1.append(key_event2);
-
-	Array different2;
-	different2.append(key_event1);
-	different2.append(key_event2);
-
+	Array different1 = { key_event2 };
+	Array different2 = { key_event1, key_event2 };
 	Array different3;
 
 	Shortcut s;

--- a/tests/core/io/test_http_client.h
+++ b/tests/core/io/test_http_client.h
@@ -58,10 +58,7 @@ TEST_CASE("[HTTPClient] query_string_from_dict") {
 	Dictionary dict2;
 	dict2["key1"] = "value";
 	dict2["key2"] = 123;
-	Array values;
-	values.push_back(1);
-	values.push_back(2);
-	values.push_back(3);
+	Array values = { 1, 2, 3 };
 	dict2["key3"] = values;
 	dict2["key4"] = Variant();
 	String multiple_keys = client->query_string_from_dict(dict2);

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -152,15 +152,7 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 
 	JSON json;
 
-	TypedArray<String> valid_escapes;
-	valid_escapes.push_back("\";\"");
-	valid_escapes.push_back("\\;\\");
-	valid_escapes.push_back("/;/");
-	valid_escapes.push_back("b;\b");
-	valid_escapes.push_back("f;\f");
-	valid_escapes.push_back("n;\n");
-	valid_escapes.push_back("r;\r");
-	valid_escapes.push_back("t;\t");
+	TypedArray<String> valid_escapes = { "\";\"", "\\;\\", "/;/", "b;\b", "f;\f", "n;\n", "r;\r", "t;\t" };
 
 	SUBCASE("Basic valid escape sequences") {
 		for (int i = 0; i < valid_escapes.size(); i++) {

--- a/tests/core/io/test_json_native.h
+++ b/tests/core/io/test_json_native.h
@@ -161,25 +161,13 @@ TEST_CASE("[JSON][Native] Conversion between native and JSON formats") {
 
 	// `Array`.
 
-	Array arr;
-	arr.push_back(true);
-	arr.push_back(1);
-	arr.push_back("abc");
-
+	Array arr = { true, 1, "abc" };
 	test(arr, R"([true,"i:1","s:abc"])");
 
-	TypedArray<int64_t> int_arr;
-	int_arr.push_back(1);
-	int_arr.push_back(2);
-	int_arr.push_back(3);
-
+	TypedArray<int64_t> int_arr = { 1, 2, 3 };
 	test(int_arr, R"({"type":"Array","elem_type":"int","args":["i:1","i:2","i:3"]})");
 
-	Array arr2;
-	arr2.push_back(1);
-	arr2.push_back(res);
-	arr2.push_back(9);
-
+	Array arr2 = { 1, res, 9 };
 	const String arr2_repr = vformat(R"(["i:1",%s,"i:9"])", res_repr);
 
 	test(arr2, arr2_repr, true);
@@ -188,9 +176,7 @@ TEST_CASE("[JSON][Native] Conversion between native and JSON formats") {
 	CHECK(decode(arr2_repr).get_construct_string() == "[1, null, 9]");
 	ERR_PRINT_ON;
 
-	TypedArray<Resource> res_arr;
-	res_arr.push_back(res);
-
+	TypedArray<Resource> res_arr = { res };
 	const String res_arr_repr = vformat(R"({"type":"Array","elem_type":"Resource","args":[%s]})", res_repr);
 
 	test(res_arr, res_arr_repr, true);

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -321,15 +321,11 @@ TEST_CASE("[Expression] Boolean expressions") {
 TEST_CASE("[Expression] Expressions with variables") {
 	Expression expression;
 
-	PackedStringArray parameter_names;
-	parameter_names.push_back("foo");
-	parameter_names.push_back("bar");
+	PackedStringArray parameter_names = { "foo", "bar" };
 	CHECK_MESSAGE(
 			expression.parse("foo + bar + 50", parameter_names) == OK,
 			"The expression should parse successfully.");
-	Array values;
-	values.push_back(60);
-	values.push_back(20);
+	Array values = { 60, 20 };
 	CHECK_MESSAGE(
 			int(expression.execute(values)) == 130,
 			"The expression should return the expected value.");
@@ -340,9 +336,7 @@ TEST_CASE("[Expression] Expressions with variables") {
 	CHECK_MESSAGE(
 			expression.parse("foo + bar + 50", parameter_names_invalid) == OK,
 			"The expression should parse successfully.");
-	Array values_invalid;
-	values_invalid.push_back(60);
-	values_invalid.push_back(20);
+	Array values_invalid = { 60, 20 };
 	// Invalid parameters will parse successfully but print an error message when executing.
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
@@ -351,31 +345,21 @@ TEST_CASE("[Expression] Expressions with variables") {
 	ERR_PRINT_ON;
 
 	// Mismatched argument count (more values than parameters).
-	PackedStringArray parameter_names_mismatch;
-	parameter_names_mismatch.push_back("foo");
-	parameter_names_mismatch.push_back("bar");
+	PackedStringArray parameter_names_mismatch = { "foo", "bar" };
 	CHECK_MESSAGE(
 			expression.parse("foo + bar + 50", parameter_names_mismatch) == OK,
 			"The expression should parse successfully.");
-	Array values_mismatch;
-	values_mismatch.push_back(60);
-	values_mismatch.push_back(20);
-	values_mismatch.push_back(110);
+	Array values_mismatch = { 60, 20, 110 };
 	CHECK_MESSAGE(
 			int(expression.execute(values_mismatch)) == 130,
 			"The expression should return the expected value.");
 
 	// Mismatched argument count (more parameters than values).
-	PackedStringArray parameter_names_mismatch2;
-	parameter_names_mismatch2.push_back("foo");
-	parameter_names_mismatch2.push_back("bar");
-	parameter_names_mismatch2.push_back("baz");
+	PackedStringArray parameter_names_mismatch2 = { "foo", "bar", "baz" };
 	CHECK_MESSAGE(
 			expression.parse("foo + bar + baz + 50", parameter_names_mismatch2) == OK,
 			"The expression should parse successfully.");
-	Array values_mismatch2;
-	values_mismatch2.push_back(60);
-	values_mismatch2.push_back(20);
+	Array values_mismatch2 = { 60, 20 };
 	// Having more parameters than values will parse successfully but print an
 	// error message when executing.
 	ERR_PRINT_OFF;

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -428,8 +428,7 @@ TEST_CASE("[Object] Signals") {
 	}
 
 	SUBCASE("Emitting an existing signal should call the connected method") {
-		Array empty_signal_args;
-		empty_signal_args.push_back(Array());
+		Array empty_signal_args = { {} };
 
 		SIGNAL_WATCH(&object, "my_custom_signal");
 		SIGNAL_CHECK_FALSE("my_custom_signal");

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -139,9 +139,7 @@ TEST_CASE("[Array] front() and back()") {
 }
 
 TEST_CASE("[Array] has() and count()") {
-	Array arr;
-	arr.push_back(1);
-	arr.push_back(1);
+	Array arr = { 1, 1 };
 	CHECK(arr.has(1));
 	CHECK(!arr.has(2));
 	CHECK(arr.count(1) == 2);
@@ -149,9 +147,7 @@ TEST_CASE("[Array] has() and count()") {
 }
 
 TEST_CASE("[Array] remove_at()") {
-	Array arr;
-	arr.push_back(1);
-	arr.push_back(2);
+	Array arr = { 1, 2 };
 	arr.remove_at(0);
 	CHECK(arr.size() == 1);
 	CHECK(int(arr[0]) == 2);
@@ -168,18 +164,12 @@ TEST_CASE("[Array] remove_at()") {
 }
 
 TEST_CASE("[Array] get()") {
-	Array arr;
-	arr.push_back(1);
+	Array arr = { 1 };
 	CHECK(int(arr.get(0)) == 1);
 }
 
 TEST_CASE("[Array] sort()") {
-	Array arr;
-
-	arr.push_back(3);
-	arr.push_back(4);
-	arr.push_back(2);
-	arr.push_back(1);
+	Array arr = { 3, 4, 2, 1 };
 	arr.sort();
 	int val = 1;
 	for (int i = 0; i < arr.size(); i++) {
@@ -206,12 +196,7 @@ TEST_CASE("[Array] push_front(), pop_front(), pop_back()") {
 TEST_CASE("[Array] pop_at()") {
 	ErrorDetector ed;
 
-	Array arr;
-	arr.push_back(2);
-	arr.push_back(4);
-	arr.push_back(6);
-	arr.push_back(8);
-	arr.push_back(10);
+	Array arr = { 2, 4, 6, 8, 10 };
 
 	REQUIRE(int(arr.pop_at(2)) == 6);
 	REQUIRE(arr.size() == 4);
@@ -266,13 +251,7 @@ TEST_CASE("[Array] max() and min()") {
 }
 
 TEST_CASE("[Array] slice()") {
-	Array array;
-	array.push_back(0);
-	array.push_back(1);
-	array.push_back(2);
-	array.push_back(3);
-	array.push_back(4);
-	array.push_back(5);
+	Array array = { 0, 1, 2, 3, 4, 5 };
 
 	Array slice0 = array.slice(0, 0);
 	CHECK(slice0.size() == 0);
@@ -617,11 +596,8 @@ TEST_CASE("[Array] Iteration and modification") {
 }
 
 TEST_CASE("[Array] Typed copying") {
-	TypedArray<int> a1;
-	a1.push_back(1);
-
-	TypedArray<double> a2;
-	a2.push_back(1.0);
+	TypedArray<int> a1 = { 1 };
+	TypedArray<double> a2 = { 1.0 };
 
 	Array a3 = a1;
 	TypedArray<int> a4 = a3;

--- a/tests/core/variant/test_callable.h
+++ b/tests/core/variant/test_callable.h
@@ -154,11 +154,7 @@ public:
 	}
 
 	static String get_output(const Callable &p_callable) {
-		Array effective_args;
-		effective_args.push_back(7);
-		effective_args.push_back(8);
-		effective_args.push_back(9);
-
+		Array effective_args = { 7, 8, 9 };
 		effective_args.resize(3 - p_callable.get_unbound_arguments_count());
 		effective_args.append_array(p_callable.get_bound_arguments());
 

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -545,11 +545,7 @@ TEST_CASE("[Dictionary] Order and find") {
 	d[12] = "twelve";
 	d["4"] = "four";
 
-	Array keys;
-	keys.append(4);
-	keys.append(8);
-	keys.append(12);
-	keys.append("4");
+	Array keys = { 4, 8, 12, "4" };
 
 	CHECK_EQ(d.keys(), keys);
 	CHECK_EQ(d.find_key("four"), Variant(4));

--- a/tests/core/variant/test_variant_utility.h
+++ b/tests/core/variant/test_variant_utility.h
@@ -92,15 +92,8 @@ TEST_CASE("[VariantUtility] Type conversion") {
 	}
 
 	{
-		Array arr;
-		arr.push_back(1.2);
-		arr.push_back(3.4);
-		arr.push_back(5.6);
-
-		PackedFloat64Array packed;
-		packed.push_back(1.2);
-		packed.push_back(3.4);
-		packed.push_back(5.6);
+		Array arr = { 1.2, 3.4, 5.6 };
+		PackedFloat64Array packed = { 1.2, 3.4, 5.6 };
 
 		converted = VariantUtilityFunctions::type_convert(arr, Variant::Type::PACKED_FLOAT64_ARRAY);
 		CHECK(converted.get_type() == Variant::Type::PACKED_FLOAT64_ARRAY);

--- a/tests/scene/test_arraymesh.h
+++ b/tests/scene/test_arraymesh.h
@@ -148,9 +148,7 @@ TEST_CASE("[SceneTree][ArrayMesh] Adding and modifying blendshapes.") {
 		blend_shape[Mesh::ARRAY_VERTEX] = cylinder_array[Mesh::ARRAY_VERTEX];
 		blend_shape[Mesh::ARRAY_NORMAL] = cylinder_array[Mesh::ARRAY_NORMAL];
 		blend_shape[Mesh::ARRAY_TANGENT] = cylinder_array[Mesh::ARRAY_TANGENT];
-		Array blend_shapes;
-		blend_shapes.push_back(blend_shape);
-		blend_shapes.push_back(blend_shape);
+		Array blend_shapes = { blend_shape, blend_shape };
 		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, cylinder_array, blend_shapes);
 		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, cylinder_array, blend_shapes);
 
@@ -188,9 +186,7 @@ TEST_CASE("[SceneTree][ArrayMesh] Adding and modifying blendshapes.") {
 		blend_shape[Mesh::ARRAY_VERTEX] = cylinder_array[Mesh::ARRAY_VERTEX];
 		blend_shape[Mesh::ARRAY_NORMAL] = cylinder_array[Mesh::ARRAY_NORMAL];
 		blend_shape[Mesh::ARRAY_TANGENT] = cylinder_array[Mesh::ARRAY_TANGENT];
-		Array blend_shapes;
-		blend_shapes.push_back(blend_shape);
-		blend_shapes.push_back(blend_shape);
+		Array blend_shapes = { blend_shape, blend_shape };
 		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, cylinder_array, blend_shapes);
 
 		ERR_PRINT_OFF

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -905,8 +905,7 @@ TEST_CASE("[SceneTree][CodeEdit] delimiters") {
 			CHECK(code_edit->get_string_delimiters().size() == 2);
 
 			/* Set should override existing, and test multiline */
-			TypedArray<String> delimiters;
-			delimiters.push_back("^^ ^^");
+			TypedArray<String> delimiters = { "^^ ^^" };
 
 			code_edit->set_string_delimiters(delimiters);
 			CHECK_FALSE(code_edit->has_string_delimiter("\""));
@@ -971,8 +970,7 @@ TEST_CASE("[SceneTree][CodeEdit] delimiters") {
 			CHECK(code_edit->get_comment_delimiters().size() == 2);
 
 			/* Set should override existing, and test multiline. */
-			TypedArray<String> delimiters;
-			delimiters.push_back("^^ ^^");
+			TypedArray<String> delimiters = { "^^ ^^" };
 
 			code_edit->set_comment_delimiters(delimiters);
 			CHECK_FALSE(code_edit->has_comment_delimiter("\""));
@@ -1770,10 +1768,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		CHECK(code_edit->is_indent_using_spaces());
 
 		/* Only the first char is registered. */
-		TypedArray<String> auto_indent_prefixes;
-		auto_indent_prefixes.push_back("::");
-		auto_indent_prefixes.push_back("s");
-		auto_indent_prefixes.push_back("1");
+		TypedArray<String> auto_indent_prefixes = { "::", "s", "1" };
 		code_edit->set_auto_indent_prefixes(auto_indent_prefixes);
 
 		auto_indent_prefixes = code_edit->get_auto_indent_prefixes();
@@ -3936,11 +3931,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		CHECK(code_edit->is_code_completion_enabled());
 
 		/* Set prefixes, single char only, disallow empty. */
-		TypedArray<String> completion_prefixes;
-		completion_prefixes.push_back("");
-		completion_prefixes.push_back(".");
-		completion_prefixes.push_back(".");
-		completion_prefixes.push_back(",,");
+		TypedArray<String> completion_prefixes = { "", ".", ".", ",," };
 
 		ERR_PRINT_OFF;
 		code_edit->set_code_completion_prefixes(completion_prefixes);
@@ -3958,8 +3949,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		SIGNAL_WATCH(code_edit, "code_completion_requested");
 		code_edit->set_code_completion_enabled(true);
 
-		Array signal_args;
-		signal_args.push_back(Array());
+		Array signal_args = { {} };
 
 		/* Force request. */
 		code_edit->request_code_completion();
@@ -3972,8 +3962,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Insert prefix. */
-		TypedArray<String> completion_prefixes;
-		completion_prefixes.push_back(".");
+		TypedArray<String> completion_prefixes = { "." };
 		code_edit->set_code_completion_prefixes(completion_prefixes);
 
 		code_edit->insert_text_at_caret(".");

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -1034,8 +1034,7 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 	}
 
 	SIGNAL_WATCH(test_control, SNAME("minimum_size_changed"))
-	Array signal_args;
-	signal_args.push_back(Array());
+	Array signal_args = { {} };
 
 	SUBCASE("Horizontal grow direction begin") {
 		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);

--- a/tests/scene/test_instance_placeholder.h
+++ b/tests/scene/test_instance_placeholder.h
@@ -502,10 +502,11 @@ TEST_CASE("[SceneTree][InstancePlaceholder] Instance a PackedScene containing an
 	REQUIRE(final_node->get_reference_property().identity_compare(instanced_main_node->get_child(1, true)));
 	Array final_array = final_node->get_reference_array_property();
 	REQUIRE(final_array.size() == 3);
-	Array wanted_node_array;
-	wanted_node_array.push_back(instanced_main_node->get_child(2, true)); // ExternalArrayMember
-	wanted_node_array.push_back(final_node->get_child(1, true)); // ArrayRef1
-	wanted_node_array.push_back(final_node->get_child(2, true)); // ArrayRef2
+	Array wanted_node_array = {
+		instanced_main_node->get_child(2, true), // ExternalArrayMember
+		final_node->get_child(1, true), // ArrayRef1
+		final_node->get_child(2, true) // ArrayRef2
+	};
 
 	// Iterate over all nodes, since the ordering is not guaranteed.
 	for (int i = 0; i < wanted_node_array.size(); i++) {

--- a/tests/scene/test_split_container.h
+++ b/tests/scene/test_split_container.h
@@ -1169,9 +1169,7 @@ TEST_CASE("[SceneTree][SplitContainer] Two children") {
 	SUBCASE("[SplitContainer] Drag") {
 		SUBCASE("[SplitContainer] Vertical, no expand flags") {
 			SIGNAL_WATCH(split_container, "dragged");
-			Array signal_args;
-			signal_args.push_back(Array());
-			((Array)signal_args[0]).push_back(0);
+			Array signal_args = { { 0 } };
 
 			split_container->set_vertical(true);
 			Point2 mouse_offset = Point2(1, 1);

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -59,8 +59,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 	text_edit->grab_focus();
 
-	Array empty_signal_args;
-	empty_signal_args.push_back(Array());
+	Array empty_signal_args = { {} };
 
 	SUBCASE("[TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "text_set");
@@ -6445,8 +6444,7 @@ TEST_CASE("[SceneTree][TextEdit] versioning") {
 
 		CHECK(text_edit->get_caret_count() == 1);
 
-		Array caret_index;
-		caret_index.push_back(0);
+		Array caret_index = { 0 };
 
 		for (int i = 1; i < 4; i++) {
 			caret_index.push_back(text_edit->add_caret(i, 0));
@@ -6710,8 +6708,7 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 	text_edit->set_multiple_carets_enabled(true);
 
-	Array empty_signal_args;
-	empty_signal_args.push_back(Array());
+	Array empty_signal_args = { {} };
 
 	SIGNAL_WATCH(text_edit, "caret_changed");
 
@@ -8005,8 +8002,7 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 	TextEdit *text_edit = memnew(TextEdit);
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 
-	Array empty_signal_args;
-	empty_signal_args.push_back(Array());
+	Array empty_signal_args = { {} };
 
 	SIGNAL_WATCH(text_edit, "gutter_clicked");
 	SIGNAL_WATCH(text_edit, "gutter_added");

--- a/tests/scene/test_timer.h
+++ b/tests/scene/test_timer.h
@@ -156,9 +156,7 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 
 		SceneTree::get_singleton()->process(0.2);
 
-		Array signal_args;
-		signal_args.push_back(Array());
-
+		Array signal_args = { {} };
 		SIGNAL_CHECK(SNAME("timeout"), signal_args);
 
 		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
@@ -170,9 +168,7 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 
 		SceneTree::get_singleton()->process(0.05);
 
-		Array signal_args;
-		signal_args.push_back(Array());
-
+		Array signal_args = { {} };
 		SIGNAL_CHECK_FALSE(SNAME("timeout"));
 
 		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
@@ -186,9 +182,7 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 
 		SceneTree::get_singleton()->physics_process(0.2);
 
-		Array signal_args;
-		signal_args.push_back(Array());
-
+		Array signal_args = { {} };
 		SIGNAL_CHECK(SNAME("timeout"), signal_args);
 
 		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
@@ -200,9 +194,7 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 
 		SceneTree::get_singleton()->physics_process(0.05);
 
-		Array signal_args;
-		signal_args.push_back(Array());
-
+		Array signal_args = { {} };
 		SIGNAL_CHECK_FALSE(SNAME("timeout"));
 
 		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -409,10 +409,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 
 			SUBCASE("[Viewport][GuiInputEvent] Signal 'gui_focus_changed' is only emitted if a previously unfocused Control grabs focus.") {
 				SIGNAL_WATCH(root, SNAME("gui_focus_changed"));
-				Array node_array;
-				node_array.push_back(node_a);
-				Array signal_args;
-				signal_args.push_back(node_array);
+				Array signal_args = { { node_a } };
 
 				SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -566,8 +563,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Mouse Enter/Exit notification propagation when moving into child.") {
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			node_j->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 
@@ -774,8 +770,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Mouse Enter/Exit notification when changing top level.") {
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			node_d->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 			node_i->set_mouse_filter(Control::MOUSE_FILTER_PASS);
@@ -853,8 +848,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Mouse Enter/Exit notification when changing the mouse filter to stop.") {
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			node_i->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 			node_j->set_mouse_filter(Control::MOUSE_FILTER_PASS);
@@ -906,8 +900,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Mouse Enter/Exit notification when changing the mouse filter to ignore.") {
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(node_i, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			node_i->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 			node_j->set_mouse_filter(Control::MOUSE_FILTER_PASS);
@@ -983,8 +976,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Mouse Enter/Exit notification when removing the hovered Control.") {
 			SIGNAL_WATCH(node_h, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(node_h, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			node_i->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 			node_j->set_mouse_filter(Control::MOUSE_FILTER_PASS);
@@ -1037,8 +1029,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Mouse Enter/Exit notification when hiding the hovered Control.") {
 			SIGNAL_WATCH(node_h, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(node_h, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			node_i->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 			node_j->set_mouse_filter(Control::MOUSE_FILTER_PASS);
@@ -1091,8 +1082,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 		SUBCASE("[Viewport][GuiInputEvent] Window Mouse Enter/Exit signals.") {
 			SIGNAL_WATCH(root, SceneStringName(mouse_entered));
 			SIGNAL_WATCH(root, SceneStringName(mouse_exited));
-			Array signal_args;
-			signal_args.push_back(Array());
+			Array signal_args = { {} };
 
 			SEND_GUI_MOUSE_MOTION_EVENT(on_outside, MouseButtonMask::NONE, Key::NONE);
 			SIGNAL_CHECK_FALSE(SceneStringName(mouse_entered));
@@ -1615,15 +1605,8 @@ TEST_CASE("[SceneTree][Viewport] Physics Picking 2D") {
 	Point2i on_01 = Point2i(10, 50);
 	Point2i on_02 = Point2i(50, 10);
 
-	Array empty_signal_args_2;
-	empty_signal_args_2.push_back(Array());
-	empty_signal_args_2.push_back(Array());
-
-	Array empty_signal_args_4;
-	empty_signal_args_4.push_back(Array());
-	empty_signal_args_4.push_back(Array());
-	empty_signal_args_4.push_back(Array());
-	empty_signal_args_4.push_back(Array());
+	Array empty_signal_args_2 = { Array(), Array() };
+	Array empty_signal_args_4 = { Array(), Array(), Array(), Array() };
 
 	for (PickingCollider E : v) {
 		E.a->init_signals();

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -771,9 +771,7 @@ TEST_SUITE("[Navigation]") {
 			query_parameters->set_map(map);
 			query_parameters->set_start_position(Vector3(10, 0, 10));
 			query_parameters->set_target_position(Vector3(0, 0, 0));
-			Array excluded_regions;
-			excluded_regions.push_back(region);
-			query_parameters->set_excluded_regions(excluded_regions);
+			query_parameters->set_excluded_regions({ region });
 			Ref<NavigationPathQueryResult3D> query_result;
 			query_result.instantiate();
 			navigation_server->query_path(query_parameters, query_result);
@@ -786,9 +784,7 @@ TEST_SUITE("[Navigation]") {
 			query_parameters->set_map(map);
 			query_parameters->set_start_position(Vector3(10, 0, 10));
 			query_parameters->set_target_position(Vector3(0, 0, 0));
-			Array included_regions;
-			included_regions.push_back(region);
-			query_parameters->set_included_regions(included_regions);
+			query_parameters->set_included_regions({ region });
 			Ref<NavigationPathQueryResult3D> query_result;
 			query_result.instantiate();
 			navigation_server->query_path(query_parameters, query_result);
@@ -801,12 +797,8 @@ TEST_SUITE("[Navigation]") {
 			query_parameters->set_map(map);
 			query_parameters->set_start_position(Vector3(10, 0, 10));
 			query_parameters->set_target_position(Vector3(0, 0, 0));
-			Array excluded_regions;
-			excluded_regions.push_back(region);
-			query_parameters->set_excluded_regions(excluded_regions);
-			Array included_regions;
-			included_regions.push_back(region);
-			query_parameters->set_included_regions(included_regions);
+			query_parameters->set_excluded_regions({ region });
+			query_parameters->set_included_regions({ region });
 			Ref<NavigationPathQueryResult3D> query_result;
 			query_result.instantiate();
 			navigation_server->query_path(query_parameters, query_result);

--- a/tests/servers/test_text_server.h
+++ b/tests/servers/test_text_server.h
@@ -72,10 +72,7 @@ TEST_SUITE("[TextServer]") {
 				ts->font_set_data_ptr(font2, _font_NotoSansThai_Regular, _font_NotoSansThai_Regular_size);
 				ts->font_set_allow_system_fallback(font2, false);
 
-				Array font;
-				font.push_back(font1);
-				font.push_back(font2);
-
+				Array font = { font1, font2 };
 				String test = U"คนอ้วน khon uan ראה";
 				//                 6^       17^
 
@@ -125,10 +122,7 @@ TEST_SUITE("[TextServer]") {
 				RID font2 = ts->create_font();
 				ts->font_set_data_ptr(font2, _font_Vazirmatn_Regular, _font_Vazirmatn_Regular_size);
 
-				Array font;
-				font.push_back(font1);
-				font.push_back(font2);
-
+				Array font = { font1, font2 };
 				String test = U"Arabic (اَلْعَرَبِيَّةُ, al-ʿarabiyyah)";
 				//                    7^      26^
 
@@ -182,11 +176,7 @@ TEST_SUITE("[TextServer]") {
 				ts->font_set_data_ptr(font3, _font_Vazirmatn_Regular, _font_Vazirmatn_Regular_size);
 				ts->font_set_allow_system_fallback(font3, false);
 
-				Array font;
-				font.push_back(font1);
-				font.push_back(font2);
-				font.push_back(font3);
-
+				Array font = { font1, font2, font3 };
 				{
 					RID ctx = ts->create_shaped_text();
 					CHECK_FALSE_MESSAGE(ctx == RID(), "Creating text buffer failed.");
@@ -579,10 +569,7 @@ TEST_SUITE("[TextServer]") {
 				RID font2 = ts->create_font();
 				ts->font_set_data_ptr(font2, _font_NotoSansThai_Regular, _font_NotoSansThai_Regular_size);
 
-				Array font;
-				font.push_back(font1);
-				font.push_back(font2);
-
+				Array font = { font1, font2 };
 				RID ctx = ts->create_shaped_text();
 				CHECK_FALSE_MESSAGE(ctx == RID(), "Creating text buffer failed.");
 				bool ok = ts->shaped_text_add_string(ctx, test_1, font, 16);
@@ -637,10 +624,7 @@ TEST_SUITE("[TextServer]") {
 				RID font2 = ts->create_font();
 				ts->font_set_data_ptr(font2, _font_Vazirmatn_Regular, _font_Vazirmatn_Regular_size);
 
-				Array font;
-				font.push_back(font1);
-				font.push_back(font2);
-
+				Array font = { font1, font2 };
 				String test_1 = U"الحمد";
 				String test_2 = U"الحمد test";
 				String test_3 = U"test test";
@@ -949,9 +933,7 @@ TEST_SUITE("[TextServer]") {
 				RID font1 = ts->create_font();
 				ts->font_set_data_ptr(font1, _font_NotoSans_Regular, _font_NotoSans_Regular_size);
 
-				Array font;
-				font.push_back(font1);
-
+				Array font = { font1 };
 				RID ctx = ts->create_shaped_text();
 				CHECK_FALSE_MESSAGE(ctx == RID(), "Creating text buffer failed.");
 				bool ok = ts->shaped_text_add_string(ctx, "T", font, 16);

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -276,23 +276,17 @@ private:
 	}
 
 	void _signal_callback_one(Variant p_arg1, const String &p_name) {
-		Array args;
-		args.push_back(p_arg1);
+		Array args = { p_arg1 };
 		_add_signal_entry(args, p_name);
 	}
 
 	void _signal_callback_two(Variant p_arg1, Variant p_arg2, const String &p_name) {
-		Array args;
-		args.push_back(p_arg1);
-		args.push_back(p_arg2);
+		Array args = { p_arg1, p_arg2 };
 		_add_signal_entry(args, p_name);
 	}
 
 	void _signal_callback_three(Variant p_arg1, Variant p_arg2, Variant p_arg3, const String &p_name) {
-		Array args;
-		args.push_back(p_arg1);
-		args.push_back(p_arg2);
-		args.push_back(p_arg3);
+		Array args = { p_arg1, p_arg2, p_arg3 };
 		_add_signal_entry(args, p_name);
 	}
 

--- a/tests/test_validate_testing.h
+++ b/tests/test_validate_testing.h
@@ -124,9 +124,7 @@ TEST_SUITE("Validate tests") {
 		dict["color"] = color;
 		INFO(dict);
 
-		Array arr;
-		arr.push_back(string);
-		arr.push_back(color);
+		Array arr = { string, color };
 		INFO(arr);
 
 		PackedByteArray byte_arr;


### PR DESCRIPTION
Allows to replace
```C++
Array a;
a.append("something");
a.append(1);
```
with
```C++
Array a{ "something", 1 };
```
I applied it to all Arrays I found it applicable.