### PR TITLE
Fix setting animation save paths on import breaking on Windows

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1343,6 +1343,7 @@ void SceneImportSettingsDialog::_save_dir_callback(const String &p_path) {
 						item->set_metadata(0, E.key);
 						item->set_editable(0, true);
 						item->set_checked(0, true);
+						name = name.validate_filename();
 						String path = p_path.path_join(name);
 						if (external_extension_type->get_selected() == 0) {
 							path += ".tres";
@@ -1396,6 +1397,7 @@ void SceneImportSettingsDialog::_save_dir_callback(const String &p_path) {
 						item->set_metadata(0, E.key);
 						item->set_editable(0, true);
 						item->set_checked(0, true);
+						name = name.validate_filename();
 						String path = p_path.path_join(name);
 						if (external_extension_type->get_selected() == 0) {
 							path += ".tres";
@@ -1448,6 +1450,7 @@ void SceneImportSettingsDialog::_save_dir_callback(const String &p_path) {
 					item->set_metadata(0, E.key);
 					item->set_editable(0, true);
 					item->set_checked(0, true);
+					name = name.validate_filename();
 					String path = p_path.path_join(name);
 					if (external_extension_type->get_selected() == 0) {
 						path += ".tres";


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86279.

Blender uses the | (pipe or vertical bar) character in its animation names which is forbidden in Windows file names. My fix simply replaces those with a _ (underscore) in the automatic path suggestion code when using the "Set Animation Save Paths" option.

There are other possible approaches to this, such as:

- Immediately renaming all the strings containing a | character on import => probably breaks compatibility with older projects
- Renaming ALL strings containing a | character when saving => probably breaks compatibility with older projects
- Making this change Windows only => would create discrepancies between different operating systems
- Using a different character => I'm open to suggestions

I chose to go for this as it seems like a safe, convenient fix with no obvious downsides.