### PR TITLE
Improve replication editor's pin button

### DIFF
--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -149,7 +149,7 @@ void MultiplayerEditorPlugin::_node_removed(Node *p_node) {
 }
 
 void MultiplayerEditorPlugin::_pinned() {
-	if (!repl_editor->get_pin()->is_pressed()) {
+	if (!repl_editor->get_pin()->is_pressed() && repl_editor->get_current() == nullptr) {
 		if (repl_editor->is_visible_in_tree()) {
 			EditorNode::get_bottom_panel()->hide_bottom_panel();
 		}

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -270,6 +270,7 @@ ReplicationEditor::ReplicationEditor() {
 	pin = memnew(Button);
 	pin->set_theme_type_variation("FlatButton");
 	pin->set_toggle_mode(true);
+	pin->set_tooltip_text(TTR("Pin replication editor"));
 	hb->add_child(pin);
 
 	tree = memnew(Tree);


### PR DESCRIPTION
When unpressed, don't hide the editor when still editing the MultiplayerSynchronizer node.

Also added tooltip text for this button (as it's icon-only).