### PR TITLE
[Core] Fix and optimize binary search

### DIFF
--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -36,11 +36,12 @@
 #include "char_range.inc"
 
 #define BSEARCH_CHAR_RANGE(m_array)                      \
-	int low = 0;                                         \
+	uint32_t low = 0;                                    \
 	int high = sizeof(m_array) / sizeof(m_array[0]) - 1; \
-	int middle = (low + high) / 2;                       \
                                                          \
-	while (low <= high) {                                \
+	while ((int)low <= high) {                           \
+		uint32_t middle = (low + high) / 2;              \
+                                                         \
 		if (p_char < m_array[middle].start) {            \
 			high = middle - 1;                           \
 		} else if (p_char > m_array[middle].end) {       \
@@ -48,8 +49,6 @@
 		} else {                                         \
 			return true;                                 \
 		}                                                \
-                                                         \
-		middle = (low + high) / 2;                       \
 	}                                                    \
                                                          \
 	return false

--- a/core/string/ucaps.h
+++ b/core/string/ucaps.h
@@ -1373,11 +1373,11 @@ static const int reverse_caps_table[CAPS_LEN - 1][2] = {
 };
 
 static int _find_upper(int ch) {
-	int low = 0;
+	uint32_t low = 0;
 	int high = CAPS_LEN - 1;
-	int middle;
+	uint32_t middle;
 
-	while (low <= high) {
+	while ((int)low <= high) {
 		middle = (low + high) / 2;
 
 		if (ch < caps_table[middle][0]) {
@@ -1393,11 +1393,11 @@ static int _find_upper(int ch) {
 }
 
 static int _find_lower(int ch) {
-	int low = 0;
+	uint32_t low = 0;
 	int high = CAPS_LEN - 2;
-	int middle;
+	uint32_t middle;
 
-	while (low <= high) {
+	while ((int)low <= high) {
 		middle = (low + high) / 2;
 
 		if (ch < reverse_caps_table[middle][0]) {

--- a/core/templates/search_array.h
+++ b/core/templates/search_array.h
@@ -39,11 +39,11 @@ public:
 	Comparator compare;
 
 	inline int64_t bisect(const T *p_array, int64_t p_len, const T &p_value, bool p_before) const {
-		int64_t lo = 0;
-		int64_t hi = p_len;
+		uint64_t lo = 0;
+		uint64_t hi = p_len;
 		if (p_before) {
 			while (lo < hi) {
-				const int64_t mid = (lo + hi) / 2;
+				const uint64_t mid = (lo + hi) / 2;
 				if (compare(p_array[mid], p_value)) {
 					lo = mid + 1;
 				} else {
@@ -52,7 +52,7 @@ public:
 			}
 		} else {
 			while (lo < hi) {
-				const int64_t mid = (lo + hi) / 2;
+				const uint64_t mid = (lo + hi) / 2;
 				if (compare(p_value, p_array[mid])) {
 					hi = mid;
 				} else {

--- a/core/templates/vmap.h
+++ b/core/templates/vmap.h
@@ -58,17 +58,17 @@ private:
 			return 0;
 		}
 
-		int low = 0;
+		uint32_t low = 0;
 		int high = _cowdata.size() - 1;
 		const Pair *a = _cowdata.ptr();
-		int middle = 0;
+		uint32_t middle = 0;
 
 #ifdef DEBUG_ENABLED
-		if (low > high) {
+		if ((int)low > high) {
 			ERR_PRINT("low > high, this may be a bug");
 		}
 #endif
-		while (low <= high) {
+		while ((int)low <= high) {
 			middle = (low + high) / 2;
 
 			if (p_val < a[middle].key) {
@@ -93,12 +93,12 @@ private:
 			return -1;
 		}
 
-		int low = 0;
+		uint32_t low = 0;
 		int high = _cowdata.size() - 1;
-		int middle;
+		uint32_t middle;
 		const Pair *a = _cowdata.ptr();
 
-		while (low <= high) {
+		while ((int)low <= high) {
 			middle = (low + high) / 2;
 
 			if (p_val < a[middle].key) {

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -44,18 +44,18 @@ class VSet {
 			return 0;
 		}
 
-		int low = 0;
+		uint32_t low = 0;
 		int high = _data.size() - 1;
 		const T *a = &_data[0];
-		int middle = 0;
+		uint32_t middle = 0;
 
 #ifdef DEBUG_ENABLED
-		if (low > high) {
+		if ((int)low > high) {
 			ERR_PRINT("low > high, this may be a bug");
 		}
 #endif
 
-		while (low <= high) {
+		while ((int)low <= high) {
 			middle = (low + high) / 2;
 
 			if (p_val < a[middle]) {
@@ -80,12 +80,12 @@ class VSet {
 			return -1;
 		}
 
-		int low = 0;
+		uint32_t low = 0;
 		int high = _data.size() - 1;
-		int middle;
+		uint32_t middle;
 		const T *a = &_data[0];
 
-		while (low <= high) {
+		while ((int)low <= high) {
 			middle = (low + high) / 2;
 
 			if (p_val < a[middle]) {


### PR DESCRIPTION
This improves binary search by using `uint` instead of `int`.

**Performance optimization**
Using the compile explorer https://godbolt.org/z/qcfPMdPbE I get asm in `while` loop.
Before:
```
.L85:
        lea     esi, [rax-1]
        cmp     edi, esi
        jg      .L84
.L38:
        lea     edx, [rsi+rdi]
        mov     eax, edx
        shr     eax, 31
        add     eax, edx
        sar     eax
        movsx   rcx, eax
        mov     r14d, eax
        mov     r8d, DWORD PTR [r9+rcx*8]
        lea     r12, [0+rcx*8]
        cmp     r8d, r13d
        jg      .L85
        jge     .L37
        lea     edi, [rax+1]
        cmp     edi, esi
        jle     .L38
.L84:
        cmp     r8d, r13d
        jl      .L86
        add     edx, 1
        mov     QWORD PTR [rsp], rcx
        jl      .L40
```

After:
```
.L120:
        lea     edx, [rax-1]
        cmp     ecx, edx
        jg      .L109
.L106:
        lea     eax, [rdx+rcx]
        shr     eax
        mov     esi, eax
        cmp     DWORD PTR [rdi+rsi*8], 100
        jg      .L120
        je      .L102
        lea     ecx, [rax+1]
        cmp     ecx, edx
        jle     .L106
.L109:
        mov     eax, -1
```
Quick benchmark results :
![image](https://github.com/godotengine/godot/assets/116561933/a1de40b1-0190-47e9-b314-ead920480bae)


**Fix**
When there are more than a billion items in a `VSet` or `VMap`, the `_find` and `_find_exact` methods break. They break if we try to find an element that is close to the end of the array. 
`(low + high) / 2` This gives a negative value.  
A simple solution would be to use something like this `middle = low + (high - low)/2` as it is used in most popular binary searches. But we're returning a signed int, so why do that when we can just use an `unsigned int`? This gives data structures their full signed int structure size (Increases from 1 billion to 2 billion). It also reduces the number of instructions that break the search.