### PR TITLE
Create new movie file if already exists

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -916,6 +916,9 @@
 		<member name="editor/import/use_multiple_threads" type="bool" setter="" getter="" default="true">
 			If [code]true[/code] importing of resources is run on multiple threads.
 		</member>
+		<member name="editor/movie_writer/create_new_file_if_existing" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], uses a new file name with a [code]_N[/code] suffix (where [code]N[/code] is an incremental number starting from 1) when writing a movie if it already exists. If [code]false[/code], overwrites the existing file.
+		</member>
 		<member name="editor/movie_writer/disable_vsync" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], requests V-Sync to be disabled when writing a movie (similar to setting [member display/window/vsync/vsync_mode] to [b]Disabled[/b]). This can speed up video writing if the hardware is fast enough to render, encode and save the video at a framerate higher than the monitor's refresh rate.
 			[b]Note:[/b] [member editor/movie_writer/disable_vsync] has no effect if the operating system or graphics driver forces V-Sync with no way for applications to disable it.

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -101,9 +101,13 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 	// Check for available disk space and warn the user if needed.
 	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String path = p_base_path.get_basename();
+	base_path = p_base_path;
+
 	if (path.is_relative_path()) {
 		path = "res://" + path;
+		base_path = "res://" + base_path;
 	}
+
 	dir->open(path);
 	if (dir->get_space_left() < 10 * Math::pow(1024.0, 3.0)) {
 		// Less than 10 GiB available.
@@ -145,6 +149,7 @@ void MovieWriter::_bind_methods() {
 	// Used by the editor.
 	GLOBAL_DEF_BASIC("editor/movie_writer/movie_file", "");
 	GLOBAL_DEF_BASIC("editor/movie_writer/disable_vsync", false);
+	GLOBAL_DEF_BASIC("editor/movie_writer/create_new_file_if_existing", true);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "editor/movie_writer/fps", PROPERTY_HINT_RANGE, "1,300,1,suffix:FPS"), 60);
 }
 
@@ -200,7 +205,7 @@ void MovieWriter::end() {
 
 	// Print a report with various statistics.
 	print_line("----------------");
-	String movie_path = Engine::get_singleton()->get_write_movie_path();
+	String movie_path = base_path;
 	if (movie_path.is_relative_path()) {
 		// Print absolute path to make finding the file easier,
 		// and to make it clickable in terminal emulators that support this.

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -47,6 +47,7 @@ class MovieWriter : public Object {
 
 	String project_name;
 
+
 	LocalVector<int32_t> audio_mix_buffer;
 
 	enum {
@@ -56,6 +57,8 @@ class MovieWriter : public Object {
 	static uint32_t writer_count;
 
 protected:
+	String base_path;
+
 	virtual uint32_t get_audio_mix_rate() const;
 	virtual AudioServer::SpeakerMode get_audio_speaker_mode() const;
 

--- a/servers/movie_writer/movie_writer_mjpeg.cpp
+++ b/servers/movie_writer/movie_writer_mjpeg.cpp
@@ -56,6 +56,17 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 
 	base_path += ".avi";
 
+	if (GLOBAL_GET("editor/movie_writer/create_new_file_if_existing")) {
+		String tmp_fullpath = base_path;
+		String tmp_basename = base_path.get_basename();
+		int number = 1;
+		while (FileAccess::exists(tmp_fullpath)) {
+			tmp_fullpath = tmp_basename + "_" + itos(number) + ".avi";
+			number++;
+		}
+		base_path = tmp_fullpath;
+	}
+
 	f = FileAccess::open(base_path, FileAccess::WRITE_READ);
 
 	fps = p_fps;

--- a/servers/movie_writer/movie_writer_mjpeg.h
+++ b/servers/movie_writer/movie_writer_mjpeg.h
@@ -38,7 +38,7 @@ class MovieWriterMJPEG : public MovieWriter {
 
 	uint32_t mix_rate = 48000;
 	AudioServer::SpeakerMode speaker_mode = AudioServer::SPEAKER_MODE_STEREO;
-	String base_path;
+
 	uint32_t frame_count = 0;
 	uint32_t fps = 0;
 	float quality = 0.75;

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -66,7 +66,19 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 		base_path = "res://" + base_path;
 	}
 
-	{
+	if (GLOBAL_GET("editor/movie_writer/create_new_file_if_existing")) {
+		// Find a unique file name
+		uint32_t idx = 0;
+		String tmp_fullpath = base_path + "_" + zeros_str(idx) + ".png";
+		String tmp_basename = base_path;
+		int number = 1;
+		while (FileAccess::exists(tmp_fullpath)) {
+			tmp_basename = base_path + "_" + itos(number);
+			tmp_fullpath = tmp_basename + "_" + zeros_str(idx) + ".png";
+			number++;
+		}
+		base_path = tmp_basename;
+	} else {
 		//Remove existing files before writing anew
 		uint32_t idx = 0;
 		Ref<DirAccess> d = DirAccess::open(base_path.get_base_dir());
@@ -144,7 +156,7 @@ Error MovieWriterPNGWAV::write_frame(const Ref<Image> &p_image, const int32_t *p
 
 	Vector<uint8_t> png_buffer = p_image->save_png_to_buffer();
 
-	Ref<FileAccess> fi = FileAccess::open(base_path + zeros_str(frame_count) + ".png", FileAccess::WRITE);
+	Ref<FileAccess> fi = FileAccess::open(base_path + "_" + zeros_str(frame_count) + ".png", FileAccess::WRITE);
 	fi->store_buffer(png_buffer.ptr(), png_buffer.size());
 	f_wav->store_buffer((const uint8_t *)p_audio_data, audio_block_size);
 

--- a/servers/movie_writer/movie_writer_pngwav.h
+++ b/servers/movie_writer/movie_writer_pngwav.h
@@ -42,7 +42,7 @@ class MovieWriterPNGWAV : public MovieWriter {
 
 	uint32_t mix_rate = 48000;
 	AudioServer::SpeakerMode speaker_mode = AudioServer::SPEAKER_MODE_STEREO;
-	String base_path;
+
 	uint32_t frame_count = 0;
 	uint32_t fps = 0;
 


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot/pull/71420, this PR implements those changes along with the requested feedback to create a new movie file if the path already exists instead of overwriting. Thank you to the original author for opening the original PR, this is a feature I've been wanting!

This is the sample project I created for testing the code: https://github.com/morganwesemann/godot-movie-maker-test

This will close https://github.com/godotengine/godot-proposals/issues/5989.

Here's what the setting looks like which defaults to true.
![Movie_Test3](https://github.com/godotengine/godot/assets/6299449/e5411704-46be-4fb8-b46a-95b7d52d96e2)

Multiple files for both `.avi` and `.png` extensions in the project movie file settings:
![Movie_Test](https://github.com/godotengine/godot/assets/6299449/c143d5f3-e0d0-48ee-8731-3422283d3b03)
![Movie_Test2](https://github.com/godotengine/godot/assets/6299449/2e68b86b-1ff6-47de-86b4-f07873838f8e)

Log output showing correct filename:
```
Movie Maker mode enabled, recording movie at 60 FPS...
----------------
Done recording movie at path: res://Movie.avi
25 frames at 60 FPS (movie length: 00:00:00), recorded in 00:00:03 (0% of real-time speed).
CPU time: 0.00 seconds (average: 0.11 ms/frame)
GPU time: 0.00 seconds (average: 0.01 ms/frame)
----------------

< more logs >

Movie Maker mode enabled, recording movie at 60 FPS...
----------------
Done recording movie at path: res://Movie_1.avi
31 frames at 60 FPS (movie length: 00:00:00), recorded in 00:00:03 (0% of real-time speed).
CPU time: 0.00 seconds (average: 0.10 ms/frame)
GPU time: 0.00 seconds (average: 0.01 ms/frame)
----------------

```
