### PR TITLE
Make depth fog aerial perspective use the first radiance mipmap

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -85,6 +85,8 @@
 		<member name="fog_aerial_perspective" type="float" setter="set_fog_aerial_perspective" getter="get_fog_aerial_perspective" default="0.0">
 			If set above [code]0.0[/code] (exclusive), blends between the fog's color and the color of the background [Sky]. This has a small performance cost when set above [code]0.0[/code]. Must have [member background_mode] set to [constant BG_SKY].
 			This is useful to simulate [url=https://en.wikipedia.org/wiki/Aerial_perspective]aerial perspective[/url] in large scenes with low density fog. However, it is not very useful for high-density fog, as the sky will shine through. When set to [code]1.0[/code], the fog color comes completely from the [Sky]. If set to [code]0.0[/code], aerial perspective is disabled.
+			[b]Note:[/b] If the fog mode is [constant FOG_MODE_DEPTH], the sky radiance map will be rendered in its sharpest form available to allow for open world fog fading. If the fog mode is [constant FOG_MODE_EXPONENTIAL], a blurred version of the radiance map is used instead.
+			[b]Note:[/b] Aerial perspective is only effective when using the Forward+ or Mobile rendering methods, not Compatibility.
 		</member>
 		<member name="fog_density" type="float" setter="set_fog_density" getter="get_fog_density" default="0.01">
 			The fog density to be used. This is demonstrated in different ways depending on the [member fog_mode] mode chosen:

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -824,16 +824,25 @@ vec4 fog_process(vec3 vertex) {
 	if (scene_data_block.data.fog_aerial_perspective > 0.0) {
 		vec3 sky_fog_color = vec3(0.0);
 		vec3 cube_view = scene_data_block.data.radiance_inverse_xform * vertex;
-		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
-		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
+
+		// With depth fog, aerial perspective doesn't read mipmaps so the fog is not blurred
+		// (and is suitable for open world fog fading).
+		float mip_level = 0.0;
+		if (!sc_use_depth_fog) {
+			// With exponential fog, mip_level always reads from the second mipmap and higher so the fog is always slightly blurred.
+			mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
+		}
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(mip_level * MAX_ROUGHNESS_LOD, lod);
 		sky_fog_color = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod)).rgb;
-		sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
+		if (!sc_use_depth_fog) {
+			sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
+		}
 #else
 		sky_fog_color = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_view, mip_level * MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
+
 		fog_color = mix(fog_color, sky_fog_color, scene_data_block.data.fog_aerial_perspective);
 	}
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -666,8 +666,13 @@ vec4 fog_process(vec3 vertex) {
 	if (scene_data_block.data.fog_aerial_perspective > 0.0) {
 		vec3 sky_fog_color = vec3(0.0);
 		vec3 cube_view = scene_data_block.data.radiance_inverse_xform * vertex;
-		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
-		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
+		// With depth fog, aerial perspective doesn't read mipmaps so the fog is not blurred
+		// (and is suitable for open world fog fading).
+		float mip_level = 0.0;
+		if (!sc_use_depth_fog) {
+			// With exponential fog, mip_level always reads from the second mipmap and higher so the fog is always slightly blurred.
+			mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
+		}
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(mip_level * MAX_ROUGHNESS_LOD, lod);
@@ -675,7 +680,7 @@ vec4 fog_process(vec3 vertex) {
 		sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
 #else
 		sky_fog_color = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_view, mip_level * MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		fog_color = mix(fog_color, sky_fog_color, scene_data_block.data.fog_aerial_perspective);
 	}
 


### PR DESCRIPTION
This makes the depth fog fade directly to the sharpest possible version of the sky, as opposed to a blurred version that is less suitable for open world fog fading.

Subtle differences may still be noticeable when using a sky material with nearest-neighbor filtered textures, as it's always sampled with bilinear filtering. I've been wondering how we can improve upon this (perhaps with a project setting to adjust this sampler like https://github.com/godotengine/godot-proposals/issues/8063), but it's not too noticeable in practice if your Camera3D's Far property is adjusted to match the fog's end distance. Doing so is also beneficial for performance anyway.

Given this makes https://github.com/godotengine/godot/pull/84792 a lot more useful for open world games and affects visuals of projects using that feature, it would be good to get this in for 4.3 if possible :slightly_smiling_face: 

The appearance of exponential fog isn't affected by this PR.

- This closes https://github.com/godotengine/godot/issues/97803.

**Testing project:** [test_fog_sky_fade.zip](https://github.com/godotengine/godot/files/14872875/test_fog_sky_fade.zip)

## Preview

### Forward+

Before | After
-|-
![Screenshot_20240328_214643 webp](https://github.com/godotengine/godot/assets/180032/79a77bcb-30f7-461c-a577-af336baa4156) | ![Screenshot_20240328_220355 webp](https://github.com/godotengine/godot/assets/180032/ffda2b3e-72c5-4bc7-b4e4-0c14f1514156)

### Mobile

*Fog aerial perspective appears darker in general (both without and with this PR), similar to its `screen_texture` issue where screen contents appear darker.*

Before | After
-|-
![Screenshot_20240328_221536 png webp](https://github.com/godotengine/godot/assets/180032/eb5e0af7-8709-4ef5-b952-5ac44e8983ee) | ![Screenshot_20240328_221523 png webp](https://github.com/godotengine/godot/assets/180032/1534f693-d051-4ca7-ad4f-7cd2fc545ca3)

### Compatibility

*Fog aerial perspective isn't implemented yet in the Compatibility rendering method.*
