### PR TITLE
Fix `EXIT_SUCCESS` on MacOS

### DIFF
--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
 	@autoreleasepool {
 		ret = Main::start();
 	}
-	if (ret) {
+	if (ret == EXIT_SUCCESS) {
 		os.run();
 	} else {
 		os.set_exit_code(EXIT_FAILURE);


### PR DESCRIPTION
Fixes: #89842
Follow-up to #89229.

Description: https://github.com/godotengine/godot/issues/89842#issuecomment-2016859099