### PR TITLE
Fix mouse-in-viewport state for `Viewport` in `TextureRect`

### DIFF
--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -16,7 +16,7 @@
 	</tutorials>
 	<members>
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
-			The path to the [Viewport] node to display. This is relative to the scene root, not to the node that uses the texture.
+			The path to the [Viewport] node to display. This is relative to the scene root [method Resource.get_local_scene], not to the node that uses the texture.
 			[b]Note:[/b] In the editor, this path is automatically updated when the target viewport or one of its ancestors is renamed or moved. At runtime, the path may not be able to automatically update due to the inability to determine the scene root.
 		</member>
 	</members>

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -30,6 +30,7 @@
 
 #include "texture_rect.h"
 
+#include "scene/main/viewport.h"
 #include "scene/resources/atlas_texture.h"
 #include "servers/rendering_server.h"
 
@@ -113,6 +114,14 @@ void TextureRect::_notification(int p_what) {
 		case NOTIFICATION_RESIZED: {
 			update_minimum_size();
 		} break;
+		case NOTIFICATION_MOUSE_ENTER_SELF:
+		case NOTIFICATION_MOUSE_EXIT_SELF: {
+			Ref<ViewportTexture> viewport_texture = texture;
+			if (viewport_texture.is_valid()) {
+				viewport_texture->set_mouse_over_state(p_what == NOTIFICATION_MOUSE_ENTER_SELF);
+			}
+			break;
+		}
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -197,6 +197,17 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 	emit_changed();
 }
 
+void ViewportTexture::set_mouse_over_state(bool p_over) {
+	Node *scene = get_local_scene();
+	if (!scene) {
+		return;
+	}
+	Viewport *viewport = Object::cast_to<Viewport>(scene->get_node(get_viewport_path_in_scene()));
+	if (viewport && viewport->gui.mouse_in_viewport != p_over) {
+		viewport->notification(p_over ? Node::NOTIFICATION_VP_MOUSE_ENTER : Node::NOTIFICATION_VP_MOUSE_EXIT);
+	}
+}
+
 void ViewportTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_viewport_path_in_scene", "path"), &ViewportTexture::set_viewport_path_in_scene);
 	ClassDB::bind_method(D_METHOD("get_viewport_path_in_scene"), &ViewportTexture::get_viewport_path_in_scene);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -87,6 +87,8 @@ public:
 
 	virtual Ref<Image> get_image() const override;
 
+	void set_mouse_over_state(bool p_over);
+
 	ViewportTexture();
 	~ViewportTexture();
 };


### PR DESCRIPTION
Pushing `InputEventMouse` to the `Viewport` used in a `TextureRect` didn't work, because of inconsistent mouse-over state. This PR sends the necessary notifications to the `Viewport`.

resolve #89757

While this PR fixes the referenced issue, which is considered a regression, this PR could be considered not necessary based on the following reason.

The referenced issue is, that a `TextureRect` is used for displaying and interacting with a `Viewport`. Godot provides `SubViewportContainer` for this functionality.

#88992 introduced a change, that made it a bit more inconvenient to use `TextureRext` for interacting with the displayed `Viewport`. This can be worked around with a few lines of GDScript by sending mouse-entered/exited notifications to the `Viewport`, when the mouse enters/exits the `TextureRect`.

So an alternative to this PR would be to better document the necessary adjustments for interacting with a `Viewport` in a `TextureRect`.