### PR TITLE
C#: Improve godot_variant conversion for godot_variant-marshable C# types

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -9,6 +9,8 @@ public partial class VariantUtils
 {
     private static Exception UnsupportedType<T>() => new InvalidOperationException(
         $"The type is not supported for conversion to/from Variant: '{typeof(T).FullName}'");
+    private delegate T ConvertToDelegate<[MustBeVariant] T>(in godot_variant variant);
+    private delegate godot_variant CreateFromDelegate<[MustBeVariant] T>(in T from);
 
     internal static class GenericConversion<T>
     {
@@ -31,380 +33,404 @@ public partial class VariantUtils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static godot_variant CreateFrom<[MustBeVariant] T>(in T from)
+    public static godot_variant CreateFrom<[MustBeVariant] T>(in T from) => CreateFromLookup<T>.CreateFrom(from);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static T ConvertTo<[MustBeVariant] T>(in godot_variant variant) => ConvertToLookup<T>.ConvertTo(variant);
+
+    // We use a generic static class to lookup the conversion method once during its initialization.
+    // The .NET runtime does the heavy lifting of creating an instance per type which makes this implementation
+    // behave similar to C++ templates: a specific implementation for each type without any overhead at runtime.
+    private static class ConvertToLookup<[MustBeVariant] T>
+    {
+        private static readonly ConvertToDelegate<T> _converter = DetermineConvertToDelegate<T>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+        public static T ConvertTo(in godot_variant variant) => _converter(variant);
+    }
+
+    // We use a generic static class to lookup the conversion method once during its initialization.
+    // The .NET runtime does the heavy lifting of creating an instance per type which makes this implementation
+    // behave similar to C++ templates: a specific implementation for each type without any overhead at runtime.
+    private static class CreateFromLookup<[MustBeVariant] T>
+    {
+        private static readonly CreateFromDelegate<T> _converter = DetermineCreateFromDelegate<T>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+        public static godot_variant CreateFrom(in T from) => _converter(from);
+    }
+
+    private static CreateFromDelegate<T> DetermineCreateFromDelegate<T>()
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static TTo UnsafeAs<TTo>(in T f) => Unsafe.As<T, TTo>(ref Unsafe.AsRef(f));
 
-        // `typeof(T) == typeof(X)` is optimized away. We cannot cache `typeof(T)` in a local variable, as it's not optimized when done like that.
-
         if (typeof(T) == typeof(bool))
-            return CreateFromBool(UnsafeAs<bool>(from));
+            return (in T from) => CreateFromBool(UnsafeAs<bool>(from));
 
         if (typeof(T) == typeof(char))
-            return CreateFromInt(UnsafeAs<char>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<char>(from));
 
         if (typeof(T) == typeof(sbyte))
-            return CreateFromInt(UnsafeAs<sbyte>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<sbyte>(from));
 
         if (typeof(T) == typeof(short))
-            return CreateFromInt(UnsafeAs<short>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<short>(from));
 
         if (typeof(T) == typeof(int))
-            return CreateFromInt(UnsafeAs<int>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<int>(from));
 
         if (typeof(T) == typeof(long))
-            return CreateFromInt(UnsafeAs<long>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<long>(from));
 
         if (typeof(T) == typeof(byte))
-            return CreateFromInt(UnsafeAs<byte>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<byte>(from));
 
         if (typeof(T) == typeof(ushort))
-            return CreateFromInt(UnsafeAs<ushort>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<ushort>(from));
 
         if (typeof(T) == typeof(uint))
-            return CreateFromInt(UnsafeAs<uint>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<uint>(from));
 
         if (typeof(T) == typeof(ulong))
-            return CreateFromInt(UnsafeAs<ulong>(from));
+            return (in T from) => CreateFromInt(UnsafeAs<ulong>(from));
 
         if (typeof(T) == typeof(float))
-            return CreateFromFloat(UnsafeAs<float>(from));
+            return (in T from) => CreateFromFloat(UnsafeAs<float>(from));
 
         if (typeof(T) == typeof(double))
-            return CreateFromFloat(UnsafeAs<double>(from));
+            return (in T from) => CreateFromFloat(UnsafeAs<double>(from));
 
         if (typeof(T) == typeof(Vector2))
-            return CreateFromVector2(UnsafeAs<Vector2>(from));
+            return (in T from) => CreateFromVector2(UnsafeAs<Vector2>(from));
 
         if (typeof(T) == typeof(Vector2I))
-            return CreateFromVector2I(UnsafeAs<Vector2I>(from));
+            return (in T from) => CreateFromVector2I(UnsafeAs<Vector2I>(from));
 
         if (typeof(T) == typeof(Rect2))
-            return CreateFromRect2(UnsafeAs<Rect2>(from));
+            return (in T from) => CreateFromRect2(UnsafeAs<Rect2>(from));
 
         if (typeof(T) == typeof(Rect2I))
-            return CreateFromRect2I(UnsafeAs<Rect2I>(from));
+            return (in T from) => CreateFromRect2I(UnsafeAs<Rect2I>(from));
 
         if (typeof(T) == typeof(Transform2D))
-            return CreateFromTransform2D(UnsafeAs<Transform2D>(from));
+            return (in T from) => CreateFromTransform2D(UnsafeAs<Transform2D>(from));
 
         if (typeof(T) == typeof(Projection))
-            return CreateFromProjection(UnsafeAs<Projection>(from));
+            return (in T from) => CreateFromProjection(UnsafeAs<Projection>(from));
 
         if (typeof(T) == typeof(Vector3))
-            return CreateFromVector3(UnsafeAs<Vector3>(from));
+            return (in T from) => CreateFromVector3(UnsafeAs<Vector3>(from));
 
         if (typeof(T) == typeof(Vector3I))
-            return CreateFromVector3I(UnsafeAs<Vector3I>(from));
+            return (in T from) => CreateFromVector3I(UnsafeAs<Vector3I>(from));
 
         if (typeof(T) == typeof(Basis))
-            return CreateFromBasis(UnsafeAs<Basis>(from));
+            return (in T from) => CreateFromBasis(UnsafeAs<Basis>(from));
 
         if (typeof(T) == typeof(Quaternion))
-            return CreateFromQuaternion(UnsafeAs<Quaternion>(from));
+            return (in T from) => CreateFromQuaternion(UnsafeAs<Quaternion>(from));
 
         if (typeof(T) == typeof(Transform3D))
-            return CreateFromTransform3D(UnsafeAs<Transform3D>(from));
+            return (in T from) => CreateFromTransform3D(UnsafeAs<Transform3D>(from));
 
         if (typeof(T) == typeof(Vector4))
-            return CreateFromVector4(UnsafeAs<Vector4>(from));
+            return (in T from) => CreateFromVector4(UnsafeAs<Vector4>(from));
 
         if (typeof(T) == typeof(Vector4I))
-            return CreateFromVector4I(UnsafeAs<Vector4I>(from));
+            return (in T from) => CreateFromVector4I(UnsafeAs<Vector4I>(from));
 
         if (typeof(T) == typeof(Aabb))
-            return CreateFromAabb(UnsafeAs<Aabb>(from));
+            return (in T from) => CreateFromAabb(UnsafeAs<Aabb>(from));
 
         if (typeof(T) == typeof(Color))
-            return CreateFromColor(UnsafeAs<Color>(from));
+            return (in T from) => CreateFromColor(UnsafeAs<Color>(from));
 
         if (typeof(T) == typeof(Plane))
-            return CreateFromPlane(UnsafeAs<Plane>(from));
+            return (in T from) => CreateFromPlane(UnsafeAs<Plane>(from));
 
         if (typeof(T) == typeof(Callable))
-            return CreateFromCallable(UnsafeAs<Callable>(from));
+            return (in T from) => CreateFromCallable(UnsafeAs<Callable>(from));
 
         if (typeof(T) == typeof(Signal))
-            return CreateFromSignal(UnsafeAs<Signal>(from));
+            return (in T from) => CreateFromSignal(UnsafeAs<Signal>(from));
 
         if (typeof(T) == typeof(string))
-            return CreateFromString(UnsafeAs<string>(from));
+            return (in T from) => CreateFromString(UnsafeAs<string>(from));
 
         if (typeof(T) == typeof(byte[]))
-            return CreateFromPackedByteArray(UnsafeAs<byte[]>(from));
+            return (in T from) => CreateFromPackedByteArray(UnsafeAs<byte[]>(from));
 
         if (typeof(T) == typeof(int[]))
-            return CreateFromPackedInt32Array(UnsafeAs<int[]>(from));
+            return (in T from) => CreateFromPackedInt32Array(UnsafeAs<int[]>(from));
 
         if (typeof(T) == typeof(long[]))
-            return CreateFromPackedInt64Array(UnsafeAs<long[]>(from));
+            return (in T from) => CreateFromPackedInt64Array(UnsafeAs<long[]>(from));
 
         if (typeof(T) == typeof(float[]))
-            return CreateFromPackedFloat32Array(UnsafeAs<float[]>(from));
+            return (in T from) => CreateFromPackedFloat32Array(UnsafeAs<float[]>(from));
 
         if (typeof(T) == typeof(double[]))
-            return CreateFromPackedFloat64Array(UnsafeAs<double[]>(from));
+            return (in T from) => CreateFromPackedFloat64Array(UnsafeAs<double[]>(from));
 
         if (typeof(T) == typeof(string[]))
-            return CreateFromPackedStringArray(UnsafeAs<string[]>(from));
+            return (in T from) => CreateFromPackedStringArray(UnsafeAs<string[]>(from));
 
         if (typeof(T) == typeof(Vector2[]))
-            return CreateFromPackedVector2Array(UnsafeAs<Vector2[]>(from));
+            return (in T from) => CreateFromPackedVector2Array(UnsafeAs<Vector2[]>(from));
 
         if (typeof(T) == typeof(Vector3[]))
-            return CreateFromPackedVector3Array(UnsafeAs<Vector3[]>(from));
+            return (in T from) => CreateFromPackedVector3Array(UnsafeAs<Vector3[]>(from));
 
         if (typeof(T) == typeof(Color[]))
-            return CreateFromPackedColorArray(UnsafeAs<Color[]>(from));
+            return (in T from) => CreateFromPackedColorArray(UnsafeAs<Color[]>(from));
 
         if (typeof(T) == typeof(StringName[]))
-            return CreateFromSystemArrayOfStringName(UnsafeAs<StringName[]>(from));
+            return (in T from) => CreateFromSystemArrayOfStringName(UnsafeAs<StringName[]>(from));
 
         if (typeof(T) == typeof(NodePath[]))
-            return CreateFromSystemArrayOfNodePath(UnsafeAs<NodePath[]>(from));
+            return (in T from) => CreateFromSystemArrayOfNodePath(UnsafeAs<NodePath[]>(from));
 
         if (typeof(T) == typeof(Rid[]))
-            return CreateFromSystemArrayOfRid(UnsafeAs<Rid[]>(from));
+            return (in T from) => CreateFromSystemArrayOfRid(UnsafeAs<Rid[]>(from));
 
         if (typeof(T) == typeof(StringName))
-            return CreateFromStringName(UnsafeAs<StringName>(from));
+            return (in T from) => CreateFromStringName(UnsafeAs<StringName>(from));
 
         if (typeof(T) == typeof(NodePath))
-            return CreateFromNodePath(UnsafeAs<NodePath>(from));
+            return (in T from) => CreateFromNodePath(UnsafeAs<NodePath>(from));
 
         if (typeof(T) == typeof(Rid))
-            return CreateFromRid(UnsafeAs<Rid>(from));
+            return (in T from) => CreateFromRid(UnsafeAs<Rid>(from));
 
         if (typeof(T) == typeof(Godot.Collections.Dictionary))
-            return CreateFromDictionary(UnsafeAs<Godot.Collections.Dictionary>(from));
+            return (in T from) => CreateFromDictionary(UnsafeAs<Godot.Collections.Dictionary>(from));
 
         if (typeof(T) == typeof(Godot.Collections.Array))
-            return CreateFromArray(UnsafeAs<Godot.Collections.Array>(from));
+            return (in T from) => CreateFromArray(UnsafeAs<Godot.Collections.Array>(from));
 
         if (typeof(T) == typeof(Variant))
-            return NativeFuncs.godotsharp_variant_new_copy((godot_variant)UnsafeAs<Variant>(from).NativeVar);
+            return (in T from) => NativeFuncs.godotsharp_variant_new_copy((godot_variant)UnsafeAs<Variant>(from).NativeVar);
 
         // More complex checks here at the end, to avoid screwing the simple ones in case they're not optimized away.
 
         // `typeof(X).IsAssignableFrom(typeof(T))` is optimized away
 
         if (typeof(GodotObject).IsAssignableFrom(typeof(T)))
-            return CreateFromGodotObject(UnsafeAs<GodotObject>(from));
+            return (in T from) => CreateFromGodotObject(UnsafeAs<GodotObject>(from));
 
         // `typeof(T).IsValueType` is optimized away
         // `typeof(T).IsEnum` is NOT optimized away: https://github.com/dotnet/runtime/issues/67113
         // Fortunately, `typeof(System.Enum).IsAssignableFrom(typeof(T))` does the job!
 
-        if (typeof(T).IsValueType && typeof(System.Enum).IsAssignableFrom(typeof(T)))
+        if (typeof(T).IsValueType && typeof(Enum).IsAssignableFrom(typeof(T)))
         {
             // `Type.GetTypeCode(typeof(T).GetEnumUnderlyingType())` is not optimized away.
             // Fortunately, `Unsafe.SizeOf<T>()` works and is optimized away.
             // We don't need to know whether it's signed or unsigned.
 
             if (Unsafe.SizeOf<T>() == 1)
-                return CreateFromInt(UnsafeAs<sbyte>(from));
+                return (in T from) => CreateFromInt(UnsafeAs<sbyte>(from));
 
             if (Unsafe.SizeOf<T>() == 2)
-                return CreateFromInt(UnsafeAs<short>(from));
+                return (in T from) => CreateFromInt(UnsafeAs<short>(from));
 
             if (Unsafe.SizeOf<T>() == 4)
-                return CreateFromInt(UnsafeAs<int>(from));
+                return (in T from) => CreateFromInt(UnsafeAs<int>(from));
 
             if (Unsafe.SizeOf<T>() == 8)
-                return CreateFromInt(UnsafeAs<long>(from));
+                return (in T from) => CreateFromInt(UnsafeAs<long>(from));
 
             throw UnsupportedType<T>();
         }
 
-        return GenericConversion<T>.ToVariant(from);
+        return (in T from) => GenericConversion<T>.ToVariant(from);
+
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static T ConvertTo<[MustBeVariant] T>(in godot_variant variant)
+    private static ConvertToDelegate<T> DetermineConvertToDelegate<T>()
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static T UnsafeAsT<TFrom>(TFrom f) => Unsafe.As<TFrom, T>(ref Unsafe.AsRef(f));
 
         if (typeof(T) == typeof(bool))
-            return UnsafeAsT(ConvertToBool(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToBool(variant));
 
         if (typeof(T) == typeof(char))
-            return UnsafeAsT(ConvertToChar(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToChar(variant));
 
         if (typeof(T) == typeof(sbyte))
-            return UnsafeAsT(ConvertToInt8(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToInt8(variant));
 
         if (typeof(T) == typeof(short))
-            return UnsafeAsT(ConvertToInt16(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToInt16(variant));
 
         if (typeof(T) == typeof(int))
-            return UnsafeAsT(ConvertToInt32(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToInt32(variant));
 
         if (typeof(T) == typeof(long))
-            return UnsafeAsT(ConvertToInt64(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToInt64(variant));
 
         if (typeof(T) == typeof(byte))
-            return UnsafeAsT(ConvertToUInt8(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToUInt8(variant));
 
         if (typeof(T) == typeof(ushort))
-            return UnsafeAsT(ConvertToUInt16(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToUInt16(variant));
 
         if (typeof(T) == typeof(uint))
-            return UnsafeAsT(ConvertToUInt32(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToUInt32(variant));
 
         if (typeof(T) == typeof(ulong))
-            return UnsafeAsT(ConvertToUInt64(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToUInt64(variant));
 
         if (typeof(T) == typeof(float))
-            return UnsafeAsT(ConvertToFloat32(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToFloat32(variant));
 
         if (typeof(T) == typeof(double))
-            return UnsafeAsT(ConvertToFloat64(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToFloat64(variant));
 
         if (typeof(T) == typeof(Vector2))
-            return UnsafeAsT(ConvertToVector2(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToVector2(variant));
 
         if (typeof(T) == typeof(Vector2I))
-            return UnsafeAsT(ConvertToVector2I(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToVector2I(variant));
 
         if (typeof(T) == typeof(Rect2))
-            return UnsafeAsT(ConvertToRect2(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToRect2(variant));
 
         if (typeof(T) == typeof(Rect2I))
-            return UnsafeAsT(ConvertToRect2I(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToRect2I(variant));
 
         if (typeof(T) == typeof(Transform2D))
-            return UnsafeAsT(ConvertToTransform2D(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToTransform2D(variant));
 
         if (typeof(T) == typeof(Vector3))
-            return UnsafeAsT(ConvertToVector3(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToVector3(variant));
 
         if (typeof(T) == typeof(Vector3I))
-            return UnsafeAsT(ConvertToVector3I(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToVector3I(variant));
 
         if (typeof(T) == typeof(Basis))
-            return UnsafeAsT(ConvertToBasis(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToBasis(variant));
 
         if (typeof(T) == typeof(Quaternion))
-            return UnsafeAsT(ConvertToQuaternion(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToQuaternion(variant));
 
         if (typeof(T) == typeof(Transform3D))
-            return UnsafeAsT(ConvertToTransform3D(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToTransform3D(variant));
 
         if (typeof(T) == typeof(Projection))
-            return UnsafeAsT(ConvertToProjection(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToProjection(variant));
 
         if (typeof(T) == typeof(Vector4))
-            return UnsafeAsT(ConvertToVector4(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToVector4(variant));
 
         if (typeof(T) == typeof(Vector4I))
-            return UnsafeAsT(ConvertToVector4I(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToVector4I(variant));
 
         if (typeof(T) == typeof(Aabb))
-            return UnsafeAsT(ConvertToAabb(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToAabb(variant));
 
         if (typeof(T) == typeof(Color))
-            return UnsafeAsT(ConvertToColor(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToColor(variant));
 
         if (typeof(T) == typeof(Plane))
-            return UnsafeAsT(ConvertToPlane(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToPlane(variant));
 
         if (typeof(T) == typeof(Callable))
-            return UnsafeAsT(ConvertToCallable(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToCallable(variant));
 
         if (typeof(T) == typeof(Signal))
-            return UnsafeAsT(ConvertToSignal(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToSignal(variant));
 
         if (typeof(T) == typeof(string))
-            return UnsafeAsT(ConvertToString(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToString(variant));
 
         if (typeof(T) == typeof(byte[]))
-            return UnsafeAsT(ConvertAsPackedByteArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedByteArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(int[]))
-            return UnsafeAsT(ConvertAsPackedInt32ArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedInt32ArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(long[]))
-            return UnsafeAsT(ConvertAsPackedInt64ArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedInt64ArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(float[]))
-            return UnsafeAsT(ConvertAsPackedFloat32ArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedFloat32ArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(double[]))
-            return UnsafeAsT(ConvertAsPackedFloat64ArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedFloat64ArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(string[]))
-            return UnsafeAsT(ConvertAsPackedStringArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedStringArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(Vector2[]))
-            return UnsafeAsT(ConvertAsPackedVector2ArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedVector2ArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(Vector3[]))
-            return UnsafeAsT(ConvertAsPackedVector3ArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedVector3ArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(Color[]))
-            return UnsafeAsT(ConvertAsPackedColorArrayToSystemArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertAsPackedColorArrayToSystemArray(variant));
 
         if (typeof(T) == typeof(StringName[]))
-            return UnsafeAsT(ConvertToSystemArrayOfStringName(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToSystemArrayOfStringName(variant));
 
         if (typeof(T) == typeof(NodePath[]))
-            return UnsafeAsT(ConvertToSystemArrayOfNodePath(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToSystemArrayOfNodePath(variant));
 
         if (typeof(T) == typeof(Rid[]))
-            return UnsafeAsT(ConvertToSystemArrayOfRid(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToSystemArrayOfRid(variant));
 
         if (typeof(T) == typeof(StringName))
-            return UnsafeAsT(ConvertToStringName(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToStringName(variant));
 
         if (typeof(T) == typeof(NodePath))
-            return UnsafeAsT(ConvertToNodePath(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToNodePath(variant));
 
         if (typeof(T) == typeof(Rid))
-            return UnsafeAsT(ConvertToRid(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToRid(variant));
 
         if (typeof(T) == typeof(Godot.Collections.Dictionary))
-            return UnsafeAsT(ConvertToDictionary(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToDictionary(variant));
 
         if (typeof(T) == typeof(Godot.Collections.Array))
-            return UnsafeAsT(ConvertToArray(variant));
+            return (in godot_variant variant) => UnsafeAsT(ConvertToArray(variant));
 
         if (typeof(T) == typeof(Variant))
-            return UnsafeAsT(Variant.CreateCopyingBorrowed(variant));
-
+            return (in godot_variant variant) => UnsafeAsT(Variant.CreateCopyingBorrowed(variant));
         // More complex checks here at the end, to avoid screwing the simple ones in case they're not optimized away.
 
         // `typeof(X).IsAssignableFrom(typeof(T))` is optimized away
 
         if (typeof(GodotObject).IsAssignableFrom(typeof(T)))
-            return (T)(object)ConvertToGodotObject(variant);
+            return (in godot_variant variant) => (T)(object)ConvertToGodotObject(variant);
 
         // `typeof(T).IsValueType` is optimized away
         // `typeof(T).IsEnum` is NOT optimized away: https://github.com/dotnet/runtime/issues/67113
         // Fortunately, `typeof(System.Enum).IsAssignableFrom(typeof(T))` does the job!
 
-        if (typeof(T).IsValueType && typeof(System.Enum).IsAssignableFrom(typeof(T)))
+        if (typeof(T).IsValueType && typeof(Enum).IsAssignableFrom(typeof(T)))
         {
             // `Type.GetTypeCode(typeof(T).GetEnumUnderlyingType())` is not optimized away.
             // Fortunately, `Unsafe.SizeOf<T>()` works and is optimized away.
             // We don't need to know whether it's signed or unsigned.
 
             if (Unsafe.SizeOf<T>() == 1)
-                return UnsafeAsT(ConvertToInt8(variant));
+                return (in godot_variant variant) => UnsafeAsT(ConvertToInt8(variant));
 
             if (Unsafe.SizeOf<T>() == 2)
-                return UnsafeAsT(ConvertToInt16(variant));
+                return (in godot_variant variant) => UnsafeAsT(ConvertToInt16(variant));
 
             if (Unsafe.SizeOf<T>() == 4)
-                return UnsafeAsT(ConvertToInt32(variant));
+                return (in godot_variant variant) => UnsafeAsT(ConvertToInt32(variant));
 
             if (Unsafe.SizeOf<T>() == 8)
-                return UnsafeAsT(ConvertToInt64(variant));
+                return (in godot_variant variant) => UnsafeAsT(ConvertToInt64(variant));
 
             throw UnsupportedType<T>();
         }
 
-        return GenericConversion<T>.FromVariant(variant);
+        return (in godot_variant variant) => GenericConversion<T>.FromVariant(variant);
     }
 }


### PR DESCRIPTION
I was working on another C# binding optimization when I noticed that `VariantUtils.ConvertTo<T>(in godot_variant variant)` did a suspicious amount of `GetTypeFromHandle` calls (aka `typeof(T)`) for a simple `Node3D` that only overrides `_Process(double delta)`:
![flamechart](https://github.com/godotengine/godot/assets/1199562/fb52b69b-bdab-4a01-8195-27d4de0c4d5a)
(Also note the accompanying `op_Equality` calls for the type comparisons)

The commit message for 3f645f980c5d7894f98075c29d1c65319be62be7 (which introduced this method) noted the following:
> C# generics don't support specialization the way C++ templates do.
 I knew NativeAOT could optimize away many type checks when the types
 are known at compile time, but I didn't trust the JIT would do as good
 a job, so I initially went with cached function pointers.

 > Well, it turns out the JIT is also very good at optimizing in this
 scenario, so I'm changing the methods to do the conversion directly,
 rather than returning a function pointer for the conversion.

While the JIT is generally good at optimizing such `typeof(T)` guarded function calls, various limitations apply - e.g. the  function *must* be inlined to enable the JIT to remove the unreachable branches for the specific callsite (and specific `T`). 
This function has grown over time and it seems like the JIT does not inline `ConvertTo` (and the accompanying `CreateFrom`) as often as we like, which makes its performance degrade, which hurts for cheap conversion like e.g. `double`.

I have run into this issue in the past and found a workaround which makes C# behave similar to C++ templates when it comes to method specialization: generic static classes with a statically evaluated delegate.
The delegate is resolved at class load time and is then "resolved and cached " for us at all call sites by the runtime. This leads to small (code size) delegates which are easily inlineable with guaranteed "zero-overhead" runtime characteristics. The new implementation is also stable in the sense that we are not praying for JIT optimization which might vary over time - especially because the performance of `ConvertTo / CreateFrom` does not depend on inlining anymore.

I created a test project which spawn 100.000 Nodes with an attached C# script. The attached C# script overrides `_Ready` and `_Process` and increments a global variable which is printed on the screen to avoid dead code elimination, which pretty much nullified my previous benchmark results. Additionally the minimum and average process time is printed, which is used in the table below. If you do your own testing with this project, please do multiple runs as the run to run variance (especially in release builds) is quite high, 5 - 10 runs should suffice. As the project is a CPU intensive synthetic scenario you should aim to reduce the noise on your machine (e.g. IDEs indexing stuff, streaming 8k videos of Godot showcases).
[HighNodeCountNoDeadCode.zip](https://github.com/godotengine/godot/files/14798335/HighNodeCountNoDeadCode.zip)


The timings on my local machine (Win11, NET.Core 7.0.2, CPU: 5800x3D, 120hz display - might matter because of vsync) are as follows:

Editor `Run Project` timings: 
| Implementation| Timings |
|--------|--------|
| `master` @ Godot 4.3 dev 5 | min: 234,20ms - avg: 239,01ms |
| This PR | min: 213,31ms - avg: 217,78ms | 

Windows release template timings:
| Implementation| Timings |
|--------|--------|
| Godot 4.3 Dev 5 official release template | min: 16,58ms - avg: 17,67ms |
| This PR with LTO=full | min: 15,23 ms - avg:  17,17ms | 

We gain around 9% in the editor debug builds and around 3-9% in release builds. It's not much, but this PR is a quite small change as it stands.
The run to run variance for the release template is pretty high, the best runs were taken for all numbers (sample size: ~10) after letting the project run for ~10-15 seconds.

Let me know if the code style or the comments feel off (or you have any other question)!