### PR TITLE
Fix concave `CollisionPolygon2D` debug drawing and docs

### DIFF
--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -4,7 +4,7 @@
 		A node that provides a polygon shape to a [CollisionObject2D] parent.
 	</brief_description>
 	<description>
-		A node that provides a thickened polygon shape (a prism) to a [CollisionObject2D] parent and allows to edit it. The polygon can be concave or convex. This can give a detection shape to an [Area2D] or turn [PhysicsBody2D] into a solid object.
+		A node that provides a polygon shape to a [CollisionObject2D] parent and allows to edit it. The polygon can be concave or convex. This can give a detection shape to an [Area2D], turn [PhysicsBody2D] into a solid object, or give a hollow shape to a [StaticBody2D].
 		[b]Warning:[/b] A non-uniformly scaled [CollisionShape2D] will likely not behave as expected. Make sure to keep its scale the same on all axes and adjust its shape resource instead.
 	</description>
 	<tutorials>

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -132,17 +132,16 @@ void CollisionPolygon2D::_notification(int p_what) {
 			}
 
 			if (polygon.size() > 2) {
-#define DEBUG_DECOMPOSE
-#if defined(TOOLS_ENABLED) && defined(DEBUG_DECOMPOSE)
-				Vector<Vector<Vector2>> decomp = _decompose_in_convex();
+#ifdef TOOLS_ENABLED
+				if (build_mode == BUILD_SOLIDS) {
+					Vector<Vector<Vector2>> decomp = _decompose_in_convex();
 
-				Color c(0.4, 0.9, 0.1);
-				for (int i = 0; i < decomp.size(); i++) {
-					c.set_hsv(Math::fmod(c.get_h() + 0.738, 1), c.get_s(), c.get_v(), 0.5);
-					draw_colored_polygon(decomp[i], c);
+					Color c(0.4, 0.9, 0.1);
+					for (int i = 0; i < decomp.size(); i++) {
+						c.set_hsv(Math::fmod(c.get_h() + 0.738, 1), c.get_s(), c.get_v(), 0.5);
+						draw_colored_polygon(decomp[i], c);
+					}
 				}
-#else
-				draw_colored_polygon(polygon, get_tree()->get_debug_collisions_color());
 #endif
 
 				const Color stroke_color = Color(0.9, 0.2, 0.0);


### PR DESCRIPTION
The debug drawing for `CollisionPolygon2D` showed the convex decomposition unconditionally, which was meaningless in Segments build mode. The dead code would show a filled polygon, which would also be misleading as you can just as well put a character on the inside (because the shape is purely built of segments), so this PR draws nothing on the inside when the build mode is Segments. (If people do prefer a filled polygon, we could do that instead.)

https://github.com/godotengine/godot/assets/229837/07f2f1f8-a7f7-4d2d-b03a-fa677b048617

The documentation had some copy/paste error from the 3D analogue, and it was mentioning only the solid option; now hollow is mentioned as well.

- Closes https://github.com/godotengine/godot/issues/10110