### PR TITLE
[CI] Improve fetching of changed files

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r HEAD~${{ github.event.pull_request.commits }}..HEAD 2> /dev/null || true)
+            files=$(git diff-tree --no-commit-id --name-only -r HEAD^1..HEAD 2> /dev/null || true)
           elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
             files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
           fi


### PR DESCRIPTION
PRs always use a merge into the repo on checkout, so checking for `HEAD^1` will show all the changes regardless of the number of commits in a PR, as it represents the target commit of the merge

You can see the improved results by comparing these two builds:
* [Before](https://github.com/godotengine/godot/actions/runs/8467322433/job/23197964285#step:6:16)
* [After](https://github.com/godotengine/godot/actions/runs/8467540675/job/23198592536#step:6:16)

It appears the CI will still catch file formatting without the files (I think it runs on all files if none are specified) but this ensures the files are properly listed, and it seems to fail on some files in the existing version when it fails to fetch files (my bad):
* It skips codespell without this fix, and possibly also some other checks
* It runs some checks on all files (like python, js, checks)

The reason it partially worked (which I failed to notice because some CI checks run regardless and I didn't check other cases like header guards) was that for *single commit* PRs it did the correct thing, checking the merge commit against its first parent, which was correct, but with multiple commit it instead broke, unsure exactly what broke with it though, but this new change ensures it always picks the first parent of the merge and that will include all the changes and have them properly aligned with the merged state

Follow up to:
* https://github.com/godotengine/godot/pull/89944

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
