### PR TITLE
Don't error multiple times when trying to load missing default bus layout

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1226,7 +1226,10 @@ void EditorAudioBuses::_load_layout() {
 void EditorAudioBuses::_load_default_layout() {
 	String layout_path = GLOBAL_GET("audio/buses/default_bus_layout");
 
-	Ref<AudioBusLayout> state = ResourceLoader::load(layout_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE);
+	Ref<AudioBusLayout> state;
+	if (ResourceLoader::exists(layout_path)) {
+		state = ResourceLoader::load(layout_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE);
+	}
 	if (state.is_null()) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("There is no '%s' file."), layout_path));
 		return;


### PR DESCRIPTION
If "Load Default" is pressed when `res://default_bus_layout.tres` is missing, along with the "There is no 'res://default_bus_layout.tres' file." warning dialog, two errors are also printed in the output:

> * Cannot open file 'res://default_bus_layout.tres'.
> * Failed loading resource: res://default_bus_layout.tres. Make sure resources have been imported by opening the project in the editor at least once.

This PR gets rid of these two errors.
