### PR TITLE
Fix floor snapping for CSG shapes with collision

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -108,6 +108,11 @@
 #include "servers/physics_3d/physics_server_3d_types.h"
 #include "servers/rendering/rendering_server.h"
 
+#include "modules/modules_enabled.gen.h" // For csg.
+#ifdef MODULE_CSG_ENABLED
+#include "modules/csg/csg_shape.h"
+#endif
+
 using namespace Node3DEditorConstants;
 
 ///////////////////////////////////////////////////////////////////
@@ -2152,6 +2157,18 @@ HashSet<RID> _get_physics_bodies_rid(Node *node) {
 	for (const PhysicsBody3D *I : child_nodes) {
 		rids.insert(I->get_rid());
 	}
+#ifdef MODULE_CSG_ENABLED
+	CSGShape3D *csg_shape = Node::cast_to<CSGShape3D>(node);
+	if (csg_shape && csg_shape->is_using_collision()) {
+		rids.insert(csg_shape->_get_root_collision_instance());
+	}
+	HashSet<CSGShape3D *> csg_child_nodes = _get_child_nodes<CSGShape3D>(node);
+	for (const CSGShape3D *I : csg_child_nodes) {
+		if (I->is_using_collision()) {
+			rids.insert(I->_get_root_collision_instance());
+		}
+	}
+#endif
 
 	return rids;
 }


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/89832

I found that the cause of this behaviour was that the CSG Shapes with collision enabled were not being included in the exclude list for the raycast that finds the object/floor underneath being placed. This is because they do not use PhysicsBody3D but instead use PhysicsServer3D directly. At certain sizes, specifically small sizes, the raycast can then hit the object that is meant to be being placed causing it to be pushed up.

To fix this I have done the following:

- Add additional checks when gathering nodes to exclude from raycast made when using the Snap Object to Floor feature of the 3D editor so that it finds and includes CSGShape3Ds that have collision enabled.