### PR TITLE
DRAFT: C#-Performance:  Use a custom static lookup to handle InvokeGodotClassMethod and HasGodotClassMethod

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
@@ -1,5 +1,6 @@
 using Godot;
 using Godot.NativeInterop;
+using Godot.Bridge;
 
 partial class Methods
 {
@@ -28,34 +29,44 @@ partial class Methods
         return methods;
     }
 #pragma warning restore CS0109
+
+    public new static readonly ScriptMethodRegistry<Methods> MethodRegistry = new ScriptMethodRegistry<Methods>()
+        .Register(global::Godot.GodotObject.MethodRegistry)
+        .Register(MethodName.MethodWithOverload, 0, (Methods scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
+        {
+            scriptInstance.MethodWithOverload();
+            ret = default;
+        })
+        .Register(MethodName.MethodWithOverload, 1, (Methods scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
+        {
+            scriptInstance.MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]));
+            ret = default;
+        })
+        .Register(MethodName.MethodWithOverload, 2, (Methods scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
+        {
+            scriptInstance.MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
+            ret = default;
+        })
+        .Compile();
+
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
     {
-        if (method == MethodName.MethodWithOverload && args.Count == 0) {
-            MethodWithOverload();
-            ret = default;
+        if (MethodRegistry.TryGetMethod(in method, args.Count, out var scriptMethod))
+        {
+            scriptMethod(this, args, out ret);
             return true;
         }
-        if (method == MethodName.MethodWithOverload && args.Count == 1) {
-            MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]));
-            ret = default;
-            return true;
-        }
-        if (method == MethodName.MethodWithOverload && args.Count == 2) {
-            MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
-            ret = default;
-            return true;
-        }
-        return base.InvokeGodotClassMethod(method, args, out ret);
+
+        ret = new godot_variant();
+        return false;
     }
+
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     protected override bool HasGodotClassMethod(in godot_string_name method)
     {
-        if (method == MethodName.MethodWithOverload) {
-           return true;
-        }
-        return base.HasGodotClassMethod(method);
+        return MethodRegistry.ContainsMethod(method);
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
@@ -1,5 +1,6 @@
 using Godot;
 using Godot.NativeInterop;
+using Godot.Bridge;
 
 partial class ScriptBoilerplate
 {
@@ -31,32 +32,39 @@ partial class ScriptBoilerplate
         return methods;
     }
 #pragma warning restore CS0109
+
+    public new static readonly ScriptMethodRegistry<ScriptBoilerplate> MethodRegistry = new ScriptMethodRegistry<ScriptBoilerplate>()
+        .Register(global::Godot.Node.MethodRegistry)
+        .Register(MethodName._Process, 1, (ScriptBoilerplate scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
+        {
+            scriptInstance._Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
+            ret = default;
+        })
+        .Register(MethodName.Bazz, 1, (ScriptBoilerplate scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
+        {
+            var callRet = scriptInstance.Bazz(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
+            ret = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(callRet);
+        })
+        .Compile();
+
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
     {
-        if (method == MethodName._Process && args.Count == 1) {
-            _Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
-            ret = default;
+        if (MethodRegistry.TryGetMethod(in method, args.Count, out var scriptMethod))
+        {
+            scriptMethod(this, args, out ret);
             return true;
         }
-        if (method == MethodName.Bazz && args.Count == 1) {
-            var callRet = Bazz(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
-            ret = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(callRet);
-            return true;
-        }
-        return base.InvokeGodotClassMethod(method, args, out ret);
+
+        ret = new godot_variant();
+        return false;
     }
+
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     protected override bool HasGodotClassMethod(in godot_string_name method)
     {
-        if (method == MethodName._Process) {
-           return true;
-        }
-        else if (method == MethodName.Bazz) {
-           return true;
-        }
-        return base.HasGodotClassMethod(method);
+        return MethodRegistry.ContainsMethod(method);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptMethodRegistry.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptMethodRegistry.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Godot.NativeInterop;
+
+namespace Godot.Bridge
+{
+    public delegate void ScriptMethod<in T>(T scriptInstance, NativeVariantPtrArgs args, out godot_variant ret)
+        where T : GodotObject;
+
+    public sealed class ScriptMethodRegistry<T> where T : GodotObject
+    {
+        internal Dictionary<(int argc, IntPtr methodName), ScriptMethod<T>> MethodsByNameAndArgc { get; } = new();
+        internal Dictionary<(int argc, IntPtr methodName), IntPtr> Aliases { get; } = new();
+
+        private readonly HashSet<IntPtr> _knownMethodNames = new();
+
+        public ScriptMethodRegistry<T> AddAlias(StringName methodName, int argumentCount, StringName alias) =>
+            AddAlias(methodName.NativeValue._data, argumentCount, alias.NativeValue._data);
+
+        public ScriptMethodRegistry<T> Register(StringName methodName, int argumentCount, ScriptMethod<T> method) =>
+            Register(methodName.NativeValue._data, argumentCount, method);
+
+        internal ScriptMethodRegistry<T> AddAlias(IntPtr methodName, int argumentCount, IntPtr alias)
+        {
+            Aliases[(argumentCount, methodName)] = alias;
+            return this;
+        }
+
+        internal ScriptMethodRegistry<T> Register(IntPtr methodName, int argumentCount, ScriptMethod<T> method)
+        {
+            MethodsByNameAndArgc[(argumentCount, methodName)] = method;
+            _knownMethodNames.Add(methodName);
+            return this;
+        }
+
+        public ScriptMethodRegistry<T> Compile()
+        {
+            foreach (var (source, alias) in Aliases)
+            {
+                if (MethodsByNameAndArgc.TryGetValue(source, out var scriptMethod))
+                {
+                    // don't apply aliases when we have an actual method for the alias already
+                    if (!MethodsByNameAndArgc.ContainsKey((source.argc, alias)))
+                    {
+                        Register(alias, source.argc, scriptMethod);
+                    }
+                }
+            }
+
+            GD.Print($"Script method registry compiled for {typeof(T)}: size={MethodsByNameAndArgc.Count}, alias_size={Aliases.Count}");
+            // TODO: I would like to discard _aliases now to free up memory, but the hierarchy above it still needs it
+            //       There are probably lots of aliases, we could at least not copy them and recursively walk our parent
+            //       hierarchy as it's only done once (here). Ideas are appreciated
+            return this;
+        }
+
+        public bool ContainsMethod(in godot_string_name name) => _knownMethodNames.Contains(name._data);
+
+        public bool TryGetMethod(in godot_string_name name, int argumentCount, out ScriptMethod<T> method) =>
+            MethodsByNameAndArgc.TryGetValue((argumentCount, name._data), out method);
+    }
+
+    public static class ScriptMethodRegistryExtensions
+    {
+        // This is an extension method because C# does not allow additional type constraints for an already existing T
+        public static ScriptMethodRegistry<T> Register<T, V>(this ScriptMethodRegistry<T> registry, ScriptMethodRegistry<V> baseTypeRegistry)
+            where T : V where V : GodotObject
+        {
+            foreach (var ((argc, method), alias) in baseTypeRegistry.Aliases)
+            {
+                registry.AddAlias(method, argc, alias);
+            }
+
+            foreach (var ((argc, method), value) in baseTypeRegistry.MethodsByNameAndArgc)
+            {
+                registry.Register(method, argc, value);
+            }
+
+            return registry;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -533,7 +533,7 @@ namespace Godot.NativeInterop
         internal readonly unsafe godot_string_name* GetUnsafeAddress()
             => (godot_string_name*)Unsafe.AsPointer(ref Unsafe.AsRef(in _data));
 
-        private IntPtr _data;
+        internal IntPtr _data;
 
         public void Dispose()
         {
@@ -584,7 +584,7 @@ namespace Godot.NativeInterop
         [StructLayout(LayoutKind.Sequential)]
         internal struct movable
         {
-            private IntPtr _data;
+            internal IntPtr _data;
 
             public static unsafe explicit operator movable(in godot_string_name value)
                 => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Core\Aabb.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />
+    <Compile Include="Core\Bridge\ScriptMethodRegistry.cs" />
     <Compile Include="Core\Callable.generics.cs" />
     <Compile Include="Core\CustomGCHandle.cs" />
     <Compile Include="Core\Array.cs" />


### PR DESCRIPTION
### Preface
This is in an **early** draft state and by no means complete. I am presenting my working proof of concept to discuss if and how to progress with the main idea of this PR. There are lots of open TODOs, questions and polishing to be done. Please focus on the idea instead of the rough sketch shown here (there is also some debug output which will obviously be removed la<zter on).

Be warned: this is a long one to give readers enough context! If you want a TL;DR scroll to the bottom for the performance numbers.

### Introduction
Everytime Godot wants to call a C# script method from C++, the auto-generated `InvokeGodotClassMethod` is invoked.
The current C# bridge implementation of `InvokeGodotClassMethod` approximately works like this for a C# script which overrides `_Ready` and `_Process`: 

```csharp
protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
{
    if (method == MethodName._Ready && args.Count == 0) {
        _Ready();
        ret = default;
        return true;
    }
    if (method == MethodName._Process && args.Count == 1) {
        _Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
        ret = default;
        return true;
    }
    return base.InvokeGodotClassMethod(method, args, out ret);
}
```
While this seems pretty o.k. there is a small detail which makes `InvokeGodotClassMethod` more complicated than it seems: the engine is passing the string `"_process"` as the method name while the user script `InvokeGodotClassMethod` checks for `"_Process"`. This case is handled by the C# glue of the builtin Godot classes (e.g. `Node2D` or `Node3D`) which all user scripts are inherting from (either directly or indirectly via other user scripts):

```csharp
// excerpt from the generated Node.cs
// MethodProxyName__* are the PascalCase variants, MethodName._Process is "_process" here
if ((method == MethodProxyName__process || method == MethodName._Process) && args.Count == 1 && HasGodotClassMethod((godot_string_name)MethodProxyName__process.NativeValue))
{
    _Process(VariantUtils.ConvertTo<double>(args[0]));
    ret = default;
    return true;
}
if ((method == MethodProxyName__ready || method == MethodName._Ready) && args.Count == 0 && HasGodotClassMethod((godot_string_name)MethodProxyName__ready.NativeValue))
{
    _Ready();
    ret = default;
    return true;
}
```

And then there is `HasGodotClassMethod` here - what does it do? It checks if a method is **actually** implemented as e.g. `Node` has to supply an empty stub implementation for `_Process(double delta)` to make this code compile. But why not just call the stub implementation? Because the C++ -> C# function parameter marshalling done via `VariantUtils` could be costly, especially for more complex types like arrays - so why marshall if an empty stub is called? This also has to be implemented this way because what happens if a user actually implements both `_Process(double)` and `_process(double)` in their script? We can't just auto-proxy `"_process"` to `"_Process"` because of this.

At this point we traversed the class hierarchy for a bit and jump back up to the original C# class to call `HasGodotClassMethod`.
This really isn't cheap and there is another part to this: the engine calls our C# script with `"_process"`, `"_enter_tree"` etc. no matter if we implement it or not and calling `HasGodotClassMethod` with an "unimplemented" method name traverses the whole class hierarchy and depending on what class the current C# script is based on, this can be quite expensive - especially for `_PhysicsProcess` for Nodes which don't override it in C#.
Additionally, every* public C# script method gets added into the `if`-chain of `InvokeClassMethod` and `HasGodotClassMethod`,  which indirectly makes all Godot base class (`Node` etc) method calls slower because of how the snake_case to PascalCase handling is implemented (see above) - this hurts, especially for `_Process` and `_PhysicsProcess`.

This makes the current implementation:

- somewhat slow (see performance numbers later)
- hard to reason about as a human
- hard to reason about for the branch predictor

### An alternative implementation
I will try to keep this section high level:

Instead of a bunch of `if`s we will use a `Dictionary<(ParameterCount, MethodName), Delegate>` to resolve functions. Adding all the C# bridge details to this yields a wrapper class (called `ScriptMethodRegistry` for now) and the following snippet for a user script called `MainScene` which implements `_Ready` and `_Process` in C#:

```csharp
public new static readonly ScriptMethodRegistry<MainScene> MethodRegistry = new ScriptMethodRegistry<MainScene>()
    .Register(MethodName._Ready, 0, (MainScene scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
    {
        scriptInstance._Ready();
        ret = default;
    })
    .Register(MethodName._Process, 1, (MainScene scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
    {
        scriptInstance._Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
        ret = default;
    })
    .Compile();
```

This still misses the  `"_process"` -> `"_Process"` mapping for the engine calls which is done via aliases, here is an excerpt from `Node.cs`:
```csharp
 public static readonly ScriptMethodRegistry<Node> MethodRegistry = new ScriptMethodRegistry<Node>()
    // remember MethodProxyName__process is the PascalCaseName here
    .AddAlias(Node.MethodProxyName__process, 0, Node.MethodName._Process)
```

These aliases are then imported which gives us:
```csharp
public new static readonly MethodRegistry<MainScene> MethodRegistry = new MethodRegistry<MainScene>()
    // this is new, we register our parents registry (aliases and function registrations)
    // our parent registry did the same with Node, which did the same with GodotObject ...
    .Register(global::Godot.Node3D.MethodRegistry)
    .Register(MethodName._Ready, 0, (MainScene scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
    {
        scriptInstance._Ready();
        ret = default;
    })
    .Register(MethodName._Process, 1, (MainScene scriptInstance, NativeVariantPtrArgs args, out godot_variant ret) => 
    {
        scriptInstance._Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
        ret = default;
    })
    .Compile();
```
This concept fixes all* evil issues:
- if a script overrides a function that its parent already implemented, it gets overriden because the registry of the parent is added first and then potentially overriden by local `.Register` definitions
- if Godot users actually implement `_process(double)` and `_Process(double)`, the correct method is invoked when the engine passes `"_process"` as the method name

The `.Compile()` step is needed because we need to apply the alias logic somewhere.

And thats about it, invoking a function is easy and fast now, a negative response is just as fast which is a big boon (see introduction): 
```csharp
protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
{
    if (MethodRegistry.TryGetMethod(in method, args.Count, out var scriptMethod))
    {
         scriptMethod(this, args, out ret);
         return true;
    }

    ret = new godot_variant();
    return false;
}
```
### HasGodotClassMethod
I went ahead and changed the implementation for `HasGodotClassMethod` as well because it kind of uses the same pattern and the `ScriptMethodRegistry` could fulfill its requirements with minor adjustments. We will have to think about other places like `InvokeGodotClassStaticMethod`, should we apply this pattern there too? 

### Downsides and caveats
Here is an unordered list of downsides / caveats I can think of:

- I pointed out that the current implementation is hard to reason about, the proposed changes are not improving this in a significant way and to some people may even seem more complex, which is understandable
- We have to be careful not to do too much work in a `static` context as it would negatively impact users (stutters, hanging because of load time initialization); this is especially annoying for Godot users because its hard to manually control static initialization (I think `RuntimeHelpers.RunClassConstructor` etc. should be avoided in Godot user code). Speaking from personal experience, we would have to do significantly more work for this to become noticable
- We need one static dictionary per C# script type (no matter if its generated C++ glue classes or user scripts), this increases Godot C#'s memory footprint which we should measure at least once

### Known issues
- Example: A user-script which inherits from `Node` which provides `_Process(int)` will erroneously be called as a substitute for `_Process(double)` because the current aliasing implementation does no type checks. This will be difficult to fix / address. The `master` version of `InvokeGodotClassMethod` would only "erroneously" call the stub `_Process(double)` in `Node`  (because `HasGodotClassMethod` does no type checks and thus returns `true`). How would this work in GDScript, what is the expected or acceptable behaviour?
  - This is already complicated in current `master` if a user defines `_Process(int)` before defining `_Process(double)` in their C# script. Overloads are deduplicated in `ScriptMethodGenerator` by name and argument count and only one of them is emitted into `InvokeGodotClassMerthod` - `_Process(int)` in this case. The correct method would still be called when the engine passes `"_process"` to `InvokeGodotMethod` though
  - We need a clear stance on method overloading with equal argument counts here, shouldn't we forbid it in general? Right now it feels like undefined behaviour (e.g. it dependent on method declaration order in C#)
- `master` handles overloading for methods with the same parameter count by using the first occurence, this PR uses the last occurence

### Personal opinion on downsides, caveats, issues and how to deal with them
This is just my personal opinion on how to deal with certain issues, feel free to skip it.

 I think we need a clear definition of what the C# integration supports and what is outright illegal, leading to compilation issues (the same as missing the `partial` identifier in user scripts).
 I propose the following new constraints:

1. same-parameter method overloading for public methods is disallowed
2. public methods are disallowed to start with `_[a-z]` (in words: underscore with a lowercase character) as this heavily conflicts with the snake_case to PascalCase resolution which even breaks `master` at the moment (`_process(int)` would be called by the engine `"_process"` call)

Users affected by 1. are already somewhat affected, as `master` only registers the first overload for signal bindings etc.
Users affected by 2. are on the wrong path anyways, using `_` as a prefix to non-engine supplied functions is suspicious on its own, going for lowercase characters afterwards is even more weird.

I think very few users will be affected by these constraints. Right now its hard to gauge what input (user scripts) the C# integration has to accomodate, which is also shown by the lack of extensive tests or documentation on what edge-cases are legal or illegal (the C# integration even silently discards all but one same parameter method overload).
Godots C# integration has good error reporting in place, we should use it more.

Method overloading was also requested in GDScript, but [declined for now because of performance concerns](https://github.com/godotengine/godot-proposals/issues/1571#issuecomment-813750673).

### Performance measurements

I created a test project which spawn 100.000 Nodes with an attached C# script. The attached C# script overrides `_Ready` and `_Process` and increments a global variable which is printed on the screen to avoid dead code elimination, which pretty much nullified my previous benchmark results. Additionally the minimum and average process time is printed, which is used in the table below. If you do your own testing with this project, please do multiple runs as the run to run variance (especially in release builds) is quite high, 5 - 10 runs should suffice. As the project is a CPU intensive synthetic scenario you should aim to reduce the noise on your machine (e.g. IDEs indexing stuff, streaming 8k videos of Godot showcases).
[HighNodeCountNoDeadCode.zip](https://github.com/godotengine/godot/files/14797723/HighNodeCountNoDeadCode.zip)

On my machine (Win11, NET.Core 7.0.2, CPU: 5800x3D, 120hz display - might matter because of vsync), I get the following results:
| Implementation | Run type | Process Time (ms) |
|--------|--------|--------|
| `master` @ Godot 4.3 Dev 5 | Editor "Run project" | min:  234,20ms - avg: 239,01ms |
| This PR | Editor "Run project" | min:  39,39ms - avg: 42,15ms | 
| `master` @ Godot 4.3 Dev 5 | Official Windows export template | min: 16,58ms -  avg: 17,67ms |
| This PR | Windows LTO=full export template | min: 13,35ms - avg: 15,35ms |

(Remember: I took the best run for all variants out of ~4-6 runs after letting the project run ~ 10-15 seconds as the run to run variance is high enough to make a difference here) 

The gains for in editor running are significant (>5x).
The gains for release builds are smaller by comparison, around 14-20%.

Having the editor be this much closer to the release template is a goodie for the developer experience, especially for large projects. 

I attached a .NET profiler to the release version of the test project and there is still some room to improve the lookup by using a custom hash code, that shaved off at most 1-2ms of process time locally. I will get to these micro-optimizations when we commit to this PR.

### TODOs

- [x] Make the PR build in CI (code style, code gen tests, spell checking)
- [x] Rename `FunctionRegistry` to `ScriptMethodRegistry`and its accompanying classes to `*Method*` to be in line with other Godot wordings
- [x] Cleanup TODOs meant for myself
- [ ] Talk to C# binding code owners about open questions, issues and how to solve them (see remaining code TODOs)
- [ ] Check with the C# binding code owners if its ok to make `godot_string_name._data` visible with `internal` as everything else breaks apart if this change is declined
- [ ] Discuss if same argument count method overloads in C# scripts should be allowed, they don't work correctly anyways. Emulating the `master` overload handling (discarding all but one overload, by definition order) would be complicated in this PR
- [ ] Clarify why the `HasGodotClassMethod` is used in `CSharpInstanceBridge._Get`  without parameter count checks, a getter with parameters makes no sense to me

### TODOs if we proceed with this PRs idea

- [ ] What about `InvokeGodotClassStaticMethod`?
- [ ] Check the assembly size, it must have shrunk a bit
- [ ] Add unit tests for `ScriptMethodRegistry` as the whole "inheritance" and aliasing part of it is pretty easily testable


Thank you to @paulloz and @raulsntos for helping me in Rocket.Chat / Discord on how to go on with my idea!