### PR TITLE
Fix decal modulate being passed as srgb instead of as linear color.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2965,7 +2965,7 @@ void TextureStorage::update_decal_buffer(const PagedArray<RID> &p_decals, const 
 			dd.emission_rect[3] = 0;
 		}
 
-		Color modulate = decal->modulate;
+		Color modulate = decal->modulate.srgb_to_linear();
 		dd.modulate[0] = modulate.r;
 		dd.modulate[1] = modulate.g;
 		dd.modulate[2] = modulate.b;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Before:
(Left is a decal, right is a transparent plane)

![image](https://github.com/godotengine/godot/assets/3101690/5ce5c3d8-dbd0-405d-963c-d52dd568d6cc)

(Note that specular differences are (I think) because decals use separate speculars.)

After:
![image](https://github.com/godotengine/godot/assets/3101690/213ad7cb-5da9-4765-b1c6-f31d1e147e27)

I don't think there's any point in not doing this conversion, since decal rendering isn't customizable anyways and since the conversion is done in TextureStorage which AFAIK already assumes linear color space rendering.