### PR TITLE
Remove a redundant `MAX` comparison within a loop in `compute_image_metrics`.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4114,7 +4114,7 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 			continue;
 		}
 
-		image_metric_max = MAX(image_metric_max, i);
+		image_metric_max = i;
 
 		double x = i * hist[i];
 


### PR DESCRIPTION
In compute_image_metrics the variable image_metric_max is set to 0 on ln4110 and the for loop on ln4112 is i=0->256. Variable image_metric_max is not set elsewhere and i is only changed in the loop increment therefore the MAX comparison on ln4117 is redundant as i will always be >= image_metric_max.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
