### PR TITLE
[macOS] Fix non-global native menu shortcuts.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -241,6 +241,8 @@ public:
 	NSImage *_convert_to_nsimg(Ref<Image> &p_image) const;
 	Point2i _get_screens_origin() const;
 
+	void set_menu_delegate(NSMenu *p_menu);
+
 	void send_event(NSEvent *p_event);
 	void send_window_event(const WindowData &p_wd, WindowEvent p_event);
 	void release_pressed_events();

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -290,6 +290,10 @@ void DisplayServerMacOS::_update_displays_arrangement() {
 	displays_arrangement_dirty = false;
 }
 
+void DisplayServerMacOS::set_menu_delegate(NSMenu *p_menu) {
+	[p_menu setDelegate:menu_delegate];
+}
+
 Point2i DisplayServerMacOS::_get_screens_origin() const {
 	// Returns the native top-left screen coordinate of the smallest rectangle
 	// that encompasses all screens. Needed in get_screen_position(),

--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -223,6 +223,11 @@ RID NativeMenuMacOS::get_system_menu(SystemMenus p_menu_id) const {
 RID NativeMenuMacOS::create_menu() {
 	MenuData *md = memnew(MenuData);
 	md->menu = [[NSMenu alloc] initWithTitle:@""];
+	[md->menu setAutoenablesItems:NO];
+	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	if (ds) {
+		ds->set_menu_delegate(md->menu);
+	}
 	RID rid = menus.make_rid(md);
 	menu_lookup[md->menu] = rid;
 	return rid;


### PR DESCRIPTION
Fixes some shortcuts on macOS - https://github.com/godotengine/godot/issues/87101#issuecomment-2023845097, regression from native menu split.