### PR TITLE
Fix separating axes for 3D cylinder-face collisions

### DIFF
--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -1962,7 +1962,7 @@ static void _collision_cylinder_face(const GodotShape3D *p_a, const Transform3D 
 
 	// Points of B, cylinder lateral surface.
 	for (int i = 0; i < 3; i++) {
-		const Vector3 &point = vertex[i];
+		const Vector3 point = vertex[i] - p_transform_a.origin;
 		Vector3 axis = Plane(cyl_axis).project(point).normalized();
 		if (axis.dot(normal) < 0.0) {
 			axis *= -1.0;


### PR DESCRIPTION
I'm not a 100% this is the correct fix, I would appreciate if someone who knows the SAT equations or the physics system better would look it over. However as far as I can see this fixes the issue and does not cause any additional ones (as far as I can see :) )

I think the issue is because when checking for lateral surfaces of a cylinder against the points on a face, the axis projection does not remove the cylinder position. This results in the axis pointing to the wrong direction and reports collisions when there shouldn't be.

I included a test scene to exhibit the issue and fix
- sandbox scene contains only the cylinder, that gets stuck without this commit
- sandbox_all scene contains a bunch of shapes rubbing against corners to make sure nothing else is broken
[sandbox.zip](https://github.com/godotengine/godot/files/14782013/sandbox.zip)

*Physics squad edit:*

- Fixes https://github.com/godotengine/godot/issues/72198