### PR TITLE
Don't save unnecessarily with `save_before_running`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2072,17 +2072,23 @@ void EditorNode::restart_editor(bool p_goto_project_manager) {
 void EditorNode::_save_all_scenes() {
 	bool all_saved = true;
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		Node *scene = editor_data.get_edited_scene_root(i);
-		if (scene) {
-			if (!scene->get_scene_file_path().is_empty() && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
-				if (i != editor_data.get_edited_scene()) {
-					_save_scene(scene->get_scene_file_path(), i);
-				} else {
-					_save_scene_with_preview(scene->get_scene_file_path());
-				}
-			} else if (!scene->get_scene_file_path().is_empty()) {
-				all_saved = false;
-			}
+		if (!_is_scene_unsaved(i)) {
+			continue;
+		}
+
+		const Node *scene = editor_data.get_edited_scene_root(i);
+		ERR_FAIL_NULL(scene);
+
+		const String &scene_path = scene->get_scene_file_path();
+		if (!scene_path.is_empty() && !DirAccess::exists(scene_path.get_base_dir())) {
+			all_saved = false;
+			continue;
+		}
+
+		if (i == editor_data.get_edited_scene()) {
+			_save_scene_with_preview(scene_path);
+		} else {
+			_save_scene(scene_path, i);
 		}
 	}
 
@@ -2108,6 +2114,28 @@ void EditorNode::_mark_unsaved_scenes() {
 
 	_update_title();
 	scene_tabs->update_scene_tabs();
+}
+
+bool EditorNode::_is_scene_unsaved(int p_idx) {
+	const Node *scene = editor_data.get_edited_scene_root(p_idx);
+	if (!scene) {
+		return false;
+	}
+
+	if (EditorUndoRedoManager::get_singleton()->is_history_unsaved(editor_data.get_scene_history_id(p_idx))) {
+		return true;
+	}
+
+	const String &scene_path = scene->get_scene_file_path();
+	if (!scene_path.is_empty()) {
+		// Check if scene has unsaved changes in built-in resources.
+		for (int j = 0; j < editor_data.get_editor_plugin_count(); j++) {
+			if (!editor_data.get_editor_plugin(j)->get_unsaved_status(scene_path).is_empty()) {
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 void EditorNode::_dialog_action(String p_file) {
@@ -3460,6 +3488,20 @@ void EditorNode::_discard_changes(const String &p_str) {
 }
 
 void EditorNode::_update_file_menu_opened() {
+	bool has_unsaved = false;
+	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
+		if (_is_scene_unsaved(i)) {
+			has_unsaved = true;
+			break;
+		}
+	}
+	if (has_unsaved) {
+		file_menu->set_item_disabled(file_menu->get_item_index(FILE_SAVE_ALL_SCENES), false);
+		file_menu->set_item_tooltip(file_menu->get_item_index(FILE_SAVE_ALL_SCENES), String());
+	} else {
+		file_menu->set_item_disabled(file_menu->get_item_index(FILE_SAVE_ALL_SCENES), true);
+		file_menu->set_item_tooltip(file_menu->get_item_index(FILE_SAVE_ALL_SCENES), TTR("All scenes are already saved."));
+	}
 	file_menu->set_item_disabled(file_menu->get_item_index(FILE_OPEN_PREV), previous_scenes.is_empty());
 	_update_undo_redo_allowed();
 }

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -615,6 +615,7 @@ private:
 	bool _find_and_save_edited_subresources(Object *obj, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	void _save_edited_subresources(Node *scene, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	void _mark_unsaved_scenes();
+	bool _is_scene_unsaved(int p_idx);
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -343,7 +343,7 @@ String ShaderEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
 
 void ShaderEditorPlugin::save_external_data() {
 	for (EditedShader &edited_shader : edited_shaders) {
-		if (edited_shader.shader_editor) {
+		if (edited_shader.shader_editor && edited_shader.shader_editor->is_unsaved()) {
 			edited_shader.shader_editor->save_external_data();
 		}
 	}


### PR DESCRIPTION
When `save_before_running` is enabled, it will save all scenes, which can lead to longer running times if you have many opened scenes. That's rather absurd.

This PR changes that mechanism to only save when there are unsaved changes in the scene (which we can detect pretty reliably).

Fixes #78753
Fixes #94563