### PR TITLE
Audio: Write to device's buffer directly without temporary buffers.

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -9,15 +9,19 @@ SConscript("unix/SCsub")
 SConscript("windows/SCsub")
 
 # Sounds drivers
-SConscript("alsa/SCsub")
-SConscript("coreaudio/SCsub")
-SConscript("pulseaudio/SCsub")
+if env["platform"] in ["ios", "macos"]:
+    SConscript("coreaudio/SCsub")
+
+if env["platform"] == "linuxbsd":
+    if env["alsa"]:
+        SConscript("alsa/SCsub")
+    if env["pulseaudio"]:
+        SConscript("pulseaudio/SCsub")
+
 if env["platform"] == "windows":
+    if env["xaudio2"]:
+        SConscript("xaudio2/SCsub")
     SConscript("wasapi/SCsub")
-    if not env.msvc:
-        SConscript("backtrace/SCsub")
-if env["xaudio2"]:
-    SConscript("xaudio2/SCsub")
 
 # Midi drivers
 SConscript("alsamidi/SCsub")
@@ -36,6 +40,8 @@ if env["opengl3"]:
 
 # Core dependencies
 SConscript("png/SCsub")
+if env["platform"] == "windows" and not env.msvc:
+    SConscript("backtrace/SCsub")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -2,8 +2,7 @@
 
 Import("env")
 
-if "alsa" in env and env["alsa"]:
-    if env["use_sowrap"]:
-        env.add_source_files(env.drivers_sources, "asound-so_wrap.c")
+if env["use_sowrap"]:
+    env.add_source_files(env.drivers_sources, "asound-so_wrap.c")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -46,10 +46,11 @@ extern int initialize_pulse(int verbose);
 Error AudioDriverALSA::init_output_device() {
 	mix_rate = _get_configured_mix_rate();
 
-	speaker_mode = SPEAKER_MODE_STEREO;
+	// TODO: `channels` and `buffer_format` are hardcoded.
 	channels = 2;
+	buffer_format = BUFFER_FORMAT_INTEGER_16;
 
-	// If there is a specified output device check that it is really present
+	// If there is a specified output device check that it is really present.
 	if (output_device_name != "Default") {
 		PackedStringArray list = get_output_device_list();
 		if (list.find(output_device_name) == -1) {
@@ -62,19 +63,14 @@ Error AudioDriverALSA::init_output_device() {
 	snd_pcm_hw_params_t *hwparams;
 	snd_pcm_sw_params_t *swparams;
 
-#define CHECK_FAIL(m_cond)                                       \
-	if (m_cond) {                                                \
-		fprintf(stderr, "ALSA ERR: %s\n", snd_strerror(status)); \
-		if (pcm_handle) {                                        \
-			snd_pcm_close(pcm_handle);                           \
-			pcm_handle = nullptr;                                \
-		}                                                        \
-		ERR_FAIL_COND_V(m_cond, ERR_CANT_OPEN);                  \
+#define CHECK_FAIL(m_cond)                                                        \
+	if (m_cond) {                                                                 \
+		if (pcm_handle) {                                                         \
+			snd_pcm_close(pcm_handle);                                            \
+			pcm_handle = nullptr;                                                 \
+		}                                                                         \
+		ERR_FAIL_V_MSG(ERR_CANT_OPEN, vformat("ALSA: %s", snd_strerror(status))); \
 	}
-
-	//todo, add
-	//6 chans - "plug:surround51"
-	//4 chans - "plug:surround40";
 
 	if (output_device_name == "Default") {
 		status = snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK);
@@ -97,33 +93,30 @@ Error AudioDriverALSA::init_output_device() {
 	status = snd_pcm_hw_params_set_access(pcm_handle, hwparams, SND_PCM_ACCESS_RW_INTERLEAVED);
 	CHECK_FAIL(status < 0);
 
-	//not interested in anything else
 	status = snd_pcm_hw_params_set_format(pcm_handle, hwparams, SND_PCM_FORMAT_S16_LE);
 	CHECK_FAIL(status < 0);
 
-	//todo: support 4 and 6
-	status = snd_pcm_hw_params_set_channels(pcm_handle, hwparams, 2);
+	status = snd_pcm_hw_params_set_channels(pcm_handle, hwparams, channels);
 	CHECK_FAIL(status < 0);
 
 	status = snd_pcm_hw_params_set_rate_near(pcm_handle, hwparams, &mix_rate, nullptr);
 	CHECK_FAIL(status < 0);
 
-	// In ALSA the period size seems to be the one that will determine the actual latency
-	// Ref: https://www.alsa-project.org/main/index.php/FramesPeriods
+	// In ALSA the period size seems to be the one that will determine the actual latency.
+	// Ref: https://www.alsa-project.org/main/index.php/FramesPeriods.
 	unsigned int periods = 2;
 	int latency = Engine::get_singleton()->get_audio_output_latency();
 	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
-	buffer_size = buffer_frames * periods;
-	period_size = buffer_frames;
 
-	// set buffer size from project settings
+	// Set buffer size from project settings.
+	snd_pcm_uframes_t buffer_size = buffer_frames * periods;
 	status = snd_pcm_hw_params_set_buffer_size_near(pcm_handle, hwparams, &buffer_size);
 	CHECK_FAIL(status < 0);
 
-	status = snd_pcm_hw_params_set_period_size_near(pcm_handle, hwparams, &period_size, nullptr);
+	status = snd_pcm_hw_params_set_period_size_near(pcm_handle, hwparams, &buffer_frames, nullptr);
 	CHECK_FAIL(status < 0);
 
-	print_verbose("Audio buffer frames: " + itos(period_size) + " calculated latency: " + itos(period_size * 1000 / mix_rate) + "ms");
+	print_verbose("Audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	status = snd_pcm_hw_params_set_periods_near(pcm_handle, hwparams, &periods, nullptr);
 	CHECK_FAIL(status < 0);
@@ -131,14 +124,12 @@ Error AudioDriverALSA::init_output_device() {
 	status = snd_pcm_hw_params(pcm_handle, hwparams);
 	CHECK_FAIL(status < 0);
 
-	//snd_pcm_hw_params_free(&hwparams);
-
 	snd_pcm_sw_params_alloca(&swparams);
 
 	status = snd_pcm_sw_params_current(pcm_handle, swparams);
 	CHECK_FAIL(status < 0);
 
-	status = snd_pcm_sw_params_set_avail_min(pcm_handle, swparams, period_size);
+	status = snd_pcm_sw_params_set_avail_min(pcm_handle, swparams, buffer_frames);
 	CHECK_FAIL(status < 0);
 
 	status = snd_pcm_sw_params_set_start_threshold(pcm_handle, swparams, 1);
@@ -147,9 +138,7 @@ Error AudioDriverALSA::init_output_device() {
 	status = snd_pcm_sw_params(pcm_handle, swparams);
 	CHECK_FAIL(status < 0);
 
-	samples_in.resize(period_size * channels);
-	samples_out.resize(period_size * channels);
-
+	samples_out.resize(buffer_frames * channels * get_size_of_sample(buffer_format));
 	return OK;
 }
 
@@ -162,7 +151,7 @@ Error AudioDriverALSA::init() {
 #endif
 #ifdef PULSEAUDIO_ENABLED
 	// On pulse enabled systems Alsa will silently use pulse.
-	// It doesn't matter if this fails as that likely means there is no pulse
+	// It doesn't matter if this fails as that likely means there is no pulse.
 	initialize_pulse(dylibloader_verbose);
 #endif
 
@@ -200,28 +189,16 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 		ad->lock();
 		ad->start_counting_ticks();
 
-		if (!ad->active.is_set()) {
-			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out.write[i] = 0;
-			}
+		ad->audio_server_process(ad->buffer_frames, ad->samples_out.ptr(), ad->active.is_set());
 
-		} else {
-			ad->audio_server_process(ad->period_size, ad->samples_in.ptrw());
-
-			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out.write[i] = ad->samples_in[i] >> 16;
-			}
-		}
-
-		int todo = ad->period_size;
+		int todo = ad->buffer_frames;
 		int total = 0;
 
 		while (todo && !ad->exit_thread.is_set()) {
-			int16_t *src = (int16_t *)ad->samples_out.ptr();
-			int wrote = snd_pcm_writei(ad->pcm_handle, (void *)(src + (total * ad->channels)), todo);
+			int wrote = snd_pcm_writei(ad->pcm_handle, ad->samples_out.ptr() + total, todo);
 
 			if (wrote > 0) {
-				total += wrote;
+				total += wrote * ad->channels * AudioDriver::get_size_of_sample(ad->buffer_format);
 				todo -= wrote;
 			} else if (wrote == -EAGAIN) {
 				ad->stop_counting_ticks();
@@ -273,8 +250,12 @@ int AudioDriverALSA::get_mix_rate() const {
 	return mix_rate;
 }
 
-AudioDriver::SpeakerMode AudioDriverALSA::get_speaker_mode() const {
-	return speaker_mode;
+int AudioDriverALSA::get_output_channels() const {
+	return channels;
+}
+
+AudioDriver::BufferFormat AudioDriverALSA::get_output_buffer_format() const {
+	return buffer_format;
 }
 
 PackedStringArray AudioDriverALSA::get_output_device_list() {

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -53,24 +53,22 @@ class AudioDriverALSA : public AudioDriver {
 	String output_device_name = "Default";
 	String new_output_device = "Default";
 
-	Vector<int32_t> samples_in;
-	Vector<int16_t> samples_out;
+	LocalVector<int8_t> samples_out;
+
+	unsigned int mix_rate = 0;
+	int channels = 0;
+
+	BufferFormat buffer_format = NO_BUFFER;
+
+	snd_pcm_uframes_t buffer_frames;
+
+	SafeFlag active;
+	SafeFlag exit_thread;
 
 	Error init_output_device();
 	void finish_output_device();
 
 	static void thread_func(void *p_udata);
-
-	unsigned int mix_rate = 0;
-	SpeakerMode speaker_mode;
-
-	snd_pcm_uframes_t buffer_frames;
-	snd_pcm_uframes_t buffer_size;
-	snd_pcm_uframes_t period_size;
-	int channels = 0;
-
-	SafeFlag active;
-	SafeFlag exit_thread;
 
 public:
 	virtual const char *get_name() const override {
@@ -80,18 +78,17 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
-	virtual SpeakerMode get_speaker_mode() const override;
 
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
 
+	virtual int get_output_channels() const override;
+	virtual BufferFormat get_output_buffer_format() const override;
+
 	virtual PackedStringArray get_output_device_list() override;
 	virtual String get_output_device() override;
 	virtual void set_output_device(const String &p_name) override;
-
-	AudioDriverALSA() {}
-	~AudioDriverALSA() {}
 };
 
 #endif // ALSA_ENABLED

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -51,12 +51,15 @@ class AudioDriverCoreAudio : public AudioDriver {
 	String input_device_name = "Default";
 
 	int mix_rate = 0;
-	unsigned int channels = 2;
-	unsigned int capture_channels = 2;
 	unsigned int buffer_frames = 0;
 
-	Vector<int32_t> samples_in;
-	Vector<int16_t> input_buf;
+	unsigned int output_channels = 2;
+	unsigned int input_channels = 2;
+
+	BufferFormat output_buffer_format = NO_BUFFER;
+	BufferFormat input_buffer_format = NO_BUFFER;
+
+	LocalVector<int8_t> input_buffer;
 
 #ifdef MACOS_ENABLED
 	PackedStringArray _get_device_list(bool capture = false);
@@ -94,11 +97,16 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
-	virtual SpeakerMode get_speaker_mode() const override;
 
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
+
+	virtual int get_output_channels() const override;
+	virtual BufferFormat get_output_buffer_format() const override;
+
+	virtual int get_input_channels() const override;
+	virtual BufferFormat get_input_buffer_format() const override;
 
 #ifdef MACOS_ENABLED
 	virtual PackedStringArray get_output_device_list() override;
@@ -115,9 +123,6 @@ public:
 
 	bool try_lock();
 	void stop();
-
-	AudioDriverCoreAudio();
-	~AudioDriverCoreAudio() {}
 };
 
 #endif // COREAUDIO_ENABLED

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -2,8 +2,7 @@
 
 Import("env")
 
-if "pulseaudio" in env and env["pulseaudio"]:
-    if env["use_sowrap"]:
-        env.add_source_files(env.drivers_sources, "pulse-so_wrap.c")
+if env["use_sowrap"]:
+    env.add_source_files(env.drivers_sources, "pulse-so_wrap.c")
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -71,7 +71,7 @@ void AudioDriverPulseAudio::pa_state_cb(pa_context *c, void *userdata) {
 void AudioDriverPulseAudio::pa_sink_info_cb(pa_context *c, const pa_sink_info *l, int eol, void *userdata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
-	// If eol is set to a positive number, you're at the end of the list
+	// If eol is set to a positive number, you're at the end of the list.
 	if (eol > 0) {
 		return;
 	}
@@ -90,7 +90,7 @@ void AudioDriverPulseAudio::pa_sink_info_cb(pa_context *c, const pa_sink_info *l
 void AudioDriverPulseAudio::pa_source_info_cb(pa_context *c, const pa_source_info *l, int eol, void *userdata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
-	// If eol is set to a positive number, you're at the end of the list
+	// If eol is set to a positive number, you're at the end of the list.
 	if (eol > 0) {
 		return;
 	}
@@ -115,12 +115,12 @@ void AudioDriverPulseAudio::pa_server_info_cb(pa_context *c, const pa_server_inf
 	ad->pa_status++;
 }
 
-Error AudioDriverPulseAudio::detect_channels(bool input) {
-	pa_channel_map_init_stereo(input ? &pa_rec_map : &pa_map);
+Error AudioDriverPulseAudio::detect_channels(bool p_input) {
+	pa_channel_map_init_stereo(p_input ? &pa_rec_map : &pa_map);
 
-	String device = input ? input_device_name : output_device_name;
+	String device = p_input ? input_device_name : output_device_name;
 	if (device == "Default") {
-		// Get the default output device name
+		// Get the default output device name.
 		pa_status = 0;
 		pa_operation *pa_op = pa_context_get_server_info(pa_ctx, &AudioDriverPulseAudio::pa_server_info_cb, (void *)this);
 		if (pa_op) {
@@ -140,16 +140,16 @@ Error AudioDriverPulseAudio::detect_channels(bool input) {
 
 	char dev[1024];
 	if (device == "Default") {
-		strcpy(dev, input ? default_input_device.utf8().get_data() : default_output_device.utf8().get_data());
+		strcpy(dev, p_input ? default_input_device.utf8().get_data() : default_output_device.utf8().get_data());
 	} else {
 		strcpy(dev, device.utf8().get_data());
 	}
 	print_verbose("PulseAudio: Detecting channels for device: " + String(dev));
 
-	// Now using the device name get the amount of channels
+	// Now using the device name get the amount of channels.
 	pa_status = 0;
 	pa_operation *pa_op;
-	if (input) {
+	if (p_input) {
 		pa_op = pa_context_get_source_info_by_name(pa_ctx, dev, &AudioDriverPulseAudio::pa_source_info_cb, (void *)this);
 	} else {
 		pa_op = pa_context_get_sink_info_by_name(pa_ctx, dev, &AudioDriverPulseAudio::pa_sink_info_cb, (void *)this);
@@ -169,7 +169,7 @@ Error AudioDriverPulseAudio::detect_channels(bool input) {
 			return FAILED;
 		}
 	} else {
-		if (input) {
+		if (p_input) {
 			ERR_PRINT("pa_context_get_source_info_by_name error");
 		} else {
 			ERR_PRINT("pa_context_get_sink_info_by_name error");
@@ -180,7 +180,7 @@ Error AudioDriverPulseAudio::detect_channels(bool input) {
 }
 
 Error AudioDriverPulseAudio::init_output_device() {
-	// If there is a specified output device, check that it is really present
+	// If there is a specified output device, check that it is really present.
 	if (output_device_name != "Default") {
 		PackedStringArray list = get_output_device_list();
 		if (list.find(output_device_name) == -1) {
@@ -189,42 +189,23 @@ Error AudioDriverPulseAudio::init_output_device() {
 		}
 	}
 
-	// Detect the amount of channels PulseAudio is using
-	// Note: If using an even amount of channels (2, 4, etc) channels and pa_map.channels will be equal,
-	// if not then pa_map.channels will have the real amount of channels PulseAudio is using and channels
-	// will have the amount of channels Godot is using (in this case it's pa_map.channels + 1)
-	Error err = detect_channels();
+	Error err = detect_channels(false);
 	if (err != OK) {
 		// This most likely means there are no sinks.
 		ERR_PRINT("PulseAudio: init_output_device failed to detect number of output channels");
 		return err;
 	}
 
-	switch (pa_map.channels) {
-		case 1: // Mono
-		case 3: // Surround 2.1
-		case 5: // Surround 5.0
-		case 7: // Surround 7.0
-			channels = pa_map.channels + 1;
-			break;
-
-		case 2: // Stereo
-		case 4: // Surround 4.0
-		case 6: // Surround 5.1
-		case 8: // Surround 7.1
-			channels = pa_map.channels;
-			break;
-
-		default:
-			WARN_PRINT("PulseAudio: Unsupported number of output channels: " + itos(pa_map.channels));
-			pa_channel_map_init_stereo(&pa_map);
-			channels = 2;
-			break;
+	if (!are_output_channels_recommended(pa_map.channels)) {
+		WARN_PRINT("PulseAudio: Unsupported number of output channels: " + itos(pa_map.channels));
+		pa_channel_map_init_stereo(&pa_map);
 	}
+
+	// TODO: `output_buffer_format` is hardcoded.
+	output_buffer_format = BUFFER_FORMAT_INTEGER_16;
 
 	int tmp_latency = Engine::get_singleton()->get_audio_output_latency();
 	buffer_frames = closest_power_of_2(tmp_latency * mix_rate / 1000);
-	pa_buffer_size = buffer_frames * pa_map.channels;
 
 	print_verbose("PulseAudio: detected " + itos(pa_map.channels) + " output channels");
 	print_verbose("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated output latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
@@ -249,13 +230,13 @@ Error AudioDriverPulseAudio::init_output_device() {
 	}
 
 	pa_buffer_attr attr;
-	// set to appropriate buffer length (in bytes) from global settings
+	// Set to appropriate buffer length (in bytes) from global settings.
 	// Note: PulseAudio defaults to 4 fragments, which means that the actual
 	// latency is tlength / fragments. It seems that the PulseAudio has no way
-	// to get the fragments number so we're hardcoding this to the default of 4
+	// to get the fragments number so we're hardcoding this to the default of 4.
 	const int fragments = 4;
-	attr.tlength = pa_buffer_size * sizeof(int16_t) * fragments;
-	// set them to be automatically chosen
+	attr.tlength = buffer_frames * pa_map.channels * get_size_of_sample(output_buffer_format) * fragments;
+	// Set them to be automatically chosen.
 	attr.prebuf = (uint32_t)-1;
 	attr.maxlength = (uint32_t)-1;
 	attr.minreq = (uint32_t)-1;
@@ -264,9 +245,6 @@ Error AudioDriverPulseAudio::init_output_device() {
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_playback(pa_str, dev, &attr, flags, nullptr, nullptr);
 	ERR_FAIL_COND_V(error_code < 0, ERR_CANT_OPEN);
-
-	samples_in.resize(buffer_frames * channels);
-	samples_out.resize(pa_buffer_size);
 
 	// Reset audio input to keep synchronization.
 	input_position = 0;
@@ -283,7 +261,7 @@ Error AudioDriverPulseAudio::init() {
 	int dylibloader_verbose = 0;
 #endif
 #ifdef ALSAMIDI_ENABLED
-	// If using PulseAudio with ALSA MIDI, we need to initialize ALSA as well
+	// If using PulseAudio with ALSA MIDI, we need to initialize ALSA as well.
 	initialize_asound(dylibloader_verbose);
 #endif
 	if (initialize_pulse(dylibloader_verbose)) {
@@ -393,50 +371,11 @@ float AudioDriverPulseAudio::get_latency() {
 
 void AudioDriverPulseAudio::thread_func(void *p_udata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(p_udata);
-	unsigned int write_ofs = 0;
-	size_t avail_bytes = 0;
 	uint64_t default_device_msec = OS::get_singleton()->get_ticks_msec();
 
 	while (!ad->exit_thread.is_set()) {
 		size_t read_bytes = 0;
 		size_t written_bytes = 0;
-
-		if (avail_bytes == 0) {
-			ad->lock();
-			ad->start_counting_ticks();
-
-			if (!ad->active.is_set()) {
-				ad->samples_out.fill(0);
-			} else {
-				ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
-
-				int16_t *out_ptr = ad->samples_out.ptrw();
-
-				if (ad->channels == ad->pa_map.channels) {
-					for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
-						out_ptr[i] = ad->samples_in[i] >> 16;
-					}
-				} else {
-					// Uneven amount of channels
-					unsigned int in_idx = 0;
-					unsigned int out_idx = 0;
-
-					for (unsigned int i = 0; i < ad->buffer_frames; i++) {
-						for (int j = 0; j < ad->pa_map.channels - 1; j++) {
-							out_ptr[out_idx++] = ad->samples_in[in_idx++] >> 16;
-						}
-						uint32_t l = ad->samples_in[in_idx++] >> 16;
-						uint32_t r = ad->samples_in[in_idx++] >> 16;
-						out_ptr[out_idx++] = (l + r) / 2;
-					}
-				}
-			}
-
-			avail_bytes = ad->pa_buffer_size * sizeof(int16_t);
-			write_ofs = 0;
-			ad->stop_counting_ticks();
-			ad->unlock();
-		}
 
 		ad->lock();
 		ad->start_counting_ticks();
@@ -446,23 +385,28 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			ret = pa_mainloop_iterate(ad->pa_ml, 0, nullptr);
 		} while (ret > 0);
 
-		if (avail_bytes > 0 && pa_stream_get_state(ad->pa_str) == PA_STREAM_READY) {
+		if (pa_stream_get_state(ad->pa_str) == PA_STREAM_READY) {
 			size_t bytes = pa_stream_writable_size(ad->pa_str);
 			if (bytes > 0) {
-				size_t bytes_to_write = MIN(bytes, avail_bytes);
-				const void *ptr = ad->samples_out.ptr();
-				ret = pa_stream_write(ad->pa_str, (char *)ptr + write_ofs, bytes_to_write, nullptr, 0LL, PA_SEEK_RELATIVE);
-				if (ret != 0) {
-					ERR_PRINT("PulseAudio: pa_stream_write error: " + String(pa_strerror(ret)));
+				void *buffer = nullptr;
+
+				ret = pa_stream_begin_write(ad->pa_str, &buffer, &bytes);
+				if (ret != 0 || buffer == nullptr) {
+					ERR_PRINT("PulseAudio: pa_stream_begin_write error: " + String(pa_strerror(ret)));
 				} else {
-					avail_bytes -= bytes_to_write;
-					write_ofs += bytes_to_write;
-					written_bytes += bytes_to_write;
+					ad->audio_server_process(bytes / (ad->pa_map.channels * AudioDriver::get_size_of_sample(ad->output_buffer_format)), buffer, ad->active.is_set());
+
+					ret = pa_stream_write(ad->pa_str, buffer, bytes, nullptr, 0, PA_SEEK_RELATIVE);
+					if (ret != 0) {
+						ERR_PRINT("PulseAudio: pa_stream_write error: " + String(pa_strerror(ret)));
+					} else {
+						written_bytes += bytes;
+					}
 				}
 			}
 		}
 
-		// User selected a new output device, finish the current one so we'll init the new output device
+		// User selected a new output device, finish the current one so we'll init the new output device.
 		if (ad->output_device_name != ad->new_output_device) {
 			ad->output_device_name = ad->new_output_device;
 			ad->finish_output_device();
@@ -480,12 +424,9 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 					break;
 				}
 			}
-
-			avail_bytes = 0;
-			write_ofs = 0;
 		}
 
-		// If we're using the default output device, check that the current output device is still the default
+		// If we're using the default output device, check that the current output device is still the default.
 		if (ad->output_device_name == "Default") {
 			uint64_t msec = OS::get_singleton()->get_ticks_msec();
 			if (msec > (default_device_msec + 1000)) {
@@ -518,9 +459,6 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 						ad->exit_thread.set();
 						break;
 					}
-
-					avail_bytes = 0;
-					write_ofs = 0;
 				}
 			}
 		}
@@ -529,23 +467,14 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			size_t bytes = pa_stream_readable_size(ad->pa_rec_str);
 			if (bytes > 0) {
 				const void *ptr = nullptr;
-				size_t maxbytes = ad->input_buffer.size() * sizeof(int16_t);
+				size_t max_bytes = ad->input_buffer.size() * ad->pa_rec_map.channels * get_size_of_sample(ad->input_buffer_format);
 
-				bytes = MIN(bytes, maxbytes);
+				bytes = MIN(bytes, max_bytes);
 				ret = pa_stream_peek(ad->pa_rec_str, &ptr, &bytes);
 				if (ret != 0) {
 					ERR_PRINT("pa_stream_peek error");
 				} else {
-					int16_t *srcptr = (int16_t *)ptr;
-					for (size_t i = bytes >> 1; i > 0; i--) {
-						int32_t sample = int32_t(*srcptr++) << 16;
-						ad->input_buffer_write(sample);
-
-						if (ad->pa_rec_map.channels == 1) {
-							// In case input device is single channel convert it to Stereo
-							ad->input_buffer_write(sample);
-						}
-					}
+					ad->input_process(bytes / (ad->pa_rec_map.channels * get_size_of_sample(ad->input_buffer_format)), ptr);
 
 					read_bytes += bytes;
 					ret = pa_stream_drop(ad->pa_rec_str);
@@ -555,7 +484,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 				}
 			}
 
-			// User selected a new input device, finish the current one so we'll init the new input device
+			// User selected a new input device, finish the current one so we'll init the new input device.
 			if (ad->input_device_name != ad->new_input_device) {
 				ad->input_device_name = ad->new_input_device;
 				ad->finish_input_device();
@@ -579,7 +508,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 		ad->stop_counting_ticks();
 		ad->unlock();
 
-		// Let the thread rest a while if we haven't read or write anything
+		// Let the thread rest a while if we haven't read or written anything.
 		if (written_bytes == 0 && read_bytes == 0) {
 			OS::get_singleton()->delay_usec(1000);
 		}
@@ -594,14 +523,18 @@ int AudioDriverPulseAudio::get_mix_rate() const {
 	return mix_rate;
 }
 
-AudioDriver::SpeakerMode AudioDriverPulseAudio::get_speaker_mode() const {
-	return get_speaker_mode_by_total_channels(channels);
+int AudioDriverPulseAudio::get_output_channels() const {
+	return pa_map.channels;
+}
+
+AudioDriver::BufferFormat AudioDriverPulseAudio::get_output_buffer_format() const {
+	return output_buffer_format;
 }
 
 void AudioDriverPulseAudio::pa_sinklist_cb(pa_context *c, const pa_sink_info *l, int eol, void *userdata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
-	// If eol is set to a positive number, you're at the end of the list
+	// If eol is set to a positive number, you're at the end of the list.
 	if (eol > 0) {
 		return;
 	}
@@ -620,7 +553,7 @@ PackedStringArray AudioDriverPulseAudio::get_output_device_list() {
 
 	lock();
 
-	// Get the output device list
+	// Get the output device list.
 	pa_status = 0;
 	pa_operation *pa_op = pa_context_get_sink_info_list(pa_ctx, pa_sinklist_cb, (void *)this);
 	if (pa_op) {
@@ -692,7 +625,7 @@ void AudioDriverPulseAudio::finish() {
 }
 
 Error AudioDriverPulseAudio::init_input_device() {
-	// If there is a specified input device, check that it is really present
+	// If there is a specified input device, check that it is really present.
 	if (input_device_name != "Default") {
 		PackedStringArray list = get_input_device_list();
 		if (list.find(input_device_name) == -1) {
@@ -701,19 +634,22 @@ Error AudioDriverPulseAudio::init_input_device() {
 		}
 	}
 
-	detect_channels(true);
-	switch (pa_rec_map.channels) {
-		case 1: // Mono
-		case 2: // Stereo
-			break;
+	Error err = detect_channels(true);
+	if (err != OK) {
+		// This most likely means there are no sources.
+		ERR_PRINT("PulseAudio: init_input_device failed to detect number of input channels");
+		return err;
+	}
 
-		default:
-			WARN_PRINT("PulseAudio: Unsupported number of input channels: " + itos(pa_rec_map.channels));
-			pa_channel_map_init_stereo(&pa_rec_map);
-			break;
+	if (!are_input_channels_recommended(pa_rec_map.channels)) {
+		WARN_PRINT("PulseAudio: Unsupported number of input channels: " + itos(pa_rec_map.channels));
+		pa_channel_map_init_stereo(&pa_rec_map);
 	}
 
 	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
+
+	// TODO: `input_buffer_format` is hardcoded.
+	input_buffer_format = BUFFER_FORMAT_INTEGER_16;
 
 	pa_sample_spec spec;
 
@@ -726,7 +662,7 @@ Error AudioDriverPulseAudio::init_input_device() {
 	int input_buffer_size = input_buffer_frames * spec.channels;
 
 	pa_buffer_attr attr;
-	attr.fragsize = input_buffer_size * sizeof(int16_t);
+	attr.fragsize = input_buffer_size * get_size_of_sample(input_buffer_format);
 
 	pa_rec_str = pa_stream_new(pa_ctx, "Record", &spec, &pa_rec_map);
 	if (pa_rec_str == nullptr) {
@@ -777,10 +713,18 @@ Error AudioDriverPulseAudio::input_stop() {
 	return OK;
 }
 
+int AudioDriverPulseAudio::get_input_channels() const {
+	return pa_rec_map.channels;
+}
+
+AudioDriver::BufferFormat AudioDriverPulseAudio::get_input_buffer_format() const {
+	return input_buffer_format;
+}
+
 void AudioDriverPulseAudio::pa_sourcelist_cb(pa_context *c, const pa_source_info *l, int eol, void *userdata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
-	// If eol is set to a positive number, you're at the end of the list
+	// If eol is set to a positive number, you're at the end of the list.
 	if (eol > 0) {
 		return;
 	}
@@ -802,7 +746,7 @@ PackedStringArray AudioDriverPulseAudio::get_input_device_list() {
 
 	lock();
 
-	// Get the device list
+	// Get the device list.
 	pa_status = 0;
 	pa_operation *pa_op = pa_context_get_source_info_list(pa_ctx, pa_sourcelist_cb, (void *)this);
 	if (pa_op) {
@@ -835,11 +779,6 @@ void AudioDriverPulseAudio::set_input_device(const String &p_name) {
 	lock();
 	new_input_device = p_name;
 	unlock();
-}
-
-AudioDriverPulseAudio::AudioDriverPulseAudio() {
-	samples_in.clear();
-	samples_out.clear();
 }
 
 #endif // PULSEAUDIO_ENABLED

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -52,8 +52,8 @@ class AudioDriverPulseAudio : public AudioDriver {
 	pa_context *pa_ctx = nullptr;
 	pa_stream *pa_str = nullptr;
 	pa_stream *pa_rec_str = nullptr;
-	pa_channel_map pa_map = {};
-	pa_channel_map pa_rec_map = {};
+	pa_channel_map pa_map = { 0, {} };
+	pa_channel_map pa_rec_map = { 0, {} };
 
 	String output_device_name = "Default";
 	String new_output_device = "Default";
@@ -63,17 +63,15 @@ class AudioDriverPulseAudio : public AudioDriver {
 	String new_input_device;
 	String default_input_device;
 
-	Vector<int32_t> samples_in;
-	Vector<int16_t> samples_out;
-
 	unsigned int mix_rate = 0;
 	unsigned int buffer_frames = 0;
-	unsigned int pa_buffer_size = 0;
-	int channels = 0;
 	int pa_ready = 0;
 	int pa_status = 0;
 	PackedStringArray pa_devices;
 	PackedStringArray pa_rec_devices;
+
+	BufferFormat output_buffer_format = NO_BUFFER;
+	BufferFormat input_buffer_format = NO_BUFFER;
 
 	SafeFlag active;
 	SafeFlag exit_thread;
@@ -93,7 +91,7 @@ class AudioDriverPulseAudio : public AudioDriver {
 	Error init_input_device();
 	void finish_input_device();
 
-	Error detect_channels(bool capture = false);
+	Error detect_channels(bool p_input);
 
 	static void thread_func(void *p_udata);
 
@@ -105,12 +103,14 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
-	virtual SpeakerMode get_speaker_mode() const override;
 	virtual float get_latency() override;
 
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
+
+	virtual int get_output_channels() const override;
+	virtual BufferFormat get_output_buffer_format() const override;
 
 	virtual PackedStringArray get_output_device_list() override;
 	virtual String get_output_device() override;
@@ -119,12 +119,12 @@ public:
 	virtual Error input_start() override;
 	virtual Error input_stop() override;
 
+	virtual int get_input_channels() const override;
+	virtual BufferFormat get_input_buffer_format() const override;
+
 	virtual PackedStringArray get_input_device_list() override;
 	virtual String get_input_device() override;
 	virtual void set_input_device(const String &p_name) override;
-
-	AudioDriverPulseAudio();
-	~AudioDriverPulseAudio() {}
 };
 
 #endif // PULSEAUDIO_ENABLED

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -35,11 +35,9 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 
-#include <stdint.h> // INT32_MAX
-
 #include <functiondiscoverykeys.h>
 
-// Define IAudioClient3 if not already defined by MinGW headers
+// Define IAudioClient3 if not already defined by MinGW headers.
 #if defined __MINGW32__ || defined __MINGW64__
 
 #ifndef __IAudioClient3_FWD_DEFINED__
@@ -52,8 +50,12 @@ typedef interface IAudioClient3 IAudioClient3;
 #ifndef __IAudioClient3_INTERFACE_DEFINED__
 #define __IAudioClient3_INTERFACE_DEFINED__
 
+// `IAudioClient2` has a non-virtual destructor.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 MIDL_INTERFACE("7ED4EE07-8E67-4CD4-8C1A-2B7A5987AD42")
 IAudioClient3 : public IAudioClient2 {
+#pragma GCC diagnostic pop
 public:
 	virtual HRESULT STDMETHODCALLTYPE GetSharedModeEnginePeriod(
 			/* [annotation][in] */
@@ -282,7 +284,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		ERR_PRINT("WASAPI: RegisterEndpointNotificationCallback error");
 	}
 
-	using_audio_client_3 = !p_input; // IID_IAudioClient3 is only used for adjustable output latency (not input)
+	using_audio_client_3 = !p_input; // IID_IAudioClient3 is only used for adjustable output latency (not input).
 
 	if (p_no_audio_client_3) {
 		using_audio_client_3 = false;
@@ -352,28 +354,51 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		}
 	}
 
-	// Since we're using WASAPI Shared Mode we can't control any of these, we just tag along
+	// Since we're using WASAPI Shared Mode we can't control any of these, we just tag along.
 	p_device->channels = pwfex->nChannels;
-	p_device->format_tag = pwfex->wFormatTag;
-	p_device->bits_per_sample = pwfex->wBitsPerSample;
-	p_device->frame_size = (p_device->bits_per_sample / 8) * p_device->channels;
+	p_device->frame_size = (pwfex->wBitsPerSample / 8) * p_device->channels;
 
-	if (p_device->format_tag == WAVE_FORMAT_EXTENSIBLE) {
+	WORD format_tag = pwfex->wFormatTag;
+	if (format_tag == WAVE_FORMAT_EXTENSIBLE) {
 		WAVEFORMATEXTENSIBLE *wfex = (WAVEFORMATEXTENSIBLE *)pwfex;
 
 		if (wfex->SubFormat == KSDATAFORMAT_SUBTYPE_PCM) {
-			p_device->format_tag = WAVE_FORMAT_PCM;
+			format_tag = WAVE_FORMAT_PCM;
 		} else if (wfex->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
-			p_device->format_tag = WAVE_FORMAT_IEEE_FLOAT;
+			format_tag = WAVE_FORMAT_IEEE_FLOAT;
 		} else {
-			ERR_PRINT("WASAPI: Format not supported");
-			ERR_FAIL_V(ERR_CANT_OPEN);
+			ERR_FAIL_V_MSG(ERR_CANT_OPEN, "WASAPI: Format not supported.");
 		}
 	} else {
-		if (p_device->format_tag != WAVE_FORMAT_PCM && p_device->format_tag != WAVE_FORMAT_IEEE_FLOAT) {
-			ERR_PRINT("WASAPI: Format not supported");
-			ERR_FAIL_V(ERR_CANT_OPEN);
+		if (format_tag != WAVE_FORMAT_PCM && format_tag != WAVE_FORMAT_IEEE_FLOAT) {
+			ERR_FAIL_V_MSG(ERR_CANT_OPEN, "WASAPI: Format not supported.");
 		}
+	}
+
+	if (format_tag == WAVE_FORMAT_PCM) {
+		switch (pwfex->wBitsPerSample) {
+			case 8:
+				p_device->buffer_format = BUFFER_FORMAT_INTEGER_8;
+				break;
+
+			case 16:
+				p_device->buffer_format = BUFFER_FORMAT_INTEGER_16;
+				break;
+
+			case 24:
+				p_device->buffer_format = BUFFER_FORMAT_INTEGER_24;
+				break;
+
+			case 32:
+				p_device->buffer_format = BUFFER_FORMAT_INTEGER_32;
+				break;
+
+			default:
+				ERR_FAIL_V_MSG(ERR_CANT_OPEN, vformat("WASAPI: Unsupported bits per sample: %d.", pwfex->wBitsPerSample));
+				break;
+		}
+	} else {
+		p_device->buffer_format = BUFFER_FORMAT_FLOAT;
 	}
 
 	if (!using_audio_client_3) {
@@ -389,15 +414,15 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		hr = p_device->audio_client->GetBufferSize(&max_frames);
 		ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 
-		// Due to WASAPI Shared Mode we have no control of the buffer size
+		// Due to WASAPI Shared Mode we have no control of the buffer size.
 		if (!p_input) {
 			buffer_frames = max_frames;
 
 			int64_t latency = 0;
 			audio_output.audio_client->GetStreamLatency(&latency);
-			// WASAPI REFERENCE_TIME units are 100 nanoseconds per unit
-			// https://docs.microsoft.com/en-us/windows/win32/directshow/reference-time
-			// Convert REFTIME to seconds as godot uses for latency
+			// WASAPI REFERENCE_TIME units are 100 nanoseconds per unit.
+			// Ref: https://docs.microsoft.com/en-us/windows/win32/directshow/reference-time.
+			// Convert REFTIME to seconds as godot uses for latency.
 			real_latency = (float)latency / (float)REFTIMES_PER_SEC;
 		}
 
@@ -466,7 +491,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 	}
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 
-	// Free memory
+	// Free memory.
 	CoTaskMemFree(pwfex);
 	SAFE_RELEASE(output_device)
 
@@ -479,30 +504,8 @@ Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 		return err;
 	}
 
-	switch (audio_output.channels) {
-		case 1: // Mono
-		case 3: // Surround 2.1
-		case 5: // Surround 5.0
-		case 7: // Surround 7.0
-			// We will downmix as required.
-			channels = audio_output.channels + 1;
-			break;
-
-		case 2: // Stereo
-		case 4: // Surround 3.1
-		case 6: // Surround 5.1
-		case 8: // Surround 7.1
-			channels = audio_output.channels;
-			break;
-
-		default:
-			WARN_PRINT("WASAPI: Unsupported number of channels: " + itos(audio_output.channels));
-			channels = 2;
-			break;
-	}
-
-	// Sample rate is independent of channels (ref: https://stackoverflow.com/questions/11048825/audio-sample-frequency-rely-on-channels)
-	samples_in.resize(buffer_frames * channels);
+	if (!are_output_channels_recommended(audio_output.channels))
+		WARN_PRINT("WASAPI: Unsupported number of channels: " + itos(audio_output.channels));
 
 	input_position = 0;
 	input_size = 0;
@@ -519,7 +522,7 @@ Error AudioDriverWASAPI::init_input_device(bool p_reinit) {
 		return err;
 	}
 
-	// Get the max frames
+	// Get the max frames.
 	UINT32 max_frames;
 	HRESULT hr = audio_input.audio_client->GetBufferSize(&max_frames);
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
@@ -575,8 +578,12 @@ float AudioDriverWASAPI::get_latency() {
 	return real_latency;
 }
 
-AudioDriver::SpeakerMode AudioDriverWASAPI::get_speaker_mode() const {
-	return get_speaker_mode_by_total_channels(channels);
+int AudioDriverWASAPI::get_output_channels() const {
+	return audio_output.channels;
+}
+
+AudioDriver::BufferFormat AudioDriverWASAPI::get_output_buffer_format() const {
+	return audio_output.buffer_format;
 }
 
 PackedStringArray AudioDriverWASAPI::audio_device_get_list(bool p_input) {
@@ -642,101 +649,19 @@ void AudioDriverWASAPI::set_output_device(const String &p_name) {
 	unlock();
 }
 
-int32_t AudioDriverWASAPI::read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i) {
-	if (format_tag == WAVE_FORMAT_PCM) {
-		int32_t sample = 0;
-		switch (bits_per_sample) {
-			case 8:
-				sample = int32_t(((int8_t *)buffer)[i]) << 24;
-				break;
-
-			case 16:
-				sample = int32_t(((int16_t *)buffer)[i]) << 16;
-				break;
-
-			case 24:
-				sample |= int32_t(((int8_t *)buffer)[i * 3 + 2]) << 24;
-				sample |= int32_t(((int8_t *)buffer)[i * 3 + 1]) << 16;
-				sample |= int32_t(((int8_t *)buffer)[i * 3 + 0]) << 8;
-				break;
-
-			case 32:
-				sample = ((int32_t *)buffer)[i];
-				break;
-		}
-
-		return sample;
-	} else if (format_tag == WAVE_FORMAT_IEEE_FLOAT) {
-		return int32_t(((float *)buffer)[i] * 32768.0) << 16;
-	} else {
-		ERR_PRINT("WASAPI: Unknown format tag");
-	}
-
-	return 0;
-}
-
-void AudioDriverWASAPI::write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i, int32_t sample) {
-	if (format_tag == WAVE_FORMAT_PCM) {
-		switch (bits_per_sample) {
-			case 8:
-				((int8_t *)buffer)[i] = sample >> 24;
-				break;
-
-			case 16:
-				((int16_t *)buffer)[i] = sample >> 16;
-				break;
-
-			case 24:
-				((int8_t *)buffer)[i * 3 + 2] = sample >> 24;
-				((int8_t *)buffer)[i * 3 + 1] = sample >> 16;
-				((int8_t *)buffer)[i * 3 + 0] = sample >> 8;
-				break;
-
-			case 32:
-				((int32_t *)buffer)[i] = sample;
-				break;
-		}
-	} else if (format_tag == WAVE_FORMAT_IEEE_FLOAT) {
-		((float *)buffer)[i] = (sample >> 16) / 32768.f;
-	} else {
-		ERR_PRINT("WASAPI: Unknown format tag");
-	}
-}
-
 void AudioDriverWASAPI::thread_func(void *p_udata) {
 	CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
 
 	AudioDriverWASAPI *ad = static_cast<AudioDriverWASAPI *>(p_udata);
-	uint32_t avail_frames = 0;
-	uint32_t write_ofs = 0;
 
 	while (!ad->exit_thread.is_set()) {
 		uint32_t read_frames = 0;
 		uint32_t written_frames = 0;
 
-		if (avail_frames == 0) {
-			ad->lock();
-			ad->start_counting_ticks();
-
-			if (ad->audio_output.active.is_set()) {
-				ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
-			} else {
-				for (int i = 0; i < ad->samples_in.size(); i++) {
-					ad->samples_in.write[i] = 0;
-				}
-			}
-
-			avail_frames = ad->buffer_frames;
-			write_ofs = 0;
-
-			ad->stop_counting_ticks();
-			ad->unlock();
-		}
-
 		ad->lock();
 		ad->start_counting_ticks();
 
-		if (avail_frames > 0 && ad->audio_output.audio_client) {
+		if (ad->audio_output.audio_client) {
 			UINT32 buffer_size;
 			UINT32 cur_frames;
 			bool invalidated = false;
@@ -746,59 +671,26 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			}
 			hr = ad->audio_output.audio_client->GetCurrentPadding(&cur_frames);
 			if (hr == S_OK) {
-				// Check how much frames are available on the WASAPI buffer
-				UINT32 write_frames = MIN(buffer_size - cur_frames, avail_frames);
+				// Check how much frames are available on the WASAPI buffer.
+				UINT32 write_frames = buffer_size - cur_frames;
 				if (write_frames > 0) {
 					BYTE *buffer = nullptr;
 					hr = ad->audio_output.render_client->GetBuffer(write_frames, &buffer);
 					if (hr == S_OK) {
-						// We're using WASAPI Shared Mode so we must convert the buffer
-						if (ad->channels == ad->audio_output.channels) {
-							for (unsigned int i = 0; i < write_frames * ad->channels; i++) {
-								ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i, ad->samples_in.write[write_ofs++]);
-							}
-						} else if (ad->channels == ad->audio_output.channels + 1) {
-							// Pass all channels except the last two as-is, and then mix the last two
-							// together as one channel. E.g. stereo -> mono, or 3.1 -> 2.1.
-							unsigned int last_chan = ad->audio_output.channels - 1;
-							for (unsigned int i = 0; i < write_frames; i++) {
-								for (unsigned int j = 0; j < last_chan; j++) {
-									ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, ad->samples_in.write[write_ofs++]);
-								}
-								int32_t l = ad->samples_in.write[write_ofs++];
-								int32_t r = ad->samples_in.write[write_ofs++];
-								int32_t c = (int32_t)(((int64_t)l + (int64_t)r) / 2);
-								ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + last_chan, c);
-							}
-						} else {
-							for (unsigned int i = 0; i < write_frames; i++) {
-								for (unsigned int j = 0; j < MIN(ad->channels, ad->audio_output.channels); j++) {
-									ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, ad->samples_in.write[write_ofs++]);
-								}
-								if (ad->audio_output.channels > ad->channels) {
-									for (unsigned int j = ad->channels; j < ad->audio_output.channels; j++) {
-										ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, 0);
-									}
-								}
-							}
-						}
+						ad->audio_server_process(write_frames, buffer, ad->audio_output.active.is_set());
 
 						hr = ad->audio_output.render_client->ReleaseBuffer(write_frames, 0);
 						if (hr != S_OK) {
 							ERR_PRINT("WASAPI: Release buffer error");
 						}
 
-						avail_frames -= write_frames;
 						written_frames += write_frames;
 					} else if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
-						// output_device is not valid anymore, reopen it
+						// `output_device` is not valid anymore, reopen it.
 
 						Error err = ad->finish_output_device();
 						if (err != OK) {
 							ERR_PRINT("WASAPI: finish_output_device error");
-						} else {
-							// We reopened the output device and samples_in may have resized, so invalidate the current avail_frames
-							avail_frames = 0;
 						}
 					} else {
 						ERR_PRINT("WASAPI: Get buffer error");
@@ -812,7 +704,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			}
 
 			if (invalidated) {
-				// output_device is not valid anymore
+				// `output_device` is not valid anymore.
 				WARN_PRINT("WASAPI: Current output_device invalidated, closing output_device");
 
 				Error err = ad->finish_output_device();
@@ -822,7 +714,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			}
 		}
 
-		// If we're using the Default output device and it changed finish it so we'll re-init the output device
+		// If we're using the Default output device and it changed finish it so we'll re-init the output device.
 		if (ad->audio_output.device_name == "Default" && default_output_device_changed) {
 			Error err = ad->finish_output_device();
 			if (err != OK) {
@@ -832,7 +724,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			default_output_device_changed = false;
 		}
 
-		// User selected a new output device, finish the current one so we'll init the new output device
+		// User selected a new output device, finish the current one so we'll init the new output device.
 		if (ad->audio_output.device_name != ad->audio_output.new_device) {
 			ad->audio_output.device_name = ad->audio_output.new_device;
 			Error err = ad->finish_output_device();
@@ -846,9 +738,6 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			if (err == OK) {
 				ad->start();
 			}
-
-			avail_frames = 0;
-			write_ofs = 0;
 		}
 
 		if (ad->audio_input.active.is_set()) {
@@ -863,26 +752,10 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 					hr = ad->audio_input.capture_client->GetBuffer(&data, &num_frames_available, &flags, nullptr, nullptr);
 					ERR_BREAK(hr != S_OK);
 
-					// fixme: Only works for floating point atm
-					for (UINT32 j = 0; j < num_frames_available; j++) {
-						int32_t l, r;
-
-						if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
-							l = r = 0;
-						} else {
-							if (ad->audio_input.channels == 2) {
-								l = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * 2);
-								r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j * 2 + 1);
-							} else if (ad->audio_input.channels == 1) {
-								l = r = read_sample(ad->audio_input.format_tag, ad->audio_input.bits_per_sample, data, j);
-							} else {
-								l = r = 0;
-								ERR_PRINT("WASAPI: unsupported channel count in microphone!");
-							}
-						}
-
-						ad->input_buffer_write(l);
-						ad->input_buffer_write(r);
+					if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
+						ad->input_process(num_frames_available, nullptr);
+					} else {
+						ad->input_process(num_frames_available, data);
 					}
 
 					read_frames += num_frames_available;
@@ -895,7 +768,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 				}
 			}
 
-			// If we're using the Default output device and it changed finish it so we'll re-init the output device
+			// If we're using the Default output device and it changed finish it so we'll re-init the output device.
 			if (ad->audio_input.device_name == "Default" && default_input_device_changed) {
 				Error err = ad->finish_input_device();
 				if (err != OK) {
@@ -905,7 +778,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 				default_input_device_changed = false;
 			}
 
-			// User selected a new input device, finish the current one so we'll init the new input device
+			// User selected a new input device, finish the current one so we'll init the new input device.
 			if (ad->audio_input.device_name != ad->audio_input.new_device) {
 				ad->audio_input.device_name = ad->audio_input.new_device;
 				Error err = ad->finish_input_device();
@@ -925,7 +798,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 		ad->stop_counting_ticks();
 		ad->unlock();
 
-		// Let the thread rest a while if we haven't read or write anything
+		// Let the thread rest a while if we haven't read or written anything.
 		if (written_frames == 0 && read_frames == 0) {
 			OS::get_singleton()->delay_usec(1000);
 		}
@@ -989,6 +862,14 @@ Error AudioDriverWASAPI::input_stop() {
 	return FAILED;
 }
 
+int AudioDriverWASAPI::get_input_channels() const {
+	return audio_input.channels;
+}
+
+AudioDriver::BufferFormat AudioDriverWASAPI::get_input_buffer_format() const {
+	return audio_input.buffer_format;
+}
+
 PackedStringArray AudioDriverWASAPI::get_input_device_list() {
 	return audio_device_get_list(true);
 }
@@ -1005,10 +886,6 @@ void AudioDriverWASAPI::set_input_device(const String &p_name) {
 	lock();
 	audio_input.new_device = p_name;
 	unlock();
-}
-
-AudioDriverWASAPI::AudioDriverWASAPI() {
-	samples_in.clear();
 }
 
 #endif // WASAPI_ENABLED

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -51,15 +51,13 @@ class AudioDriverWASAPI : public AudioDriver {
 		IAudioCaptureClient *capture_client = nullptr; // Input
 		SafeFlag active;
 
-		WORD format_tag = 0;
-		WORD bits_per_sample = 0;
 		unsigned int channels = 0;
 		unsigned int frame_size = 0;
 
-		String device_name = "Default"; // Output OR Input
-		String new_device = "Default"; // Output OR Input
+		BufferFormat buffer_format = NO_BUFFER;
 
-		AudioDeviceWASAPI() {}
+		String device_name = "Default";
+		String new_device = "Default";
 	};
 
 	AudioDeviceWASAPI audio_input;
@@ -68,9 +66,6 @@ class AudioDriverWASAPI : public AudioDriver {
 	Mutex mutex;
 	Thread thread;
 
-	Vector<int32_t> samples_in;
-
-	unsigned int channels = 0;
 	int mix_rate = 0;
 	int buffer_frames = 0;
 	int target_latency_ms = 0;
@@ -79,8 +74,6 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	SafeFlag exit_thread;
 
-	static _FORCE_INLINE_ void write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i, int32_t sample);
-	static _FORCE_INLINE_ int32_t read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i);
 	static void thread_func(void *p_udata);
 
 	Error init_output_device(bool p_reinit = false);
@@ -101,12 +94,14 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
-	virtual SpeakerMode get_speaker_mode() const override;
 	virtual float get_latency() override;
 
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
+
+	virtual int get_output_channels() const override;
+	virtual BufferFormat get_output_buffer_format() const override;
 
 	virtual PackedStringArray get_output_device_list() override;
 	virtual String get_output_device() override;
@@ -115,11 +110,12 @@ public:
 	virtual Error input_start() override;
 	virtual Error input_stop() override;
 
+	virtual int get_input_channels() const override;
+	virtual BufferFormat get_input_buffer_format() const override;
+
 	virtual PackedStringArray get_input_device_list() override;
 	virtual String get_input_device() override;
 	virtual void set_input_device(const String &p_name) override;
-
-	AudioDriverWASAPI();
 };
 
 #endif // WASAPI_ENABLED

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -4,4 +4,8 @@ Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 env.Append(CPPDEFINES=["XAUDIO2_ENABLED"])
-env.Append(LINKFLAGS=["xaudio2_8.lib"])
+
+if env.msvc:
+    env.Append(LINKFLAGS=["xaudio2_8.lib"])
+else:
+    env.Append(LIBS=["xaudio2_8"])

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -47,12 +47,20 @@ class AudioDriverOpenSL : public AudioDriver {
 
 	bool pause = false;
 
-	uint32_t buffer_size = 0;
-	int16_t *buffers[BUFFER_COUNT] = {};
-	int32_t *mixdown_buffer = nullptr;
+	uint32_t output_buffer_frames = 0;
+	LocalVector<int8_t> buffers[BUFFER_COUNT];
 	int last_free = 0;
 
-	Vector<int16_t> rec_buffer;
+	int mix_rate = 0;
+
+	unsigned int output_channels = 0;
+	unsigned int input_channels = 0;
+
+	BufferFormat output_buffer_format = NO_BUFFER;
+	BufferFormat input_buffer_format = NO_BUFFER;
+
+	uint32_t input_buffer_frames = 0;
+	LocalVector<int8_t> input_buffer;
 
 	SLPlayItf playItf;
 	SLRecordItf recordItf;
@@ -94,18 +102,21 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
-	virtual SpeakerMode get_speaker_mode() const override;
 
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
 
+	virtual int get_output_channels() const override;
+	virtual BufferFormat get_output_buffer_format() const override;
+
 	virtual Error input_start() override;
 	virtual Error input_stop() override;
 
-	void set_pause(bool p_pause);
+	virtual int get_input_channels() const override;
+	virtual BufferFormat get_input_buffer_format() const override;
 
-	AudioDriverOpenSL();
+	void set_pause(bool p_pause);
 };
 
 #endif // AUDIO_DRIVER_OPENSL_H

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -51,127 +51,113 @@ void AudioDriverWeb::_latency_update_callback(float p_latency) {
 }
 
 void AudioDriverWeb::_audio_driver_process(int p_from, int p_samples) {
-	int32_t *stream_buffer = reinterpret_cast<int32_t *>(output_rb);
-	const int max_samples = memarr_len(output_rb);
+	const int max_samples = output_buffer.size();
 
 	int write_pos = p_from;
 	int to_write = p_samples;
 	if (to_write == 0) {
 		to_write = max_samples;
 	}
-	// High part
+
+	// High part.
 	if (write_pos + to_write > max_samples) {
 		const int samples_high = max_samples - write_pos;
-		audio_server_process(samples_high / channel_count, &stream_buffer[write_pos]);
-		for (int i = write_pos; i < max_samples; i++) {
-			output_rb[i] = float(stream_buffer[i] >> 16) / 32768.f;
-		}
+		audio_server_process(samples_high / audio_context.output_channels, &output_buffer[write_pos]);
 		to_write -= samples_high;
 		write_pos = 0;
 	}
-	// Leftover
-	audio_server_process(to_write / channel_count, &stream_buffer[write_pos]);
-	for (int i = write_pos; i < write_pos + to_write; i++) {
-		output_rb[i] = float(stream_buffer[i] >> 16) / 32768.f;
-	}
+
+	// Leftover.
+	audio_server_process(to_write / audio_context.output_channels, &output_buffer[write_pos]);
 }
 
 void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
-	if (get_input_buffer().size() == 0) {
+	if (unlikely(!audio_context.is_input_active)) {
 		return; // Input capture stopped.
 	}
-	const int max_samples = memarr_len(input_rb);
+
+	if (unlikely(audio_context.input_channels == 0)) {
+		audio_context.input_channels = godot_audio_get_input_channels();
+	}
+
+	const int max_samples = input_buffer.size();
 
 	int read_pos = p_from;
 	int to_read = p_samples;
 	if (to_read == 0) {
 		to_read = max_samples;
 	}
-	// High part
+
+	// High part.
 	if (read_pos + to_read > max_samples) {
 		const int samples_high = max_samples - read_pos;
-		for (int i = read_pos; i < max_samples; i++) {
-			input_buffer_write(int32_t(input_rb[i] * 32768.f) * (1U << 16));
-		}
+		input_process(samples_high / audio_context.input_channels, &input_buffer[read_pos]);
 		to_read -= samples_high;
 		read_pos = 0;
 	}
-	// Leftover
-	for (int i = read_pos; i < read_pos + to_read; i++) {
-		input_buffer_write(int32_t(input_rb[i] * 32768.f) * (1U << 16));
-	}
+
+	// Leftover.
+	input_process(to_read / audio_context.input_channels, &input_buffer[read_pos]);
 }
 
 Error AudioDriverWeb::init() {
 	int latency = Engine::get_singleton()->get_audio_output_latency();
+
 	if (!audio_context.inited) {
 		audio_context.mix_rate = _get_configured_mix_rate();
-		audio_context.channel_count = godot_audio_init(&audio_context.mix_rate, latency, &_state_change_callback, &_latency_update_callback);
+		audio_context.output_channels = godot_audio_init(&audio_context.mix_rate, latency, &_state_change_callback, &_latency_update_callback);
 		audio_context.inited = true;
 	}
-	mix_rate = audio_context.mix_rate;
-	channel_count = audio_context.channel_count;
-	buffer_length = closest_power_of_2((latency * mix_rate / 1000));
-	Error err = create(buffer_length, channel_count);
+
+	buffer_frames = closest_power_of_2(latency * audio_context.mix_rate / 1000);
+	Error err = create(buffer_frames, audio_context.output_channels);
 	if (err != OK) {
 		return err;
 	}
-	if (output_rb) {
-		memdelete_arr(output_rb);
-	}
-	const size_t array_size = buffer_length * (size_t)channel_count;
-	output_rb = memnew_arr(float, array_size);
-	if (!output_rb) {
-		return ERR_OUT_OF_MEMORY;
-	}
-	if (input_rb) {
-		memdelete_arr(input_rb);
-	}
-	input_rb = memnew_arr(float, array_size);
-	if (!input_rb) {
-		return ERR_OUT_OF_MEMORY;
-	}
+
+	const size_t buffer_size = buffer_frames * (size_t)audio_context.output_channels;
+	output_buffer.resize(buffer_size);
+	input_buffer.resize(buffer_size);
 	return OK;
 }
 
 void AudioDriverWeb::start() {
-	start(output_rb, memarr_len(output_rb), input_rb, memarr_len(input_rb));
+	start(output_buffer.ptr(), output_buffer.size(), input_buffer.ptr(), input_buffer.size());
 }
 
 void AudioDriverWeb::resume() {
-	if (audio_context.state == 0) { // 'suspended'
+	if (audio_context.state == 0) { // 'suspended'.
 		godot_audio_resume();
 	}
 }
 
 float AudioDriverWeb::get_latency() {
-	return audio_context.output_latency + (float(buffer_length) / mix_rate);
+	return audio_context.output_latency + (float)buffer_frames / audio_context.mix_rate;
 }
 
 int AudioDriverWeb::get_mix_rate() const {
-	return mix_rate;
+	return audio_context.mix_rate;
 }
 
-AudioDriver::SpeakerMode AudioDriverWeb::get_speaker_mode() const {
-	return get_speaker_mode_by_total_channels(channel_count);
+int AudioDriverWeb::get_output_channels() const {
+	return audio_context.output_channels;
+}
+
+AudioDriver::BufferFormat AudioDriverWeb::get_output_buffer_format() const {
+	return output_buffer_format;
 }
 
 void AudioDriverWeb::finish() {
 	finish_driver();
-	if (output_rb) {
-		memdelete_arr(output_rb);
-		output_rb = nullptr;
-	}
-	if (input_rb) {
-		memdelete_arr(input_rb);
-		input_rb = nullptr;
-	}
 }
 
 Error AudioDriverWeb::input_start() {
 	lock();
-	input_buffer_init(buffer_length);
+	audio_context.is_input_active = true;
+	audio_context.input_channels = 0;
+	input_buffer_init(buffer_frames);
 	unlock();
+
 	if (godot_audio_input_start()) {
 		return FAILED;
 	}
@@ -180,52 +166,68 @@ Error AudioDriverWeb::input_start() {
 
 Error AudioDriverWeb::input_stop() {
 	godot_audio_input_stop();
+
 	lock();
-	input_buffer.clear();
+	audio_context.is_input_active = false;
 	unlock();
 	return OK;
 }
 
+int AudioDriverWeb::get_input_channels() const {
+	return audio_context.input_channels;
+}
+
+AudioDriver::BufferFormat AudioDriverWeb::get_input_buffer_format() const {
+	return input_buffer_format;
+}
+
 #ifdef THREADS_ENABLED
 
-/// AudioWorkletNode implementation (threads)
+/// AudioWorkletNode implementation (threads).
 void AudioDriverWorklet::_audio_thread_func(void *p_data) {
-	AudioDriverWorklet *driver = static_cast<AudioDriverWorklet *>(p_data);
-	const int out_samples = memarr_len(driver->get_output_rb());
-	const int in_samples = memarr_len(driver->get_input_rb());
+	AudioDriverWorklet *ad = static_cast<AudioDriverWorklet *>(p_data);
+
+	const int out_samples = ad->get_output_buffer_size();
+	const int in_samples = ad->get_input_buffer_size();
+
 	int wpos = 0;
 	int to_write = out_samples;
 	int rpos = 0;
 	int to_read = 0;
 	int32_t step = 0;
-	while (!driver->quit) {
+
+	while (!ad->quit) {
 		if (to_read) {
-			driver->lock();
-			driver->_audio_driver_capture(rpos, to_read);
-			godot_audio_worklet_state_add(driver->state, STATE_SAMPLES_IN, -to_read);
-			driver->unlock();
+			ad->lock();
+			ad->_audio_driver_capture(rpos, to_read);
+			godot_audio_worklet_state_add(ad->state, STATE_SAMPLES_IN, -to_read);
+			ad->unlock();
+
 			rpos += to_read;
 			if (rpos >= in_samples) {
 				rpos -= in_samples;
 			}
 		}
+
 		if (to_write) {
-			driver->lock();
-			driver->_audio_driver_process(wpos, to_write);
-			godot_audio_worklet_state_add(driver->state, STATE_SAMPLES_OUT, to_write);
-			driver->unlock();
+			ad->lock();
+			ad->_audio_driver_process(wpos, to_write);
+			godot_audio_worklet_state_add(ad->state, STATE_SAMPLES_OUT, to_write);
+			ad->unlock();
+
 			wpos += to_write;
 			if (wpos >= out_samples) {
 				wpos -= out_samples;
 			}
 		}
-		step = godot_audio_worklet_state_wait(driver->state, STATE_PROCESS, step, 1);
-		to_write = out_samples - godot_audio_worklet_state_get(driver->state, STATE_SAMPLES_OUT);
-		to_read = godot_audio_worklet_state_get(driver->state, STATE_SAMPLES_IN);
+
+		step = godot_audio_worklet_state_wait(ad->state, STATE_PROCESS, step, 1);
+		to_write = out_samples - godot_audio_worklet_state_get(ad->state, STATE_SAMPLES_OUT);
+		to_read = godot_audio_worklet_state_get(ad->state, STATE_SAMPLES_IN);
 	}
 }
 
-Error AudioDriverWorklet::create(int &p_buffer_size, int p_channels) {
+Error AudioDriverWorklet::create(int &p_buffer_frames, int p_channels) {
 	if (!godot_audio_has_worklet()) {
 		return ERR_UNAVAILABLE;
 	}
@@ -252,10 +254,10 @@ void AudioDriverWorklet::finish_driver() {
 
 #else // No threads.
 
-/// AudioWorkletNode implementation (no threads)
+/// AudioWorkletNode implementation (no threads).
 AudioDriverWorklet *AudioDriverWorklet::singleton = nullptr;
 
-Error AudioDriverWorklet::create(int &p_buffer_size, int p_channels) {
+Error AudioDriverWorklet::create(int &p_buffer_frames, int p_channels) {
 	if (!godot_audio_has_worklet()) {
 		return ERR_UNAVAILABLE;
 	}
@@ -268,16 +270,16 @@ void AudioDriverWorklet::start(float *p_out_buf, int p_out_buf_size, float *p_in
 }
 
 void AudioDriverWorklet::_process_callback(int p_pos, int p_samples) {
-	AudioDriverWorklet *driver = AudioDriverWorklet::get_singleton();
-	driver->_audio_driver_process(p_pos, p_samples);
+	AudioDriverWorklet *ad = AudioDriverWorklet::get_singleton();
+	ad->_audio_driver_process(p_pos, p_samples);
 }
 
 void AudioDriverWorklet::_capture_callback(int p_pos, int p_samples) {
-	AudioDriverWorklet *driver = AudioDriverWorklet::get_singleton();
-	driver->_audio_driver_capture(p_pos, p_samples);
+	AudioDriverWorklet *ad = AudioDriverWorklet::get_singleton();
+	ad->_audio_driver_capture(p_pos, p_samples);
 }
 
-/// ScriptProcessorNode implementation
+/// ScriptProcessorNode implementation.
 AudioDriverScriptProcessor *AudioDriverScriptProcessor::singleton = nullptr;
 
 void AudioDriverScriptProcessor::_process_callback() {
@@ -285,11 +287,11 @@ void AudioDriverScriptProcessor::_process_callback() {
 	AudioDriverScriptProcessor::get_singleton()->_audio_driver_process();
 }
 
-Error AudioDriverScriptProcessor::create(int &p_buffer_samples, int p_channels) {
+Error AudioDriverScriptProcessor::create(int &p_buffer_frames, int p_channels) {
 	if (!godot_audio_has_script_processor()) {
 		return ERR_UNAVAILABLE;
 	}
-	return (Error)godot_audio_script_create(&p_buffer_samples, p_channels);
+	return (Error)godot_audio_script_create(&p_buffer_frames, p_channels);
 }
 
 void AudioDriverScriptProcessor::start(float *p_out_buf, int p_out_buf_size, float *p_in_buf, int p_in_buf_size) {

--- a/platform/web/godot_audio.h
+++ b/platform/web/godot_audio.h
@@ -47,6 +47,8 @@ extern void godot_audio_resume();
 extern int godot_audio_input_start();
 extern void godot_audio_input_stop();
 
+extern int godot_audio_get_input_channels();
+
 // Worklet
 typedef int32_t GodotAudioState[4];
 extern int godot_audio_worklet_create(int p_channels);

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -41,15 +41,13 @@ class AudioDriverDummy : public AudioDriver {
 	Thread thread;
 	Mutex mutex;
 
-	int32_t *samples_in = nullptr;
-
 	static void thread_func(void *p_udata);
 
 	uint32_t buffer_frames = 4096;
 	int32_t mix_rate = -1;
-	SpeakerMode speaker_mode = SPEAKER_MODE_STEREO;
+	int channels = 2;
 
-	int channels;
+	BufferFormat buffer_format = BufferFormat::NO_BUFFER;
 
 	SafeFlag active;
 	SafeFlag exit_thread;
@@ -66,24 +64,24 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
-	virtual SpeakerMode get_speaker_mode() const override;
 
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
 
-	void set_use_threads(bool p_use_threads);
-	void set_speaker_mode(SpeakerMode p_mode);
-	void set_mix_rate(int p_rate);
+	virtual int get_output_channels() const override;
+	virtual BufferFormat get_output_buffer_format() const override;
 
-	uint32_t get_channels() const;
+	void set_use_threads(bool p_use_threads);
+	void set_mix_rate(int p_rate);
+	void set_output_channels(int p_channels);
+	void set_output_buffer_format(BufferFormat p_buffer_format);
 
 	void mix_audio(int p_frames, int32_t *p_buffer);
 
 	static AudioDriverDummy *get_dummy_singleton() { return singleton; }
 
-	AudioDriverDummy();
-	~AudioDriverDummy() {}
+	AudioDriverDummy() { singleton = this; }
 };
 
 #endif // AUDIO_DRIVER_DUMMY_H

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -324,7 +324,7 @@ AudioStreamMicrophone::AudioStreamMicrophone() {
 int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	AudioDriver::get_singleton()->lock();
 
-	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
+	Vector<AudioFrame> buf = AudioDriver::get_singleton()->get_input_buffer();
 	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
 	int mix_rate = AudioDriver::get_singleton()->get_mix_rate();
 	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
@@ -342,16 +342,10 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 	} else {
 		for (int i = 0; i < p_frames; i++) {
 			if (input_size > input_ofs && (int)input_ofs < buf.size()) {
-				float l = (buf[input_ofs++] >> 16) / 32768.f;
+				p_buffer[i] = buf[input_ofs++];
 				if ((int)input_ofs >= buf.size()) {
 					input_ofs = 0;
 				}
-				float r = (buf[input_ofs++] >> 16) / 32768.f;
-				if ((int)input_ofs >= buf.size()) {
-					input_ofs = 0;
-				}
-
-				p_buffer[i] = AudioFrame(l, r);
 			} else {
 				if (mixed_frames == p_frames) {
 					mixed_frames = i;

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -114,16 +114,18 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 	gpu_time = 0.0f;
 
 	mix_rate = get_audio_mix_rate();
+	audio_channels = AudioServer::get_total_channels_by_speaker_mode(get_audio_speaker_mode());
+
 	AudioDriverDummy::get_dummy_singleton()->set_mix_rate(mix_rate);
-	AudioDriverDummy::get_dummy_singleton()->set_speaker_mode(AudioDriver::SpeakerMode(get_audio_speaker_mode()));
+	AudioDriverDummy::get_dummy_singleton()->set_output_channels(audio_channels);
+	AudioDriverDummy::get_dummy_singleton()->set_output_buffer_format(AudioDriver::BUFFER_FORMAT_INTEGER_32);
+
 	fps = p_fps;
 	if ((mix_rate % fps) != 0) {
 		WARN_PRINT("MovieWriter's audio mix rate (" + itos(mix_rate) + ") can not be divided by the recording FPS (" + itos(fps) + "). Audio may go out of sync over time.");
 	}
 
-	audio_channels = AudioDriverDummy::get_dummy_singleton()->get_channels();
 	audio_mix_buffer.resize(mix_rate * audio_channels / fps);
-
 	write_begin(p_movie_size, p_fps, p_base_path);
 }
 


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/issues/8797
* Closes https://github.com/godotengine/godot-proposals/issues/8815
* Fixes #82823 (will take the first 2 channels) (didn't test, but the code should account for that)

Also, a little bit of a clean-up.

TODO:
- [x] Implement for the input buffer;
- [ ] Test on MacOS/iOS. (I don't have them, so would appreciate some help)