### PR TITLE
Prohibit execution of delayed input events by different means

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -724,6 +724,9 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 			if (!is_inside_tree()) {
 				return;
 			}
+			// Ensure keeping the order of input events and window events when input events are buffered or accumulated.
+			Input::get_singleton()->flush_buffered_events();
+
 			Window *root = get_tree()->get_root();
 			if (!root->gui.windowmanager_window_over) {
 #ifdef DEV_ENABLED
@@ -2717,9 +2720,6 @@ void Window::_update_mouse_over(Vector2 p_pos) {
 		if (is_embedded()) {
 			mouse_in_window = true;
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_ENTER);
-		} else {
-			// Prevent update based on delayed InputEvents from DisplayServer.
-			return;
 		}
 	}
 


### PR DESCRIPTION
In some cases it can happen, that the order of input events and window events is not followed, when input buffering or input accumulation is active.

The display server order "`InputEvent` => window-event" gets changed to "window-event => `InputEvent`" which becomes problematic in certain situations.
An example, where this was noticed is #80334, where the problem was mitigated by different means:

https://github.com/godotengine/godot/blob/7d151c83811f8ac8873439826c16d88c83aba12f/scene/main/window.cpp#L2720-L2723

However this solution was problematic in some situations like Android. (fix #89683)

This PR makes sure, that the order is adhered to by flushing input events before a window event is sent.

The solution of this PR is global for all platforms, since now the new behavior is ensured in the Window-class.

fix #85695