### PR TITLE
GDScript: Add `IMPLICIT_CONVERSION_CAUSES_COPY` warning

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -492,6 +492,9 @@
 		<member name="debug/gdscript/warnings/get_node_default_without_onready" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when [method Node.get_node] (or the shorthand [code]$[/code]) is used as default value of a class variable without the [code]@onready[/code] annotation.
 		</member>
+		<member name="debug/gdscript/warnings/implicit_conversion_causes_copy" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an implicit type conversion causes a copy.
+		</member>
 		<member name="debug/gdscript/warnings/incompatible_ternary" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a ternary operator may emit values with incompatible types.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -43,7 +43,7 @@
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/templates/hash_map.h"
-#include "scene/resources/packed_scene.h"
+#include "scene/main/node.h"
 
 #if defined(TOOLS_ENABLED) && !defined(DISABLE_DEPRECATED)
 #define SUGGEST_GODOT4_RENAMES
@@ -1360,9 +1360,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 						} else {
 							has_valid_getter = true;
 #ifdef DEBUG_ENABLED
-							if (member.variable->datatype.builtin_type == Variant::INT && return_datatype.builtin_type == Variant::FLOAT) {
-								parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
-							}
+							check_conversion(member.variable, return_datatype.builtin_type, member.variable->datatype.builtin_type);
 #endif
 						}
 					}
@@ -1386,9 +1384,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 						has_valid_setter = true;
 
 #ifdef DEBUG_ENABLED
-						if (member.variable->datatype.builtin_type == Variant::FLOAT && setter_function->parameters[0]->datatype.builtin_type == Variant::INT) {
-							parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
-						}
+						check_conversion(member.variable, member.variable->datatype.builtin_type, setter_function->parameters[0]->datatype.builtin_type);
 #endif
 					}
 				}
@@ -1546,9 +1542,7 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 
 		if (value.get_type() != argument_info.type) {
 #ifdef DEBUG_ENABLED
-			if (argument_info.type == Variant::INT && value.get_type() == Variant::FLOAT) {
-				parser->push_warning(argument, GDScriptWarning::NARROWING_CONVERSION);
-			}
+			check_conversion(argument, value.get_type(), argument_info.type);
 #endif
 
 			if (!Variant::can_convert_strict(value.get_type(), argument_info.type)) {
@@ -1941,8 +1935,8 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 			} else if (specified_type.has_container_element_type(0) && !initializer_type.has_container_element_type(0)) {
 				mark_node_unsafe(p_assignable->initializer);
 #ifdef DEBUG_ENABLED
-			} else if (specified_type.builtin_type == Variant::INT && initializer_type.builtin_type == Variant::FLOAT) {
-				parser->push_warning(p_assignable->initializer, GDScriptWarning::NARROWING_CONVERSION);
+			} else {
+				check_conversion(p_assignable->initializer, initializer_type.builtin_type, specified_type.builtin_type);
 #endif
 			}
 		}
@@ -2394,8 +2388,8 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 				push_error(vformat(R"(Cannot return value of type "%s" because the function return type is "%s".)", result.to_string(), expected_type.to_string()), p_return);
 			}
 #ifdef DEBUG_ENABLED
-		} else if (expected_type.builtin_type == Variant::INT && result.builtin_type == Variant::FLOAT) {
-			parser->push_warning(p_return, GDScriptWarning::NARROWING_CONVERSION);
+		} else {
+			check_conversion(p_return->return_value, result.builtin_type, expected_type.builtin_type);
 #endif
 		}
 	}
@@ -2574,9 +2568,7 @@ void GDScriptAnalyzer::update_const_expression_builtin_type(GDScriptParser::Expr
 	}
 
 #ifdef DEBUG_ENABLED
-	if (p_type.builtin_type == Variant::INT && value_type.builtin_type == Variant::FLOAT) {
-		parser->push_warning(p_expression, GDScriptWarning::NARROWING_CONVERSION);
-	}
+	check_conversion(p_expression, value_type.builtin_type, p_type.builtin_type);
 #endif
 
 	p_expression->reduced_value = converted_to;
@@ -2751,8 +2743,8 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 	}
 
 #ifdef DEBUG_ENABLED
-	if (assignee_type.is_hard_type() && assignee_type.builtin_type == Variant::INT && assigned_value_type.builtin_type == Variant::FLOAT) {
-		parser->push_warning(p_assignment->assigned_value, GDScriptWarning::NARROWING_CONVERSION);
+	if (assignee_type.is_hard_type()) {
+		check_conversion(p_assignment->assigned_value, assigned_value_type.builtin_type, assignee_type.builtin_type);
 	}
 #endif
 }
@@ -5168,8 +5160,8 @@ void GDScriptAnalyzer::validate_call_arg(const List<GDScriptParser::DataType> &p
 #endif
 			}
 #ifdef DEBUG_ENABLED
-		} else if (par_type.kind == GDScriptParser::DataType::BUILTIN && par_type.builtin_type == Variant::INT && arg_type.kind == GDScriptParser::DataType::BUILTIN && arg_type.builtin_type == Variant::FLOAT) {
-			parser->push_warning(p_call->arguments[i], GDScriptWarning::NARROWING_CONVERSION, p_call->function_name);
+		} else if (par_type.kind == GDScriptParser::DataType::BUILTIN && arg_type.kind == GDScriptParser::DataType::BUILTIN) {
+			check_conversion(p_call->arguments[i], arg_type.builtin_type, par_type.builtin_type);
 #endif
 		}
 	}
@@ -5238,6 +5230,30 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 			return;
 		}
 		parent = ClassDB::get_parent_class(parent);
+	}
+}
+
+void GDScriptAnalyzer::check_conversion(const GDScriptParser::Node *p_source, Variant::Type p_from_type, Variant::Type p_to_type) {
+	if (p_from_type == p_to_type) {
+		return;
+	}
+
+	if (p_from_type == Variant::NIL || p_to_type == Variant::NIL) {
+		return;
+	}
+
+	if (p_from_type == Variant::FLOAT && p_to_type == Variant::INT) {
+		parser->push_warning(p_source, GDScriptWarning::NARROWING_CONVERSION);
+		return;
+	}
+
+	bool conversion_causes_copy = (Variant::is_type_shared(p_from_type) || p_from_type >= Variant::PACKED_BYTE_ARRAY) && (Variant::is_type_shared(p_to_type) || p_to_type >= Variant::PACKED_BYTE_ARRAY);
+	// We only want to warn about a copy if the use comes from a variable access.
+	bool from_variable = p_source && p_source->type == GDScriptParser::Node::IDENTIFIER;
+	if (from_variable && conversion_causes_copy) {
+		String from_name = Variant::get_type_name(p_from_type);
+		String to_name = Variant::get_type_name(p_to_type);
+		parser->push_warning(p_source, GDScriptWarning::IMPLICIT_CONVERSION_CAUSES_COPY, from_name, to_name);
 	}
 }
 #endif

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -36,7 +36,6 @@
 
 #include "core/object/object.h"
 #include "core/object/ref_counted.h"
-#include "core/templates/hash_set.h"
 
 class GDScriptAnalyzer {
 	GDScriptParser *parser = nullptr;
@@ -136,6 +135,7 @@ class GDScriptAnalyzer {
 	void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
 #ifdef DEBUG_ENABLED
 	void is_shadowing(GDScriptParser::IdentifierNode *p_identifier, const String &p_context, const bool p_in_local_scope);
+	void check_conversion(const GDScriptParser::Node *p_source, Variant::Type p_from, Variant::Type p_to);
 #endif
 
 public:

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -153,6 +153,8 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case IMPLICIT_CONVERSION_CAUSES_COPY:
+			return vformat(R"*(Implicit conversion from "%s" to "%s" causes value to be copied.)*", symbols[0], symbols[1]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -231,6 +233,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",
 		"ONREADY_WITH_EXPORT",
+		"IMPLICIT_CONVERSION_CAUSES_COPY",
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -88,6 +88,7 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		IMPLICIT_CONVERSION_CAUSES_COPY, // Implicit type conversion between array types resulting in array being passed by value
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -139,6 +140,7 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // IMPLICIT_CONVERSION_CAUSES_COPY
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/features/return_conversions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_conversions.gd
@@ -3,7 +3,9 @@ func convert_arg_int_to_float(arg: int) -> float: return arg
 func convert_var_int_to_float() -> float: var number := 59; return number
 
 func convert_literal_array_to_packed() -> PackedStringArray: return ['46']
+@warning_ignore("implicit_conversion_causes_copy")
 func convert_arg_array_to_packed(arg: Array) -> PackedStringArray: return arg
+@warning_ignore("implicit_conversion_causes_copy")
 func convert_var_array_to_packed() -> PackedStringArray: var array := ['79']; return array
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/warnings/implicit_conversion_copy.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/implicit_conversion_copy.gd
@@ -1,0 +1,15 @@
+func untyped_func(_x: Variant) -> void:
+	pass
+
+func array_func(_x: Array) -> void:
+	pass
+
+func typed_array_func(_x: Array[int]) -> void:
+	pass
+
+func test():
+	var pba := PackedByteArray()
+	untyped_func(pba)
+	array_func(pba)
+	typed_array_func(pba)
+

--- a/modules/gdscript/tests/scripts/analyzer/warnings/implicit_conversion_copy.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/implicit_conversion_copy.out
@@ -1,0 +1,9 @@
+GDTEST_OK
+>> WARNING
+>> Line: 13
+>> IMPLICIT_CONVERSION_CAUSES_COPY
+>> Implicit conversion from "PackedByteArray" to "Array" causes value to be copied.
+>> WARNING
+>> Line: 14
+>> IMPLICIT_CONVERSION_CAUSES_COPY
+>> Implicit conversion from "PackedByteArray" to "Array" causes value to be copied.


### PR DESCRIPTION
Fixes #89829
