### PR TITLE
[CI] Work around diff size limit for static checks

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+            files=$(git diff-tree --no-commit-id --name-only -r HEAD~${{ github.event.pull_request.commits }}..HEAD 2> /dev/null || true)
           elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
             files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
           fi


### PR DESCRIPTION
See:
* https://github.com/godotengine/godot/pull/88783#issuecomment-2022935933

~Includes that PR just to verify it will solve the limit issue~

Edit: Works as expected with the fetch, see [here](https://github.com/godotengine/godot/actions/runs/8454472643/job/23159573226#step:6:17)

Affects (as far as I can find):
* https://github.com/godotengine/godot/pull/88199
* https://github.com/godotengine/godot/pull/88783

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
