### PR TITLE
Fix regression with C# build editor crash due to `EditorHelpHighlighter`

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3471,7 +3471,9 @@ EditorHelpHighlighter::HighlightData EditorHelpHighlighter::_get_highlight_data(
 	}
 
 	text_edits[p_language]->set_text(p_source);
-	scripts[p_language]->set_source_code(p_source);
+	if (scripts[p_language].is_valid()) { // See GH-89610.
+		scripts[p_language]->set_source_code(p_source);
+	}
 	highlighters[p_language]->_update_cache();
 
 	HighlightData result;
@@ -3561,16 +3563,18 @@ EditorHelpHighlighter::EditorHelpHighlighter() {
 #ifdef MODULE_MONO_ENABLED
 	TextEdit *csharp_text_edit = memnew(TextEdit);
 
-	Ref<CSharpScript> csharp;
-	csharp.instantiate();
+	// See GH-89610.
+	//Ref<CSharpScript> csharp;
+	//csharp.instantiate();
 
 	Ref<EditorStandardSyntaxHighlighter> csharp_highlighter;
 	csharp_highlighter.instantiate();
 	csharp_highlighter->set_text_edit(csharp_text_edit);
-	csharp_highlighter->_set_edited_resource(csharp);
+	//csharp_highlighter->_set_edited_resource(csharp);
+	csharp_highlighter->_set_script_language(CSharpLanguage::get_singleton());
 
 	text_edits[LANGUAGE_CSHARP] = csharp_text_edit;
-	scripts[LANGUAGE_CSHARP] = csharp;
+	//scripts[LANGUAGE_CSHARP] = csharp;
 	highlighters[LANGUAGE_CSHARP] = csharp_highlighter;
 #endif
 }
@@ -3578,14 +3582,10 @@ EditorHelpHighlighter::EditorHelpHighlighter() {
 EditorHelpHighlighter::~EditorHelpHighlighter() {
 #ifdef MODULE_GDSCRIPT_ENABLED
 	memdelete(text_edits[LANGUAGE_GDSCRIPT]);
-	scripts[LANGUAGE_GDSCRIPT].unref();
-	highlighters[LANGUAGE_GDSCRIPT].unref();
 #endif
 
 #ifdef MODULE_MONO_ENABLED
 	memdelete(text_edits[LANGUAGE_CSHARP]);
-	scripts[LANGUAGE_CSHARP].unref();
-	highlighters[LANGUAGE_CSHARP].unref();
 #endif
 }
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -137,12 +137,22 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		}
 	}
 
-	const Ref<Script> scr = _get_edited_resource();
-	if (scr.is_valid()) {
+	const ScriptLanguage *scr_lang = script_language;
+	StringName instance_base;
+
+	if (scr_lang == nullptr) {
+		const Ref<Script> scr = _get_edited_resource();
+		if (scr.is_valid()) {
+			scr_lang = scr->get_language();
+			instance_base = scr->get_instance_base_type();
+		}
+	}
+
+	if (scr_lang != nullptr) {
 		/* Core types. */
 		const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
 		List<String> core_types;
-		scr->get_language()->get_core_type_words(&core_types);
+		scr_lang->get_core_type_words(&core_types);
 		for (const String &E : core_types) {
 			highlighter->add_keyword_color(E, basetype_color);
 		}
@@ -151,9 +161,9 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
 		const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
 		List<String> keywords;
-		scr->get_language()->get_reserved_words(&keywords);
+		scr_lang->get_reserved_words(&keywords);
 		for (const String &E : keywords) {
-			if (scr->get_language()->is_control_flow_keyword(E)) {
+			if (scr_lang->is_control_flow_keyword(E)) {
 				highlighter->add_keyword_color(E, control_flow_keyword_color);
 			} else {
 				highlighter->add_keyword_color(E, keyword_color);
@@ -162,7 +172,6 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 
 		/* Member types. */
 		const Color member_variable_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
-		StringName instance_base = scr->get_instance_base_type();
 		if (instance_base != StringName()) {
 			List<PropertyInfo> plist;
 			ClassDB::get_property_list(instance_base, &plist);
@@ -187,7 +196,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Comments */
 		const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
 		List<String> comments;
-		scr->get_language()->get_comment_delimiters(&comments);
+		scr_lang->get_comment_delimiters(&comments);
 		for (const String &comment : comments) {
 			String beg = comment.get_slice(" ", 0);
 			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
@@ -197,7 +206,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Doc comments */
 		const Color doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
 		List<String> doc_comments;
-		scr->get_language()->get_doc_comment_delimiters(&doc_comments);
+		scr_lang->get_doc_comment_delimiters(&doc_comments);
 		for (const String &doc_comment : doc_comments) {
 			String beg = doc_comment.get_slice(" ", 0);
 			String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
@@ -207,7 +216,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		/* Strings */
 		const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
 		List<String> strings;
-		scr->get_language()->get_string_delimiters(&strings);
+		scr_lang->get_string_delimiters(&strings);
 		for (const String &string : strings) {
 			String beg = string.get_slice(" ", 0);
 			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -78,6 +78,7 @@ class EditorStandardSyntaxHighlighter : public EditorSyntaxHighlighter {
 
 private:
 	Ref<CodeHighlighter> highlighter;
+	ScriptLanguage *script_language = nullptr; // See GH-89610.
 
 public:
 	virtual void _update_cache() override;
@@ -86,6 +87,8 @@ public:
 	virtual String _get_name() const override { return TTR("Standard"); }
 
 	virtual Ref<EditorSyntaxHighlighter> _create() const override;
+
+	void _set_script_language(ScriptLanguage *p_script_language) { script_language = p_script_language; }
 
 	EditorStandardSyntaxHighlighter() { highlighter.instantiate(); }
 };


### PR DESCRIPTION
* Fixes #89610.
* Fixes #89709.

The crash is caused by double free.

```
Thread 1 "godot.linuxbsd." received signal SIGABRT, Aborted.

#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff7c428e6 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff7c268b7 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff7c27750 in __libc_message (fmt=fmt@entry=0x7ffff7dc3b34 "%s\n") at ../sysdeps/posix/libc_fatal.c:150
#6  0x00007ffff7ca3ce7 in malloc_printerr (str=str@entry=0x7ffff7dc6a40 "double free or corruption (!prev)") at ./malloc/malloc.c:5765
#7  0x00007ffff7ca5cdc in _int_free_merge_chunk (av=0x7ffff7dfeca0 <main_arena>, p=0x55555d673b80, size=880) at ./malloc/malloc.c:4672
#8  0x00007ffff7ca5fd9 in _int_free (av=0x7ffff7dfeca0 <main_arena>, p=<optimized out>, have_lock=<optimized out>) at ./malloc/malloc.c:4639
#9  0x00007ffff7ca8873 in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3391
#10 0x0000555556de22ca in memdelete<Script> (p_class=0x55555d673ba0) at ./core/os/memory.h:119
#11 memdelete<Script> (p_class=0x55555d673ba0) at ./core/os/memory.h:111
#12 Ref<Script>::unref (this=0x55556fa21ad0) at ./core/object/ref_counted.h:210
#13 Ref<Script>::~Ref (this=0x55556fa21ad0, __in_chrg=<optimized out>) at ./core/object/ref_counted.h:223
#14 EditorHelpHighlighter::~EditorHelpHighlighter (this=0x55556fa21a50, __in_chrg=<optimized out>) at editor/editor_help.cpp:3579
#15 0x0000555556de4959 in memdelete<EditorHelpHighlighter> (p_class=0x55556fa21a50) at ./core/os/memory.h:111
#16 EditorHelpHighlighter::free_singleton () at editor/editor_help.cpp:3442
#17 0x0000555556eadadc in EditorNode::~EditorNode (this=0x55555fbcbb90, __in_chrg=<optimized out>) at editor/editor_node.cpp:7439
#18 0x0000555557e30772 in memdelete<Node> (p_class=0x55555fbcbb90) at ./core/os/memory.h:111
#19 memdelete<Node> (p_class=0x55555fbcbb90) at ./core/os/memory.h:111
#20 Node::_notification (this=0x55555fb5b950, p_notification=<optimized out>) at scene/main/node.cpp:235
#21 0x000055555a1e831e in Object::_predelete (this=0x55555fb5b950) at core/object/object.cpp:199
#22 predelete_handler (p_object=p_object@entry=0x55555fb5b950) at core/object/object.cpp:2135
#23 0x0000555557e7274f in memdelete<Window> (p_class=0x55555fb5b950) at ./core/os/memory.h:111
#24 SceneTree::finalize (this=0x55555fb5b440) at scene/main/scene_tree.cpp:630
#25 0x0000555555aff38c in main (argc=<optimized out>, argv=0x7fffffffe418) at platform/linuxbsd/godot_linuxbsd.cpp:86
```

I'm guessing this is related to `SelfList`:

https://github.com/godotengine/godot/blob/99ff024f78f65ba0bc54fb409cfeca43ba2008fe/modules/mono/csharp_script.cpp#L2841-L2863

To save the C# highlighting, I added a hack to `EditorStandardSyntaxHighlighter`. In the future we should refactor, the highlighter should probably not depend on `Script` and `TextEdit`.