### PR TITLE
Relax grid parameter constraints in texture region editor

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -31,18 +31,17 @@
 #ifndef TEXTURE_REGION_EDITOR_PLUGIN_H
 #define TEXTURE_REGION_EDITOR_PLUGIN_H
 
-#include "canvas_item_editor_plugin.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
-#include "scene/2d/sprite_2d.h"
-#include "scene/3d/sprite_3d.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/nine_patch_rect.h"
-#include "scene/resources/style_box_texture.h"
 
 class AtlasTexture;
+class NinePatchRect;
 class OptionButton;
 class PanelContainer;
+class Sprite2D;
+class Sprite3D;
+class StyleBoxTexture;
 class ViewPanner;
 
 class TextureRegionEditor : public AcceptDialog {
@@ -137,6 +136,8 @@ class TextureRegionEditor : public AcceptDialog {
 	void _clear_edited_object();
 
 	void _draw_margin_line(Vector2 p_from, Vector2 p_to);
+
+	void _set_grid_parameters_clamping(bool p_enabled);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
In grid snap mode, grid parameters like offset, step, and separation have a hard-coded range. It's not necessary and makes it hard to edit large assets.

This PR sets their range based on the image size (like how the SpriteFrames editor does).

Also fixes an overlay drawing bug only noticeable when using large separations.