### PR TITLE
Optimize rendering_device `_add_dependency` and `_free_dependencies`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -138,17 +138,8 @@ RenderingDevice::ShaderSPIRVGetCacheKeyFunction RenderingDevice::get_spirv_cache
 /***************************/
 
 void RenderingDevice::_add_dependency(RID p_id, RID p_depends_on) {
-	HashSet<RID> *set = dependency_map.getptr(p_depends_on);
-	if (set == nullptr) {
-		set = &dependency_map.insert(p_depends_on, HashSet<RID>())->value;
-	}
-	set->insert(p_id);
-
-	set = reverse_dependency_map.getptr(p_id);
-	if (set == nullptr) {
-		set = &reverse_dependency_map.insert(p_id, HashSet<RID>())->value;
-	}
-	set->insert(p_depends_on);
+	dependency_map[p_depends_on].insert(p_id);
+	reverse_dependency_map[p_id].insert(p_depends_on);
 }
 
 void RenderingDevice::_free_dependencies(RID p_id) {
@@ -169,8 +160,7 @@ void RenderingDevice::_free_dependencies(RID p_id) {
 		for (const RID &F : E->value) {
 			HashMap<RID, HashSet<RID>>::Iterator G = dependency_map.find(F);
 			ERR_CONTINUE(!G);
-			ERR_CONTINUE(!G->value.has(p_id));
-			G->value.erase(p_id);
+			ERR_CONTINUE_MSG(!G->value.erase(p_id), "Attempted to erase non-existing dependency, bug?");
 		}
 
 		reverse_dependency_map.remove(E);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -145,7 +145,9 @@ void RenderingDevice::_add_dependency(RID p_id, RID p_depends_on) {
 void RenderingDevice::_free_dependencies(RID p_id) {
 	// Direct dependencies must be freed.
 
-	HashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
+	HashMap<RID, HashSet<RID>, HashMapHasherDefault,
+			HashMapComparatorDefault<RID>,
+			PagedAllocator<HashMapElement<RID, HashSet<RID>>, false, 512>>::Iterator E = dependency_map.find(p_id);
 	if (E) {
 		while (E->value.size()) {
 			free(*E->value.begin());
@@ -158,7 +160,9 @@ void RenderingDevice::_free_dependencies(RID p_id) {
 
 	if (E) {
 		for (const RID &F : E->value) {
-			HashMap<RID, HashSet<RID>>::Iterator G = dependency_map.find(F);
+			HashMap<RID, HashSet<RID>, HashMapHasherDefault,
+					HashMapComparatorDefault<RID>,
+					PagedAllocator<HashMapElement<RID, HashSet<RID>>, false, 512>>::Iterator G = dependency_map.find(F);
 			ERR_CONTINUE(!G);
 			ERR_CONTINUE_MSG(!G->value.erase(p_id), "Attempted to erase non-existing dependency, bug?");
 		}
@@ -4843,7 +4847,9 @@ bool RenderingDevice::_dependency_make_mutable(RID p_id, RID p_resource_id, RDG:
 
 bool RenderingDevice::_dependencies_make_mutable(RID p_id, RDG::ResourceTracker *p_resource_tracker) {
 	bool made_mutable = false;
-	HashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
+	HashMap<RID, HashSet<RID>, HashMapHasherDefault,
+			HashMapComparatorDefault<RID>,
+			PagedAllocator<HashMapElement<RID, HashSet<RID>>, false, 512>>::Iterator E = dependency_map.find(p_id);
 	if (E) {
 		for (RID rid : E->value) {
 			made_mutable = _dependency_make_mutable(rid, p_id, p_resource_tracker) || made_mutable;

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -119,8 +119,20 @@ public:
 	};
 
 private:
-	HashMap<RID, HashSet<RID>> dependency_map; // IDs to IDs that depend on it.
-	HashMap<RID, HashSet<RID>> reverse_dependency_map; // Same as above, but in reverse.
+	HashMap<
+			RID,
+			HashSet<RID>,
+			HashMapHasherDefault,
+			HashMapComparatorDefault<RID>,
+			PagedAllocator<HashMapElement<RID, HashSet<RID>>, false, 512>>
+			dependency_map; // IDs to IDs that depend on it.
+	HashMap<
+			RID,
+			HashSet<RID>,
+			HashMapHasherDefault,
+			HashMapComparatorDefault<RID>,
+			PagedAllocator<HashMapElement<RID, HashSet<RID>>, false, 512>>
+			reverse_dependency_map; // Same as above, but in reverse.
 
 	void _add_dependency(RID p_id, RID p_depends_on);
 	void _free_dependencies(RID p_id);


### PR DESCRIPTION
I removed unnecessary `has` checks that slow down `_add_dependency` and `_free_dependencies`. Added `PagedAllocator` for `dependency_map` and `reverse_dependency_map` as they can have 5000+ elements.