### PR TITLE
Fix regression when duplicating a node with a resource attached

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2737,9 +2737,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 				}
 
 			} else {
-				if (value.get_type() != Variant::OBJECT && (value.get_type() != Variant::ARRAY || static_cast<Array>(value).get_typed_builtin() != Variant::OBJECT)) {
-					current_node->set(name, value);
-				}
+				current_node->set(name, value);
 			}
 		}
 	}


### PR DESCRIPTION
So basically there was an if-statement that caused resources to not duplicate since they inherit object. The original thought was that nodes were the only things that inherited object and because of it we could leave the duplication to ```_duplicate_properties_node``` function. However, since that wasn't the case the simplest change that I decided to just remove the if-statement entirely.

Fixes: https://github.com/godotengine/godot/issues/89824, Fixes https://github.com/godotengine/godot/issues/89947