### PR TITLE
Apply margin to camera and shape in SpringArm3D

### DIFF
--- a/scene/3d/physics/spring_arm_3d.cpp
+++ b/scene/3d/physics/spring_arm_3d.cpp
@@ -162,6 +162,9 @@ void SpringArm3D::process_spring() {
 			shape_params.collision_mask = mask;
 
 			get_world_3d()->get_direct_space_state()->cast_motion(shape_params, motion_delta, motion_delta_unsafe);
+			if (motion_delta != 1) {
+				motion_delta -= margin / spring_length;
+			}
 		} else {
 			PhysicsDirectSpaceState3D::RayParameters ray_params;
 			ray_params.from = get_global_transform().origin;
@@ -186,6 +189,9 @@ void SpringArm3D::process_spring() {
 		shape_params.collision_mask = mask;
 
 		get_world_3d()->get_direct_space_state()->cast_motion(shape_params, motion_delta, motion_delta_unsafe);
+		if (motion_delta != 1) {
+			motion_delta -= margin / spring_length;
+		}
 	}
 
 	current_spring_length = spring_length * motion_delta;


### PR DESCRIPTION
Fixes [ !76220](https://github.com/godotengine/godot/issues/76220)

Currently, margin is only being used when neither a Camera3D is the SpringArm3D's child node nor when a shape has been set, which doesn't seem to align with the described behavior in the docs https://docs.godotengine.org/en/stable/classes/class_springarm3d.html#class-springarm3d-property-margin.

After this change, in addition to the scenario it currently works for, the margin value will also apply when the child node of the SpringArm3D is a Camera3D node, and it will apply when there's a shape set for SpringArm3D.

And for those who were wondering, SpringArm3D already has an if condition for handling a child node with Camera3D, so I'm just adding this application of margin there as well.

[springarmmarginfix.zip](https://github.com/godotengine/godot/files/14734275/springarmmarginfix.zip)
- Three SpringArm3D nodes: one with Camera3D as child node, one that uses SpringArm3D's shape, and one that does neither of the previous two so it uses a raycast.  Margin should apply to all three.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
