### PR TITLE
Prefer family name in fonts' names table

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2110,12 +2110,12 @@ CharString String::utf8() const {
 
 String String::utf16(const char16_t *p_utf16, int p_len) {
 	String ret;
-	ret.parse_utf16(p_utf16, p_len);
+	ret.parse_utf16(p_utf16, p_len, true);
 
 	return ret;
 }
 
-Error String::parse_utf16(const char16_t *p_utf16, int p_len) {
+Error String::parse_utf16(const char16_t *p_utf16, int p_len, bool p_default_little_endian) {
 	if (!p_utf16) {
 		return ERR_INVALID_DATA;
 	}
@@ -2125,8 +2125,12 @@ Error String::parse_utf16(const char16_t *p_utf16, int p_len) {
 	int cstr_size = 0;
 	int str_size = 0;
 
+#ifdef BIG_ENDIAN_ENABLED
+	bool byteswap = p_default_little_endian;
+#else
+	bool byteswap = !p_default_little_endian;
+#endif
 	/* HANDLE BOM (Byte Order Mark) */
-	bool byteswap = false; // assume correct endianness if no BOM found
 	if (p_len < 0 || p_len >= 1) {
 		bool has_bom = false;
 		if (uint16_t(p_utf16[0]) == 0xfeff) { // correct BOM, read as is

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -393,7 +393,7 @@ public:
 	static String utf8(const char *p_utf8, int p_len = -1);
 
 	Char16String utf16() const;
-	Error parse_utf16(const char16_t *p_utf16, int p_len = -1);
+	Error parse_utf16(const char16_t *p_utf16, int p_len = -1, bool p_default_little_endian = true);
 	static String utf16(const char16_t *p_utf16, int p_len = -1);
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */


### PR DESCRIPTION
Currently, `family_name` is used as a font's name. This field is an ASCII string, but

> In case the font doesn't provide a specific family name entry, FreeType tries to synthesize one, deriving it from other name entries.

FreeType converts non-ASCII characters into question marks ("?") in this process, resulting in unreadable names for some fonts.

This PR prioritizes reading SFNT names (the name table of TrueType and OpenType fonts) to avoid possible question marks. English (US) is still preferred, so it's mostly compatible.

Among possible encodings, UTF-16 is the most common one that Godot's `String` supports. But it's always in big endian, so I added an extra parameter to `String::parse_utf16()` to specify the endianness to use when no BOM is present.