### PR TITLE
[Core] Fix `ResourceLoader.load` cache with relative paths

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -402,7 +402,7 @@ static String _validate_local_path(const String &p_path) {
 	if (uid != ResourceUID::INVALID_ID) {
 		return ResourceUID::get_singleton()->get_id_path(uid);
 	} else if (p_path.is_relative_path()) {
-		return "res://" + p_path;
+		return ("res://" + p_path).simplify_path();
 	} else {
 		return ProjectSettings::get_singleton()->localize_path(p_path);
 	}


### PR DESCRIPTION
Paths were not simplified meaning that `res://foo.bar` was treated differently from `./foo.bar` and similar

This matches how paths with the `res://` prefix are handled, which are simplified as part of the `localize_path`

The documentation for `load` states that these paths are not loaded, that's something to discuss and evaluate in a separate PR though, as this is is specific to `ResourceLoader.load` and just happens to affect this part as well, and loading relative paths in the resource loader is supported (no claim in the documentation to the contrary)

There are also some potential issues with how threaded loading handles paths that I will look into separately, as it might be more consequential, as opposed to this which is a straightforward fix

* See: https://github.com/godotengine/godot/issues/90029 (doesn't "fix" it as such, the documentation part needs to be discussed further)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
