### PR TITLE
Fix scroll to description

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2306,7 +2306,8 @@ void EditorHelp::_help_callback(const String &p_topic) {
 	}
 
 	if (class_desc->is_ready()) {
-		callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph).call_deferred(line);
+		// call_deferred() is not enough.
+		class_desc->connect("draw", callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph).bind(line), CONNECT_ONE_SHOT | CONNECT_DEFERRED);
 	} else {
 		scroll_to = line;
 	}


### PR DESCRIPTION
Fixes #88281

I verified that `scroll_to_paragrah()` is called with the same argument, but apparently it's too early, because it scrolls to completely wrong position. I tried setting `scroll_to` regardless of `is_ready()`, but it doesn't help.

I call the thing I used "super_call_deferred()" in my project and it sometimes helps me to fix bugs, but I didn't expect that it would help in the engine too :/ If anyone knows a better solution feel free to suggest it, but the issue has to be fixed quick, because it's annoying.

EDIT:
I did something less hacky.