### PR TITLE
Expose `Node::get_internal_mode()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -364,6 +364,12 @@
 				If [param include_internal] is [code]false[/code], returns the index ignoring internal children. The first, non-internal child will have an index of [code]0[/code] (see [method add_child]'s [code]internal[/code] parameter).
 			</description>
 		</method>
+		<method name="get_internal_mode" qualifiers="const">
+			<return type="int" enum="Node.InternalMode" />
+			<description>
+				Returns the node's internal mode. See [method add_child], [method add_sibling].
+			</description>
+		</method>
 		<method name="get_last_exclusive_window" qualifiers="const">
 			<return type="Window" />
 			<description>
@@ -1298,13 +1304,13 @@
 			Duplicate using [method PackedScene.instantiate]. If the node comes from a scene saved on disk, re-uses [method PackedScene.instantiate] as the base for the duplicated node and its children.
 		</constant>
 		<constant name="INTERNAL_MODE_DISABLED" value="0" enum="InternalMode">
-			The node will not be internal.
+			The node is not internal.
 		</constant>
 		<constant name="INTERNAL_MODE_FRONT" value="1" enum="InternalMode">
-			The node will be placed at the beginning of the parent's children, before any non-internal sibling.
+			The node is placed at the beginning of the parent's children, before any non-internal sibling.
 		</constant>
 		<constant name="INTERNAL_MODE_BACK" value="2" enum="InternalMode">
-			The node will be placed at the end of the parent's children, after any non-internal sibling.
+			The node is placed at the end of the parent's children, after any non-internal sibling.
 		</constant>
 		<constant name="AUTO_TRANSLATE_MODE_INHERIT" value="0" enum="AutoTranslateMode">
 			Inherits [member auto_translate_mode] from the node's parent. This is the default for any newly created node.

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3518,6 +3518,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("find_parent", "pattern"), &Node::find_parent);
 	ClassDB::bind_method(D_METHOD("has_node_and_resource", "path"), &Node::has_node_and_resource);
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
+	ClassDB::bind_method(D_METHOD("get_internal_mode"), &Node::get_internal_mode);
 
 	ClassDB::bind_method(D_METHOD("is_inside_tree"), &Node::is_inside_tree);
 	ClassDB::bind_method(D_METHOD("is_ancestor_of", "node"), &Node::is_ancestor_of);


### PR DESCRIPTION
Expose `Node::get_internal_mode()` so that we can easily check if the child entered is a internal node:

```gdscript
extends ScrollContainer

func _init():
	child_entered_tree.connect(_child_entered_tree)

func _child_entered_tree(child : Node):
	if child.get_internal_mode() != INTERNAL_MODE_DISABLED:
		return # Ignore its two ScrollBars.

	print(child)

```