### PR TITLE
Improve `includes` in `core/variant`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -32,13 +32,11 @@
 
 #include "container_type_validate.h"
 #include "core/math/math_funcs.h"
-#include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/search_array.h"
 #include "core/templates/vector.h"
 #include "core/variant/callable.h"
-#include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
 class ArrayPrivate {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -37,7 +37,6 @@
 
 class Variant;
 class ArrayPrivate;
-class Object;
 class StringName;
 class Callable;
 

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -33,11 +33,12 @@
 
 #include "core/object/object_id.h"
 #include "core/string/string_name.h"
-#include "core/templates/list.h"
 
 class Object;
 class Variant;
 class CallableCustom;
+template <class T>
+class Vector;
 
 // This is an abstraction of things that can be called.
 // It is used for signals and other cases where efficient calling of functions

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -31,7 +31,6 @@
 #ifndef DICTIONARY_H
 #define DICTIONARY_H
 
-#include "core/string/ustring.h"
 #include "core/templates/list.h"
 #include "core/variant/array.h"
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -33,10 +33,8 @@
 #include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/json.h"
-#include "core/io/marshalls.h"
 #include "core/io/resource.h"
 #include "core/math/math_funcs.h"
-#include "core/string/print_string.h"
 #include "core/variant/variant_parser.h"
 
 PagedAllocator<Variant::Pools::BucketSmall, true> Variant::Pools::_bucket_small;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -31,7 +31,6 @@
 #ifndef VARIANT_H
 #define VARIANT_H
 
-#include "core/input/input_enums.h"
 #include "core/io/ip_address.h"
 #include "core/math/aabb.h"
 #include "core/math/basis.h"
@@ -51,7 +50,6 @@
 #include "core/math/vector4.h"
 #include "core/math/vector4i.h"
 #include "core/object/object_id.h"
-#include "core/os/keyboard.h"
 #include "core/string/node_path.h"
 #include "core/string/ustring.h"
 #include "core/templates/paged_allocator.h"
@@ -59,6 +57,13 @@
 #include "core/variant/array.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
+
+enum class JoyAxis;
+enum class JoyButton;
+enum class Key;
+enum class KeyLocation;
+enum class MIDIMessage;
+enum class MouseButton;
 
 class Object;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -30,13 +30,9 @@
 
 #include "variant.h"
 
-#include "core/core_string_names.h"
-#include "core/crypto/crypto_core.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
-#include "core/object/class_db.h"
-#include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
 

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -30,6 +30,11 @@
 
 #include "variant_construct.h"
 
+#include "core/object/ref_counted.h"
+#include "core/templates/list.h"
+#include "core/templates/local_vector.h"
+#include "core/templates/vector.h"
+
 struct VariantConstructData {
 	void (*construct)(Variant &r_base, const Variant **p_args, Callable::CallError &r_error) = nullptr;
 	Variant::ValidatedConstructor validated_construct = nullptr;

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -33,14 +33,17 @@
 
 #include "variant.h"
 
-#include "core/core_string_names.h"
-#include "core/crypto/crypto_core.h"
-#include "core/debugger/engine_debugger.h"
-#include "core/io/compression.h"
-#include "core/object/class_db.h"
-#include "core/os/os.h"
-#include "core/templates/local_vector.h"
-#include "core/templates/oa_hash_map.h"
+#include "core/object/object_id.h"
+#include "core/os/memory.h"
+#include "core/templates/rid.h"
+#include "core/variant/binder_common.h"
+#include "core/variant/method_ptrcall.h"
+#include "core/variant/type_info.h"
+#include "core/variant/variant_internal.h"
+
+class Object;
+template <class T>
+struct PtrConstruct;
 
 template <typename T>
 struct PtrConstruct {};

--- a/core/variant/variant_destruct.cpp
+++ b/core/variant/variant_destruct.cpp
@@ -30,8 +30,6 @@
 
 #include "variant_destruct.h"
 
-#include "core/templates/local_vector.h"
-
 static Variant::PTRDestructor destruct_pointers[Variant::VARIANT_MAX] = { nullptr };
 
 template <typename T>

--- a/core/variant/variant_destruct.h
+++ b/core/variant/variant_destruct.h
@@ -31,9 +31,9 @@
 #ifndef VARIANT_DESTRUCT_H
 #define VARIANT_DESTRUCT_H
 
-#include "core/variant/variant.h"
-
-#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/string/string_name.h"
+#include "core/variant/type_info.h"
 
 template <typename T>
 struct VariantDestruct {};

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -33,9 +33,11 @@
 
 #include "variant.h"
 
-#include "core/core_string_names.h"
-#include "core/debugger/engine_debugger.h"
 #include "core/object/class_db.h"
+#include "core/string/string_name.h"
+#include "core/variant/method_ptrcall.h"
+#include "core/variant/type_info.h"
+#include "core/variant/variant_internal.h"
 
 template <typename R, typename A, typename B>
 class OperatorEvaluatorAdd {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -30,10 +30,8 @@
 
 #include "variant_parser.h"
 
-#include "core/input/input_event.h"
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
-#include "core/os/keyboard.h"
 #include "core/string/string_buffer.h"
 
 char32_t VariantParser::Stream::get_char() {

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -30,6 +30,8 @@
 
 #include "variant_setget.h"
 
+#include "core/core_string_names.h"
+#include "core/debugger/engine_debugger.h"
 #include "variant_callable.h"
 
 struct VariantSetterGetterInfo {

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -33,10 +33,7 @@
 
 #include "variant.h"
 
-#include "core/core_string_names.h"
-#include "core/debugger/engine_debugger.h"
 #include "core/object/class_db.h"
-#include "core/templates/local_vector.h"
 #include "core/variant/variant_internal.h"
 
 /**** NAMED SETTERS AND GETTERS ****/

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -30,7 +30,6 @@
 
 #include "variant_utility.h"
 
-#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/object/ref_counted.h"
 #include "core/os/os.h"


### PR DESCRIPTION
Similar to this #89568

**Benchmark**
SCU build time:
Before:
04:29.433
After:
04:26.880

Edit:
I made benchmarks for variants `.cpp` compille time.
Command (for linuxbsd):
```
time g++ -c -std=gnu++17 -fno-exceptions -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -pipe -O3 -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow -Wno-misleading-indentation -Wno-type-limits -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wattribute-alias=2 -Werror -DNDEBUG -DNO_EDITOR_SPLASH -DDISABLE_DEPRECATED -DSOWRAP_ENABLED -DTOUCH_ENABLED -DFONTCONFIG_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DSPEECHD_ENABLED -DXKB_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DLINUXBSD_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DX11_ENABLED -DLIBDECOR_ENABLED -DWAYLAND_ENABLED -DVULKAN_ENABLED -DRD_ENABLED -DGLES3_ENABLED -DCRASH_HANDLER_ENABLED -D_3D_DISABLED -DADVANCED_GUI_DISABLED -DBROTLI_ENABLED -DTHREADS_ENABLED -DCLIPPER2_ENABLED -DZSTD_STATIC_LINKING_ONLY -Ithirdparty/zstd -Ithirdparty/zlib -Ithirdparty/clipper2/include -Ithirdparty/brotli/include -Iplatform/linuxbsd -Ithirdparty/linuxbsd_headers/wayland -Ithirdparty/linuxbsd_headers -Iplatform/linuxbsd -I. <FILENAME.cpp>
```
| File                                   | Before  | After  |
|----------------------------------------|---------------------|--------------------|
| core/variant/array.cpp                | real 0m2.020s      | real 0m2.008s     |
|                                        | user 0m1.964s      | user 0m1.944s     |
|                                        | sys 0m0.080s       | sys 0m0.088s      |
| core/variant/callable.cpp             | real 0m0.829s      | real 0m0.825s     |
|                                        | user 0m0.778s      | user 0m0.759s     |
|                                        | sys 0m0.056s       | sys 0m0.070s      |
| core/variant/dictionary.cpp           | real 0m0.727s      | real 0m0.714s     |
|                                        | user 0m0.687s      | user 0m0.679s     |
|                                        | sys 0m0.037s       | sys 0m0.040s      |
| core/variant/variant.cpp              | real 0m2.753s      | real 0m2.694s     |
|                                        | user 0m2.698s      | user 0m2.633s     |
|                                        | sys 0m0.086s       | sys 0m0.092s      |
| core/variant/variant_call.cpp         | real 0m23.388s     | real 0m23.292s    |
|                                        | user 0m23.309s     | user 0m23.252s    |
|                                        | sys 0m0.329s       | sys 0m0.290s      |
| core/variant/variant_construct.cpp    | real 0m4.642s      | real 0m4.623s     |
|                                        | user 0m4.593s      | user 0m4.555s     |
|                                        | sys 0m0.114s       | sys 0m0.111s      |
| core/variant/variant_destruct.cpp     | real 0m0.491s      | real 0m0.403s     |
|                                        | user 0m0.470s      | user 0m0.367s     |
|                                        | sys 0m0.021s       | sys 0m0.039s      |
| core/variant/variant_op.cpp           | real 0m8.431s      | real 0m8.426s     |
|                                        | user 0m8.365s      | user 0m8.394s     |
|                                        | sys 0m0.165s       | sys 0m0.128s      |
| core/variant/variant_parser.cpp       | real 0m1.978s      | real 0m1.958s     |
|                                        | user 0m1.899s      | user 0m1.891s     |
|                                        | sys 0m0.095s       | sys 0m0.081s      |
| core/variant/variant_setget.cpp       | real 0m2.195s      | real 0m2.185s     |
|                                        | user 0m2.154s      | user 0m2.120s     |
|                                        | sys 0m0.072s       | sys 0m0.098s      |
| core/variant/variant_utility.cpp      | real 0m4.353s      | real 0m4.272s     |
|                                        | user 0m4.306s      | user 0m4.245s     |
|                                        | sys 0m0.103s       | sys 0m0.085s      |