### PR TITLE
Add reference to InputEventJoypadButton in `_shortcut_input` doc

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -100,7 +100,7 @@
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Called when an [InputEventKey] or [InputEventShortcut] hasn't been consumed by [method _input] or any GUI [Control] item. It is called before [method _unhandled_key_input] and [method _unhandled_input]. The input event propagates up through the node tree until a node consumes it.
+				Called when an [InputEventKey], [InputEventShortcut], or [InputEventJoypadButton] hasn't been consumed by [method _input] or any GUI [Control] item. It is called before [method _unhandled_key_input] and [method _unhandled_input]. The input event propagates up through the node tree until a node consumes it.
 				It is only called if shortcut processing is enabled, which is done automatically if this method is overridden, and can be toggled with [method set_process_shortcut_input].
 				To consume the input event and stop it propagating further to other nodes, [method Viewport.set_input_as_handled] can be called.
 				This method can be used to handle shortcuts. For generic GUI events, use [method _input] instead. Gameplay events should usually be handled with either [method _unhandled_input] or [method _unhandled_key_input].


### PR DESCRIPTION
According to the fix in https://github.com/godotengine/godot/pull/66750, InputEventJoypadButton can now be used in _shortcut_input, but it looks like this info hasn't been added to the docs https://docs.godotengine.org/en/latest/classes/class_node.html#class-node-private-method-shortcut-input.

After this change, InputEventJoypadButton will be mentioned alongside the other InputEvents in this method's doc.

Note that information about this has already been added to https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html#how-does-it-work.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
