### PR TITLE
Add `target=gdscript`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -58,9 +58,13 @@ import gles3_builders
 import scu_builders
 from platform_methods import architectures, architecture_aliases, generate_export_icons
 
+gdscript_build = False
 if ARGUMENTS.get("target", "editor") == "editor":
     _helper_module("editor.editor_builders", "editor/editor_builders.py")
     _helper_module("editor.template_builders", "editor/template_builders.py")
+elif ARGUMENTS.get("target") == "gdscript":
+    # Check early so we can disable platform specific modules like rendering and audio
+    gdscript_build = True
 
 # Scan possible build platforms
 
@@ -101,7 +105,7 @@ for x in sorted(glob.glob("platform/*")):
         x = x.replace("platform/", "")  # rest of world
         x = x.replace("platform\\", "")  # win32
         platform_list += [x]
-        platform_opts[x] = detect.get_opts()
+        platform_opts[x] = detect.get_opts(gdscript_build)
         platform_flags[x] = detect.get_flags()
     sys.path.remove(tmppath)
     sys.modules.pop("detect")
@@ -170,7 +174,9 @@ opts = Variables(customs, ARGUMENTS)
 # Target build options
 opts.Add("platform", "Target platform (%s)" % ("|".join(platform_list),), "")
 opts.Add("p", "Platform (alias for 'platform')", "")
-opts.Add(EnumVariable("target", "Compilation target", "editor", ("editor", "template_release", "template_debug")))
+opts.Add(
+    EnumVariable("target", "Compilation target", "editor", ("editor", "template_release", "template_debug", "gdscript"))
+)
 opts.Add(EnumVariable("arch", "CPU architecture", "auto", ["auto"] + architectures, architecture_aliases))
 opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
 opts.Add(
@@ -178,6 +184,10 @@ opts.Add(
         "optimize", "Optimization level", "speed_trace", ("none", "custom", "debug", "speed", "speed_trace", "size")
     )
 )
+opts.Update(env_base)
+env_base.gdscript_build = env_base["target"] == "gdscript"
+if_non_gdscript = not env_base.gdscript_build
+
 opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", False))
 opts.Add(BoolVariable("separate_debug_symbols", "Extract debugging symbols to a separate file", False))
 opts.Add(EnumVariable("lto", "Link-time optimization (production builds)", "none", ("none", "auto", "thin", "full")))
@@ -187,14 +197,14 @@ opts.Add(BoolVariable("threads", "Enable threading support", True))
 # Components
 opts.Add(BoolVariable("deprecated", "Enable compatibility code for deprecated and removed features", True))
 opts.Add(EnumVariable("precision", "Set the floating-point precision level", "single", ("single", "double")))
-opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", True))
-opts.Add(BoolVariable("brotli", "Enable Brotli for decompresson and WOFF2 fonts support", True))
+opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", if_non_gdscript))
+opts.Add(BoolVariable("brotli", "Enable Brotli for decompresson and WOFF2 fonts support", if_non_gdscript))
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
-opts.Add(BoolVariable("vulkan", "Enable the vulkan rendering driver", True))
-opts.Add(BoolVariable("opengl3", "Enable the OpenGL/GLES3 rendering driver", True))
+opts.Add(BoolVariable("vulkan", "Enable the vulkan rendering driver", if_non_gdscript))
+opts.Add(BoolVariable("opengl3", "Enable the OpenGL/GLES3 rendering driver", if_non_gdscript))
 opts.Add(BoolVariable("d3d12", "Enable the Direct3D 12 rendering driver (Windows only)", False))
-opts.Add(BoolVariable("openxr", "Enable the OpenXR driver", True))
-opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", True))
+opts.Add(BoolVariable("openxr", "Enable the OpenXR driver", if_non_gdscript))
+opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", if_non_gdscript))
 opts.Add(BoolVariable("disable_exceptions", "Force disabling exception handling code", True))
 opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
 opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
@@ -217,7 +227,11 @@ opts.Add("import_env_vars", "A comma-separated list of environment variables to 
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
-opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
+opts.Add(
+    BoolVariable(
+        "modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", if_non_gdscript
+    )
+)
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add(
     "system_certs_path",
@@ -386,7 +400,7 @@ for name, path in modules_detected.items():
     sys.path.insert(0, path)
     import config
 
-    if env_base["modules_enabled_by_default"]:
+    if env_base["modules_enabled_by_default"] or (env_base.gdscript_build and name == "gdscript"):
         enabled = True
         try:
             enabled = config.is_enabled()
@@ -431,7 +445,7 @@ env_base.platform_apis = platform_apis
 
 env_base.editor_build = env_base["target"] == "editor"
 env_base.dev_build = env_base["dev_build"]
-env_base.debug_features = env_base["target"] in ["editor", "template_debug"]
+env_base.debug_features = env_base["target"] in ["editor", "template_debug", "gdscript"]
 
 if env_base.dev_build:
     opt_level = "none"
@@ -445,6 +459,9 @@ env_base["debug_symbols"] = methods.get_cmdline_bool("debug_symbols", env_base.d
 
 if env_base.editor_build:
     env_base.Append(CPPDEFINES=["TOOLS_ENABLED"])
+
+if env_base.gdscript_build:
+    env_base.Append(CPPDEFINES=["GDSCRIPT_BUILD"])
 
 if env_base.debug_features:
     # DEBUG_ENABLED enables debugging *features* and debug-only code, which is intended
@@ -996,8 +1013,9 @@ if env["threads"]:
 Export("env")
 
 SConscript("core/SCsub")
-SConscript("servers/SCsub")
-SConscript("scene/SCsub")
+if not env.gdscript_build:
+    SConscript("servers/SCsub")
+    SConscript("scene/SCsub")
 if env.editor_build:
     SConscript("editor/SCsub")
 SConscript("drivers/SCsub")
@@ -1006,7 +1024,11 @@ SConscript("platform/SCsub")
 SConscript("modules/SCsub")
 if env["tests"]:
     SConscript("tests/SCsub")
-SConscript("main/SCsub")
+
+if env.gdscript_build:
+    SConscript("modules/gdscript/main/SCsub")
+else:
+    SConscript("main/SCsub")
 
 SConscript("platform/" + selected_platform + "/SCsub")  # Build selected platform.
 

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1223,8 +1223,10 @@ TypedArray<Dictionary> ProjectSettings::get_global_class_list() {
 		global_class_list = cf->get_value("", "list", Array());
 	} else {
 #ifndef TOOLS_ENABLED
+#ifndef GDSCRIPT_BUILD
 		// Script classes can't be recreated in exported project, so print an error.
 		ERR_PRINT("Could not load global script cache.");
+#endif
 #endif
 	}
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -370,9 +370,11 @@ String OS::get_version() const {
 	return ::OS::get_singleton()->get_version();
 }
 
+#ifndef GDSCRIPT_BUILD
 Vector<String> OS::get_video_adapter_driver_info() const {
 	return ::OS::get_singleton()->get_video_adapter_driver_info();
 }
+#endif
 
 Vector<String> OS::get_cmdline_args() {
 	List<String> cmdline = ::OS::get_singleton()->get_cmdline_args();
@@ -615,7 +617,9 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &OS::get_cmdline_args);
 	ClassDB::bind_method(D_METHOD("get_cmdline_user_args"), &OS::get_cmdline_user_args);
 
+#ifndef GDSCRIPT_BUILD
 	ClassDB::bind_method(D_METHOD("get_video_adapter_driver_info"), &OS::get_video_adapter_driver_info);
+#endif
 
 	ClassDB::bind_method(D_METHOD("set_restart_on_exit", "restart", "arguments"), &OS::set_restart_on_exit, DEFVAL(Vector<String>()));
 	ClassDB::bind_method(D_METHOD("is_restart_on_exit_set"), &OS::is_restart_on_exit_set);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -181,7 +181,9 @@ public:
 	Vector<String> get_cmdline_args();
 	Vector<String> get_cmdline_user_args();
 
+#ifndef GDSCRIPT_BUILD
 	Vector<String> get_video_adapter_driver_info() const;
+#endif
 
 	String get_locale() const;
 	String get_locale_language() const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -130,12 +130,14 @@ public:
 
 	static OS *get_singleton();
 
+#ifndef GDSCRIPT_BUILD
 	String get_current_rendering_driver_name() const { return _current_rendering_driver_name; }
 	String get_current_rendering_method() const { return _current_rendering_method; }
 
 	int get_display_driver_id() const { return _display_driver_id; }
 
 	virtual Vector<String> get_video_adapter_driver_info() const = 0;
+#endif // GDSCRIPT_BUILD
 
 	void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, Logger::ErrorType p_type = Logger::ERR_ERROR);
 	void print(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -9,31 +9,35 @@ SConscript("unix/SCsub")
 SConscript("windows/SCsub")
 
 # Sounds drivers
-SConscript("alsa/SCsub")
-SConscript("coreaudio/SCsub")
-SConscript("pulseaudio/SCsub")
-if env["platform"] == "windows":
-    SConscript("wasapi/SCsub")
-if env["xaudio2"]:
-    SConscript("xaudio2/SCsub")
+if not env.gdscript_build:
+    SConscript("alsa/SCsub")
+    SConscript("coreaudio/SCsub")
+    SConscript("pulseaudio/SCsub")
+    if env["platform"] == "windows":
+        SConscript("wasapi/SCsub")
+    if env["xaudio2"]:
+        SConscript("xaudio2/SCsub")
 
 # Midi drivers
-SConscript("alsamidi/SCsub")
-SConscript("coremidi/SCsub")
-SConscript("winmidi/SCsub")
+if not env.gdscript_build:
+    SConscript("alsamidi/SCsub")
+    SConscript("coremidi/SCsub")
+    SConscript("winmidi/SCsub")
 
 # Graphics drivers
-if env["vulkan"]:
-    SConscript("vulkan/SCsub")
-if env["d3d12"]:
-    SConscript("d3d12/SCsub")
-if env["opengl3"]:
-    SConscript("gl_context/SCsub")
-    SConscript("gles3/SCsub")
-    SConscript("egl/SCsub")
+if not env.gdscript_build:
+    if env["vulkan"]:
+        SConscript("vulkan/SCsub")
+    if env["d3d12"]:
+        SConscript("d3d12/SCsub")
+    if env["opengl3"]:
+        SConscript("gl_context/SCsub")
+        SConscript("gles3/SCsub")
+        SConscript("egl/SCsub")
 
 # Core dependencies
-SConscript("png/SCsub")
+if not env.gdscript_build:
+    SConscript("png/SCsub")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -176,9 +176,11 @@ void OS_Unix::finalize_core() {
 	NetSocketPosix::cleanup();
 }
 
+#ifndef GDSCRIPT_BUILD
 Vector<String> OS_Unix::get_video_adapter_driver_info() const {
 	return Vector<String>();
 }
+#endif
 
 String OS_Unix::get_stdin_string() {
 	char buff[1024];

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -49,7 +49,9 @@ protected:
 public:
 	OS_Unix();
 
+#ifndef GDSCRIPT_BUILD
 	virtual Vector<String> get_video_adapter_driver_info() const override;
+#endif
 
 	virtual String get_stdin_string() override;
 

--- a/modules/gdscript/README.md
+++ b/modules/gdscript/README.md
@@ -135,7 +135,7 @@ There are many other classes in the GDScript module. Here is a brief overview of
 - [`GDScriptFunction`](gdscript_function.h), which represents an executable GDScript function. The relevant file contains both static as well as runtime information.
 - The [virtual machine](gdscript_vm.cpp) is essentially defined as calling `GDScriptFunction::call()`.
 - Editor-related functions can be found in parts of `GDScriptLanguage`, originally declared in [`gdscript.h`](gdscript.h) but defined in [`gdscript_editor.cpp`](gdscript_editor.cpp). Code highlighting can be found in [`GDScriptSyntaxHighlighter`](editor/gdscript_highlighter.h).
-- GDScript decompilation is found in [`gdscript_disassembler.cpp`](gdscript_disassembler.h), defined as `GDScriptFunction::disassemble()`.
+- GDScript decompilation is found in [`gdscript_disassembler.cpp`](gdscript_disassembler.cpp), defined as `GDScriptFunction::disassemble()`.
 - Documentation generation from GDScript comments in [`GDScriptDocGen`](editor/gdscript_docgen.h)
 
 A dedicated binary for developing GDScript (built with `target=gdscript` is located in [`main`](main/main.cpp).

--- a/modules/gdscript/README.md
+++ b/modules/gdscript/README.md
@@ -137,3 +137,5 @@ There are many other classes in the GDScript module. Here is a brief overview of
 - Editor-related functions can be found in parts of `GDScriptLanguage`, originally declared in [`gdscript.h`](gdscript.h) but defined in [`gdscript_editor.cpp`](gdscript_editor.cpp). Code highlighting can be found in [`GDScriptSyntaxHighlighter`](editor/gdscript_highlighter.h).
 - GDScript decompilation is found in [`gdscript_disassembler.cpp`](gdscript_disassembler.h), defined as `GDScriptFunction::disassemble()`.
 - Documentation generation from GDScript comments in [`GDScriptDocGen`](editor/gdscript_docgen.h)
+
+A dedicated binary for developing GDScript (built with `target=gdscript` is located in [`main`](main/main.cpp).

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -34,9 +34,12 @@
 #include "gdscript_cache.h"
 #include "gdscript_compiler.h"
 #include "gdscript_parser.h"
-#include "gdscript_rpc_callable.h"
 #include "gdscript_tokenizer_buffer.h"
 #include "gdscript_warning.h"
+
+#ifndef GDSCRIPT_BUILD
+#include "gdscript_rpc_callable.h"
+#endif
 
 #ifdef TOOLS_ENABLED
 #include "editor/gdscript_docgen.h"
@@ -917,11 +920,15 @@ bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {
 		{
 			HashMap<StringName, GDScriptFunction *>::ConstIterator E = top->member_functions.find(p_name);
 			if (E && E->value->is_static()) {
+#ifdef GDSCRIPT_BUILD
+				r_ret = Callable(const_cast<GDScript *>(top), E->key);
+#else
 				if (top->rpc_config.has(p_name)) {
 					r_ret = Callable(memnew(GDScriptRPCCallable(const_cast<GDScript *>(top), E->key)));
 				} else {
 					r_ret = Callable(const_cast<GDScript *>(top), E->key);
 				}
+#endif
 				return true;
 			}
 		}
@@ -1719,11 +1726,16 @@ bool GDScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 		{
 			HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(p_name);
 			if (E) {
+#ifdef GDSCRIPT_BUILD
+				r_ret = Callable(owner, E->key);
+#else
 				if (sptr->rpc_config.has(p_name)) {
 					r_ret = Callable(memnew(GDScriptRPCCallable(owner, E->key)));
 				} else {
 					r_ret = Callable(owner, E->key);
 				}
+
+#endif
 				return true;
 			}
 		}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4026,6 +4026,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		return;
 	}
 
+#ifndef GDSCRIPT_BUILD
 	// Try singletons.
 	// Do this before globals because this might be a singleton loading another one before it's compiled.
 	if (ProjectSettings::get_singleton()->has_autoload(name)) {
@@ -4068,6 +4069,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			return;
 		}
 	}
+#endif // GDSCRIPT_BUILD
 
 	if (CoreConstants::is_global_constant(name)) {
 		int index = CoreConstants::get_global_constant_index(name);

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -838,17 +838,20 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				GDScriptFunction *lambda = _lambdas_ptr[_code_ptr[ip + 2 + instr_var_args]];
 
 				text += DADDR(1 + captures_count);
-				text += "create lambda from ";
-				text += lambda->name.operator String();
-				text += "function, captures (";
+				text += " = create lambda from ";
+				text += lambda->name;
+				text += " function";
 
-				for (int i = 0; i < captures_count; i++) {
-					if (i > 0) {
-						text += ", ";
+				if (captures_count) {
+					text += ", captures (";
+					for (int i = 0; i < captures_count; i++) {
+						if (i > 0) {
+							text += ", ";
+						}
+						text += DADDR(1 + i);
 					}
-					text += DADDR(1 + i);
+					text += ")";
 				}
-				text += ")";
 
 				incr = 4 + captures_count;
 			} break;
@@ -858,17 +861,20 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				GDScriptFunction *lambda = _lambdas_ptr[_code_ptr[ip + 2 + instr_var_args]];
 
 				text += DADDR(1 + captures_count);
-				text += "create self lambda from ";
-				text += lambda->name.operator String();
-				text += "function, captures (";
+				text += " = create self lambda from ";
+				text += lambda->name;
+				text += " function";
 
-				for (int i = 0; i < captures_count; i++) {
-					if (i > 0) {
-						text += ", ";
+				if (captures_count) {
+					text += ", captures (";
+					for (int i = 0; i < captures_count; i++) {
+						if (i > 0) {
+							text += ", ";
+						}
+						text += DADDR(1 + i);
 					}
-					text += DADDR(1 + i);
+					text += ")";
 				}
-				text += ")";
 
 				incr = 4 + captures_count;
 			} break;

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(GDSCRIPT_BUILD)
 
 #include "gdscript.h"
 #include "gdscript_function.h"
@@ -1128,4 +1128,16 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 	}
 }
 
-#endif // DEBUG_ENABLED
+String GDScriptFunction::signature() const {
+	const MethodInfo &mi = get_method_info();
+	String signature = mi.name + "(";
+	for (int i = 0; i < mi.arguments.size(); i++) {
+		if (i > 0) {
+			signature += ", ";
+		}
+		signature += mi.arguments[i].name;
+	}
+	signature += ")";
+	return signature;
+}
+#endif // DEBUG_ENABLED || GDSCRIPT_BUILD

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -521,9 +521,10 @@ public:
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
 	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const;
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(GDSCRIPT_BUILD)
 	void _profile_native_call(uint64_t p_t_taken, const String &p_function_name, const String &p_instance_class_name = String());
 	void disassemble(const Vector<String> &p_code_lines) const;
+	String signature() const;
 #endif
 
 	GDScriptFunction();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2459,10 +2459,12 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_expression(bool p_can_assi
 GDScriptParser::IdentifierNode *GDScriptParser::parse_identifier() {
 	IdentifierNode *identifier = static_cast<IdentifierNode *>(parse_identifier(nullptr, false));
 #ifdef DEBUG_ENABLED
+#ifndef GDSCRIPT_BUILD
 	// Check for spoofing here (if available in TextServer) since this isn't called inside expressions. This is only relevant for declarations.
 	if (identifier && TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && TS->spoof_check(identifier->name)) {
 		push_warning(identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, identifier->name.operator String());
 	}
+#endif
 #endif
 	return identifier;
 }
@@ -3290,10 +3292,12 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_get_node(ExpressionNode *p
 
 			String identifier = previous.get_identifier();
 #ifdef DEBUG_ENABLED
+#ifndef GDSCRIPT_BUILD
 			// Check spoofing.
 			if (TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && TS->spoof_check(identifier)) {
 				push_warning(get_node, GDScriptWarning::CONFUSABLE_IDENTIFIER, identifier);
 			}
+#endif
 #endif
 			get_node->full_path += identifier;
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -588,6 +588,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::potential_identifier() {
 		Token id = make_identifier(name);
 
 #ifdef DEBUG_ENABLED
+#ifndef GDSCRIPT_BUILD
 		// Additional checks for identifiers but only in debug and if it's available in TextServer.
 		if (TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY)) {
 			int64_t confusable = TS->is_confusable(name, keyword_list);
@@ -595,6 +596,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::potential_identifier() {
 				push_error(vformat(R"(Identifier "%s" is visually similar to the GDScript keyword "%s" and thus not allowed.)", name, keyword_list[confusable]));
 			}
 		}
+#endif
 #endif // DEBUG_ENABLED
 
 		// Cannot be a keyword, as keywords are ASCII only.

--- a/modules/gdscript/main/SCsub
+++ b/modules/gdscript/main/SCsub
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.main_sources = []
+
+env_main = env.Clone()
+
+env_main.add_source_files(env.main_sources, "main.cpp")
+
+if env["tests"]:
+    env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
+
+lib = env_main.add_library("main", env.main_sources)
+env.Prepend(LIBS=[lib])

--- a/modules/gdscript/main/main.cpp
+++ b/modules/gdscript/main/main.cpp
@@ -1,0 +1,149 @@
+/**************************************************************************/
+/*  main.cpp                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "main.h"
+
+#include "core/config/project_settings.h"
+#include "core/register_core_types.h"
+#include "modules/gdscript/gdscript.h"
+#include "modules/gdscript/gdscript_analyzer.h"
+#include "modules/gdscript/gdscript_compiler.h"
+#include "modules/gdscript/gdscript_parser.h"
+#include "modules/register_module_types.h"
+
+static Vector<String> args;
+static Engine *engine;
+static ProjectSettings *globals;
+
+int Main::test_entrypoint(int p_argc, char *p_argv[], bool &r_tests_need_run) {
+	return 0;
+}
+
+Error Main::setup(const char *p_execpath, int p_argc, char *p_argv[], bool p_second_phase) {
+	if (p_argc < 1)
+		return ERR_BUG;
+	for (int i = 0; i < p_argc; i++) {
+		args.push_back(String::utf8(p_argv[i]));
+	}
+
+	Thread::make_main_thread();
+	OS::get_singleton()->initialize();
+	engine = memnew(Engine);
+	register_core_types();
+	globals = memnew(ProjectSettings);
+	register_core_settings();
+	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
+	register_core_extensions();
+	register_core_singletons();
+
+	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
+
+	ScriptServer::init_languages();
+	return OK;
+}
+
+int Main::start() {
+	Error err = OK;
+	Ref<GDScript> script;
+	script.instantiate();
+	const String &source_file = args[0];
+	script->set_path(source_file);
+	err = script->load_source_code(source_file);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Could not load source code for: '" + source_file + "'");
+	GDScriptParser parser;
+	err = parser.parse(script->get_source_code(), source_file, false);
+	if (err != OK) {
+		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
+		if (!errors.is_empty()) {
+			print_line(errors[0].message);
+		}
+		return err;
+	}
+	GDScriptAnalyzer analyzer(&parser);
+	err = analyzer.analyze();
+	if (err != OK) {
+		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
+		if (!errors.is_empty()) {
+			print_line(errors[0].message);
+		}
+		return err;
+	}
+
+	GDScriptCompiler compiler;
+	err = compiler.compile(&parser, script.ptr(), false);
+	if (err != OK) {
+		print_line(compiler.get_error());
+		return err;
+	}
+	const HashMap<StringName, GDScriptFunction *>::ConstIterator main_func = script->get_member_functions().find("main");
+	ERR_FAIL_COND_V_MSG(!main_func, ERR_CANT_RESOLVE, "Could not find main function in: '" + source_file + "'");
+
+	err = script->reload();
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Could not reload script: '" + source_file + "'");
+
+	Object *obj = ClassDB::instantiate(script->get_native()->get_name());
+	Ref<RefCounted> obj_ref;
+	if (obj->is_ref_counted()) {
+		obj_ref = Ref<RefCounted>(Object::cast_to<RefCounted>(obj));
+	}
+	obj->set_script(script);
+	GDScriptInstance *instance = static_cast<GDScriptInstance *>(obj->get_script_instance());
+
+	Callable::CallError call_err;
+	instance->callp("main", nullptr, 0, call_err);
+
+	ERR_FAIL_COND_V_MSG(call_err.error != Callable::CallError::CALL_OK, ERR_SCRIPT_FAILED, "Could not call main function in: '" + source_file + "'");
+
+	if (obj_ref.is_null()) {
+		memdelete(obj);
+	}
+	return 0;
+}
+
+void Main::cleanup(bool p_force) {
+	OS::get_singleton()->delete_main_loop();
+	ScriptServer::finish_languages();
+	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
+	OS::get_singleton()->finalize();
+	if (globals) {
+		memdelete(globals);
+	}
+	if (engine) {
+		memdelete(engine);
+	}
+	unregister_core_extensions();
+	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
+	unregister_core_types();
+	OS::get_singleton()->finalize_core();
+}
+
+bool Main::iteration() {
+	return true;
+}

--- a/modules/gdscript/main/main.h
+++ b/modules/gdscript/main/main.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  main.h                                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef MAIN_H
+#define MAIN_H
+
+#include "core/error/error_list.h"
+
+class Main {
+public:
+	static Error setup(const char *p_execpath, int p_argc, char *p_argv[], bool p_second_phase = true);
+	static int start();
+	static void cleanup(bool p_force = false);
+	static int test_entrypoint(int p_argc, char *p_argv[], bool &r_tests_need_run);
+	static bool iteration();
+};
+
+#endif // MAIN_H

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -185,16 +185,7 @@ static void test_parser(const String &p_code, const String &p_script_path, const
 static void recursively_disassemble_functions(const Ref<GDScript> script, const Vector<String> &p_lines) {
 	for (const KeyValue<StringName, GDScriptFunction *> &E : script->get_member_functions()) {
 		const GDScriptFunction *func = E.value;
-
-		const MethodInfo &mi = func->get_method_info();
-		String signature = "Disassembling " + mi.name + "(";
-		for (int i = 0; i < mi.arguments.size(); i++) {
-			if (i > 0) {
-				signature += ", ";
-			}
-			signature += mi.arguments[i].name;
-		}
-		print_line(signature + ")");
+		print_line("Disassembling " + func->signature());
 #ifdef TOOLS_ENABLED
 		func->disassemble(p_lines);
 #endif

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -17,7 +17,7 @@ def can_build():
     return os.path.exists(get_env_android_sdk_root())
 
 
-def get_opts():
+def get_opts(_gdscript_build: bool):
     from SCons.Variables import BoolVariable
 
     return [

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -19,7 +19,7 @@ def can_build():
     return False
 
 
-def get_opts():
+def get_opts(_gdscript_build: bool):
     from SCons.Variables import BoolVariable
 
     return [

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -7,10 +7,16 @@ import platform_linuxbsd_builders
 common_linuxbsd = [
     "crash_handler_linuxbsd.cpp",
     "os_linuxbsd.cpp",
-    "joypad_linux.cpp",
-    "freedesktop_portal_desktop.cpp",
-    "freedesktop_screensaver.cpp",
 ]
+
+if not env.gdscript_build:
+    common_linuxbsd.extend(
+        [
+            "joypad_linux.cpp",
+            "freedesktop_portal_desktop.cpp",
+            "freedesktop_screensaver.cpp",
+        ]
+    )
 
 if env["use_sowrap"]:
     common_linuxbsd.append("xkbcommon-so_wrap.c")

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -277,6 +277,7 @@ String OS_LinuxBSD::get_version() const {
 	return release_version;
 }
 
+#ifndef GDSCRIPT_BUILD
 Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
 	if (RenderingServer::get_singleton() == nullptr) {
 		return Vector<String>();
@@ -399,6 +400,7 @@ Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
 
 	return info;
 }
+#endif // GDSCRIPT_BUILD
 
 Vector<String> OS_LinuxBSD::lspci_device_filter(Vector<String> vendor_device_id_mapping, String class_suffix, String check_column, String whitelist) const {
 	// NOTE: whitelist can be changed to `Vector<String>`, if the need arises.
@@ -931,7 +933,9 @@ void OS_LinuxBSD::run() {
 	//uint64_t frame=0;
 
 	while (true) {
+#ifndef GDSCRIPT_BUILD
 		DisplayServer::get_singleton()->process_events(); // get rid of pending events
+#endif
 #ifdef JOYDEV_ENABLED
 		joypad->process_joypads();
 #endif

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -102,7 +102,9 @@ public:
 	virtual String get_distribution_name() const override;
 	virtual String get_version() const override;
 
+#ifndef GDSCRIPT_BUILD
 	virtual Vector<String> get_video_adapter_driver_info() const override;
+#endif
 
 	virtual MainLoop *get_main_loop() const override;
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -20,7 +20,7 @@ def can_build():
     return False
 
 
-def get_opts():
+def get_opts(_gdscript_build: bool):
     from SCons.Variables import BoolVariable, EnumVariable
 
     return [

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -26,7 +26,7 @@ def can_build():
     return WhereIs("emcc") is not None
 
 
-def get_opts():
+def get_opts(_gdscript_build: bool):
     from SCons.Variables import BoolVariable
 
     return [

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -159,7 +159,7 @@ def detect_build_env_arch():
     return ""
 
 
-def get_opts():
+def get_opts(_gdscript_build: bool):
     from SCons.Variables import BoolVariable, EnumVariable
 
     mingw = os.getenv("MINGW_PREFIX", "")


### PR DESCRIPTION
While trying to work on GDScript in isolation, I was getting hour long build + link times, with a long time taken for incremental rebuilds. I thought it might be useful to add a build configuration to compile only what is necessary to run GDScript code.

This is pretty much the bare minimum to run a script like
```gdscript
func main():
	print("Hello world")
```

on Linux/BSD platforms. I wanted to publish this as a draft for suggestions on if this is worth pursuing, and if there's any issues with the approach

~~Building this requires `scons target=gdscript x11=false wayland=false pulseaudio=false alsa=false midi=false speechd=false dbus=false fontconfig=false` to link properly, I need to rework the scons setup a little to disable unused modules properly~~ Not any more!

[Proposal](https://github.com/godotengine/godot-proposals/issues/9444)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9444*