### PR TITLE
Fix `Input.action_press()` accepting out-of-bounds strength values

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -894,7 +894,7 @@ void Input::action_press(const StringName &p_action, float p_strength) {
 	}
 	action_state.exact = true;
 	action_state.api_pressed = true;
-	action_state.api_strength = p_strength;
+	action_state.api_strength = CLAMP(p_strength, 0.0f, 1.0f);
 	_update_action_cache(p_action, action_state);
 }
 


### PR DESCRIPTION
Fixes #89945.

Fixed `Input.action_press()` treatment of strength parameter by clamping between 0 and 1. Fixes `Input.action_press()` setting out-of-bounds values into action state, and out-of-bounds values subsequently being returned by `Input.get_action_strength()`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
