### PR TITLE
Fix proximity fade's `world_pos` is calculated incorrectly when in gl_compatibility

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1619,6 +1619,11 @@ void fragment() {)";
 		code += R"(
 	// Proximity Fade: Enabled
 	float depth_tex = textureLod(depth_texture, SCREEN_UV, 0.0).r;
+)";
+		if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+			code += "	depth_tex = depth_tex * 2.0 - 1.0;";
+		}
+		code += R"(
 	vec4 world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, depth_tex, 1.0);
 	world_pos.xyz /= world_pos.w;
 	ALPHA *= clamp(1.0 - smoothstep(world_pos.z + proximity_fade_distance, world_pos.z, VERTEX.z), 0.0, 1.0);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/89942

OpenGL ndc's z range is-1.0 to 1.0 by default while the Vulkan is 0.0 to 1.0.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
