### PR TITLE
Core: Expand string conversions for `char16_t`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -376,22 +376,30 @@ void String::copy_from(const char *p_cstr, const int p_clip_to) {
 
 void String::copy_from(const wchar_t *p_cstr) {
 #ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit, parse as UTF-16
-	parse_utf16((const char16_t *)p_cstr);
+	// wchar_t is 16-bit
+	copy_from((const char16_t *)p_cstr);
 #else
-	// wchar_t is 32-bit, copy directly
+	// wchar_t is 32-bit
 	copy_from((const char32_t *)p_cstr);
 #endif
 }
 
 void String::copy_from(const wchar_t *p_cstr, const int p_clip_to) {
 #ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit, parse as UTF-16
-	parse_utf16((const char16_t *)p_cstr, p_clip_to);
+	// wchar_t is 16-bit
+	copy_from((const char16_t *)p_cstr, p_clip_to);
 #else
-	// wchar_t is 32-bit, copy directly
+	// wchar_t is 32-bit
 	copy_from((const char32_t *)p_cstr, p_clip_to);
 #endif
+}
+
+void String::copy_from(const char16_t *p_cstr) {
+	parse_utf16(p_cstr);
+}
+
+void String::copy_from(const char16_t *p_cstr, const int p_clip_to) {
+	parse_utf16(p_cstr, p_clip_to);
 }
 
 void String::copy_from(const char32_t &p_char) {
@@ -490,6 +498,10 @@ void String::operator=(const char *p_str) {
 	copy_from(p_str);
 }
 
+void String::operator=(const char16_t *p_str) {
+	copy_from(p_str);
+}
+
 void String::operator=(const char32_t *p_str) {
 	copy_from(p_str);
 }
@@ -519,11 +531,23 @@ String operator+(const char *p_chr, const String &p_str) {
 String operator+(const wchar_t *p_chr, const String &p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	String tmp = String::utf16((const char16_t *)p_chr);
+	String tmp = (const char16_t *)p_chr;
 #else
 	// wchar_t is 32-bit
 	String tmp = (const char32_t *)p_chr;
 #endif
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(const char16_t *p_chr, const String &p_str) {
+	String tmp = p_chr;
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(const char32_t *p_chr, const String &p_str) {
+	String tmp = p_chr;
 	tmp += p_str;
 	return tmp;
 }
@@ -588,11 +612,16 @@ String &String::operator+=(const char *p_str) {
 String &String::operator+=(const wchar_t *p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	*this += String::utf16((const char16_t *)p_str);
+	*this += String((const char16_t *)p_str);
 #else
 	// wchar_t is 32-bit
 	*this += String((const char32_t *)p_str);
 #endif
+	return *this;
+}
+
+String &String::operator+=(const char16_t *p_str) {
+	*this += String(p_str);
 	return *this;
 }
 
@@ -659,11 +688,15 @@ bool String::operator==(const char *p_str) const {
 bool String::operator==(const wchar_t *p_str) const {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit, parse as UTF-16
-	return *this == String::utf16((const char16_t *)p_str);
+	return *this == (const char16_t *)p_str;
 #else
 	// wchar_t is 32-bit, compare char by char
 	return *this == (const char32_t *)p_str;
 #endif
+}
+
+bool String::operator==(const char16_t *p_str) const {
+	return *this == String(p_str);
 }
 
 bool String::operator==(const char32_t *p_str) const {
@@ -745,13 +778,21 @@ bool operator==(const char *p_chr, const String &p_str) {
 	return p_str == p_chr;
 }
 
+bool operator==(const char16_t *p_chr, const String &p_str) {
+	return p_str == p_chr;
+}
+
+bool operator==(const char32_t *p_chr, const String &p_str) {
+	return p_str == p_chr;
+}
+
 bool operator==(const wchar_t *p_chr, const String &p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return p_str == String::utf16((const char16_t *)p_chr);
+	return p_str == (const char16_t *)p_chr;
 #else
-	// wchar_t is 32-bi
-	return p_str == String((const char32_t *)p_chr);
+	// wchar_t is 32-bit
+	return p_str == (const char32_t *)p_chr;
 #endif
 }
 
@@ -759,12 +800,20 @@ bool operator!=(const char *p_chr, const String &p_str) {
 	return !(p_str == p_chr);
 }
 
+bool operator!=(const char16_t *p_chr, const String &p_str) {
+	return !(p_str == p_chr);
+}
+
+bool operator!=(const char32_t *p_chr, const String &p_str) {
+	return !(p_str == p_chr);
+}
+
 bool operator!=(const wchar_t *p_chr, const String &p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return !(p_str == String::utf16((const char16_t *)p_chr));
+	return !(p_str == String((const char16_t *)p_chr));
 #else
-	// wchar_t is 32-bi
+	// wchar_t is 32-bit
 	return !(p_str == String((const char32_t *)p_chr));
 #endif
 }
@@ -774,6 +823,10 @@ bool String::operator!=(const char *p_str) const {
 }
 
 bool String::operator!=(const wchar_t *p_str) const {
+	return (!(*this == p_str));
+}
+
+bool String::operator!=(const char16_t *p_str) const {
 	return (!(*this == p_str));
 }
 
@@ -817,11 +870,22 @@ bool String::operator<(const wchar_t *p_str) const {
 
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return is_str_less(get_data(), String::utf16((const char16_t *)p_str).get_data());
+	return is_str_less(get_data(), String((const char16_t *)p_str).get_data());
 #else
 	// wchar_t is 32-bit
 	return is_str_less(get_data(), (const char32_t *)p_str);
 #endif
+}
+
+bool String::operator<(const char16_t *p_str) const {
+	if (is_empty() && p_str[0] == 0) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	return is_str_less(get_data(), String(p_str).get_data());
 }
 
 bool String::operator<(const char32_t *p_str) const {
@@ -2514,6 +2578,10 @@ String::String(const wchar_t *p_str) {
 	copy_from(p_str);
 }
 
+String::String(const char16_t *p_str) {
+	copy_from(p_str);
+}
+
 String::String(const char32_t *p_str) {
 	copy_from(p_str);
 }
@@ -2523,6 +2591,10 @@ String::String(const char *p_str, int p_clip_to_len) {
 }
 
 String::String(const wchar_t *p_str, int p_clip_to_len) {
+	copy_from(p_str, p_clip_to_len);
+}
+
+String::String(const char16_t *p_str, int p_clip_to_len) {
 	copy_from(p_str, p_clip_to_len);
 }
 
@@ -2689,6 +2761,37 @@ int64_t String::to_int(const wchar_t *p_str, int p_len) {
 
 	for (int i = 0; i < to; i++) {
 		wchar_t c = p_str[i];
+		if (is_digit(c)) {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (c == '-' && integer == 0) {
+			sign = -sign;
+		} else if (c != ' ') {
+			break;
+		}
+	}
+
+	return integer * sign;
+}
+
+int64_t String::to_int(const char16_t *p_str, int p_len) {
+	int to = 0;
+	if (p_len >= 0) {
+		to = p_len;
+	} else {
+		while (p_str[to] != 0 && p_str[to] != '.') {
+			to++;
+		}
+	}
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		char16_t c = p_str[i];
 		if (is_digit(c)) {
 			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
 			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
@@ -2957,6 +3060,10 @@ double String::to_float(const char *p_str) {
 	return built_in_strtod<char>(p_str);
 }
 
+double String::to_float(const char16_t *p_str, const char16_t **r_end) {
+	return built_in_strtod<char16_t>(p_str, (char16_t **)r_end);
+}
+
 double String::to_float(const char32_t *p_str, const char32_t **r_end) {
 	return built_in_strtod<char32_t>(p_str, (char32_t **)r_end);
 }
@@ -3098,6 +3205,27 @@ uint32_t String::hash(const wchar_t *p_cstr) {
 	while (c) {
 		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
 		c = static_cast<wide_unsigned>(*p_cstr++);
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char16_t *p_cstr, int p_len) {
+	uint32_t hashv = 5381;
+	for (int i = 0; i < p_len; i++) {
+		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char16_t *p_cstr) {
+	uint32_t hashv = 5381;
+	uint32_t c = *p_cstr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *p_cstr++;
 	}
 
 	return hashv;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -189,6 +189,8 @@ class String {
 	void copy_from(const char *p_cstr, const int p_clip_to);
 	void copy_from(const wchar_t *p_cstr);
 	void copy_from(const wchar_t *p_cstr, const int p_clip_to);
+	void copy_from(const char16_t *p_cstr);
+	void copy_from(const char16_t *p_cstr, const int p_clip_to);
 	void copy_from(const char32_t *p_cstr);
 	void copy_from(const char32_t *p_cstr, const int p_clip_to);
 
@@ -232,30 +234,35 @@ public:
 	String operator+(const String &p_str) const;
 	String operator+(char32_t p_char) const;
 
-	String &operator+=(const String &);
+	String &operator+=(const String &p_str);
 	String &operator+=(char32_t p_char);
 	String &operator+=(const char *p_str);
 	String &operator+=(const wchar_t *p_str);
+	String &operator+=(const char16_t *p_str);
 	String &operator+=(const char32_t *p_str);
 
 	/* Compatibility Operators */
 
 	void operator=(const char *p_str);
 	void operator=(const wchar_t *p_str);
+	void operator=(const char16_t *p_str);
 	void operator=(const char32_t *p_str);
 
 	bool operator==(const char *p_str) const;
 	bool operator==(const wchar_t *p_str) const;
+	bool operator==(const char16_t *p_str) const;
 	bool operator==(const char32_t *p_str) const;
 	bool operator==(const StrRange &p_str_range) const;
 
 	bool operator!=(const char *p_str) const;
 	bool operator!=(const wchar_t *p_str) const;
+	bool operator!=(const char16_t *p_str) const;
 	bool operator!=(const char32_t *p_str) const;
 
-	bool operator<(const char32_t *p_str) const;
 	bool operator<(const char *p_str) const;
 	bool operator<(const wchar_t *p_str) const;
+	bool operator<(const char16_t *p_str) const;
+	bool operator<(const char32_t *p_str) const;
 
 	bool operator<(const String &p_str) const;
 	bool operator<=(const String &p_str) const;
@@ -348,10 +355,12 @@ public:
 
 	static int64_t to_int(const char *p_str, int p_len = -1);
 	static int64_t to_int(const wchar_t *p_str, int p_len = -1);
+	static int64_t to_int(const char16_t *p_str, int p_len = -1);
 	static int64_t to_int(const char32_t *p_str, int p_len = -1, bool p_clamp = false);
 
 	static double to_float(const char *p_str);
 	static double to_float(const wchar_t *p_str, const wchar_t **r_end = nullptr);
+	static double to_float(const char16_t *p_str, const char16_t **r_end = nullptr);
 	static double to_float(const char32_t *p_str, const char32_t **r_end = nullptr);
 	static uint32_t num_characters(int64_t p_int);
 
@@ -413,6 +422,8 @@ public:
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const char32_t *p_cstr); /* hash the string */
+	static uint32_t hash(const char16_t *p_cstr, int p_len); /* hash the string */
+	static uint32_t hash(const char16_t *p_cstr); /* hash the string */
 	static uint32_t hash(const wchar_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const wchar_t *p_cstr); /* hash the string */
 	static uint32_t hash(const char *p_cstr, int p_len); /* hash the string */
@@ -491,20 +502,27 @@ public:
 
 	String(const char *p_str);
 	String(const wchar_t *p_str);
+	String(const char16_t *p_str);
 	String(const char32_t *p_str);
 	String(const char *p_str, int p_clip_to_len);
 	String(const wchar_t *p_str, int p_clip_to_len);
+	String(const char16_t *p_str, int p_clip_to_len);
 	String(const char32_t *p_str, int p_clip_to_len);
 	String(const StrRange &p_range);
 };
 
 bool operator==(const char *p_chr, const String &p_str);
 bool operator==(const wchar_t *p_chr, const String &p_str);
+bool operator==(const char16_t *p_chr, const String &p_str);
+bool operator==(const char32_t *p_chr, const String &p_str);
 bool operator!=(const char *p_chr, const String &p_str);
 bool operator!=(const wchar_t *p_chr, const String &p_str);
-
+bool operator!=(const char16_t *p_chr, const String &p_str);
+bool operator!=(const char32_t *p_chr, const String &p_str);
 String operator+(const char *p_chr, const String &p_str);
 String operator+(const wchar_t *p_chr, const String &p_str);
+String operator+(const char16_t *p_chr, const String &p_str);
+String operator+(const char32_t *p_chr, const String &p_str);
 String operator+(char32_t p_chr, const String &p_str);
 
 String itos(int64_t p_val);

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2515,14 +2515,24 @@ Variant::Variant(const String &p_string) :
 	memnew_placement(_data._mem, String(p_string));
 }
 
-Variant::Variant(const char *const p_cstring) :
+Variant::Variant(const char *p_cstring) :
 		type(STRING) {
-	memnew_placement(_data._mem, String((const char *)p_cstring));
+	memnew_placement(_data._mem, String(p_cstring));
 }
 
-Variant::Variant(const char32_t *p_wstring) :
+Variant::Variant(const wchar_t *p_wstring) :
 		type(STRING) {
 	memnew_placement(_data._mem, String(p_wstring));
+}
+
+Variant::Variant(const char16_t *p_c16string) :
+		type(STRING) {
+	memnew_placement(_data._mem, String(p_c16string));
+}
+
+Variant::Variant(const char32_t *p_c32string) :
+		type(STRING) {
+	memnew_placement(_data._mem, String(p_c32string));
 }
 
 Variant::Variant(const Vector3 &p_vector3) :

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -463,8 +463,10 @@ public:
 	Variant(const ObjectID &p_id);
 	Variant(const String &p_string);
 	Variant(const StringName &p_string);
-	Variant(const char *const p_cstring);
-	Variant(const char32_t *p_wstring);
+	Variant(const char *p_cstring);
+	Variant(const wchar_t *p_wstring);
+	Variant(const char16_t *p_c16string);
+	Variant(const char32_t *p_c32string);
 	Variant(const Vector2 &p_vector2);
 	Variant(const Vector2i &p_vector2i);
 	Variant(const Rect2 &p_rect2);


### PR DESCRIPTION
Implements explicit conversions/functions for character pointer types that previously lacked proper String equivalents. This was most prominently for `char16_t`, which previously had to exclusively rely on `wchar_t` (for Windows) or necessitated `Char16String` as a middleman. Also expands character pointer types in Variant constructors as well, similar to what's seen in godot-cpp's equivalents.