### PR TITLE
Fix GPUParticles2D trails and turbulence not pausing

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1018,7 +1018,7 @@ void ParticleProcessMaterial::_update_shader() {
 			code += "		if (!COLLIDED) {\n";
 		}
 		code += "			float vel_mag = length(VELOCITY);\n";
-		code += "			float vel_infl = clamp(dynamic_params.turb_influence * turbulence_influence, 0.0,1.0);\n";
+		code += "			float vel_infl = clamp(dynamic_params.turb_influence * turbulence_influence, 0.0,1.0) * DELTA * 30.0;\n";
 		code += "			VELOCITY = mix(VELOCITY, normalize(noise_direction) * vel_mag * (1.0 + (1.0 - vel_infl) * 0.2), vel_infl);\n";
 		code += "			vel_mag = length(controlled_displacement);\n";
 		code += "			controlled_displacement = mix(controlled_displacement, normalize(noise_direction) * vel_mag * (1.0 + (1.0 - vel_infl) * 0.2), vel_infl);\n";

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1138,6 +1138,10 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 		//fill the trail params
 		for (uint32_t i = 0; i < p_particles->trail_params.size(); i++) {
 			uint32_t src_idx = i * p_particles->frame_history.size() / p_particles->trail_params.size();
+			if (p_particles->speed_scale <= 0.0) {
+				// Stop trails.
+				src_idx = 0;
+			}
 			p_particles->trail_params[i] = p_particles->frame_history[src_idx];
 		}
 	} else {


### PR DESCRIPTION
When using particles with trails or turbulence, some simulation would continue to happen when the scene tree was paused, because neither feature was taking the particle system's speed scale into account.

With this commit, trails are frozen at the latest frame when the speed scale is zero, while changes in velocity resulting from turbulence are multiplied by delta time so that they adjust for speed scale and fixed FPS. The default values of speed 1.0 and 30 FPS were used as reference for correct behavior.

Fixes #85213.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
