### PR TITLE
[TileMap] Fix forcing cleanup on exiting tree/canvas

### DIFF
--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -300,7 +300,6 @@ private:
 		bool flags[DIRTY_FLAGS_MAX] = { false };
 		SelfList<CellData>::List cell_list;
 	} dirty;
-	bool in_destructor = false;
 
 	// Rect cache.
 	mutable Rect2 rect_cache;
@@ -310,7 +309,7 @@ private:
 
 	// Runtime tile data.
 	bool _runtime_update_tile_data_was_cleaned_up = false;
-	void _build_runtime_update_tile_data();
+	void _build_runtime_update_tile_data(bool p_force_cleanup);
 	void _build_runtime_update_tile_data_for_cell(CellData &r_cell_data, bool p_use_tilemap_for_runtime, bool p_auto_add_to_dirty_list = false);
 	bool _runtime_update_needs_all_cells_cleaned_up = false;
 	void _clear_runtime_update_tile_data();
@@ -321,13 +320,13 @@ private:
 	HashMap<Vector2i, Ref<DebugQuadrant>> debug_quadrant_map;
 	Vector2i _coords_to_debug_quadrant_coords(const Vector2i &p_coords) const;
 	bool _debug_was_cleaned_up = false;
-	void _debug_update();
+	void _debug_update(bool p_force_cleanup);
 	void _debug_quadrants_update_cell(CellData &r_cell_data, SelfList<DebugQuadrant>::List &r_dirty_debug_quadrant_list);
 #endif // DEBUG_ENABLED
 
 	HashMap<Vector2i, Ref<RenderingQuadrant>> rendering_quadrant_map;
 	bool _rendering_was_cleaned_up = false;
-	void _rendering_update();
+	void _rendering_update(bool p_force_cleanup);
 	void _rendering_notification(int p_what);
 	void _rendering_quadrants_update_cell(CellData &r_cell_data, SelfList<RenderingQuadrant>::List &r_dirty_rendering_quadrant_list);
 	void _rendering_occluders_clear_cell(CellData &r_cell_data);
@@ -338,7 +337,7 @@ private:
 
 	HashMap<RID, Vector2i> bodies_coords; // Mapping for RID to coords.
 	bool _physics_was_cleaned_up = false;
-	void _physics_update();
+	void _physics_update(bool p_force_cleanup);
 	void _physics_notification(int p_what);
 	void _physics_clear_cell(CellData &r_cell_data);
 	void _physics_update_cell(CellData &r_cell_data);
@@ -347,7 +346,7 @@ private:
 #endif // DEBUG_ENABLED
 
 	bool _navigation_was_cleaned_up = false;
-	void _navigation_update();
+	void _navigation_update(bool p_force_cleanup);
 	void _navigation_notification(int p_what);
 	void _navigation_clear_cell(CellData &r_cell_data);
 	void _navigation_update_cell(CellData &r_cell_data);
@@ -356,7 +355,7 @@ private:
 #endif // DEBUG_ENABLED
 
 	bool _scenes_was_cleaned_up = false;
-	void _scenes_update();
+	void _scenes_update(bool p_force_cleanup);
 	void _scenes_clear_cell(CellData &r_cell_data);
 	void _scenes_update_cell(CellData &r_cell_data);
 #ifdef DEBUG_ENABLED
@@ -376,7 +375,7 @@ private:
 	// Internal updates.
 	void _queue_internal_update();
 	void _deferred_internal_update();
-	void _internal_update();
+	void _internal_update(bool p_force_cleanup);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
The code relies on that the deferred call is handled after the node exits the tree or canvas, this is because before the end of these notifications call both `is_inside_tree` and `is_visible_in_tree` retain the values they had before, so these changes being called immediately makes it not force cleanup properly

This feels like a pretty robust fix, and removes some unnecessary code, like the dedicated destructor flag, with the `p_force_cleanup` argument doing double duty here, I also moved the `pending_update` clearing to `_internal_update`, this avoids going through two other methods to reach the update (`update_internals` -> `_deferred_internal_update` -> `_internal_update`), while still catching any pending updates that might come after

~Edit 2: Will write up a 4.2 dedicated version as this can't be cherry-picked directly, will open a PR for that when this is approved~
Done, as the solution got a basic go-ahead and will wait on other changes in 4.3

---

* Fixes: https://github.com/godotengine/godot/issues/89769
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
