### PR TITLE
[macOS] Use `expand_to_title` for the project manager.

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -38,6 +38,7 @@ class CheckBox;
 class EditorAbout;
 class EditorAssetLibrary;
 class EditorFileDialog;
+class EditorTitleBar;
 class HFlowContainer;
 class LineEdit;
 class LinkButton;
@@ -71,12 +72,17 @@ class ProjectManager : public Control {
 
 	void _update_size_limits();
 	void _update_theme(bool p_skip_creation = false);
+	void _titlebar_resized();
 
 	MarginContainer *root_container = nullptr;
 	Panel *background_panel = nullptr;
 	VBoxContainer *main_vbox = nullptr;
 
-	HBoxContainer *title_bar = nullptr;
+	EditorTitleBar *title_bar = nullptr;
+	Control *left_menu_spacer = nullptr;
+	Control *left_spacer = nullptr;
+	Control *right_menu_spacer = nullptr;
+	Control *right_spacer = nullptr;
 	Button *title_bar_logo = nullptr;
 	HBoxContainer *main_view_toggles = nullptr;
 	Button *quick_settings_button = nullptr;


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/64777 but for the Project Manager, it was not working nice with old PM design, but seems to look OK with new one. Can be controlled with the same editor setting as the main editor window title. 

<img width="1062" alt="Screenshot 2024-03-23 at 21 08 59" src="https://github.com/godotengine/godot/assets/7645683/be92890b-9e48-42bb-9f1b-acb1da60dcbc">
