### PR TITLE
[WIP] Linux/BSD: Add status indicator support through DBus

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -948,7 +948,7 @@ bool FreeDesktopPortalDesktop::indicator_register(DisplayServer::IndicatorID p_i
 	return true;
 }
 
-bool FreeDesktopPortalDesktop::indicator_create(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon) {
+bool FreeDesktopPortalDesktop::indicator_create(DisplayServer::IndicatorID p_id, const Ref<Texture2D> &p_icon) {
 	MutexLock mutex_lock(dbus_mutex);
 
 	ERR_FAIL_COND_V(indicators.has(p_id), false);
@@ -992,7 +992,7 @@ bool FreeDesktopPortalDesktop::indicator_create(DisplayServer::IndicatorID p_id,
 	return true;
 }
 
-Error FreeDesktopPortalDesktop::indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon) {
+Error FreeDesktopPortalDesktop::indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Texture2D> &p_icon) {
 	MutexLock mutex_lock(dbus_mutex);
 
 	ERR_FAIL_COND_V(!indicators.has(p_id), ERR_UNCONFIGURED);
@@ -1001,9 +1001,9 @@ Error FreeDesktopPortalDesktop::indicator_set_icon(DisplayServer::IndicatorID p_
 	ERR_FAIL_COND_V(p_icon.is_null(), FAILED);
 
 	// We'll have to manipulate the icon a bit.
-	Ref<Image> image = p_icon->duplicate(true);
+	Ref<Image> image = p_icon->get_image();
 
-	if (p_icon->is_compressed()) {
+	if (image->is_compressed()) {
 		Error err = image->decompress();
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Couldn't decompress VRAM-compressed status-icon. Switch to a lossless compression mode in the Import dock.");
 	}

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -602,7 +602,6 @@ DBusHandlerResult FreeDesktopPortalDesktop::_handle_message(DBusConnection *conn
 
 			if (name_space == "org.freedesktop.appearance" && key == "color-scheme") {
 				callable_mp(portal, &FreeDesktopPortalDesktop::_system_theme_changed_callback).call_deferred();
-				dbus_message_unref(message);
 				return DBUS_HANDLER_RESULT_HANDLED;
 			}
 		}
@@ -647,8 +646,6 @@ DBusHandlerResult FreeDesktopPortalDesktop::_handle_message(DBusConnection *conn
 				break;
 			}
 		}
-
-		dbus_message_unref(message);
 		return DBUS_HANDLER_RESULT_HANDLED;
 	}
 

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -937,8 +937,10 @@ bool FreeDesktopPortalDesktop::indicator_register(DisplayServer::IndicatorID p_i
 
 	StatusNotifierItem &item = indicators[p_id];
 
+	const char *item_name = item.name.utf8();
+
 	DBusMessage *message = dbus_message_new_method_call(BUS_STATUS_NOTIFIER_WATCHER_NAME, BUS_STATUS_NOTIFIER_WATCHER_PATH, BUS_INTERFACE_STATUS_NOTIFIER_WATCHER, "RegisterStatusNotifierItem");
-	dbus_message_append_args(message, DBUS_TYPE_STRING, &item.name.utf8().ptr(), DBUS_TYPE_INVALID);
+	dbus_message_append_args(message, DBUS_TYPE_STRING, &item_name, DBUS_TYPE_INVALID);
 
 	dbus_connection_send(monitor_connection, message, NULL);
 	dbus_message_unref(message);

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -38,19 +38,25 @@
 #include "core/string/ustring.h"
 #include "core/variant/variant.h"
 
-#ifdef SOWRAP_ENABLED
-#include "dbus-so_wrap.h"
-#else
-#include <dbus/dbus.h>
-#endif
-
+#include <poll.h>
+#include <strings.h>
 #include <unistd.h>
 
 #define BUS_OBJECT_NAME "org.freedesktop.portal.Desktop"
 #define BUS_OBJECT_PATH "/org/freedesktop/portal/desktop"
 
+#define BUS_INTERFACE_PROPERTIES "org.freedesktop.DBus.Properties"
+
 #define BUS_INTERFACE_SETTINGS "org.freedesktop.portal.Settings"
 #define BUS_INTERFACE_FILE_CHOOSER "org.freedesktop.portal.FileChooser"
+
+#define BUS_INTERFACE_STATUS_NOTIFIER_ITEM "org.freedesktop.StatusNotifierItem"
+#define BUS_STATUS_NOTIFIER_ITEM_NAME "org.freedesktop.StatusNotifierItem"
+#define BUS_STATUS_NOTIFIER_ITEM_PATH "/StatusNotifierItem"
+
+#define BUS_INTERFACE_STATUS_NOTIFIER_WATCHER "org.freedesktop.StatusNotifierWatcher"
+#define BUS_STATUS_NOTIFIER_WATCHER_NAME "org.freedesktop.StatusNotifierWatcher"
+#define BUS_STATUS_NOTIFIER_WATCHER_PATH "/StatusNotifierWatcher"
 
 bool FreeDesktopPortalDesktop::try_parse_variant(DBusMessage *p_reply_message, int p_type, void *r_value) {
 	DBusMessageIter iter[3];
@@ -507,14 +513,157 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 	}
 	dbus_message_unref(reply);
 
-	MutexLock lock(file_dialog_mutex);
+	//MutexLock lock(dbus_mutex);
 	file_dialogs.push_back(fd);
 
 	return OK;
 }
 
+dbus_bool_t FreeDesktopPortalDesktop::_dbus_message_iter_append_pixmap(DBusMessageIter *p_iter, Size2i p_size, Vector<uint8_t> p_data) {
+	DBusMessageIter iter_data;
+	DBusMessageIter image_array;
+	DBusMessageIter image_struct;
+	ERR_FAIL_COND_V(!dbus_message_iter_open_container(p_iter, DBUS_TYPE_VARIANT, "a(iiay)", &iter_data), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_open_container(&iter_data, DBUS_TYPE_ARRAY, "(iiay)", &image_array), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_open_container(&image_array, DBUS_TYPE_STRUCT, nullptr, &image_struct), FALSE);
+
+	// Image size
+	ERR_FAIL_COND_V(!dbus_message_iter_append_basic(&image_struct, DBUS_TYPE_INT32, &p_size.width), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_append_basic(&image_struct, DBUS_TYPE_INT32, &p_size.height), FALSE);
+
+	DBusMessageIter image_data_array;
+	ERR_FAIL_COND_V(!dbus_message_iter_open_container(&image_struct, DBUS_TYPE_ARRAY, "y", &image_data_array), FALSE);
+
+	// Image data
+	const char *data_ptr = (const char *)p_data.ptr();
+	ERR_FAIL_COND_V(!dbus_message_iter_append_fixed_array(&image_data_array, DBUS_TYPE_BYTE, &data_ptr, p_data.size()), FALSE);
+
+	ERR_FAIL_COND_V(!dbus_message_iter_close_container(&image_struct, &image_data_array), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_close_container(&image_array, &image_struct), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_close_container(&iter_data, &image_array), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_close_container(p_iter, &iter_data), FALSE);
+
+	return TRUE;
+}
+
+dbus_bool_t FreeDesktopPortalDesktop::_dbus_messsage_iter_append_basic_variant(DBusMessageIter *p_iter, int p_type, const void *p_value) {
+	ERR_FAIL_COND_V(!dbus_type_is_basic(p_type), FALSE);
+
+	char content_signature[2] = { (char)p_type, 0 };
+
+	const void *data = p_value;
+
+	if (!dbus_type_is_fixed(p_type)) {
+		// Non-fixed types are string-like and as such are already a pointer by
+		// themselves. To avoid going insane, we'll detect that and make the passed
+		// value a pointer-to-a-pointer ourselves.
+		data = &p_value;
+	}
+
+	DBusMessageIter variant_data;
+
+	ERR_FAIL_COND_V(!dbus_message_iter_open_container(p_iter, DBUS_TYPE_VARIANT, content_signature, &variant_data), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_append_basic(&variant_data, p_type, data), FALSE);
+	ERR_FAIL_COND_V(!dbus_message_iter_close_container(p_iter, &variant_data), FALSE);
+
+	return TRUE;
+}
+
+dbus_bool_t FreeDesktopPortalDesktop::_dbus_message_iter_append_bool_variant(DBusMessageIter *p_iter, bool p_bool) {
+	dbus_bool_t value = p_bool ? TRUE : FALSE;
+	return _dbus_messsage_iter_append_basic_variant(p_iter, DBUS_TYPE_BOOLEAN, &value);
+}
+
+dbus_bool_t FreeDesktopPortalDesktop::_dbus_message_iter_append_uint32_variant(DBusMessageIter *p_iter, uint32_t p_uint32) {
+	dbus_uint32_t value = p_uint32;
+	return _dbus_messsage_iter_append_basic_variant(p_iter, DBUS_TYPE_BOOLEAN, &value);
+}
+
+DBusHandlerResult FreeDesktopPortalDesktop::_handle_message(DBusConnection *connection, DBusMessage *message, void *user_data) {
+	FreeDesktopPortalDesktop *portal = (FreeDesktopPortalDesktop *)user_data;
+
+	if (dbus_message_is_signal(message, "org.freedesktop.portal.Settings", "SettingChanged")) {
+		DBusMessageIter iter;
+		if (dbus_message_iter_init(message, &iter)) {
+			const char *value;
+			dbus_message_iter_get_basic(&iter, &value);
+			String name_space = String::utf8(value);
+			dbus_message_iter_next(&iter);
+			dbus_message_iter_get_basic(&iter, &value);
+			String key = String::utf8(value);
+
+			if (name_space == "org.freedesktop.appearance" && key == "color-scheme") {
+				callable_mp(portal, &FreeDesktopPortalDesktop::_system_theme_changed_callback).call_deferred();
+				dbus_message_unref(message);
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+		}
+	}
+
+	if (dbus_message_is_signal(message, "org.freedesktop.portal.Request", "Response")) {
+		String path = String::utf8(dbus_message_get_path(message));
+		MutexLock lock(portal->dbus_mutex);
+		for (int i = 0; i < portal->file_dialogs.size(); i++) {
+			FreeDesktopPortalDesktop::FileDialogData &fd = portal->file_dialogs.write[i];
+			if (fd.path == path) {
+				DBusMessageIter iter;
+				if (dbus_message_iter_init(message, &iter)) {
+					bool cancel = false;
+					Vector<String> uris;
+					Dictionary options;
+					int index = 0;
+					file_chooser_parse_response(&iter, fd.filter_names, cancel, uris, index, options);
+
+					if (fd.callback.is_valid()) {
+						FileDialogCallback cb;
+						cb.callback = fd.callback;
+						cb.status = !cancel;
+						cb.files = uris;
+						cb.index = index;
+						cb.options = options;
+						cb.opt_in_cb = fd.opt_in_cb;
+						portal->pending_cbs.push_back(cb);
+					}
+
+					if (fd.prev_focus != DisplayServer::INVALID_WINDOW_ID) {
+						callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(fd.prev_focus);
+					}
+				}
+
+				DBusError err;
+				dbus_error_init(&err);
+				dbus_bus_remove_match(portal->monitor_connection, fd.filter.utf8(), &err);
+				dbus_error_free(&err);
+
+				portal->file_dialogs.remove_at(i);
+				break;
+			}
+		}
+
+		dbus_message_unref(message);
+		return DBUS_HANDLER_RESULT_HANDLED;
+	}
+
+	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
+
+dbus_bool_t FreeDesktopPortalDesktop::_handle_add_watch(DBusWatch *watch, void *data) {
+	FreeDesktopPortalDesktop *portal = (FreeDesktopPortalDesktop *)data;
+	portal->dbus_watches.append(watch);
+
+	return TRUE;
+}
+
+void FreeDesktopPortalDesktop::_handle_remove_watch(DBusWatch *watch, void *data) {
+	FreeDesktopPortalDesktop *portal = (FreeDesktopPortalDesktop *)data;
+	portal->dbus_watches.erase(watch);
+}
+
+void FreeDesktopPortalDesktop::_handle_watch_toggled(DBusWatch *watch, void *data) {
+}
+
 void FreeDesktopPortalDesktop::process_file_dialog_callbacks() {
-	MutexLock lock(file_dialog_mutex);
+	MutexLock lock(dbus_mutex);
 	while (!pending_cbs.is_empty()) {
 		FileDialogCallback cb = pending_cbs.front()->get();
 		pending_cbs.pop_front();
@@ -544,72 +693,79 @@ void FreeDesktopPortalDesktop::process_file_dialog_callbacks() {
 void FreeDesktopPortalDesktop::_thread_monitor(void *p_ud) {
 	FreeDesktopPortalDesktop *portal = (FreeDesktopPortalDesktop *)p_ud;
 
-	while (!portal->monitor_thread_abort.is_set()) {
-		if (portal->monitor_connection) {
-			while (true) {
-				DBusMessage *msg = dbus_connection_pop_message(portal->monitor_connection);
-				if (!msg) {
-					break;
-				} else if (dbus_message_is_signal(msg, "org.freedesktop.portal.Settings", "SettingChanged")) {
-					DBusMessageIter iter;
-					if (dbus_message_iter_init(msg, &iter)) {
-						const char *value;
-						dbus_message_iter_get_basic(&iter, &value);
-						String name_space = String::utf8(value);
-						dbus_message_iter_next(&iter);
-						dbus_message_iter_get_basic(&iter, &value);
-						String key = String::utf8(value);
+	while (true) {
+		LocalVector<struct pollfd> fds;
 
-						if (name_space == "org.freedesktop.appearance" && key == "color-scheme") {
-							callable_mp(portal, &FreeDesktopPortalDesktop::_system_theme_changed_callback).call_deferred();
-						}
-					}
-				} else if (dbus_message_is_signal(msg, "org.freedesktop.portal.Request", "Response")) {
-					String path = String::utf8(dbus_message_get_path(msg));
-					MutexLock lock(portal->file_dialog_mutex);
-					for (int i = 0; i < portal->file_dialogs.size(); i++) {
-						FreeDesktopPortalDesktop::FileDialogData &fd = portal->file_dialogs.write[i];
-						if (fd.path == path) {
-							DBusMessageIter iter;
-							if (dbus_message_iter_init(msg, &iter)) {
-								bool cancel = false;
-								Vector<String> uris;
-								Dictionary options;
-								int index = 0;
-								file_chooser_parse_response(&iter, fd.filter_names, cancel, uris, index, options);
+		{
+			MutexLock mutex_lock(portal->dbus_mutex);
 
-								if (fd.callback.is_valid()) {
-									FileDialogCallback cb;
-									cb.callback = fd.callback;
-									cb.status = !cancel;
-									cb.files = uris;
-									cb.index = index;
-									cb.options = options;
-									cb.opt_in_cb = fd.opt_in_cb;
-									portal->pending_cbs.push_back(cb);
-								}
-								if (fd.prev_focus != DisplayServer::INVALID_WINDOW_ID) {
-									callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(fd.prev_focus);
-								}
-							}
+			for (DBusWatch *watch : portal->dbus_watches) {
+				struct pollfd fd = {
+					dbus_watch_get_unix_fd(watch), // fd
+					POLLERR | POLLHUP, // events
+					0, // revents
+				};
 
-							DBusError err;
-							dbus_error_init(&err);
-							dbus_bus_remove_match(portal->monitor_connection, fd.filter.utf8().get_data(), &err);
-							dbus_error_free(&err);
+				DBusWatchFlags watch_flags = (DBusWatchFlags)dbus_watch_get_flags(watch);
 
-							portal->file_dialogs.remove_at(i);
-							break;
-						}
-					}
+				if (watch_flags & DBUS_WATCH_READABLE) {
+					fd.events |= POLLIN;
 				}
-				dbus_message_unref(msg);
+
+				if (watch_flags & DBUS_WATCH_WRITABLE) {
+					fd.events |= POLLOUT;
+				}
+
+				fds.push_back(fd);
 			}
-			dbus_connection_read_write(portal->monitor_connection, 0);
 		}
 
-		OS::get_singleton()->delay_usec(50'000);
+		if (fds.ptr() == nullptr || fds.size() == 0) {
+			continue;
+		}
+
+		poll(fds.ptr(), fds.size(), -1);
+
+		for (unsigned int i = 0; i < fds.size(); ++i) {
+			struct pollfd &fd = fds[i];
+			if (fd.revents) {
+				DBusWatchFlags flags = (DBusWatchFlags)0;
+
+				if (fd.events & POLLIN) {
+					flags = (DBusWatchFlags)(flags | (int)DBUS_WATCH_READABLE);
+				}
+
+				if (fd.events & POLLOUT) {
+					flags = (DBusWatchFlags)(flags | (int)DBUS_WATCH_WRITABLE);
+				}
+
+				// Sweet lord, I can't think of a better way of associating an fd with a
+				// watch.
+				dbus_watch_handle(portal->dbus_watches[i], flags);
+			}
+		}
+
+		MutexLock mutex_lock(portal->dbus_mutex);
+
+		while (dbus_connection_get_dispatch_status(portal->monitor_connection) == DBUS_DISPATCH_DATA_REMAINS) {
+			dbus_connection_dispatch(portal->monitor_connection);
+		}
+
+		if (!dbus_connection_get_is_connected(portal->monitor_connection) || portal->monitor_thread_abort.is_set()) {
+			break;
+		}
 	}
+}
+
+void FreeDesktopPortalDesktop::_dbus_connection_reply_error(DBusConnection *p_connection, DBusMessage *p_message, String p_error_message) {
+	ERR_PRINT(p_error_message);
+
+	DBusMessage *reply = dbus_message_new_error(p_message, DBUS_ERROR_UNKNOWN_PROPERTY, p_error_message.utf8());
+
+	dbus_uint32_t serial = dbus_message_get_serial(p_message);
+	dbus_connection_send(p_connection, reply, &serial);
+
+	dbus_message_unref(reply);
 }
 
 void FreeDesktopPortalDesktop::_system_theme_changed_callback() {
@@ -621,6 +777,295 @@ void FreeDesktopPortalDesktop::_system_theme_changed_callback() {
 			ERR_PRINT(vformat("Failed to execute system theme changed callback: %s.", Variant::get_callable_error_text(system_theme_changed, nullptr, 0, ce)));
 		}
 	}
+}
+
+void FreeDesktopPortalDesktop::_status_notifier_item_unregister(DBusConnection *connection, void *user_data) {
+}
+
+DBusHandlerResult FreeDesktopPortalDesktop::_status_notifier_item_handle_message(DBusConnection *connection, DBusMessage *message, void *user_data) {
+	FreeDesktopPortalDesktop *portal = (FreeDesktopPortalDesktop *)user_data;
+	ERR_FAIL_NULL_V(portal, DBUS_HANDLER_RESULT_HANDLED);
+
+	String interface = dbus_message_get_interface(message);
+	String member = dbus_message_get_member(message);
+
+	const char *destination_ptr = dbus_message_get_destination(message);
+	ERR_FAIL_NULL_V(destination_ptr, DBUS_HANDLER_RESULT_HANDLED);
+
+	String destination;
+	destination.parse_utf8(destination_ptr);
+
+	ERR_FAIL_COND_V(!portal->indicator_id_map.has(destination), DBUS_HANDLER_RESULT_HANDLED);
+	DisplayServer::IndicatorID id = portal->indicator_id_map[destination];
+
+	ERR_FAIL_COND_V(!portal->indicators.has(id), DBUS_HANDLER_RESULT_HANDLED);
+	StatusNotifierItem &item = portal->indicators[id];
+
+	if (dbus_message_is_method_call(message, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "Activate")) {
+		if (item.activate_callback.is_valid()) {
+			dbus_int32_t x = 0;
+			dbus_int32_t y = 0;
+
+			DBusError error;
+			dbus_error_init(&error);
+			dbus_message_get_args(message, &error, DBUS_TYPE_INT32, &x, DBUS_TYPE_INT32, &y, DBUS_TYPE_INVALID);
+			if (dbus_error_is_set(&error)) {
+				_dbus_connection_reply_error(connection, message, vformat("Invalid arguments for %s.%s at %s", interface, member, destination));
+				dbus_error_free(&error);
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+
+			item.activate_callback.call_deferred(MouseButton::LEFT, Point2i(x, y));
+		}
+
+		return DBUS_HANDLER_RESULT_HANDLED;
+	}
+
+	if (dbus_message_is_method_call(message, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "SecondaryActivate")) {
+		if (item.activate_callback.is_valid()) {
+			dbus_int32_t x = 0;
+			dbus_int32_t y = 0;
+
+			DBusError error;
+			dbus_error_init(&error);
+			dbus_message_get_args(message, &error, DBUS_TYPE_INT32, &x, DBUS_TYPE_INT32, &y, DBUS_TYPE_INVALID);
+			if (dbus_error_is_set(&error)) {
+				_dbus_connection_reply_error(connection, message, vformat("Invalid arguments for %s.%s at %s", interface, member, destination));
+				dbus_error_free(&error);
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+
+			item.activate_callback.call_deferred(MouseButton::MIDDLE, Point2i(x, y));
+		}
+
+		return DBUS_HANDLER_RESULT_HANDLED;
+	}
+
+	if (dbus_message_get_type(message) == DBUS_MESSAGE_TYPE_METHOD_CALL && interface == BUS_INTERFACE_PROPERTIES && member == "Get") {
+		const char *object_name;
+		const char *property;
+
+		DBusError error;
+		dbus_error_init(&error);
+		dbus_message_get_args(message, &error, DBUS_TYPE_STRING, &object_name, DBUS_TYPE_STRING, &property, DBUS_TYPE_INVALID);
+		if (dbus_error_is_set(&error)) {
+			_dbus_connection_reply_error(connection, message, vformat("Invalid arguments for %s.%s at %s", interface, member, destination));
+			dbus_error_free(&error);
+			return DBUS_HANDLER_RESULT_HANDLED;
+		}
+
+		if (strcmp(object_name, BUS_STATUS_NOTIFIER_ITEM_NAME) == 0) {
+			DBusMessage *reply = dbus_message_new_method_return(message);
+
+			if (!reply) {
+				_dbus_connection_reply_error(connection, message, "Failed to build response");
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+
+			DBusMessageIter reply_iter;
+			dbus_message_iter_init_append(reply, &reply_iter);
+
+			dbus_bool_t success = FALSE;
+			if (strcmp(property, "Category") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "ApplicationStatus");
+			} else if (strcmp(property, "Id") == 0) {
+				// TODO: No idea what would be a good value.
+				// The documentation says that this is pretty much an app id.
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "org.godotengine.Godot");
+			} else if (strcmp(property, "Title") == 0) {
+				// TODO: No idea what would be a good value.
+				// Same thing as above, although it's meant to be a little bit more verbose.
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "Godot game engine");
+			} else if (strcmp(property, "Status") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "Active");
+			} else if (strcmp(property, "WindowId") == 0) {
+				success = _dbus_message_iter_append_uint32_variant(&reply_iter, 0);
+			} else if (strcmp(property, "IconName") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "");
+			} else if (strcmp(property, "IconPixmap") == 0) {
+				success = _dbus_message_iter_append_pixmap(&reply_iter, item.icon_size, item.icon_data);
+			} else if (strcmp(property, "OverlayIconName") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "");
+			} else if (strcmp(property, "OverlayIconPixmap") == 0) {
+				success = _dbus_message_iter_append_pixmap(&reply_iter, Size2i(), Vector<uint8_t>());
+			} else if (strcmp(property, "AttentionIconName") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "");
+			} else if (strcmp(property, "AttentionIconPixmap") == 0) {
+				success = _dbus_message_iter_append_pixmap(&reply_iter, Size2i(), Vector<uint8_t>());
+			} else if (strcmp(property, "AttentionMovieName") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, "");
+			} else if (strcmp(property, "ToolTip") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_STRING, item.tooltip.utf8());
+			} else if (strcmp(property, "ItemIsMenu") == 0) {
+				success = _dbus_message_iter_append_bool_variant(&reply_iter, false);
+			} else if (strcmp(property, "Menu") == 0) {
+				success = _dbus_messsage_iter_append_basic_variant(&reply_iter, DBUS_TYPE_OBJECT_PATH, "/");
+			} else {
+				_dbus_connection_reply_error(connection, message, vformat("Property %s not found.", property));
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+
+			if (!success) {
+				_dbus_connection_reply_error(connection, message, "Failed to build response");
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+
+			dbus_uint32_t serial = dbus_message_get_serial(message);
+			dbus_connection_send(connection, reply, &serial);
+
+			dbus_message_unref(reply);
+
+			return DBUS_HANDLER_RESULT_HANDLED;
+		}
+	}
+
+	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
+
+bool FreeDesktopPortalDesktop::indicator_create(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon) {
+	MutexLock mutex_lock(dbus_mutex);
+
+	ERR_FAIL_COND_V(indicators.has(p_id), false);
+
+	if (unsupported) {
+		return false;
+	}
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	DBusConnection *bus = dbus_bus_get(DBUS_BUS_SESSION, &error);
+	if (dbus_error_is_set(&error)) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			ERR_PRINT(vformat("Error opening D-Bus connection: %s", error.message));
+		}
+		dbus_error_free(&error);
+		unsupported = true;
+		return false;
+	}
+
+	int pid = OS::get_singleton()->get_process_id();
+
+	String name = vformat("org.freedesktop.StatusNotifierItem-%d-%d", pid, p_id);
+	dbus_bus_request_name(bus, name.utf8(), DBUS_NAME_FLAG_DO_NOT_QUEUE, &error);
+	if (dbus_error_is_set(&error)) {
+		dbus_error_free(&error);
+		return false;
+	}
+
+	indicator_id_map[name] = p_id;
+
+	StatusNotifierItem &item = indicators[p_id];
+	item.id = p_id;
+	item.name = name;
+
+	// TODO: Error handling.
+	indicator_set_icon(p_id, p_icon);
+
+	const char *name_ptr = name.utf8();
+
+	DBusMessage *message = dbus_message_new_method_call(
+			BUS_STATUS_NOTIFIER_WATCHER_NAME, BUS_STATUS_NOTIFIER_WATCHER_PATH, BUS_INTERFACE_STATUS_NOTIFIER_WATCHER,
+			"RegisterStatusNotifierItem");
+	dbus_message_append_args(
+			message,
+			DBUS_TYPE_STRING, &name_ptr,
+			DBUS_TYPE_INVALID);
+
+	dbus_connection_send(bus, message, NULL);
+	dbus_message_unref(message);
+
+	item.registered = true;
+
+	return true;
+}
+
+Error FreeDesktopPortalDesktop::indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon) {
+	MutexLock mutex_lock(dbus_mutex);
+
+	ERR_FAIL_COND_V(!indicators.has(p_id), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(p_icon->get_size().x == 0, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_icon->get_size().y == 0, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_icon.is_null(), FAILED);
+
+	// We'll have to manipulate the icon a bit.
+	Ref<Image> image = p_icon->duplicate(true);
+
+	if (p_icon->is_compressed()) {
+		Error err = image->decompress();
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Couldn't decompress VRAM-compressed status-icon. Switch to a lossless compression mode in the Import dock.");
+	}
+
+	// TODO: Figure out the size limits (at least swaybar errors on big pixmaps)
+	image->resize(64, 64);
+
+	// The API requires ARGB32 (or ARGB8888), which `Image` does not support.
+	// Luckily, we can convert to RGBA8 (which is actually RGBA8888), so we'll just
+	// need to reorder the bytes ourselves.
+	image->convert(Image::FORMAT_RGBA8);
+
+	Vector<uint8_t> image_data = image->get_data();
+
+	StatusNotifierItem &item = indicators[p_id];
+	item.icon_size = image->get_size();
+
+	item.icon_data.clear();
+	for (int i = 0; i < image_data.size(); i += 4) {
+		item.icon_data.append(image_data[i + 3]); // A
+		item.icon_data.append(image_data[i + 0]); // R
+		item.icon_data.append(image_data[i + 1]); // G
+		item.icon_data.append(image_data[i + 2]); // B
+	}
+
+	if (item.registered) {
+		DBusMessage *signal = dbus_message_new_signal(BUS_STATUS_NOTIFIER_ITEM_PATH, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "NewIcon");
+		dbus_connection_send(monitor_connection, signal, NULL);
+		dbus_message_unref(signal);
+	}
+
+	return OK;
+}
+
+void FreeDesktopPortalDesktop::indicator_set_tooltip(DisplayServer::IndicatorID p_id, const String &p_tooltip) {
+	MutexLock mutex_lock(dbus_mutex);
+
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	StatusNotifierItem &item = indicators[p_id];
+
+	item.tooltip = p_tooltip;
+
+	if (item.registered) {
+		DBusMessage *signal = dbus_message_new_signal(BUS_STATUS_NOTIFIER_ITEM_PATH, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "NewToolTip");
+		dbus_connection_send(monitor_connection, signal, NULL);
+		dbus_message_unref(signal);
+	}
+}
+
+void FreeDesktopPortalDesktop::indicator_set_callback(DisplayServer::IndicatorID p_id, const Callable &p_callback) {
+	MutexLock mutex_lock(dbus_mutex);
+
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	StatusNotifierItem &item = indicators[p_id];
+
+	item.activate_callback = p_callback;
+}
+
+void FreeDesktopPortalDesktop::indicator_destroy(DisplayServer::IndicatorID p_id) {
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	StatusNotifierItem &item = indicators[p_id];
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	dbus_bus_release_name(monitor_connection, item.name.utf8(), &error);
+
+	dbus_error_free(&error);
+
+	indicator_id_map.erase(item.name);
+	indicators.erase(p_id);
 }
 
 FreeDesktopPortalDesktop::FreeDesktopPortalDesktop() {
@@ -664,12 +1109,27 @@ FreeDesktopPortalDesktop::FreeDesktopPortalDesktop() {
 			dbus_connection_unref(monitor_connection);
 			monitor_connection = nullptr;
 		}
-		dbus_connection_read_write(monitor_connection, 0);
 	}
 
 	if (!unsupported) {
+		dbus_threads_init_default();
+		dbus_connection_add_filter(monitor_connection, _handle_message, this, _dbus_arg_noop);
+
+		dbus_connection_set_watch_functions(monitor_connection, _handle_add_watch, _handle_remove_watch, _handle_watch_toggled, this, _dbus_arg_noop);
+
 		monitor_thread_abort.clear();
 		monitor_thread.start(FreeDesktopPortalDesktop::_thread_monitor, this);
+
+		DBusError error;
+		dbus_error_init(&error);
+
+		dbus_connection_try_register_object_path(monitor_connection, BUS_STATUS_NOTIFIER_ITEM_PATH, &status_indicator_item_vtable, this, &error);
+		if (dbus_error_is_set(&error)) {
+			if (OS::get_singleton()->is_stdout_verbose()) {
+				ERR_PRINT(vformat("Error on D-Bus communication: %s", error.message));
+			}
+			dbus_error_free(&error);
+		}
 	}
 }
 

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -938,7 +938,7 @@ bool FreeDesktopPortalDesktop::indicator_register(DisplayServer::IndicatorID p_i
 	StatusNotifierItem &item = indicators[p_id];
 
 	DBusMessage *message = dbus_message_new_method_call(BUS_STATUS_NOTIFIER_WATCHER_NAME, BUS_STATUS_NOTIFIER_WATCHER_PATH, BUS_INTERFACE_STATUS_NOTIFIER_WATCHER, "RegisterStatusNotifierItem");
-	dbus_message_append_args(message, DBUS_TYPE_STRING, item.name.utf8(), DBUS_TYPE_INVALID);
+	dbus_message_append_args(message, DBUS_TYPE_STRING, &item.name.utf8().ptr(), DBUS_TYPE_INVALID);
 
 	dbus_connection_send(monitor_connection, message, NULL);
 	dbus_message_unref(message);

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -977,8 +977,6 @@ bool FreeDesktopPortalDesktop::indicator_create(DisplayServer::IndicatorID p_id,
 		return false;
 	}
 
-	item.name_assigned = true;
-
 	indicator_id_map[name] = p_id;
 
 	StatusNotifierItem &item = indicators[p_id];
@@ -1029,11 +1027,9 @@ Error FreeDesktopPortalDesktop::indicator_set_icon(DisplayServer::IndicatorID p_
 		item.icon_data.append(image_data[i + 2]); // B
 	}
 
-	if (item.name_assigned) {
-		DBusMessage *signal = dbus_message_new_signal(BUS_STATUS_NOTIFIER_ITEM_PATH, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "NewIcon");
-		dbus_connection_send(monitor_connection, signal, NULL);
-		dbus_message_unref(signal);
-	}
+	DBusMessage *signal = dbus_message_new_signal(BUS_STATUS_NOTIFIER_ITEM_PATH, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "NewIcon");
+	dbus_connection_send(monitor_connection, signal, NULL);
+	dbus_message_unref(signal);
 
 	return OK;
 }
@@ -1047,11 +1043,9 @@ void FreeDesktopPortalDesktop::indicator_set_tooltip(DisplayServer::IndicatorID 
 
 	item.tooltip = p_tooltip;
 
-	if (item.name_assigned) {
-		DBusMessage *signal = dbus_message_new_signal(BUS_STATUS_NOTIFIER_ITEM_PATH, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "NewToolTip");
-		dbus_connection_send(monitor_connection, signal, NULL);
-		dbus_message_unref(signal);
-	}
+	DBusMessage *signal = dbus_message_new_signal(BUS_STATUS_NOTIFIER_ITEM_PATH, BUS_INTERFACE_STATUS_NOTIFIER_ITEM, "NewToolTip");
+	dbus_connection_send(monitor_connection, signal, NULL);
+	dbus_message_unref(signal);
 }
 
 void FreeDesktopPortalDesktop::indicator_set_callback(DisplayServer::IndicatorID p_id, const Callable &p_callback) {

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -850,19 +850,19 @@ DBusHandlerResult FreeDesktopPortalDesktop::_status_notifier_item_handle_message
 	}
 
 	if (dbus_message_get_type(message) == DBUS_MESSAGE_TYPE_METHOD_CALL && interface == BUS_INTERFACE_PROPERTIES && member == "Get") {
-		const char *object_name;
+		const char *interface_name;
 		const char *property;
 
 		DBusError error;
 		dbus_error_init(&error);
-		dbus_message_get_args(message, &error, DBUS_TYPE_STRING, &object_name, DBUS_TYPE_STRING, &property, DBUS_TYPE_INVALID);
+		dbus_message_get_args(message, &error, DBUS_TYPE_STRING, &interface_name, DBUS_TYPE_STRING, &property, DBUS_TYPE_INVALID);
 		if (dbus_error_is_set(&error)) {
 			_dbus_connection_reply_error(connection, message, vformat("Invalid arguments for %s.%s at %s", interface, member, destination));
 			dbus_error_free(&error);
 			return DBUS_HANDLER_RESULT_HANDLED;
 		}
 
-		if (strcmp(object_name, BUS_STATUS_NOTIFIER_ITEM_NAME) == 0) {
+		if (strcmp(interface_name, BUS_STATUS_NOTIFIER_ITEM_NAME) == 0) {
 			DBusMessage *reply = dbus_message_new_method_return(message);
 
 			if (!reply) {

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -95,7 +95,7 @@ private:
 		String name;
 		String tooltip;
 		Callable activate_callback;
-		bool registered = false;
+		bool name_assigned = false;
 		Size2i icon_size;
 		Vector<uint8_t> icon_data;
 	};
@@ -156,6 +156,7 @@ public:
 		system_theme_changed = p_system_theme_changed;
 	}
 
+	bool indicator_register(DisplayServer::IndicatorID p_id);
 	bool indicator_create(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon);
 	Error indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon);
 	void indicator_set_tooltip(DisplayServer::IndicatorID p_id, const String &p_tooltip);

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -33,9 +33,9 @@
 
 #ifdef DBUS_ENABLED
 
-#include "core/io/image.h"
 #include "core/os/thread.h"
 #include "core/os/thread_safe.h"
+#include "scene/resources/texture.h"
 #include "servers/display_server.h"
 
 #ifdef SOWRAP_ENABLED
@@ -68,7 +68,6 @@ private:
 		bool opt_in_cb = false;
 	};
 
-	
 	struct FileDialogCallback {
 		Callable callback;
 		Variant status;
@@ -156,8 +155,8 @@ public:
 	}
 
 	bool indicator_register(DisplayServer::IndicatorID p_id);
-	bool indicator_create(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon);
-	Error indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon);
+	bool indicator_create(DisplayServer::IndicatorID p_id, const Ref<Texture2D> &p_icon);
+	Error indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Texture2D> &p_icon);
 	void indicator_set_tooltip(DisplayServer::IndicatorID p_id, const String &p_tooltip);
 	void indicator_set_callback(DisplayServer::IndicatorID p_id, const Callable &p_callback);
 	void indicator_destroy(DisplayServer::IndicatorID p_id);

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -33,13 +33,16 @@
 
 #ifdef DBUS_ENABLED
 
+#include "core/io/image.h"
 #include "core/os/thread.h"
 #include "core/os/thread_safe.h"
 #include "servers/display_server.h"
 
-struct DBusMessage;
-struct DBusConnection;
-struct DBusMessageIter;
+#ifdef SOWRAP_ENABLED
+#include "dbus-so_wrap.h"
+#else
+#include <dbus/dbus.h>
+#endif
 
 class FreeDesktopPortalDesktop : public Object {
 private:
@@ -65,6 +68,7 @@ private:
 		bool opt_in_cb = false;
 	};
 
+	
 	struct FileDialogCallback {
 		Callable callback;
 		Variant status;
@@ -75,15 +79,62 @@ private:
 	};
 	List<FileDialogCallback> pending_cbs;
 
-	Mutex file_dialog_mutex;
+	Mutex dbus_mutex;
 	Vector<FileDialogData> file_dialogs;
 	Thread monitor_thread;
 	SafeFlag monitor_thread_abort;
 	DBusConnection *monitor_connection = nullptr;
 
+	Vector<DBusWatch *> dbus_watches;
+
 	String theme_path;
 	Callable system_theme_changed;
+
+	struct StatusNotifierItem {
+		DisplayServer::IndicatorID id = DisplayServer::INVALID_INDICATOR_ID;
+		String name;
+		String tooltip;
+		Callable activate_callback;
+		bool registered = false;
+		Size2i icon_size;
+		Vector<uint8_t> icon_data;
+	};
+
+	HashMap<DisplayServer::IndicatorID, StatusNotifierItem> indicators;
+	HashMap<String, DisplayServer::IndicatorID> indicator_id_map;
+
+	Size2i icon_image_size;
+	Vector<uint8_t> icon_image_data;
+
+	struct DBusObjectPathVTable status_indicator_item_vtable = {
+		_status_notifier_item_unregister, // unregister_function
+		_status_notifier_item_handle_message, // message_function
+		_dbus_arg_noop, // dbus_internal_pad1
+		_dbus_arg_noop, // dbus_internal_pad2
+		_dbus_arg_noop, // dbus_internal_pad3
+		_dbus_arg_noop, // dbus_internal_pad4
+	};
+
+	static void _dbus_connection_reply_error(DBusConnection *p_connection, DBusMessage *p_message, String p_error_message);
 	void _system_theme_changed_callback();
+
+	static void _dbus_arg_noop(void *arg) {}
+
+	// Useful for responding to property requests.
+	static dbus_bool_t _dbus_messsage_iter_append_basic_variant(DBusMessageIter *p_iter, int p_type, const void *p_value);
+	static dbus_bool_t _dbus_message_iter_append_bool_variant(DBusMessageIter *p_iter, bool p_bool);
+	static dbus_bool_t _dbus_message_iter_append_uint32_variant(DBusMessageIter *p_iter, uint32_t p_uint32);
+
+	// Implements the StatusNotifierItem icon spec.
+	static dbus_bool_t _dbus_message_iter_append_pixmap(DBusMessageIter *p_iter, Size2i p_size, Vector<uint8_t> p_data);
+
+	static DBusHandlerResult _handle_message(DBusConnection *connection, DBusMessage *message, void *user_data);
+	static dbus_bool_t _handle_add_watch(DBusWatch *watch, void *data);
+	static void _handle_remove_watch(DBusWatch *watch, void *data);
+	static void _handle_watch_toggled(DBusWatch *watch, void *data);
+
+	static void _status_notifier_item_unregister(DBusConnection *connection, void *user_data);
+	static DBusHandlerResult _status_notifier_item_handle_message(DBusConnection *connection, DBusMessage *message, void *user_data);
 
 	static void _thread_monitor(void *p_ud);
 
@@ -104,6 +155,12 @@ public:
 	void set_system_theme_change_callback(const Callable &p_system_theme_changed) {
 		system_theme_changed = p_system_theme_changed;
 	}
+
+	bool indicator_create(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon);
+	Error indicator_set_icon(DisplayServer::IndicatorID p_id, const Ref<Image> &p_icon);
+	void indicator_set_tooltip(DisplayServer::IndicatorID p_id, const String &p_tooltip);
+	void indicator_set_callback(DisplayServer::IndicatorID p_id, const Callable &p_callback);
+	void indicator_destroy(DisplayServer::IndicatorID p_id);
 };
 
 #endif // DBUS_ENABLED

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -95,7 +95,6 @@ private:
 		String name;
 		String tooltip;
 		Callable activate_callback;
-		bool name_assigned = false;
 		Size2i icon_size;
 		Vector<uint8_t> icon_data;
 	};

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -207,6 +207,7 @@ bool DisplayServerWayland::has_feature(Feature p_feature) const {
 		case FEATURE_WINDOW_TRANSPARENCY:
 		case FEATURE_HIDPI:
 		case FEATURE_SWAP_BUFFERS:
+		case FEATURE_STATUS_INDICATOR:
 		case FEATURE_KEEP_SCREEN_ON:
 		case FEATURE_IME:
 		case FEATURE_CLIPBOARD_PRIMARY: {

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1270,6 +1270,32 @@ void DisplayServerWayland::swap_buffers() {
 #endif
 }
 
+DisplayServer::IndicatorID DisplayServerWayland::create_status_indicator(const Ref<Texture2D> &p_icon, const String &p_tooltip, const Callable &p_callback) {
+	IndicatorID id = indicator_id_counter++;
+	indicators.insert(id);
+
+	portal_desktop->indicator_create(id, p_icon);
+	portal_desktop->indicator_set_callback(id, p_callback);
+
+	return id;
+}
+
+void DisplayServerWayland::status_indicator_set_icon(IndicatorID p_id, const Ref<Texture2D> &p_icon) {
+	portal_desktop->indicator_set_icon(p_id, p_icon);
+}
+
+void DisplayServerWayland::status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) {
+	portal_desktop->indicator_set_tooltip(p_id, p_tooltip);
+}
+
+void DisplayServerWayland::status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) {
+	portal_desktop->indicator_set_callback(p_id, p_callback);
+}
+
+void DisplayServerWayland::delete_status_indicator(IndicatorID p_id) {
+	portal_desktop->indicator_destroy(p_id);
+}
+
 void DisplayServerWayland::set_context(Context p_context) {
 	MutexLock mutex_lock(wayland_thread.mutex);
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -140,6 +140,9 @@ class DisplayServerWayland : public DisplayServer {
 #if DBUS_ENABLED
 	FreeDesktopPortalDesktop *portal_desktop = nullptr;
 
+	IndicatorID indicator_id_counter = 0;
+	HashSet<IndicatorID> indicators;
+
 	FreeDesktopScreenSaver *screensaver = nullptr;
 	bool screensaver_inhibited = false;
 #endif
@@ -285,6 +288,12 @@ public:
 
 	virtual void release_rendering_thread() override;
 	virtual void swap_buffers() override;
+
+	virtual IndicatorID create_status_indicator(const Ref<Texture2D> &p_icon, const String &p_tooltip, const Callable &p_callback) override;
+	virtual void status_indicator_set_icon(IndicatorID p_id, const Ref<Texture2D> &p_icon) override;
+	virtual void status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) override;
+	virtual void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) override;
+	virtual void delete_status_indicator(IndicatorID p_id) override;
 
 	virtual void set_context(Context p_context) override;
 


### PR DESCRIPTION
This PR adds support for status indicators in the `FreeDesktopPortalDesktop` class.

While it's technically not part of the portal API, splitting it would've been too inconvenient for now. I'd like to eventually put most of the abstractions/tools into a separate class (a bit like a homebrew binding) or at worst rename it to something more generic like `FreeDesktopDBus`.

## Changes to event handling

This PR also fleshes further the "core" of the DBus handling logic, as the StatusNotifierItem API is very object-oriented[^1].

Most importantly, I changed the monitor loop from a polling loop to a `poll(2)`-based one (no idea how it's properly named), by tracking the various `DBusWatch`es that libdbus throws at us. 

Note that technically we should also track `DBusTimeout`s ~but I did not investigate on what they're for yet. Stuff works for now so :shrug:~

Edit: they're for timeouts duh xD

I also removed most of the "simple" event logic (`dbus_connection_pop_message`) to go through the "builtin" event handlers, as otherwise we would've had to rebuild the event handling logic from scratch.

Finally, I added a bunch of utility methods to populate common "variant" (the DBus kind) based messages . I wonder if it would be worth it to make a fancier `Variant`-based API/binding of sorts as the feature list grows (I want to plumb in the whole portal API eventually) or if that's a bad idea.

## Final remarks

Despite it being technically feature-complete (although I didn't test the tooltip because swaybar does not support it), I marked this PR as WIP because the code is still a bit rough, it needs some more testing and I only plumbed it into the Wayland backend (should be trivial to do the same on X11 though).

Most importantly, I'd like to discuss the changes I did to the DBus event loop and whether I should split them up into a separate PR.

CC @bruvzg

## TODO

 - [x] Fix issue where the icons don't get reassigned when the bar (e.g. swaybar) gets restarted
 - [ ] Implement DBusTimeout support (the docs say what we should do but not why, doesn't sound too hard)
 - [ ] Investigate in some prettier way of writing OO interactions (custom bindings?)

[^1]: https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/