### PR TITLE
[TileSet] Expose `TileData.is_valid_terrain_peering_bit`

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -93,7 +93,7 @@
 			<return type="int" />
 			<param index="0" name="peering_bit" type="int" enum="TileSet.CellNeighbor" />
 			<description>
-				Returns the tile's terrain bit for the given [param peering_bit] direction.
+				Returns the tile's terrain bit for the given [param peering_bit] direction. To check that a direction is valid, use [method is_valid_terrain_peering_bit].
 			</description>
 		</method>
 		<method name="is_collision_polygon_one_way" qualifiers="const">
@@ -102,6 +102,13 @@
 			<param index="1" name="polygon_index" type="int" />
 			<description>
 				Returns whether one-way collisions are enabled for the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
+			</description>
+		</method>
+		<method name="is_valid_terrain_peering_bit" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="peering_bit" type="int" enum="TileSet.CellNeighbor" />
+			<description>
+				Returns whether the given [param peering_bit] direction is valid for this tile.
 			</description>
 		</method>
 		<method name="remove_collision_polygon">
@@ -200,7 +207,7 @@
 			<param index="0" name="peering_bit" type="int" enum="TileSet.CellNeighbor" />
 			<param index="1" name="terrain" type="int" />
 			<description>
-				Sets the tile's terrain bit for the given [param peering_bit] direction.
+				Sets the tile's terrain bit for the given [param peering_bit] direction. To check that a direction is valid, use [method is_valid_terrain_peering_bit].
 			</description>
 		</method>
 	</methods>

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6918,6 +6918,7 @@ void TileData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_terrain"), &TileData::get_terrain);
 	ClassDB::bind_method(D_METHOD("set_terrain_peering_bit", "peering_bit", "terrain"), &TileData::set_terrain_peering_bit);
 	ClassDB::bind_method(D_METHOD("get_terrain_peering_bit", "peering_bit"), &TileData::get_terrain_peering_bit);
+	ClassDB::bind_method(D_METHOD("is_valid_terrain_peering_bit", "peering_bit"), &TileData::is_valid_terrain_peering_bit);
 
 	// Navigation
 	ClassDB::bind_method(D_METHOD("set_navigation_polygon", "layer_id", "navigation_polygon"), &TileData::set_navigation_polygon);


### PR DESCRIPTION
Some additional information might be added to the documentation around this but I don't know the details well enough to add them, this solves the immediate issue of making it possible to check the valid bits from script

* Fixes: https://github.com/godotengine/godot/issues/89909

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
