### PR TITLE
Editor: Disable auto-translation of titles in `AssetLib`.

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -143,6 +143,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem(bool p_clickable) {
 	vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	title = memnew(LinkButton);
+	title->set_auto_translate_mode(AutoTranslateMode::AUTO_TRANSLATE_MODE_DISABLED);
 	title->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	vb->add_child(title);
 


### PR DESCRIPTION
Fix unexpected auto-translation of assets' title.

![image](https://github.com/godotengine/godot/assets/12966814/de8fd3a0-33ff-4ae1-83a9-286efd1fb19c)