### PR TITLE
Change how ImageTexture's image is defined

### DIFF
--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -52,26 +52,6 @@ void ImageTexture::reload_from_file() {
 	}
 }
 
-bool ImageTexture::_set(const StringName &p_name, const Variant &p_value) {
-	if (p_name == "image") {
-		set_image(p_value);
-		return true;
-	}
-	return false;
-}
-
-bool ImageTexture::_get(const StringName &p_name, Variant &r_ret) const {
-	if (p_name == "image") {
-		r_ret = get_image();
-		return true;
-	}
-	return false;
-}
-
-void ImageTexture::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("image"), PROPERTY_HINT_RESOURCE_TYPE, "Image", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT));
-}
-
 Ref<ImageTexture> ImageTexture::create_from_image(const Ref<Image> &p_image) {
 	ERR_FAIL_COND_V_MSG(p_image.is_null(), Ref<ImageTexture>(), "Invalid image: null");
 	ERR_FAIL_COND_V_MSG(p_image->is_empty(), Ref<ImageTexture>(), "Invalid image: image is empty");
@@ -232,6 +212,10 @@ void ImageTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_image", "image"), &ImageTexture::set_image);
 	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &ImageTexture::set_size_override);
+
+	ClassDB::bind_method(D_METHOD("_set_image", "image"), &ImageTexture::set_image);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "image", PROPERTY_HINT_RESOURCE_TYPE, "Image", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT), "_set_image", "get_image");
 }
 
 ImageTexture::ImageTexture() {}

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -49,11 +49,6 @@ class ImageTexture : public Texture2D {
 
 protected:
 	virtual void reload_from_file() override;
-
-	bool _set(const StringName &p_name, const Variant &p_value);
-	bool _get(const StringName &p_name, Variant &r_ret) const;
-	void _get_property_list(List<PropertyInfo> *p_list) const;
-
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot-proposals/issues/9385

This PR changes how `image` of ImageTexture is defined. It's now a real property (still internal). The only thing that changed is that you can modify it using `_validate_property()`.