### PR TITLE
Fix `input_event` signal on Android

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -290,6 +290,7 @@ MainLoop *OS_Android::get_main_loop() const {
 void OS_Android::main_loop_begin() {
 	if (main_loop) {
 		main_loop->initialize();
+		DisplayServerAndroid::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_MOUSE_ENTER);
 	}
 }
 
@@ -324,6 +325,7 @@ void OS_Android::main_loop_end() {
 
 void OS_Android::main_loop_focusout() {
 	DisplayServerAndroid::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_FOCUS_OUT);
+	DisplayServerAndroid::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_MOUSE_EXIT);
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 	}
@@ -332,6 +334,7 @@ void OS_Android::main_loop_focusout() {
 
 void OS_Android::main_loop_focusin() {
 	DisplayServerAndroid::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_FOCUS_IN);
+	DisplayServerAndroid::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_MOUSE_ENTER);
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
 	}


### PR DESCRIPTION
Fixes: #89683


**Test**: [Area2DInputTestAndroid-4.3-dev5.zip](https://github.com/godotengine/godot/files/14654874/Area2DInputTestAndroid-4.3-dev5.zip)

https://github.com/godotengine/godot/assets/41921395/bb50725c-8153-437b-bbb1-fd3a5eb94b6c

