### PR TITLE
Don't force-cleanup already cleaned up `TileMap` cells

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -213,6 +213,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 			(is_y_sort_enabled() && (dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ORIGIN] || dirty.flags[DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED] || dirty.flags[DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM])) ||
 			(!is_y_sort_enabled() && dirty.flags[DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE]);
 
+	bool quadrants_were_cleaned_up = false;
 	// Free all quadrants.
 	if (forced_cleanup || quadrant_shape_changed) {
 		for (const KeyValue<Vector2i, Ref<RenderingQuadrant>> &kv : rendering_quadrant_map) {
@@ -224,12 +225,12 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 			kv.value->cells.clear();
 		}
 		rendering_quadrant_map.clear();
-		_rendering_was_cleaned_up = true;
+		quadrants_were_cleaned_up = true;
 	}
 
 	if (!forced_cleanup) {
 		// List all quadrants to update, recreating them if needed.
-		if (dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || _rendering_was_cleaned_up) {
+		if (dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || _rendering_was_cleaned_up || quadrants_were_cleaned_up) {
 			// Update all cells.
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
 				CellData &cell_data = kv.value;
@@ -412,9 +413,11 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 	// ----------- Occluders processing -----------
 	if (forced_cleanup) {
-		// Clean everything.
-		for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
-			_rendering_occluders_clear_cell(kv.value);
+		if (!_rendering_was_cleaned_up) {
+			// Clean everything.
+			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
+				_rendering_occluders_clear_cell(kv.value);
+			}
 		}
 	} else {
 		if (_rendering_was_cleaned_up || dirty.flags[DIRTY_FLAGS_TILE_SET]) {
@@ -688,9 +691,11 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 	// Check if we should cleanup everything.
 	bool forced_cleanup = p_force_cleanup || !enabled || !collision_enabled || !is_inside_tree() || tile_set.is_null();
 	if (forced_cleanup) {
-		// Clean everything.
-		for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
-			_physics_clear_cell(kv.value);
+		if (!_physics_was_cleaned_up) {
+			// Clean everything.
+			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
+				_physics_clear_cell(kv.value);
+			}
 		}
 	} else {
 		if (_physics_was_cleaned_up || dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_USE_KINEMATIC_BODIES] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE]) {
@@ -967,9 +972,11 @@ void TileMapLayer::_navigation_update(bool p_force_cleanup) {
 
 	// ----------- Navigation regions processing -----------
 	if (forced_cleanup) {
-		// Clean everything.
-		for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
-			_navigation_clear_cell(kv.value);
+		if (!_navigation_was_cleaned_up) {
+			// Clean everything.
+			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
+				_navigation_clear_cell(kv.value);
+			}
 		}
 	} else {
 		if (_navigation_was_cleaned_up || dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || dirty.flags[DIRTY_FLAGS_LAYER_NAVIGATION_MAP]) {
@@ -1212,9 +1219,11 @@ void TileMapLayer::_scenes_update(bool p_force_cleanup) {
 	bool forced_cleanup = p_force_cleanup || !enabled || !is_inside_tree() || tile_set.is_null();
 
 	if (forced_cleanup) {
-		// Clean everything.
-		for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
-			_scenes_clear_cell(kv.value);
+		if (!_scenes_was_cleaned_up) {
+			// Clean everything.
+			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
+				_scenes_clear_cell(kv.value);
+			}
 		}
 	} else {
 		if (_scenes_was_cleaned_up || dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE]) {


### PR DESCRIPTION
Fixes #89774.
cc @MagmaGuy if you could please [test](https://docs.godotengine.org/en/4.2/contributing/workflow/testing_pull_requests.html) for confirmation.

GDScript version of the MRP from #89774:
[Godot_MRP_GDScript.zip](https://github.com/user-attachments/files/16727875/Godot_MRP_GDScript.zip)


This seems like a band aid fix though, I'd say there's plenty to improve regarding cleaning/freeing stuff. There should probably be more control about it. E.g. currently when toggling visibility of a TileMapLayer it cleanups all rendering stuff on hiding, and recreates everything on show. Meaning if you'd e.g. want to keep blinking a TileMapLayer (without making any other changes to it) then it would still do all needless freeing/recreating, very inefficient (blinking is of course quite an exteme example). I'd say it should be somehow possible to prevent freeing (and thus recreating), on demand or something like that.