### PR TITLE
[MenuBar] Use NativeMenu RIDs instead of indices to track items.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -553,7 +553,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="tag" type="Variant" />
 			<description>
-				Returns the index of the item with the specified [param tag]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				Returns the index of the item with the specified [param tag]. Indices are automatically assigned to each item by the engine, and cannot be set manually.
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
@@ -562,7 +562,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="text" type="String" />
 			<description>
-				Returns the index of the item with the specified [param text]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				Returns the index of the item with the specified [param text]. Indices are automatically assigned to each item by the engine, and cannot be set manually.
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>

--- a/doc/classes/NativeMenu.xml
+++ b/doc/classes/NativeMenu.xml
@@ -211,12 +211,21 @@
 				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
+		<method name="find_item_index_with_submenu" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="rid" type="RID" />
+			<param index="1" name="submenu_rid" type="RID" />
+			<description>
+				Returns the index of the item with the submenu specified by [param submenu_rid]. Indices are automatically assigned to each item by the engine, and cannot be set manually.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
 		<method name="find_item_index_with_tag" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="rid" type="RID" />
 			<param index="1" name="tag" type="Variant" />
 			<description>
-				Returns the index of the item with the specified [param tag]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				Returns the index of the item with the specified [param tag]. Indices are automatically assigned to each item by the engine, and cannot be set manually.
 				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
@@ -225,7 +234,7 @@
 			<param index="0" name="rid" type="RID" />
 			<param index="1" name="text" type="String" />
 			<description>
-				Returns the index of the item with the specified [param text]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				Returns the index of the item with the specified [param text]. Indices are automatically assigned to each item by the engine, and cannot be set manually.
 				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -55,7 +55,7 @@ class MenuBar : public Control {
 		Ref<TextLine> text_buf;
 		bool hidden = false;
 		bool disabled = false;
-		int global_index = -1;
+		RID submenu_rid;
 
 		Menu(const String &p_name) {
 			name = p_name;

--- a/servers/native_menu.cpp
+++ b/servers/native_menu.cpp
@@ -68,6 +68,7 @@ void NativeMenu::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("find_item_index_with_text", "rid", "text"), &NativeMenu::find_item_index_with_text);
 	ClassDB::bind_method(D_METHOD("find_item_index_with_tag", "rid", "tag"), &NativeMenu::find_item_index_with_tag);
+	ClassDB::bind_method(D_METHOD("find_item_index_with_submenu", "rid", "submenu_rid"), &NativeMenu::find_item_index_with_submenu);
 
 	ClassDB::bind_method(D_METHOD("is_item_checked", "rid", "idx"), &NativeMenu::is_item_checked);
 	ClassDB::bind_method(D_METHOD("is_item_checkable", "rid", "idx"), &NativeMenu::is_item_checkable);
@@ -260,6 +261,19 @@ int NativeMenu::find_item_index_with_text(const RID &p_rid, const String &p_text
 
 int NativeMenu::find_item_index_with_tag(const RID &p_rid, const Variant &p_tag) const {
 	WARN_PRINT("Global menus are not supported on this platform.");
+	return -1;
+}
+
+int NativeMenu::find_item_index_with_submenu(const RID &p_rid, const RID &p_submenu_rid) const {
+	if (!has_menu(p_rid) || !has_menu(p_submenu_rid)) {
+		return -1;
+	}
+	int count = get_item_count(p_rid);
+	for (int i = 0; i < count; i++) {
+		if (p_submenu_rid == get_item_submenu(p_rid, i)) {
+			return i;
+		}
+	}
 	return -1;
 }
 

--- a/servers/native_menu.h
+++ b/servers/native_menu.h
@@ -102,6 +102,7 @@ public:
 
 	virtual int find_item_index_with_text(const RID &p_rid, const String &p_text) const;
 	virtual int find_item_index_with_tag(const RID &p_rid, const Variant &p_tag) const;
+	virtual int find_item_index_with_submenu(const RID &p_rid, const RID &p_submenu_rid) const;
 
 	virtual bool is_item_checked(const RID &p_rid, int p_idx) const;
 	virtual bool is_item_checkable(const RID &p_rid, int p_idx) const;


### PR DESCRIPTION
With the addition of `NativeMenu`, using RIDs to keep track of items should be more reliable than using indices (which can be externally changed by calling `NativeMenu` methods directly).

Should fix https://github.com/godotengine/godot/issues/89066 (I can't reproduce the crash, but it's most likely related).